### PR TITLE
Move orjson to general requirements

### DIFF
--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -9,4 +9,3 @@ kubernetes-asyncio==10.0.0
 kubernetes==10.0.0
 apscheduler~=3.6
 humanfriendly~=8.2
-orjson>=3,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ seaborn
 google-auth<2.0dev,>=1.19.1
 azure-storage-blob
 pydantic~=1.5
+orjson>=3,<4


### PR DESCRIPTION
https://github.com/mlrun/mlrun/pull/490 changed SQLDB to use orjson - therefore needed in general requirements 