### PR TITLE
Improve integration tests

### DIFF
--- a/examples/mlrun_basics.ipynb
+++ b/examples/mlrun_basics.ipynb
@@ -1355,7 +1355,9 @@
     }
    ],
    "source": [
-    "!mlrun run --name train_hyper -x p1=\"[3,7,5]\" --selector max.accuracy -p p2=5 --out-path {artifact_path} training.py"
+    "!mlrun run --name train_hyper -x p1=\"[3,7,5]\" --selector max.accuracy -p p2=5 --out-path {artifact_path} training.py\n",
+    "if _exit_code != 0:\n",
+    "    raise RuntimeError()"
    ]
   },
   {
@@ -1389,7 +1391,9 @@
    ],
    "source": [
     "# see other CLI commands\n",
-    "!mlrun"
+    "!mlrun\n",
+    "if _exit_code != 0:\n",
+    "    raise RuntimeError()"
    ]
   },
   {

--- a/examples/mlrun_dask.ipynb
+++ b/examples/mlrun_dask.ipynb
@@ -644,8 +644,11 @@
    "source": [
     "arguments={'x':4,'y':-5}\n",
     "artifact_path = '/User/test'\n",
-    "run_pipeline(dask_pipe, arguments, artifact_path=artifact_path,\n",
-    "             run=\"DaskExamplePipeline\", experiment=\"dask pipe\")"
+    "run_id = run_pipeline(dask_pipe, \n",
+    "                      arguments, \n",
+    "                      artifact_path=artifact_path,\n",
+    "                      run=\"DaskExamplePipeline\", \n",
+    "                      experiment=\"dask pipe\")"
    ]
   },
   {
@@ -653,7 +656,12 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from mlrun import wait_for_pipeline_completion, get_run_db\n",
+    "wait_for_pipeline_completion(run_id)\n",
+    "db = get_run_db().connect()\n",
+    "db.list_runs(project='default', labels=f'workflow={run_id}').show()\n"
+   ]
   }
  ],
  "metadata": {

--- a/examples/mlrun_jobs.ipynb
+++ b/examples/mlrun_jobs.ipynb
@@ -1924,7 +1924,8 @@
     }
    ],
    "source": [
-    "from mlrun import get_run_db\n",
+    "from mlrun import wait_for_pipeline_completion, get_run_db\n",
+    "wait_for_pipeline_completion(run_id)\n",
     "db = get_run_db().connect()\n",
     "db.list_runs(project='default', labels=f'workflow={run_id}').show()"
    ]

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -694,18 +694,20 @@ def run_pipeline(pipeline, arguments=None, project=None, experiment=None,
 
 def wait_for_pipeline_completion(run_id,
                                  timeout=60 * 60,
-                                 expected_statuses: typing.List[str]=None,
-                                 namespace=None):
+                                 expected_statuses: typing.List[str] = None,
+                                 namespace = None):
     """Wait for Pipeline status, timeout in sec
 
     :param run_id:     id of pipelines run
     :param timeout:    wait timeout in sec
-    :param expected_statuses:  list of expected statuses, otherwise will raise
-                               succeeded | failed | skipped | error | running
+    :param expected_statuses:  list of expected statuses, one of [ succeeded | failed | skipped | error ], by default
+                               [ succeeded ]
     :param namespace:  k8s namespace if not default
 
     :return kfp run dict
     """
+    if expected_statuses is None:
+        expected_statuses = ['succeeded']
     namespace = namespace or mlconf.namespace
     remote = not get_k8s_helper(init=False).is_running_inside_kubernetes_cluster()
     logger.debug(f"Waiting for run completion."
@@ -749,7 +751,7 @@ def wait_for_pipeline_completion(run_id,
 
     status = resp['run']['status'] if resp else 'unknown'
     if expected_statuses:
-        if status not in expected_statuses:
+        if status.lower() not in expected_statuses:
             raise RuntimeError(f"run status {status} not in expected statuses")
 
     logger.debug(f"Finished waiting for pipeline completion."

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -46,11 +46,11 @@ from .utils import (get_in, logger, parse_function_uri, update_in,
 
 
 class RunStatuses(object):
-    succeeded = 'succeeded'
-    failed = 'failed'
-    skipped = 'skipped'
-    error = 'error'
-    running = 'running'
+    succeeded = 'Succeeded'
+    failed = 'Failed'
+    skipped = 'Skipped'
+    error = 'Error'
+    running = 'Running'
 
     @staticmethod
     def all():
@@ -700,14 +700,14 @@ def wait_for_pipeline_completion(run_id,
 
     :param run_id:     id of pipelines run
     :param timeout:    wait timeout in sec
-    :param expected_statuses:  list of expected statuses, one of [ succeeded | failed | skipped | error ], by default
-                               [ succeeded ]
+    :param expected_statuses:  list of expected statuses, one of [ Succeeded | Failed | Skipped | Error ], by default
+                               [ Succeeded ]
     :param namespace:  k8s namespace if not default
 
     :return kfp run dict
     """
     if expected_statuses is None:
-        expected_statuses = ['succeeded']
+        expected_statuses = [RunStatuses.succeeded]
     namespace = namespace or mlconf.namespace
     remote = not get_k8s_helper(init=False).is_running_inside_kubernetes_cluster()
     logger.debug(f"Waiting for run completion."
@@ -723,7 +723,7 @@ def wait_for_pipeline_completion(run_id,
         def get_pipeline_if_completed(run_id, namespace=namespace):
             resp = mldb.get_pipeline(run_id, namespace=namespace)
             status = resp['run']['status']
-            if status.lower() not in RunStatuses.stable_statuses():
+            if status not in RunStatuses.stable_statuses():
 
                 # TODO: think of nicer liveness indication and make it re-usable
                 # log '.' each retry as a liveness indication
@@ -751,7 +751,7 @@ def wait_for_pipeline_completion(run_id,
 
     status = resp['run']['status'] if resp else 'unknown'
     if expected_statuses:
-        if status.lower() not in expected_statuses:
+        if status not in expected_statuses:
             raise RuntimeError(f"run status {status} not in expected statuses")
 
     logger.debug(f"Finished waiting for pipeline completion."

--- a/tests/Dockerfile.test-nb
+++ b/tests/Dockerfile.test-nb
@@ -24,6 +24,7 @@ RUN python -m pip install \
     -r requirements.txt
 COPY . .
 ENV PYTHONPATH=/mlrun
+RUN python setup.py install
 {args}
 {pip}
 RUN jupyter nbconvert --execute {notebook}

--- a/tests/integration/Dockerfile.test-nb
+++ b/tests/integration/Dockerfile.test-nb
@@ -24,6 +24,7 @@ RUN python -m pip install \
     -r requirements.txt
 COPY . .
 ENV PYTHONPATH=/mlrun
+RUN python setup.py install
 {args}
 {pip}
 RUN jupyter nbconvert --ExecutePreprocessor.timeout=600 --execute {notebook}

--- a/tests/integration/test-notebooks.yml
+++ b/tests/integration/test-notebooks.yml
@@ -1,23 +1,15 @@
 env:
-  # The mlrun-api URL. e.g. https://mlrun-api.default-tenant.app.provazio-hedingber-28-1.iguazio-cd0.com
+  # The mlrun-api URL. e.g. https://mlrun-api.default-tenant.app.hedingber-28-1.iguazio-cd2.com
   MLRUN_DBPATH:
 
-  # path in which artifacts will be stored - must start with "/User". e.g. /User/test-artifacts
-  MLRUN_ARTIFACT_PATH:
-
-  # IP of the app node in which dask scheduler is running. e.g. 3.20.113.215
-  MLRUN_REMOTE_HOST:
-
-  # user used to pass the mlrun-api ingress auth - e.g. iguazio
-  MLRUN_httpdb__user:
-
-  # in 2.8 - control session, in 2.10 and on - access key. e.g. b7713b10-9c11-466e-8bc0-cddae0b25be4
-  # control session can be extracted using this command:
-  # echo '{"data":{"type":"session","attributes":{"plane": "control", "username": "<username>","password": "<password>"}}}' | http --verify=no -b <Dashbord URL>/api/sessions | jq '."data"."id"'
-  MLRUN_httpdb__password:
+  # The webapi https_direct url - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com:8444
+  V3IO_API:
 
   # user used to add v3io mounts to pods - e.g. iguazio
   V3IO_USERNAME:
+
+  # password used to generate control sessions (needed only in 2.8) - e.g. password
+  V3IO_PASSWORD:
 
   # access key used to add v3io mounts to pods - e.g. 4c1c2011-618f-434a-abd6-d456770fd33c
   V3IO_ACCESS_KEY:
@@ -26,16 +18,19 @@ notebook_tests:
 - notebook_name: mlrun_db.ipynb
   env:
     MLRUN_DBPATH: ${MLRUN_DBPATH}
-    MLRUN_httpdb__user: ${MLRUN_httpdb__user}
-    MLRUN_httpdb__password: ${MLRUN_httpdb__password}
+    V3IO_USERNAME: ${V3IO_USERNAME}
+    V3IO_PASSWORD: ${V3IO_PASSWORD}
+    V3IO_API: ${V3IO_API}
+    V3IO_ACCESS_KEY: ${V3IO_ACCESS_KEY}
 
     JUPYTER_NOTEBOOK_FILE_NAME: 'mlrun_db.ipynb'
 - notebook_name: mlrun_basics.ipynb
   env:
     MLRUN_DBPATH: ${MLRUN_DBPATH}
-    MLRUN_ARTIFACT_PATH: ${MLRUN_ARTIFACT_PATH}
-    MLRUN_httpdb__user: ${MLRUN_httpdb__user}
-    MLRUN_httpdb__password: ${MLRUN_httpdb__password}
+    V3IO_USERNAME: ${V3IO_USERNAME}
+    V3IO_PASSWORD: ${V3IO_PASSWORD}
+    V3IO_API: ${V3IO_API}
+    V3IO_ACCESS_KEY: ${V3IO_ACCESS_KEY}
 
     JUPYTER_NOTEBOOK_FILE_NAME: 'mlrun_basics.ipynb'
   pip:
@@ -43,21 +38,18 @@ notebook_tests:
 - notebook_name: mlrun_jobs.ipynb
   env:
     MLRUN_DBPATH: ${MLRUN_DBPATH}
-    MLRUN_ARTIFACT_PATH: ${MLRUN_ARTIFACT_PATH}
-    MLRUN_httpdb__user: ${MLRUN_httpdb__user}
-    MLRUN_httpdb__password: ${MLRUN_httpdb__password}
     V3IO_USERNAME: ${V3IO_USERNAME}
+    V3IO_PASSWORD: ${V3IO_PASSWORD}
+    V3IO_API: ${V3IO_API}
     V3IO_ACCESS_KEY: ${V3IO_ACCESS_KEY}
 
     JUPYTER_NOTEBOOK_FILE_NAME: 'mlrun_jobs.ipynb'
 - notebook_name: mlrun_dask.ipynb
   env:
     MLRUN_DBPATH: ${MLRUN_DBPATH}
-    MLRUN_ARTIFACT_PATH: ${MLRUN_ARTIFACT_PATH}
-    MLRUN_REMOTE_HOST: ${MLRUN_REMOTE_HOST}
-    MLRUN_httpdb__user: ${MLRUN_httpdb__user}
-    MLRUN_httpdb__password: ${MLRUN_httpdb__password}
     V3IO_USERNAME: ${V3IO_USERNAME}
+    V3IO_PASSWORD: ${V3IO_PASSWORD}
+    V3IO_API: ${V3IO_API}
     V3IO_ACCESS_KEY: ${V3IO_ACCESS_KEY}
 
     JUPYTER_NOTEBOOK_FILE_NAME: 'mlrun_dask.ipynb'


### PR DESCRIPTION
* minimize env vars required for integration test
* add this code snippet wherever `!` is being used in the notebooks so the cell execution (and as an outcome the test) will fail if the command execution failed
```
if _exit_code != 0:
    raise RuntimeError()
```
* change `wait_for_pipeline_completion` default `expected_statuses` to be `[ Succeeded ]` (was empty) and other correctness and docs changes for this function
* use `wait_for_pipeline_completion` in the test notebooks so that test will fail when the pipeline fail (and will succeed only after pipeline finished successfully)