### PR TITLE
[System Tests]: Changed access_token param to Authorization header

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -240,7 +240,7 @@ class SystemTestPreparer:
     def _get_provctl_version_and_url(self):
         response = requests.get(
             self.Constants.provctl_releases,
-            params={"access_token": self._github_access_token},
+            headers={"Authorization:": f"token {self._github_access_token}"},
         )
         response.raise_for_status()
         latest_provazio_release = json.loads(response.content)


### PR DESCRIPTION
The `access_token` GET param is now deprecated in Githubs API, and this causes the CI to fail as it cannot download the latest provctl.