### PR TITLE
Fix boto3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ urllib3>=1.24.2, <1.25
 GitPython>=2.1.0
 # required by google-auth
 aiohttp<4.0.0dev,>=3.6.2
-boto3>=1.9
+# In 1.19 boto3 requires urllib3>=1.25.4,<1.26 which conflicting with our dependencies
+boto3>=1.9, <1.19
 # ==7.0 from kfp
 click==7.0
 # this is the pipelines version running in 2.8/2.10 iguazio system, for now locking it to this version

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,8 @@ urllib3>=1.24.2, <1.25
 GitPython>=2.1.0
 # required by google-auth
 aiohttp<4.0.0dev,>=3.6.2
-# In 1.19 botocore requires urllib3>=1.25.4,<1.26 which conflicting with our dependencies
-botocore<1.19
-boto3>=1.9
+# In 1.16 boto3 requires botocore >=1.19.0 which requires urllib3>=1.25.4,<1.26 which conflicting with our dependencies
+boto3>=1.9, <1.16
 # ==7.0 from kfp
 click==7.0
 # this is the pipelines version running in 2.8/2.10 iguazio system, for now locking it to this version

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ urllib3>=1.24.2, <1.25
 GitPython>=2.1.0
 # required by google-auth
 aiohttp<4.0.0dev,>=3.6.2
-# In 1.19 boto3 requires urllib3>=1.25.4,<1.26 which conflicting with our dependencies
-boto3>=1.9, <1.19
+# In 1.19 botocore requires urllib3>=1.25.4,<1.26 which conflicting with our dependencies
+botocore<1.19
+boto3>=1.9
 # ==7.0 from kfp
 click==7.0
 # this is the pipelines version running in 2.8/2.10 iguazio system, for now locking it to this version


### PR DESCRIPTION
So far the dependency was defined as `boto3>=1.9`, recently boto3 1.16 was released, which requires `botocore >=1.19.0`, which requires `urllib3>=1.25.4,<1.26` which conflicting ours `urllib3>=1.24.2, <1.25`
So added upbound for boto3: `boto3>=1.9, <1.16`

This was causing errors such as: 
`botocore 1.19.2 requires urllib3<1.26,>=1.25.4; python_version != "3.4", but you'll have urllib3 1.24.3 which is incompatible.` when installing MLRun
And also caused this error in our CI:
```
ImportError while loading conftest '/mlrun/tests/conftest.py'.
tests/conftest.py:50: in <module>
    from mlrun.api.db.sqldb.db import run_time_fmt  # noqa: E402
mlrun/__init__.py:29: in <module>
    from .datastore import DataItem
mlrun/datastore/__init__.py:17: in <module>
    from .datastore import StoreManager, uri_to_ipython, get_object_stat, in_memory_store
mlrun/datastore/datastore.py:22: in <module>
    from .s3 import S3Store
mlrun/datastore/s3.py:15: in <module>
    import boto3
/usr/local/lib/python3.7/site-packages/boto3/__init__.py:16: in <module>
    from boto3.session import Session
/usr/local/lib/python3.7/site-packages/boto3/session.py:17: in <module>
    import botocore.session
/usr/local/lib/python3.7/site-packages/botocore/session.py:30: in <module>
    import botocore.credentials
/usr/local/lib/python3.7/site-packages/botocore/credentials.py:34: in <module>
    from botocore.config import Config
/usr/local/lib/python3.7/site-packages/botocore/config.py:16: in <module>
    from botocore.endpoint import DEFAULT_TIMEOUT, MAX_POOL_CONNECTIONS
/usr/local/lib/python3.7/site-packages/botocore/endpoint.py:22: in <module>
    from botocore.awsrequest import create_request_object
/usr/local/lib/python3.7/site-packages/botocore/awsrequest.py:25: in <module>
    import botocore.utils
/usr/local/lib/python3.7/site-packages/botocore/utils.py:30: in <module>
    from urllib3.util.url import IPV6_ADDRZ_RE
E   ImportError: cannot import name 'IPV6_ADDRZ_RE' from 'urllib3.util.url' (/usr/local/lib/python3.7/site-packages/urllib3/util/url.py)
```
here's the related botocore issue - https://github.com/boto/botocore/issues/2187