### PR TITLE
Adding option to give name filter in list_schedules

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -30,10 +30,11 @@ def create_schedule(
 @router.get("/projects/{project}/schedules", response_model=schemas.SchedulesOutput)
 def list_schedules(
     project: str,
+    name: str = None,
     kind: schemas.ScheduleKinds = None,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    return get_scheduler().list_schedules(db_session, project, kind)
+    return get_scheduler().list_schedules(db_session, project, name, kind)
 
 
 @router.get(

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -132,7 +132,11 @@ class DBInterface(ABC):
 
     @abstractmethod
     def list_schedules(
-        self, session, project: str = None, name: str = None, kind: schemas.ScheduleKinds = None
+        self,
+        session,
+        project: str = None,
+        name: str = None,
+        kind: schemas.ScheduleKinds = None,
     ) -> List[schemas.ScheduleRecord]:
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -132,7 +132,7 @@ class DBInterface(ABC):
 
     @abstractmethod
     def list_schedules(
-        self, session, project: str = None, kind: schemas.ScheduleKinds = None
+        self, session, project: str = None, name: str = None, kind: schemas.ScheduleKinds = None
     ) -> List[schemas.ScheduleRecord]:
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -124,7 +124,7 @@ class FileDB(DBInterface):
         raise NotImplementedError()
 
     def list_schedules(
-        self, session, project: str = None, kind: schemas.ScheduleKinds = None
+        self, session, project: str = None, name: str = None, kind: schemas.ScheduleKinds = None
     ) -> List[schemas.ScheduleRecord]:
         raise NotImplementedError()
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -124,7 +124,11 @@ class FileDB(DBInterface):
         raise NotImplementedError()
 
     def list_schedules(
-        self, session, project: str = None, name: str = None, kind: schemas.ScheduleKinds = None
+        self,
+        session,
+        project: str = None,
+        name: str = None,
+        kind: schemas.ScheduleKinds = None,
     ) -> List[schemas.ScheduleRecord]:
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -400,13 +400,15 @@ class SQLDB(DBInterface):
         self._upsert(session, schedule)
 
     def list_schedules(
-        self, session: Session, project: str = None, kind: schemas.ScheduleKinds = None,
+        self, session: Session, project: str = None, name: str = None, kind: schemas.ScheduleKinds = None,
     ) -> List[schemas.ScheduleRecord]:
-        logger.debug("Getting schedules from db", project=project, kind=kind)
-        db_schedules = self._query(session, Schedule, project=project, kind=kind)
+        logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
+        query = self._query(session, Schedule, project=project, kind=kind)
+        if name is not None:
+            query = query.filter(Schedule.name.ilike(f'%{name}%'))
         schedules = [
             self._transform_schedule_model_to_scheme(db_schedule)
-            for db_schedule in db_schedules
+            for db_schedule in query
         ]
         return schedules
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -400,12 +400,16 @@ class SQLDB(DBInterface):
         self._upsert(session, schedule)
 
     def list_schedules(
-        self, session: Session, project: str = None, name: str = None, kind: schemas.ScheduleKinds = None,
+        self,
+        session: Session,
+        project: str = None,
+        name: str = None,
+        kind: schemas.ScheduleKinds = None,
     ) -> List[schemas.ScheduleRecord]:
         logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
         query = self._query(session, Schedule, project=project, kind=kind)
         if name is not None:
-            query = query.filter(Schedule.name.ilike(f'%{name}%'))
+            query = query.filter(Schedule.name.ilike(f"%{name}%"))
         schedules = [
             self._transform_schedule_model_to_scheme(db_schedule)
             for db_schedule in query

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -73,10 +73,10 @@ class Scheduler:
         )
 
     def list_schedules(
-        self, db_session: Session, project: str = None, kind: str = None
+        self, db_session: Session, project: str = None, name: str = None, kind: str = None
     ) -> schemas.SchedulesOutput:
-        logger.debug("Getting schedules", project=project, kind=kind)
-        db_schedules = get_db().list_schedules(db_session, project, kind)
+        logger.debug("Getting schedules", project=project, name=name, kind=kind)
+        db_schedules = get_db().list_schedules(db_session, project, name, kind)
         schedules = []
         for db_schedule in db_schedules:
             schedule = self._transform_db_schedule_to_schedule(db_schedule)

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -73,7 +73,11 @@ class Scheduler:
         )
 
     def list_schedules(
-        self, db_session: Session, project: str = None, name: str = None, kind: str = None
+        self,
+        db_session: Session,
+        project: str = None,
+        name: str = None,
+        kind: str = None,
     ) -> schemas.SchedulesOutput:
         logger.debug("Getting schedules", project=project, name=name, kind=kind)
         db_schedules = get_db().list_schedules(db_session, project, name, kind)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -441,12 +441,12 @@ class HTTPRunDB(RunDBInterface):
         return schemas.ScheduleOutput(**resp.json())
 
     def list_schedules(
-        self, project: str, kind: schemas.ScheduleKinds = None
+        self, project: str, name: str = None, kind: schemas.ScheduleKinds = None
     ) -> schemas.SchedulesOutput:
         project = project or default_project
-        params = {"kind": kind}
+        params = {"kind": kind, "name": name}
         path = f"projects/{project}/schedules"
-        error_message = f"Failed listing schedules for {project} ? {kind}"
+        error_message = f"Failed listing schedules for {project} ? {kind} {name}"
         resp = self.api_call("GET", path, error_message, params=params)
         return schemas.SchedulesOutput(**resp.json())
 

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -237,50 +237,23 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
 @pytest.mark.asyncio
 async def test_list_schedules_name_filter(db: Session, scheduler: Scheduler):
     cases = [
-        {
-            'name': 'some_prefix-mlrun',
-            'should_find': True,
-        },
-        {
-            'name': 'some_prefix-mlrun-some_suffix',
-            'should_find': True,
-        },
-        {
-            'name': 'mlrun-some_suffix',
-            'should_find': True,
-        },
-        {
-            'name': 'mlrun',
-            'should_find': True,
-        },
-        {
-            'name': 'MLRun',
-            'should_find': True,
-        },
-        {
-            'name': 'bla-MLRun-bla',
-            'should_find': True,
-        },
-        {
-            'name': 'mlun',
-            'should_find': False,
-        },
-        {
-            'name': 'mlurn',
-            'should_find': False,
-        },
-        {
-            'name': 'mluRn',
-            'should_find': False,
-        },
+        {"name": "some_prefix-mlrun", "should_find": True},
+        {"name": "some_prefix-mlrun-some_suffix", "should_find": True},
+        {"name": "mlrun-some_suffix", "should_find": True},
+        {"name": "mlrun", "should_find": True},
+        {"name": "MLRun", "should_find": True},
+        {"name": "bla-MLRun-bla", "should_find": True},
+        {"name": "mlun", "should_find": False},
+        {"name": "mlurn", "should_find": False},
+        {"name": "mluRn", "should_find": False},
     ]
 
     cron_trigger = schemas.ScheduleCronTrigger(minute="*/10")
     project = config.default_project
     expected_schedule_names = []
     for case in cases:
-        name = case['name']
-        should_find = case['should_find']
+        name = case["name"]
+        should_find = case["should_find"]
         scheduler.create_schedule(
             db,
             project,
@@ -292,7 +265,7 @@ async def test_list_schedules_name_filter(db: Session, scheduler: Scheduler):
         if should_find:
             expected_schedule_names.append(name)
 
-    schedules = scheduler.list_schedules(db, project, 'mlrun')
+    schedules = scheduler.list_schedules(db, project, "mlrun")
     assert len(schedules.schedules) == len(expected_schedule_names)
     for schedule in schedules.schedules:
         assert schedule.name in expected_schedule_names

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -235,6 +235,71 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
 
 
 @pytest.mark.asyncio
+async def test_list_schedules_name_filter(db: Session, scheduler: Scheduler):
+    cases = [
+        {
+            'name': 'some_prefix-mlrun',
+            'should_find': True,
+        },
+        {
+            'name': 'some_prefix-mlrun-some_suffix',
+            'should_find': True,
+        },
+        {
+            'name': 'mlrun-some_suffix',
+            'should_find': True,
+        },
+        {
+            'name': 'mlrun',
+            'should_find': True,
+        },
+        {
+            'name': 'MLRun',
+            'should_find': True,
+        },
+        {
+            'name': 'bla-MLRun-bla',
+            'should_find': True,
+        },
+        {
+            'name': 'mlun',
+            'should_find': False,
+        },
+        {
+            'name': 'mlurn',
+            'should_find': False,
+        },
+        {
+            'name': 'mluRn',
+            'should_find': False,
+        },
+    ]
+
+    cron_trigger = schemas.ScheduleCronTrigger(minute="*/10")
+    project = config.default_project
+    expected_schedule_names = []
+    for case in cases:
+        name = case['name']
+        should_find = case['should_find']
+        scheduler.create_schedule(
+            db,
+            project,
+            name,
+            schemas.ScheduleKinds.local_function,
+            do_nothing,
+            cron_trigger,
+        )
+        if should_find:
+            expected_schedule_names.append(name)
+
+    schedules = scheduler.list_schedules(db, project, 'mlrun')
+    assert len(schedules.schedules) == len(expected_schedule_names)
+    for schedule in schedules.schedules:
+        assert schedule.name in expected_schedule_names
+        expected_schedule_names.remove(schedule.name)
+
+
+@pytest.mark.asyncio
 async def test_delete_schedule(db: Session, scheduler: Scheduler):
     cron_trigger = schemas.ScheduleCronTrigger(year="1999")
     schedule_name = "schedule-name"


### PR DESCRIPTION
We filter the name in DB using `query.filter(Schedule.name.ilike(f"%{name}%"))` meaning:
1. using `ilike` - ignoring case
2. wrapping with `%` meaning any schedule that the name is a substring of its name will be matched