### PR TITLE
Fix models images

### DIFF
--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -57,7 +57,7 @@ RUN conda clean -ayq
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN python -m pip install -U intel-tensorflow
+RUN python -m pip install -U intel-tensorflow mxnet
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install horovod

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -58,7 +58,7 @@ RUN conda install -y -c plotly plotly-orca python=3.6
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN python -m pip install -U 'intel-tensorflow<2' keras
+RUN python -m pip install -U 'intel-tensorflow<2' keras mxnet
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install horovod


### PR DESCRIPTION
When building the models and models legacy images this occured when trying to install horovod:
```
    -- Could NOT find Mxnet (missing: Mxnet_LIBRARIES) (Required is at least version "1.4.0")
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ModuleNotFoundError: No module named 'mxnet'
    CMake Error at cmake/Modules/FindMxnet.cmake:59 (string):
      string no output variable specified
    Call Stack (most recent call first):
      horovod/mxnet/CMakeLists.txt:12 (find_package)
```
Full log: 
[models-image-bug.txt](https://github.com/mlrun/mlrun/files/5285917/models-image-bug.txt)

So added installation of `mxnet` in the previous step
