### PR TITLE
[DOC REVIEW] Edit RST doc for the auto-generated readthedocs reference [IG-13721]

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,14 +1,8 @@
 General
 =======
 
-A generic an easy to use mechanism for data scientists and developers/engineers
-to describe and run machine learning related tasks in various scalable runtime
-environments while automatically tracking code, metadata, inputs, and outputs
-of executions.
+MLRun is a generic and convenient mechanism for data scientists and software developers to describe and run tasks related to machine learning (ML) in various, scalable runtime environments and ML pipelines while automatically tracking executed code, metadata, inputs, and outputs.
+MLRun integrates with the `Nuclio <https://nuclio.io/>`_ serverless project and with `Kubeflow Pipelines <https://github.com/kubeflow/pipelines>`_.
 
-MLRun is integrated with `Nuclio serverless project`_
+The MLRun package (``mlrun``) includes a Python API library and the ``mlrun`` command-line interface (CLI).
 
-Read more details in `this doc link`_
-
-.. _`Nuclio serverless project`: https://github.com/nuclio/nuclio
-.. _`this doc link`: https://docs.google.com/document/d/1JRoWx4X7ld3fzQtdTGVIbcZx-5HzlYmkFiQz6ei8izE/edit?usp=sharing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to mlrun's documentation!
-=================================
+mlrun Package Documentation
+============================
 
 .. toctree::
    :maxdepth: 4
@@ -14,7 +14,7 @@ Welcome to mlrun's documentation!
    mlrun
 
 
-Indices and tables
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/docs/mlrun.rst
+++ b/docs/mlrun.rst
@@ -1,4 +1,4 @@
-mlrun package
+mlrun Package
 =============
 
 Module contents

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-A generic an easy to use mechanism for data scientists and
-developers/engineers.
+MLRun is a generic and convenient mechanism for data scientists and software developers to describe and run tasks related to machine learning (ML) in various, scalable runtime environments and ML pipelines while automatically tracking executed code, metadata, inputs, and outputs.
+MLRun integrates with the `Nuclio <https://nuclio.io/>`_ serverless project and with `Kubeflow Pipelines <https://github.com/kubeflow/pipelines>`_.
 
-to describe and run machine learning related tasks in various scalable runtime
-environments and ML pipelines while automatically tracking code, metadata,
-inputs, and outputs of executions.  MLRun integrate/use
-`Nuclio serverless project`_ and `KubeFlow`_.
-
-.. _`Nuclio serverless project`: https://github.com/nuclio/nuclio
-.. _KubeFlow: https://www.kubeflow.org/
+The MLRun package (``mlrun``) includes a Python API library and the ``mlrun`` command-line interface (CLI).
 """
 
 __version__ = '0.4.6'


### PR DESCRIPTION
@yaronha please review.
NOTE: Currently, we have similar intro text on the **General** and **mlrun Package** pages (created from duplicate sources at **docs/api.rst** and **mlrun/__init__.py**). I spoke with Miki about eliminating this duplication. I'll discuss this with you f2f. This PR just slightly edits the text in both places in a similar manner. The output looks like this (this is from the mlrun package page; General has a similar intro):
![mlrun_package_rst_doc 200312 pr201](https://user-images.githubusercontent.com/27913885/76521072-c5713e00-646c-11ea-86de-79d05ecd3896.png)
