### PR TITLE
Change API default response to ORJSONResponse

### DIFF
--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -9,3 +9,4 @@ kubernetes-asyncio==10.0.0
 kubernetes==10.0.0
 apscheduler~=3.6
 humanfriendly~=8.2
+orjson>=3,<4

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -29,6 +29,7 @@ app = fastapi.FastAPI(
     openapi_url="/api/openapi.json",
     docs_url="/api/docs",
     redoc_url="/api/redoc",
+    default_response_class=fastapi.responses.ORJSONResponse,
 )
 
 app.include_router(api_router, prefix="/api")

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -8,15 +8,7 @@ from mlrun.api.utils.singletons.db import get_db
 
 def test_run_with_nan_in_body(db: Session, client: TestClient, monkeypatch) -> None:
     run_with_nan_float = {
-        "status": {
-            "artifacts": [
-                {
-                    "preview": [
-                        [0.0, float("Nan"), 1.3],
-                    ],
-                },
-            ],
-        },
+        "status": {"artifacts": [{"preview": [[0.0, float("Nan"), 1.3]]}]},
     }
     uid = "some-uid"
     project = "some-project"

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from mlrun.api.utils.singletons.db import get_db
 
 
-def test_run_with_nan_in_body(db: Session, client: TestClient, monkeypatch) -> None:
+def test_run_with_nan_in_body(db: Session, client: TestClient) -> None:
     """
     This test wouldn't pass if we were using FastAPI default JSONResponse which uses json.dumps to serialize jsons
     It passes only because we changed to use fastapi.responses.ORJSONResponse by default which uses orjson.dumps

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -1,0 +1,25 @@
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from mlrun.api.utils.singletons.db import get_db
+
+
+def test_run_with_nan_in_body(db: Session, client: TestClient, monkeypatch) -> None:
+    run_with_nan_float = {
+        "status": {
+            "artifacts": [
+                {
+                    "preview": [
+                        [0.0, float("Nan"), 1.3],
+                    ],
+                },
+            ],
+        },
+    }
+    uid = "some-uid"
+    project = "some-project"
+    get_db().store_run(db, run_with_nan_float, uid, project)
+    resp = client.get(f"/api/run/{project}/{uid}")
+    assert resp.status_code == HTTPStatus.OK.value

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -7,6 +7,11 @@ from mlrun.api.utils.singletons.db import get_db
 
 
 def test_run_with_nan_in_body(db: Session, client: TestClient, monkeypatch) -> None:
+    """
+    This test wouldn't pass if we were using FastAPI default JSONResponse which uses json.dumps to serialize jsons
+    It passes only because we changed to use fastapi.responses.ORJSONResponse by default which uses orjson.dumps
+    which do handles float("Nan")
+    """
     run_with_nan_float = {
         "status": {"artifacts": [{"preview": [[0.0, float("Nan"), 1.3]]}]},
     }


### PR DESCRIPTION
We had a bug in which one of the runs in the DB was this:
[run-with-nan-float.txt](https://github.com/mlrun/mlrun/files/5120876/run-with-nan-float.txt)
you can note that inside the value of the preview key of one of this run's artifacts there is a Nan.
The default response in FastAPI is JSONResponse which uses `json.dumps` to serialize jsons which would fail with this message:
```
INFO:     10.200.0.20:48732 - "GET /api/run/model-deployment-with-streaming-iguazio/dec577c6f1e74aed9e1911c4b6a8bddc HTTP/1.0" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/httptools_impl.py", line 390, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.7/site-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/fastapi/applications.py", line 180, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/applications.py", line 111, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 566, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 227, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 41, in app
    response = await func(request)
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 218, in app
    background=background_tasks,
  File "/usr/local/lib/python3.7/site-packages/starlette/responses.py", line 49, in __init__
    self.body = self.render(content)
  File "/usr/local/lib/python3.7/site-packages/starlette/responses.py", line 162, in render
    separators=(",", ":"),
  File "/usr/local/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant
```
In this PR I changed the default response to `fastapi.responses.ORJSONResponse` which uses `orjson.dumps` which do handles float("Nan") (and should also be much faster)
