### PR TITLE
Added support for Azure blobs as an MLRun data store

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -1,0 +1,62 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import os
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobClient, BlobServiceClient
+from azure.core.exceptions import ResourceExistsError
+from .base import DataStore, get_range, FileStats
+
+# Azure blobs will be represented with the following URL: az://<container name>. The storage account is already
+# pointed to by the connection string, so the user is not expected to specify it in any way.
+
+
+class AzureBlobStore(DataStore):
+    def __init__(self, parent, schema, name, endpoint=''):
+        super().__init__(parent, name, schema, endpoint)
+
+        con_string = self._secret('AZURE_STORAGE_CONNECTION_STRING') or os.getenv('AZURE_STORAGE_CONNECTION_STRING')
+        if con_string:
+            self.bsc = BlobServiceClient.from_connection_string(con_string)
+
+    def upload(self, key, src_path):
+        # Need to strip leading / from key
+        blob_client = self.bsc.get_blob_client(container=self.endpoint, blob=key[1:])
+        with open(src_path, 'rb') as data:
+            blob_client.upload_blob(data)
+
+    def get(self, key, size=None, offset=0):
+        blob_client = self.bsc.get_blob_client(container=self.endpoint, blob=key[1:])
+        return blob_client.download_blob(offset, size).readall()
+
+    def put(self, key, data, append=False):
+        blob_client = self.bsc.get_blob_client(container=self.endpoint, blob=key[1:])
+        # Note that append=True is not supported. If the blob already exists, this call will fail
+        blob_client.upload_blob(data)
+
+    def stat(self, key):
+        blob_client = self.bsc.get_blob_client(container=self.endpoint, blob=key[1:])
+        props = blob_client.get_blob_properties()
+        size = props.size
+        modified = props.last_modified
+        return FileStats(size, time.mktime(modified.timetuple()))
+
+    def listdir(self, key):
+        if not key.endswith('/'):
+            key = key[1:] + '/'
+
+        container_client = self.bsc.get_container_client(self.endpoint)
+        blob_list = container_client.list_blobs(name_starts_with=key)
+        return [blob.name for blob in blob_list]

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -25,7 +25,9 @@ class AzureBlobStore(DataStore):
     def __init__(self, parent, schema, name, endpoint=''):
         super().__init__(parent, name, schema, endpoint)
 
-        con_string = self._secret('AZURE_STORAGE_CONNECTION_STRING') or os.getenv('AZURE_STORAGE_CONNECTION_STRING')
+        con_string = self._secret('AZURE_STORAGE_CONNECTION_STRING') or os.getenv(
+            'AZURE_STORAGE_CONNECTION_STRING'
+        )
         if con_string:
             self.bsc = BlobServiceClient.from_connection_string(con_string)
 

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -14,10 +14,8 @@
 
 import time
 import os
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobClient, BlobServiceClient
-from azure.core.exceptions import ResourceExistsError
-from .base import DataStore, get_range, FileStats
+from azure.storage.blob import BlobServiceClient
+from .base import DataStore, FileStats
 
 # Azure blobs will be represented with the following URL: az://<container name>. The storage account is already
 # pointed to by the connection string, so the user is not expected to specify it in any way.

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -54,9 +54,10 @@ class AzureBlobStore(DataStore):
         return FileStats(size, time.mktime(modified.timetuple()))
 
     def listdir(self, key):
-        if not key.endswith('/'):
+        if key and not key.endswith('/'):
             key = key[1:] + '/'
 
+        key_length = len(key)
         container_client = self.bsc.get_container_client(self.endpoint)
         blob_list = container_client.list_blobs(name_starts_with=key)
-        return [blob.name for blob in blob_list]
+        return [blob.name[key_length:] for blob in blob_list]

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -22,6 +22,7 @@ from .base import DataItem, HttpStore
 from .s3 import S3Store
 from .filestore import FileStore
 from .v3io import V3ioStore
+from .azure_blob import AzureBlobStore
 
 
 def get_object_stat(url, secrets=None):
@@ -43,6 +44,8 @@ def schema_to_store(schema):
         return FileStore
     elif schema == 's3':
         return S3Store
+    elif schema == 'az':
+        return AzureBlobStore
     elif schema in ['v3io', 'v3ios']:
         return V3ioStore
     elif schema in ['http', 'https']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,4 @@ v3io>=0.3.3
 matplotlib
 scikit-learn
 seaborn
-azure-mgmt-resource
-azure-mgmt-storage
-azure-cli-core
 azure-storage-blob
-azure-identity

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,8 @@ v3io>=0.3.3
 matplotlib
 scikit-learn
 seaborn
+azure-mgmt-resource
+azure-mgmt-storage
+azure-cli-core
+azure-storage-blob
+azure-identity

--- a/tests/integration/azure_blob/test-azure-blob.yml
+++ b/tests/integration/azure_blob/test-azure-blob.yml
@@ -1,0 +1,7 @@
+env:
+  # The Azure connection string which points at a storage account. For example:
+  # DefaultEndpointsProtocol=https;AccountName=myAcct;AccountKey=XXXX;EndpointSuffix=core.windows.net
+  AZURE_STORAGE_CONNECTION_STRING:
+
+  # Storage container within the given storage account where objects will be created.
+  AZURE_CONTAINER:

--- a/tests/integration/azure_blob/test.txt
+++ b/tests/integration/azure_blob/test.txt
@@ -1,0 +1,2 @@
+This is just a test file, meant to test the upload functionality.
+Nothing really interesting here.

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -16,7 +16,9 @@ def azure_connection_configured():
 
 
 def prepare_env():
-    os.environ['AZURE_STORAGE_CONNECTION_STRING'] = config['env'].get('AZURE_STORAGE_CONNECTION_STRING')
+    os.environ['AZURE_STORAGE_CONNECTION_STRING'] = config['env'].get(
+        'AZURE_STORAGE_CONNECTION_STRING'
+    )
 
 
 @pytest.mark.skipif(
@@ -52,13 +54,15 @@ def test_azure_blob():
     # Check dir list
     dir_data_item = mlrun.run.get_dataitem(blob_path + '/' + blob_dir)
     dir_list = dir_data_item.listdir()
-    assert any(blob_file in item for item in dir_list), 'List dir did not contain our file name'
+    assert any(
+        blob_file in item for item in dir_list
+    ), 'List dir did not contain our file name'
 
 
 @pytest.mark.skipif(
     not azure_connection_configured(),
     reason='This is an integration test, add the needed environment variables in test-azure-blob.yml '
-           'to run it',
+    'to run it',
 )
 def test_blob_upload():
     # Check upload functionality

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -1,0 +1,82 @@
+import mlrun
+import pytest
+import yaml
+import os
+import random
+from pathlib import Path
+
+here = Path(__file__).absolute().parent
+config_file_path = here / 'test-azure-blob.yml'
+with config_file_path.open() as fp:
+    config = yaml.safe_load(fp)
+
+
+def azure_connection_configured():
+    return config['env'].get('AZURE_STORAGE_CONNECTION_STRING') is not None
+
+
+def prepare_env():
+    os.environ['AZURE_STORAGE_CONNECTION_STRING'] = config['env'].get('AZURE_STORAGE_CONNECTION_STRING')
+
+
+@pytest.mark.skipif(
+    not azure_connection_configured(),
+    reason='This is an integration test, add the needed environment variables in test-azure-blob.yml '
+    'to run it',
+)
+def test_azure_blob():
+    prepare_env()
+
+    blob_path = 'az://' + config['env'].get('AZURE_CONTAINER')
+    blob_dir = 'test_mlrun_azure_blob'
+    test_filename = here / 'test.txt'
+    with open(test_filename, 'r') as f:
+        test_string = f.read()
+
+    blob_file = 'file_{0}.txt'.format(random.randint(0, 1000))
+    blob_url = blob_path + '/' + blob_dir + '/' + blob_file
+    print(f'\nBlob URL: {blob_url}')
+
+    data_item = mlrun.run.get_dataitem(blob_url)
+    data_item.put(test_string)
+
+    response = data_item.get()
+    assert response.decode() == test_string, 'Result differs from original test'
+
+    response = data_item.get(offset=20)
+    assert response.decode() == test_string[20:], 'Partial result not as expected'
+
+    stat = data_item.stat()
+    assert stat.size == len(test_string), 'Stat size different than expected'
+
+    # Check dir list
+    dir_data_item = mlrun.run.get_dataitem(blob_path + '/' + blob_dir)
+    dir_list = dir_data_item.listdir()
+    assert any(blob_file in item for item in dir_list), 'List dir did not contain our file name'
+
+
+@pytest.mark.skipif(
+    not azure_connection_configured(),
+    reason='This is an integration test, add the needed environment variables in test-azure-blob.yml '
+           'to run it',
+)
+def test_blob_upload():
+    # Check upload functionality
+    prepare_env()
+
+    blob_path = 'az://' + config['env'].get('AZURE_CONTAINER')
+    blob_dir = 'test_mlrun_azure_blob'
+    test_filename = here / 'test.txt'
+    blob_file = 'file_{0}.txt'.format(random.randint(0, 1000))
+    blob_url = blob_path + '/' + blob_dir + '/' + blob_file
+    print(f'\nBlob URL: {blob_url}')
+
+    upload_data_item = mlrun.run.get_dataitem(blob_url)
+    upload_data_item.upload(test_filename)
+
+    response = upload_data_item.get()
+
+    with open(test_filename, 'r') as f:
+        test_string = f.read()
+
+    assert response.decode() == test_string, 'Result differs from original test'

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -57,7 +57,7 @@ def test_azure_blob():
 @pytest.mark.skipif(
     not azure_connection_configured(),
     reason='This is an integration test, add the needed environment variables in test-azure-blob.yml '
-           'to run it',
+    'to run it',
 )
 def test_list_dir():
     prepare_env()


### PR DESCRIPTION
Commit has the code needed and unit tests for new functionality.
Data store URLs should begin with az:// for Azure blob files.