### PR TITLE
Fix extra requirements definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'mlrun.api.utils.singletons',
     ],
     install_requires=install_requires,
-    extra_requires={'api': api_deps},
+    extras_require={'api': api_deps},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
there was a typo in `setup.py` - `extra_requires` instead of `extras_require`
now doing `pip install mlrun[api]` is really working