### PR TITLE
Fix typo in model server initialization

### DIFF
--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -49,7 +49,7 @@ def new_model_server(
     handler=None,
 ):
     if protocol:
-        new_v2_model_server(
+        return new_v2_model_server(
             name,
             model_class,
             models=models,
@@ -61,7 +61,7 @@ def new_model_server(
             canary=canary,
         )
     else:
-        new_v1_model_server(
+        return new_v1_model_server(
             name,
             model_class,
             models=models,


### PR DESCRIPTION
`return` was missing