### PR TITLE
Run update-version-file in docker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,12 +28,6 @@ jobs:
 #        - models-gpu-legacy
     steps:
     - uses: actions/checkout@v2
-    - name: Set up python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install automation scripts dependencies
-      run: pip install -r automation/requirements.txt
     - name: Docker login
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Set GIT_HASH env var

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install automation scripts dependencies
-      run: pip install -r automation/requirements.txt
     - name: Run Dockerized tests
       run: make test-dockerized
 
@@ -60,12 +54,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Install automation scripts dependencies
-        run: pip install -r automation/requirements.txt
       - name: Generate HTML docs
         run: make html-docs-dockerized
       - name: Upload generated docs

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,18 @@ endif
 	find . \( ! -regex '.*/\..*' \) -a \( -iname \*.md -o -iname \*.txt -o -iname \*.yaml -o -iname \*.yml \)  \
 	-type f -print0 | xargs -0 sed -i '' -e 's/:$(MLRUN_OLD_VERSION_ESCAPED)/:$(MLRUN_NEW_VERSION)/g'
 
+MLRUN_AUTOMATION_IMAGE_NAME := $(MLRUN_DOCKER_IMAGE_PREFIX)/automation:$(MLRUN_DOCKER_TAG)
+
+.PHONY: automation
+automation: ## Build automation docker image
+	docker build \
+		--file dockerfiles/automation/Dockerfile \
+		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
+		--tag $(MLRUN_AUTOMATION_IMAGE_NAME) .
+
 .PHONY: update-version-file
-update-version-file: ## Update the version file
-	python ./automation/version/version_file.py create $(MLRUN_VERSION)
+update-version-file: automation ## Update the version file
+	docker run -t --rm -e "MLRUN_VERSION=$(MLRUN_VERSION)" -v $(PWD):/mlrun $(MLRUN_AUTOMATION_IMAGE_NAME)
 
 .PHONY: build
 build: docker-images package-wheel ## Build all artifacts

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -40,9 +40,7 @@ def create(mlrun_version: str):
         json.dump(version_info, version_file, sort_keys=True, indent=2)
 
 
-def _run_command(
-    command: str, args: list = None,
-) -> (str, str, int):
+def _run_command(command: str, args: list = None,) -> (str, str, int):
     if args:
         command += " " + " ".join(args)
 

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -7,7 +7,8 @@ import click
 import logging
 
 # not using mlrun.utils.logger to not require mlrun package
-logger = logging.Logger(name="version", level="DEBUG")
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("version_file")
 
 
 @click.group()
@@ -22,6 +23,7 @@ def create(mlrun_version: str):
     try:
         out, _, _ = _run_command("git", args=["rev-parse", "HEAD"])
         git_commit = out.strip()
+        logger.debug(f"Found git commit: {git_commit}")
 
     except Exception as exc:
         logger.warning("Failed to get version", exc_info=exc)
@@ -39,7 +41,7 @@ def create(mlrun_version: str):
 
 
 def _run_command(
-    command: str, args: list = None, suppress_errors: bool = False,
+    command: str, args: list = None,
 ) -> (str, str, int):
     if args:
         command += " " + " ".join(args)

--- a/dockerfiles/automation/Dockerfile
+++ b/dockerfiles/automation/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG MLRUN_PYTHON_VERSION=3.7
+
+FROM python:${MLRUN_PYTHON_VERSION}-slim
+
+RUN apt-get update && apt-get install -y \
+  git-core
+
+RUN python -m pip install --upgrade --no-cache pip
+
+COPY ./automation/requirements.txt ./requirements.txt
+
+RUN python -m pip install -r requirements.txt
+
+WORKDIR /mlrun
+
+VOLUME /mlrun
+
+# "sh" is needed to enforce running in a shell - otherwise env vars substitution won't happen
+CMD ["sh", "-c", "python ./automation/version/version_file.py create $MLRUN_VERSION"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ except ImportError:
 import json
 import logging
 
-logger = logging.Logger(name="mlrun-setup", level="INFO")
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mlrun-setup")
 
 
 def version():


### PR DESCRIPTION
https://github.com/mlrun/mlrun/pull/437 introduced a new `version_file.py` script that used to create/update the version file.
This script is being run in the `update-version-file` makefile target, which is a dependency of every step that is building something (images/package).
Running this script requires to python3.7 and the `automation/requirements.txt` to be installed, so:
1. we needed to add several setup tests to the CI in several places
2. If you want to clone the repo and build some image you now can't - you need to do the above setup steps
I thought that although it will add some time (building an image and running it >> running python script) it worth moving this script to be ran dockerized when running it the from the `update-version-file` makefile target

I also fixed some logging issues (logging simply didn't work)