### PR TITLE
Add performance analysis to hvd

### DIFF
--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -263,7 +263,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
                                                                Defaults to None.
         """
 
-        log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if file_path is None \
+        log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if log_file_path is None \
             else log_file_path
         horovod_autotune_settings = {'HOROVOD_AUTOTUNE': 1,
                                      'HOROVOD_AUTOTUNE_LOG': log_path}

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -235,7 +235,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         )
         horovod_timeline_settings = {
             "HOROVOD_TIMELINE": log_path,
-            "HOROVOD_TIMELINE_MARK_CYCLES": str(int(enable_cycle_markers)),
+            "HOROVOD_TIMELINE_MARK_CYCLES": int(enable_cycle_markers),
         }
         self.set_envs(horovod_timeline_settings)
 
@@ -283,18 +283,16 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
             "HOROVOD_AUTOTUNE_LOG": log_path,
         }
         if warmup_samples is not None:
-            horovod_autotune_settings["autotune-warmup-samples"] = str(warmup_samples)
+            horovod_autotune_settings["autotune-warmup-samples"] = warmup_samples
         if steps_per_sample is not None:
-            horovod_autotune_settings["autotune-steps-per-sample"] = str(
-                steps_per_sample
-            )
+            horovod_autotune_settings["autotune-steps-per-sample"] = steps_per_sample
         if bayes_opt_max_samples is not None:
-            horovod_autotune_settings["autotune-bayes-opt-max-samples"] = str(
-                bayes_opt_max_samples
-            )
+            horovod_autotune_settings[
+                "autotune-bayes-opt-max-samples"
+            ] = bayes_opt_max_samples
         if gaussian_process_noise is not None:
-            horovod_autotune_settings["autotune-gaussian-process-noise"] = str(
-                gaussian_process_noise
-            )
+            horovod_autotune_settings[
+                "autotune-gaussian-process-noise"
+            ] = gaussian_process_noise
 
         self.set_envs(horovod_autotune_settings)

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -228,15 +228,15 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         log_path = os.path.join(config.artifact_path, 'hvd_logs', 'trace.log') if log_file_path is None \
             else log_file_path
         horovod_timeline_settings = {'HOROVOD_TIMELINE': log_path,
-                                     'HOROVOD_TIMELINE_MARK_CYCLES': enable_cycle_markers}
+                                     'HOROVOD_TIMELINE_MARK_CYCLES': str(int(enable_cycle_markers))}
         self.set_envs(horovod_timeline_settings)
 
     def with_autotune(self,
-                      autotune_file_path: str = None,
-                      autotune_warmup_samples: int = None,
-                      autotune_steps_per_sample: int = None,
-                      autotune_bayes_opt_max_samples: int = None,
-                      autotune_gaussian_process_noise: float = None):
+                      log_file_path: str = None,
+                      warmup_samples: int = None,
+                      steps_per_sample: int = None,
+                      bayes_opt_max_samples: int = None,
+                      gaussian_process_noise: float = None):
         """Adds an Autotuner to help optimize Horovod's Parameters for better performence.
 
         The autotuner will collect metrics and tune horovod's parameters while running using
@@ -252,28 +252,28 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         https://horovod.readthedocs.io/en/latest/autotune_include.html
 
         Args:
-            autotune_file_path (str, optional):        filepath for the csv log file.
+            file_path (str, optional):        filepath for the csv log file.
                                                        Defaults to <artifacts_path>/hvd_logs
-            autotune_warmup_samples (int, optional):   number of discarded samples at the beginning of the training
+            warmup_samples (int, optional):   number of discarded samples at the beginning of the training
                                                        process. Defaults to None.
-            autotune_steps_per_sample (int, optional): steps per sample. Defaults to None.
-            autotune_bayes_opt_max_samples (int, optional):    maximum number of samples. Defaults to None.
-            autotune_gaussian_process_noise (float, optional): Bayes optimizer's Alpha (noise regularization), to
+            steps_per_sample (int, optional): steps per sample. Defaults to None.
+            bayes_opt_max_samples (int, optional):    maximum number of samples. Defaults to None.
+            gaussian_process_noise (float, optional): Bayes optimizer's Alpha (noise regularization), to
                                                                account for network and resources variance.
                                                                Defaults to None.
         """
 
-        log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if autotune_file_path is None \
-            else autotune_file_path
+        log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if file_path is None \
+            else log_file_path
         horovod_autotune_settings = {'HOROVOD_AUTOTUNE': 1,
                                      'HOROVOD_AUTOTUNE_LOG': log_path}
-        if autotune_warmup_samples is not None:
-            horovod_autotune_settings['autotune-warmup-samples'] = autotune_warmup_samples
-        if autotune_steps_per_sample is not None:
-            horovod_autotune_settings['autotune-steps-per-sample'] = autotune_steps_per_sample
-        if autotune_bayes_opt_max_samples is not None:
-            horovod_autotune_settings['autotune-bayes-opt-max-samples'] = autotune_bayes_opt_max_samples
-        if autotune_gaussian_process_noise is not None:
-            horovod_autotune_settings['autotune-gaussian-process-noise'] = autotune_gaussian_process_noise
+        if warmup_samples is not None:
+            horovod_autotune_settings['autotune-warmup-samples'] = warmup_samples
+        if steps_per_sample is not None:
+            horovod_autotune_settings['autotune-steps-per-sample'] = steps_per_sample
+        if bayes_opt_max_samples is not None:
+            horovod_autotune_settings['autotune-bayes-opt-max-samples'] = bayes_opt_max_samples
+        if gaussian_process_noise is not None:
+            horovod_autotune_settings['autotune-gaussian-process-noise'] = gaussian_process_noise
 
         self.set_envs(horovod_autotune_settings)

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -27,7 +27,7 @@ from mlrun.utils import logger, get_in
 
 
 class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
-    kind = "mpijob"
+    kind = 'mpijob'
     _is_nested = False
 
     @abc.abstractmethod
@@ -52,14 +52,14 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         pass
 
     def _pretty_print_jobs(self, items: typing.List):
-        print("{:10} {:20} {:21} {}".format("status", "name", "start", "end"))
+        print('{:10} {:20} {:21} {}'.format('status', 'name', 'start', 'end'))
         for i in items:
             print(
-                "{:10} {:20} {:21} {}".format(
+                '{:10} {:20} {:21} {}'.format(
                     self._get_job_launcher_status(i),
-                    get_in(i, "metadata.name", ""),
-                    get_in(i, "status.startTime", ""),
-                    get_in(i, "status.completionTime", ""),
+                    get_in(i, 'metadata.name', ''),
+                    get_in(i, 'status.startTime', ''),
+                    get_in(i, 'status.completionTime', ''),
                 )
             )
 
@@ -84,43 +84,43 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
             time.sleep(1)
 
         if resp:
-            logger.info("MpiJob {} state={}".format(meta.name, state or "unknown"))
+            logger.info('MpiJob {} state={}'.format(meta.name, state or 'unknown'))
             if state:
                 state = state.lower()
                 launcher, _ = self._get_launcher(meta.name, meta.namespace)
                 execution.set_hostname(launcher)
-                execution.set_state("running" if state == "active" else state)
+                execution.set_state('running' if state == 'active' else state)
                 if self.kfp:
                     writer = AsyncLogWriter(self._db_conn, runobj)
                     status = self._get_k8s().watch(
                         launcher, meta.namespace, writer=writer
                     )
                     logger.info(
-                        "MpiJob {} finished with state {}".format(meta.name, status)
+                        'MpiJob {} finished with state {}'.format(meta.name, status)
                     )
-                    if status == "succeeded":
-                        execution.set_state("completed")
+                    if status == 'succeeded':
+                        execution.set_state('completed')
                     else:
                         execution.set_state(
-                            "error",
-                            "MpiJob {} finished with state {}".format(
+                            'error',
+                            'MpiJob {} finished with state {}'.format(
                                 meta.name, status
                             ),
                         )
                 else:
-                    txt = "MpiJob {} launcher pod {} state {}".format(
+                    txt = 'MpiJob {} launcher pod {} state {}'.format(
                         meta.name, launcher, state
                     )
                     logger.info(txt)
                     runobj.status.status_text = txt
             else:
-                txt = "MpiJob status unknown or failed, check pods: {}".format(
+                txt = 'MpiJob status unknown or failed, check pods: {}'.format(
                     self.get_pods(meta.name, meta.namespace)
                 )
                 logger.warning(txt)
                 runobj.status.status_text = txt
                 if self.kfp:
-                    execution.set_state("error", txt)
+                    execution.set_state('error', txt)
 
         return None
 
@@ -133,8 +133,8 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
             resp = k8s.crdapi.create_namespaced_custom_object(
                 mpi_group, mpi_version, namespace=namespace, plural=mpi_plural, body=job
             )
-            name = get_in(resp, "metadata.name", "unknown")
-            logger.info("MpiJob {} created".format(name))
+            name = get_in(resp, 'metadata.name', 'unknown')
+            logger.info('MpiJob {} created'.format(name))
             return resp
         except client.rest.ApiException as e:
             logger.error("Exception when creating MPIJob: %s" % e)
@@ -150,11 +150,11 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
             resp = k8s.crdapi.delete_namespaced_custom_object(
                 mpi_group, mpi_version, namespace, mpi_plural, name, body
             )
-            logger.info("del status: {}".format(get_in(resp, "status", "unknown")))
+            logger.info('del status: {}'.format(get_in(resp, 'status', 'unknown')))
         except client.rest.ApiException as e:
             print("Exception when deleting MPIJob: %s" % e)
 
-    def list_jobs(self, namespace=None, selector="", show=True):
+    def list_jobs(self, namespace=None, selector='', show=True):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()
         k8s = self._get_k8s()
         namespace = k8s.resolve_namespace(namespace)
@@ -172,7 +172,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
 
         items = []
         if resp:
-            items = resp.get("items", [])
+            items = resp.get('items', [])
             if show and items:
                 self._pretty_print_jobs(items)
         return items
@@ -202,7 +202,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
     def _get_launcher(self, name, namespace=None):
         pods = self.get_pods(name, namespace, launcher=True)
         if not pods:
-            logger.error("no pod matches that job name")
+            logger.error('no pod matches that job name')
             return
         # TODO: Why was this here?
         # k8s = self._get_k8s()

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -219,10 +219,11 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         https://horovod.readthedocs.io/en/latest/timeline_include.html
 
         Args:
-            log_file_path (str, optional): filepath for the json log file.
+            log_file_path (str, optional):         filepath for the json log file.
+                                                   Defaults to <artifacts_path>/hvd_logs/trace.log.
             enable_cycle_markers (bool, optional): Add cycle markers to the log for
-            Tensor Fusion aid. Could make the trace very crowded.
-            Defaults to False.
+                                                   Tensor Fusion aid. Could make the trace very crowded.
+                                                   Defaults to False.
         """
 
         log_path = os.path.join(config.artifact_path, 'hvd_logs', 'trace.log') if log_file_path is None \
@@ -252,15 +253,15 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         https://horovod.readthedocs.io/en/latest/autotune_include.html
 
         Args:
-            file_path (str, optional):        filepath for the csv log file.
-                                                       Defaults to <artifacts_path>/hvd_logs
-            warmup_samples (int, optional):   number of discarded samples at the beginning of the training
-                                                       process. Defaults to None.
-            steps_per_sample (int, optional): steps per sample. Defaults to None.
+            file_path (str, optional):                filepath for the csv log file.
+                                                      Defaults to <artifacts_path>/hvd_logs/autotune.csv
+            warmup_samples (int, optional):           number of discarded samples at the beginning of the training
+                                                      process. Defaults to None.
+            steps_per_sample (int, optional):         steps per sample. Defaults to None.
             bayes_opt_max_samples (int, optional):    maximum number of samples. Defaults to None.
             gaussian_process_noise (float, optional): Bayes optimizer's Alpha (noise regularization), to
-                                                               account for network and resources variance.
-                                                               Defaults to None.
+                                                      account for network and resources variance.
+                                                      Defaults to None.
         """
 
         log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if log_file_path is None \

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -265,15 +265,15 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
 
         log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if log_file_path is None \
             else log_file_path
-        horovod_autotune_settings = {'HOROVOD_AUTOTUNE': 1,
+        horovod_autotune_settings = {'HOROVOD_AUTOTUNE': '1',
                                      'HOROVOD_AUTOTUNE_LOG': log_path}
         if warmup_samples is not None:
-            horovod_autotune_settings['autotune-warmup-samples'] = warmup_samples
+            horovod_autotune_settings['autotune-warmup-samples'] = str(warmup_samples)
         if steps_per_sample is not None:
-            horovod_autotune_settings['autotune-steps-per-sample'] = steps_per_sample
+            horovod_autotune_settings['autotune-steps-per-sample'] = str(steps_per_sample)
         if bayes_opt_max_samples is not None:
-            horovod_autotune_settings['autotune-bayes-opt-max-samples'] = bayes_opt_max_samples
+            horovod_autotune_settings['autotune-bayes-opt-max-samples'] = str(bayes_opt_max_samples)
         if gaussian_process_noise is not None:
-            horovod_autotune_settings['autotune-gaussian-process-noise'] = gaussian_process_noise
+            horovod_autotune_settings['autotune-gaussian-process-noise'] = str(gaussian_process_noise)
 
         self.set_envs(horovod_autotune_settings)

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -262,7 +262,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         https://horovod.readthedocs.io/en/latest/autotune_include.html
 
         Args:
-            file_path (str, optional):                filepath for the csv log file.
+            log_file_path (str, optional):            filepath for the csv log file.
                                                       Defaults to <artifacts_path>/hvd_logs/autotune.csv
             warmup_samples (int, optional):           number of discarded samples at the beginning of the training
                                                       process. Defaults to None.

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -14,6 +14,7 @@
 import abc
 import time
 import typing
+import os
 
 from kubernetes import client
 
@@ -206,3 +207,73 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         # TODO: Why was this here?
         # k8s = self._get_k8s()
         return list(pods.items())[0]
+
+    def with_tracing(self, log_file_path: str = None, enable_cycle_markers: bool = False):
+        """Add Horovod Timeline activity tracking to the job to analyse
+        its performence.
+
+        The data will be saved as JSON to {log_file_path}. It can then be viewed via
+        a trace viewer like chrome or edge's `edge://tracing`.
+
+        More information can be found in the official documentation:
+        https://horovod.readthedocs.io/en/latest/timeline_include.html
+
+        Args:
+            log_file_path (str, optional): filepath for the json log file.
+            enable_cycle_markers (bool, optional): Add cycle markers to the log for
+            Tensor Fusion aid. Could make the trace very crowded.
+            Defaults to False.
+        """
+
+        log_path = os.path.join(config.artifact_path, 'hvd_logs', 'trace.log') if log_file_path is None \
+            else log_file_path
+        horovod_timeline_settings = {'HOROVOD_TIMELINE': log_path,
+                                     'HOROVOD_TIMELINE_MARK_CYCLES': enable_cycle_markers}
+        self.set_envs(horovod_timeline_settings)
+
+    def with_autotune(self,
+                      autotune_file_path: str = None,
+                      autotune_warmup_samples: int = None,
+                      autotune_steps_per_sample: int = None,
+                      autotune_bayes_opt_max_samples: int = None,
+                      autotune_gaussian_process_noise: float = None):
+        """Adds an Autotuner to help optimize Horovod's Parameters for better performence.
+
+        The autotuner will collect metrics and tune horovod's parameters while running using
+        Bayesian optimiation. This may affect the performence of the run initially but after
+        arriving to the best parameters should increase performence.
+
+        Since autotuning imposes a tradeoff between early performence for better performence
+        later on, It's advised to enable it when both:
+        - Training should take a long timeout
+        - Scaling efficiency was found lacking with the default settings
+
+        More information can be found in the official documentation:
+        https://horovod.readthedocs.io/en/latest/autotune_include.html
+
+        Args:
+            autotune_file_path (str, optional):        filepath for the csv log file.
+                                                       Defaults to <artifacts_path>/hvd_logs
+            autotune_warmup_samples (int, optional):   number of discarded samples at the beginning of the training
+                                                       process. Defaults to None.
+            autotune_steps_per_sample (int, optional): steps per sample. Defaults to None.
+            autotune_bayes_opt_max_samples (int, optional):    maximum number of samples. Defaults to None.
+            autotune_gaussian_process_noise (float, optional): Bayes optimizer's Alpha (noise regularization), to
+                                                               account for network and resources variance.
+                                                               Defaults to None.
+        """
+
+        log_path = os.path.join(config.artifact_path, 'hvd_logs', 'autotune.csv') if autotune_file_path is None \
+            else autotune_file_path
+        horovod_autotune_settings = {'HOROVOD_AUTOTUNE': 1,
+                                     'HOROVOD_AUTOTUNE_LOG': log_path}
+        if autotune_warmup_samples is not None:
+            horovod_autotune_settings['autotune-warmup-samples'] = autotune_warmup_samples
+        if autotune_steps_per_sample is not None:
+            horovod_autotune_settings['autotune-steps-per-sample'] = autotune_steps_per_sample
+        if autotune_bayes_opt_max_samples is not None:
+            horovod_autotune_settings['autotune-bayes-opt-max-samples'] = autotune_bayes_opt_max_samples
+        if autotune_gaussian_process_noise is not None:
+            horovod_autotune_settings['autotune-gaussian-process-noise'] = autotune_gaussian_process_noise
+
+        self.set_envs(horovod_autotune_settings)

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -99,12 +99,12 @@ class KubeResourceSpec(FunctionSpec):
 
 
 class KubeResource(BaseRuntime):
-    kind = "job"
+    kind = 'job'
     _is_nested = True
 
     def __init__(self, spec=None, metadata=None):
         super().__init__(metadata, spec)
-        self._cop = ContainerOp("name", "image")
+        self._cop = ContainerOp('name', 'image')
         self.verbose = False
 
     @property
@@ -113,21 +113,21 @@ class KubeResource(BaseRuntime):
 
     @spec.setter
     def spec(self, spec):
-        self._spec = self._verify_dict(spec, "spec", KubeResourceSpec)
+        self._spec = self._verify_dict(spec, 'spec', KubeResourceSpec)
 
     def to_dict(self, fields=None, exclude=None, strip=False):
         struct = super().to_dict(fields, exclude, strip=strip)
         api = client.ApiClient()
         struct = api.sanitize_for_serialization(struct)
         if strip:
-            spec = struct["spec"]
-            for attr in ["volumes", "volume_mounts"]:
+            spec = struct['spec']
+            for attr in ['volumes', 'volume_mounts']:
                 if attr in spec:
                     del spec[attr]
-            if "env" in spec and spec["env"]:
-                for ev in spec["env"]:
-                    if ev["name"].startswith("V3IO_"):
-                        ev["value"] = ""
+            if 'env' in spec and spec['env']:
+                for ev in spec['env']:
+                    if ev['name'].startswith('V3IO_'):
+                        ev['value'] = ''
         return struct
 
     def apply(self, modify):
@@ -162,28 +162,28 @@ class KubeResource(BaseRuntime):
             self.set_env(name, value)
         return self
 
-    def gpus(self, gpus, gpu_type="nvidia.com/gpu"):
-        update_in(self.spec.resources, ["limits", gpu_type], gpus)
+    def gpus(self, gpus, gpu_type='nvidia.com/gpu'):
+        update_in(self.spec.resources, ['limits', gpu_type], gpus)
 
-    def with_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def with_limits(self, mem=None, cpu=None, gpus=None, gpu_type='nvidia.com/gpu'):
         """set pod cpu/memory/gpu limits"""
         limits = {}
         if gpus:
             limits[gpu_type] = gpus
         if mem:
-            limits["memory"] = mem
+            limits['memory'] = mem
         if cpu:
-            limits["cpu"] = cpu
-        update_in(self.spec.resources, "limits", limits)
+            limits['cpu'] = cpu
+        update_in(self.spec.resources, 'limits', limits)
 
     def with_requests(self, mem=None, cpu=None):
         """set requested (desired) pod cpu/memory/gpu resources"""
         requests = {}
         if mem:
-            requests["memory"] = mem
+            requests['memory'] = mem
         if cpu:
-            requests["cpu"] = cpu
-        update_in(self.spec.resources, "requests", requests)
+            requests['cpu'] = cpu
+        update_in(self.spec.resources, 'requests', requests)
 
     def _get_meta(self, runobj, unique=False):
         namespace = self._get_k8s().resolve_namespace()
@@ -191,12 +191,12 @@ class KubeResource(BaseRuntime):
         labels = get_resource_labels(self, runobj, runobj.spec.scrape_metrics)
         new_meta = client.V1ObjectMeta(namespace=namespace, labels=labels)
 
-        name = runobj.metadata.name or "mlrun"
-        norm_name = "{}-".format(normalize_name(name))
+        name = runobj.metadata.name or 'mlrun'
+        norm_name = '{}-'.format(normalize_name(name))
         if unique:
             norm_name += uuid.uuid4().hex[:8]
             new_meta.name = norm_name
-            runobj.set_label("mlrun/job", norm_name)
+            runobj.set_label('mlrun/job', norm_name)
         else:
             new_meta.generate_name = norm_name
         return new_meta
@@ -204,6 +204,6 @@ class KubeResource(BaseRuntime):
     def copy(self):
         self._cop = None
         fn = deepcopy(self)
-        self._cop = ContainerOp("name", "image")
-        fn._cop = ContainerOp("name", "image")
+        self._cop = ContainerOp('name', 'image')
+        fn._cop = ContainerOp('name', 'image')
         return fn

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -99,12 +99,12 @@ class KubeResourceSpec(FunctionSpec):
 
 
 class KubeResource(BaseRuntime):
-    kind = 'job'
+    kind = "job"
     _is_nested = True
 
     def __init__(self, spec=None, metadata=None):
         super().__init__(metadata, spec)
-        self._cop = ContainerOp('name', 'image')
+        self._cop = ContainerOp("name", "image")
         self.verbose = False
 
     @property
@@ -113,21 +113,21 @@ class KubeResource(BaseRuntime):
 
     @spec.setter
     def spec(self, spec):
-        self._spec = self._verify_dict(spec, 'spec', KubeResourceSpec)
+        self._spec = self._verify_dict(spec, "spec", KubeResourceSpec)
 
     def to_dict(self, fields=None, exclude=None, strip=False):
         struct = super().to_dict(fields, exclude, strip=strip)
         api = client.ApiClient()
         struct = api.sanitize_for_serialization(struct)
         if strip:
-            spec = struct['spec']
-            for attr in ['volumes', 'volume_mounts']:
+            spec = struct["spec"]
+            for attr in ["volumes", "volume_mounts"]:
                 if attr in spec:
                     del spec[attr]
-            if 'env' in spec and spec['env']:
-                for ev in spec['env']:
-                    if ev['name'].startswith('V3IO_'):
-                        ev['value'] = ''
+            if "env" in spec and spec["env"]:
+                for ev in spec["env"]:
+                    if ev["name"].startswith("V3IO_"):
+                        ev["value"] = ""
         return struct
 
     def apply(self, modify):
@@ -143,7 +143,7 @@ class KubeResource(BaseRuntime):
 
     def set_env(self, name, value):
         """set pod environment var from value"""
-        return self._set_env(name, value=value)
+        return self._set_env(name, value=str(value))
 
     def _set_env(self, name, value=None, value_from=None):
         new_var = client.V1EnvVar(name=name, value=value, value_from=value_from)
@@ -162,28 +162,28 @@ class KubeResource(BaseRuntime):
             self.set_env(name, value)
         return self
 
-    def gpus(self, gpus, gpu_type='nvidia.com/gpu'):
-        update_in(self.spec.resources, ['limits', gpu_type], gpus)
+    def gpus(self, gpus, gpu_type="nvidia.com/gpu"):
+        update_in(self.spec.resources, ["limits", gpu_type], gpus)
 
-    def with_limits(self, mem=None, cpu=None, gpus=None, gpu_type='nvidia.com/gpu'):
+    def with_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
         """set pod cpu/memory/gpu limits"""
         limits = {}
         if gpus:
             limits[gpu_type] = gpus
         if mem:
-            limits['memory'] = mem
+            limits["memory"] = mem
         if cpu:
-            limits['cpu'] = cpu
-        update_in(self.spec.resources, 'limits', limits)
+            limits["cpu"] = cpu
+        update_in(self.spec.resources, "limits", limits)
 
     def with_requests(self, mem=None, cpu=None):
         """set requested (desired) pod cpu/memory/gpu resources"""
         requests = {}
         if mem:
-            requests['memory'] = mem
+            requests["memory"] = mem
         if cpu:
-            requests['cpu'] = cpu
-        update_in(self.spec.resources, 'requests', requests)
+            requests["cpu"] = cpu
+        update_in(self.spec.resources, "requests", requests)
 
     def _get_meta(self, runobj, unique=False):
         namespace = self._get_k8s().resolve_namespace()
@@ -191,12 +191,12 @@ class KubeResource(BaseRuntime):
         labels = get_resource_labels(self, runobj, runobj.spec.scrape_metrics)
         new_meta = client.V1ObjectMeta(namespace=namespace, labels=labels)
 
-        name = runobj.metadata.name or 'mlrun'
-        norm_name = '{}-'.format(normalize_name(name))
+        name = runobj.metadata.name or "mlrun"
+        norm_name = "{}-".format(normalize_name(name))
         if unique:
             norm_name += uuid.uuid4().hex[:8]
             new_meta.name = norm_name
-            runobj.set_label('mlrun/job', norm_name)
+            runobj.set_label("mlrun/job", norm_name)
         else:
             new_meta.generate_name = norm_name
         return new_meta
@@ -204,6 +204,6 @@ class KubeResource(BaseRuntime):
     def copy(self):
         self._cop = None
         fn = deepcopy(self)
-        self._cop = ContainerOp('name', 'image')
-        fn._cop = ContainerOp('name', 'image')
+        self._cop = ContainerOp("name", "image")
+        fn._cop = ContainerOp("name", "image")
         return fn


### PR DESCRIPTION
Added easy performance analysis and tuning capabilities to MLRun's MPIJob runtime.

[**Horovod Autotune**](https://horovod.readthedocs.io/en/latest/autotune_include.html)
```
<mpi-function>.with_autotune(log_file_path: str, warmup_samples: int, steps_per_sample: int, bayes_opt_max_samples: int, 
gaussian_process_noise: float)
```
Adds an Autotuner to help optimize Horovod's Parameters for better performence. The autotuner will collect metrics and tune horovod's parameters while running using Bayesian optimiation. This may affect the performence of the run initially but after arriving to the best parameters should increase performence.

Since autotuning imposes a tradeoff between early performence for better performence later on, It's advised to enable it when both: 
- Training should take a long timeout
- Scaling efficiency was found lacking with the default settings

[**Horovod Timeline**]( https://horovod.readthedocs.io/en/latest/timeline_include.html)
`<mpi-function>.with_tracing(log_file_path: str, enable_cycle_markers: bool)`
Add Horovod Timeline activity tracking to the job to analyse its performence. The data will be saved as JSON to {log_file_path}. It can then be viewed via a trace viewer like chrome or edge's `edge://tracing`.