### PR TITLE
Unauthorized v3io file access

### DIFF
--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -1,9 +1,10 @@
 import mimetypes
 from http import HTTPStatus
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, Query, Request, Response, status
 
 from mlrun.api.api.utils import log_and_raise, get_obj_path, get_secrets
+from mlrun.datastore.base import ForbiddenPathAccessException
 from mlrun.datastore import get_object_stat, store_manager
 
 router = APIRouter()
@@ -41,6 +42,8 @@ def get_files(
         body = obj.get(size, offset)
     except FileNotFoundError as e:
         log_and_raise(HTTPStatus.NOT_FOUND, path=objpath, err=str(e))
+    except ForbiddenPathAccessException as e:
+        log_and_raise(status.HTTP_403_FORBIDDEN, path=objpath, err=str(e))
     if body is None:
         log_and_raise(HTTPStatus.NOT_FOUND, path=objpath)
 

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -79,6 +79,15 @@ def get_filestat(request: Request, schema: str = "", path: str = "", user: str =
         stat = get_object_stat(path, secrets)
     except FileNotFoundError as e:
         log_and_raise(HTTPStatus.NOT_FOUND, path=path, err=str(e))
+    except ForbiddenPathAccessException as e:
+        log_and_raise(status.HTTP_403_FORBIDDEN, path=path, err=str(e))
+    except requests.HTTPError as e:
+        if e.response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]:
+            log_and_raise(status.HTTP_403_FORBIDDEN, path=path, err=str(e))
+        raise e
 
     ctype, _ = mimetypes.guess_type(path)
     if not ctype:

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -19,7 +19,6 @@ from tempfile import mktemp
 import requests
 import urllib3
 import pandas as pd
-from fastapi import status
 
 from mlrun.utils import logger
 

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -281,7 +281,9 @@ def http_get(url, headers=None, auth=None):
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
 
     if resp.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
-        raise ForbiddenPathAccessException(url)
+        resp.raise_for_status()
+    # if resp.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
+    #     raise ForbiddenPathAccessException(url)
 
     if not resp.ok:
         raise OSError('failed to read file in {}'.format(url))

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -221,7 +221,12 @@ class DataItem:
 
     def listdir(self):
         """return a list of child file names"""
-        return self._store.listdir(self._path)
+        try:
+            return self._store.listdir(self._path)
+        except RuntimeError as e:
+            if 'Permission denied' in str(e):
+                raise ForbiddenPathAccessException(self._path)
+            raise e
 
     def local(self):
         """get the local path of the file, download to tmp first if its a remote object"""
@@ -279,11 +284,7 @@ def http_get(url, headers=None, auth=None):
         raise ForbiddenPathAccessException(url)
 
     if not resp.ok:
-        raise OSError(
-            'failed to read file in {0}, status code: {1}, content: {2}'.format(
-                url, resp.status_code, resp.content
-            )
-        )
+        raise OSError('failed to read file in {}'.format(url))
     return resp.content
 
 

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -283,6 +283,10 @@ def http_head(url, headers=None, auth=None):
         resp = requests.head(url, headers=headers, auth=auth, verify=verify_ssl)
     except OSError as e:
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
+
+    if resp.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
+        resp.raise_for_status()
+
     if not resp.ok:
         raise OSError('failed to read file head in {}'.format(url))
     return resp.headers

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -28,11 +28,6 @@ if not verify_ssl:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
-class ForbiddenPathAccessException(Exception):
-    def __init__(self, accessed_path):
-        super().__init__('Access to the path {0} is forbidden'.format(accessed_path))
-
-
 class FileStats:
     def __init__(self, size, modified, content_type=None):
         self.size = size
@@ -201,12 +196,7 @@ class DataItem:
 
     def get(self, size=None, offset=0):
         """read all or a range and return the content"""
-        try:
-            return self._store.get(self._path, size=size, offset=offset)
-        except requests.HTTPError as e:
-            if e.response.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
-                raise ForbiddenPathAccessException(self._path)
-            raise e
+        return self._store.get(self._path, size=size, offset=offset)
 
     def download(self, target_path):
         """download to the target dir/path"""
@@ -226,12 +216,7 @@ class DataItem:
 
     def listdir(self):
         """return a list of child file names"""
-        try:
-            return self._store.listdir(self._path)
-        except RuntimeError as e:
-            if 'Permission denied' in str(e):
-                raise ForbiddenPathAccessException(self._path)
-            raise e
+        return self._store.listdir(self._path)
 
     def local(self):
         """get the local path of the file, download to tmp first if its a remote object"""

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -28,6 +28,11 @@ if not verify_ssl:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
+class ForbiddenPathAccessException(Exception):
+    def __init__(self, accessed_path):
+        super().__init__('Access to the path {0} is forbidden'.format(accessed_path))
+
+
 class FileStats:
     def __init__(self, size, modified, content_type=None):
         self.size = size
@@ -266,30 +271,24 @@ def basic_auth_header(user, password):
 
 def http_get(url, headers=None, auth=None):
     try:
-        resp = requests.get(url, headers=headers, auth=auth, verify=verify_ssl)
+        response = requests.get(url, headers=headers, auth=auth, verify=verify_ssl)
     except OSError as e:
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
 
-    if resp.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
-        resp.raise_for_status()
+    response.raise_for_status()
 
-    if not resp.ok:
-        raise OSError('failed to read file in {}'.format(url))
-    return resp.content
+    return response.content
 
 
 def http_head(url, headers=None, auth=None):
     try:
-        resp = requests.head(url, headers=headers, auth=auth, verify=verify_ssl)
+        response = requests.head(url, headers=headers, auth=auth, verify=verify_ssl)
     except OSError as e:
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
 
-    if resp.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
-        resp.raise_for_status()
+    response.raise_for_status()
 
-    if not resp.ok:
-        raise OSError('failed to read file head in {}'.format(url))
-    return resp.headers
+    return response.headers
 
 
 def http_put(url, data, headers=None, auth=None):

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -279,7 +279,11 @@ def http_get(url, headers=None, auth=None):
         raise ForbiddenPathAccessException(url)
 
     if not resp.ok:
-        raise OSError('failed to read file in {0}, status code: {1}'.format(url, resp.status_code))
+        raise OSError(
+            'failed to read file in {0}, status code: {1}, content: {2}'.format(
+                url, resp.status_code, resp.content
+            )
+        )
     return resp.content
 
 

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -279,7 +279,7 @@ def http_get(url, headers=None, auth=None):
         raise ForbiddenPathAccessException(url)
 
     if not resp.ok:
-        raise OSError('failed to read file in {}'.format(url))
+        raise OSError('failed to read file in {0}, status code: {1}'.format(url, resp.status_code))
     return resp.content
 
 

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -30,15 +30,11 @@ from .base import (
     http_put,
     http_head,
     http_upload,
+    ForbiddenPathAccessException
 )
 
 
 V3IO_LOCAL_ROOT = 'v3io'
-
-
-class ForbiddenPathAccessException(Exception):
-    def __init__(self, accessed_path):
-        super().__init__('Access to the path {0} is forbidden'.format(accessed_path))
 
 
 class V3ioStore(DataStore):

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -30,7 +30,7 @@ from .base import (
     http_put,
     http_head,
     http_upload,
-    ForbiddenPathAccessException
+    ForbiddenPathAccessException,
 )
 
 

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -14,9 +14,16 @@
 from os import listdir
 from tempfile import TemporaryDirectory
 
-from tests.conftest import rundb_path
-import mlrun
 import pandas as pd
+import requests
+from fastapi import status
+from unittest.mock import Mock
+import pytest
+
+import mlrun
+from mlrun.datastore.v3io import ForbiddenPathAccessException
+import v3io.dataplane
+from tests.conftest import rundb_path
 
 mlrun.mlconf.dbpath = rundb_path
 
@@ -94,3 +101,35 @@ def test_parse_url_preserve_case():
     expected_endpoint = 'Hedi'
     _, endpoint, _ = mlrun.datastore.datastore.parse_url(url)
     assert expected_endpoint, endpoint
+
+
+def test_forbidden_file_access(monkeypatch):
+    class MockV3ioClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_container_contents(self, *args, **kwargs):
+            raise RuntimeError('Permission denied')
+
+    def mock_get(*args, **kwargs):
+        mock_forbidden_response = Mock()
+        mock_forbidden_response.status_code = status.HTTP_403_FORBIDDEN
+        mock_forbidden_response.raise_for_status = Mock(
+            side_effect=requests.HTTPError('Error', response=mock_forbidden_response)
+        )
+        return mock_forbidden_response
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr(v3io.dataplane, "Client", MockV3ioClient)
+
+    store = mlrun.datastore.datastore.StoreManager(
+        secrets={'V3IO_ACCESS_KEY': 'some-access-key'}
+    )
+
+    with pytest.raises(ForbiddenPathAccessException):
+        obj = store.object('v3io://some-system/some-dir/')
+        obj.listdir()
+
+    with pytest.raises(ForbiddenPathAccessException):
+        obj = store.object('v3io://some-system/some-dir/some-file')
+        obj.get()

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -120,6 +120,7 @@ def test_forbidden_file_access(monkeypatch):
         return mock_forbidden_response
 
     monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr(requests, "head", mock_get)
     monkeypatch.setattr(v3io.dataplane, "Client", MockV3ioClient)
 
     store = mlrun.datastore.datastore.StoreManager(
@@ -133,3 +134,7 @@ def test_forbidden_file_access(monkeypatch):
     with pytest.raises(ForbiddenPathAccessException):
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.get()
+
+    with pytest.raises(ForbiddenPathAccessException):
+        obj = store.object('v3io://some-system/some-dir/some-file')
+        obj.stat()


### PR DESCRIPTION
When using `/files` or `/filestat`, if user is unauthorised to access the files in the v3io container, return a 403 status code