### PR TITLE
Scheduler fixes

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -1,4 +1,3 @@
-import copy
 import traceback
 from http import HTTPStatus
 from os import environ
@@ -112,16 +111,12 @@ def submit(db_session: Session, data):
         # fn.spec.rundb = "http://mlrun-api:8080"
         schedule = data.get("schedule")
         if schedule:
-            # removing the schedule from the body otherwise when the scheduler will submit this job it will go to an
-            # endless scheduling loop
-            data_without_schedule = copy.deepcopy(data)
-            del data_without_schedule['schedule']
             get_scheduler().create_schedule(
                 db_session,
-                fn.metadata.project,
-                fn.metadata.name,
+                task['metadata']['project'],
+                task['metadata']['name'],
                 schemas.ScheduleKinds.job,
-                data_without_schedule,
+                data,
                 schemas.ScheduleCronTrigger(**schedule),
             )
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 from typing import Any, Callable, List, Tuple, Dict, Union, Optional
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -152,7 +153,12 @@ class Scheduler:
             # import here to avoid circular imports
             from mlrun.api.api.utils import submit
 
-            return submit, [db_session, scheduled_object], {}
+            # removing the schedule from the body otherwise when the scheduler will submit this job it will go to an
+            # endless scheduling loop
+            scheduled_object_without_schedule = copy.deepcopy(scheduled_object)
+            scheduled_object_without_schedule.pop('schedule', None)
+
+            return submit, [db_session, scheduled_object_without_schedule], {}
         if scheduled_kind == schemas.ScheduleKinds.local_function:
             return scheduled_object, None, None
 


### PR DESCRIPTION
* use run name to for the schedule name (instead of function name)
* move some logic from `submit` to inside the scheduler