### PR TITLE
Ignore underscored functions in find_handlers

### DIFF
--- a/mlrun/funcdoc.py
+++ b/mlrun/funcdoc.py
@@ -242,7 +242,7 @@ def find_handlers(code: str, handlers=None):
 def filter_funcs(funcs, markers):
     markers = list(markers)
     if not markers:
-        return funcs
+        return [func for func in funcs if func['name'][0] != '_']
 
     return [func for func in funcs if is_marked(func, markers)]
 

--- a/tests/test_funcdoc.py
+++ b/tests/test_funcdoc.py
@@ -155,3 +155,21 @@ def test_ast_compound():
         if i in (4, 8):
             continue
         assert param['type'], f'{i}: {param}'
+
+
+underscore_code = '''
+def info(message):
+    _log('INFO', message)
+
+def warning(message):
+    _log('WARNING', message)
+
+def _log(level, message):
+    print(f'{level} - {message}')
+'''
+
+
+def test_ignore_underscore():
+    funcs = funcdoc.find_handlers(underscore_code)
+    names = {fn['name'] for fn in funcs}
+    assert {'info', 'warning'} == names, 'names'


### PR DESCRIPTION
fixes #235