### PR TITLE
Be selective on CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,15 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+    - development
+    - '[0-9]+.[0-9]+.x'
+
+  # Run CI also on push to master
+  push:
+    branches:
+    - master
 
 jobs:
   lint:


### PR DESCRIPTION
We have bots pushing commits to branches, these shouldn't trigger CI
From now on - trigger CI on pull requests to reasonable base branches, and on pushes to master only (before release)