### PR TITLE
Fix dask image build

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -245,11 +245,6 @@ def build_runtime(runtime, with_mlrun, interactive=False):
         )
     logger.info(f"building image ({build.image})")
 
-    if runtime.kind == "dask":
-        extra = 'ENTRYPOINT ["tini", "-g", "--", "/usr/bin/prepare.sh"]'
-    else:
-        extra = None
-
     name = normalize_name("mlrun-build-{}".format(runtime.metadata.name))
     base_image = enrich_image_url(build.base_image or "mlrun/mlrun")
     if not build.base_image:
@@ -265,7 +260,6 @@ def build_runtime(runtime, with_mlrun, interactive=False):
         secret_name=build.secret,
         interactive=interactive,
         name=name,
-        extra=extra,
         with_mlrun=with_mlrun,
     )
     runtime.status.build_pod = None


### PR DESCRIPTION
This `tini` looks like some left over from the days we had special docker image for dask, not needed anymore, it currently explodes on this when trying to use built dask function image:
```
Error: failed to start container "base": Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"tini\": executable file not found in $PATH": unknown
```