### PR TITLE
[Cleanup] Adding cleanup tests + minor improvements

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -997,25 +997,22 @@ class BaseRuntimeHandler(ABC):
 
             # best effort - don't let one failure in pod deletion to cut the whole operation
             try:
-                if force:
-                    self._delete_pod(namespace, pod)
-                    continue
-
                 (
                     in_terminal_state,
                     last_update,
                     run_state,
                 ) = self._resolve_pod_status_info(db, db_session, pod.to_dict())
-                if not in_terminal_state:
-                    continue
+                if not force:
+                    if not in_terminal_state:
+                        continue
 
-                # give some grace period if we have last update time
-                now = datetime.now(timezone.utc)
-                if (
-                    last_update is not None
-                    and last_update + timedelta(seconds=float(grace_period)) > now
-                ):
-                    continue
+                    # give some grace period if we have last update time
+                    now = datetime.now(timezone.utc)
+                    if (
+                        last_update is not None
+                        and last_update + timedelta(seconds=float(grace_period)) > now
+                    ):
+                        continue
 
                 if self._consider_run_on_resources_deletion():
                     try:
@@ -1063,27 +1060,22 @@ class BaseRuntimeHandler(ABC):
             for crd_object in crd_objects["items"]:
                 # best effort - don't let one failure in pod deletion to cut the whole operation
                 try:
-                    if force:
-                        self._delete_crd(
-                            namespace, crd_group, crd_version, crd_plural, crd_object
-                        )
-                        continue
-
                     (
                         in_terminal_state,
                         last_update,
                         desired_run_state,
                     ) = self._resolve_crd_object_status_info(db, db_session, crd_object)
-                    if not in_terminal_state:
-                        continue
+                    if not force:
+                        if not in_terminal_state:
+                            continue
 
-                    # give some grace period if we have last update time
-                    now = datetime.now(timezone.utc)
-                    if (
-                        last_update is not None
-                        and last_update + timedelta(seconds=float(grace_period)) > now
-                    ):
-                        continue
+                        # give some grace period if we have last update time
+                        now = datetime.now(timezone.utc)
+                        if (
+                            last_update is not None
+                            and last_update + timedelta(seconds=float(grace_period)) > now
+                        ):
+                            continue
 
                     if self._consider_run_on_resources_deletion():
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -801,7 +801,13 @@ class BaseRuntimeHandler(ABC):
                 db, db_session, namespace, label_selector, force, grace_period
             )
         self._delete_resources(
-            db, db_session, namespace, deleted_resources, label_selector, force, grace_period,
+            db,
+            db_session,
+            namespace,
+            deleted_resources,
+            label_selector,
+            force,
+            grace_period,
         )
 
     def delete_runtime_object_resources(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1073,7 +1073,8 @@ class BaseRuntimeHandler(ABC):
                         now = datetime.now(timezone.utc)
                         if (
                             last_update is not None
-                            and last_update + timedelta(seconds=float(grace_period)) > now
+                            and last_update + timedelta(seconds=float(grace_period))
+                            > now
                         ):
                             continue
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -14,7 +14,7 @@
 import inspect
 import socket
 from os import environ
-from typing import Dict
+from typing import Dict, List
 
 from kubernetes.client.rest import ApiException
 from sqlalchemy.orm import Session
@@ -494,6 +494,7 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         db: DBInterface,
         db_session: Session,
         namespace: str,
+        deleted_resources: List[Dict],
         label_selector: str = None,
         force: bool = False,
         grace_period: int = config.runtime_resources_deletion_grace_period,
@@ -501,20 +502,14 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         """
         Handling services deletion
         """
-        k8s_helper = get_k8s_helper()
-        pods = k8s_helper.v1api.list_namespaced_pod(
-            namespace, label_selector=label_selector
-        )
         service_names = []
-        for pod in pods.items:
-            in_terminal_phase = pod.status.phase in PodPhases.terminal_phases()
-            if in_terminal_phase or (force and not in_terminal_phase):
-                comp = pod.metadata.labels.get("dask.org/component")
-                if comp == "scheduler":
-                    service_names.append(
-                        pod.metadata.labels.get("dask.org/cluster-name")
-                    )
+        for pod_dict in deleted_resources:
+            dask_component = pod_dict["metadata"].get("labels", {}).get("dask.org/component")
+            cluster_name = pod_dict["metadata"].get("labels", {}).get("dask.org/cluster-name")
+            if dask_component == "scheduler" and cluster_name:
+                service_names.append(cluster_name)
 
+        k8s_helper = get_k8s_helper()
         services = k8s_helper.v1api.list_namespaced_service(
             namespace, label_selector=label_selector
         )

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -504,8 +504,12 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         """
         service_names = []
         for pod_dict in deleted_resources:
-            dask_component = pod_dict["metadata"].get("labels", {}).get("dask.org/component")
-            cluster_name = pod_dict["metadata"].get("labels", {}).get("dask.org/cluster-name")
+            dask_component = (
+                pod_dict["metadata"].get("labels", {}).get("dask.org/component")
+            )
+            cluster_name = (
+                pod_dict["metadata"].get("labels", {}).get("dask.org/cluster-name")
+            )
             if dask_component == "scheduler" and cluster_name:
                 service_names.append(cluster_name)
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -22,7 +22,6 @@ from sqlalchemy.orm import Session
 from mlrun.api.db.base import DBInterface
 from mlrun.runtimes.base import BaseRuntimeHandler
 from .base import FunctionStatus
-from .constants import PodPhases
 from .kubejob import KubejobRuntime
 from .local import load_module, exec_from_params
 from .pod import KubeResourceSpec

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -168,7 +168,10 @@ class TestRuntimeHandlerBase:
             unittest.mock.call(expected_pod_name, expected_pod_namespace)
             for expected_pod_name in expected_pod_names
         ]
-        get_k8s().v1api.delete_namespaced_pod.assert_has_calls(calls)
+        if not expected_pod_names:
+            assert get_k8s().v1api.delete_namespaced_pod.call_count == 0
+        else:
+            get_k8s().v1api.delete_namespaced_pod.assert_has_calls(calls)
 
     @staticmethod
     def _assert_delete_namespaced_services(
@@ -178,7 +181,10 @@ class TestRuntimeHandlerBase:
             unittest.mock.call(expected_service_name, expected_service_namespace)
             for expected_service_name in expected_service_names
         ]
-        get_k8s().v1api.delete_namespaced_service.assert_has_calls(calls)
+        if not expected_service_names:
+            assert get_k8s().v1api.delete_namespaced_service.call_count == 0
+        else:
+            get_k8s().v1api.delete_namespaced_service.assert_has_calls(calls)
 
     @staticmethod
     def _assert_delete_namespaced_custom_objects(
@@ -198,7 +204,10 @@ class TestRuntimeHandlerBase:
             )
             for expected_custom_object_name in expected_custom_object_names
         ]
-        get_k8s().crdapi.delete_namespaced_custom_object.assert_has_calls(calls)
+        if not expected_custom_object_names:
+            assert get_k8s().crdapi.delete_namespaced_custom_object.call_count == 0
+        else:
+            get_k8s().crdapi.delete_namespaced_custom_object.assert_has_calls(calls)
 
     @staticmethod
     def _mock_delete_namespaced_pods():

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -171,8 +171,22 @@ class TestRuntimeHandlerBase:
         get_k8s().v1api.delete_namespaced_pod.assert_has_calls(calls)
 
     @staticmethod
+    def _assert_delete_namespaced_services(
+        expected_service_names: List[str], expected_service_namespace: str = None
+    ):
+        calls = [
+            unittest.mock.call(expected_service_name, expected_service_namespace)
+            for expected_service_name in expected_service_names
+        ]
+        get_k8s().v1api.delete_namespaced_service.assert_has_calls(calls)
+
+    @staticmethod
     def _mock_delete_namespaced_pods():
         get_k8s().v1api.delete_namespaced_pod = unittest.mock.Mock()
+
+    @staticmethod
+    def _mock_delete_namespaced_services():
+        get_k8s().v1api.delete_namespaced_service = unittest.mock.Mock()
 
     @staticmethod
     def _mock_list_namespaced_crds(crd_dicts_call_responses: List[List[Dict]]):

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -181,8 +181,32 @@ class TestRuntimeHandlerBase:
         get_k8s().v1api.delete_namespaced_service.assert_has_calls(calls)
 
     @staticmethod
+    def _assert_delete_namespaced_custom_objects(
+        runtime_handler,
+        expected_custom_object_names: List[str],
+        expected_custom_object_namespace: str = None,
+    ):
+        crd_group, crd_version, crd_plural = runtime_handler._get_crd_info()
+        calls = [
+            unittest.mock.call(
+                crd_group,
+                crd_version,
+                expected_custom_object_namespace,
+                crd_plural,
+                expected_custom_object_name,
+                client.V1DeleteOptions(),
+            )
+            for expected_custom_object_name in expected_custom_object_names
+        ]
+        get_k8s().crdapi.delete_namespaced_custom_object.assert_has_calls(calls)
+
+    @staticmethod
     def _mock_delete_namespaced_pods():
         get_k8s().v1api.delete_namespaced_pod = unittest.mock.Mock()
+
+    @staticmethod
+    def _mock_delete_namespaced_custom_objects():
+        get_k8s().crdapi.delete_namespaced_custom_object = unittest.mock.Mock()
 
     @staticmethod
     def _mock_delete_namespaced_services():

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -222,6 +222,11 @@ class TestRuntimeHandlerBase:
         get_k8s().v1api.delete_namespaced_service = unittest.mock.Mock()
 
     @staticmethod
+    def _mock_read_namespaced_pod_log():
+        log = "Some log string"
+        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+
+    @staticmethod
     def _mock_list_namespaced_crds(crd_dicts_call_responses: List[List[Dict]]):
         calls = []
         for crd_dicts_call_response in crd_dicts_call_responses:

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -152,7 +152,7 @@ class TestRuntimeHandlerBase:
                 )
 
     @staticmethod
-    def _mock_list_namespaces_pods(list_pods_call_responses: List[List[client.V1Pod]]):
+    def _mock_list_namespaced_pods(list_pods_call_responses: List[List[client.V1Pod]]):
         calls = []
         for list_pods_call_response in list_pods_call_responses:
             pods = client.V1PodList(items=list_pods_call_response)

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -225,6 +225,7 @@ class TestRuntimeHandlerBase:
     def _mock_read_namespaced_pod_log():
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        return log
 
     @staticmethod
     def _mock_list_namespaced_crds(crd_dicts_call_responses: List[List[Dict]]):

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -76,7 +76,9 @@ class TestRuntimeHandlerBase:
             restart_count=0,
         )
         status = client.V1PodStatus(phase=phase, container_statuses=[container_status])
-        metadata = client.V1ObjectMeta(name=name, labels=labels, namespace=get_k8s().resolve_namespace())
+        metadata = client.V1ObjectMeta(
+            name=name, labels=labels, namespace=get_k8s().resolve_namespace()
+        )
         pod = client.V1Pod(metadata=metadata, status=status)
         return pod
 
@@ -159,8 +161,13 @@ class TestRuntimeHandlerBase:
         return calls
 
     @staticmethod
-    def _assert_delete_namespaced_pods(expected_pod_names: List[str], expected_pod_namespace: str = None):
-        calls = [unittest.mock.call(expected_pod_name, expected_pod_namespace) for expected_pod_name in expected_pod_names]
+    def _assert_delete_namespaced_pods(
+        expected_pod_names: List[str], expected_pod_namespace: str = None
+    ):
+        calls = [
+            unittest.mock.call(expected_pod_name, expected_pod_namespace)
+            for expected_pod_name in expected_pod_names
+        ]
         get_k8s().v1api.delete_namespaced_pod.assert_has_calls(calls)
 
     @staticmethod

--- a/tests/api/runtime_handlers/test_daskjob.py
+++ b/tests/api/runtime_handlers/test_daskjob.py
@@ -80,7 +80,7 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.completed_worker_pod, self.completed_scheduler_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_services([self.cluster_service])
         self._mock_delete_namespaced_pods()
         self._mock_delete_namespaced_services()
@@ -104,7 +104,7 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.running_worker_pod, self.running_scheduler_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_services([self.cluster_service])
         self._mock_delete_namespaced_pods()
         self._mock_delete_namespaced_services()
@@ -116,7 +116,7 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
         )
 
     def _mock_list_resources_pods(self):
-        mocked_responses = TestDaskjobRuntimeHandler._mock_list_namespaces_pods(
+        mocked_responses = TestDaskjobRuntimeHandler._mock_list_namespaced_pods(
             [[self.running_scheduler_pod, self.running_worker_pod]]
         )
         return mocked_responses[0].items

--- a/tests/api/runtime_handlers/test_daskjob.py
+++ b/tests/api/runtime_handlers/test_daskjob.py
@@ -79,7 +79,6 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
     def test_delete_resources_completed_cluster(self, db: Session, client: TestClient):
         list_namespaced_pods_calls = [
             [self.completed_worker_pod, self.completed_scheduler_pod],
-            [self.completed_worker_pod, self.completed_scheduler_pod],
         ]
         self._mock_list_namespaces_pods(list_namespaced_pods_calls)
         self._mock_list_services([self.cluster_service])
@@ -103,7 +102,6 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
 
     def test_delete_resources_running_cluster(self, db: Session, client: TestClient):
         list_namespaced_pods_calls = [
-            [self.running_worker_pod, self.running_scheduler_pod],
             [self.running_worker_pod, self.running_scheduler_pod],
         ]
         self._mock_list_namespaces_pods(list_namespaced_pods_calls)

--- a/tests/api/runtime_handlers/test_daskjob.py
+++ b/tests/api/runtime_handlers/test_daskjob.py
@@ -1,12 +1,18 @@
+from fastapi.testclient import TestClient
 from kubernetes import client
+from sqlalchemy.orm import Session
 
+from mlrun.api.utils.singletons.db import get_db
 from mlrun.runtimes import RuntimeKinds
+from mlrun.runtimes import get_runtime_handler
 from mlrun.runtimes.constants import PodPhases
 from tests.api.runtime_handlers.base import TestRuntimeHandlerBase
 
 
 class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
     def custom_setup(self):
+        self.runtime_handler = get_runtime_handler(RuntimeKinds.dask)
+
         # initializing them here to save space in tests
         scheduler_pod_labels = {
             "app": "dask",
@@ -21,8 +27,11 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
         }
         scheduler_pod_name = "mlrun-mydask-d7656bc1-0n4z9z"
 
-        self.scheduler_pod = self._generate_pod(
+        self.running_scheduler_pod = self._generate_pod(
             scheduler_pod_name, scheduler_pod_labels, PodPhases.running,
+        )
+        self.completed_scheduler_pod = self._generate_pod(
+            scheduler_pod_name, scheduler_pod_labels, PodPhases.succeeded,
         )
 
         worker_pod_labels = {
@@ -38,27 +47,15 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
         }
         worker_pod_name = "mlrun-mydask-d7656bc1-0pqbnc"
 
-        self.worker_pod = self._generate_pod(
+        self.running_worker_pod = self._generate_pod(
             worker_pod_name, worker_pod_labels, PodPhases.running,
         )
-
-    def test_list_resources(self):
-        pods = self._mock_list_resources_pods()
-        services = self._create_daskjob_service_mocks()
-        self._assert_runtime_handler_list_resources(
-            RuntimeKinds.dask, expected_pods=pods, expected_services=services,
+        self.completed_worker_pod = self._generate_pod(
+            worker_pod_name, worker_pod_labels, PodPhases.succeeded,
         )
 
-    def _mock_list_resources_pods(self):
-        mocked_responses = TestDaskjobRuntimeHandler._mock_list_namespaces_pods(
-            [[self.scheduler_pod, self.worker_pod]]
-        )
-        return mocked_responses[0].items
-
-    @staticmethod
-    def _create_daskjob_service_mocks():
-        name = "mlrun-mydask-d7656bc1-0"
-        labels = {
+        service_name = "mlrun-mydask-d7656bc1-0"
+        service_labels = {
             "app": "dask",
             "dask.org/cluster-name": "mlrun-mydask-d7656bc1-0",
             "dask.org/component": "scheduler",
@@ -69,6 +66,64 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
             "mlrun/tag": "latest",
             "user": "root",
         }
+
+        self.cluster_service = self._generate_service(service_name, service_labels)
+
+    def test_list_resources(self):
+        pods = self._mock_list_resources_pods()
+        services = self._mock_list_services([self.cluster_service])
+        self._assert_runtime_handler_list_resources(
+            RuntimeKinds.dask, expected_pods=pods, expected_services=services,
+        )
+
+    def test_delete_resources_completed_cluster(self, db: Session, client: TestClient):
+        list_namespaced_pods_calls = [
+            [self.completed_worker_pod, self.completed_scheduler_pod],
+            [self.completed_worker_pod, self.completed_scheduler_pod],
+        ]
+        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_services([self.cluster_service])
+        self._mock_delete_namespaced_pods()
+        self._mock_delete_namespaced_services()
+        self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
+        self._assert_delete_namespaced_pods(
+            [
+                self.completed_worker_pod.metadata.name,
+                self.completed_scheduler_pod.metadata.name,
+            ],
+            self.completed_scheduler_pod.metadata.namespace,
+        )
+        self._assert_delete_namespaced_services(
+            [self.completed_scheduler_pod.metadata.labels.get("dask.org/cluster-name")],
+            self.completed_scheduler_pod.metadata.namespace,
+        )
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler, len(list_namespaced_pods_calls)
+        )
+
+    def test_delete_resources_running_cluster(self, db: Session, client: TestClient):
+        list_namespaced_pods_calls = [
+            [self.running_worker_pod, self.running_scheduler_pod],
+            [self.running_worker_pod, self.running_scheduler_pod],
+        ]
+        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_services([self.cluster_service])
+        self._mock_delete_namespaced_pods()
+        self._mock_delete_namespaced_services()
+        self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
+        self._assert_delete_namespaced_pods([])
+        self._assert_delete_namespaced_services([])
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler, len(list_namespaced_pods_calls)
+        )
+
+    def _mock_list_resources_pods(self):
+        mocked_responses = TestDaskjobRuntimeHandler._mock_list_namespaces_pods(
+            [[self.running_scheduler_pod, self.running_worker_pod]]
+        )
+        return mocked_responses[0].items
+
+    @staticmethod
+    def _generate_service(name, labels):
         metadata = client.V1ObjectMeta(name=name, labels=labels)
-        service = client.V1Service(metadata=metadata)
-        return TestDaskjobRuntimeHandler._mock_list_services([service])
+        return client.V1Service(metadata=metadata)

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -53,7 +53,9 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
-        self._assert_delete_namespaced_pods([self.completed_pod.metadata.name], self.completed_pod.metadata.namespace)
+        self._assert_delete_namespaced_pods(
+            [self.completed_pod.metadata.name], self.completed_pod.metadata.namespace
+        )
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler, expected_number_of_list_pods_calls
         )
@@ -106,7 +108,9 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10, force=True)
-        self._assert_delete_namespaced_pods([self.running_pod.metadata.name], self.running_pod.metadata.namespace)
+        self._assert_delete_namespaced_pods(
+            [self.running_pod.metadata.name], self.running_pod.metadata.namespace
+        )
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler, expected_number_of_list_pods_calls
         )

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -47,7 +47,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for the get_logger_pods
             [self.completed_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -69,7 +69,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.running_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
 
@@ -83,7 +83,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.completed_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10)
 
@@ -99,7 +99,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for the get_logger_pods
             [self.running_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -125,7 +125,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for the get_logger_pods
             [self.completed_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -152,7 +152,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for the get_logger_pods
             [self.failed_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -175,7 +175,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [],
             [],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_pods_calls
@@ -198,7 +198,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for the get_logger_pods
             [self.failed_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -229,7 +229,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         get_db().store_run(db, self.run, self.run_uid, self.project)
 
         # Mocking pod that is still in non-terminal state
-        self._mock_list_namespaces_pods([[self.running_pod]])
+        self._mock_list_namespaced_pods([[self.running_pod]])
 
         # Triggering monitor cycle
         self.runtime_handler.monitor_runs(get_db(), db)
@@ -247,7 +247,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         get_db().store_run(db, self.run, self.run_uid, self.project)
 
         # Mocking pod that is still in non-terminal state
-        self._mock_list_namespaces_pods([[self.running_pod]])
+        self._mock_list_namespaced_pods([[self.running_pod]])
 
         # Triggering monitor cycle
         self.runtime_handler.monitor_runs(get_db(), db)
@@ -258,7 +258,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         )
 
         # Mocking pod that is in terminal state (extra one for the log collection)
-        self._mock_list_namespaces_pods([[self.completed_pod], [self.completed_pod]])
+        self._mock_list_namespaced_pods([[self.completed_pod], [self.completed_pod]])
 
         # Mocking read log calls
         log = "Some log string"
@@ -283,7 +283,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for the get_logger_pods
             [self.completed_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -303,5 +303,5 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         )
 
     def _mock_list_resources_pods(self):
-        mocked_responses = self._mock_list_namespaces_pods([[self.completed_pod]])
+        mocked_responses = self._mock_list_namespaced_pods([[self.completed_pod]])
         return mocked_responses[0].items

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -49,7 +49,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaces_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
@@ -57,7 +56,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [self.completed_pod.metadata.name], self.completed_pod.metadata.namespace
         )
         self._assert_list_namespaced_pods_calls(
-            self.runtime_handler, expected_number_of_list_pods_calls
+            self.runtime_handler, len(list_namespaced_pods_calls)
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
@@ -72,13 +71,12 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaces_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
 
         # nothing removed cause pod is running
         self._assert_delete_namespaced_pods([])
         self._assert_list_namespaced_pods_calls(
-            self.runtime_handler, expected_number_of_list_pods_calls
+            self.runtime_handler, len(list_namespaced_pods_calls)
         )
 
     def test_delete_resources_with_grace_period(self, db: Session, client: TestClient):
@@ -87,13 +85,12 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaces_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10)
 
         # nothing removed cause pod grace period didn't pass
         self._assert_delete_namespaced_pods([])
         self._assert_list_namespaced_pods_calls(
-            self.runtime_handler, expected_number_of_list_pods_calls
+            self.runtime_handler, len(list_namespaced_pods_calls)
         )
 
     def test_delete_resources_with_force(self, db: Session, client: TestClient):
@@ -104,7 +101,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaces_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10, force=True)
@@ -112,7 +108,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [self.running_pod.metadata.name], self.running_pod.metadata.namespace
         )
         self._assert_list_namespaced_pods_calls(
-            self.runtime_handler, expected_number_of_list_pods_calls
+            self.runtime_handler, len(list_namespaced_pods_calls)
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -49,8 +49,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
         self._assert_delete_namespaced_pods(
             [self.completed_pod.metadata.name], self.completed_pod.metadata.namespace
@@ -101,8 +100,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10, force=True)
         self._assert_delete_namespaced_pods(
             [self.running_pod.metadata.name], self.running_pod.metadata.namespace
@@ -127,8 +125,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_pods_calls - 1
         )
@@ -154,8 +151,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_pods_calls - 1
         )
@@ -200,8 +196,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         self.run["status"]["state"] = RunStates.completed
         get_db().store_run(db, self.run, self.run_uid, self.project)
         expected_monitor_cycles_to_reach_expected_state = (
@@ -261,8 +256,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._mock_list_namespaced_pods([[self.completed_pod], [self.completed_pod]])
 
         # Mocking read log calls
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
 
         # Triggering monitor cycle
         self.runtime_handler.monitor_runs(get_db(), db)
@@ -285,8 +279,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_pods_calls - 1
         )

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -1,11 +1,9 @@
-import unittest.mock
 from datetime import timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from mlrun.api.utils.singletons.db import get_db
-from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds
 from mlrun.runtimes import get_runtime_handler

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -1,6 +1,7 @@
+from datetime import datetime, timezone
+
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
-from datetime import datetime, timezone
 
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
@@ -77,7 +78,9 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
 
     def test_delete_resources_with_grace_period(self, db: Session, client: TestClient):
         recently_completed_crd_dict = self._generate_mpijob_crd(
-            self.project, self.run_uid, self._get_succeeded_crd_status(datetime.now(timezone.utc).isoformat()),
+            self.project,
+            self.run_uid,
+            self._get_succeeded_crd_status(datetime.now(timezone.utc).isoformat()),
         )
         list_namespaced_crds_calls = [
             [recently_completed_crd_dict],

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -68,8 +68,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
 
         # nothing removed cause crd is active
         self._assert_delete_namespaced_custom_objects(
-            self.runtime_handler,
-            [],
+            self.runtime_handler, [],
         )
         self._assert_list_namespaced_crds_calls(
             self.runtime_handler, len(list_namespaced_crds_calls),
@@ -85,8 +84,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
 
         # nothing removed cause grace period didn't pass
         self._assert_delete_namespaced_custom_objects(
-            self.runtime_handler,
-            [],
+            self.runtime_handler, [],
         )
         self._assert_list_namespaced_crds_calls(
             self.runtime_handler, len(list_namespaced_crds_calls),

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -30,7 +30,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         # there's currently a bug (fix was merged but not released https://github.com/kubeflow/mpi-operator/pull/271)
         # that causes mpijob's pods to not being labels with the given (MLRun's) labels - this prevents list resources
         # from finding the pods, so we're simulating the same thing here
-        self._mock_list_namespaces_pods([[]])
+        self._mock_list_namespaced_pods([[]])
 
     def test_list_mpijob_resources(self):
         mocked_responses = self._mock_list_namespaced_crds([[self.succeeded_crd_dict]])

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -92,7 +92,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.executor_pod, self.driver_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_custom_objects()
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -158,7 +158,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.executor_pod, self.driver_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_custom_objects()
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -193,7 +193,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.executor_pod, self.driver_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -227,7 +227,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         list_namespaced_pods_calls = [
             [self.executor_pod, self.driver_pod],
         ]
-        self._mock_list_namespaces_pods(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
         log = "Some log string"
         get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
@@ -250,7 +250,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         )
 
     def _mock_list_resources_pods(self):
-        mocked_responses = self._mock_list_namespaces_pods(
+        mocked_responses = self._mock_list_namespaced_pods(
             [[self.executor_pod, self.driver_pod]]
         )
         return mocked_responses[0].items

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -108,7 +108,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            self.pod_label_selector
+            self.pod_label_selector,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
@@ -174,7 +174,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            self.pod_label_selector
+            self.pod_label_selector,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -95,8 +95,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_custom_objects()
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -166,8 +165,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_custom_objects()
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, force=True)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -201,8 +199,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -235,8 +232,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = "Some log string"
-        get_k8s().v1api.read_namespaced_pod_log = unittest.mock.Mock(return_value=log)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -1,4 +1,3 @@
-import unittest.mock
 from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -1,8 +1,8 @@
 import unittest.mock
+from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
-from datetime import datetime, timezone
 
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
@@ -136,7 +136,9 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
 
     def test_delete_resources_with_grace_period(self, db: Session, client: TestClient):
         recently_completed_crd_dict = self._generate_sparkjob_crd(
-            self.project, self.run_uid, self._get_completed_crd_status(datetime.now(timezone.utc).isoformat()),
+            self.project,
+            self.run_uid,
+            self._get_completed_crd_status(datetime.now(timezone.utc).isoformat()),
         )
         list_namespaced_crds_calls = [
             [recently_completed_crd_dict],


### PR DESCRIPTION
minor improvements:
* custom `_delete_resources` gets the list of `deleted_resources` instead of duplicating logic and generate it by itself
* resources that are forced deleted will also pass the pre-deletion actions