### PR TITLE
Fix scheduled job submission bug

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -103,13 +103,13 @@ def submit(db_session: Session, data):
         else:
             run = fn.run(task, watch=False)
             if run:
-                response = run.to_yaml()
+                response = run.to_dict()
 
-        logger.info("response: %s", response)
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
 
+    logger.info("response: %s", response)
     return {
         "data": response,
     }

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -68,7 +68,7 @@ def submit(db_session: Session, data):
     # TODO: block exec for function["kind"] in ["", "local]  (must be a
     # remote/container runtime)
 
-    resp = None
+    response = None
     try:
         if function and not url:
             fn = new_function(runtime=function)
@@ -99,17 +99,17 @@ def submit(db_session: Session, data):
             args = (task,)
             job_id = get_scheduler().add(schedule, fn, args)
             get_db().store_schedule(db_session, data)
-            resp = {"schedule": schedule, "id": job_id}
+            response = {"schedule": schedule, "id": job_id}
         else:
-            resp = fn.run(task, watch=False)
+            run = fn.run(task, watch=False)
+            if run:
+                response = run.to_yaml()
 
-        logger.info("resp: %s", resp.to_yaml())
+        logger.info("response: %s", response)
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
 
-    if not isinstance(resp, dict):
-        resp = resp.to_dict()
     return {
-        "data": resp,
+        "data": response,
     }

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -27,10 +27,14 @@ async def startup_event():
 
     initialize_singletons()
 
-    task = periodic.Task()
-    periodic.schedule(task, 60)
+    # don't fail the app on re-scheduling failure
+    try:
+        task = periodic.Task()
+        periodic.schedule(task, 60)
 
-    _reschedule_tasks()
+        _reschedule_tasks()
+    except Exception as exc:
+        logger.warning(f'Failed rescheduling tasks, err: {exc}')
 
     _start_periodic_cleanup()
 


### PR DESCRIPTION
there were 2 bugs:
* line 106 in `utils.py` - `resp.to_yaml()` in case of a schedule job `resp` is a dict which doesn't have the `to_yaml` method so it would fail on it - calling `to_yaml` only when relevant
* If the mlrun api pod got restarted, when it comes up, it tries to reschedule the job (it fails after it insert it to the DB), then it fails (for the same reason) but since it's happening on the startup event it fails the app initalization and the pod gets into crash loop - wrapped the rescheduling with try except so it won't fail the app initialization 