### PR TITLE
Markdown badges - CircleCI, License & PyPI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # MLrun
+
+[![CircleCI](https://circleci.com/gh/mlrun/mlrun/tree/development.svg?style=svg)](https://circleci.com/gh/mlrun/mlrun/tree/development)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![PyPI version fury.io](https://badge.fury.io/py/mlrun.svg)](https://pypi.python.org/pypi/mlrun/)
+
 A generic an easy to use mechanism for data scientists and developers/engineers 
 to describe and run machine learning related tasks in various scalable runtime environments 
 while automatically tracking code, metadata, inputs, and outputs of (executions).


### PR DESCRIPTION
Markdown badges
- CircleCI build status
- Licence
- PyPI version

See how it looks [here](https://github.com/mlrun/mlrun/tree/markdown-badges#mlrun)