### PR TITLE
Make project's owner field optional

### DIFF
--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -18,7 +18,7 @@ class ProjectBase(BaseModel):
 # Properties to receive via API on creation
 class ProjectCreate(ProjectBase):
     name: str
-    owner: str
+    owner: Optional[str] = None
 
 
 # Properties to receive via API on update


### PR DESCRIPTION
The field is currently not really in use so shouldn't be mandatory