### PR TITLE
Fixing logger to consider log level correctly

### DIFF
--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -123,7 +123,9 @@ class Logger(object):
         kw_args.update(self._bound_variables)
 
         if kw_args:
-            self._logger.log(level, message, *args, exc_info=exc_info, extra={'with': kw_args})
+            self._logger.log(
+                level, message, *args, exc_info=exc_info, extra={'with': kw_args}
+            )
             return
 
         self._logger.log(level, message, *args, exc_info=exc_info)

--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -123,10 +123,10 @@ class Logger(object):
         kw_args.update(self._bound_variables)
 
         if kw_args:
-            self._logger._log(level, message, args, exc_info, extra={'with': kw_args})
+            self._logger.log(level, message, *args, exc_info=exc_info, extra={'with': kw_args})
             return
 
-        self._logger._log(level, message, args, exc_info)
+        self._logger.log(level, message, *args, exc_info=exc_info)
 
 
 class FormatterKinds(Enum):

--- a/tests/utils/logger/test_logger.py
+++ b/tests/utils/logger/test_logger.py
@@ -24,6 +24,13 @@ def test_regular(make_stream_logger):
     assert "SomeText" in stream.getvalue()
 
 
+def test_log_level(make_stream_logger):
+    stream, test_logger = make_stream_logger
+    test_logger.set_logger_level('INFO')
+    test_logger.debug("SomeText")
+    assert "SomeText" not in stream.getvalue()
+
+
 def test_with_args(make_stream_logger):
     stream, test_logger = make_stream_logger
     test_logger.debug("special_arg %s", "special_arg_value")


### PR DESCRIPTION
The difference between the `log` to the `_log` method is exactly the call to `.isEnabledFor` which verifies whether the log message level is above the log level set for the logger (if not it won't be logged)