### PR TITLE
Fix missing args when instantiating function from runtime

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -457,7 +457,8 @@ def new_function(
 
     :return: function object
     """
-    if runtime:
+    # don't override given dict
+    if runtime and isinstance(runtime, dict):
         runtime = deepcopy(runtime)
     kind, runtime = _process_runtime(command, runtime, kind)
     command = get_in(runtime, "spec.command", command)

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -457,6 +457,8 @@ def new_function(
 
     :return: function object
     """
+    if runtime:
+        runtime = deepcopy(runtime)
     kind, runtime = _process_runtime(command, runtime, kind)
     command = get_in(runtime, "spec.command", command)
     name = name or get_in(runtime, "metadata.name", "")

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -510,7 +510,10 @@ def _process_runtime(command, runtime, kind):
         runtime = runtime.to_dict()
     if runtime and isinstance(runtime, dict):
         kind = kind or runtime.get("kind", "")
-        command = command or get_in(runtime, "spec.command", "")
+        if not command:
+            runtime_command = get_in(runtime, "spec.command", "")
+            runtime_args = get_in(runtime, "spec.args", [])
+            command = f"{runtime_command} {' '.join(runtime_args)}"
     if "://" in command and command.startswith("http"):
         kind = kind or RuntimeKinds.remote
     if not runtime:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -511,10 +511,10 @@ def _process_runtime(command, runtime, kind):
         runtime = runtime.to_dict()
     if runtime and isinstance(runtime, dict):
         kind = kind or runtime.get("kind", "")
-        if not command:
-            runtime_command = get_in(runtime, "spec.command", "")
-            runtime_args = get_in(runtime, "spec.args", [])
-            command = f"{runtime_command} {' '.join(runtime_args)}"
+        command = command or get_in(runtime, "spec.command", "")
+        runtime_args = get_in(runtime, "spec.args", [])
+        if runtime_args:
+            command = f"{command} {' '.join(runtime_args)}"
     if "://" in command and command.startswith("http"):
         kind = kind or RuntimeKinds.remote
     if not runtime:

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -1,0 +1,43 @@
+from deepdiff import DeepDiff
+
+import mlrun
+
+
+def test_new_function_from_runtime():
+    runtime = {
+            "kind": "job",
+            "metadata": {
+                "name": "spark-submit",
+                "project": "default",
+                "categories": [],
+                "tag": "",
+                "hash": "7b3064c6b334535a5d949ebe9cfc61a094f98c78",
+                "updated": "2020-10-21T22:40:35.042132+00:00"
+            },
+            "spec": {
+                "command": "spark-submit",
+                "args": [
+                    "--class",
+                    "org.apache.spark.examples.SparkPi",
+                    "/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
+                ],
+                "image": "iguazio/shell:3.0_b5533_20201020062229",
+                "mode": "pass",
+                "volumes": [],
+                "volume_mounts": [],
+                "env": [],
+                "description": "",
+                "build": {
+                    "commands": []
+                }
+            },
+    }
+    function = mlrun.new_function(runtime=runtime)
+    assert (
+        DeepDiff(
+            runtime,
+            function.to_dict(),
+            ignore_order=True,
+        )
+        == {}
+    )

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -5,39 +5,30 @@ import mlrun
 
 def test_new_function_from_runtime():
     runtime = {
-            "kind": "job",
-            "metadata": {
-                "name": "spark-submit",
-                "project": "default",
-                "categories": [],
-                "tag": "",
-                "hash": "7b3064c6b334535a5d949ebe9cfc61a094f98c78",
-                "updated": "2020-10-21T22:40:35.042132+00:00"
-            },
-            "spec": {
-                "command": "spark-submit",
-                "args": [
-                    "--class",
-                    "org.apache.spark.examples.SparkPi",
-                    "/spark/examples/jars/spark-examples_2.11-2.4.4.jar"
-                ],
-                "image": "iguazio/shell:3.0_b5533_20201020062229",
-                "mode": "pass",
-                "volumes": [],
-                "volume_mounts": [],
-                "env": [],
-                "description": "",
-                "build": {
-                    "commands": []
-                }
-            },
+        "kind": "job",
+        "metadata": {
+            "name": "spark-submit",
+            "project": "default",
+            "categories": [],
+            "tag": "",
+            "hash": "7b3064c6b334535a5d949ebe9cfc61a094f98c78",
+            "updated": "2020-10-21T22:40:35.042132+00:00",
+        },
+        "spec": {
+            "command": "spark-submit",
+            "args": [
+                "--class",
+                "org.apache.spark.examples.SparkPi",
+                "/spark/examples/jars/spark-examples_2.11-2.4.4.jar",
+            ],
+            "image": "iguazio/shell:3.0_b5533_20201020062229",
+            "mode": "pass",
+            "volumes": [],
+            "volume_mounts": [],
+            "env": [],
+            "description": "",
+            "build": {"commands": []},
+        },
     }
     function = mlrun.new_function(runtime=runtime)
-    assert (
-        DeepDiff(
-            runtime,
-            function.to_dict(),
-            ignore_order=True,
-        )
-        == {}
-    )
+    assert DeepDiff(runtime, function.to_dict(), ignore_order=True,) == {}


### PR DESCRIPTION
When doing `mlrun.new_function(runtime=runtime)` if runtime had any `args` defined in its `spec` they were missing in the resulting function object, this PR fixes it