### PR TITLE
[Dask] Pass memory limit to dask worker

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -352,8 +352,11 @@ def deploy_function(function: DaskCluster, secrets=None):
 
     pod_labels = get_resource_labels(function, scrape_metrics=False)
     args = ["dask-worker", "--nthreads", str(spec.nthreads)]
+    memory_limit = spec.resources.get('limits', {}).get("memory")
+    if memory_limit:
+        args.extend(["--memory-limit", str(memory_limit)])
     if spec.args:
-        args += spec.args
+        args.extend(spec.args)
 
     container = client.V1Container(
         name="base",


### PR DESCRIPTION
When you do `function.with_limits(mem="4GB")` on dask function, it will automatically add `--memory-limit 4GB` to the args (in addition to setting the memory limit on the pod)