### PR TITLE
Replace back fastapi status with http status

### DIFF
--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -1,8 +1,9 @@
 from base64 import b64decode
+from http import HTTPStatus
 from typing import Generator
-from sqlalchemy.orm import Session
 
-from fastapi import Request, status
+from fastapi import Request
+from sqlalchemy.orm import Session
 
 from mlrun.api.api.utils import log_and_raise
 from mlrun.api.db.session import create_session, close_session
@@ -31,20 +32,20 @@ class AuthVerifier:
         header = request.headers.get('Authorization', '')
         if self._basic_auth_required(cfg):
             if not header.startswith(self._basic_prefix):
-                log_and_raise(status.HTTP_401_UNAUTHORIZED, reason="missing basic auth")
+                log_and_raise(HTTPStatus.UNAUTHORIZED.value, reason="missing basic auth")
             user, password = self._parse_basic_auth(header)
             if user != cfg.user or password != cfg.password:
-                log_and_raise(status.HTTP_401_UNAUTHORIZED, reason="bad basic auth")
+                log_and_raise(HTTPStatus.UNAUTHORIZED.value, reason="bad basic auth")
             self.username = user
             self.password = password
         elif self._bearer_auth_required(cfg):
             if not header.startswith(self._bearer_prefix):
                 log_and_raise(
-                    status.HTTP_401_UNAUTHORIZED, reason="missing bearer auth"
+                    HTTPStatus.UNAUTHORIZED.valueD, reason="missing bearer auth"
                 )
             token = header[len(self._bearer_prefix) :]
             if token != cfg.token:
-                log_and_raise(status.HTTP_401_UNAUTHORIZED, reason="bad basic auth")
+                log_and_raise(HTTPStatus.UNAUTHORIZED.value, reason="bad basic auth")
             self.token = token
 
     @staticmethod

--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -32,7 +32,9 @@ class AuthVerifier:
         header = request.headers.get('Authorization', '')
         if self._basic_auth_required(cfg):
             if not header.startswith(self._basic_prefix):
-                log_and_raise(HTTPStatus.UNAUTHORIZED.value, reason="missing basic auth")
+                log_and_raise(
+                    HTTPStatus.UNAUTHORIZED.value, reason="missing basic auth"
+                )
             user, password = self._parse_basic_auth(header)
             if user != cfg.user or password != cfg.password:
                 log_and_raise(HTTPStatus.UNAUTHORIZED.value, reason="bad basic auth")

--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -1,6 +1,7 @@
+from http import HTTPStatus
 from typing import List
 
-from fastapi import APIRouter, Depends, Request, Query, status
+from fastapi import APIRouter, Depends, Request, Query
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -28,7 +29,7 @@ async def store_artifact(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     logger.debug(data)
     await run_in_threadpool(

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -1,6 +1,7 @@
 import mimetypes
+from http import HTTPStatus
 
-from fastapi import APIRouter, Query, Request, Response, status
+from fastapi import APIRouter, Query, Request, Response
 
 from mlrun.api.api.utils import log_and_raise, get_obj_path, get_secrets
 from mlrun.datastore import get_object_stat, store_manager
@@ -24,7 +25,7 @@ def get_files(
     objpath = get_obj_path(schema, objpath, user=user)
     if not objpath:
         log_and_raise(
-            status.HTTP_404_NOT_FOUND, path=objpath, err="illegal path prefix or schema"
+            HTTPStatus.NOT_FOUND.value, path=objpath, err="illegal path prefix or schema"
         )
 
     secrets = get_secrets(request)
@@ -40,12 +41,12 @@ def get_files(
 
         body = obj.get(size, offset)
     except FileNotFoundError as exc:
-        log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath, err=str(exc))
+        log_and_raise(HTTPStatus.NOT_FOUND.value, path=objpath, err=str(exc))
     except MLRunDataStoreError as exc:
         log_and_raise(exc.response.status_code, path=objpath, err=str(exc))
 
     if body is None:
-        log_and_raise(status.HTTP_404_NOT_FOUND, path=objpath)
+        log_and_raise(HTTPStatus.NOT_FOUND.value, path=objpath)
 
     ctype, _ = mimetypes.guess_type(objpath)
     if not ctype:
@@ -63,14 +64,14 @@ def get_filestat(request: Request, schema: str = "", path: str = "", user: str =
     path = get_obj_path(schema, path, user=user)
     if not path:
         log_and_raise(
-            status.HTTP_404_NOT_FOUND, path=path, err="illegal path prefix or schema"
+            HTTPStatus.NOT_FOUND.value, path=path, err="illegal path prefix or schema"
         )
     secrets = get_secrets(request)
     stat = None
     try:
         stat = get_object_stat(path, secrets)
     except FileNotFoundError as exc:
-        log_and_raise(status.HTTP_404_NOT_FOUND, path=path, err=str(exc))
+        log_and_raise(HTTPStatus.NOT_FOUND.value, path=path, err=str(exc))
     except MLRunDataStoreError as exc:
         log_and_raise(exc.response.status_code, path=path, err=str(exc))
 

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -25,7 +25,9 @@ def get_files(
     objpath = get_obj_path(schema, objpath, user=user)
     if not objpath:
         log_and_raise(
-            HTTPStatus.NOT_FOUND.value, path=objpath, err="illegal path prefix or schema"
+            HTTPStatus.NOT_FOUND.value,
+            path=objpath,
+            err="illegal path prefix or schema",
         )
 
     secrets = get_secrets(request)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -1,8 +1,9 @@
 import traceback
 from distutils.util import strtobool
+from http import HTTPStatus
 from typing import List
 
-from fastapi import APIRouter, Depends, Request, Query, Response, status
+from fastapi import APIRouter, Depends, Request, Query, Response
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -33,7 +34,7 @@ async def store_function(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     logger.debug(data)
     logger.info("store function: project=%s, name=%s, tag=%s", project, name, tag)
@@ -91,7 +92,7 @@ async def build_function(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     logger.info("build_function:\n{}".format(data))
     function = data.get("function")
@@ -115,7 +116,7 @@ async def start_function(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     fn = await run_in_threadpool(_start_function, db_session, data)
 
@@ -132,7 +133,7 @@ async def function_status(request: Request):
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     resp = await run_in_threadpool(_get_function_status, data)
     return {
@@ -153,7 +154,7 @@ def build_status(
 ):
     fn = get_db().get_function(db_session, name, project, tag)
     if not fn:
-        log_and_raise(status.HTTP_404_NOT_FOUND, name=name, project=project, tag=tag)
+        log_and_raise(HTTPStatus.NOT_FOUND.value, name=name, project=project, tag=tag)
 
     state = get_in(fn, "status.state", "")
     pod = get_in(fn, "status.build_pod", "")
@@ -219,7 +220,7 @@ def _build_function(db_session, function, with_mlrun):
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, reason="runtime error: {}".format(err)
+            HTTPStatus.BAD_REQUEST.value, reason="runtime error: {}".format(err)
         )
     return fn, ready
 
@@ -229,7 +230,7 @@ def _start_function(db_session, data):
     url = data.get("functionUrl")
     if not url:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="runtime error: functionUrl not specified",
         )
 
@@ -237,7 +238,7 @@ def _start_function(db_session, data):
     runtime = get_db().get_function(db_session, name, project, tag, hash_key)
     if not runtime:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="runtime error: function {} not found".format(url),
         )
 
@@ -245,7 +246,7 @@ def _start_function(db_session, data):
     resource = runtime_resources_map.get(fn.kind)
     if "start" not in resource:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="runtime error: 'start' not supported by this runtime",
         )
 
@@ -260,7 +261,7 @@ def _start_function(db_session, data):
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, reason="runtime error: {}".format(err)
+            HTTPStatus.BAD_REQUEST.value, reason="runtime error: {}".format(err)
         )
 
     return fn
@@ -272,14 +273,14 @@ def _get_function_status(data):
     kind = data.get("kind")
     if not selector or not kind:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="runtime error: selector or runtime kind not specified",
         )
 
     resource = runtime_resources_map.get(kind)
     if "status" not in resource:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="runtime error: 'status' not supported by this runtime",
         )
 
@@ -290,5 +291,5 @@ def _get_function_status(data):
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, reason="runtime error: {}".format(err)
+            HTTPStatus.BAD_REQUEST.value, reason="runtime error: {}".format(err)
         )

--- a/mlrun/api/api/endpoints/pipelines.py
+++ b/mlrun/api/api/endpoints/pipelines.py
@@ -1,9 +1,10 @@
 import ast
 import tempfile
 from datetime import datetime
+from http import HTTPStatus
 from os import remove
 
-from fastapi import APIRouter, Request, Query, status
+from fastapi import APIRouter, Request, Query
 from fastapi.concurrency import run_in_threadpool
 from kfp import Client as kfclient
 
@@ -29,7 +30,7 @@ async def submit_pipeline(
 
     data = await request.body()
     if not data:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="post data is empty")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="post data is empty")
 
     run = await run_in_threadpool(
         _submit_pipeline, request, data, namespace, experiment_name, run_name
@@ -53,7 +54,7 @@ def get_pipeline(run_id, namespace: str = Query(config.namespace)):
             run = run.to_dict()
     except Exception as e:
         log_and_raise(
-            status.HTTP_500_INTERNAL_SERVER_ERROR, reason="get kfp error: {}".format(e)
+            HTTPStatus.INTERNAL_SERVER_ERROR.value, reason="get kfp error: {}".format(e)
         )
 
     return run
@@ -73,7 +74,7 @@ def _submit_pipeline(request, data, namespace, experiment_name, run_name):
         ctype = ".zip"
     else:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="unsupported pipeline type {}".format(ctype),
         )
 
@@ -91,7 +92,7 @@ def _submit_pipeline(request, data, namespace, experiment_name, run_name):
         run = client.run_pipeline(experiment.id, run_name, pipe_tmp, params=arguments)
     except Exception as e:
         remove(pipe_tmp)
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="kfp err: {}".format(e))
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="kfp err: {}".format(e))
 
     remove(pipe_tmp)
 

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -1,6 +1,7 @@
+from http import HTTPStatus
 from typing import List
 
-from fastapi import APIRouter, Depends, Request, Query, status
+from fastapi import APIRouter, Depends, Request, Query
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -25,7 +26,7 @@ async def store_run(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     logger.debug(data)
     await run_in_threadpool(
@@ -48,7 +49,7 @@ async def update_run(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     logger.debug(data)
     await run_in_threadpool(

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,5 +1,7 @@
+from http import HTTPStatus
+
 from fastapi import APIRouter, Depends
-from fastapi import status, Response
+from fastapi import Response
 from sqlalchemy.orm import Session
 
 from mlrun.api.api import deps
@@ -26,7 +28,7 @@ def list_runtimes(label_selector: str = None):
 def get_runtime(kind: str, label_selector: str = None):
     if kind not in RuntimeKinds.runtime_with_handlers():
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind'
+            HTTPStatus.BAD_REQUEST.value, kind=kind, err='Invalid runtime kind'
         )
     runtime_handler = get_runtime_handler(kind)
     resources = runtime_handler.list_resources(label_selector)
@@ -48,7 +50,7 @@ def delete_runtimes(
         runtime_handler.delete_resources(
             get_db(), db_session, label_selector, force, grace_period
         )
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
 @router.delete("/runtimes/{kind}")
@@ -61,13 +63,13 @@ def delete_runtime(
 ):
     if kind not in RuntimeKinds.runtime_with_handlers():
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind'
+            HTTPStatus.BAD_REQUEST.value, kind=kind, err='Invalid runtime kind'
         )
     runtime_handler = get_runtime_handler(kind)
     runtime_handler.delete_resources(
         get_db(), db_session, label_selector, force, grace_period
     )
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
 # FIXME: find a more REST-y path
@@ -82,10 +84,10 @@ def delete_runtime_object(
 ):
     if kind not in RuntimeKinds.runtime_with_handlers():
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, kind=kind, err='Invalid runtime kind'
+            HTTPStatus.BAD_REQUEST.value, kind=kind, err='Invalid runtime kind'
         )
     runtime_handler = get_runtime_handler(kind)
     runtime_handler.delete_runtime_object_resources(
         get_db(), db_session, object_id, label_selector, force, grace_period
     )
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, Response, status
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy.orm import Session
 
 from mlrun.api import schemas
@@ -22,7 +24,7 @@ def create_schedule(
         schedule.scheduled_object,
         schedule.cron_trigger,
     )
-    return Response(status_code=status.HTTP_201_CREATED)
+    return Response(status_code=HTTPStatus.CREATED.value)
 
 
 @router.get("/projects/{project}/schedules", response_model=schemas.SchedulesOutput)
@@ -48,4 +50,4 @@ def delete_schedule(
     project: str, name: str, db_session: Session = Depends(deps.get_db_session),
 ):
     get_scheduler().delete_schedule(db_session, project, name)
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, Depends, Request, Header, status
+from http import HTTPStatus
 from typing import Optional
+
+from fastapi import APIRouter, Depends, Request, Header
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -24,7 +26,7 @@ async def submit_job(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     # enrich job task with the username from the request header
     if username:

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, Request, status
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, Request
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -21,7 +23,7 @@ async def tag_objects(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(status.HTTP_400_BAD_REQUEST, reason="bad JSON body")
+        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
     objs = await run_in_threadpool(_tag_objects, db_session, data, project, name)
     return {
@@ -70,7 +72,7 @@ def _tag_objects(db_session, data, project, name):
         cls = table2cls(typ)
         if cls is None:
             err = f"unknown type - {typ}"
-            log_and_raise(status.HTTP_400_BAD_REQUEST, reason=err)
+            log_and_raise(HTTPStatus.BAD_REQUEST.value, reason=err)
         # {"name": "bugs"} -> [Function.name=="bugs"]
         db_query = [getattr(cls, key) == value for key, value in query.items()]
         # TODO: Change _query to query?

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -1,8 +1,9 @@
 import traceback
+from http import HTTPStatus
 from os import environ
 from pathlib import Path
 
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request
 from sqlalchemy.orm import Session
 
 from mlrun.api import schemas
@@ -16,7 +17,7 @@ from mlrun.run import import_function, new_function
 from mlrun.utils import get_in, logger, parse_function_uri
 
 
-def log_and_raise(status=status.HTTP_400_BAD_REQUEST, **kw):
+def log_and_raise(status=HTTPStatus.BAD_REQUEST.value, **kw):
     logger.error(str(kw))
     raise HTTPException(status_code=status, detail=kw)
 
@@ -63,7 +64,7 @@ def submit(db_session: Session, data):
         url = get_in(task, "spec.function")
     if not (function or url) or not task:
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST,
+            HTTPStatus.BAD_REQUEST.value,
             reason="bad JSON, need to include function/url and task objects",
         )
 
@@ -84,7 +85,7 @@ def submit(db_session: Session, data):
                 )
                 if not runtime:
                     log_and_raise(
-                        status.HTTP_404_NOT_FOUND,
+                        HTTPStatus.NOT_FOUND.value,
                         reason="runtime error: function {} not found".format(url),
                     )
                 fn = new_function(runtime=runtime)
@@ -137,7 +138,7 @@ def submit(db_session: Session, data):
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(
-            status.HTTP_400_BAD_REQUEST, reason="runtime error: {}".format(err)
+            HTTPStatus.BAD_REQUEST.value, reason="runtime error: {}".format(err)
         )
 
     logger.info("response: %s", response)

--- a/mlrun/api/crud/logs.py
+++ b/mlrun/api/crud/logs.py
@@ -1,9 +1,9 @@
-from fastapi import status
+from http import HTTPStatus
 
 from sqlalchemy.orm import Session
 
-from mlrun.api.constants import LogSources
 from mlrun.api.api.utils import log_and_raise, log_path
+from mlrun.api.constants import LogSources
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.utils import get_in, now_date, update_in
@@ -38,7 +38,7 @@ class Logs:
         elif source in [LogSources.AUTO, LogSources.K8S]:
             data = get_db().read_run(db_session, uid, project)
             if not data:
-                log_and_raise(status.HTTP_404_NOT_FOUND, project=project, uid=uid)
+                log_and_raise(HTTPStatus.NOT_FOUND.value, project=project, uid=uid)
 
             pod_status = get_in(data, "status.state", "")
             if get_k8s():

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -1,5 +1,6 @@
+from http import HTTPStatus
+
 import requests
-from fastapi import status
 
 
 class MLRunBaseError(Exception):
@@ -56,19 +57,19 @@ def raise_for_status(response: requests.Response):
 
 
 class UnauthorizedError(MLRunDataStoreError):
-    error_status_code = status.HTTP_401_UNAUTHORIZED
+    error_status_code = HTTPStatus.UNAUTHORIZED.value
 
 
 class AccessDeniedError(MLRunDataStoreError):
-    error_status_code = status.HTTP_403_FORBIDDEN
+    error_status_code = HTTPStatus.FORBIDDEN.value
 
 
 class NotFoundError(MLRunDataStoreError):
-    error_status_code = status.HTTP_404_NOT_FOUND
+    error_status_code = HTTPStatus.NOT_FOUND.value
 
 
 STATUS_ERRORS = {
-    status.HTTP_401_UNAUTHORIZED: UnauthorizedError,
-    status.HTTP_403_FORBIDDEN: AccessDeniedError,
-    status.HTTP_404_NOT_FOUND: NotFoundError,
+    HTTPStatus.UNAUTHORIZED.value: UnauthorizedError,
+    HTTPStatus.FORBIDDEN.value: AccessDeniedError,
+    HTTPStatus.NOT_FOUND.value: NotFoundError,
 }

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -15,6 +15,7 @@ import json
 import os
 import requests
 import urllib3
+from http import HTTPStatus
 from datetime import datetime
 
 
@@ -277,7 +278,7 @@ def is_iguazio_system_2_10_or_above(dashboard_url):
     response = requests.get(f'{dashboard_url}/api/external_versions', verify=False)
 
     if not response.ok:
-        if response.status_code == 404:
+        if response.status_code == HTTPStatus.NOT_FOUND.value:
             # in iguazio systems prior to 2.10 this endpoint didn't exist, so the api returns 404 cause endpoint not
             # found
             return False

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -1,4 +1,5 @@
-from fastapi import status
+from http import HTTPStatus
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -6,5 +7,5 @@ from sqlalchemy.orm import Session
 def test_list_artifact_tags(db: Session, client: TestClient) -> None:
     project = 'p11'
     resp = client.get(f'/api/projects/{project}/artifact-tags')
-    assert resp.status_code == status.HTTP_200_OK, 'status'
+    assert resp.status_code == HTTPStatus.OK.value, 'status'
     assert resp.json()['project'] == project, 'project'

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -1,6 +1,6 @@
+from http import HTTPStatus
 from uuid import uuid4
 
-from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -14,7 +14,7 @@ def test_project(db: Session, client: TestClient) -> None:
         # 'users': ['u1', 'u2'],
     }
     resp = client.post('/api/project', json=prj1)
-    assert resp.status_code == status.HTTP_200_OK, 'add'
+    assert resp.status_code == HTTPStatus.OK.value, 'add'
     resp = client.get(f'/api/project/{name1}')
     out = {key: val for key, val in resp.json()['project'].items() if val}
     # out['users'].sort()
@@ -23,7 +23,7 @@ def test_project(db: Session, client: TestClient) -> None:
 
     data = {'description': 'lemon', 'name': name1}
     resp = client.post(f'/api/project/{name1}', json=data)
-    assert resp.status_code == status.HTTP_200_OK, 'update'
+    assert resp.status_code == HTTPStatus.OK.value, 'update'
     resp = client.get(f'/api/project/{name1}')
     assert name1 == resp.json()['project']['name'], 'name after update'
 
@@ -35,7 +35,7 @@ def test_project(db: Session, client: TestClient) -> None:
         # 'users': ['u1', 'u3'],
     }
     resp = client.post('/api/project', json=prj2)
-    assert resp.status_code == status.HTTP_200_OK, 'add (2)'
+    assert resp.status_code == HTTPStatus.OK.value, 'add (2)'
 
     resp = client.get('/api/projects')
     expected = {name1, name2}

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -1,9 +1,10 @@
-from fastapi import status
+from http import HTTPStatus
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 
 def test_list_schedules(db: Session, client: TestClient) -> None:
     resp = client.get('/api/projects/default/schedules')
-    assert resp.status_code == status.HTTP_200_OK, 'status'
+    assert resp.status_code == HTTPStatus.OK.value, 'status'
     assert 'schedules' in resp.json(), 'no schedules'

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -1,4 +1,5 @@
-from fastapi import status
+from http import HTTPStatus
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -11,7 +12,7 @@ def test_submit_job_failure_function_not_found(db: Session, client: TestClient) 
         'task': {'spec': {'function': function_reference}},
     }
     resp = client.post('/api/submit_job', json=body)
-    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert resp.status_code == HTTPStatus.NOT_FOUND.value
     assert (
         resp.json()['detail']['reason']
         == f"runtime error: function {function_reference} not found"

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -1,6 +1,6 @@
+from http import HTTPStatus
 from uuid import uuid4
 
-from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -15,21 +15,21 @@ def test_tag(db: Session, client: TestClient) -> None:
         fn = new_function(name=name, project=prj).to_dict()
         tag = uuid4().hex
         resp = client.post(f'/api/func/{prj}/{name}?tag={tag}', json=fn)
-        assert resp.status_code == status.HTTP_200_OK, 'status create'
+        assert resp.status_code == HTTPStatus.OK.value, 'status create'
     tag = 't1'
     tagged = {fn_name(i) for i in (1, 3, 4)}
     for name in tagged:
         query = {'functions': {'name': name}}
         resp = client.post(f'/api/{prj}/tag/{tag}', json=query)
-        assert resp.status_code == status.HTTP_200_OK, 'status tag'
+        assert resp.status_code == HTTPStatus.OK.value, 'status tag'
 
     resp = client.get(f'/api/{prj}/tag/{tag}')
-    assert resp.status_code == status.HTTP_200_OK, 'status get tag'
+    assert resp.status_code == HTTPStatus.OK.value, 'status get tag'
     objs = resp.json()['objects']
     assert {obj['name'] for obj in objs} == tagged, 'tagged'
 
     resp = client.delete(f'/api/{prj}/tag/{tag}')
-    assert resp.status_code == status.HTTP_200_OK, 'delete'
+    assert resp.status_code == HTTPStatus.OK.value, 'delete'
     resp = client.get(f'/api/{prj}/tags')
-    assert resp.status_code == status.HTTP_200_OK, 'list tags'
+    assert resp.status_code == HTTPStatus.OK.value, 'list tags'
     assert tag not in resp.json()['tags'], 'tag not deleted'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,19 +14,18 @@
 
 import shutil
 from datetime import datetime
+from http import HTTPStatus
 from os import environ
 from pathlib import Path
 from sys import platform
 from time import monotonic, sleep
 from urllib.request import URLError, urlopen
-from fastapi import status
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from mlrun.api.db.sqldb.models import Base
 from mlrun.api.db.sqldb.db import run_time_fmt
-
+from mlrun.api.db.sqldb.models import Base
 
 here = Path(__file__).absolute().parent
 results = here / 'test_results'
@@ -86,7 +85,7 @@ def wait_for_server(url, timeout_sec):
     while monotonic() - start <= timeout_sec:
         try:
             with urlopen(url) as resp:
-                if resp.status == status.HTTP_200_OK:
+                if resp.status == HTTPStatus.OK.value:
                     return True
         except (URLError, ConnectionError):
             pass

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -1,8 +1,8 @@
 import os
+from http import HTTPStatus
 from unittest.mock import Mock
 
 import requests
-from fastapi import status
 
 from mlrun.platforms import add_or_refresh_credentials
 
@@ -19,7 +19,7 @@ def test_add_or_refresh_credentials_iguazio_2_8_success(monkeypatch):
     def mock_get(*args, **kwargs):
         not_found_response_mock = Mock()
         not_found_response_mock.ok = False
-        not_found_response_mock.status_code = status.HTTP_404_NOT_FOUND
+        not_found_response_mock.status_code = HTTPStatus.NOT_FOUND.value
         return not_found_response_mock
 
     def mock_session(*args, **kwargs):

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -11,18 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from http import HTTPStatus
 from os import listdir
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 import pandas as pd
-import requests
-from fastapi import status
-from unittest.mock import Mock
 import pytest
+import requests
+import v3io.dataplane
 
 import mlrun
 import mlrun.errors
-import v3io.dataplane
 from tests.conftest import rundb_path
 
 mlrun.mlconf.dbpath = rundb_path
@@ -113,7 +113,7 @@ def test_forbidden_file_access(monkeypatch):
 
     def mock_get(*args, **kwargs):
         mock_forbidden_response = Mock()
-        mock_forbidden_response.status_code = status.HTTP_403_FORBIDDEN
+        mock_forbidden_response.status_code = HTTPStatus.FORBIDDEN.value
         mock_forbidden_response.raise_for_status = Mock(
             side_effect=requests.HTTPError('Error', response=mock_forbidden_response)
         )
@@ -131,16 +131,16 @@ def test_forbidden_file_access(monkeypatch):
         obj = store.object('v3io://some-system/some-dir/')
         obj.listdir()
 
-    assert access_denied_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
+    assert access_denied_exc.value.response.status_code == HTTPStatus.FORBIDDEN.value
 
     with pytest.raises(mlrun.errors.AccessDeniedError) as access_denied_exc:
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.get()
 
-    assert access_denied_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
+    assert access_denied_exc.value.response.status_code == HTTPStatus.FORBIDDEN.value
 
     with pytest.raises(mlrun.errors.AccessDeniedError) as access_denied_exc:
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.stat()
 
-    assert access_denied_exc.value.response.status_code == status.HTTP_403_FORBIDDEN
+    assert access_denied_exc.value.response.status_code == HTTPStatus.FORBIDDEN.value


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/375 we moved from `http.HTTPStatus` to `fastapi.status` for 2 reasons:
1. I thought we anyway need FastAPI which have the http status codes enums, so why having a special package - `http` for it (more packages, longer package install time)
2. the http status caused for weird error messages in some cases

After some time I understood that:
1. Apparently http is part of the python standard library - so we saved nothing
2. The wrong usage fix is simple - instead of doing `HTTPStatus.NOT_FOUND` we should do `HTTPStatus.NOT_FOUND.value` which would give only the number (404) itself
3. We need the status codes also in the client side and we don't want to make `fastapi` a requirement of the package

bottomline - changing everything back to `http.HTTPStatus` but with the `.value`