### PR TITLE
Enable to trigger workflows manually

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - development
-    - action_fixes
 #    - '[0-9]+.[0-9]+.x'
 
   workflow_dispatch: ~
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'hedingber/mlrun'
+    if: github.repository == 'mlrun/mlrun'
 
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,8 +59,8 @@ jobs:
           echo ${input_docker_registry:-ghcr.io/})"
     - name: Docker login
       run: |
-        echo ${{ secrets.CR_PAT }} | \
-        docker login ${{ steps.computed_params.outputs.mlrun_docker_registry }} -u ${{ secrets.CR_USERNAME }} --password-stdin
+        echo ${{ secrets.DOCKER_REGISTRY_PASSWORD }} | \
+        docker login ${{ steps.computed_params.outputs.mlrun_docker_registry }} -u ${{ secrets.DOCKER_REGISTRY_USERNAME }} --password-stdin
     - name: Pull cache, build and push image
 
       # we don't really want per-commit test image we just want to build and push the cache image so CI will be able

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
         required: true
         default: 'ghcr.io/'
       docker_repo:
-        description: 'Docker repo to push images to (default: lowered github repository owner name)'
+        description: 'Docker repo to push images to (default: lowercase github repository owner name)'
         required: false
         default: ''
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
     inputs:
       docker_registry:
         description: 'Docker registry to push images to (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
-        required: false
+        required: true
         default: 'ghcr.io/'
       docker_repo:
         description: 'Docker repo to push images to (default: lowered github repository owner name)'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/mlrun'
+    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
 
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
     - development
 #    - '[0-9]+.[0-9]+.x'
 
+  workflow_dispatch: ~
+
 jobs:
   build-images:
     name: Build and push image - ${{ matrix.image-name }}
@@ -29,22 +31,36 @@ jobs:
 #        - models-gpu-legacy
     steps:
     - uses: actions/checkout@v2
-    - name: Docker login
-      run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
-    - name: Set MLRUN_DOCKER_REPO env var
-      run: echo "::set-env name=MLRUN_DOCKER_REPO::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
-    - name: Set GIT_HASH env var
-      run: echo "::set-env name=GIT_HASH::$(git rev-parse --short $GITHUB_SHA)"
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-    - name: Set LATEST_VERSION env var
-      run: echo "::set-env name=LATEST_VERSION::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
+    - name: Extract git hashes and latest version
+      id: git_info
+      run: |
+        echo "::set-output name=mlrun_commit_hash::$(git rev-parse --short $GITHUB_SHA)"
+        echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
+    - name: Set computed versions params
+      id: computed_params
+      run: |
+        echo "::set-output name=mlrun_version::${{ steps.git_info.outputs.latest_version }}-${{ steps.git_info.outputs.mlrun_commit_hash }}"
+        echo "::set-output name=mlrun_docker_repo::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
+    - name: Docker login
+      run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Pull cache, build and push image
 
       # we don't really want per-commit test image we just want to build and push the cache image so CI will be able
       # to use it and run much faster
       if: ${{ matrix.image-name != 'test' }}
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_VERSION="$LATEST_VERSION"-"$GIT_HASH" MLRUN_DOCKER_CACHE_FROM_TAG=unstable-cache make push-${{ matrix.image-name }}
+      run: |
+        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
+        MLRUN_VERSION=${{ steps.computed_params.outputs.mlrun_version }} \
+        MLRUN_DOCKER_CACHE_FROM_TAG=unstable-cache \
+        make push-${{ matrix.image-name }}
     - name: Pull cache, build and push test image
       if: ${{ matrix.image-name == 'test' }}
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_REPO="$MLRUN_DOCKER_REPO" MLRUN_VERSION=unstable-cache MLRUN_DOCKER_CACHE_FROM_TAG=unstable-cache make push-${{ matrix.image-name }}
+      run: |
+        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
+        MLRUN_VERSION=unstable-cache \
+        MLRUN_DOCKER_CACHE_FROM_TAG=unstable-cache \
+        make push-${{ matrix.image-name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,9 @@ jobs:
           input_docker_registry=${{ github.event.inputs.docker_registry }} && \
           echo ${input_docker_registry:-ghcr.io/})"
     - name: Docker login
-      run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
+      run: |
+        echo ${{ secrets.CR_PAT }} | \
+        docker login ${{ steps.computed_params.outputs.mlrun_docker_registry }} -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Pull cache, build and push image
 
       # we don't really want per-commit test image we just want to build and push the cache image so CI will be able

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       docker_registry:
-        description: 'Docker registry to push images to (default: ghcr.io/)'
+        description: 'Docker registry to push images to (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
         required: false
         default: 'ghcr.io/'
       docker_repo:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,8 +6,16 @@ on:
     - development
 #    - '[0-9]+.[0-9]+.x'
 
-  workflow_dispatch: ~
-
+  workflow_dispatch:
+    inputs:
+      docker_registry:
+        description: 'Docker registry to push images to (default: ghcr.io/)'
+        required: false
+        default: 'ghcr.io/'
+      docker_repo:
+        description: 'Docker repo to push images to (default: lowered github repository owner name)'
+        required: false
+        default: ''
 jobs:
   build-images:
     name: Build and push image - ${{ matrix.image-name }}
@@ -42,7 +50,13 @@ jobs:
       id: computed_params
       run: |
         echo "::set-output name=mlrun_version::${{ steps.git_info.outputs.latest_version }}-${{ steps.git_info.outputs.mlrun_commit_hash }}"
-        echo "::set-output name=mlrun_docker_repo::$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')"
+        echo "::set-output name=mlrun_docker_repo::$( \
+          input_docker_repo=${{ github.event.inputs.docker_repo }} && \
+          default_docker_repo=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') && \
+          echo ${input_docker_repo:-`echo $default_docker_repo`})"
+        echo "::set-output name=mlrun_docker_registry::$( \
+          input_docker_registry=${{ github.event.inputs.docker_registry }} && \
+          echo ${input_docker_registry:-ghcr.io/})"
     - name: Docker login
       run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ secrets.CR_USERNAME }} --password-stdin
     - name: Pull cache, build and push image
@@ -51,7 +65,7 @@ jobs:
       # to use it and run much faster
       if: ${{ matrix.image-name != 'test' }}
       run: |
-        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_REGISTRY=${{ steps.computed_params.outputs.mlrun_docker_registry }} \
         MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
         MLRUN_VERSION=${{ steps.computed_params.outputs.mlrun_version }} \
         MLRUN_DOCKER_CACHE_FROM_TAG=unstable-cache \
@@ -59,7 +73,7 @@ jobs:
     - name: Pull cache, build and push test image
       if: ${{ matrix.image-name == 'test' }}
       run: |
-        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_REGISTRY=${{ steps.computed_params.outputs.mlrun_docker_registry }} \
         MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
         MLRUN_VERSION=unstable-cache \
         MLRUN_DOCKER_CACHE_FROM_TAG=unstable-cache \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - development
+    - action_fixes
 #    - '[0-9]+.[0-9]+.x'
 
   workflow_dispatch: ~
@@ -14,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/mlrun'
+    if: github.repository == 'hedingber/mlrun'
 
     strategy:
       matrix:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,12 +15,12 @@ on:
     inputs:
       docker_registry:
         description: 'Docker registry to pull images from (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
-        required: false
+        required: true
         default: 'ghcr.io/'
       docker_repo:
         description: 'Docker repo to pull images from (default: mlrun)'
-        required: false
-        default: ''
+        required: true
+        default: 'mlrun'
 
 jobs:
   run-system-tests-ci:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -14,11 +14,11 @@ on:
   workflow_dispatch:
     inputs:
       docker_registry:
-        description: 'Docker registry to push images to (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
+        description: 'Docker registry to pull images from (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
         required: false
         default: 'ghcr.io/'
       docker_repo:
-        description: 'Docker repo to push images to (default: lowered github repository owner name)'
+        description: 'Docker repo to pull images from (default: mlrun)'
         required: false
         default: ''
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -70,7 +70,7 @@ jobs:
         fork_mlrun_hash=${{ steps.git_fork_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
         export mlrun_hash=${fork_mlrun_hash:-`echo $upstream_mlrun_hash`}
-        echo "::set-output name=mlrun_version::$(${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
+        echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
         echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-${{ steps.git_upstream_info.outputs.ui_hash }}"
         echo "::set-output name=mlrun_docker_repo::$( \
           input_docker_repo=${{ github.event.inputs.docker_repo }} && \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -22,7 +22,7 @@ on:
         required: true
         default: 'mlrun'
       test_code_from_action:
-        description: 'Test code will be taken from the action REF anyways, this determines whether the tested code will be taken from there or from upstream (default: false)'
+        description: 'Take tested code from action REF (default: false - take from upstream) (note that test code will be taken from the action REF anyways)'
         required: true
         default: 'false'
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -11,6 +11,17 @@ on:
     # Run the system tests every 3 hours
     - cron:  '0 */3 * * *'
 
+  workflow_dispatch:
+    inputs:
+      docker_registry:
+        description: 'Docker registry to push images to (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
+        required: false
+        default: 'ghcr.io/'
+      docker_repo:
+        description: 'Docker repo to push images to (default: lowered github repository owner name)'
+        required: false
+        default: ''
+
 jobs:
   run-system-tests-ci:
     timeout-minutes: 60
@@ -18,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/mlrun'
+    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v2
@@ -30,8 +41,13 @@ jobs:
       run: pip install -r automation/requirements.txt && python setup.py develop
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-    - name: Extract git hashes and latest version
-      id: git_info
+    - name: Extract git hash from mlrun fork
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      id: git_fork_info
+      run: |
+        echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+    - name: Extract git hashes from upstream and latest version
+      id: git_upstream_info
       run: |
         echo "::set-output name=mlrun_hash::$( \
           cd /tmp && \
@@ -49,10 +65,19 @@ jobs:
           rm -rf mlrun-ui)"
         echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Set computed versions params
-      id: mlrun_versions
+      id: computed_params
       run: |
-        echo "::set-output name=mlrun::${{ steps.git_info.outputs.latest_version }}-${{ steps.git_info.outputs.mlrun_hash }}"
-        echo "::set-output name=ui::${{ steps.git_info.outputs.latest_version }}-${{ steps.git_info.outputs.ui_hash }}"
+        fork_mlrun_hash=${{ steps.git_fork_info.outputs.mlrun_hash }} && \
+        upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
+        export mlrun_hash=${fork_mlrun_hash:-`echo $upstream_mlrun_hash`})"
+        echo "::set-output name=mlrun_version::$(${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
+        echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-${{ steps.git_upstream_info.outputs.ui_hash }}"
+        echo "::set-output name=mlrun_docker_repo::$( \
+          input_docker_repo=${{ github.event.inputs.docker_repo }} && \
+          echo ${input_docker_repo:-mlrun})"
+        echo "::set-output name=mlrun_docker_registry::$( \
+          input_docker_registry=${{ github.event.inputs.docker_registry }} && \
+          echo ${input_docker_registry:-ghcr.io/})"
     - name: Wait for existing runs to complete
       uses: softprops/turnstyle@v1
       with:
@@ -62,7 +87,7 @@ jobs:
     - name: Prepare System Test env.yaml and system
       run: |
         python automation/system_test/prepare.py run \
-          ${{ steps.mlrun_versions.outputs.mlrun }} \
+          ${{ steps.computed_params.outputs.mlrun_version }} \
           ${{ secrets.SYSTEM_TEST_DATA_CLUSTER_IP }} \
           ${{ secrets.SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
           ${{ secrets.SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
@@ -72,10 +97,10 @@ jobs:
           ${{ secrets.SYSTEM_TEST_USERNAME }} \
           ${{ secrets.SYSTEM_TEST_ACCESS_KEY }} \
           ${{ secrets.SYSTEM_TEST_PASSWORD }} \
-          --override-image-registry "ghcr.io/" \
-          --override-image-repo mlrun \
+          --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
+          --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
           --override-mlrun-images \
-          "ghcr.io/mlrun/mlrun-api:${{ steps.mlrun_versions.outputs.mlrun }},ghcr.io/mlrun/mlrun-ui:${{ steps.mlrun_versions.outputs.ui }}"
+          "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_version }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}"
 
     - name: Run System Tests
       run: make test-system

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -21,6 +21,10 @@ on:
         description: 'Docker repo to pull images from (default: mlrun)'
         required: true
         default: 'mlrun'
+      test_code_from_action:
+        description: 'Test code will be taken from the action REF anyways, this determines whether the tested code will be taken from there or from upstream (default: false)'
+        required: true
+        default: 'false'
 
 jobs:
   run-system-tests-ci:
@@ -42,7 +46,7 @@ jobs:
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git hash from action mlrun version
-      if: ${{ github.event_name == 'workflow_dispatch' }}
+      if: ${{ github.event.inputs.test_code_from_action == 'true' }}
       id: git_action_info
       run: |
         echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -69,7 +69,7 @@ jobs:
       run: |
         fork_mlrun_hash=${{ steps.git_fork_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
-        export mlrun_hash=${fork_mlrun_hash:-`echo $upstream_mlrun_hash`})"
+        export mlrun_hash=${fork_mlrun_hash:-`echo $upstream_mlrun_hash`}
         echo "::set-output name=mlrun_version::$(${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
         echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-${{ steps.git_upstream_info.outputs.ui_hash }}"
         echo "::set-output name=mlrun_docker_repo::$( \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -41,9 +41,9 @@ jobs:
       run: pip install -r automation/requirements.txt && python setup.py develop
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-    - name: Extract git hash from mlrun fork
+    - name: Extract git hash from action mlrun version
       if: ${{ github.event_name == 'workflow_dispatch' }}
-      id: git_fork_info
+      id: git_action_info
       run: |
         echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
     - name: Extract git hashes from upstream and latest version
@@ -67,9 +67,9 @@ jobs:
     - name: Set computed versions params
       id: computed_params
       run: |
-        fork_mlrun_hash=${{ steps.git_fork_info.outputs.mlrun_hash }} && \
+        action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
-        export mlrun_hash=${fork_mlrun_hash:-`echo $upstream_mlrun_hash`}
+        export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
         echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
         echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-${{ steps.git_upstream_info.outputs.ui_hash }}"
         echo "::set-output name=mlrun_docker_repo::$( \

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -327,8 +327,8 @@ class SystemTestPreparer:
         mlrun_archive = f"./mlrun-{self._mlrun_version}.tar"
 
         repo_arg = ""
-        if self._override_full_image_repo:
-            repo_arg = f"--override-image-pull-repo {self._override_full_image_repo}"
+        # if self._override_full_image_repo:
+        #     repo_arg = f"--override-image-pull-repo {self._override_full_image_repo}"
 
         override_image_arg = ""
         if self._override_mlrun_images:

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -58,16 +58,6 @@ class SystemTestPreparer:
         self._app_cluster_ssh_password = app_cluster_ssh_password
         self._github_access_token = github_access_token
 
-        self._override_full_image_repo = None
-
-        if self._override_image_repo or self._override_image_registry:
-
-            # complete with defaults if override is partial
-            override_registry = (self._override_image_registry or "quay.io").strip("/")
-            override_repo = (self._override_image_repo or "mlrun").strip("/")
-
-            self._override_full_image_repo = f"{override_registry}/{override_repo}"
-
         self._env_config = {
             "MLRUN_DBPATH": mlrun_dbpath,
             "V3IO_API": webapi_direct_http,
@@ -326,10 +316,6 @@ class SystemTestPreparer:
         )
         mlrun_archive = f"./mlrun-{self._mlrun_version}.tar"
 
-        repo_arg = ""
-        # if self._override_full_image_repo:
-        #     repo_arg = f"--override-image-pull-repo {self._override_full_image_repo}"
-
         override_image_arg = ""
         if self._override_mlrun_images:
             override_image_arg = f"--override-images {self._override_mlrun_images}"
@@ -340,7 +326,6 @@ class SystemTestPreparer:
                 f"--logger-file-path={str(self.Constants.workdir)}/provctl-create-patch-{time_string}.log",
                 "create-patch",
                 "appservice",
-                repo_arg,
                 override_image_arg,
                 "mlrun",
                 self._mlrun_version,


### PR DESCRIPTION
Terminology:
* test code - This is the code of the tests themselves, today the CI is running `make test-system` which builds a test image out of the local code - which means the test code is the code from the REF of the action (cloned by `- uses: actions/checkout@v2`)
* tested code - This is the code that being tested, practically this is the MLRun version that is being transplanted to the system, after this PR this version of code changes according to the scenario.

3 scenarios I'm trying to address in this PR:
1. we want to run system tests (one time, not periodically) on some branch in upstream which is not `development`, for example - on `0.5.x` before releasing. 
In this scenario both test and tested code should be from `0.5.x`
2. we want make changes in system tests code (test code, or the code/conf that runs the tests). 
In this scenario test code should be from fork branch, tested code should be from upstream.
3. we have a big feature PR which we want to run system tests on before merging
In this scenario both test and tested code should be from fork branch.

My PR adds the `workflow_dispatch` event to `build` and `system_tests` workflows which enables to trigger them manually from GH UI.

Outcome:
1. Can be easily done, simply go to the UI, first trigger the `Build` workflow (on the desired branch) which builds a version out of the code (since we want tested code not from upstream), then trigger the `System Tests` workflow (on the desired branch)
2. Can be easily done, instead of changing the branches of the `on.push.branches` in the action config, you can simply work on the changes, and when it's ready, trigger the `System Tests` workflow (on the desired branch)
Note: it will require you to set all needed secrets on your mlrun repo fork
3. Not possible yet, this is help getting us there - after this PR you can easily build a version out of your fork code (since we want tested code from fork) and push it to whereever you want (doesn't have to be `ghcr.io/`), and also trigger system tests to run from your fork. the problem is that the test code hard code jobs images to be from the mlrun repo (e.g. `mlrun/ml-models` `mlrun/ml-base` etc...) I will enable that in a followup PR