### PR TITLE
Save versioned function at the end of deploy - phase 2

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -193,7 +193,7 @@ def build_status(
     if state == "ready":
         update_in(fn, "spec.image", image)
 
-    get_db().store_function(db_session, fn, name, project, tag)
+    get_db().store_function(db_session, fn, name, project, tag, versioned=True)
 
     return Response(
         content=out,
@@ -213,7 +213,7 @@ def _build_function(db_session, function, with_mlrun):
         fn.save(versioned=False)
 
         ready = build_runtime(fn, with_mlrun)
-        fn.save(versioned=True)
+        fn.save(versioned=False)
         logger.info("Fn:\n %s", fn.to_yaml())
     except Exception as err:
         logger.error(traceback.format_exc())

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -213,7 +213,7 @@ def _build_function(db_session, function, with_mlrun):
         fn.save(versioned=False)
 
         ready = build_runtime(fn, with_mlrun)
-        fn.save(versioned=False)
+        fn.save(versioned=True)
         logger.info("Fn:\n %s", fn.to_yaml())
     except Exception as err:
         logger.error(traceback.format_exc())

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -193,7 +193,10 @@ def build_status(
     if state == "ready":
         update_in(fn, "spec.image", image)
 
-    get_db().store_function(db_session, fn, name, project, tag, versioned=True)
+    versioned = False
+    if state == "ready":
+        versioned = True
+    get_db().store_function(db_session, fn, name, project, tag, versioned=versioned)
 
     return Response(
         content=out,


### PR DESCRIPTION
Continuing https://github.com/mlrun/mlrun/pull/386 - currently the way `deploy` works is that by default (can be changed with the `watch` arg) the client "polls" the `/build/status` endpoint, which also does `store_function` each time, so this actually do the last `store_function` in the `deploy` phase, therefore added logic to `store_function` with `versioned=True` when `state == "ready"`