### PR TITLE
Fix doc-build warnings

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -1,1 +1,0 @@
-.. Don't delete this file, it's required by readthedocs

--- a/docs/mlrun.rst
+++ b/docs/mlrun.rst
@@ -16,7 +16,7 @@ mlrun.run module
    :show-inheritance:
 
 mlrun.project module
-----------------
+--------------------
 
 .. automodule:: mlrun.project
    :members:


### PR DESCRIPTION
- Fix **conf.py** cosmetics for new project module to eliminate the following doc-build warning:
Eliminate the following build warning:
  ```
  mlrun.project module
  ----------------
  <...>\mlrun\docs\mlrun.rst:19: WARNING: Title underline too short.
  ```
- Remove unused file **docs/contents.rst** to eliminate the following docs build error:
  ```
  checking consistency... <...>\mlrun\docs\contents.rst: WARNING: document isn't included in any toctree
  ```