### PR TITLE
[Scheduling] Populate last run uri in schedule

### DIFF
--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -153,6 +153,7 @@ class DBInterface(ABC):
         scheduled_object: Any = None,
         cron_trigger: schemas.ScheduleCronTrigger = None,
         labels: Dict = None,
+        last_run_uri: str = None,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -204,6 +204,7 @@ class FileDB(DBInterface):
         scheduled_object: Any = None,
         cron_trigger: schemas.ScheduleCronTrigger = None,
         labels: Dict = None,
+        last_run_uri: str = None,
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -506,6 +506,7 @@ class SQLDB(DBInterface):
         scheduled_object: Any = None,
         cron_trigger: schemas.ScheduleCronTrigger = None,
         labels: Dict = None,
+        last_run_uri: str = None,
     ):
         self._ensure_project(session, project)
         query = self._query(session, Schedule, project=project, name=name)
@@ -520,6 +521,9 @@ class SQLDB(DBInterface):
 
         if labels is not None:
             update_labels(schedule, labels)
+
+        if last_run_uri is not None:
+            schedule.last_run_uri = last_run_uri
 
         logger.debug(
             "Updating schedule in db",

--- a/mlrun/api/db/sqldb/models.py
+++ b/mlrun/api/db/sqldb/models.py
@@ -175,6 +175,7 @@ with warnings.catch_warnings():
         state = Column(String)
         creation_time = Column(TIMESTAMP)
         cron_trigger_str = Column(String)
+        last_run_uri = Column(String)
         struct = Column(BLOB)
         labels = relationship(Label, cascade="all, delete-orphan")
 

--- a/mlrun/api/migrations/tests/test_migrations.py
+++ b/mlrun/api/migrations/tests/test_migrations.py
@@ -8,22 +8,35 @@ from mlrun.api.db.sqldb.models import Schedule
 log = logging.getLogger(__name__)
 
 
+class Constants:
+    schedule_table = "schedules_v2"
+
+    schedule_id_revision = "cf21882f938e"
+    schedule_id_project = "schedule-id-project"
+
+    last_run_uri_revision = "1c954f8cb32d"
+    last_run_uri_project = "last-run-uri-project"
+
+
 @pytest.fixture
 def alembic_config():
     return {
         "before_revision_data": {
-            # schedule id migration revision
-            "cf21882f938e": [
+            Constants.schedule_id_revision: [
                 {
-                    "__tablename__": "schedules_v2",
-                    "project": "test-project",
-                    "name": "test-schedule1",
-                },
+                    "__tablename__": Constants.schedule_table,
+                    "project": Constants.schedule_id_project,
+                    "name": name,
+                }
+                for name in ["test-schedule1", "test-schedule2"]
+            ],
+            Constants.last_run_uri_revision: [
                 {
-                    "__tablename__": "schedules_v2",
-                    "project": "test-project",
-                    "name": "test-schedule2",
-                },
+                    "__tablename__": Constants.schedule_table,
+                    "project": Constants.last_run_uri_project,
+                    "name": name,
+                }
+                for name in ["test-schedule3", "test-schedule4"]
             ],
         },
     }
@@ -39,14 +52,35 @@ def alembic_session(alembic_engine):
 
 @pytest.mark.alembic
 def test_schedule_id_column(alembic_runner, alembic_session, alembic_config):
-    alembic_runner.migrate_up_to("head")
+    alembic_runner.migrate_up_to(Constants.schedule_id_revision)
 
-    # schedule id migration revision
-    revision_data = alembic_config["before_revision_data"]["cf21882f938e"]
+    revision_data = alembic_config["before_revision_data"][
+        Constants.schedule_id_revision
+    ]
 
     for index, instance in enumerate(
-        alembic_session.query(Schedule).order_by(Schedule.id)
+        alembic_session.query(Schedule.id, Schedule.name, Schedule.project)
+        .filter_by(project=Constants.schedule_id_project)
+        .order_by(Schedule.id)
     ):
         assert instance.id == index + 1
         assert instance.name == revision_data[index]["name"]
         assert instance.project == revision_data[index]["project"]
+
+
+@pytest.mark.alembic
+def test_schedule_last_run_uri_column(alembic_runner, alembic_session, alembic_config):
+    alembic_runner.migrate_up_to(Constants.last_run_uri_revision)
+
+    revision_data = alembic_config["before_revision_data"][
+        Constants.last_run_uri_revision
+    ]
+
+    for index, instance in enumerate(
+        alembic_session.query(Schedule.name, Schedule.project, Schedule.last_run_uri)
+        .filter_by(project=Constants.last_run_uri_project)
+        .order_by(Schedule.id)
+    ):
+        assert instance.name == revision_data[index]["name"]
+        assert instance.project == revision_data[index]["project"]
+        assert instance.last_run_uri is None

--- a/mlrun/api/migrations/versions/1c954f8cb32d_schedule_last_run_uri.py
+++ b/mlrun/api/migrations/versions/1c954f8cb32d_schedule_last_run_uri.py
@@ -1,0 +1,26 @@
+"""Schedule last run uri
+
+Revision ID: 1c954f8cb32d
+Revises: f7b5a1a03629
+Create Date: 2020-11-11 09:39:09.551025
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "1c954f8cb32d"
+down_revision = "f7b5a1a03629"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("schedules_v2") as batch_op:
+        batch_op.add_column(sa.Column("last_run_uri", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("schedules_v2") as batch_op:
+        batch_op.drop_column("last_run_uri")

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -94,6 +94,7 @@ class ScheduleInput(BaseModel):
 class ScheduleRecord(ScheduleInput):
     creation_time: datetime
     project: str
+    last_run_uri: Optional[str]
     state: Optional[str]
 
     class Config:

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from mlrun.api import schemas
 from mlrun.api.db.session import create_session, close_session
 from mlrun.api.utils.singletons.db import get_db
+from mlrun.model import RunObject
 from mlrun.config import config
 from mlrun.utils import logger
 
@@ -147,7 +148,7 @@ class Scheduler:
         logger.debug("Invoking schedule", project=project, name=name)
         db_schedule = get_db().get_schedule(db_session, project, name)
         function, args, kwargs = self._resolve_job_function(
-            db_schedule.kind, db_schedule.scheduled_object
+            db_schedule.kind, db_schedule.scheduled_object, name
         )
         return await function(*args, **kwargs)
 
@@ -212,7 +213,7 @@ class Scheduler:
     ):
         job_id = self._resolve_job_id(project, name)
         logger.debug("Adding schedule to scheduler", job_id=job_id)
-        function, args, kwargs = self._resolve_job_function(kind, scheduled_object)
+        function, args, kwargs = self._resolve_job_function(kind, scheduled_object, name)
         self._scheduler.add_job(
             function,
             self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
@@ -233,7 +234,7 @@ class Scheduler:
     ):
         job_id = self._resolve_job_id(project, name)
         logger.debug("Updating schedule in scheduler", job_id=job_id)
-        function, args, kwargs = self._resolve_job_function(kind, scheduled_object)
+        function, args, kwargs = self._resolve_job_function(kind, scheduled_object, name)
         trigger = self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
             cron_trigger
         )
@@ -278,7 +279,7 @@ class Scheduler:
         return schedule
 
     def _resolve_job_function(
-        self, scheduled_kind: schemas.ScheduleKinds, scheduled_object: Any,
+        self, scheduled_kind: schemas.ScheduleKinds, scheduled_object: Any, schedule_name: str
     ) -> Tuple[Callable, Optional[Union[List, Tuple]], Optional[Dict]]:
         """
         :return: a tuple (function, args, kwargs) to be used with the APScheduler.add_job
@@ -286,7 +287,7 @@ class Scheduler:
 
         if scheduled_kind == schemas.ScheduleKinds.job:
             scheduled_object_copy = copy.deepcopy(scheduled_object)
-            return Scheduler.submit_run_wrapper, [scheduled_object_copy], {}
+            return Scheduler.submit_run_wrapper, [scheduled_object_copy, schedule_name], {}
         if scheduled_kind == schemas.ScheduleKinds.local_function:
             return scheduled_object, [], {}
 
@@ -302,7 +303,7 @@ class Scheduler:
         return self._job_id_separator.join([project, name])
 
     @staticmethod
-    async def submit_run_wrapper(scheduled_object):
+    async def submit_run_wrapper(scheduled_object, schedule_name):
         # import here to avoid circular imports
         from mlrun.api.api.utils import submit_run
 
@@ -317,6 +318,17 @@ class Scheduler:
         db_session = create_session()
 
         response = await submit_run(db_session, scheduled_object)
+
+        run_metadata = response["data"]["metadata"]
+        run_uri = RunObject.create_uri(
+            run_metadata["project"], run_metadata["uid"], run_metadata["iteration"]
+        )
+        get_db().update_schedule(
+            db_session,
+            run_metadata['project'],
+            schedule_name,
+            last_run_uri=run_uri,
+        )
 
         close_session(db_session)
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -213,7 +213,9 @@ class Scheduler:
     ):
         job_id = self._resolve_job_id(project, name)
         logger.debug("Adding schedule to scheduler", job_id=job_id)
-        function, args, kwargs = self._resolve_job_function(kind, scheduled_object, name)
+        function, args, kwargs = self._resolve_job_function(
+            kind, scheduled_object, name
+        )
         self._scheduler.add_job(
             function,
             self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
@@ -234,7 +236,9 @@ class Scheduler:
     ):
         job_id = self._resolve_job_id(project, name)
         logger.debug("Updating schedule in scheduler", job_id=job_id)
-        function, args, kwargs = self._resolve_job_function(kind, scheduled_object, name)
+        function, args, kwargs = self._resolve_job_function(
+            kind, scheduled_object, name
+        )
         trigger = self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
             cron_trigger
         )
@@ -279,7 +283,10 @@ class Scheduler:
         return schedule
 
     def _resolve_job_function(
-        self, scheduled_kind: schemas.ScheduleKinds, scheduled_object: Any, schedule_name: str
+        self,
+        scheduled_kind: schemas.ScheduleKinds,
+        scheduled_object: Any,
+        schedule_name: str,
     ) -> Tuple[Callable, Optional[Union[List, Tuple]], Optional[Dict]]:
         """
         :return: a tuple (function, args, kwargs) to be used with the APScheduler.add_job
@@ -287,7 +294,11 @@ class Scheduler:
 
         if scheduled_kind == schemas.ScheduleKinds.job:
             scheduled_object_copy = copy.deepcopy(scheduled_object)
-            return Scheduler.submit_run_wrapper, [scheduled_object_copy, schedule_name], {}
+            return (
+                Scheduler.submit_run_wrapper,
+                [scheduled_object_copy, schedule_name],
+                {},
+            )
         if scheduled_kind == schemas.ScheduleKinds.local_function:
             return scheduled_object, [], {}
 
@@ -324,10 +335,7 @@ class Scheduler:
             run_metadata["project"], run_metadata["uid"], run_metadata["iteration"]
         )
         get_db().update_schedule(
-            db_session,
-            run_metadata['project'],
-            schedule_name,
-            last_run_uri=run_uri,
+            db_session, run_metadata["project"], schedule_name, last_run_uri=run_uri,
         )
 
         close_session(db_session)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -441,6 +441,15 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed creating schedule {project}/{schedule.name}"
         self.api_call("POST", path, error_message, body=json.dumps(schedule.dict()))
 
+    def update_schedule(
+        self, project: str, name: str, schedule: schemas.ScheduleUpdate
+    ):
+        project = project or default_project
+        path = f"projects/{project}/schedules/{name}"
+
+        error_message = f"Failed updating schedule {project}/{name}"
+        self.api_call("PUT", path, error_message, body=json.dumps(schedule.dict()))
+
     def get_schedule(self, project: str, name: str) -> schemas.ScheduleOutput:
         project = project or default_project
         path = f"projects/{project}/schedules/{name}"

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -17,6 +17,8 @@ import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from os import environ
+import re
+import typing
 
 from .config import config
 from .db import get_run_db
@@ -589,6 +591,30 @@ class RunObject(RunTemplate):
         if state:
             print("final state: {}".format(state))
         return state
+
+    @staticmethod
+    def create_uri(project: str, uid: str, iteration: str, tag: str = ""):
+        if tag:
+            tag = f":{tag}"
+        return f"{project}@{uid}#{iteration}{tag}"
+
+    @staticmethod
+    def parse_uri(uri: str) -> typing.Tuple[str, str, str, str]:
+        uri_pattern = (
+            r"^(?P<project>.*)@(?P<uid>.*)\#(?P<iteration>.*?)(:(?P<tag>.*))?$"
+        )
+        match = re.match(uri_pattern, uri)
+        if not match:
+            raise ValueError(
+                "Uri not in supported format <project>@<uid>#<iteration>[:tag]"
+            )
+        group_dict = match.groupdict()
+        return (
+            group_dict["project"],
+            group_dict["uid"],
+            group_dict["iteration"],
+            group_dict["tag"],
+        )
 
 
 # TODO: remove in 0.9.0

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -126,6 +126,11 @@ async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler)
     assert len(runs) == 1
     assert runs[0]["status"]["state"] == RunStates.completed
 
+    expected_last_run_uri = f"{project}@{runs[0]['metadata']['uid']}#0"
+
+    schedule = get_db().get_schedule(db, project, schedule_name)
+    assert schedule.last_run_uri == expected_last_run_uri
+
 
 @pytest.mark.asyncio
 async def test_create_schedule_success_cron_trigger_validation(


### PR DESCRIPTION
Added a text field in Schedule called `last_run_uri` which contains a uri representing the last run of that schedule.
The uri is built as such:
`<project>@<run_uid>#<iteration>[:<tag>]`

For example:
1. For `project = 'default'; run_uid = '1234abcd'; iteration = 2; tag = None` :
    The uri is `default@1234abcd#2`
2. For `project = 'myproj'; run_uid = '9876zyxw'; iteration = 5; tag = 'mytag'` :
    The uri is `myproj@9876zyxw#5:mytag `