### PR TITLE
Bound ipython version to less than 7.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kfp==0.2.5
 nest-asyncio>=1.0.0
 # <0.16 from botocore inside nuclio-jupyter, >=0.13.1 from readme-renderer inside twine (from dev-requirements)
 docutils<0.16, >=0.13.1
-# >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and legacy images build fail)
+# >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
 nuclio-jupyter>=0.8.3
 pandas>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ kfp==0.2.5
 nest-asyncio>=1.0.0
 # <0.16 from botocore inside nuclio-jupyter, >=0.13.1 from readme-renderer inside twine (from dev-requirements)
 docutils<0.16, >=0.13.1
+# >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and legacy images build fail)
+ipython>=5.5, <7.17
 nuclio-jupyter>=0.8.3
 pandas>=1.0.1
 pyarrow>=0.13


### PR DESCRIPTION
cause from 7.17 python 3.6 is not supported and models-gpu-legacy image build fail