### PR TITLE
Fixing labels query param typo

### DIFF
--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -79,7 +79,7 @@ def list_artifacts(
         project: str = config.default_project,
         name: str = None,
         tag: str = None,
-        labels: List[str] = Query([]),
+        labels: List[str] = Query([], alias='label'),
         db_session: Session = Depends(deps.get_db_session)):
     artifacts = get_db().list_artifacts(db_session, name, project, tag, labels)
     return {
@@ -93,7 +93,7 @@ def del_artifacts(
         project: str = "",
         name: str = "",
         tag: str = "",
-        labels: List[str] = Query([]),
+        labels: List[str] = Query([], alias='label'),
         db_session: Session = Depends(deps.get_db_session)):
     get_db().del_artifacts(db_session, name, project, tag, labels)
     return {}

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -61,7 +61,7 @@ def list_functions(
         project: str = config.default_project,
         name: str = None,
         tag: str = None,
-        labels: List[str] = Query([]),
+        labels: List[str] = Query([], alias='label'),
         db_session: Session = Depends(deps.get_db_session)):
     funcs = get_db().list_functions(db_session, name, project, tag, labels)
     return {

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -84,7 +84,7 @@ def list_runs(
         project: str = None,
         name: str = None,
         uid: str = None,
-        labels: List[str] = Query([]),
+        labels: List[str] = Query([], alias='label'),
         state: str = None,
         last: int = 0,
         sort: str = "on",
@@ -113,7 +113,7 @@ def list_runs(
 def del_runs(
         project: str = None,
         name: str = None,
-        labels: List[str] = Query([]),
+        labels: List[str] = Query([], alias='label'),
         state: str = None,
         days_ago: int = 0,
         db_session: Session = Depends(deps.get_db_session)):


### PR DESCRIPTION
A typo happened in the big refactor of httpd -> FastAPI (https://github.com/mlrun/mlrun/pull/255)