### PR TITLE
[Build] Optimize images size by removing redundant caches

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -2,6 +2,8 @@ ARG MLRUN_PYTHON_VERSION=3.7
 
 FROM python:${MLRUN_PYTHON_VERSION}-slim-buster
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -1,5 +1,7 @@
 FROM jupyter/scipy-notebook
 
+ENV PIP_NO_CACHE_DIR=1
+
 # by default COPY creates files with root permissions, so doing all the preparation with root and chown-ing everything
 # in the end
 USER root

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -6,10 +6,10 @@ ENV PIP_NO_CACHE_DIR=1
 # in the end
 USER root
 COPY . /tmp/mlrun
-RUN cd /tmp/mlrun && python -m pip install --no-cache-dir ".[api]" && cd /tmp && rm -rf mlrun
+RUN cd /tmp/mlrun && python -m pip install ".[api]" && cd /tmp && rm -rf mlrun
 
 COPY ./dockerfiles/jupyter/requirements.txt /tmp
-RUN python -m pip install --no-cache-dir -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
+RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 WORKDIR $HOME
 

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y \
   git-core \
   sqlite3 \
   procps \
-  vim
+  vim \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install --upgrade --no-cache pip
 

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -15,6 +15,8 @@ ARG MLRUN_PYTHON_VERSION=3.7
 
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -16,6 +16,8 @@ ARG MLRUN_PYTHON_VERSION=3.7
 
 FROM python:${MLRUN_PYTHON_VERSION}
 
+ENV PIP_NO_CACHE_DIR=1
+
 WORKDIR /mlrun
 
 RUN pip install --upgrade pip

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -15,6 +15,8 @@ ARG CUDA_VER=10.1
 
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/models-gpu/py36/Dockerfile
+++ b/dockerfiles/models-gpu/py36/Dockerfile
@@ -2,6 +2,8 @@ ARG CUDA_VER=10.1
 
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -1,5 +1,7 @@
 FROM continuumio/anaconda3:2020.02
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -1,5 +1,7 @@
 FROM continuumio/anaconda3:2020.02
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -56,6 +56,8 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 RUN conda install -y -c plotly plotly-orca python=3.6
 
+RUN conda clean -ayq
+
 # pytorch caused cuda download, this guarantees cpu version:
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -15,6 +15,8 @@ ARG MLRUN_PYTHON_VERSION=3.7
 
 FROM python:${MLRUN_PYTHON_VERSION}
 
+ENV PIP_NO_CACHE_DIR=1
+
 COPY . /tmp/mlrun
 RUN pip install --upgrade pytest
 RUN cd /tmp/mlrun && python -m pip install --no-cache-dir ".[api]" && mv tests /tests && cd /tmp && rm -rf mlrun

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -19,6 +19,6 @@ ENV PIP_NO_CACHE_DIR=1
 
 COPY . /tmp/mlrun
 RUN pip install --upgrade pytest
-RUN cd /tmp/mlrun && python -m pip install --no-cache-dir ".[api]" && mv tests /tests && cd /tmp && rm -rf mlrun
+RUN cd /tmp/mlrun && python -m pip install ".[api]" && mv tests /tests && cd /tmp && rm -rf mlrun
 
 CMD ["pytest",  "--capture=no", "-rf",  "-v",  "--disable-warnings", "/tests/system"]

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -15,6 +15,8 @@ ARG MLRUN_PYTHON_VERSION=3.7
 
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
+ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
 


### PR DESCRIPTION
* add `ENV PIP_NO_CACHE_DIR=1` to all images
* add `rm -rf /var/lib/apt/lists/*` (remove apt-get cache) to mlrun-api (already exists in the rest of the images)
* add `RUN conda clean -ayq` (remove conda cache) to models-legacy (already exists in the rest of the images)

Image | Before | After | percentage
--- | --- | --- | ---
`mlrun/mlrun` | `1.61GB` | `1.47GB` | 8.7%
`mlrun/mlrun-api` | `1.16GB` | `996MB` | 14.1%
`mlrun/jupyter` | `3.61GB` | `3.61GB` | 0%
`mlrun/ml-base` | `2.3GB` | `1.9GB` | 17.4%
`mlrun/ml-base` (`-py36` tag) | `2.3GB` | `1.89GB` | 17.8%
`mlrun/ml-models` | `7.91GB` | `7GB` | 11.5%
`mlrun/ml-models` (`-py36` tag) | `7.98GB` | `7.3GB` | 8.5%
`mlrun/ml-models-gpu` | `23.5GB` | `22.8GB` | 3%
`mlrun/ml-models-gpu` (`-py36` tag) | `21.2GB` | `20.6GB` | 2.8%