### PR TITLE
Add invoke schedule endpoint

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -50,7 +50,7 @@ def get_schedule(
 async def invoke_schedule(
     project: str, name: str, db_session: Session = Depends(deps.get_db_session),
 ):
-    await get_scheduler().invoke_schedule(db_session, project, name)
+    return await get_scheduler().invoke_schedule(db_session, project, name)
 
 
 @router.delete(

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -46,6 +46,15 @@ def get_schedule(
     return get_scheduler().get_schedule(db_session, project, name)
 
 
+@router.post(
+    "/projects/{project}/schedules/{name}/invoke"
+)
+async def invoke_schedule(
+    project: str, name: str, db_session: Session = Depends(deps.get_db_session),
+):
+    await get_scheduler().invoke_schedule(db_session, project, name)
+
+
 @router.delete(
     "/projects/{project}/schedules/{name}", status_code=HTTPStatus.NO_CONTENT.value
 )

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -46,9 +46,7 @@ def get_schedule(
     return get_scheduler().get_schedule(db_session, project, name)
 
 
-@router.post(
-    "/projects/{project}/schedules/{name}/invoke"
-)
+@router.post("/projects/{project}/schedules/{name}/invoke")
 async def invoke_schedule(
     project: str, name: str, db_session: Session = Depends(deps.get_db_session),
 ):

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -101,12 +101,12 @@ class Scheduler:
         self._scheduler.remove_job(job_id)
         get_db().delete_schedule(db_session, project, name)
 
-    async def invoke_schedule(
-        self, db_session: Session, project: str, name: str
-    ):
+    async def invoke_schedule(self, db_session: Session, project: str, name: str):
         logger.debug("Invoking schedule", project=project, name=name)
         db_schedule = get_db().get_schedule(db_session, project, name)
-        function, args, kwargs = self._resolve_job_function(db_schedule.kind, db_schedule.scheduled_object)
+        function, args, kwargs = self._resolve_job_function(
+            db_schedule.kind, db_schedule.scheduled_object
+        )
         await function(*args, **kwargs)
 
     def _validate_cron_trigger(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -221,7 +221,7 @@ class Scheduler:
             scheduled_object_copy = copy.deepcopy(scheduled_object)
             return Scheduler.submit_run_wrapper, [scheduled_object_copy], {}
         if scheduled_kind == schemas.ScheduleKinds.local_function:
-            return scheduled_object, None, None
+            return scheduled_object, [], {}
 
         # sanity
         message = "Scheduled object kind missing implementation"

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -107,7 +107,7 @@ class Scheduler:
         function, args, kwargs = self._resolve_job_function(
             db_schedule.kind, db_schedule.scheduled_object
         )
-        await function(*args, **kwargs)
+        return await function(*args, **kwargs)
 
     def _validate_cron_trigger(
         self,
@@ -249,9 +249,11 @@ class Scheduler:
 
         db_session = create_session()
 
-        await submit_run(db_session, scheduled_object)
+        response = await submit_run(db_session, scheduled_object)
 
         close_session(db_session)
+
+        return response
 
     @staticmethod
     def transform_schemas_cron_trigger_to_apscheduler_cron_trigger(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -101,6 +101,14 @@ class Scheduler:
         self._scheduler.remove_job(job_id)
         get_db().delete_schedule(db_session, project, name)
 
+    async def invoke_schedule(
+        self, db_session: Session, project: str, name: str
+    ):
+        logger.debug("Invoking schedule", project=project, name=name)
+        db_schedule = get_db().get_schedule(db_session, project, name)
+        function, args, kwargs = self._resolve_job_function(db_schedule.kind, db_schedule.scheduled_object)
+        await function(*args, **kwargs)
+
     def _validate_cron_trigger(
         self,
         cron_trigger: schemas.ScheduleCronTrigger,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -462,6 +462,12 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed deleting schedule {project}/{name}"
         self.api_call("DELETE", path, error_message)
 
+    def invoke_schedule(self, project: str, name: str):
+        project = project or default_project
+        path = f"projects/{project}/schedules/{name}/invoke"
+        error_message = f"Failed invoking schedule {project}/{name}"
+        self.api_call("POST", path, error_message)
+
     def delete_project(self, name: str):
         path = f"projects/{name}"
         error_message = f"Failed deleting project {name}"

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -2,9 +2,9 @@ import asyncio
 import pathlib
 from datetime import datetime, timedelta, timezone
 from typing import Generator
-from deepdiff import DeepDiff
 
 import pytest
+from deepdiff import DeepDiff
 from sqlalchemy.orm import Session
 
 import mlrun
@@ -89,16 +89,11 @@ async def test_invoke_schedule(db: Session, scheduler: Scheduler):
     assert len(runs) == 2
     for run in runs:
         assert run["status"]["state"] == RunStates.completed
-    response_uids = [response['data']['metadata']['uid'] for response in [response_1, response_2]]
-    db_uids = [run['metadata']['uid'] for run in runs]
-    assert (
-            DeepDiff(
-                response_uids,
-                db_uids,
-                ignore_order=True,
-            )
-            == {}
-    )
+    response_uids = [
+        response["data"]["metadata"]["uid"] for response in [response_1, response_2]
+    ]
+    db_uids = [run["metadata"]["uid"] for run in runs]
+    assert DeepDiff(response_uids, db_uids, ignore_order=True,) == {}
 
 
 @pytest.mark.asyncio

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -29,12 +29,12 @@ async def scheduler(db: Session) -> Generator:
 call_counter: int = 0
 
 
-def bump_counter():
+async def bump_counter():
     global call_counter
     call_counter += 1
 
 
-def do_nothing():
+async def do_nothing():
     pass
 
 
@@ -63,6 +63,34 @@ async def test_create_schedule(db: Session, scheduler: Scheduler):
 
 
 @pytest.mark.asyncio
+async def test_invoke_schedule(db: Session, scheduler: Scheduler):
+    cron_trigger = schemas.ScheduleCronTrigger(year=1999)
+    schedule_name = "schedule-name"
+    project = config.default_project
+    scheduled_object = _create_mlrun_function_and_matching_scheduled_object(db, project)
+    runs = get_db().list_runs(db, project=project)
+    assert len(runs) == 0
+    scheduler.create_schedule(
+        db,
+        project,
+        schedule_name,
+        schemas.ScheduleKinds.job,
+        scheduled_object,
+        cron_trigger,
+    )
+    runs = get_db().list_runs(db, project=project)
+    assert len(runs) == 0
+    await scheduler.invoke_schedule(db, project, schedule_name)
+    runs = get_db().list_runs(db, project=project)
+    assert len(runs) == 1
+    await scheduler.invoke_schedule(db, project, schedule_name)
+    runs = get_db().list_runs(db, project=project)
+    assert len(runs) == 2
+    for run in runs:
+        assert run["status"]["state"] == RunStates.completed
+
+
+@pytest.mark.asyncio
 async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler):
     now = datetime.now()
     now_plus_1_second = now + timedelta(seconds=1)
@@ -71,24 +99,7 @@ async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler)
     )
     schedule_name = "schedule-name"
     project = config.default_project
-    function_name = "my-function"
-    code_path = pathlib.Path(__file__).absolute().parent / "function.py"
-    function = mlrun.code_to_function(
-        name=function_name, kind="local", filename=str(code_path)
-    )
-    function.spec.command = f"{str(code_path)}"
-    hash_key = get_db().store_function(
-        db, function.to_dict(), function_name, project, versioned=True
-    )
-    scheduled_object = {
-        "task": {
-            "spec": {
-                "function": f"{project}/{function_name}@{hash_key}",
-                "handler": "do_nothing",
-            },
-            "metadata": {"name": "my-task", "project": f"{project}"},
-        }
-    }
+    scheduled_object = _create_mlrun_function_and_matching_scheduled_object(db, project)
     runs = get_db().list_runs(db, project=project)
     assert len(runs) == 0
     scheduler.create_schedule(
@@ -230,7 +241,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
     schedule = scheduler.get_schedule(db, project, schedule_name)
 
     # no next run time cause we put year=1999
-    assert_schedule(
+    _assert_schedule(
         schedule,
         project,
         schedule_name,
@@ -252,7 +263,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
     )
     schedule_2 = scheduler.get_schedule(db, project, schedule_name_2)
     year_datetime = datetime(year=year, month=1, day=1, tzinfo=timezone.utc)
-    assert_schedule(
+    _assert_schedule(
         schedule_2,
         project,
         schedule_name_2,
@@ -263,7 +274,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
 
     schedules = scheduler.list_schedules(db)
     assert len(schedules.schedules) == 2
-    assert_schedule(
+    _assert_schedule(
         schedules.schedules[0],
         project,
         schedule_name,
@@ -271,7 +282,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
         cron_trigger,
         None,
     )
-    assert_schedule(
+    _assert_schedule(
         schedules.schedules[1],
         project,
         schedule_name_2,
@@ -375,7 +386,7 @@ async def test_rescheduling(db: Session, scheduler: Scheduler):
     assert call_counter == 2
 
 
-def assert_schedule(
+def _assert_schedule(
     schedule: schemas.ScheduleOutput, project, name, kind, cron_trigger, next_run_time
 ):
     assert schedule.name == name
@@ -384,3 +395,25 @@ def assert_schedule(
     assert schedule.next_run_time == next_run_time
     assert schedule.cron_trigger == cron_trigger
     assert schedule.creation_time is not None
+
+
+def _create_mlrun_function_and_matching_scheduled_object(db: Session, project: str):
+    function_name = "my-function"
+    code_path = pathlib.Path(__file__).absolute().parent / "function.py"
+    function = mlrun.code_to_function(
+        name=function_name, kind="local", filename=str(code_path)
+    )
+    function.spec.command = f"{str(code_path)}"
+    hash_key = get_db().store_function(
+        db, function.to_dict(), function_name, project, versioned=True
+    )
+    scheduled_object = {
+        "task": {
+            "spec": {
+                "function": f"{project}/{function_name}@{hash_key}",
+                "handler": "do_nothing",
+            },
+            "metadata": {"name": "my-task", "project": f"{project}"},
+        }
+    }
+    return scheduled_object

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -2,6 +2,7 @@ import asyncio
 import pathlib
 from datetime import datetime, timedelta, timezone
 from typing import Generator
+from deepdiff import DeepDiff
 
 import pytest
 from sqlalchemy.orm import Session
@@ -80,14 +81,24 @@ async def test_invoke_schedule(db: Session, scheduler: Scheduler):
     )
     runs = get_db().list_runs(db, project=project)
     assert len(runs) == 0
-    await scheduler.invoke_schedule(db, project, schedule_name)
+    response_1 = await scheduler.invoke_schedule(db, project, schedule_name)
     runs = get_db().list_runs(db, project=project)
     assert len(runs) == 1
-    await scheduler.invoke_schedule(db, project, schedule_name)
+    response_2 = await scheduler.invoke_schedule(db, project, schedule_name)
     runs = get_db().list_runs(db, project=project)
     assert len(runs) == 2
     for run in runs:
         assert run["status"]["state"] == RunStates.completed
+    response_uids = [response['data']['metadata']['uid'] for response in [response_1, response_2]]
+    db_uids = [run['metadata']['uid'] for run in runs]
+    assert (
+            DeepDiff(
+                response_uids,
+                db_uids,
+                ignore_order=True,
+            )
+            == {}
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adding `POST /projects/{project}/schedules/{name}/invoke` endpoint to enable manually one-time invocation of the schedule scheduled object