### PR TITLE
Adding artifact name filter

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -765,7 +765,9 @@ class SQLDB(DBInterface):
             ),
         )
 
-    def _find_artifacts(self, session, project, uids, labels=None, since=None, until=None, name=None):
+    def _find_artifacts(
+        self, session, project, uids, labels=None, since=None, until=None, name=None
+    ):
         """
         TODO: refactor this method
         basically uids should be list of strings (representing uids), but we also handle two special cases (mainly for

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -257,7 +257,7 @@ class SQLDB(DBInterface):
         arts = ArtifactList(
             obj.struct
             for obj in self._find_artifacts(
-                session, project, uids, labels, since, until
+                session, project, uids, labels, since, until, name
             )
         )
         return arts
@@ -307,7 +307,7 @@ class SQLDB(DBInterface):
 
     def del_artifacts(self, session, name="", project="", tag="*", labels=None):
         project = project or config.default_project
-        for obj in self._find_artifacts(session, project, tag, labels, None, None):
+        for obj in self._find_artifacts(session, project, tag, labels, name=name):
             self.del_artifact(session, obj.key, "", project)
 
     def store_function(
@@ -765,7 +765,7 @@ class SQLDB(DBInterface):
             ),
         )
 
-    def _find_artifacts(self, session, project, uids, labels, since, until):
+    def _find_artifacts(self, session, project, uids, labels=None, since=None, until=None, name=None):
         """
         TODO: refactor this method
         basically uids should be list of strings (representing uids), but we also handle two special cases (mainly for
@@ -789,6 +789,9 @@ class SQLDB(DBInterface):
             query = query.filter(
                 and_(Artifact.updated >= since, Artifact.updated <= until)
             )
+
+        if name is not None:
+            query = query.filter(Artifact.key.ilike(f"%{name}%"))
 
         return query
 

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -1,0 +1,37 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from mlrun.api.db.base import DBInterface
+from tests.api.db.conftest import dbs
+
+
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
+def test_list_artifact_name_filter(db: DBInterface, db_session: Session):
+    artifact_name_1 = "artifact_name_1"
+    artifact_name_2 = "artifact_name_2"
+    artifact_1 = {"metadata": {"name": artifact_name_1}, "status": {"bla": "blabla"}}
+    artifact_2 = {"metadata": {"name": artifact_name_2}, "status": {"bla": "blabla"}}
+    uid = "artifact_uid"
+
+    db.store_artifact(
+        db_session, artifact_name_1, artifact_1, uid,
+    )
+    db.store_artifact(
+        db_session, artifact_name_2, artifact_2, uid,
+    )
+    artifacts = db.list_artifacts(db_session)
+    assert len(artifacts) == 2
+
+    artifacts = db.list_artifacts(db_session, name=artifact_name_1)
+    assert len(artifacts) == 1
+    assert artifacts[0]["metadata"]["name"] == artifact_name_1
+
+    artifacts = db.list_artifacts(db_session, name=artifact_name_2)
+    assert len(artifacts) == 1
+    assert artifacts[0]["metadata"]["name"] == artifact_name_2
+
+    artifacts = db.list_artifacts(db_session, name="artifact_name")
+    assert len(artifacts) == 2


### PR DESCRIPTION
Theortically it should be `key` not `name` but since it's already `name` in the APIs leaving it as is