### PR TITLE
Change SQLDB to be the default DB

### DIFF
--- a/hack/mlrun-all.yaml
+++ b/hack/mlrun-all.yaml
@@ -27,7 +27,7 @@ spec:
         - name: MLRUN_LOG_LEVEL
           value: ERROR
         - name: MLRUN_HTTPDB__DB_TYPE
-          value: filerundb
+          value: sqldb
         - name: MLRUN_HTTPDB__DIRPATH
           value: "/mlrun/db"
         - name: DEFAULT_DOCKER_REGISTRY

--- a/hack/mlrunapi.yaml
+++ b/hack/mlrunapi.yaml
@@ -23,7 +23,7 @@ spec:
         - name: MLRUN_LOG_LEVEL
           value: ERROR
         - name: MLRUN_HTTPDB__DB_TYPE
-          value: filerundb
+          value: sqldb
         - name: MLRUN_HTTPDB__DIRPATH
           value: "/mlrun/db"
         - name: DEFAULT_DOCKER_REGISTRY

--- a/mlrun/api/db/init_db.py
+++ b/mlrun/api/db/init_db.py
@@ -6,5 +6,5 @@ from mlrun.config import config
 
 
 def init_db(db_session: Session) -> None:
-    if config.httpdb.db_type == "sqldb":
+    if config.httpdb.db_type != "filedb":
         Base.metadata.create_all(bind=get_engine())

--- a/mlrun/api/db/session.py
+++ b/mlrun/api/db/session.py
@@ -6,10 +6,10 @@ from mlrun.config import config
 
 def create_session(db_type=None) -> Session:
     db_type = db_type or config.httpdb.db_type
-    if db_type == "sqldb":
-        return sqldb_create_session()
-    else:
+    if db_type == "filedb":
         return None
+    else:
+        return sqldb_create_session()
 
 
 def close_session(db_session):

--- a/mlrun/api/singletons.py
+++ b/mlrun/api/singletons.py
@@ -43,7 +43,11 @@ def _initialize_logs_dir():
 
 def _initialize_db():
     global db
-    if config.httpdb.db_type == "sqldb":
+    if config.httpdb.db_type == "filedb":
+        logger.info("using FileRunDB")
+        db = FileDB(config.httpdb.dirpath)
+        db.initialize(None)
+    else:
         logger.info("using SQLDB")
         db = SQLDB(config.httpdb.dsn)
         db_session = None
@@ -52,10 +56,6 @@ def _initialize_db():
             db.initialize(db_session)
         finally:
             db_session.close()
-    else:
-        logger.info("using FileRunDB")
-        db = FileDB(config.httpdb.dirpath)
-        db.initialize(None)
 
 
 def get_db() -> DBInterface:

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -63,7 +63,7 @@ default_config = {
     'httpdb': {
         'port': 8080,
         'dirpath': expanduser('~/.mlrun/db'),
-        'dsn': 'sqlite:////tmp/mlrun.db?check_same_thread=false',
+        'dsn': 'sqlite:////mlrun/db/mlrun.db?check_same_thread=false',
         'debug': False,
         'user': '',
         'password': '',
@@ -202,6 +202,10 @@ def read_env(env=None, prefix=env_prefix):
             if ':' in igz_domain:
                 igz_domain = igz_domain[:igz_domain.rfind(':')]
             env['IGZ_NAMESPACE_DOMAIN'] = igz_domain
+
+    # workaround wrongly sqldb dsn in 2.8
+    if config.get('httpdb', {}).get('dsn') == 'sqlite:///mlrun.sqlite3?check_same_thread=false':
+        config['httpdb']['dsn'] = 'sqlite:////mlrun/db/mlrun.db?check_same_thread=false'
 
     if uisvc and not config.get('ui_url'):
         if igz_domain:


### PR DESCRIPTION
* Changing the default DB to be SQLDB

Hacks in order to enable upgrading iguazio 2.8 systems to latest MLRun without touching helm charts or env vars (only replacing images):
* In order to get filedb the `config.httpdb.db_type` value used to be `filerundb`. 
we change this value to be `filedb` so from now on any value except `filedb` will give you SQLDB (so `filerundb` will give SQLDB)
* if the `config.httpdb.dsn` value is `sqlite:///mlrun.sqlite3?check_same_thread=false` (2.8 default) it will be replaced to `sqlite:////mlrun/db/mlrun.db?check_same_thread=false` so that the db file will be under the fuse mount (so will persist pod restarts)