### PR TITLE
[SDK] Change printed items background colors to support Jupyter dark theme

### DIFF
--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -160,13 +160,13 @@ def ipython_display(html, display=True, alt_text=None):
 
 style = """<style>
 .dictlist {
-  background-color: #D08E60;
+  background-color: #FF6A00;
   text-align: center;
   margin: 4px;
   border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}
 .artifact {
   cursor: pointer;
-  background-color: #D08E60;
+  background-color: #FF6A00;
   text-align: left;
   margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;
 }
@@ -208,7 +208,7 @@ iframe.fileview {
 }
 .pane-header {
   line-height: 1;
-  background-color: #D08E60;
+  background-color: #FF6A00;
   padding: 3px;
 }
 .pane-header .close {

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -160,13 +160,13 @@ def ipython_display(html, display=True, alt_text=None):
 
 style = """<style>
 .dictlist {
-  background-color: #C47A45;
+  background-color: #D08E60;
   text-align: center;
   margin: 4px;
   border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}
 .artifact {
   cursor: pointer;
-  background-color: #C47A45;
+  background-color: #D08E60;
   text-align: left;
   margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;
 }
@@ -208,7 +208,7 @@ iframe.fileview {
 }
 .pane-header {
   line-height: 1;
-  background-color: #C47A45;
+  background-color: #D08E60;
   padding: 3px;
 }
 .pane-header .close {

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -160,13 +160,13 @@ def ipython_display(html, display=True, alt_text=None):
 
 style = """<style>
 .dictlist {
-  background-color: #b3edff;
+  background-color: #C47A45;
   text-align: center;
   margin: 4px;
   border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}
 .artifact {
   cursor: pointer;
-  background-color: #ffe6cc;
+  background-color: #C47A45;
   text-align: left;
   margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;
 }
@@ -208,7 +208,7 @@ iframe.fileview {
 }
 .pane-header {
   line-height: 1;
-  background-color: #ffe6cc;
+  background-color: #C47A45;
   padding: 3px;
 }
 .pane-header .close {

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -160,13 +160,13 @@ def ipython_display(html, display=True, alt_text=None):
 
 style = """<style>
 .dictlist {
-  background-color: #FF6A00;
+  background-color: #ca8452;
   text-align: center;
   margin: 4px;
   border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}
 .artifact {
   cursor: pointer;
-  background-color: #FF6A00;
+  background-color: #ca8452;
   text-align: left;
   margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;
 }
@@ -208,7 +208,7 @@ iframe.fileview {
 }
 .pane-header {
   line-height: 1;
-  background-color: #FF6A00;
+  background-color: #ca8452;
   padding: 3px;
 }
 .pane-header .close {

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -264,6 +264,9 @@ class RemoteRuntime(KubeResource):
         spec.cmd = self.spec.build.commands or []
         project = project or self.metadata.project or "default"
         handler = self.spec.function_handler
+
+        # In Nuclio 1.6.0 default serviceType changed to "ClusterIP", make sure we're using NodePort
+        spec.set_config("serviceType", "NodePort")
         if self.spec.readiness_timeout:
             spec.set_config("spec.readinessTimeoutSeconds", self.spec.readiness_timeout)
         if self.spec.resources:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -264,9 +264,6 @@ class RemoteRuntime(KubeResource):
         spec.cmd = self.spec.build.commands or []
         project = project or self.metadata.project or "default"
         handler = self.spec.function_handler
-
-        # In Nuclio 1.6.0 default serviceType changed to "ClusterIP", make sure we're using NodePort
-        spec.set_config("serviceType", "NodePort")
         if self.spec.readiness_timeout:
             spec.set_config("spec.readinessTimeoutSeconds", self.spec.readiness_timeout)
         if self.spec.resources:


### PR DESCRIPTION
Couldn't find a nice way to condition the color based on the Jupyter theme so used a color that looks ok on both themes

Before:
![image](https://user-images.githubusercontent.com/22135088/97807506-ee4b7b00-1c69-11eb-9509-ff2c9febd1cb.png)
![image](https://user-images.githubusercontent.com/22135088/97807510-f0add500-1c69-11eb-81f6-0cbf73002a58.png)

After:
![image](https://user-images.githubusercontent.com/22135088/97807425-577ebe80-1c69-11eb-9e20-8c3b13d81b00.png)
![image](https://user-images.githubusercontent.com/22135088/97807422-5188dd80-1c69-11eb-9c60-95922e17b7fd.png)
