### PR TITLE
Fix sparkjob driver resources

### DIFF
--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -59,8 +59,8 @@ _sparkjob_template = {
      'deps': {},
      'volumes': [],
      'driver': {
-         'cores': 0.1,
-         'coreLimit': '200m',
+         'cores': 1,
+         'coreLimit': '1200m',
          'memory': '512m',
          'labels': {},
          'serviceAccount': 'spark-operator-spark',


### PR DESCRIPTION
@yaronha - This is critcal for spark job performance (cuts it from 2-3 minutes to 30 secs)