### PR TITLE
Fix models legacy image

### DIFF
--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -57,8 +57,6 @@ RUN conda clean -ayq
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-# plain vanilla tensorflow isn't compiled optimaly for the architectures
-# we are likely to encounter.  this should become an option:
 RUN python -m pip install -U intel-tensorflow
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -58,11 +58,7 @@ RUN conda install -y -c plotly plotly-orca python=3.6
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-# plain vanilla tensorflow isn't compiled optimaly for the architectures
-# we are likely to encounter.  this should become an option:
-#RUN python -m pip install -U intel-tensorflow==1.15 keras pillow requests
-
-RUN conda install -n base -c anaconda tensorflow=1.15 keras
+RUN python -m pip install -U intel-tensorflow==1.15 keras
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install horovod

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -58,7 +58,7 @@ RUN conda install -y -c plotly plotly-orca python=3.6
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN python -m pip install -U intel-tensorflow==1.15 keras
+RUN python -m pip install -U intel-tensorflow<2 keras
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install horovod

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -60,9 +60,9 @@ RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
 
 # plain vanilla tensorflow isn't compiled optimaly for the architectures
 # we are likely to encounter.  this should become an option:
-#RUN python -m pip install -U intel-tensorflow==1.14 keras pillow requests
+#RUN python -m pip install -U intel-tensorflow==1.15 keras pillow requests
 
-RUN conda install -n base -c anaconda tensorflow=1.14 keras
+RUN conda install -n base -c anaconda tensorflow=1.15 keras
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install horovod


### PR DESCRIPTION
Got this error trying to build `models-legacy` image:
```
CMake Error at /usr/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:137 (message):

    Could NOT find Tensorflow: Found unsuitable version "1.14.0", but required

    is at least "1.15.0" (found

    -L/opt/conda/lib/python3.6/site-packages/tensorflow;-l:libtensorflow_framework.so.1)
```
full build log here - 
[models-legacy-build-bug.txt](https://github.com/mlrun/mlrun/files/5180435/models-legacy-build-bug.txt)

It happened since in the new horovod version - [0.20.0](https://github.com/horovod/horovod/releases/tag/v0.20.0) - they support only 1.15 and above (https://github.com/horovod/horovod/pull/2169)

So bumped to use tensorflow 1.15 (instead of 1.14) and changed to install with `pip` instead of `conda` like the regular image
