### PR TITLE
Use FastApi facilities instead of older packages

### DIFF
--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -1,9 +1,8 @@
 from base64 import b64decode
-from http import HTTPStatus
 from typing import Generator
 from sqlalchemy.orm import Session
 
-from fastapi import Request
+from fastapi import Request, status
 
 from mlrun.api.api.utils import log_and_raise
 from mlrun.api.db.session import create_session, close_session
@@ -32,18 +31,20 @@ class AuthVerifier:
         header = request.headers.get('Authorization', '')
         if self._basic_auth_required(cfg):
             if not header.startswith(self._basic_prefix):
-                log_and_raise(HTTPStatus.UNAUTHORIZED, reason="missing basic auth")
+                log_and_raise(status.HTTP_401_UNAUTHORIZED, reason="missing basic auth")
             user, password = self._parse_basic_auth(header)
             if user != cfg.user or password != cfg.password:
-                log_and_raise(HTTPStatus.UNAUTHORIZED, reason="bad basic auth")
+                log_and_raise(status.HTTP_401_UNAUTHORIZED, reason="bad basic auth")
             self.username = user
             self.password = password
         elif self._bearer_auth_required(cfg):
             if not header.startswith(self._bearer_prefix):
-                log_and_raise(HTTPStatus.UNAUTHORIZED, reason="missing bearer auth")
+                log_and_raise(
+                    status.HTTP_401_UNAUTHORIZED, reason="missing bearer auth"
+                )
             token = header[len(self._bearer_prefix) :]
             if token != cfg.token:
-                log_and_raise(HTTPStatus.UNAUTHORIZED, reason="bad basic auth")
+                log_and_raise(status.HTTP_401_UNAUTHORIZED, reason="bad basic auth")
             self.token = token
 
     @staticmethod

--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -1,7 +1,6 @@
-from http import HTTPStatus
 from typing import List
 
-from fastapi import APIRouter, Depends, Request, Query
+from fastapi import APIRouter, Depends, Request, Query, status
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -29,7 +28,7 @@ async def store_artifact(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
 
     logger.debug(data)
     await run_in_threadpool(

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -1,7 +1,6 @@
 import mimetypes
-from http import HTTPStatus
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, Query, Request, Response, status
 
 from mlrun.api.api.utils import log_and_raise, get_obj_path, get_secrets
 from mlrun.datastore import get_object_stat, store_manager
@@ -24,7 +23,7 @@ def get_files(
     objpath = get_obj_path(schema, objpath, user=user)
     if not objpath:
         log_and_raise(
-            HTTPStatus.NOT_FOUND, path=objpath, err="illegal path prefix or schema"
+            status.HTTP_404_NOT_FOUND, path=objpath, err="illegal path prefix or schema"
         )
 
     secrets = get_secrets(request)
@@ -40,9 +39,9 @@ def get_files(
 
         body = obj.get(size, offset)
     except FileNotFoundError as e:
-        log_and_raise(HTTPStatus.NOT_FOUND, path=objpath, err=str(e))
+        log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath, err=str(e))
     if body is None:
-        log_and_raise(HTTPStatus.NOT_FOUND, path=objpath)
+        log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath)
 
     ctype, _ = mimetypes.guess_type(objpath)
     if not ctype:
@@ -60,14 +59,14 @@ def get_filestat(request: Request, schema: str = "", path: str = "", user: str =
     path = get_obj_path(schema, path, user=user)
     if not path:
         log_and_raise(
-            HTTPStatus.NOT_FOUND, path=path, err="illegal path prefix or schema"
+            status.HTTP_404_NOT_FOUND, path=path, err="illegal path prefix or schema"
         )
     secrets = get_secrets(request)
     stat = None
     try:
         stat = get_object_stat(path, secrets)
     except FileNotFoundError as e:
-        log_and_raise(HTTPStatus.NOT_FOUND, path=path, err=str(e))
+        log_and_raise(status.HTTP_404_NOT_FOUND, path=path, err=str(e))
 
     ctype, _ = mimetypes.guess_type(path)
     if not ctype:

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -148,10 +148,9 @@ def build_status(
     project: str = "",
     tag: str = "",
     offset: int = 0,
-    logs: str = "on",
+    logs: bool = True,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    logs = strtobool(logs)
     fn = get_db().get_function(db_session, name, project, tag)
     if not fn:
         log_and_raise(status.HTTP_404_NOT_FOUND, name=name, project=project, tag=tag)

--- a/mlrun/api/api/endpoints/logs.py
+++ b/mlrun/api/api/endpoints/logs.py
@@ -1,5 +1,3 @@
-from distutils.util import strtobool
-
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
@@ -12,8 +10,7 @@ router = APIRouter()
 
 # curl -d@/path/to/log http://localhost:8080/log/prj/7?append=true
 @router.post("/log/{project}/{uid}")
-async def store_log(request: Request, project: str, uid: str, append: str = "on"):
-    append = strtobool(append)
+async def store_log(request: Request, project: str, uid: str, append: bool = True):
     body = await request.body()
     await run_in_threadpool(crud.Logs.store_log, body, project, uid, append)
     return {}

--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -51,7 +51,9 @@ def get_project(name: str, db_session: Session = Depends(deps.get_db_session)):
 
 # curl http://localhost:8080/projects?full=true
 @router.get("/projects")
-def list_projects(full: bool = False, db_session: Session = Depends(deps.get_db_session)):
+def list_projects(
+    full: bool = False, db_session: Session = Depends(deps.get_db_session)
+):
     fn = db2dict if full else attrgetter("name")
     projects = []
     for p in get_db().list_projects(db_session):

--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from operator import attrgetter
 
 from fastapi import APIRouter, Depends
@@ -52,8 +51,7 @@ def get_project(name: str, db_session: Session = Depends(deps.get_db_session)):
 
 # curl http://localhost:8080/projects?full=true
 @router.get("/projects")
-def list_projects(full: str = "no", db_session: Session = Depends(deps.get_db_session)):
-    full = strtobool(full)
+def list_projects(full: bool = False, db_session: Session = Depends(deps.get_db_session)):
     fn = db2dict if full else attrgetter("name")
     projects = []
     for p in get_db().list_projects(db_session):

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -1,8 +1,7 @@
 from distutils.util import strtobool
-from http import HTTPStatus
 from typing import List
 
-from fastapi import APIRouter, Depends, Request, Query
+from fastapi import APIRouter, Depends, Request, Query, status
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -27,7 +26,7 @@ async def store_run(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
 
     logger.debug(data)
     await run_in_threadpool(
@@ -50,7 +49,7 @@ async def update_run(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
 
     logger.debug(data)
     await run_in_threadpool(

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from typing import List
 
 from fastapi import APIRouter, Depends, Request, Query, status
@@ -94,12 +93,10 @@ def list_runs(
     labels: List[str] = Query([], alias='label'),
     state: str = None,
     last: int = 0,
-    sort: str = "on",
-    iter: str = "on",
+    sort: bool = True,
+    iter: bool = True,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    sort = strtobool(sort)
-    iter = strtobool(iter)
     runs = get_db().list_runs(
         db_session,
         name=name,

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -1,6 +1,4 @@
-from http import HTTPStatus
-
-from fastapi import APIRouter, Depends, Request, Header
+from fastapi import APIRouter, Depends, Request, Header, status
 from typing import Optional
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
@@ -26,7 +24,7 @@ async def submit_job(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
 
     # enrich job task with the username from the request header
     if username:

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -1,6 +1,4 @@
-from http import HTTPStatus
-
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, status
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -23,7 +21,7 @@ async def tag_objects(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
 
     objs = await run_in_threadpool(_tag_objects, db_session, data, project, name)
     return {
@@ -72,7 +70,7 @@ def _tag_objects(db_session, data, project, name):
         cls = table2cls(typ)
         if cls is None:
             err = f"unknown type - {typ}"
-            log_and_raise(HTTPStatus.BAD_REQUEST, reason=err)
+            log_and_raise(status.HTTP_400_BAD_REQUEST, reason=err)
         # {"name": "bugs"} -> [Function.name=="bugs"]
         db_query = [getattr(cls, key) == value for key, value in query.items()]
         # TODO: Change _query to query?

--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -1,5 +1,3 @@
-from distutils.util import strtobool
-
 from fastapi import APIRouter
 
 from mlrun.run import list_piplines
@@ -14,10 +12,9 @@ def list_workflows(
     namespace: str = None,
     sort_by: str = "",
     page_token: str = "",
-    full: str = "0",
+    full: bool = False,
     page_size: int = 10,
 ):
-    full = strtobool(full)
     total_size, next_page_token, runs = list_piplines(
         full=full,
         page_token=page_token,

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -1,10 +1,8 @@
 import traceback
-from http import HTTPStatus
 from os import environ
 from pathlib import Path
 
-from fastapi import HTTPException
-from fastapi import Request
+from fastapi import HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from mlrun.api import schemas
@@ -18,7 +16,7 @@ from mlrun.run import import_function, new_function
 from mlrun.utils import get_in, logger, parse_function_uri
 
 
-def log_and_raise(status=HTTPStatus.BAD_REQUEST, **kw):
+def log_and_raise(status=status.HTTP_400_BAD_REQUEST, **kw):
     logger.error(str(kw))
     raise HTTPException(status_code=status, detail=kw)
 
@@ -65,7 +63,7 @@ def submit(db_session: Session, data):
         url = get_in(task, "spec.function")
     if not (function or url) or not task:
         log_and_raise(
-            HTTPStatus.BAD_REQUEST,
+            status.HTTP_400_BAD_REQUEST,
             reason="bad JSON, need to include function/url and task objects",
         )
 
@@ -86,7 +84,7 @@ def submit(db_session: Session, data):
                 )
                 if not runtime:
                     log_and_raise(
-                        HTTPStatus.BAD_REQUEST,
+                        status.HTTP_400_BAD_REQUEST,
                         reason="runtime error: function {} not found".format(url),
                     )
                 fn = new_function(runtime=runtime)
@@ -135,7 +133,9 @@ def submit(db_session: Session, data):
 
     except Exception as err:
         logger.error(traceback.format_exc())
-        log_and_raise(HTTPStatus.BAD_REQUEST, reason="runtime error: {}".format(err))
+        log_and_raise(
+            status.HTTP_400_BAD_REQUEST, reason="runtime error: {}".format(err)
+        )
 
     logger.info("response: %s", response)
     return {

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -1,5 +1,4 @@
-from http import HTTPStatus
-
+from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -7,5 +6,5 @@ from sqlalchemy.orm import Session
 def test_list_artifact_tags(db: Session, client: TestClient) -> None:
     project = 'p11'
     resp = client.get(f'/api/projects/{project}/artifact-tags')
-    assert resp.status_code == HTTPStatus.OK, 'status'
+    assert resp.status_code == status.HTTP_200_OK, 'status'
     assert resp.json()['project'] == project, 'project'

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -1,6 +1,6 @@
-from http import HTTPStatus
 from uuid import uuid4
 
+from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -14,7 +14,7 @@ def test_project(db: Session, client: TestClient) -> None:
         # 'users': ['u1', 'u2'],
     }
     resp = client.post('/api/project', json=prj1)
-    assert resp.status_code == HTTPStatus.OK, 'add'
+    assert resp.status_code == status.HTTP_200_OK, 'add'
     resp = client.get(f'/api/project/{name1}')
     out = {key: val for key, val in resp.json()['project'].items() if val}
     # out['users'].sort()
@@ -23,7 +23,7 @@ def test_project(db: Session, client: TestClient) -> None:
 
     data = {'description': 'lemon', 'name': name1}
     resp = client.post(f'/api/project/{name1}', json=data)
-    assert resp.status_code == HTTPStatus.OK, 'update'
+    assert resp.status_code == status.HTTP_200_OK, 'update'
     resp = client.get(f'/api/project/{name1}')
     assert name1 == resp.json()['project']['name'], 'name after update'
 
@@ -35,7 +35,7 @@ def test_project(db: Session, client: TestClient) -> None:
         # 'users': ['u1', 'u3'],
     }
     resp = client.post('/api/project', json=prj2)
-    assert resp.status_code == HTTPStatus.OK, 'add (2)'
+    assert resp.status_code == status.HTTP_200_OK, 'add (2)'
 
     resp = client.get('/api/projects')
     expected = {name1, name2}

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -1,10 +1,9 @@
-from http import HTTPStatus
-
+from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 
 def test_list_schedules(db: Session, client: TestClient) -> None:
     resp = client.get('/api/projects/default/schedules')
-    assert resp.status_code == HTTPStatus.OK, 'status'
+    assert resp.status_code == status.HTTP_200_OK, 'status'
     assert 'schedules' in resp.json(), 'no schedules'

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -1,5 +1,4 @@
-from http import HTTPStatus
-
+from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -12,7 +11,7 @@ def test_submit_job_failure_function_not_found(db: Session, client: TestClient) 
         'task': {'spec': {'function': function_reference}},
     }
     resp = client.post('/api/submit_job', json=body)
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
     assert (
         resp.json()['detail']['reason']
         == f"runtime error: function {function_reference} not found"

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -1,6 +1,6 @@
-from http import HTTPStatus
 from uuid import uuid4
 
+from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -15,21 +15,21 @@ def test_tag(db: Session, client: TestClient) -> None:
         fn = new_function(name=name, project=prj).to_dict()
         tag = uuid4().hex
         resp = client.post(f'/api/func/{prj}/{name}?tag={tag}', json=fn)
-        assert resp.status_code == HTTPStatus.OK, 'status create'
+        assert resp.status_code == status.HTTP_200_OK, 'status create'
     tag = 't1'
     tagged = {fn_name(i) for i in (1, 3, 4)}
     for name in tagged:
         query = {'functions': {'name': name}}
         resp = client.post(f'/api/{prj}/tag/{tag}', json=query)
-        assert resp.status_code == HTTPStatus.OK, 'status tag'
+        assert resp.status_code == status.HTTP_200_OK, 'status tag'
 
     resp = client.get(f'/api/{prj}/tag/{tag}')
-    assert resp.status_code == HTTPStatus.OK, 'status get tag'
+    assert resp.status_code == status.HTTP_200_OK, 'status get tag'
     objs = resp.json()['objects']
     assert {obj['name'] for obj in objs} == tagged, 'tagged'
 
     resp = client.delete(f'/api/{prj}/tag/{tag}')
-    assert resp.status_code == HTTPStatus.OK, 'delete'
+    assert resp.status_code == status.HTTP_200_OK, 'delete'
     resp = client.get(f'/api/{prj}/tags')
-    assert resp.status_code == HTTPStatus.OK, 'list tags'
+    assert resp.status_code == status.HTTP_200_OK, 'list tags'
     assert tag not in resp.json()['tags'], 'tag not deleted'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,12 @@
 
 import shutil
 from datetime import datetime
-from http import HTTPStatus
 from os import environ
 from pathlib import Path
 from sys import platform
 from time import monotonic, sleep
 from urllib.request import URLError, urlopen
+from fastapi import status
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -86,7 +86,7 @@ def wait_for_server(url, timeout_sec):
     while monotonic() - start <= timeout_sec:
         try:
             with urlopen(url) as resp:
-                if resp.status == HTTPStatus.OK:
+                if resp.status == status.HTTP_200_OK:
                     return True
         except (URLError, ConnectionError):
             pass

--- a/tests/integration/test-notebooks.yml
+++ b/tests/integration/test-notebooks.yml
@@ -1,18 +1,18 @@
 env:
   # The mlrun-api URL. e.g. https://mlrun-api.default-tenant.app.hedingber-28-1.iguazio-cd2.com
-  MLRUN_DBPATH:
+  MLRUN_DBPATH: https://admin:42f21a2a-5647-4cd5-95a9-983263ee8814@mlrun-api.default-tenant.app.pwacdqrgqtcn.iguazio-cd2.com
 
   # The webapi https_direct url - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com:8444
-  V3IO_API:
+  V3IO_API: https://default-tenant.app.pwacdqrgqtcn.iguazio-cd2.com:8444
 
   # user used to add v3io mounts to pods - e.g. iguazio
-  V3IO_USERNAME:
+  V3IO_USERNAME: admin
 
   # password used to generate control sessions (needed only in 2.8) - e.g. password
-  V3IO_PASSWORD:
+  V3IO_PASSWORD: 24Tango!
 
   # access key used to add v3io mounts to pods - e.g. 4c1c2011-618f-434a-abd6-d456770fd33c
-  V3IO_ACCESS_KEY:
+  V3IO_ACCESS_KEY: 42f21a2a-5647-4cd5-95a9-983263ee8814
 
 notebook_tests:
 - notebook_name: mlrun_db.ipynb

--- a/tests/integration/test-notebooks.yml
+++ b/tests/integration/test-notebooks.yml
@@ -1,18 +1,18 @@
 env:
   # The mlrun-api URL. e.g. https://mlrun-api.default-tenant.app.hedingber-28-1.iguazio-cd2.com
-  MLRUN_DBPATH: https://admin:42f21a2a-5647-4cd5-95a9-983263ee8814@mlrun-api.default-tenant.app.pwacdqrgqtcn.iguazio-cd2.com
+  MLRUN_DBPATH:
 
   # The webapi https_direct url - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com:8444
-  V3IO_API: https://default-tenant.app.pwacdqrgqtcn.iguazio-cd2.com:8444
+  V3IO_API:
 
   # user used to add v3io mounts to pods - e.g. iguazio
-  V3IO_USERNAME: admin
+  V3IO_USERNAME:
 
   # password used to generate control sessions (needed only in 2.8) - e.g. password
-  V3IO_PASSWORD: 24Tango!
+  V3IO_PASSWORD:
 
   # access key used to add v3io mounts to pods - e.g. 4c1c2011-618f-434a-abd6-d456770fd33c
-  V3IO_ACCESS_KEY: 42f21a2a-5647-4cd5-95a9-983263ee8814
+  V3IO_ACCESS_KEY:
 
 notebook_tests:
 - notebook_name: mlrun_db.ipynb


### PR DESCRIPTION
- Converted all uses of `http.HTTPStatus` to `fastapi.status`
- Converted all boolean url params to be actual booleans instead of strings which then get converted using `strtobool`