### PR TITLE
Fix list functions bugs

### DIFF
--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -128,7 +128,7 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def list_functions(self, session, name, project="", tag="", labels=None):
+    def list_functions(self, session, name=None, project="", tag="", labels=None):
         pass
 
     @abstractmethod

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -110,7 +110,7 @@ class FileDB(DBInterface):
     def delete_function(self, session, project: str, name: str):
         raise NotImplementedError()
 
-    def list_functions(self, session, name, project="", tag="", labels=None):
+    def list_functions(self, session, name=None, project="", tag="", labels=None):
         return self._transform_run_db_error(
             self.db.list_functions, name, project, tag, labels
         )

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -426,7 +426,9 @@ class SQLDB(DBInterface):
                     # function status should be added only to tagged functions
                     function_dict["status"] = None
 
-                    # function has no tags, but its uid is the "unversioned" uid for the tag - don't send it
+                    # the unversioned uid is only a place holder for tagged instance that are is versioned
+                    # if another instance "took" the tag, we're left with an unversioned untagged instance
+                    # don't list it
                     if function.uid.startswith(unversioned_tagged_object_uid_prefix):
                         continue
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -413,7 +413,9 @@ class SQLDB(DBInterface):
         project = project or config.default_project
         uids = None
         if tag:
-            uids = self._resolve_tag_function_uids(session, Function, project, tag, name)
+            uids = self._resolve_tag_function_uids(
+                session, Function, project, tag, name
+            )
         functions = FunctionList()
         for function in self._find_functions(session, name, project, uids, labels):
             function_dict = function.struct
@@ -676,7 +678,9 @@ class SQLDB(DBInterface):
             return self._query(session, cls).get(tag.obj_id).uid
         return None
 
-    def _resolve_tag_function_uids(self, session, cls, project, tag_name, function_name=None) -> List[str]:
+    def _resolve_tag_function_uids(
+        self, session, cls, project, tag_name, function_name=None
+    ) -> List[str]:
         uids = []
         for tag in self._query(
             session, cls.Tag, project=project, obj_name=function_name, name=tag_name

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -111,7 +111,7 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def list_functions(self, name, project="", tag="", labels=None):
+    def list_functions(self, name=None, project="", tag="", labels=None):
         pass
 
     @abstractmethod

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -322,7 +322,7 @@ class FileRunDB(RunDBInterface):
     def delete_function(self, name: str, project: str = ""):
         raise NotImplementedError()
 
-    def list_functions(self, name, project="", tag="", labels=None):
+    def list_functions(self, name=None, project="", tag="", labels=None):
         labels = labels or []
         logger.info(f"reading functions in {project} name/mask: {name} tag: {tag} ...")
         filepath = path.join(

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -153,7 +153,7 @@ class SQLDB(RunDBInterface):
             self.db.delete_function, self.session, project, name
         )
 
-    def list_functions(self, name, project=None, tag=None, labels=None):
+    def list_functions(self, name=None, project=None, tag=None, labels=None):
         return self._transform_db_error(
             self.db.list_functions, self.session, name, project, tag, labels
         )

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -98,14 +98,14 @@ def test_store_function_not_versioned(db: DBInterface, db_session: Session):
 @pytest.mark.parametrize(
     "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
 )
-def test_list_functions_filtering_unversioned_untagged(db: DBInterface, db_session: Session):
+def test_list_functions_filtering_unversioned_untagged(
+    db: DBInterface, db_session: Session
+):
     function_1 = {"bla": "blabla"}
     function_2 = {"bla": "blablablabla"}
     function_name_1 = "function_name_1"
     tag = "some_tag"
-    db.store_function(
-        db_session, function_1, function_name_1, versioned=False, tag=tag
-    )
+    db.store_function(db_session, function_1, function_name_1, versioned=False, tag=tag)
     tagged_function_hash_key = db.store_function(
         db_session, function_2, function_name_1, versioned=True, tag=tag
     )

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -94,29 +94,6 @@ def test_store_function_not_versioned(db: DBInterface, db_session: Session):
     assert len(functions) == 1
 
 
-# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
-@pytest.mark.parametrize(
-    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
-)
-def test_list_functions_filtering_unversioned_untagged(
-    db: DBInterface, db_session: Session
-):
-    function_1 = {"bla": "blabla"}
-    function_2 = {"bla": "blablablabla"}
-    function_name_1 = "function_name_1"
-    tag = "some_tag"
-    db.store_function(db_session, function_1, function_name_1, versioned=False, tag=tag)
-    tagged_function_hash_key = db.store_function(
-        db_session, function_2, function_name_1, versioned=True, tag=tag
-    )
-    functions = db.list_functions(db_session, function_name_1)
-
-    # First we stored to the tag without versioning (unversioned instance) then we stored to the tag with version
-    # so the unversioned instance remained untagged, verifying we're not getting it
-    assert len(functions) == 1
-    assert functions[0]["metadata"]["hash"] == tagged_function_hash_key
-
-
 @pytest.mark.parametrize(
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
@@ -222,6 +199,29 @@ def test_list_functions_multiple_tags(db: DBInterface, db_session: Session):
         function_tag = function["metadata"]["tag"]
         tags.remove(function_tag)
     assert len(tags) == 0
+
+
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
+def test_list_functions_filtering_unversioned_untagged(
+    db: DBInterface, db_session: Session
+):
+    function_1 = {"bla": "blabla"}
+    function_2 = {"bla": "blablablabla"}
+    function_name_1 = "function_name_1"
+    tag = "some_tag"
+    db.store_function(db_session, function_1, function_name_1, versioned=False, tag=tag)
+    tagged_function_hash_key = db.store_function(
+        db_session, function_2, function_name_1, versioned=True, tag=tag
+    )
+    functions = db.list_functions(db_session, function_name_1)
+
+    # First we stored to the tag without versioning (unversioned instance) then we stored to the tag with version
+    # so the unversioned instance remained untagged, verifying we're not getting it
+    assert len(functions) == 1
+    assert functions[0]["metadata"]["hash"] == tagged_function_hash_key
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -201,9 +201,28 @@ def test_list_functions_multiple_tags(db: DBInterface, db_session: Session):
     assert len(tags) == 0
 
 
-# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
 @pytest.mark.parametrize(
-    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+    "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
+)
+def test_list_functions_by_tag(db: DBInterface, db_session: Session):
+    tag = "function_name_1"
+
+    names = ["some_name", "some_name2", "some_name3"]
+    for name in names:
+        function_body = {"metadata": {"name": name}}
+        db.store_function(
+            db_session, function_body, name, tag=tag, versioned=True
+        )
+    functions = db.list_functions(db_session, tag=tag)
+    assert len(functions) == len(names)
+    for function in functions:
+        function_name = function["metadata"]["name"]
+        names.remove(function_name)
+    assert len(names) == 0
+
+
+@pytest.mark.parametrize(
+    "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_list_functions_filtering_unversioned_untagged(
     db: DBInterface, db_session: Session

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -210,9 +210,7 @@ def test_list_functions_by_tag(db: DBInterface, db_session: Session):
     names = ["some_name", "some_name2", "some_name3"]
     for name in names:
         function_body = {"metadata": {"name": name}}
-        db.store_function(
-            db_session, function_body, name, tag=tag, versioned=True
-        )
+        db.store_function(db_session, function_body, name, tag=tag, versioned=True)
     functions = db.list_functions(db_session, tag=tag)
     assert len(functions) == len(names)
     for function in functions:

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -94,6 +94,29 @@ def test_store_function_not_versioned(db: DBInterface, db_session: Session):
     assert len(functions) == 1
 
 
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
+def test_list_functions_filtering_unversioned_untagged(db: DBInterface, db_session: Session):
+    function_1 = {"bla": "blabla"}
+    function_2 = {"bla": "blablablabla"}
+    function_name_1 = "function_name_1"
+    tag = "some_tag"
+    db.store_function(
+        db_session, function_1, function_name_1, versioned=False, tag=tag
+    )
+    tagged_function_hash_key = db.store_function(
+        db_session, function_2, function_name_1, versioned=True, tag=tag
+    )
+    functions = db.list_functions(db_session, function_name_1)
+
+    # First we stored to the tag without versioning (unversioned instance) then we stored to the tag with version
+    # so the unversioned instance remained untagged, verifying we're not getting it
+    assert len(functions) == 1
+    assert functions[0]["metadata"]["hash"] == tagged_function_hash_key
+
+
 @pytest.mark.parametrize(
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )


### PR DESCRIPTION
2 bugs:
* tag filter (only, without name) didn't work - was returning only the first function - simply wasn't handled
* unversioned untagged function was returned in list functions (see test)