### PR TITLE
Fix models gpu legacy image

### DIFF
--- a/dockerfiles/models-gpu/py36/Dockerfile
+++ b/dockerfiles/models-gpu/py36/Dockerfile
@@ -118,8 +118,10 @@ RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
 RUN conda clean -aqy
 
+# TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
+    #   possible (should be safe to remove if it works ~5 times without it)
 RUN ldconfig /usr/local/cuda-10.1/targets/x86_64-linux/lib/stubs && \
-    HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_GPU_BROADCAST=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
+    MAKEFLAGS="-j1" HOROVOD_GPU_ALLREDUCE=NCCL HOROVOD_GPU_BROADCAST=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install horovod && \
     ldconfig
 


### PR DESCRIPTION
A transient failure started occuring pretty often when trying to build the models gpu legacy image in the step that installs horovod (log attached below).
I couldn't identify what exactly is the root cause, but I did notice that when I add `MAKEFLAGS="-j1"` - which means that there will be no concurrency between make executions it doesn't happen anymore.
It does make some sense that the issue is realted to concurrency since it is transient.

[error_log.txt](https://github.com/mlrun/mlrun/files/5373319/error_log.txt)
