### PR TITLE
Changing NewTask deprecation plan

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -441,7 +441,7 @@ class RunObject(RunTemplate):
         return state
 
 
-# TODO: remove in 0.7.0
+# TODO: remove in 0.9.0
 def NewTask(
     name=None,
     project=None,
@@ -462,7 +462,8 @@ def NewTask(
     """Creates a new task - see new_task
     """
     warnings.warn(
-        "NewTask is deprecated and will be removed in 0.7.0, use new_task instead",
+        "NewTask will be deprecated in 0.7.0, and will be removed in 0.9.0, use new_task instead",
+        # TODO: change to FutureWarning in 0.7.0
         PendingDeprecationWarning,
     )
     return new_task(

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -463,7 +463,7 @@ def NewTask(
     """
     warnings.warn(
         "NewTask is deprecated and will be removed in 0.7.0, use new_task instead",
-        FutureWarning,
+        PendingDeprecationWarning,
     )
     return new_task(
         name,


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/442 I created `new_task` to be instead `NewTask`.
`NewTask` remained but with a deprecation warning that it will be removed in `0.7.0`, the chosen warning class was `FutureWarning` because `DeprecationWarning` is ignored by default while `FutureWarning` is not.

The problem is that our examples and demos use `NewTask` a lot.
If we'll change all of them to `new_task` it will be problematic since users running MLRun <0.5.3 won't have this `new_task` and they'll have to search for the examples relevant to their release which is very inconvient.
On the other hand keeping them as is means that when running them the deprecation warning will be printed which is also not nice (new user running latest version with latest examples getting deprecation warnings)

So my plan is this:
* Currently change the warning to  `PendingDeprecationWarning` which is ignored by default meaning users wouldn't really see it.
* at `0.7.0` when it will be very unlikely that someone is running `<0.5.3` we'll change the examples & demos + change the warning to `FutureWarning` - that way running latest code with latest examples won't print warnings, but using the `NewTask` will print warnings
* at `0.9.0` when it will be very unlikely that someone is still using `NewTask` we'll remove it.

**Note:**
This change (`NewTask` -> `new_task`) is very minor change, not funtional at all, only cosmetic, however I'm purposely 
putting effort on doing its deprecation right, by that I'm "practicing" on it, and when real stuff will come, we'll already know what's the right way to do it
