### PR TITLE
Fix hash vs tag prioritization 

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -168,10 +168,12 @@ class BaseRuntime(ModelObj):
 
     def _function_uri(self, tag=None, hash_key=None):
         url = '{}/{}'.format(self.metadata.project, self.metadata.name)
-        if tag or self.metadata.tag:
-            url += ':{}'.format(tag or self.metadata.tag)
-        elif hash_key:
+
+        # prioritize hash key over tag
+        if hash_key:
             url += '@{}'.format(hash_key)
+        elif tag or self.metadata.tag:
+            url += ':{}'.format(tag or self.metadata.tag)
         return url
 
     def _get_db(self):


### PR DESCRIPTION
the `_function_uri` function was prioritizing tags over hash key - should be the opposite
The effect was that when you run a job, the function linked to it was linked by tag instead of by hash, unlike hash key, tag is dynamic, so linking by tag may not let you to re-run a job with the exact version of the function is was created with