### PR TITLE
Save versioned function at the end of deploy

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -213,7 +213,7 @@ def _build_function(db_session, function, with_mlrun):
         fn.save(versioned=False)
 
         ready = build_runtime(fn, with_mlrun)
-        fn.save(versioned=False)
+        fn.save(versioned=True)
         logger.info("Fn:\n %s", fn.to_yaml())
     except Exception as err:
         logger.error(traceback.format_exc())


### PR DESCRIPTION
We have a problem that a function saved with `versioned=False` is not query-able using its uid (hash-key)
When running/scheduling a function from the UI it uses the uid to identify a function. 
A function that was deployed but never ran last saved with `versioned=False` so it can't be triggered from the UI, doing this as an intermediate fix - we should make it so any function would be queryable by its uid