### PR TITLE
Fix CI

### DIFF
--- a/mlrun/mlutils/data.py
+++ b/mlrun/mlutils/data.py
@@ -4,7 +4,9 @@ from ..datastore import DataItem
 from typing import Union
 
 
-def get_sample(src: Union[DataItem, pd.core.frame.DataFrame], sample: int, label: str, reader=None):
+def get_sample(
+    src: Union[DataItem, pd.core.frame.DataFrame], sample: int, label: str, reader=None
+):
     """generate data sample to be split (candidate for mlrun)
 
     Returns features matrix and header (x), and labels (y)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,5 @@ v3io>=0.3.3
 matplotlib
 scikit-learn
 seaborn
+google-api-core~=1.20
 azure-storage-blob


### PR DESCRIPTION
https://github.com/mlrun/mlrun/commit/4c18db675d7d4b7bf771892b3701fa758c838430 broke lint
https://github.com/mlrun/mlrun/pull/338 - broke build (https://classb-jenkins.devops.iguazeng.com/blue/organizations/jenkins/mlrun/detail/unstable/26/pipeline, looks like one of our packages requires specifically `google-auth 1.14.1` while one of other packages takes latest `google-api-core` which its latest `1.21.0` requires `"google-auth >= 1.18.0, < 2.0dev"`, so I added the `google-api-core~=1.20` requirement