### PR TITLE
API - Fix endpoints with mix of sync and async code

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -1,10 +1,10 @@
-import asyncio
 import traceback
 from distutils.util import strtobool
 from http import HTTPStatus
 from typing import List
 
 from fastapi import APIRouter, Depends, Request, Query, Response
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 from mlrun.api.api import deps
@@ -21,7 +21,7 @@ router = APIRouter()
 
 # curl -d@/path/to/func.json http://localhost:8080/func/prj/7?tag=0.3.2
 @router.post("/func/{project}/{name}")
-def store_function(
+async def store_function(
         request: Request,
         project: str,
         name: str,
@@ -30,14 +30,14 @@ def store_function(
         db_session: Session = Depends(deps.get_db_session)):
     data = None
     try:
-        data = asyncio.run(request.json())
+        data = await request.json()
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
 
     logger.debug(data)
     logger.info(
         "store function: project=%s, name=%s, tag=%s", project, name, tag)
-    get_db().store_function(db_session, data, name, project, tag=tag, versioned=versioned)
+    await run_in_threadpool(get_db().store_function, db_session, data, name, project, tag=tag, versioned=versioned)
     return {}
 
 
@@ -72,34 +72,19 @@ def list_functions(
 # curl -d@/path/to/job.json http://localhost:8080/build/function
 @router.post("/build/function")
 @router.post("/build/function/")
-def build_function(
+async def build_function(
         request: Request,
         db_session: Session = Depends(deps.get_db_session)):
     data = None
     try:
-        data = asyncio.run(request.json())
+        data = await request.json()
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
 
     logger.info("build_function:\n{}".format(data))
     function = data.get("function")
     with_mlrun = strtobool(data.get("with_mlrun", "on"))
-
-    fn = None
-    ready = None
-    try:
-        fn = new_function(runtime=function)
-
-        run_db = get_run_db_instance(db_session)
-        fn.set_db_connection(run_db)
-        fn.save(versioned=False)
-
-        ready = build_runtime(fn, with_mlrun)
-        fn.save(versioned=False)
-        logger.info("Fn:\n %s", fn.to_yaml())
-    except Exception as err:
-        logger.error(traceback.format_exc())
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
+    fn, ready = await run_in_threadpool(_build_function, db_session, function, with_mlrun)
     return {
         "data": fn.to_dict(),
         "ready": ready,
@@ -109,41 +94,16 @@ def build_function(
 # curl -d@/path/to/job.json http://localhost:8080/start/function
 @router.post("/start/function")
 @router.post("/start/function/")
-def start_function(
+async def start_function(
         request: Request,
         db_session: Session = Depends(deps.get_db_session)):
     data = None
     try:
-        data = asyncio.run(request.json())
+        data = await request.json()
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
 
-    logger.info("start_function:\n{}".format(data))
-    url = data.get("functionUrl")
-    if not url:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: functionUrl not specified")
-
-    project, name, tag, hash_key = parse_function_uri(url)
-    runtime = get_db().get_function(db_session, name, project, tag, hash_key)
-    if not runtime:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: function {} not found".format(url))
-
-    fn = new_function(runtime=runtime)
-    resource = runtime_resources_map.get(fn.kind)
-    if "start" not in resource:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: 'start' not supported by this runtime")
-
-    try:
-
-        run_db = get_run_db_instance(db_session)
-        fn.set_db_connection(run_db)
-        #  resp = resource["start"](fn)  # TODO: handle resp?
-        resource["start"](fn)
-        fn.save(versioned=False)
-        logger.info("Fn:\n %s", fn.to_yaml())
-    except Exception as err:
-        logger.error(traceback.format_exc())
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
+    fn = await run_in_threadpool(_start_function, db_session, data)
 
     return {
         "data": fn.to_dict(),
@@ -153,31 +113,15 @@ def start_function(
 # curl -d@/path/to/job.json http://localhost:8080/status/function
 @router.post("/status/function")
 @router.post("/status/function/")
-def function_status(
+async def function_status(
         request: Request):
     data = None
     try:
-        data = asyncio.run(request.json())
+        data = await request.json()
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
 
-    logger.info("function_status:\n{}".format(data))
-    selector = data.get("selector")
-    kind = data.get("kind")
-    if not selector or not kind:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: selector or runtime kind not specified")
-
-    resource = runtime_resources_map.get(kind)
-    if "status" not in resource:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: 'status' not supported by this runtime")
-
-    resp = None
-    try:
-        resp = resource["status"](selector)
-        logger.info("status: %s", resp)
-    except Exception as err:
-        logger.error(traceback.format_exc())
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
+    resp = await run_in_threadpool(_get_function_status, data)
     return {
         "data": resp,
     }
@@ -238,3 +182,73 @@ def build_status(
                     headers={"function_status": state,
                              "function_image": image,
                              "builder_pod": pod})
+
+
+def _build_function(db_session, function, with_mlrun):
+    fn = None
+    ready = None
+    try:
+        fn = new_function(runtime=function)
+
+        run_db = get_run_db_instance(db_session)
+        fn.set_db_connection(run_db)
+        fn.save(versioned=False)
+
+        ready = build_runtime(fn, with_mlrun)
+        fn.save(versioned=False)
+        logger.info("Fn:\n %s", fn.to_yaml())
+    except Exception as err:
+        logger.error(traceback.format_exc())
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
+    return fn, ready
+
+
+def _start_function(db_session, data):
+    logger.info("start_function:\n{}".format(data))
+    url = data.get("functionUrl")
+    if not url:
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: functionUrl not specified")
+
+    project, name, tag, hash_key = parse_function_uri(url)
+    runtime = get_db().get_function(db_session, name, project, tag, hash_key)
+    if not runtime:
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: function {} not found".format(url))
+
+    fn = new_function(runtime=runtime)
+    resource = runtime_resources_map.get(fn.kind)
+    if "start" not in resource:
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: 'start' not supported by this runtime")
+
+    try:
+
+        run_db = get_run_db_instance(db_session)
+        fn.set_db_connection(run_db)
+        #  resp = resource["start"](fn)  # TODO: handle resp?
+        resource["start"](fn)
+        fn.save(versioned=False)
+        logger.info("Fn:\n %s", fn.to_yaml())
+    except Exception as err:
+        logger.error(traceback.format_exc())
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
+
+    return fn
+
+
+def _get_function_status(data):
+    logger.info("function_status:\n{}".format(data))
+    selector = data.get("selector")
+    kind = data.get("kind")
+    if not selector or not kind:
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: selector or runtime kind not specified")
+
+    resource = runtime_resources_map.get(kind)
+    if "status" not in resource:
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: 'status' not supported by this runtime")
+
+    resp = None
+    try:
+        resp = resource["status"](selector)
+        logger.info("status: %s", resp)
+    except Exception as err:
+        logger.error(traceback.format_exc())
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))

--- a/mlrun/api/api/endpoints/pipelines.py
+++ b/mlrun/api/api/endpoints/pipelines.py
@@ -1,11 +1,11 @@
 import ast
-import asyncio
 import tempfile
 from datetime import datetime
 from http import HTTPStatus
 from os import remove
 
 from fastapi import APIRouter, Request, Query
+from fastapi.concurrency import run_in_threadpool
 from kfp import Client as kfclient
 
 from mlrun.api.api.utils import log_and_raise
@@ -18,13 +18,26 @@ router = APIRouter()
 # curl -d@/path/to/pipe.yaml http://localhost:8080/submit_pipeline
 @router.post("/submit_pipeline")
 @router.post("/submit_pipeline/")
-def submit_pipeline(
+async def submit_pipeline(
         request: Request,
         namespace: str = config.namespace,
         experiment_name: str = Query("Default", alias="experiment"),
         run_name: str = Query("", alias="run")):
     run_name = run_name or experiment_name + " " + datetime.now().strftime("%Y-%m-%d %H-%M-%S")
 
+    data = await request.body()
+    if not data:
+        log_and_raise(HTTPStatus.BAD_REQUEST, reason="post data is empty")
+
+    run = await run_in_threadpool(_submit_pipeline, request, data, namespace, experiment_name, run_name)
+
+    return {
+        "id": run.id,
+        "name": run.name,
+    }
+
+
+def _submit_pipeline(request, data, namespace, experiment_name, run_name):
     arguments = {}
     arguments_data = request.headers.get("pipeline-arguments")
     if arguments_data:
@@ -40,9 +53,6 @@ def submit_pipeline(
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="unsupported pipeline type {}".format(ctype))
 
     logger.info("writing file {}".format(ctype))
-    data = asyncio.run(request.body())
-    if not data:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="post data is empty")
 
     print(str(data))
     pipe_tmp = tempfile.mktemp(suffix=ctype)
@@ -60,7 +70,5 @@ def submit_pipeline(
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="kfp err: {}".format(e))
 
     remove(pipe_tmp)
-    return {
-        "id": run.id,
-        "name": run.name,
-    }
+
+    return run

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -1,9 +1,9 @@
-import asyncio
 from distutils.util import strtobool
 from http import HTTPStatus
 from typing import List
 
 from fastapi import APIRouter, Depends, Request, Query
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 from mlrun.api.api import deps
@@ -16,7 +16,7 @@ router = APIRouter()
 
 # curl -d @/path/to/run.json http://localhost:8080/run/p1/3?commit=yes
 @router.post("/run/{project}/{uid}")
-def store_run(
+async def store_run(
         request: Request,
         project: str,
         uid: str,
@@ -24,19 +24,19 @@ def store_run(
         db_session: Session = Depends(deps.get_db_session)):
     data = None
     try:
-        data = asyncio.run(request.json())
+        data = await request.json()
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
 
     logger.debug(data)
-    get_db().store_run(db_session, data, uid, project, iter=iter)
+    await run_in_threadpool(get_db().store_run, db_session, data, uid, project, iter=iter)
     logger.info("store run: {}".format(data))
     return {}
 
 
 # curl -X PATCH -d @/path/to/run.json http://localhost:8080/run/p1/3?commit=yes
 @router.patch("/run/{project}/{uid}")
-def update_run(
+async def update_run(
         request: Request,
         project: str,
         uid: str,
@@ -44,12 +44,12 @@ def update_run(
         db_session: Session = Depends(deps.get_db_session)):
     data = None
     try:
-        data = asyncio.run(request.json())
+        data = await request.json()
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
 
     logger.debug(data)
-    get_db().update_run(db_session, data, uid, project, iter=iter)
+    await run_in_threadpool(get_db().update_run, db_session, data, uid, project, iter=iter)
     logger.info("update run: {}".format(data))
     return {}
 


### PR DESCRIPTION
Running the horovod demo caused to this bug https://github.com/tiangolo/fastapi/issues/1475
Looks like the better way t run sync and async code in a path operation (endpoint) is to define the endpoint as async (`async def`) and use `run_in_threadpool` for the sync code
This is the original error logs (not from the minified example):
```
10.200.0.52:43328 - "POST /api/log/cat-and-dog-servers/794107eb9af243e6b59a3d472705d87e?append=yes HTTP/1.1" 500
[2020-05-08 01:44:42 +0000] [130] [ERROR] Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 385, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/fastapi/applications.py", line 149, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/applications.py", line 102, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/usr/local/lib/python3.8/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.8/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 550, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 227, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/site-packages/starlette/routing.py", line 41, in app
    response = await func(request)
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 196, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.8/site-packages/fastapi/routing.py", line 150, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/usr/local/lib/python3.8/site-packages/starlette/concurrency.py", line 34, in run_in_threadpool
    return await loop.run_in_executor(None, func, *args)
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/mlrun/api/api/endpoints/logs.py", line 26, in store_log
    body = asyncio.run(request.body())  # TODO: Check size
  File "/usr/local/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1456, in uvloop.loop.Loop.run_until_complete
  File "/usr/local/lib/python3.8/site-packages/starlette/requests.py", line 194, in body
    async for chunk in self.stream():
  File "/usr/local/lib/python3.8/site-packages/starlette/requests.py", line 179, in stream
    message = await self._receive()
  File "/usr/local/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 533, in receive
    await self.message_event.wait()
  File "/usr/local/lib/python3.8/asyncio/locks.py", line 309, in wait
    await fut
RuntimeError: Task <Task pending name='Task-181' coro=<Request.body() running at /usr/local/lib/python3.8/site-packages/starlette/requests.py:194> cb=[run_until_complete.<locals>.<lambda>()]> got Future <Future pending> attached to a different loop

```