### PR TITLE
API docs fixes

### DIFF
--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.54.1
+fastapi~=0.60.0
 uvicorn==0.11.3
 dask==2.12.0
 dask_kubernetes==0.10.0

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -22,6 +22,10 @@ app = FastAPI(
     description="Machine Learning automation and tracking",
     version=config.version,
     debug=config.httpdb.debug,
+    # adding /api prefix
+    openapi_url="/api/openapi.json",
+    docs_url="/api/docs",
+    redoc_url="/api/redoc",
 )
 
 app.include_router(api_router, prefix="/api")


### PR DESCRIPTION
* Bumping FastAPI version to get this bugfix https://github.com/tiangolo/fastapi/pull/1463 related to enums in docs
* Changing docs endpoints so they will more easily accessible in iguazio system