### PR TITLE
Fix scheduler not running anything

### DIFF
--- a/mlrun/api/db/sqldb/models.py
+++ b/mlrun/api/db/sqldb/models.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
+import orjson
 import pickle
 import warnings
 from datetime import datetime
@@ -180,11 +180,11 @@ with warnings.catch_warnings():
 
         @property
         def cron_trigger(self) -> schemas.ScheduleCronTrigger:
-            return json.loads(self.cron_trigger_str)
+            return orjson.loads(self.cron_trigger_str)
 
         @cron_trigger.setter
         def cron_trigger(self, trigger: schemas.ScheduleCronTrigger):
-            self.cron_trigger_str = json.dumps(trigger.dict(exclude_unset=True))
+            self.cron_trigger_str = orjson.dumps(trigger.dict(exclude_unset=True))
 
     # Define "many to many" users/projects
     project_users = Table(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -211,7 +211,7 @@ class Scheduler:
 
         if scheduled_kind == schemas.ScheduleKinds.job:
             scheduled_object_copy = copy.deepcopy(scheduled_object)
-            return Scheduler.submit_task_wrapper, [scheduled_object_copy], {}
+            return Scheduler.submit_run_wrapper, [scheduled_object_copy], {}
         if scheduled_kind == schemas.ScheduleKinds.local_function:
             return scheduled_object, None, None
 
@@ -227,7 +227,7 @@ class Scheduler:
         return self._job_id_separator.join([project, name])
 
     @staticmethod
-    async def submit_task_wrapper(scheduled_object):
+    async def submit_run_wrapper(scheduled_object):
         # import here to avoid circular imports
         from mlrun.api.api.utils import submit_run
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -227,7 +227,7 @@ class Scheduler:
         return self._job_id_separator.join([project, name])
 
     @staticmethod
-    def submit_task_wrapper(scheduled_object):
+    async def submit_task_wrapper(scheduled_object):
         # import here to avoid circular imports
         from mlrun.api.api.utils import submit_run
 
@@ -241,7 +241,7 @@ class Scheduler:
 
         db_session = create_session()
 
-        submit_run(db_session, scheduled_object)
+        await submit_run(db_session, scheduled_object)
 
         close_session(db_session)
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -206,8 +206,8 @@ class BaseRuntime(ModelObj):
         )
 
     def _get_db(self):
+        self.spec.rundb = self.spec.rundb or get_or_set_dburl()
         if not self._db_conn:
-            self.spec.rundb = self.spec.rundb or get_or_set_dburl()
             if self.spec.rundb:
                 self._db_conn = get_run_db(self.spec.rundb).connect(self._secrets)
         return self._db_conn

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -24,7 +24,11 @@ def db() -> Generator:
     db_file = NamedTemporaryFile(suffix="-mlrun.db")
     logger.info(f"Created temp db file: {db_file.name}")
     config.httpdb.db_type = "sqldb"
-    config.httpdb.dsn = f"sqlite:///{db_file.name}?check_same_thread=false"
+    dsn = f"sqlite:///{db_file.name}?check_same_thread=false"
+    config.httpdb.dsn = dsn
+
+    # we're also running client code in tests
+    config.dbpath = dsn
 
     # TODO: make it simpler - doesn't make sense to call 3 different functions to initialize the db
     # we need to force re-init the engine cause otherwise it is cached between tests

--- a/tests/api/utils/function.py
+++ b/tests/api/utils/function.py
@@ -1,0 +1,2 @@
+def do_nothing():
+    pass

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -77,19 +77,16 @@ async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler)
         name=function_name, kind="local", filename=str(code_path)
     )
     function.spec.command = f"{str(code_path)}"
-    hash_key = get_db().store_function(db,
-        function.to_dict(), function_name, project, versioned=True
+    hash_key = get_db().store_function(
+        db, function.to_dict(), function_name, project, versioned=True
     )
     scheduled_object = {
         "task": {
             "spec": {
                 "function": f"{project}/{function_name}@{hash_key}",
-                "handler": "do_nothing"
+                "handler": "do_nothing",
             },
-            "metadata": {
-                "name": "my-task",
-                "project": f"{project}",
-            }
+            "metadata": {"name": "my-task", "project": f"{project}"},
         }
     }
     runs = get_db().list_runs(db, project=project)
@@ -105,7 +102,7 @@ async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler)
     await asyncio.sleep(1)
     runs = get_db().list_runs(db, project=project)
     assert len(runs) == 1
-    assert runs[0]['status']['state'] == RunStates.completed
+    assert runs[0]["status"]["state"] == RunStates.completed
 
 
 @pytest.mark.asyncio

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1,13 +1,17 @@
 import asyncio
+import pathlib
 from datetime import datetime, timedelta, timezone
 from typing import Generator
 
 import pytest
 from sqlalchemy.orm import Session
 
+import mlrun
 from mlrun.api import schemas
 from mlrun.api.utils.scheduler import Scheduler
+from mlrun.api.utils.singletons.db import get_db
 from mlrun.config import config
+from mlrun.runtimes.base import RunStates
 from mlrun.utils import logger
 
 
@@ -56,6 +60,68 @@ async def test_create_schedule(db: Session, scheduler: Scheduler):
     )
     await asyncio.sleep(expected_call_counter)
     assert call_counter == expected_call_counter
+
+
+@pytest.mark.asyncio
+async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler):
+    now = datetime.now()
+    now_plus_1_second = now + timedelta(seconds=1)
+    cron_trigger = schemas.ScheduleCronTrigger(
+        second="*/1", start_date=now, end_date=now_plus_1_second
+    )
+    schedule_name = "schedule-name"
+    project = config.default_project
+    function_name = "my-function"
+    code_path = pathlib.Path(__file__).absolute().parent / "function.py"
+    function = mlrun.code_to_function(
+        name=function_name, kind="local", filename=str(code_path)
+    )
+    function.spec.command = f"{str(code_path)}"
+    hash_key = get_db().store_function(db,
+        function.to_dict(), function_name, project, versioned=True
+    )
+    scheduled_object = {
+        "task": {
+            "spec": {
+                "parameters": {
+                    "context": "",
+                    "fail": False
+                },
+                "inputs": {},
+                "hyperparams": {},
+                "secret_sources": [],
+                "param_file": "",
+                "tuning_strategy": "list",
+                # "output_path": "v3io:///users/{{run.user}}/artifacts/{{run.project}}",
+                "output_path": "",
+                "input_path": "",
+                "function": f"{project}/{function_name}@{hash_key}",
+                "handler": "do_nothing"
+            },
+            "metadata": {
+                "name": "my-task",
+                "project": f"{project}",
+                # "labels": {
+                #     "v3io_user": "iguazio",
+                #     "owner": "iguazio"
+                # }
+            }
+        }
+    }
+    runs = get_db().list_runs(db, project=project)
+    assert len(runs) == 0
+    scheduler.create_schedule(
+        db,
+        project,
+        schedule_name,
+        schemas.ScheduleKinds.job,
+        scheduled_object,
+        cron_trigger,
+    )
+    await asyncio.sleep(1)
+    runs = get_db().list_runs(db, project=project)
+    assert len(runs) == 1
+    assert runs[0]['status']['state'] == RunStates.completed
 
 
 @pytest.mark.asyncio

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -352,7 +352,7 @@ async def test_rescheduling(db: Session, scheduler: Scheduler):
     now = datetime.now()
     now_plus_2_seconds = now + timedelta(seconds=2)
     cron_trigger = schemas.ScheduleCronTrigger(
-        second="*/1", start_time=now, end_time=now_plus_2_seconds
+        second="*/1", start_date=now, end_date=now_plus_2_seconds
     )
     schedule_name = "schedule-name"
     project = config.default_project

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -46,7 +46,7 @@ async def test_create_schedule(db: Session, scheduler: Scheduler):
     expected_call_counter = 5
     now_plus_5_seconds = now + timedelta(seconds=expected_call_counter)
     cron_trigger = schemas.ScheduleCronTrigger(
-        second="*/1", start_time=now, end_time=now_plus_5_seconds
+        second="*/1", start_date=now, end_date=now_plus_5_seconds
     )
     schedule_name = "schedule-name"
     project = config.default_project

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -83,28 +83,12 @@ async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler)
     scheduled_object = {
         "task": {
             "spec": {
-                "parameters": {
-                    "context": "",
-                    "fail": False
-                },
-                "inputs": {},
-                "hyperparams": {},
-                "secret_sources": [],
-                "param_file": "",
-                "tuning_strategy": "list",
-                # "output_path": "v3io:///users/{{run.user}}/artifacts/{{run.project}}",
-                "output_path": "",
-                "input_path": "",
                 "function": f"{project}/{function_name}@{hash_key}",
                 "handler": "do_nothing"
             },
             "metadata": {
                 "name": "my-task",
                 "project": f"{project}",
-                # "labels": {
-                #     "v3io_user": "iguazio",
-                #     "owner": "iguazio"
-                # }
             }
         }
     }


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/467 I changed `submit_run` to be `async def` and forgot to add `await` when calling it in the `submit_run_wrapper` of the scheduler which made the scheduler completely broken (runs nothing) - fixed it, and also:
* Unlike all current tests that use `local_function` schedule kind (created for tests), added a test that run a schedule with the real `job` schedule kind which would have caught this breakage.
* Found that the tests were using `start_time` and `end_time` while it should be `start_date` and `end_date` - fixed that which showed that there is a bug - the standard lib `json` is unable to `dumps` and `loads` datetime, changed to use `orjson`
* minor changes to allow running `local` runtime inside the api context