### PR TITLE
MLRun Errors + v3io access forbidden uses errors

### DIFF
--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -39,10 +39,10 @@ def get_files(
             }
 
         body = obj.get(size, offset)
-    except FileNotFoundError as e:
-        log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath, err=str(e))
-    except MLRunDataStoreError as e:
-        log_and_raise(e.response.status_code, path=objpath, err=str(e))
+    except FileNotFoundError as exc:
+        log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath, err=str(exc))
+    except MLRunDataStoreError as exc:
+        log_and_raise(exc.response.status_code, path=objpath, err=str(exc))
 
     if body is None:
         log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath)
@@ -69,10 +69,10 @@ def get_filestat(request: Request, schema: str = "", path: str = "", user: str =
     stat = None
     try:
         stat = get_object_stat(path, secrets)
-    except FileNotFoundError as e:
-        log_and_raise(status.HTTP_404_NOT_FOUND, path=path, err=str(e))
-    except MLRunDataStoreError as e:
-        log_and_raise(e.response.status_code, path=path, err=str(e))
+    except FileNotFoundError as exc:
+        log_and_raise(status.HTTP_404_NOT_FOUND, path=path, err=str(exc))
+    except MLRunDataStoreError as exc:
+        log_and_raise(exc.response.status_code, path=path, err=str(exc))
 
     ctype, _ = mimetypes.guess_type(path)
     if not ctype:

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Query, Request, Response, status
 
 from mlrun.api.api.utils import log_and_raise, get_obj_path, get_secrets
 from mlrun.datastore import get_object_stat, store_manager
+from mlrun.errors import MLRunDataStoreError
 
 router = APIRouter()
 
@@ -40,6 +41,9 @@ def get_files(
         body = obj.get(size, offset)
     except FileNotFoundError as e:
         log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath, err=str(e))
+    except MLRunDataStoreError as e:
+        log_and_raise(e.response.status_code, path=objpath, err=str(e))
+
     if body is None:
         log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath)
 
@@ -67,6 +71,8 @@ def get_filestat(request: Request, schema: str = "", path: str = "", user: str =
         stat = get_object_stat(path, secrets)
     except FileNotFoundError as e:
         log_and_raise(status.HTTP_404_NOT_FOUND, path=path, err=str(e))
+    except MLRunDataStoreError as e:
+        log_and_raise(e.response.status_code, path=path, err=str(e))
 
     ctype, _ = mimetypes.guess_type(path)
     if not ctype:

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -20,6 +20,7 @@ import requests
 import urllib3
 import pandas as pd
 
+import mlrun.errors
 from mlrun.utils import logger
 
 verify_ssl = False
@@ -265,34 +266,35 @@ def basic_auth_header(user, password):
 
 def http_get(url, headers=None, auth=None):
     try:
-        resp = requests.get(url, headers=headers, auth=auth, verify=verify_ssl)
+        response = requests.get(url, headers=headers, auth=auth, verify=verify_ssl)
     except OSError as e:
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
 
-    if not resp.ok:
-        raise OSError('failed to read file in {}'.format(url))
-    return resp.content
+    mlrun.errors.raise_for_status(response)
+
+    return response.content
 
 
 def http_head(url, headers=None, auth=None):
     try:
-        resp = requests.head(url, headers=headers, auth=auth, verify=verify_ssl)
+        response = requests.head(url, headers=headers, auth=auth, verify=verify_ssl)
     except OSError as e:
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
-    if not resp.ok:
-        raise OSError('failed to read file head in {}'.format(url))
-    return resp.headers
+
+    mlrun.errors.raise_for_status(response)
+
+    return response.headers
 
 
 def http_put(url, data, headers=None, auth=None):
     try:
-        resp = requests.put(
+        response = requests.put(
             url, data=data, headers=headers, auth=auth, verify=verify_ssl
         )
     except OSError as e:
         raise OSError('error: cannot connect to {}: {}'.format(url, e))
-    if not resp.ok:
-        raise OSError('failed to upload to {} {}'.format(url, resp.status_code))
+
+    mlrun.errors.raise_for_status(response)
 
 
 def http_upload(url, file_path, headers=None, auth=None):

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -18,7 +18,7 @@ from os import environ
 import time
 import v3io.dataplane
 
-from mlrun.errors import AccessForbiddenError
+import mlrun.errors
 from ..platforms.iguazio import split_path
 from .base import (
     DataStore,
@@ -109,10 +109,12 @@ class V3ioStore(DataStore):
                 get_all_attributes=False,
                 directories_only=False,
             )
-        except RuntimeError as e:
-            if 'Permission denied' in str(e):
-                raise AccessForbiddenError(f'Access forbidden to path: {key}') from e
-            raise e
+        except RuntimeError as exc:
+            if 'Permission denied' in str(exc):
+                raise mlrun.errors.AccessDeniedError(
+                    f'Access denied to path: {key}'
+                ) from exc
+            raise
 
         # todo: full = key, size, last_modified
         return [obj.key[subpath_length:] for obj in response.output.contents]

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -1,0 +1,69 @@
+import requests
+from fastapi import status
+
+
+class MLRunSDKError(Exception):
+    pass
+
+
+class MLRunHTTPError(MLRunSDKError, requests.HTTPError):
+    def __init__(
+        self, message: str, response: requests.Response = None, status_code: int = None
+    ):
+
+        # because response object is probably with an error, it returns False, so we
+        # should use 'is None' specifically
+        if response is None:
+            response = requests.Response()
+        if status_code:
+            response.status_code = status_code
+
+        requests.HTTPError.__init__(self, message, response=response)
+
+
+class MLRunDataStoreError(MLRunHTTPError):
+    error_status_code = None
+
+    def __init__(self, message: str, response: requests.Response = None):
+        super(MLRunDataStoreError, self).__init__(
+            message, response=response, status_code=self.error_status_code
+        )
+
+
+class MLRunDBError(MLRunHTTPError):
+    pass
+
+
+def raise_for_status(response: requests.Response):
+    """
+    Raise a specific MLRunSDK error depending on the given response status code.
+    If no specific error exists, raises an MLRunHTTPError
+    """
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        if response.status_code in STATUS_ERRORS:
+            raise STATUS_ERRORS[response.status_code](str(e), response=response) from e
+        raise MLRunHTTPError(str(e), response=response)
+
+
+# Specific Errors
+
+
+class UnauthorizedError(MLRunDataStoreError):
+    error_status_code = status.HTTP_401_UNAUTHORIZED
+
+
+class AccessForbiddenError(MLRunDataStoreError):
+    error_status_code = status.HTTP_403_FORBIDDEN
+
+
+class NotFoundError(MLRunDataStoreError):
+    error_status_code = status.HTTP_404_NOT_FOUND
+
+
+STATUS_ERRORS = {
+    status.HTTP_401_UNAUTHORIZED: UnauthorizedError,
+    status.HTTP_403_FORBIDDEN: AccessForbiddenError,
+    status.HTTP_404_NOT_FOUND: NotFoundError,
+}

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -21,7 +21,7 @@ from unittest.mock import Mock
 import pytest
 
 import mlrun
-from mlrun.errors import AccessForbiddenError
+import mlrun.errors
 import v3io.dataplane
 from tests.conftest import rundb_path
 
@@ -127,20 +127,20 @@ def test_forbidden_file_access(monkeypatch):
         secrets={'V3IO_ACCESS_KEY': 'some-access-key'}
     )
 
-    with pytest.raises(AccessForbiddenError) as forbidden_exc:
+    with pytest.raises(mlrun.errors.AccessDeniedError) as access_denied_exc:
         obj = store.object('v3io://some-system/some-dir/')
         obj.listdir()
 
-    assert forbidden_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
+    assert access_denied_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
 
-    with pytest.raises(AccessForbiddenError) as forbidden_exc:
+    with pytest.raises(mlrun.errors.AccessDeniedError) as access_denied_exc:
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.get()
 
-    assert forbidden_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
+    assert access_denied_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
 
-    with pytest.raises(AccessForbiddenError) as forbidden_exc:
+    with pytest.raises(mlrun.errors.AccessDeniedError) as access_denied_exc:
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.stat()
 
-    assert forbidden_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
+    assert access_denied_exc.value.response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
- Added `errors.py` to mlrun.
- The errors are built in a way that they can be used as HTTP errors with a custom `raise_for_status(response)` function, or just regular errors that aren't HTTP.

Used the errors in:
- When using /files or /filestat, if user is unauthorised to access the files in the v3io container, return a 403 status code