### PR TITLE
Add Installation of procps in mlrun-api 

### DIFF
--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
   gcc \
   git-core \
   sqlite3 \
+  procps \
   vim
 
 RUN python -m pip install --upgrade --no-cache pip


### PR DESCRIPTION
I want to add a liveness probe which will use `ps` to check the whether the main process is running
`procps` is actually `ps` 