### PR TITLE
Adding runtimes handlers

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -589,7 +589,7 @@ def project(context, name, url, run, arguments, artifact_path,
 
 @main.command()
 @click.argument('kind', type=str, default='', required=False)
-@click.argument('id', 'object_id', type=str, default='', required=False)
+@click.argument('object_id', metavar='id', type=str, default='', required=False)
 @click.option('--api', help='api and db service url')
 @click.option('--label-selector', '-ls', default='', help='label selector')
 @click.option('--force', '-f', is_flag=True,

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -398,6 +398,15 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
                 if i.status.start_time:
                     start = i.status.start_time.strftime("%b %d %H:%M:%S")
                 print('{:10} {:16} {:8} {}'.format(state, start, task, name))
+    elif kind.startswith('runtime'):
+        mldb = get_run_db(db or mlconf.dbpath).connect()
+        if name:
+            # the runtime identifier is its kind
+            runtime = mldb.get_runtime(kind=name, label_selector=selector)
+            print(dict_to_yaml(runtime))
+            return
+        runtimes = mldb.list_runtimes(label_selector=selector)
+        print(dict_to_yaml(runtimes))
     elif kind.startswith('run'):
         mldb = get_run_db(db or mlconf.dbpath).connect()
         if name:
@@ -440,15 +449,6 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
             ]
             lines.append(line)
         print(tabulate(lines, headers=headers))
-    elif kind.startswith('runtime'):
-        mldb = get_run_db(db or mlconf.dbpath).connect()
-        if name:
-            # the runtime identifier is its kind
-            runtime = mldb.get_runtime(kind=name, label_selector=selector)
-            print(dict_to_yaml(runtime))
-            return
-        runtimes = mldb.list_runtimes(label_selector=selector)
-        print(dict_to_yaml(runtimes))
     else:
         print('currently only get pods | runs | artifacts | func [name] | runtime are supported')
 

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -588,17 +588,16 @@ def project(context, name, url, run, arguments, artifact_path,
 
 
 @main.command()
-@click.argument('name', type=str, default='', required=False)
+@click.argument('kind', type=str, default='', required=False)
 @click.option('--api', help='api and db service url')
 @click.option('--label-selector', '-ls', default='', help='label selector')
 @click.option('--force', '-f', is_flag=True,
               help='clean resources in transient states as well')
-def clean(name, api, label_selector, force):
-    """Clean completed or failed pods/jobs"""
+def clean(kind, api, label_selector, force):
+    """Clean runtime resources"""
     mldb = get_run_db(api or mlconf.dbpath).connect()
-    if name:
-        # the runtime identifier is its kind
-        mldb.delete_runtime(kind=name, label_selector=label_selector, force=force)
+    if kind:
+        mldb.delete_runtime(kind=kind, label_selector=label_selector, force=force)
         return
 
     mldb.delete_runtimes(label_selector=label_selector, force=force)

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -589,18 +589,21 @@ def project(context, name, url, run, arguments, artifact_path,
 
 @main.command()
 @click.argument('kind', type=str, default='', required=False)
+@click.argument('id', 'object_id', type=str, default='', required=False)
 @click.option('--api', help='api and db service url')
 @click.option('--label-selector', '-ls', default='', help='label selector')
 @click.option('--force', '-f', is_flag=True,
               help='clean resources in transient states as well')
-def clean(kind, api, label_selector, force):
+def clean(kind, object_id, api, label_selector, force):
     """Clean runtime resources"""
     mldb = get_run_db(api or mlconf.dbpath).connect()
     if kind:
-        mldb.delete_runtime(kind=kind, label_selector=label_selector, force=force)
-        return
-
-    mldb.delete_runtimes(label_selector=label_selector, force=force)
+        if object_id:
+            mldb.delete_runtime_object(kind=kind, object_id=object_id, label_selector=label_selector, force=force)
+        else:
+            mldb.delete_runtime(kind=kind, label_selector=label_selector, force=force)
+    else:
+        mldb.delete_runtimes(label_selector=label_selector, force=force)
 
 
 @main.command(name='config')

--- a/mlrun/api/api/api.py
+++ b/mlrun/api/api/api.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Depends
 
 from mlrun.api.api import deps
-from mlrun.api.api.endpoints import artifacts, files, functions, healthz, logs, pipelines, projects, runs, schedules, \
-    submit, tags, workflows
+from mlrun.api.api.endpoints import artifacts, files, functions, healthz, logs, pipelines, projects, runs, runtimes, \
+    schedules, submit, tags, workflows
 
 api_router = APIRouter()
 api_router.include_router(artifacts.router, tags=["artifacts"], dependencies=[Depends(deps.AuthVerifier)])
@@ -13,6 +13,7 @@ api_router.include_router(logs.router, tags=["logs"], dependencies=[Depends(deps
 api_router.include_router(pipelines.router, tags=["pipelines"], dependencies=[Depends(deps.AuthVerifier)])
 api_router.include_router(projects.router, tags=["projects"], dependencies=[Depends(deps.AuthVerifier)])
 api_router.include_router(runs.router, tags=["runs"], dependencies=[Depends(deps.AuthVerifier)])
+api_router.include_router(runtimes.router, tags=["runtimes"], dependencies=[Depends(deps.AuthVerifier)])
 api_router.include_router(schedules.router, tags=["schedules"], dependencies=[Depends(deps.AuthVerifier)])
 api_router.include_router(submit.router, tags=["submit"], dependencies=[Depends(deps.AuthVerifier)])
 api_router.include_router(tags.router, tags=["tags"], dependencies=[Depends(deps.AuthVerifier)])

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -10,12 +10,11 @@ router = APIRouter()
 @router.get("/runtimes/{kind}")
 def get_runtime(
         kind: str,
-        namespace: str = None,
         label_selector: str = None):
     if kind not in RuntimeKinds.all():
         log_and_raise(status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
-    resources = runtime_handler.list_resources(namespace, label_selector)
+    resources = runtime_handler.list_resources(label_selector)
     return {
         'resources': resources
     }
@@ -24,11 +23,10 @@ def get_runtime(
 @router.delete("/runtimes/{kind}")
 def delete_runtime(
         kind: str,
-        namespace: str = None,
         label_selector: str = None,
         running: bool = False):
     if kind not in RuntimeKinds.all():
         log_and_raise(status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
-    runtime_handler.delete_resources(namespace, label_selector, running)
+    runtime_handler.delete_resources(label_selector, running)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -35,6 +35,16 @@ def get_runtime(
     }
 
 
+@router.delete("/runtimes")
+def delete_runtimes(
+        label_selector: str = None,
+        running: bool = False):
+    for kind in RuntimeKinds.runtime_with_handlers():
+        runtime_handler = get_runtime_handler(kind)
+        runtime_handler.delete_resources(label_selector, running)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 @router.delete("/runtimes/{kind}")
 def delete_runtime(
         kind: str,

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -38,10 +38,10 @@ def get_runtime(
 @router.delete("/runtimes")
 def delete_runtimes(
         label_selector: str = None,
-        running: bool = False):
+        force: bool = False):
     for kind in RuntimeKinds.runtime_with_handlers():
         runtime_handler = get_runtime_handler(kind)
-        runtime_handler.delete_resources(label_selector, running)
+        runtime_handler.delete_resources(label_selector, force)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -49,9 +49,9 @@ def delete_runtimes(
 def delete_runtime(
         kind: str,
         label_selector: str = None,
-        running: bool = False):
+        force: bool = False):
     if kind not in RuntimeKinds.runtime_with_handlers():
         log_and_raise(status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
-    runtime_handler.delete_resources(label_selector, running)
+    runtime_handler.delete_resources(label_selector, force)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,5 +1,9 @@
+from http import HTTPStatus
+
 from fastapi import APIRouter, status, Response
 
+from mlrun.api.api.utils import log_and_raise
+from mlrun.runtimes import RuntimeKinds
 from mlrun.runtimes import get_runtime_handler
 
 router = APIRouter()
@@ -10,6 +14,8 @@ def get_runtime(
         kind: str,
         namespace: str = None,
         label_selector: str = None):
+    if kind not in RuntimeKinds.all():
+        log_and_raise(HTTPStatus.NOT_FOUND, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
     resources = runtime_handler.list_resources(namespace, label_selector)
     return {

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, Response
 
 from mlrun.runtimes import get_runtime_handler
 
@@ -17,7 +17,7 @@ def get_runtime(
     }
 
 
-@router.delete("/runtimes/{kind}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/runtimes/{kind}")
 def delete_runtime(
         kind: str,
         namespace: str = None,
@@ -25,3 +25,4 @@ def delete_runtime(
         running: bool = False):
     runtime_handler = get_runtime_handler(kind)
     runtime_handler.delete_resources(namespace, label_selector, running)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, status
+
+from mlrun.runtimes import get_runtime_handler_class
+
+router = APIRouter()
+
+
+@router.get("/runtimes/{kind}")
+def get_runtime(
+        kind: str,
+        namespace: str = None,
+        label_selector: str = None):
+    runtime_handler = get_runtime_handler_class(kind)
+    resources = runtime_handler.list_resources(namespace, label_selector)
+    return {
+        'resources': resources
+    }
+
+
+@router.delete("/runtimes/{kind}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_runtime(
+        kind: str,
+        namespace: str = None,
+        label_selector: str = None,
+        running: bool = False):
+    runtime_handler = get_runtime_handler_class(kind)
+    runtime_handler.delete_resources(namespace, label_selector, running)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, status
 
-from mlrun.runtimes import get_runtime_handler_class
+from mlrun.runtimes import get_runtime_handler
 
 router = APIRouter()
 
@@ -10,7 +10,7 @@ def get_runtime(
         kind: str,
         namespace: str = None,
         label_selector: str = None):
-    runtime_handler = get_runtime_handler_class(kind)
+    runtime_handler = get_runtime_handler(kind)
     resources = runtime_handler.list_resources(namespace, label_selector)
     return {
         'resources': resources
@@ -23,5 +23,5 @@ def delete_runtime(
         namespace: str = None,
         label_selector: str = None,
         running: bool = False):
-    runtime_handler = get_runtime_handler_class(kind)
+    runtime_handler = get_runtime_handler(kind)
     runtime_handler.delete_resources(namespace, label_selector, running)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -15,7 +15,7 @@ def get_runtime(
         namespace: str = None,
         label_selector: str = None):
     if kind not in RuntimeKinds.all():
-        log_and_raise(HTTPStatus.BAD_REQUEST, kind=kind, err='Invalid runtime kind')
+        log_and_raise(status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
     resources = runtime_handler.list_resources(namespace, label_selector)
     return {

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -15,7 +15,7 @@ def get_runtime(
         namespace: str = None,
         label_selector: str = None):
     if kind not in RuntimeKinds.all():
-        log_and_raise(HTTPStatus.NOT_FOUND, kind=kind, err='Invalid runtime kind')
+        log_and_raise(HTTPStatus.BAD_REQUEST, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
     resources = runtime_handler.list_resources(namespace, label_selector)
     return {
@@ -29,6 +29,8 @@ def delete_runtime(
         namespace: str = None,
         label_selector: str = None,
         running: bool = False):
+    if kind not in RuntimeKinds.all():
+        log_and_raise(status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind')
     runtime_handler = get_runtime_handler(kind)
     runtime_handler.delete_resources(namespace, label_selector, running)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -55,3 +55,17 @@ def delete_runtime(
     runtime_handler = get_runtime_handler(kind)
     runtime_handler.delete_resources(label_selector, force)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# FIXME: find a more REST-y path
+@router.delete("/runtimes/{kind}/{object_id}")
+def delete_runtime_object(
+        kind: str,
+        object_id: str,
+        label_selector: str = None,
+        force: bool = False):
+    if kind not in RuntimeKinds.runtime_with_handlers():
+        log_and_raise(status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind')
+    runtime_handler = get_runtime_handler(kind)
+    runtime_handler.delete_runtime_object_resources(object_id, label_selector, force)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,5 +1,3 @@
-from http import HTTPStatus
-
 from fastapi import APIRouter, status, Response
 
 from mlrun.api.api.utils import log_and_raise

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -193,7 +193,7 @@ def build_image(dest,
         kpod.mount_v3io(remote=source, mount_path='/context')
 
     k8s = get_k8s_helper()
-    kpod.namespace = k8s.ns(namespace)
+    kpod.namespace = k8s.resolve_namespace(namespace)
 
     if interactive:
         return k8s.run_job(kpod)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -332,13 +332,13 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call('GET', path, error, params=params)
         return resp.json()
 
-    def delete_runtimes(self, label_selector: str = None, running: bool = False):
-        params = {'label_selector': label_selector, 'running': running}
+    def delete_runtimes(self, label_selector: str = None, force: bool = False):
+        params = {'label_selector': label_selector, 'force': force}
         error = 'delete runtimes'
         self.api_call('DELETE', 'runtimes', error, params=params)
 
-    def delete_runtime(self, kind: str, label_selector: str = None, running: bool = False):
-        params = {'label_selector': label_selector, 'running': running}
+    def delete_runtime(self, kind: str, label_selector: str = None, force: bool = False):
+        params = {'label_selector': label_selector, 'force': force}
         path = f'runtimes/{kind}'
         error = f'delete runtime {kind}'
         self.api_call('DELETE', path, error, params=params)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -332,6 +332,11 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call('GET', path, error, params=params)
         return resp.json()
 
+    def delete_runtimes(self, label_selector: str = None, running: bool = False):
+        params = {'label_selector': label_selector, 'running': running}
+        error = 'delete runtimes'
+        self.api_call('DELETE', 'runtimes', error, params=params)
+
     def delete_runtime(self, kind: str, label_selector: str = None, running: bool = False):
         params = {'label_selector': label_selector, 'running': running}
         path = f'runtimes/{kind}'

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -319,6 +319,12 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call('GET', 'funcs', error, params=params)
         return resp.json()['funcs']
 
+    def list_runtimes(self, label_selector: str = None):
+        params = {'label_selector': label_selector}
+        error = 'list runtimes'
+        resp = self.api_call('GET', 'runtimes', error, params=params)
+        return resp.json()
+
     def get_runtime(self, kind: str, label_selector: str = None):
         params = {'label_selector': label_selector}
         path = f'runtimes/{kind}'
@@ -330,7 +336,7 @@ class HTTPRunDB(RunDBInterface):
         params = {'label_selector': label_selector, 'running': running}
         path = f'runtimes/{kind}'
         error = f'delete runtime {kind}'
-        resp = self.api_call('DELETE', path, error, params=params)
+        self.api_call('DELETE', path, error, params=params)
 
     def remote_builder(self, func, with_mlrun):
         try:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -16,6 +16,7 @@ import json
 import tempfile
 import time
 from os import path, remove, environ
+from typing import List, Dict
 
 import kfp
 import requests
@@ -319,13 +320,13 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call('GET', 'funcs', error, params=params)
         return resp.json()['funcs']
 
-    def list_runtimes(self, label_selector: str = None):
+    def list_runtimes(self, label_selector: str = None) -> List:
         params = {'label_selector': label_selector}
         error = 'list runtimes'
         resp = self.api_call('GET', 'runtimes', error, params=params)
         return resp.json()
 
-    def get_runtime(self, kind: str, label_selector: str = None):
+    def get_runtime(self, kind: str, label_selector: str = None) -> Dict:
         params = {'label_selector': label_selector}
         path = f'runtimes/{kind}'
         error = f'get runtime {kind}'

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -344,6 +344,12 @@ class HTTPRunDB(RunDBInterface):
         error = f'delete runtime {kind}'
         self.api_call('DELETE', path, error, params=params)
 
+    def delete_runtime_object(self, kind: str, object_id: str, label_selector: str = None, force: bool = False):
+        params = {'label_selector': label_selector, 'force': force}
+        path = f'runtimes/{kind}/{object_id}'
+        error = f'delete runtime object {kind} {object_id}'
+        self.api_call('DELETE', path, error, params=params)
+
     def remote_builder(self, func, with_mlrun):
         try:
             req = {'function': func.to_dict(),

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -319,6 +319,19 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call('GET', 'funcs', error, params=params)
         return resp.json()['funcs']
 
+    def get_runtime(self, kind: str, label_selector: str = None):
+        params = {'label_selector': label_selector}
+        path = f'runtimes/{kind}'
+        error = f'get runtime {kind}'
+        resp = self.api_call('GET', path, error, params=params)
+        return resp.json()
+
+    def delete_runtime(self, kind: str, label_selector: str = None, running: bool = False):
+        params = {'label_selector': label_selector, 'running': running}
+        path = f'runtimes/{kind}'
+        error = f'delete runtime {kind}'
+        resp = self.api_call('DELETE', path, error, params=params)
+
     def remote_builder(self, func, with_mlrun):
         try:
             req = {'function': func.to_dict(),

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -36,12 +36,23 @@ class RuntimeKinds(object):
 
     @staticmethod
     def all():
-        return [RuntimeKinds.remote,
-                RuntimeKinds.nuclio,
-                RuntimeKinds.dask,
-                RuntimeKinds.job,
-                RuntimeKinds.spark,
-                RuntimeKinds.mpijob]
+        return [
+            RuntimeKinds.remote,
+            RuntimeKinds.nuclio,
+            RuntimeKinds.dask,
+            RuntimeKinds.job,
+            RuntimeKinds.spark,
+            RuntimeKinds.mpijob,
+        ]
+
+    @staticmethod
+    def runtime_with_handlers():
+        return [
+            RuntimeKinds.dask,
+            RuntimeKinds.job,
+            RuntimeKinds.spark,
+            RuntimeKinds.mpijob,
+        ]
 
 
 runtime_resources_map = {

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -81,7 +81,7 @@ def _resolve_mpi_runtime():
 
     if not mpijob_crd_version:
         k8s_helper = get_k8s_helper()
-        namespace = k8s_helper.ns()
+        namespace = k8s_helper.resolve_namespace()
 
         # set default mpijob crd version
         mpijob_crd_version = MPIJobCRDVersions.default()

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -19,7 +19,7 @@ from .function import RemoteRuntime, new_model_server  # noqa
 from .mpijob import MpiRuntimeV1Alpha1, MpiRuntimeV1, MPIJobCRDVersions  # noqa
 from .daskjob import DaskCluster, DaskRuntimeHandler, get_dask_resource  # noqa
 from .kubejob import KubejobRuntime  # noqa
-from .sparkjob import SparkRuntime  # noqa
+from .sparkjob import SparkRuntime, SparkRuntimeHandler  # noqa
 from .nuclio import nuclio_init_hook
 from .serving import MLModelServer
 from mlrun.k8s_utils import get_k8s_helper
@@ -51,6 +51,7 @@ runtime_resources_map = {
 def get_runtime_handler_class(kind: str) -> BaseRuntimeHandler:
     kind_runtime_handler_map = {
         RuntimeKinds.dask: DaskRuntimeHandler,
+        RuntimeKinds.spark: SparkRuntimeHandler,
     }
 
     return kind_runtime_handler_map[kind]

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from mlrun.config import config
-from .base import RunError, BaseRuntime  # noqa
+from .base import RunError, BaseRuntime, BaseRuntimeHandler  # noqa
 from .local import HandlerRuntime, LocalRuntime  # noqa
 from .function import RemoteRuntime, new_model_server  # noqa
 from .mpijob import MpiRuntimeV1Alpha1, MpiRuntimeV1, MPIJobCRDVersions  # noqa
-from .daskjob import DaskCluster, get_dask_resource  # noqa
+from .daskjob import DaskCluster, DaskRuntimeHandler, get_dask_resource  # noqa
 from .kubejob import KubejobRuntime  # noqa
 from .sparkjob import SparkRuntime  # noqa
 from .nuclio import nuclio_init_hook
@@ -46,6 +46,14 @@ class RuntimeKinds(object):
 runtime_resources_map = {
     RuntimeKinds.dask: get_dask_resource()
 }
+
+
+def get_runtime_handler_class(kind: str) -> BaseRuntimeHandler:
+    kind_runtime_handler_map = {
+        RuntimeKinds.dask: DaskRuntimeHandler,
+    }
+
+    return kind_runtime_handler_map[kind]
 
 
 def get_runtime_class(kind: str):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -779,12 +779,11 @@ class BaseRuntimeHandler:
     def _build_pod_resources(pods) -> List:
         pod_resources = []
         for pod in pods:
-            status = pod.status.phase.lower()
             pod_resources.append(
                 {
                     'name': pod.metadata.name,
                     'labels': pod.metadata.labels,
-                    'status': status,
+                    'status': pod.status,
                 })
         return pod_resources
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -637,9 +637,9 @@ def is_local(url):
 
 class BaseRuntimeHandler:
 
-    def list_resources(self, namespace: str = None, label_selector: str = None) -> Dict:
+    def list_resources(self, label_selector: str = None) -> Dict:
         k8s_helper = get_k8s_helper()
-        namespace = k8s_helper.resolve_namespace(namespace)
+        namespace = k8s_helper.resolve_namespace()
         label_selector = self._resolve_label_selector(label_selector)
         pod_resources = self._list_pod_resources(namespace, label_selector)
         crd_resources = self._list_crd_resources(namespace, label_selector)
@@ -647,9 +647,9 @@ class BaseRuntimeHandler:
         response = self._enrich_list_resources_response(response, namespace, label_selector)
         return response
 
-    def delete_resources(self, namespace: str = None, label_selector: str = None, running: bool = False):
+    def delete_resources(self, label_selector: str = None, running: bool = False):
         k8s_helper = get_k8s_helper()
-        namespace = k8s_helper.resolve_namespace(namespace)
+        namespace = k8s_helper.resolve_namespace()
         label_selector = self._resolve_label_selector(label_selector)
         self._delete_resources(namespace, label_selector, running)
         crd_group, crd_version, crd_plural = self._get_crd_info()

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -796,11 +796,12 @@ class BaseRuntimeHandler(ABC):
     def _build_pod_resources(pods) -> List:
         pod_resources = []
         for pod in pods:
+            pod_dict = pod.to_dict()
             pod_resources.append(
                 {
-                    'name': pod.metadata.name,
-                    'labels': pod.metadata.labels,
-                    'status': pod.status,
+                    'name': pod_dict['metadata']['name'],
+                    'labels': pod_dict['metadata']['labels'],
+                    'status': pod_dict['status'],
                 })
         return pod_resources
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -647,16 +647,16 @@ class BaseRuntimeHandler:
         response = self._enrich_list_resources_response(response, namespace, label_selector)
         return response
 
-    def delete_resources(self, label_selector: str = None, running: bool = False):
+    def delete_resources(self, label_selector: str = None, force: bool = False):
         k8s_helper = get_k8s_helper()
         namespace = k8s_helper.resolve_namespace()
         label_selector = self._resolve_label_selector(label_selector)
-        self._delete_resources(namespace, label_selector, running)
+        self._delete_resources(namespace, label_selector, force)
         crd_group, crd_version, crd_plural = self._get_crd_info()
         if crd_group and crd_version and crd_plural:
-            self._delete_crd_resources(namespace, label_selector, running)
+            self._delete_crd_resources(namespace, label_selector, force)
         else:
-            self._delete_pod_resources(namespace, label_selector, running)
+            self._delete_pod_resources(namespace, label_selector, force)
 
     def _enrich_list_resources_response(self, response: Dict, namespace: str, label_selector: str = None) -> Dict:
         """
@@ -664,7 +664,7 @@ class BaseRuntimeHandler:
         """
         return response
 
-    def _delete_resources(self, namespace: str, label_selector: str = None, running: bool = False):
+    def _delete_resources(self, namespace: str, label_selector: str = None, force: bool = False):
         """
         Override this to handle deletion of resources other then pods or CRDs (which are handled by the base class)
         Note that this is happening before the deletion of the CRDs or the pods
@@ -722,14 +722,14 @@ class BaseRuntimeHandler:
 
         return label_selector
 
-    def _delete_pod_resources(self, namespace: str, label_selector: str = None, running: bool = False):
+    def _delete_pod_resources(self, namespace: str, label_selector: str = None, force: bool = False):
         k8s_helper = get_k8s_helper()
         pods = k8s_helper.v1api.list_namespaced_pod(namespace, label_selector=label_selector)
         for pod in pods.items:
             # it is less likely that there will be new stable states, or the existing ones will change so better to
             # resolve whether it's a transient state by checking if it's not a stable state
             in_transient_phase = pod.status.phase not in PodPhases.stable_phases()
-            if not in_transient_phase or (running and in_transient_phase):
+            if not in_transient_phase or (force and in_transient_phase):
                 try:
                     k8s_helper.v1api.delete_namespaced_pod(pod.metadata.name, namespace)
                     logger.info(f"Deleted pod: {pod.metadata.name}")
@@ -738,7 +738,7 @@ class BaseRuntimeHandler:
                     if e.status != 404:
                         raise
 
-    def _delete_crd_resources(self, namespace: str, label_selector: str = None, running: bool = False):
+    def _delete_crd_resources(self, namespace: str, label_selector: str = None, force: bool = False):
         k8s_helper = get_k8s_helper()
         crd_group, crd_version, crd_plural = self._get_crd_info()
         crd_objects = k8s_helper.crdapi.list_namespaced_custom_object(crd_group,
@@ -749,7 +749,7 @@ class BaseRuntimeHandler:
 
         for crd_object in crd_objects['items']:
             in_transient_state = self._is_crd_object_in_transient_state(crd_object)
-            if not in_transient_state or (running and in_transient_state):
+            if not in_transient_state or (force and in_transient_state):
                 name = crd_object['metadata']['name']
                 try:
                     k8s_helper.crdapi.delete_namespaced_custom_object(crd_group,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -676,14 +676,13 @@ class BaseRuntimeHandler:
         """
         Override this if the runtime has CRD resources. this should return the CRD info:
         crd group, crd version, crd plural
-        Note that _is_crd_object_in_transient_state should be overridden as well to enable CRD objects deletion
         """
         return '', '', ''
 
     @staticmethod
     def _is_crd_object_in_transient_state(crd_object) -> bool:
         """
-        Override this to enable CRD objects deletion
+        Override this if the runtime has CRD resources.
         this should return a bool determining whether the CRD object is in transient state
         """
         return False
@@ -775,12 +774,11 @@ class BaseRuntimeHandler:
     def _build_crd_resources(custom_objects) -> List:
         crd_resources = []
         for custom_object in custom_objects['items']:
-            status = custom_object['status']['phase'].lower()
             crd_resources.append(
                 {
                     'name': custom_object['metadata']['name'],
                     'labels': custom_object['metadata']['labels'],
-                    'status': status,
+                    'status': custom_object['status'],
                 })
         return crd_resources
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -741,10 +741,10 @@ class BaseRuntimeHandler:
                                                                       crd_plural,
                                                                       label_selector=label_selector)
 
-        for crd_object in crd_objects.items:
+        for crd_object in crd_objects['items']:
             in_transient_state = self._is_crd_object_in_transient_state(crd_object)
             if not in_transient_state or (running and in_transient_state):
-                name = crd_object.metadata.name
+                name = crd_object['metadata']['name']
                 try:
                     k8s_helper.crdapi.delete_namespaced_custom_object(crd_group,
                                                                       crd_version,
@@ -774,12 +774,12 @@ class BaseRuntimeHandler:
     @staticmethod
     def _build_crd_resources(custom_objects) -> List:
         crd_resources = []
-        for custom_object in custom_objects.items:
-            status = custom_object.status.phase.lower()
+        for custom_object in custom_objects['items']:
+            status = custom_object['status']['phase'].lower()
             crd_resources.append(
                 {
-                    'name': custom_object.metadata.name,
-                    'labels': custom_object.metadata.labels,
+                    'name': custom_object['metadata']['name'],
+                    'labels': custom_object['metadata']['labels'],
                     'status': status,
                 })
         return crd_resources

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from ast import literal_eval
 from copy import deepcopy
 from os import environ
-from typing import Dict
+from typing import Dict, List
 
 from .generators import get_generator
 from .utils import calc_hash, RunError, results_to_iter
@@ -643,3 +643,40 @@ class BaseRuntimeHandler(ABC):
     @abstractmethod
     def delete_resources(namespace: str = None, label_selector: str = None, running: bool = False):
         raise NotImplementedError()
+
+    @staticmethod
+    def build_pod_resources(pods):
+        pod_resources = []
+        for pod in pods:
+            status = pod.status.phase.lower()
+            pod_resources.append(
+                {
+                    'name': pod.metadata.name,
+                    'labels': pod.metadata.labels,
+                    'status': status,
+                })
+        return pod_resources
+
+    @staticmethod
+    def build_crd_resources(custom_objects):
+        crd_resources = []
+        for custom_object in custom_objects.items:
+            status = custom_object.status.phase.lower()
+            crd_resources.append(
+                {
+                    'name': custom_object.metadata.name,
+                    'labels': custom_object.metadata.labels,
+                    'status': status,
+                })
+        return crd_resources
+
+    @staticmethod
+    def build_list_resources_response(pod_resources: List = None, crd_resources: List = None):
+        if crd_resources is None:
+            crd_resources = []
+        if pod_resources is None:
+            pod_resources = []
+        return {
+            'crd_resources': crd_resources,
+            'pod_resources': pod_resources,
+        }

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -644,6 +644,7 @@ class BaseRuntimeHandler:
         pod_resources = self._list_pod_resources(namespace, label_selector)
         crd_resources = self._list_crd_resources(namespace, label_selector)
         response = self._build_list_resources_response(pod_resources, crd_resources)
+        response = self._enrich_list_resources_response(response, namespace, label_selector)
         return response
 
     def delete_resources(self, namespace: str = None, label_selector: str = None, running: bool = False):
@@ -656,6 +657,12 @@ class BaseRuntimeHandler:
             self._delete_crd_resources(namespace, label_selector, running)
         else:
             self._delete_pod_resources(namespace, label_selector, running)
+
+    def _enrich_list_resources_response(self, response: Dict, namespace: str, label_selector: str = None) -> Dict:
+        """
+        Override this to list resources other then pods or CRDs (which are handled by the base class)
+        """
+        return response
 
     def _delete_resources(self, namespace: str, label_selector: str = None, running: bool = False):
         """

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -1,0 +1,10 @@
+class PodPhases:
+    succeeded = 'Succeeded'
+    failed = 'Failed'
+
+    @staticmethod
+    def stable_phases():
+        return [
+            PodPhases.succeeded,
+            PodPhases.failed,
+        ]

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -376,7 +376,7 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
     @staticmethod
     def list_resources(namespace: str = None, label_selector: str = None) -> Dict:
         k8s = get_k8s_helper()
-        namespace = namespace or config.namespace
+        namespace = k8s.resolve_namespace(namespace)
 
         default_label_selector = 'dask.org/component=scheduler'
         if label_selector:
@@ -401,7 +401,7 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
     @staticmethod
     def delete_resources(namespace: str = None, label_selector: str = None, running: bool = False):
         k8s = get_k8s_helper()
-        namespace = namespace or config.namespace
+        namespace = k8s.resolve_namespace(namespace)
 
         default_label_selector = 'dask.org/component=scheduler'
         if label_selector is not None:

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -388,7 +388,6 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
                 {
                     'name': service.metadata.name,
                     'labels': service.metadata.labels,
-                    'status': service.to_dict()['status'],
                 })
         response['service_resources'] = service_resources
         return response

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -373,6 +373,10 @@ def get_obj_status(selector=[], namespace=None):
 class DaskRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
+    def _get_object_label_selector(object_id: str) -> str:
+        return f'mlrun/function={object_id}'
+
+    @staticmethod
     def _get_default_label_selector() -> str:
         return 'mlrun/class=dask'
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -373,7 +373,7 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
     def _get_default_label_selector() -> str:
-        return 'dask.org/component=scheduler'
+        return 'mlrun/class=dask'
 
     def _delete_resources(self, namespace: str, label_selector: str = None, running: bool = False):
         """

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -388,7 +388,7 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
                 {
                     'name': service.metadata.name,
                     'labels': service.metadata.labels,
-                    'status': service.status,
+                    'status': service.to_dict()['status'],
                 })
         response['service_resources'] = service_resources
         return response

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -21,7 +21,8 @@ from mlrun.runtimes.base import BaseRuntimeHandler
 from .base import FunctionStatus
 from .kubejob import KubejobRuntime
 from .local import load_module, exec_from_params
-from .pod import KubeResourceSpec, PodPhases
+from .pod import KubeResourceSpec
+from .constants import PodPhases
 from .utils import mlrun_key, get_resource_labels, get_func_selector, log_std, RunError
 from ..config import config
 from ..execution import MLClientCtx
@@ -371,7 +372,7 @@ def get_obj_status(selector=[], namespace=None):
 class DaskRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
-    def _get_pod_default_label_selector() -> str:
+    def _get_default_label_selector() -> str:
         return 'dask.org/component=scheduler'
 
     def _delete_resources(self, namespace: str, label_selector: str = None, running: bool = False):
@@ -379,7 +380,6 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         Handling services deletion
         """
         k8s_helper = get_k8s_helper()
-        label_selector = self._resolve_pod_label_selector(label_selector)
         pods = k8s_helper.v1api.list_namespaced_pod(namespace, label_selector=label_selector)
         service_names = []
         for pod in pods.items:

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kubernetes import client
-
-from ..kfpops import build_op
-from .pod import KubeResource
-from .utils import AsyncLogWriter, default_image_name
-from ..model import RunObject
-from .base import RunError
-from ..db import RunDBError
-from ..builder import build_runtime
-from ..utils import get_in, logger
-
 import time
 from base64 import b64encode
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from mlrun.runtimes.base import BaseRuntimeHandler
+from .base import RunError
+from .pod import KubeResource
+from .utils import AsyncLogWriter, default_image_name
+from ..builder import build_runtime
+from ..db import RunDBError
+from ..kfpops import build_op
+from ..model import RunObject
+from ..utils import logger, get_in
 
 
 class KubejobRuntime(KubeResource):
@@ -104,8 +106,7 @@ class KubejobRuntime(KubeResource):
             logger.info('running build to add mlrun package, set '
                         'with_mlrun=False to skip if its already in the image')
 
-        self.spec.build.image = self.spec.build.image \
-                                or default_image_name(self)
+        self.spec.build.image = self.spec.build.image or default_image_name(self)
         self.status.state = ''
 
         if self._is_remote_api() and not is_kfp:
@@ -239,3 +240,10 @@ def func_to_pod(image, runtime, extra_env, command, args, workdir):
             client.V1LocalObjectReference(name=runtime.spec.image_pull_secret)]
 
     return pod_spec
+
+
+class KubeRuntimeHandler(BaseRuntimeHandler):
+
+    @staticmethod
+    def _get_pod_default_label_selector() -> str:
+        return 'mlrun/class in (build, job)'

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -245,5 +245,9 @@ def func_to_pod(image, runtime, extra_env, command, args, workdir):
 class KubeRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
+    def _get_object_label_selector(object_id: str) -> str:
+        return f'mlrun/uid={object_id}'
+
+    @staticmethod
     def _get_default_label_selector() -> str:
         return 'mlrun/class in (build, job)'

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -245,5 +245,5 @@ def func_to_pod(image, runtime, extra_env, command, args, workdir):
 class KubeRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
-    def _get_pod_default_label_selector() -> str:
+    def _get_default_label_selector() -> str:
         return 'mlrun/class in (build, job)'

--- a/mlrun/runtimes/mpijob/__init__.py
+++ b/mlrun/runtimes/mpijob/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .v1 import MpiRuntimeV1
-from .v1alpha1 import MpiRuntimeV1Alpha1
+from .v1 import MpiRuntimeV1, MpiV1RuntimeHandler
+from .v1alpha1 import MpiRuntimeV1Alpha1, MpiV1Alpha1RuntimeHandler
 from .abstract import MPIJobCRDVersions

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -130,7 +130,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()
 
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         try:
             resp = k8s.crdapi.create_namespaced_custom_object(
                 mpi_group, mpi_version, namespace=namespace,
@@ -145,7 +145,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
     def delete_job(self, name, namespace=None):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         try:
             # delete the mpi job
             body = client.V1DeleteOptions()
@@ -159,7 +159,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
     def list_jobs(self, namespace=None, selector='', show=True):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         try:
             resp = k8s.crdapi.list_namespaced_custom_object(
                 mpi_group, mpi_version, namespace, mpi_plural,
@@ -177,7 +177,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
     def get_job(self, name, namespace=None):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         try:
             resp = k8s.crdapi.get_namespaced_custom_object(
                 mpi_group, mpi_version, namespace, mpi_plural, name)
@@ -187,7 +187,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
 
     def get_pods(self, name=None, namespace=None, launcher=False):
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
 
         selector = self._generate_pods_selector(name, launcher)
 

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -11,18 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import time
 import abc
+import time
 import typing
 
-from mlrun.execution import MLClientCtx
+from kubernetes import client
+
 from mlrun.config import config
+from mlrun.execution import MLClientCtx
 from mlrun.model import RunObject
 from mlrun.runtimes.kubejob import KubejobRuntime
 from mlrun.runtimes.utils import AsyncLogWriter, RunError
 from mlrun.utils import logger, get_in
-
-from kubernetes import client
 
 
 class MPIJobCRDVersions(object):
@@ -43,11 +43,6 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
     kind = 'mpijob'
     _is_nested = False
 
-    # should return the mpijob CRD information -> (group, version, plural)
-    @abc.abstractmethod
-    def _get_crd_info(self) -> typing.Tuple[str, str, str]:
-        pass
-
     @abc.abstractmethod
     def _generate_mpi_job(self, runobj: RunObject, execution: MLClientCtx, meta: client.V1ObjectMeta) -> typing.Dict:
         pass
@@ -56,8 +51,15 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
     def _get_job_launcher_status(self, resp: list) -> str:
         pass
 
+    @staticmethod
     @abc.abstractmethod
-    def _generate_pods_selector(self, name: str, launcher: bool) -> str:
+    def _generate_pods_selector(name: str, launcher: bool) -> str:
+        pass
+
+    # should return the mpijob CRD information -> (group, version, plural)
+    @staticmethod
+    @abc.abstractmethod
+    def _get_crd_info() -> typing.Tuple[str, str, str]:
         pass
 
     def _pretty_print_jobs(self, items: typing.List):

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -161,6 +161,10 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
 class MpiV1RuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
+    def _get_object_label_selector(object_id: str) -> str:
+        return f'mlrun/uid={object_id}'
+
+    @staticmethod
     def _get_default_label_selector() -> str:
         return 'mlrun/class=mpijob'
 

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -161,7 +161,7 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
 class MpiV1RuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
-    def _get_pod_default_label_selector() -> str:
+    def _get_default_label_selector() -> str:
         return 'mlrun/class=mpijob'
 
     @staticmethod

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -171,4 +171,4 @@ class MpiV1RuntimeHandler(BaseRuntimeHandler):
     @staticmethod
     def _is_crd_object_in_transient_state(crd_object) -> bool:
         # FIXME: this is not correct, check what's mpi job states
-        return crd_object.status.applicationState.state == 'RUNNING'
+        return False

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -170,5 +170,9 @@ class MpiV1RuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
     def _is_crd_object_in_transient_state(crd_object) -> bool:
-        # FIXME: this is not correct, check what's mpi job states
+        # it is less likely that there will be new stable states, or the existing ones will change so better to resolve
+        # whether it's a transient state by checking if it's not a stable state
+        for replica_type, replica_status in crd_object.get('status', {}).items():
+            if replica_status.get('active', 0) != 0:
+                return True
         return False

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -114,6 +114,10 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
 class MpiV1Alpha1RuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
+    def _get_object_label_selector(object_id: str) -> str:
+        return f'mlrun/uid={object_id}'
+
+    @staticmethod
     def _get_default_label_selector() -> str:
         return 'mlrun/class=mpijob'
 

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -11,16 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from copy import deepcopy
 import typing
-
-from .abstract import MPIJobCRDVersions
-from mlrun.execution import MLClientCtx
-from mlrun.runtimes.mpijob.abstract import AbstractMPIJobRuntime
-from mlrun.model import RunObject
-from mlrun.utils import update_in, get_in
+from copy import deepcopy
 
 from kubernetes import client
+
+from mlrun.execution import MLClientCtx
+from mlrun.model import RunObject
+from mlrun.runtimes.base import BaseRuntimeHandler
+from mlrun.runtimes.mpijob.abstract import AbstractMPIJobRuntime, MPIJobCRDVersions
+from mlrun.utils import update_in, get_in
 
 
 class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
@@ -49,15 +49,12 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
                     'volumes': []
                 }}}}
 
+    crd_group = 'kubeflow.org'
+    crd_version = MPIJobCRDVersions.v1alpha1
+    crd_plural = 'mpijobs'
+
     def _update_container(self, struct, key, value):
         struct['spec']['template']['spec']['containers'][0][key] = value
-
-    def _get_crd_info(self) -> typing.Tuple[str, str, str]:
-        mpi_group = 'kubeflow.org'
-        mpi_version = MPIJobCRDVersions.v1alpha1
-        mpi_plural = 'mpijobs'
-
-        return mpi_group, mpi_version, mpi_plural
 
     def _generate_mpi_job(self, runobj: RunObject, execution: MLClientCtx, meta: client.V1ObjectMeta) -> typing.Dict:
         job = deepcopy(self._mpijob_template)
@@ -99,7 +96,8 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
     def _get_job_launcher_status(self, resp: typing.List) -> str:
         return get_in(resp, 'status.launcherStatus')
 
-    def _generate_pods_selector(self, name: str, launcher: bool) -> str:
+    @staticmethod
+    def _generate_pods_selector(name: str, launcher: bool) -> str:
         selector = 'mlrun/class=mpijob'
         if name:
             selector += ',mpi_job_name={}'.format(name)
@@ -107,3 +105,23 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
             selector += ',mpi_role_type=launcher'
 
         return selector
+
+    @staticmethod
+    def _get_crd_info() -> typing.Tuple[str, str, str]:
+        return MpiRuntimeV1Alpha1.crd_group, MpiRuntimeV1Alpha1.crd_version, MpiRuntimeV1Alpha1.crd_plural
+
+
+class MpiV1Alpha1RuntimeHandler(BaseRuntimeHandler):
+
+    @staticmethod
+    def _get_pod_default_label_selector() -> str:
+        return 'mlrun/class=mpijob'
+
+    @staticmethod
+    def _get_crd_info() -> typing.Tuple[str, str, str]:
+        return MpiRuntimeV1Alpha1.crd_group, MpiRuntimeV1Alpha1.crd_version, MpiRuntimeV1Alpha1.crd_plural
+
+    @staticmethod
+    def _is_crd_object_in_transient_state(crd_object) -> bool:
+        # FIXME: this is not correct, check what's mpi job states
+        return crd_object.status.applicationState.state == 'RUNNING'

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -114,7 +114,7 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
 class MpiV1Alpha1RuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
-    def _get_pod_default_label_selector() -> str:
+    def _get_default_label_selector() -> str:
         return 'mlrun/class=mpijob'
 
     @staticmethod

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -123,5 +123,10 @@ class MpiV1Alpha1RuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
     def _is_crd_object_in_transient_state(crd_object) -> bool:
-        # FIXME: this is not correct, check what's mpi job states
-        return False
+        # it is less likely that there will be new stable states, or the existing ones will change so better to resolve
+        # whether it's a transient state by checking if it's not a stable state
+        return crd_object.get('status', {}).get('launcherStatus', '') not in ['Succeeded', 'Failed']
+
+    @staticmethod
+    def _get_crd_object_status(crd_object) -> str:
+        return crd_object.get('status', {}).get('launcherStatus', '')

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -124,4 +124,4 @@ class MpiV1Alpha1RuntimeHandler(BaseRuntimeHandler):
     @staticmethod
     def _is_crd_object_in_transient_state(crd_object) -> bool:
         # FIXME: this is not correct, check what's mpi job states
-        return crd_object.status.applicationState.state == 'RUNNING'
+        return False

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -150,7 +150,7 @@ class KubeResource(BaseRuntime):
         update_in(self.spec.resources, 'requests', requests)
 
     def _get_meta(self, runobj, unique=False):
-        namespace = self._get_k8s().ns()
+        namespace = self._get_k8s().resolve_namespace()
         uid = runobj.metadata.uid
         labels = {'mlrun/class': self.kind, 'mlrun/uid': uid}
         new_meta = client.V1ObjectMeta(namespace=namespace,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -23,18 +23,6 @@ from ..utils import normalize_name, update_in
 from .base import BaseRuntime, FunctionSpec
 
 
-class PodPhases:
-    succeeded = 'Succeeded'
-    failed = 'Failed'
-
-    @staticmethod
-    def stable_phases():
-        return [
-            PodPhases.succeeded,
-            PodPhases.failed,
-        ]
-
-
 class KubeResourceSpec(FunctionSpec):
     def __init__(self, command=None, args=None, image=None, mode=None,
                  volumes=None, volume_mounts=None, env=None, resources=None,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -23,6 +23,18 @@ from ..utils import normalize_name, update_in
 from .base import BaseRuntime, FunctionSpec
 
 
+class PodPhases:
+    succeeded = 'Succeeded'
+    failed = 'Failed'
+
+    @staticmethod
+    def stable_phases():
+        return [
+            PodPhases.succeeded,
+            PodPhases.failed,
+        ]
+
+
 class KubeResourceSpec(FunctionSpec):
     def __init__(self, command=None, args=None, image=None, mode=None,
                  volumes=None, volume_mounts=None, env=None, resources=None,

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -260,7 +260,7 @@ class SparkRuntime(KubejobRuntime):
 class SparkRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
-    def _get_pod_default_label_selector() -> str:
+    def _get_default_label_selector() -> str:
         return 'mlrun/class=spark'
 
     @staticmethod

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -191,7 +191,7 @@ class SparkRuntime(KubejobRuntime):
 
     def _submit_job(self, job, namespace=None):
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         try:
             resp = k8s.crdapi.create_namespaced_custom_object(
                 SparkRuntime.group, SparkRuntime.version, namespace=namespace,
@@ -206,7 +206,7 @@ class SparkRuntime(KubejobRuntime):
 
     def get_job(self, name, namespace=None):
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         try:
             resp = k8s.crdapi.get_namespaced_custom_object(
                 SparkRuntime.group, SparkRuntime.version, namespace, SparkRuntime.plural, name)
@@ -233,7 +233,7 @@ class SparkRuntime(KubejobRuntime):
 
     def get_pods(self, name=None, namespace=None, driver=False):
         k8s = self._get_k8s()
-        namespace = k8s.ns(namespace)
+        namespace = k8s.resolve_namespace(namespace)
         selector = 'mlrun/class=spark'
         if name:
             selector += ',sparkoperator.k8s.io/app-name={}'.format(name)

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -271,4 +271,4 @@ class SparkRuntimeHandler(BaseRuntimeHandler):
     def _is_crd_object_in_transient_state(crd_object) -> bool:
         # it is less likely that there will be new stable states, or the existing ones will change so better to resolve
         # whether it's a transient state by checking if it's not a stable state
-        return crd_object.status.applicationState.state not in ['COMPLETED', 'FAILED']
+        return crd_object.get('status', {}).get('applicationState', {}).get('state') not in ['COMPLETED', 'FAILED']

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -260,6 +260,10 @@ class SparkRuntime(KubejobRuntime):
 class SparkRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
+    def _get_object_label_selector(object_id: str) -> str:
+        return f'mlrun/uid={object_id}'
+
+    @staticmethod
     def _get_default_label_selector() -> str:
         return 'mlrun/class=spark'
 

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -269,4 +269,6 @@ class SparkRuntimeHandler(BaseRuntimeHandler):
 
     @staticmethod
     def _is_crd_object_in_transient_state(crd_object) -> bool:
-        return crd_object.status.applicationState.state == 'RUNNING'
+        # it is less likely that there will be new stable states, or the existing ones will change so better to resolve
+        # whether it's a transient state by checking if it's not a stable state
+        return crd_object.status.applicationState.state not in ['COMPLETED', 'FAILED']


### PR DESCRIPTION
1. Added endpoints:
* `GET /runtimes`
* `GET /runtimes/{kind}`
* `DELETE /runtimes`
* `DELETE /runtimes/{kind}`

2. Added `RuntimeHandler` classes that currently exposes `list_resources` and `delete_resources` methods

3. Changed the mlrun cli `clean` command to use the delete runtime endpoints

4. Added support in the mlrun cli `get` command to the get runtime endpoints

