### PR TITLE
Fix chart artifact to have db key

### DIFF
--- a/mlrun/artifacts/plots.py
+++ b/mlrun/artifacts/plots.py
@@ -86,17 +86,6 @@ chart_template = """
 
 class ChartArtifact(Artifact):
     kind = "chart"
-    _dict_fields = [
-        "key",
-        "kind",
-        "iter",
-        "tree",
-        "src_path",
-        "target_path",
-        "hash",
-        "description",
-        "viewer",
-    ]
 
     def __init__(
         self,

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -12,7 +12,9 @@ def test_artifacts_export_required_fields():
     ]
 
     required_fields = [
-        "db_key"  # used as the identifier of the artifact
+        "key",
+        "kind",
+        "db_key",
     ]
 
     for artifact_class in artifact_classes:

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -1,0 +1,20 @@
+import mlrun.artifacts
+
+
+def test_artifacts_export_required_fields():
+    artifact_classes = [
+        mlrun.artifacts.Artifact,
+        mlrun.artifacts.ChartArtifact,
+        mlrun.artifacts.PlotArtifact,
+        mlrun.artifacts.DatasetArtifact,
+        mlrun.artifacts.ModelArtifact,
+        mlrun.artifacts.TableArtifact,
+    ]
+
+    required_fields = [
+        "db_key"  # used as the identifier of the artifact
+    ]
+
+    for artifact_class in artifact_classes:
+        for required_field in required_fields:
+            assert required_field in artifact_class._dict_fields


### PR DESCRIPTION
When running the [model_server_tester function](https://github.com/mlrun/functions/tree/master/model_server_tester) we noticed that in the UI the `latency` artifact has no name.
The reason for that was that the artifact (which is `ChartArtifact` instance) had no `db_key` field.
It didn't had the field since `db_key` is not in the class's `_dict_fields` attribute, I noticed that this class's dict fields is simply a subset of the base class's dict fields, so I just removed it (and the class will use the base class dict fields)
