### PR TITLE
Add old pod_status header for BC with <0.5.3 clients

### DIFF
--- a/mlrun/api/api/endpoints/logs.py
+++ b/mlrun/api/api/endpoints/logs.py
@@ -26,6 +26,11 @@ def get_log(
     db_session: Session = Depends(deps.get_db_session),
 ):
     run_state, log = crud.Logs.get_logs(db_session, project, uid, size, offset)
-    return Response(
-        content=log, media_type="text/plain", headers={"x-mlrun-run-state": run_state}
-    )
+    headers = {
+        "x-mlrun-run-state": run_state,
+        # pod_status was changed x-mlrun-run-state in 0.5.3, keeping it here for backwards compatibility (so <0.5.3
+        # clients will work with the API)
+        # TODO: remove this in 0.7.0
+        "pod_status": run_state,
+    }
+    return Response(content=log, media_type="text/plain", headers=headers)


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/467 I've changed the header name from `pod_status` to `x-mlrun-run-state`
After this PR API will send both headers so it will backwards compatible with <0.5.3 clients