### PR TITLE
Pin models-gpu image python version to 3.7

### DIFF
--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -118,7 +118,7 @@ RUN conda config --add channels conda-forge && \
         wrapt
 
 RUN conda install -n base -c rapidsai -c nvidia \
-    -c anaconda -c conda-forge -c defaults rapids=0.12
+    -c anaconda -c conda-forge -c defaults rapids=0.12 python=3.7
 
 RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 


### PR DESCRIPTION
Building it raised this:
```
Step 17/27 : RUN conda install -n base -c rapidsai -c nvidia     -c anaconda -c conda-forge -c defaults rapids=0.12

 ---> Running in a4bee57dd883

Collecting package metadata (current_repodata.json): ...working... done

Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.

Solving environment: ...working... failed with repodata from current_repodata.json, will retry with next repodata source.

Collecting package metadata (repodata.json): ...working... done

Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.

Solving environment: ...working... 
Building graph of deps:   0%|          | 0/3 [00:00<?, ?it/s]
Examining python=3.8:   0%|          | 0/3 [00:00<?, ?it/s]  
Examining @/linux-64::__glibc==2.27=0:  33%|███▎      | 1/3 [00:00<00:01,  1.69it/s]
Examining @/linux-64::__glibc==2.27=0:  67%|██████▋   | 2/3 [00:00<00:00,  3.39it/s]
Examining rapids=0.12:  67%|██████▋   | 2/3 [00:00<00:00,  3.39it/s]                
                                                                    

Determining conflicts:   0%|          | 0/3 [00:00<?, ?it/s]
Examining conflict for python rapids:   0%|          | 0/3 [00:00<?, ?it/s]
                                                                           

Found conflicts! Looking for incompatible packages.

This can take several minutes.  Press CTRL-C to abort.

failed



UnsatisfiableError: The following specifications were found

to be incompatible with the existing python installation in your environment:



Specifications:



  - rapids=0.12 -> python[version='>=3.6,<3.7.0a0|>=3.7,<3.8.0a0']



Your python: python=3.8



If python is on the left-most side of the chain, that's the version you've asked for.

When python appears to the right, that indicates that the thing on the left is somehow

not available for the python version you are constrained to. Note that conda will not

change your python version to a different minor version unless you explicitly specify

that.
``` 
so pinning it to 3.7