### PR TITLE
[SDK] - Fix function initialization with args without command

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -513,7 +513,7 @@ def _process_runtime(command, runtime, kind):
         kind = kind or runtime.get("kind", "")
         command = command or get_in(runtime, "spec.command", "")
         runtime_args = get_in(runtime, "spec.args", [])
-        if runtime_args:
+        if runtime_args and command:
             command = f"{command} {' '.join(runtime_args)}"
     if "://" in command and command.startswith("http"):
         kind = kind or RuntimeKinds.remote

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -32,3 +32,34 @@ def test_new_function_from_runtime():
     }
     function = mlrun.new_function(runtime=runtime)
     assert DeepDiff(runtime, function.to_dict(), ignore_order=True,) == {}
+
+
+def test_new_function_args_without_command():
+    runtime = {
+        "kind": "job",
+        "metadata": {
+            "name": "spark-submit",
+            "project": "default",
+            "categories": [],
+            "tag": "",
+            "hash": "7b3064c6b334535a5d949ebe9cfc61a094f98c78",
+            "updated": "2020-10-21T22:40:35.042132+00:00",
+        },
+        "spec": {
+            "command": "",
+            "args": [
+                "--class",
+                "org.apache.spark.examples.SparkPi",
+                "/spark/examples/jars/spark-examples_2.11-2.4.4.jar",
+            ],
+            "image": "iguazio/shell:3.0_b5533_20201020062229",
+            "mode": "pass",
+            "volumes": [],
+            "volume_mounts": [],
+            "env": [],
+            "description": "",
+            "build": {"commands": []},
+        },
+    }
+    function = mlrun.new_function(runtime=runtime)
+    assert DeepDiff(runtime, function.to_dict(), ignore_order=True,) == {}


### PR DESCRIPTION
Before this fix when giving args without command the first argument was parsed as the command, e.g. 
`args=["--memory-limit", "4GB"]` would become `command="--memory-limit"` and `args="4GB"`