### PR TITLE
Pin black requirement

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ msgpack<1.0.0
 pytest~=5.4
 twine==3.1.1
 xgboost
-black
+# from 20.8 (the next version) it requires click>=7.1.2 which conflicts with kfp
+black<=19.10b0
 flake8
 pytest-asyncio~=0.14

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -41,9 +41,7 @@ def list_schedules(
     "/projects/{project}/schedules/{name}", response_model=schemas.ScheduleOutput
 )
 def get_schedule(
-    project: str,
-    name: str,
-    db_session: Session = Depends(deps.get_db_session),
+    project: str, name: str, db_session: Session = Depends(deps.get_db_session),
 ):
     return get_scheduler().get_schedule(db_session, project, name)
 
@@ -52,9 +50,7 @@ def get_schedule(
     "/projects/{project}/schedules/{name}", status_code=HTTPStatus.NO_CONTENT.value
 )
 def delete_schedule(
-    project: str,
-    name: str,
-    db_session: Session = Depends(deps.get_db_session),
+    project: str, name: str, db_session: Session = Depends(deps.get_db_session),
 ):
     get_scheduler().delete_schedule(db_session, project, name)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -289,11 +289,7 @@ class SQLDB(DBInterface):
         update_in(function, "metadata.updated", updated)
         fn = self._get_function(session, name, project, uid)
         if not fn:
-            fn = Function(
-                name=name,
-                project=project,
-                uid=uid,
-            )
+            fn = Function(name=name, project=project, uid=uid,)
         fn.updated = updated
         labels = get_in(function, "metadata.labels", {})
         update_labels(fn, labels)
@@ -644,10 +640,7 @@ class SQLDB(DBInterface):
                 Artifact.key,
                 func.max(Artifact.updated),
             )
-            .group_by(
-                Artifact.project,
-                Artifact.key.label("key"),
-            )
+            .group_by(Artifact.project, Artifact.key.label("key"),)
             .subquery("max_key")
         )
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -110,10 +110,8 @@ class Scheduler:
         Enforce no more then one job per min_allowed_interval
         """
         logger.debug("Validating cron trigger")
-        apscheduler_cron_trigger = (
-            self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
-                cron_trigger
-            )
+        apscheduler_cron_trigger = self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
+            cron_trigger
         )
         now = now or datetime.now(apscheduler_cron_trigger.timezone)
         next_run_time = None

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -59,10 +59,7 @@ def dict_to_artifact(struct: dict):
 
 class ArtifactManager:
     def __init__(
-        self,
-        stores: StoreManager,
-        db: RunDBInterface = None,
-        calc_hash=True,
+        self, stores: StoreManager, db: RunDBInterface = None, calc_hash=True,
     ):
         self.calc_hash = calc_hash
 

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -405,10 +405,7 @@ class FileRunDB(RunDBInterface):
 
     def store_schedule(self, data):
         sched_id = 1 + sum(1 for _ in scandir(self.schedules_dir))
-        fname = path.join(
-            self.schedules_dir,
-            "{}{}".format(sched_id, self.format),
-        )
+        fname = path.join(self.schedules_dir, "{}{}".format(sched_id, self.format),)
         with open(fname, "w") as out:
             out.write(self._dumps(data))
 

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -355,10 +355,7 @@ class BasePod:
         self.add_volume(
             client.V1Volume(
                 name=name,
-                secret=client.V1SecretVolumeSource(
-                    secret_name=name,
-                    items=items,
-                ),
+                secret=client.V1SecretVolumeSource(secret_name=name, items=items,),
             ),
             mount_path=path,
         )

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -41,10 +41,7 @@ def xcp_op(
         args = ["-r"] + args
 
     return dsl.ContainerOp(
-        name="xcp",
-        image="yhaviv/invoke",
-        command=["xcp"],
-        arguments=args,
+        name="xcp", image="yhaviv/invoke", command=["xcp"], arguments=args,
     )
 
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1095,10 +1095,7 @@ class BaseRuntimeHandler(ABC):
         self._ensure_runtime_resource_run_logs_collected(db, db_session, project, uid)
 
     def _is_runtime_resource_run_in_transient_state(
-        self,
-        db: DBInterface,
-        db_session: Session,
-        runtime_resource: Dict,
+        self, db: DBInterface, db_session: Session, runtime_resource: Dict,
     ) -> Tuple[bool, Optional[datetime]]:
         """
         A runtime can have different underlying resources (like pods or CRDs) - to generalize we call it runtime

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -452,11 +452,7 @@ class RemoteRuntime(KubeResource):
             for run in runs:
                 self.store_run(run)
                 run.spec.secret_sources = secrets or []
-                tasks.append(
-                    asyncio.ensure_future(
-                        submit(session, url, run, headers),
-                    )
-                )
+                tasks.append(asyncio.ensure_future(submit(session, url, run, headers),))
 
             for status, resp, logs, run in await asyncio.gather(*tasks):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ urllib3>=1.24.2, <1.25
 GitPython>=2.1.0
 aiohttp>=3.5.0
 boto3>=1.9
-click==7.0
+click~=7.0
 # this is the pipelines version running in 2.8/2.10 iguazio system, for now locking it to this version
 kfp==0.2.5
 nest-asyncio>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ urllib3>=1.24.2, <1.25
 GitPython>=2.1.0
 aiohttp>=3.5.0
 boto3>=1.9
-click~=7.0
+# ==7.0 from kfp
+click==7.0
 # this is the pipelines version running in 2.8/2.10 iguazio system, for now locking it to this version
 kfp==0.2.5
 nest-asyncio>=1.0.0

--- a/tests/system/demos/base.py
+++ b/tests/system/demos/base.py
@@ -11,8 +11,7 @@ class TestDemo(TestMLRunSystem):
 
     def custom_setup(self):
         mlrun.set_environment(
-            artifact_path="/User/data",
-            project=self.project_name,
+            artifact_path="/User/data", project=self.project_name,
         )
 
         # specifically for each workflow, this combines the artifact path above with a

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -31,10 +31,7 @@ class TestHorovodTFv2(TestDemo):
         self._logger.debug("Creating iris-generator function")
         function_path = str(self.assets_path / "utils_functions.py")
         utils = mlrun.code_to_function(
-            name="utils",
-            kind="job",
-            filename=function_path,
-            image="mlrun/mlrun",
+            name="utils", kind="job", filename=function_path, image="mlrun/mlrun",
         )
 
         utils.spec.remote = True

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -18,10 +18,7 @@ class TestSKLearn(TestDemo):
         self._logger.debug("Creating iris-generator function")
         function_path = str(self.assets_path / "iris_generator_function.py")
         iris_generator_function = mlrun.code_to_function(
-            name="gen-iris",
-            kind="job",
-            filename=function_path,
-            image="mlrun/mlrun",
+            name="gen-iris", kind="job", filename=function_path, image="mlrun/mlrun",
         )
 
         iris_generator_function.spec.remote = True

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -20,9 +20,7 @@ class TestDask(TestMLRunSystem):
     def custom_setup(self):
         self._logger.debug("Creating dask function")
         self.dask_function = code_to_function(
-            "mydask",
-            kind="dask",
-            filename=str(self.assets_path / "dask_function.py"),
+            "mydask", kind="dask", filename=str(self.assets_path / "dask_function.py"),
         ).apply(mount_v3io())
 
         self.dask_function.spec.image = "mlrun/ml-models"

--- a/tests/test_kfp.py
+++ b/tests/test_kfp.py
@@ -190,7 +190,5 @@ def _assert_metrics_file(
 
 def _generate_task(p1, out_path):
     return NewTask(
-        params={"p1": p1},
-        out_path=out_path,
-        outputs=["accuracy", "loss"],
+        params={"p1": p1}, out_path=out_path, outputs=["accuracy", "loss"],
     ).set_label("tests", "kfp")


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/423 I changed the code to be formatted according to the new black version - `20.8b1` the problem is that from 20.8 black requires `click>=7.1.2`, and we're pinned to `7.0` because of kfp
so bounded black - `black<=19.10b0` and did the needed formatting