### PR TITLE
Fix url parsing to preserve case

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -36,15 +36,16 @@ def get_object_stat(url, secrets=None):
 def parseurl(url):
     p = urlparse(url)
     schema = p.scheme.lower()
-    # HACK - urlparse returns the hostname after in lower case - we want the original case:
-    # the hostname is a substring of the netloc, in which it's the original case, so we find the indexes of the hostname
-    # in the netloc and take it from there
-    lower_hostname = p.hostname
-    netloc = str(p.netloc)
-    lower_netloc = netloc.lower()
-    logger.warn('WTF', lower_hostname=lower_hostname, lower_netloc=lower_netloc, url=str(url))
-    hostname_index_in_netloc = lower_netloc.index(str(lower_hostname))
-    endpoint = netloc[hostname_index_in_netloc:hostname_index_in_netloc+len(lower_hostname)]
+    endpoint = p.hostname
+    if endpoint:
+        # HACK - urlparse returns the hostname after in lower case - we want the original case:
+        # the hostname is a substring of the netloc, in which it's the original case, so we find the indexes of the
+        # hostname in the netloc and take it from there
+        lower_hostname = p.hostname
+        netloc = str(p.netloc)
+        lower_netloc = netloc.lower()
+        hostname_index_in_netloc = lower_netloc.index(str(lower_hostname))
+        endpoint = netloc[hostname_index_in_netloc:hostname_index_in_netloc+len(lower_hostname)]
     if p.port:
         endpoint += ':{}'.format(p.port)
     return schema, endpoint, p

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -44,7 +44,9 @@ def parse_url(url):
         netloc = str(parsed_url.netloc)
         lower_netloc = netloc.lower()
         hostname_index_in_netloc = lower_netloc.index(str(lower_hostname))
-        endpoint = netloc[hostname_index_in_netloc:hostname_index_in_netloc+len(lower_hostname)]
+        endpoint = netloc[
+            hostname_index_in_netloc : hostname_index_in_netloc + len(lower_hostname)
+        ]
     if parsed_url.port:
         endpoint += ':{}'.format(parsed_url.port)
     return schema, endpoint, parsed_url

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 import mlrun
 
 from ..config import config
-from ..utils import run_keys, DB_SCHEMA
+from ..utils import run_keys, DB_SCHEMA, logger
 
 from .base import DataItem, HttpStore
 from .s3 import S3Store
@@ -42,7 +42,8 @@ def parseurl(url):
     lower_hostname = p.hostname
     netloc = str(p.netloc)
     lower_netloc = netloc.lower()
-    hostname_index_in_netloc = lower_netloc.index(str(p.hostname))
+    logger.warn('WTF', lower_hostname=lower_hostname, lower_netloc=lower_netloc, url=str(url))
+    hostname_index_in_netloc = lower_netloc.index(str(lower_hostname))
     endpoint = netloc[hostname_index_in_netloc:hostname_index_in_netloc+len(lower_hostname)]
     if p.port:
         endpoint += ':{}'.format(p.port)

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -36,7 +36,14 @@ def get_object_stat(url, secrets=None):
 def parseurl(url):
     p = urlparse(url)
     schema = p.scheme.lower()
-    endpoint = p.hostname
+    # HACK - urlparse returns the hostname after in lower case - we want the original case:
+    # the hostname is a substring of the netloc, in which it's the original case, so we find the indexes of the hostname
+    # in the netloc and take it from there
+    lower_hostname = p.hostname
+    netloc = str(p.netloc)
+    lower_netloc = netloc.lower()
+    hostname_index_in_netloc = lower_netloc.index(str(p.hostname))
+    endpoint = netloc[hostname_index_in_netloc:hostname_index_in_netloc+len(lower_hostname)]
     if p.port:
         endpoint += ':{}'.format(p.port)
     return schema, endpoint, p

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 
 from urllib.parse import urlparse
+
 import mlrun
-
-from ..config import config
-from ..utils import run_keys, DB_SCHEMA, logger
-
-from .base import DataItem, HttpStore
-from .s3 import S3Store
-from .filestore import FileStore
-from .v3io import V3ioStore
 from .azure_blob import AzureBlobStore
+from .base import DataItem, HttpStore
+from .filestore import FileStore
 from .inmem import InMemoryStore
+from .s3 import S3Store
+from .v3io import V3ioStore
+from ..config import config
+from ..utils import run_keys, DB_SCHEMA
 
 in_memory_store = InMemoryStore()
 

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -94,4 +94,3 @@ def test_parse_url_preserve_case():
     expected_endpoint = 'Hedi'
     _, endpoint, _ = mlrun.datastore.datastore.parse_url(url)
     assert expected_endpoint, endpoint
-

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -87,3 +87,11 @@ def test_file():
         assert artifact.column_metadata == {
             'age': 'great'
         }, 'failed artifact update test'
+
+
+def test_parse_url_preserve_case():
+    url = 'store://Hedi/mlrun-dbd7ef-training_mymodel#a5dc8e34a46240bb9a07cd9deb3609c7'
+    expected_endpoint = 'Hedi'
+    _, endpoint, _ = mlrun.datastore.datastore.parse_url(url)
+    assert expected_endpoint, endpoint
+


### PR DESCRIPTION
When this `parseurl` function was called with `'store://Hedi/mlrun-dbd7ef-training_mymodel#a5dc8e34a46240bb9a07cd9deb3609c7'` (which represent an artifact reference) the second value it returns, called `endpoint` (which is later used as the `project` to query the artifact) was equal to `hedi` instead of `Hedi`
this is because the underlying `urllib.parse.urlparse` is lowering the `hostname` (which is used to the endpoint).
Added logic to preserve the hostname/endpoint case

Other then that:
* ordered imports
* changed some weirdly named variables (`p`)
* added test