### PR TITLE
Fix default logs path

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -75,7 +75,7 @@ default_config = {
         'user': '',
         'password': '',
         'token': '',
-        'logs_path': expanduser('~/.mlrun/logs'),
+        'logs_path': '/mlrun/db/logs',
         'data_volume': '',
         'real_path': '',
         'db_type': 'sqldb',


### PR DESCRIPTION
Change the default logs path from `~/.mlrun/logs` to `/mlrun/db/logs` so logs will persist pod restarts (since the volume mount is on `/mlrun/db`