### PR TITLE
Fix hub function url resolution

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -331,12 +331,15 @@ def parse_function_uri(uri):
 def extend_hub_uri(uri):
     if not uri.startswith(hub_prefix):
         return uri
-    name = uri[len(hub_prefix) :]
+    name = uri[len(hub_prefix):]
     tag = "master"
     if ":" in name:
         loc = name.find(":")
-        tag = name[loc + 1 :]
+        tag = name[loc + 1:]
         name = name[:loc]
+
+    # hub function directory name are with underscores instead of hyphens
+    name = name.replace('-', '_')
     return config.hub_url.format(name=name, tag=tag)
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -331,15 +331,15 @@ def parse_function_uri(uri):
 def extend_hub_uri(uri):
     if not uri.startswith(hub_prefix):
         return uri
-    name = uri[len(hub_prefix):]
+    name = uri[len(hub_prefix) :]
     tag = "master"
     if ":" in name:
         loc = name.find(":")
-        tag = name[loc + 1:]
+        tag = name[loc + 1 :]
         name = name[:loc]
 
     # hub function directory name are with underscores instead of hyphens
-    name = name.replace('-', '_')
+    name = name.replace("-", "_")
     return config.hub_url.format(name=name, tag=tag)
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,4 +1,4 @@
-from mlrun.utils.helpers import verify_field_regex
+from mlrun.utils.helpers import verify_field_regex, extend_hub_uri
 from mlrun.utils.regex import run_name
 
 
@@ -40,3 +40,33 @@ def test_run_name_regex():
         except Exception:
             if case["valid"]:
                 raise
+
+
+def test_extend_hub_uri():
+    cases = [
+        {
+            "input": "http://no-hub-prefix",
+            "expected_output": 'http://no-hub-prefix',
+        },
+        {
+            "input": "hub://function_name",
+            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml',
+        },
+        {
+            "input": "hub://function_name:development",
+            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.yaml',
+        },
+        {
+            "input": "hub://function-name",
+            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml',
+        },
+        {
+            "input": "hub://function-name:development",
+            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.yaml',
+        },
+    ]
+    for case in cases:
+        input = case['input']
+        expected_output = case['expected_output']
+        output = extend_hub_uri(input)
+        assert expected_output == output

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -44,29 +44,28 @@ def test_run_name_regex():
 
 def test_extend_hub_uri():
     cases = [
-        {
-            "input": "http://no-hub-prefix",
-            "expected_output": 'http://no-hub-prefix',
-        },
+        {"input": "http://no-hub-prefix", "expected_output": "http://no-hub-prefix"},
         {
             "input": "hub://function_name",
-            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml',
+            "expected_output": "https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml",
         },
         {
             "input": "hub://function_name:development",
-            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.yaml',
+            "expected_output": "https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.ya"
+            "ml",
         },
         {
             "input": "hub://function-name",
-            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml',
+            "expected_output": "https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml",
         },
         {
             "input": "hub://function-name:development",
-            "expected_output": 'https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.yaml',
+            "expected_output": "https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.ya"
+            "ml",
         },
     ]
     for case in cases:
-        input = case['input']
-        expected_output = case['expected_output']
+        input = case["input"]
+        expected_output = case["expected_output"]
         output = extend_hub_uri(input)
         assert expected_output == output

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -44,28 +44,31 @@ def test_run_name_regex():
 
 def test_extend_hub_uri():
     cases = [
-        {"input": "http://no-hub-prefix", "expected_output": "http://no-hub-prefix"},
         {
-            "input": "hub://function_name",
+            "input_uri": "http://no-hub-prefix",
+            "expected_output": "http://no-hub-prefix",
+        },
+        {
+            "input_uri": "hub://function_name",
             "expected_output": "https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml",
         },
         {
-            "input": "hub://function_name:development",
+            "input_uri": "hub://function_name:development",
             "expected_output": "https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.ya"
             "ml",
         },
         {
-            "input": "hub://function-name",
+            "input_uri": "hub://function-name",
             "expected_output": "https://raw.githubusercontent.com/mlrun/functions/master/function_name/function.yaml",
         },
         {
-            "input": "hub://function-name:development",
+            "input_uri": "hub://function-name:development",
             "expected_output": "https://raw.githubusercontent.com/mlrun/functions/development/function_name/function.ya"
             "ml",
         },
     ]
     for case in cases:
-        input = case["input"]
+        input_uri = case["input_uri"]
         expected_output = case["expected_output"]
-        output = extend_hub_uri(input)
+        output = extend_hub_uri(input_uri)
         assert expected_output == output


### PR DESCRIPTION
hub function directories have underscores instead of hyphens - so if someone request from us this function `hub://some-function` we should look for it in the `some_function` directory