### PR TITLE
[Tests] Skip horovod demo system test

### DIFF
--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -1,12 +1,15 @@
 import pathlib
+import pytest
 
 import mlrun
 
-from tests.system.base import TestMLRunSystem
+# from tests.system.base import TestMLRunSystem
 from tests.system.demos.base import TestDemo
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+# @TestMLRunSystem.skip_test_if_env_not_configured
+# FIXME: we need to cut the train data size
+@pytest.mark.skip("this test fails cause the mpi worker getting OOM killed, skipping")
 class TestHorovodTFv2(TestDemo):
 
     project_name = "horovod-project"


### PR DESCRIPTION
The test fails cause the mpi worker getting OOM killed, skipping for now
we need to cut the train data size