### PR TITLE
[Scheduling] Include last run on get and list

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -52,18 +52,26 @@ def list_schedules(
     name: str = None,
     labels: str = None,
     kind: schemas.ScheduleKinds = None,
+    include_last_run: bool = False,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    return get_scheduler().list_schedules(db_session, project, name, labels, kind)
+    return get_scheduler().list_schedules(
+        db_session, project, name, labels, kind, include_last_run=include_last_run
+    )
 
 
 @router.get(
     "/projects/{project}/schedules/{name}", response_model=schemas.ScheduleOutput
 )
 def get_schedule(
-    project: str, name: str, db_session: Session = Depends(deps.get_db_session),
+    project: str,
+    name: str,
+    include_last_run: bool = False,
+    db_session: Session = Depends(deps.get_db_session),
 ):
-    return get_scheduler().get_schedule(db_session, project, name)
+    return get_scheduler().get_schedule(
+        db_session, project, name, include_last_run=include_last_run
+    )
 
 
 @router.post("/projects/{project}/schedules/{name}/invoke")

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional, List, Union, Any
+from typing import Optional, List, Union, Any, Dict
 
 from pydantic import BaseModel
 
@@ -104,6 +104,7 @@ class ScheduleRecord(ScheduleInput):
 # Additional properties to return via API
 class ScheduleOutput(ScheduleRecord):
     next_run_time: Optional[datetime]
+    last_run: Optional[Dict]
 
 
 class SchedulesOutput(BaseModel):

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -128,9 +128,9 @@ class Scheduler:
         db_schedules = get_db().list_schedules(db_session, project, name, labels, kind)
         schedules = []
         for db_schedule in db_schedules:
-            schedule = self._transform_db_schedule_to_schedule(db_schedule)
-            if include_last_run:
-                schedule = self._enrich_schedule_with_last_run(db_session, schedule)
+            schedule = self._transform_and_enrich_db_schedule(
+                db_session, db_schedule, include_last_run
+            )
             schedules.append(schedule)
         return schemas.SchedulesOutput(schedules=schedules)
 
@@ -143,10 +143,9 @@ class Scheduler:
     ) -> schemas.ScheduleOutput:
         logger.debug("Getting schedule", project=project, name=name)
         db_schedule = get_db().get_schedule(db_session, project, name)
-        schedule = self._transform_db_schedule_to_schedule(db_schedule)
-        if include_last_run:
-            schedule = self._enrich_schedule_with_last_run(db_session, schedule)
-        return schedule
+        return self._transform_and_enrich_db_schedule(
+            db_session, db_schedule, include_last_run
+        )
 
     def delete_schedule(self, db_session: Session, project: str, name: str):
         logger.debug("Deleting schedule", project=project, name=name)
@@ -283,13 +282,21 @@ class Scheduler:
                     db_schedule=db_schedule,
                 )
 
-    def _transform_db_schedule_to_schedule(
-        self, schedule_record: schemas.ScheduleRecord
+    def _transform_and_enrich_db_schedule(
+        self,
+        db_session: Session,
+        schedule_record: schemas.ScheduleRecord,
+        include_last_run: bool = True,
     ) -> schemas.ScheduleOutput:
+        schedule = schemas.ScheduleOutput(**schedule_record.dict())
+
         job_id = self._resolve_job_id(schedule_record.project, schedule_record.name)
         job = self._scheduler.get_job(job_id)
-        schedule = schemas.ScheduleOutput(**schedule_record.dict())
         schedule.next_run_time = job.next_run_time
+
+        if include_last_run:
+            schedule = self._enrich_schedule_with_last_run(db_session, schedule)
+
         return schedule
 
     @staticmethod
@@ -297,10 +304,10 @@ class Scheduler:
         db_session: Session, schedule_output: schemas.ScheduleOutput
     ):
         if schedule_output.last_run_uri:
-            run_project, run_uid, _, _ = RunObject.parse_uri(
+            run_project, run_uid, iteration, _ = RunObject.parse_uri(
                 schedule_output.last_run_uri
             )
-            run_data = get_db().read_run(db_session, run_uid, run_project)
+            run_data = get_db().read_run(db_session, run_uid, run_project, iteration)
             schedule_output.last_run = run_data
         return schedule_output
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -103,7 +103,7 @@ class Scheduler:
             db_session, project, name, scheduled_object, cron_trigger, labels
         )
         db_schedule = get_db().get_schedule(db_session, project, name)
-        updated_schedule = self._transform_db_schedule_to_schedule(db_schedule)
+        updated_schedule = self._transform_and_enrich_db_schedule(db_session, db_schedule)
 
         self._update_schedule_in_scheduler(
             project,
@@ -286,7 +286,7 @@ class Scheduler:
         self,
         db_session: Session,
         schedule_record: schemas.ScheduleRecord,
-        include_last_run: bool = True,
+        include_last_run: bool = False,
     ) -> schemas.ScheduleOutput:
         schedule = schemas.ScheduleOutput(**schedule_record.dict())
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -103,7 +103,9 @@ class Scheduler:
             db_session, project, name, scheduled_object, cron_trigger, labels
         )
         db_schedule = get_db().get_schedule(db_session, project, name)
-        updated_schedule = self._transform_and_enrich_db_schedule(db_session, db_schedule)
+        updated_schedule = self._transform_and_enrich_db_schedule(
+            db_session, db_schedule
+        )
 
         self._update_schedule_in_scheduler(
             project,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -450,18 +450,26 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed updating schedule {project}/{name}"
         self.api_call("PUT", path, error_message, body=json.dumps(schedule.dict()))
 
-    def get_schedule(self, project: str, name: str) -> schemas.ScheduleOutput:
+    def get_schedule(
+        self, project: str, name: str, include_last_run: bool = False
+    ) -> schemas.ScheduleOutput:
         project = project or default_project
         path = f"projects/{project}/schedules/{name}"
         error_message = f"Failed getting schedule for {project}/{name}"
-        resp = self.api_call("GET", path, error_message)
+        resp = self.api_call(
+            "GET", path, error_message, params={"include_last_run": include_last_run}
+        )
         return schemas.ScheduleOutput(**resp.json())
 
     def list_schedules(
-        self, project: str, name: str = None, kind: schemas.ScheduleKinds = None
+        self,
+        project: str,
+        name: str = None,
+        kind: schemas.ScheduleKinds = None,
+        include_last_run: bool = False,
     ) -> schemas.SchedulesOutput:
         project = project or default_project
-        params = {"kind": kind, "name": name}
+        params = {"kind": kind, "name": name, "include_last_run": include_last_run}
         path = f"projects/{project}/schedules"
         error_message = f"Failed listing schedules for {project} ? {kind} {name}"
         resp = self.api_call("GET", path, error_message, params=params)

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -98,6 +98,11 @@ async def test_invoke_schedule(db: Session, scheduler: Scheduler):
     db_uids = [run["metadata"]["uid"] for run in runs]
     assert DeepDiff(response_uids, db_uids, ignore_order=True,) == {}
 
+    schedule = scheduler.get_schedule(db, project, schedule_name, include_last_run=True)
+    assert schedule.last_run is not None
+    assert schedule.last_run["metadata"]["uid"] == response_uids[-1]
+    assert schedule.last_run["metadata"]["project"] == project
+
 
 @pytest.mark.asyncio
 async def test_create_schedule_mlrun_function(db: Session, scheduler: Scheduler):


### PR DESCRIPTION
Include last run dict in output schema for get and list schedules, if `include_last_run` flag is used