### PR TITLE
[SDK] Make starting run log message more clear

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -339,7 +339,7 @@ class BaseRuntime(ModelObj):
         if not self.is_child:
             dbstr = "self" if self._is_api_server else self.spec.rundb
             logger.info(
-                "starting run {} uid={}  -> {}".format(meta.name, meta.uid, dbstr)
+                "starting run {} uid={} DB={}".format(meta.name, meta.uid, dbstr)
             )
             meta.labels["kind"] = self.kind
             if "owner" not in meta.labels:


### PR DESCRIPTION
People see a line like this
```
> 2020-10-29 08:36:12,525 [info] starting run scala_emd_no_sc_stop_pwfs uid=ff2e9b5cce574148a2474b24eb55d9a7 -> http://mlrun-api:8080 
``` 

and thinks the link is to MLRun UI