### PR TITLE
Fix schedules datetime fields formatting

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -85,7 +85,7 @@ class SQLDB(DBInterface):
                 project=project,
                 iteration=iter,
                 state=run_state(struct),
-                start_time=run_start_time(struct) or datetime.now(),
+                start_time=run_start_time(struct) or datetime.now(timezone.utc),
             )
         labels = run_labels(struct)
         update_labels(run, labels)
@@ -162,7 +162,7 @@ class SQLDB(DBInterface):
         project = project or config.default_project
         query = self._find_runs(session, None, project, labels, state)
         if days_ago:
-            since = datetime.now() - timedelta(days=days_ago)
+            since = datetime.now(timezone.utc) - timedelta(days=days_ago)
             query = query.filter(Run.start_time >= since)
         for run in query:  # Can not use query.delete with join
             session.delete(run)
@@ -382,7 +382,7 @@ class SQLDB(DBInterface):
             project=project,
             name=name,
             kind=kind.value,
-            creation_time=datetime.now(),
+            creation_time=datetime.now(timezone.utc),
             # these are properties of the object that map manually (using getters and setters) to other column of the
             # table and therefore Pycharm yells that they're unexpected
             scheduled_object=scheduled_object,

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1,3 +1,4 @@
+import pytz
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from typing import Any, List
@@ -712,4 +713,13 @@ class SQLDB(DBInterface):
         db_schedule: Schedule,
     ) -> schemas.ScheduleRecord:
         schedule = schemas.ScheduleRecord.from_orm(db_schedule)
+        SQLDB._add_utc_timezone(schedule, 'creation_time')
         return schedule
+
+    @staticmethod
+    def _add_utc_timezone(obj, attribute_name):
+        """
+        sqlalchemy losing timezone information with sqlite so we're returning it
+        https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite
+        """
+        setattr(obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name)))

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -145,6 +145,29 @@ async def test_validate_cron_trigger_multi_checks(db: Session, scheduler: Schedu
 
 
 @pytest.mark.asyncio
+async def test_get_schedule_datetime_fields_timezone(db: Session, scheduler: Scheduler):
+    cron_trigger = schemas.ScheduleCronTrigger(minute='*/10')
+    schedule_name = "schedule-name"
+    project = config.default_project
+    scheduler.create_schedule(
+        db,
+        project,
+        schedule_name,
+        schemas.ScheduleKinds.local_function,
+        do_nothing,
+        cron_trigger,
+    )
+    schedule = scheduler.get_schedule(db, project, schedule_name)
+    assert schedule.creation_time.tzinfo is not None
+    assert schedule.next_run_time.tzinfo is not None
+
+    schedules = scheduler.list_schedules(db, project)
+    assert len(schedules.schedules) == 1
+    assert schedules.schedules[0].creation_time.tzinfo is not None
+    assert schedules.schedules[0].next_run_time.tzinfo is not None
+
+
+@pytest.mark.asyncio
 async def test_get_schedule(db: Session, scheduler: Scheduler):
     cron_trigger = schemas.ScheduleCronTrigger(year="1999")
     schedule_name = "schedule-name"


### PR DESCRIPTION
* Fixed to do `datetime.now(timezone.utc)` instead of `datetime.now()` (also in schedules un-related places)
* apparently [sqlalchemy losing timezone information with sqlite](https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite) so added a function to add back the timezone after retrieving records from the DB, currently using it only for schedules