### PR TITLE
Update function entry points when updating code

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -628,8 +628,7 @@ def code_to_function(
             update_in(spec, "kind", "Function")
             r.spec.base_spec = spec
             if with_doc:
-                handlers = find_handlers(code)
-                r.spec.entry_points = {h["name"]: as_func(h) for h in handlers}
+                update_function_entry_points(r, code)
         else:
             r.spec.source = filename
             r.spec.function_handler = handler
@@ -680,8 +679,7 @@ def code_to_function(
             r.spec.volume_mounts.append(vol.get("volumeMount"))
 
     if with_doc:
-        handlers = find_handlers(code)
-        r.spec.entry_points = {h["name"]: as_func(h) for h in handlers}
+        update_function_entry_points(r, code)
     r.spec.default_handler = handler
     update_meta(r)
     return r
@@ -927,6 +925,11 @@ def as_func(handler):
         outputs=[ret] if ret else None,
         lineno=handler["lineno"],
     ).to_dict()
+
+
+def update_function_entry_points(function, code):
+    handlers = find_handlers(code)
+    function.spec.entry_points = {handler["name"]: as_func(handler) for handler in handlers}
 
 
 def clean(struct: dict):

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing
+import importlib.util as imputil
 import json
 import socket
+import typing
 import uuid
-from ast import literal_eval
 from base64 import b64decode
 from copy import deepcopy
 from os import environ, makedirs, path
@@ -26,14 +26,11 @@ from tempfile import mktemp
 import yaml
 from kfp import Client
 from nuclio import build_file
-import importlib.util as imputil
 
-from .utils import retry_until_successful
 from .config import config as mlconf
 from .datastore import store_manager
 from .db import get_or_set_dburl, get_run_db
 from .execution import MLClientCtx
-from .funcdoc import find_handlers
 from .k8s_utils import get_k8s_helper
 from .model import RunObject, BaseMetadata, RunTemplate
 from .runtimes import (
@@ -43,7 +40,7 @@ from .runtimes import (
     RuntimeKinds,
     get_runtime_class,
 )
-from .runtimes.base import FunctionEntrypoint
+from .runtimes.funcdoc import update_function_entry_points
 from .runtimes.utils import add_code_metadata, global_context
 from .utils import (
     get_in,
@@ -53,6 +50,7 @@ from .utils import (
     new_pipe_meta,
     extend_hub_uri,
 )
+from .utils import retry_until_successful
 
 
 class RunStatuses(object):
@@ -914,40 +912,6 @@ def list_piplines(
             )
 
     return resp.total_size, resp.next_page_token, runs
-
-
-def as_func(handler):
-    ret = clean(handler["return"])
-    return FunctionEntrypoint(
-        name=handler["name"],
-        doc=handler["doc"],
-        parameters=[clean(p) for p in handler["params"]],
-        outputs=[ret] if ret else None,
-        lineno=handler["lineno"],
-    ).to_dict()
-
-
-def update_function_entry_points(function, code):
-    handlers = find_handlers(code)
-    function.spec.entry_points = {
-        handler["name"]: as_func(handler) for handler in handlers
-    }
-
-
-def clean(struct: dict):
-    if not struct:
-        return None
-    if "default" in struct:
-        struct["default"] = py_eval(struct["default"])
-    return {k: v for k, v in struct.items() if v or k == "default"}
-
-
-def py_eval(data):
-    try:
-        value = literal_eval(data)
-        return value
-    except (SyntaxError, ValueError):
-        return data
 
 
 def get_object(url, secrets=None, size=None, offset=0, db=None):

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -929,7 +929,9 @@ def as_func(handler):
 
 def update_function_entry_points(function, code):
     handlers = find_handlers(code)
-    function.spec.entry_points = {handler["name"]: as_func(handler) for handler in handlers}
+    function.spec.entry_points = {
+        handler["name"]: as_func(handler) for handler in handlers
+    }
 
 
 def clean(struct: dict):

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -18,9 +18,9 @@ from base64 import b64encode
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 
-from mlrun.run import update_function_entry_points
 from mlrun.runtimes.base import BaseRuntimeHandler
 from .base import RunError
+from .funcdoc import update_function_entry_points
 from .pod import KubeResource
 from .utils import AsyncLogWriter, default_image_name
 from ..builder import build_runtime

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -18,6 +18,7 @@ from base64 import b64encode
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 
+from mlrun.run import update_function_entry_points
 from mlrun.runtimes.base import BaseRuntimeHandler
 from .base import RunError
 from .pod import KubeResource
@@ -35,15 +36,20 @@ class KubejobRuntime(KubeResource):
 
     _is_remote = True
 
-    def with_code(self, from_file="", body=None):
+    def with_code(self, from_file="", body=None, with_doc=True):
+        """Update the function code
+        This function eliminates the need to build container images every time we edit the code
+
+        :param from_file:   blank for current notebook, or path to .py/.ipynb file
+        :param body:        will use the body as the function code
+        :param with_doc:    update the document of the function parameters
+
+        :return: function object
+        """
         if (not body and not from_file) or (from_file and from_file.endswith(".ipynb")):
             from nuclio import build_file
 
-            name, spec, code = build_file(from_file)
-            self.spec.build.functionSourceCode = get_in(
-                spec, "spec.build.functionSourceCode"
-            )
-            return self
+            _, _, body = build_file(from_file)
 
         if from_file:
             with open(from_file) as fp:
@@ -51,6 +57,8 @@ class KubejobRuntime(KubeResource):
         self.spec.build.functionSourceCode = b64encode(body.encode("utf-8")).decode(
             "utf-8"
         )
+        if with_doc:
+            update_function_entry_points(self, body)
         return self
 
     @property

--- a/tests/runtimes/test_funcdoc.py
+++ b/tests/runtimes/test_funcdoc.py
@@ -18,8 +18,8 @@ from textwrap import dedent
 import pytest
 import yaml
 
+from mlrun.runtimes import funcdoc
 from tests.conftest import here
-from mlrun import funcdoc
 
 
 def load_rst_cases(name):


### PR DESCRIPTION
This is purposed to fix a bug in which a user updated function params and saved the function but when using the run job X he saw the old params.
The solution is simple, took code that was duplicated in several places, moved it to a function `update_function_entry_points` and added a call to it in `with_code` function.

`with_code` is sitting in `mlrun/runtimes/kubejob.py` and `update_function_entry_points` would have sit in `mlrun/run.py` which itself import the runtimes module which caused an import cycle.
to solve it I moved `update_function_entry_points` and its helpers to `mlrun/funcdoc.py` and moved it to `mlrun/runtimes/funcdoc.py`.
Also moved the `test_funcdoc.pt` under `tests/runtimes` and added docstring to `with_code`