### PR TITLE
Improving errors infrastructure

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -119,7 +119,7 @@ class SQLDB(DBInterface):
         project = project or config.default_project
         run = self._get_run(session, uid, project, iter)
         if not run:
-            raise mlrun.errors.NotFoundError(f"Run {uid}:{project} not found")
+            raise mlrun.errors.MLRunNotFoundError(f"Run {uid}:{project} not found")
         return run.struct
 
     def list_runs(

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -1,5 +1,5 @@
+import fastapi
 import uvicorn
-from fastapi import FastAPI, Request, HTTPException
 from fastapi.exception_handlers import http_exception_handler
 
 import mlrun.errors
@@ -20,7 +20,7 @@ from mlrun.runtimes import RuntimeKinds
 from mlrun.runtimes import get_runtime_handler
 from mlrun.utils import logger
 
-app = FastAPI(
+app = fastapi.FastAPI(
     title="MLRun",
     description="Machine Learning automation and tracking",
     version=config.version,
@@ -36,7 +36,7 @@ app.include_router(api_router, prefix="/api")
 
 @app.exception_handler(mlrun.errors.HTTPStatusError)
 async def http_status_error_handler(
-    request: Request, exc: mlrun.errors.HTTPStatusError
+    request: fastapi.Request, exc: mlrun.errors.HTTPStatusError
 ):
     status_code = exc.response.status_code
     error_message = repr(exc)
@@ -44,7 +44,7 @@ async def http_status_error_handler(
         'Request handling returned error status', error_message=error_message, status_code=status_code
     )
     return await http_exception_handler(
-        request, HTTPException(status_code=status_code, detail=error_message)
+        request, fastapi.HTTPException(status_code=status_code, detail=error_message)
     )
 
 

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -34,9 +34,9 @@ app = FastAPI(
 app.include_router(api_router, prefix="/api")
 
 
-@app.exception_handler(mlrun.errors.HTTPStatusableError)
-async def http_statusable_error_handler(
-    request: Request, exc: mlrun.errors.HTTPStatusableError
+@app.exception_handler(mlrun.errors.HTTPStatusError)
+async def http_status_error_handler(
+    request: Request, exc: mlrun.errors.HTTPStatusError
 ):
     status_code = exc.response.status_code
     error_message = repr(exc)

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -41,7 +41,9 @@ async def http_status_error_handler(
     status_code = exc.response.status_code
     error_message = repr(exc)
     logger.warning(
-        'Request handling returned error status', error_message=error_message, status_code=status_code
+        'Request handling returned error status',
+        error_message=error_message,
+        status_code=status_code,
     )
     return await http_exception_handler(
         request, fastapi.HTTPException(status_code=status_code, detail=error_message)

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -1,8 +1,6 @@
 import uvicorn
 from fastapi import FastAPI, Request, HTTPException
-from fastapi.exception_handlers import (
-    http_exception_handler,
-)
+from fastapi.exception_handlers import http_exception_handler
 
 import mlrun.errors
 from mlrun.api.api.api import api_router
@@ -37,11 +35,17 @@ app.include_router(api_router, prefix="/api")
 
 
 @app.exception_handler(mlrun.errors.HTTPStatusableError)
-async def http_statusable_error_handler(request: Request, exc: mlrun.errors.HTTPStatusableError):
+async def http_statusable_error_handler(
+    request: Request, exc: mlrun.errors.HTTPStatusableError
+):
     status_code = exc.response.status_code
     error_message = repr(exc)
-    logger.warning('Failed handling request', error_message=error_message, status_code=status_code)
-    return await http_exception_handler(request, HTTPException(status_code=status_code, detail=error_message))
+    logger.warning(
+        'Failed handling request', error_message=error_message, status_code=status_code
+    )
+    return await http_exception_handler(
+        request, HTTPException(status_code=status_code, detail=error_message)
+    )
 
 
 @app.on_event("startup")

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -34,9 +34,9 @@ app = fastapi.FastAPI(
 app.include_router(api_router, prefix="/api")
 
 
-@app.exception_handler(mlrun.errors.HTTPStatusError)
+@app.exception_handler(mlrun.errors.MLRunHTTPStatusError)
 async def http_status_error_handler(
-    request: fastapi.Request, exc: mlrun.errors.HTTPStatusError
+    request: fastapi.Request, exc: mlrun.errors.MLRunHTTPStatusError
 ):
     status_code = exc.response.status_code
     error_message = repr(exc)

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -41,7 +41,7 @@ async def http_status_error_handler(
     status_code = exc.response.status_code
     error_message = repr(exc)
     logger.warning(
-        'Failed handling request', error_message=error_message, status_code=status_code
+        'Request handling returned error status', error_message=error_message, status_code=status_code
     )
     return await http_exception_handler(
         request, HTTPException(status_code=status_code, detail=error_message)

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -111,7 +111,7 @@ class V3ioStore(DataStore):
             )
         except RuntimeError as exc:
             if 'Permission denied' in str(exc):
-                raise mlrun.errors.AccessDeniedError(
+                raise mlrun.errors.MLRunAccessDeniedError(
                     f'Access denied to path: {key}'
                 ) from exc
             raise

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -103,7 +103,7 @@ class FileRunDB(RunDBInterface):
             + self.format
         )
         if not pathlib.Path(filepath).is_file():
-            raise mlrun.errors.NotFoundError(uid)
+            raise mlrun.errors.MLRunNotFoundError(uid)
         data = self._datastore.get(filepath)
         return self._loads(data)
 

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -28,17 +28,17 @@ class HTTPError(BaseError, requests.HTTPError):
         requests.HTTPError.__init__(self, message, response=response)
 
 
-class HTTPStatusableError(HTTPError):
+class HTTPStatusError(HTTPError):
     """
     When an error has a matching http status code it is "HTTP statusable"
-    HTTP Statusable errors should inherit from this class and set the right status code in the
+    HTTP Status errors should inherit from this class and set the right status code in the
     error_status_code attribute
     """
 
     error_status_code = None
 
     def __init__(self, message: str, response: requests.Response = None):
-        super(HTTPStatusableError, self).__init__(
+        super(HTTPStatusError, self).__init__(
             message, response=response, status_code=self.error_status_code
         )
 
@@ -60,23 +60,23 @@ def raise_for_status(response: requests.Response):
 
 
 # Specific Errors
-class UnauthorizedError(HTTPStatusableError):
+class UnauthorizedError(HTTPStatusError):
     error_status_code = HTTPStatus.UNAUTHORIZED.value
 
 
-class AccessDeniedError(HTTPStatusableError):
+class AccessDeniedError(HTTPStatusError):
     error_status_code = HTTPStatus.FORBIDDEN.value
 
 
-class NotFoundError(HTTPStatusableError):
+class NotFoundError(HTTPStatusError):
     error_status_code = HTTPStatus.NOT_FOUND.value
 
 
-class BadRequestError(HTTPStatusableError):
+class BadRequestError(HTTPStatusError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 
-class InvalidArgumentError(HTTPStatusableError, ValueError):
+class InvalidArgumentError(HTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -34,6 +34,7 @@ class HTTPStatusableError(HTTPError):
     HTTP Statusable errors should inherit from this class and set the right status code in the
     error_status_code attribute
     """
+
     error_status_code = None
 
     def __init__(self, message: str, response: requests.Response = None):
@@ -55,7 +56,9 @@ def raise_for_status(response: requests.Response):
                 str(exc), response=response
             ) from exc
         except KeyError:
-            raise HTTPError(str(exc), response=response, status_code=response.status_code) from exc
+            raise HTTPError(
+                str(exc), response=response, status_code=response.status_code
+            ) from exc
 
 
 # Specific Errors

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -56,9 +56,7 @@ def raise_for_status(response: requests.Response):
                 str(exc), response=response
             ) from exc
         except KeyError:
-            raise HTTPError(
-                str(exc), response=response, status_code=response.status_code
-            ) from exc
+            raise HTTPError(str(exc), response=response) from exc
 
 
 # Specific Errors

--- a/tests/rundb/test_dbs.py
+++ b/tests/rundb/test_dbs.py
@@ -120,7 +120,7 @@ def test_runs(db: RunDBInterface):
     assert run3 == runs[0], 'state run'
 
     db.del_run(uid3)
-    with pytest.raises(mlrun.errors.NotFoundError):
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
         db.read_run(uid3)
 
     label = 'l1'

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -195,14 +195,14 @@ def test_forbidden_file_access():
         secrets={'V3IO_ACCESS_KEY': 'some-access-key'}
     )
 
-    with pytest.raises(mlrun.errors.AccessDeniedError):
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         obj = store.object('v3io://some-system/some-dir/')
         obj.listdir()
 
-    with pytest.raises(mlrun.errors.AccessDeniedError):
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.get()
 
-    with pytest.raises(mlrun.errors.AccessDeniedError):
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         obj = store.object('v3io://some-system/some-dir/some-file')
         obj.stat()


### PR DESCRIPTION
Changes:
* All the status specific errors inherited from `MLRunDataStoreError` although they might be used in a non data store related context, renamed to `HTTPStatusableError` (I'm open to other name suggestions)
* Added the `BadRequestError` and `InvalidArgumentError` to show that it's ok and possible for 2 errors to match the same status code (but only one of them will be used when doing `raise_for_status()`)
* Added usage of [FastAPI's capability to set a global exception handler](https://fastapi.tiangolo.com/tutorial/handling-errors/#install-custom-exception-handlers) so we handle `HTTPStatusableError` in one place
* Removed the `MLRun` prefix for the error classes names, I don't think we need it since it's `mlrun.errors.BaseError`