### PR TITLE
Enrich owner on job submission

### DIFF
--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -18,7 +18,9 @@ router = APIRouter()
 @router.post("/submit_job")
 @router.post("/submit_job/")
 async def submit_job(
-    request: Request, username: Optional[str] = Header(None, alias='x-remote-user'), db_session: Session = Depends(deps.get_db_session)
+    request: Request,
+    username: Optional[str] = Header(None, alias='x-remote-user'),
+    db_session: Session = Depends(deps.get_db_session),
 ):
     data = None
     try:


### PR DESCRIPTION
This enrichment is needed so when we "render" the `{{run.user}}` in the output path the right user will be used (otherwise we're using the `V3IO_USERNAME` env var which is actually the username under which the MLRun DB is sitting 