### PR TITLE
[Nuclio] Specify nodeport service type explicitly

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -266,7 +266,7 @@ class RemoteRuntime(KubeResource):
         handler = self.spec.function_handler
 
         # In Nuclio 1.6.0 default serviceType changed to "ClusterIP", make sure we're using NodePort
-        spec.set_config("serviceType", "NodePort")
+        spec.set_config("spec.serviceType", "NodePort")
         if self.spec.readiness_timeout:
             spec.set_config("spec.readinessTimeoutSeconds", self.spec.readiness_timeout)
         if self.spec.resources:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -264,6 +264,9 @@ class RemoteRuntime(KubeResource):
         spec.cmd = self.spec.build.commands or []
         project = project or self.metadata.project or "default"
         handler = self.spec.function_handler
+
+        # In Nuclio 1.6.0 default serviceType changed to "ClusterIP", make sure we're using NodePort
+        spec.set_config("serviceType", "NodePort")
         if self.spec.readiness_timeout:
             spec.set_config("spec.readinessTimeoutSeconds", self.spec.readiness_timeout)
         if self.spec.resources:


### PR DESCRIPTION
In Nuclio 1.6.0 default service type will be changed to "ClusterIP" so as a preparation we explictly specify nodeport in the spec