### PR TITLE
[Feature store] Feature set api refactoring

### DIFF
--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -43,7 +43,7 @@ class AuthVerifier:
         elif self._bearer_auth_required(cfg):
             if not header.startswith(self._bearer_prefix):
                 log_and_raise(
-                    HTTPStatus.UNAUTHORIZED.valueD, reason="missing bearer auth"
+                    HTTPStatus.UNAUTHORIZED.value, reason="missing bearer auth"
                 )
             token = header[len(self._bearer_prefix) :]
             if token != cfg.token:

--- a/mlrun/api/api/endpoints/feature_sets.py
+++ b/mlrun/api/api/endpoints/feature_sets.py
@@ -12,14 +12,14 @@ from mlrun.api.api.utils import parse_reference
 router = APIRouter()
 
 
-@router.post("/projects/{project}/feature_sets", response_model=schemas.FeatureSet)
-def add_feature_set(
+@router.post("/projects/{project}/feature-sets", response_model=schemas.FeatureSet)
+def create_feature_set(
     project: str,
     feature_set: schemas.FeatureSet,
     versioned: bool = True,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    feature_set_uid = get_db().add_feature_set(
+    feature_set_uid = get_db().create_feature_set(
         db_session, project, feature_set, versioned
     )
 
@@ -33,14 +33,14 @@ def add_feature_set(
 
 
 @router.put(
-    "/projects/{project}/feature_sets/{name}/references/{reference}",
+    "/projects/{project}/feature-sets/{name}/references/{reference}",
     response_model=schemas.FeatureSet,
 )
 def store_feature_set(
     project: str,
     name: str,
-    feature_set: schemas.FeatureSet,
     reference: str,
+    feature_set: schemas.FeatureSet,
     versioned: bool = True,
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -52,24 +52,26 @@ def store_feature_set(
     return get_db().get_feature_set(db_session, project, name, uid=uid,)
 
 
-@router.patch("/projects/{project}/feature_sets/{name}/references/{reference}")
+@router.patch("/projects/{project}/feature-sets/{name}/references/{reference}")
 def patch_feature_set(
     project: str,
     name: str,
     feature_set_update: dict,
     reference: str,
-    additive: bool = False,
+    patch_mode: schemas.PatchMode = Query(
+        schemas.PatchMode.replace, alias="patch-mode"
+    ),
     db_session: Session = Depends(deps.get_db_session),
 ):
     tag, uid = parse_reference(reference)
-    get_db().update_feature_set(
-        db_session, project, name, feature_set_update, tag, uid, additive
+    get_db().patch_feature_set(
+        db_session, project, name, feature_set_update, tag, uid, patch_mode
     )
     return Response(status_code=HTTPStatus.OK.value)
 
 
 @router.get(
-    "/projects/{project}/feature_sets/{name}/references/{reference}",
+    "/projects/{project}/feature-sets/{name}/references/{reference}",
     response_model=schemas.FeatureSet,
 )
 def get_feature_set(
@@ -83,7 +85,7 @@ def get_feature_set(
     return feature_set
 
 
-@router.delete("/projects/{project}/feature_sets/{name}")
+@router.delete("/projects/{project}/feature-sets/{name}")
 def delete_feature_set(
     project: str, name: str, db_session: Session = Depends(deps.get_db_session),
 ):
@@ -92,7 +94,7 @@ def delete_feature_set(
 
 
 @router.get(
-    "/projects/{project}/feature_sets", response_model=schemas.FeatureSetsOutput
+    "/projects/{project}/feature-sets", response_model=schemas.FeatureSetsOutput
 )
 def list_feature_sets(
     project: str,

--- a/mlrun/api/api/endpoints/feature_sets.py
+++ b/mlrun/api/api/endpoints/feature_sets.py
@@ -13,13 +13,13 @@ router = APIRouter()
 
 
 @router.post("/projects/{project}/feature_sets", response_model=schemas.FeatureSet)
-def create_feature_set(
+def add_feature_set(
     project: str,
     feature_set: schemas.FeatureSet,
     versioned: bool = True,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    feature_set_uid = get_db().create_feature_set(
+    feature_set_uid = get_db().add_feature_set(
         db_session, project, feature_set, versioned
     )
 
@@ -32,16 +32,39 @@ def create_feature_set(
     )
 
 
-@router.put("/projects/{project}/feature_sets/{name}/references/{reference}")
-def update_feature_set(
+@router.put(
+    "/projects/{project}/feature_sets/{name}/references/{reference}",
+    response_model=schemas.FeatureSet,
+)
+def store_feature_set(
     project: str,
     name: str,
-    feature_set_update: schemas.FeatureSetUpdate,
+    feature_set: schemas.FeatureSet,
     reference: str,
+    versioned: bool = True,
     db_session: Session = Depends(deps.get_db_session),
 ):
     tag, uid = parse_reference(reference)
-    get_db().update_feature_set(db_session, project, name, feature_set_update, tag, uid)
+    uid = get_db().store_feature_set(
+        db_session, project, name, feature_set, tag, uid, versioned
+    )
+
+    return get_db().get_feature_set(db_session, project, name, uid=uid,)
+
+
+@router.patch("/projects/{project}/feature_sets/{name}/references/{reference}")
+def patch_feature_set(
+    project: str,
+    name: str,
+    feature_set_update: dict,
+    reference: str,
+    additive: bool = False,
+    db_session: Session = Depends(deps.get_db_session),
+):
+    tag, uid = parse_reference(reference)
+    get_db().update_feature_set(
+        db_session, project, name, feature_set_update, tag, uid, additive
+    )
     return Response(status_code=HTTPStatus.OK.value)
 
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -197,7 +197,7 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def add_feature_set(
+    def create_feature_set(
         self, session, project, feature_set: schemas.FeatureSet, versioned=True
     ):
         pass
@@ -249,7 +249,7 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def update_feature_set(
+    def patch_feature_set(
         self,
         session,
         project,
@@ -257,7 +257,7 @@ class DBInterface(ABC):
         feature_set_update: dict,
         tag=None,
         uid=None,
-        additive=False,
+        patch_mode: schemas.PatchMode = schemas.PatchMode.replace,
     ):
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -196,8 +196,22 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def create_feature_set(
+    def add_feature_set(
         self, session, project, feature_set: schemas.FeatureSet, versioned=True
+    ):
+        pass
+
+    @abstractmethod
+    def store_feature_set(
+        self,
+        session,
+        project,
+        name,
+        feature_set: schemas.FeatureSet,
+        tag=None,
+        uid=None,
+        versioned=True,
+        always_overwrite=False,
     ):
         pass
 
@@ -239,9 +253,10 @@ class DBInterface(ABC):
         session,
         project,
         name,
-        feature_set_update: schemas.FeatureSetUpdate,
+        feature_set_update: dict,
         tag=None,
         uid=None,
+        additive=False,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -133,8 +133,21 @@ class FileDB(DBInterface):
     def delete_project(self, session, name: str):
         raise NotImplementedError()
 
-    def create_feature_set(
+    def add_feature_set(
         self, session, project, feature_set: schemas.FeatureSet, versioned=True
+    ):
+        raise NotImplementedError()
+
+    def store_feature_set(
+        self,
+        session,
+        project,
+        name,
+        feature_set: schemas.FeatureSet,
+        tag=None,
+        uid=None,
+        versioned=True,
+        always_overwrite=False,
     ):
         raise NotImplementedError()
 
@@ -172,9 +185,10 @@ class FileDB(DBInterface):
         session,
         project,
         name,
-        feature_set_update: schemas.FeatureSetUpdate,
+        feature_set_update: dict,
         tag=None,
         uid=None,
+        additive=False,
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -133,7 +133,7 @@ class FileDB(DBInterface):
     def delete_project(self, session, name: str):
         raise NotImplementedError()
 
-    def add_feature_set(
+    def create_feature_set(
         self, session, project, feature_set: schemas.FeatureSet, versioned=True
     ):
         raise NotImplementedError()
@@ -180,7 +180,7 @@ class FileDB(DBInterface):
     ) -> schemas.FeatureSetsOutput:
         raise NotImplementedError()
 
-    def update_feature_set(
+    def patch_feature_set(
         self,
         session,
         project,
@@ -188,7 +188,7 @@ class FileDB(DBInterface):
         feature_set_update: dict,
         tag=None,
         uid=None,
-        additive=False,
+        patch_mode: schemas.PatchMode = schemas.PatchMode.replace,
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -16,7 +16,6 @@ from mlrun.api.db.sqldb.helpers import (
     run_labels,
     run_state,
     update_labels,
-    transform_label_list_to_dict,
 )
 from mlrun.api.db.sqldb.models import (
     Artifact,
@@ -42,6 +41,7 @@ from mlrun.utils import (
     fill_object_hash,
     generate_object_uri,
 )
+from mergedeep import merge, Strategy
 
 NULL = None  # Avoid flake8 issuing warnings when comparing in filter
 run_time_fmt = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -697,9 +697,9 @@ class SQLDB(DBInterface):
     def list_projects(self, session, owner=None):
         return self._query(session, Project, owner=owner)
 
-    def get_feature_set(
-        self, session, project: str, name: str, tag: str = None, uid: str = None
-    ) -> schemas.FeatureSet:
+    def _get_feature_set(
+        self, session, project: str, name: str, tag: str = None, uid: str = None,
+    ):
         query = self._query(session, FeatureSet, name=name, project=project)
         computed_tag = tag or "latest"
         feature_set_tag_uid = None
@@ -708,10 +708,7 @@ class SQLDB(DBInterface):
                 session, FeatureSet, project, name, computed_tag
             )
             if feature_set_tag_uid is None:
-                feature_set_uri = generate_object_uri(project, name, tag)
-                raise mlrun.errors.MLRunNotFoundError(
-                    f"Feature-set tag not found {feature_set_uri}"
-                )
+                return None
             uid = feature_set_tag_uid
         if uid:
             query = query.filter(FeatureSet.uid == uid)
@@ -724,10 +721,19 @@ class SQLDB(DBInterface):
                 feature_set.metadata.tag = computed_tag
             return feature_set
         else:
+            return None
+
+    def get_feature_set(
+        self, session, project: str, name: str, tag: str = None, uid: str = None,
+    ) -> schemas.FeatureSet:
+        feature_set = self._get_feature_set(session, project, name, tag, uid)
+        if not feature_set:
             feature_set_uri = generate_object_uri(project, name, tag)
             raise mlrun.errors.MLRunNotFoundError(
-                f"Feature-set not found {feature_set_uri}"
+                f"Feature-set tag not found {feature_set_uri}"
             )
+
+        return feature_set
 
     def _get_feature_sets_tags_map(self, session, project, tag, name=None):
         # Find object IDs by tag, project and feature-set-name (which is a like query)
@@ -757,7 +763,7 @@ class SQLDB(DBInterface):
                 )
             )
         else:
-            feature_set_tags = obj_id_tags[feature_set_record.id]
+            feature_set_tags = obj_id_tags.get(feature_set_record.id, [])
             if len(feature_set_tags) == 0 and not feature_set_record.uid.startswith(
                 unversioned_tagged_object_uid_prefix
             ):
@@ -814,25 +820,29 @@ class SQLDB(DBInterface):
         features_results = []
         for row in query:
             feature_record = schemas.FeatureRecord.from_orm(row.Feature)
+            feature_name = feature_record.name
+
             feature_sets = self._generate_feature_set_results_with_tags_assigned(
                 row.FeatureSet, feature_set_id_tags, tag
             )
 
-            feature = schemas.Feature(
-                name=feature_record.name,
-                value_type=feature_record.value_type,
-                labels=transform_label_list_to_dict(feature_record.labels),
-            )
-
-            features_results.append(
-                schemas.FeatureListOutput(
-                    feature=feature,
-                    feature_set_digests=[
-                        self._generate_feature_set_digest(feature_set)
-                        for feature_set in feature_sets
-                    ],
+            for feature_set in feature_sets:
+                # Get the feature from the feature-set full structure, as it may contain extra fields (which are not
+                # in the DB)
+                feature = next(
+                    feature
+                    for feature in feature_set.spec.features
+                    if feature.name == feature_name
                 )
-            )
+
+                features_results.append(
+                    schemas.FeatureListOutput(
+                        feature=feature,
+                        feature_set_digest=self._generate_feature_set_digest(
+                            feature_set
+                        ),
+                    )
+                )
         return schemas.FeaturesOutput(features=features_results)
 
     def list_feature_sets(
@@ -883,17 +893,88 @@ class SQLDB(DBInterface):
 
         for obj in objects:
             labels = obj.get("labels") or {}
-            obj["labels"] = []
             if is_entity:
-                entity = Entity(**obj)
+                entity = Entity(
+                    name=obj["name"], value_type=obj["value_type"], labels=[],
+                )
                 update_labels(entity, labels)
                 feature_set.entities.append(entity)
             else:
-                feature = Feature(**obj)
+                feature = Feature(
+                    name=obj["name"], value_type=obj["value_type"], labels=[],
+                )
                 update_labels(feature, labels)
                 feature_set.features.append(feature)
 
-    def create_feature_set(
+    def _get_feature_set_by_project_and_uid(self, session, name, project, uid):
+        query = self._query(session, FeatureSet, name=name, project=project, uid=uid)
+        return query.one_or_none()
+
+    def _update_existing_feature_set(
+        self, feature_set: FeatureSet, new_feature_set_dict: dict
+    ):
+        feature_set_spec = new_feature_set_dict.get("spec")
+        if feature_set_spec:
+            features = feature_set_spec.pop("features", [])
+            entities = feature_set_spec.pop("entities", [])
+
+        self._update_feature_set_features_or_entities(
+            feature_set, features, is_entity=False
+        )
+        self._update_feature_set_features_or_entities(
+            feature_set, entities, is_entity=True
+        )
+
+        labels = new_feature_set_dict["metadata"].pop("labels", {})
+        update_labels(feature_set, labels)
+
+    def store_feature_set(
+        self,
+        session,
+        project,
+        name,
+        feature_set: schemas.FeatureSet,
+        tag=None,
+        uid=None,
+        versioned=True,
+        always_overwrite=False,
+    ):
+        if not tag and not uid:
+            raise ValueError("cannot store feature set without reference (tag or uid)")
+
+        existing_feature_set = self._get_feature_set(session, project, name, tag, uid)
+        if not existing_feature_set:
+            return self.add_feature_set(session, project, feature_set, versioned)
+
+        feature_set_dict = feature_set.dict()
+        hash_key = fill_object_hash(feature_set_dict, "uid", tag)
+        if versioned:
+            uid = hash_key
+        else:
+            uid = f"{unversioned_tagged_object_uid_prefix}{tag}"
+            feature_set_dict["metadata"]["uid"] = uid
+
+        if uid == existing_feature_set.metadata.uid or always_overwrite:
+            db_feature_set = self._get_feature_set_by_project_and_uid(
+                session, name, project, existing_feature_set.metadata.uid
+            )
+        else:
+            db_feature_set = FeatureSet(project=project)
+
+        db_feature_set.name = feature_set.metadata.name
+        db_feature_set.updated = datetime.now(timezone.utc)
+        db_feature_set.state = feature_set_dict.get("status", {}).get("state")
+        db_feature_set.uid = uid
+        db_feature_set.full_object = feature_set_dict
+
+        self._update_existing_feature_set(db_feature_set, feature_set_dict)
+
+        self._upsert(session, db_feature_set)
+        self.tag_objects_v2(session, [db_feature_set], project, tag)
+
+        return uid
+
+    def add_feature_set(
         self, session, project, feature_set: schemas.FeatureSet, versioned=True
     ):
         name = feature_set.metadata.name
@@ -910,31 +991,28 @@ class SQLDB(DBInterface):
             uid = hash_key
         else:
             uid = f"{unversioned_tagged_object_uid_prefix}{tag}"
+            feature_set_dict["metadata"]["uid"] = uid
 
         state = feature_set_dict.get("status", {}).get("state")
 
-        feature_set = FeatureSet(
-            name=name,
-            project=project,
-            state=state,
-            status=feature_set_dict.get("status", {}),
-            uid=uid,
+        feature_set = self._get_feature_set_by_project_and_uid(
+            session, name, project, uid
         )
+        if feature_set:
+            feature_set_uri = generate_object_uri(project, name, tag)
+            raise mlrun.errors.MLRunBadRequestError(
+                f"Adding an already-existing feature-set {feature_set_uri}"
+            )
+        else:
+            feature_set = FeatureSet(
+                name=name,
+                project=project,
+                state=state,
+                uid=uid,
+                full_object=feature_set_dict,
+            )
 
-        feature_set_spec = feature_set_dict.get("spec")
-        if feature_set_spec:
-            features = feature_set_spec.pop("features", [])
-            entities = feature_set_spec.pop("entities", [])
-
-        self._update_feature_set_features_or_entities(
-            feature_set, features, is_entity=False
-        )
-        self._update_feature_set_features_or_entities(
-            feature_set, entities, is_entity=True
-        )
-
-        labels = feature_set_dict["metadata"].pop("labels", {})
-        update_labels(feature_set, labels)
+        self._update_existing_feature_set(feature_set, feature_set_dict)
 
         self._upsert(session, feature_set)
         self.tag_objects_v2(session, [feature_set], project, tag)
@@ -946,60 +1024,39 @@ class SQLDB(DBInterface):
         session,
         project,
         name,
-        feature_set_update: schemas.FeatureSetUpdate,
+        feature_set_update: dict,
         tag=None,
         uid=None,
+        additive=False,
     ):
-        # If object uid was given, use it. Else, find it by tag
-        if not uid:
-            tag = tag or "latest"
-            tag = self._query(
-                session, FeatureSet.Tag, project=project, name=tag, obj_name=name
-            ).one_or_none()
-            if not tag:
-                feature_set_uri = generate_object_uri(project, name, tag)
-                raise mlrun.errors.MLRunNotFoundError(
-                    f"Feature-set not found {feature_set_uri}"
-                )
-            query = self._query(session, FeatureSet, id=tag.obj_id)
-        else:
-            query = self._query(
-                session, FeatureSet, name=name, project=project, uid=uid
-            )
-
-        feature_set_record = query.one_or_none()
+        feature_set_record = self._get_feature_set(session, project, name, tag, uid)
         if not feature_set_record:
             feature_set_uri = generate_object_uri(project, name, tag)
             raise mlrun.errors.MLRunNotFoundError(
                 f"Feature-set not found {feature_set_uri}"
             )
 
-        data = feature_set_update.dict()
+        feature_set_struct = feature_set_record.dict()
+        # using mergedeep for merging the patch content into the existing dictionary
+        strategy = Strategy.REPLACE
+        if additive:
+            strategy = Strategy.ADDITIVE
+        merge(feature_set_struct, feature_set_update, strategy=strategy)
 
-        # TODO (future) - granular update of JSON fields.
-        status = data.pop("status", None)
-        if status:
-            feature_set_record.status = status
-            feature_set_record.state = status.get("status") or feature_set_record.state
-
-        features = data.pop("features", [])
-        if features:
-            self._update_feature_set_features_or_entities(
-                feature_set_record, features, is_entity=False, replace=True
-            )
-
-        entities = data.pop("entities", [])
-        if entities:
-            self._update_feature_set_features_or_entities(
-                feature_set_record, entities, is_entity=True, replace=True
-            )
-
-        update_labels(feature_set_record, data.pop("labels", {}))
-        feature_set_record.updated = datetime.now(timezone.utc)
-
-        self._upsert(session, feature_set_record)
-
-        return feature_set_record.id
+        versioned = not feature_set_struct["metadata"]["uid"].startswith(
+            unversioned_tagged_object_uid_prefix
+        )
+        feature_set = schemas.FeatureSet(**feature_set_struct)
+        return self.store_feature_set(
+            session,
+            project,
+            name,
+            feature_set,
+            feature_set.metadata.tag,
+            uid,
+            versioned,
+            always_overwrite=True,
+        )
 
     def delete_feature_set(self, session, project, name):
         self._delete(session, FeatureSet.Tag, project=project, obj_name=name)
@@ -1350,38 +1407,8 @@ class SQLDB(DBInterface):
     def _transform_feature_set_model_to_schema(
         feature_set_record: FeatureSet, tag=None,
     ) -> schemas.FeatureSet:
-
-        feature_set = schemas.FeatureSetRecord.from_orm(feature_set_record)
-
-        feature_set_metadata = schemas.FeatureSetMetadata(
-            name=feature_set.name,
-            updated=feature_set.updated,
-            labels=transform_label_list_to_dict(feature_set.labels),
-            uid=feature_set.uid,
-        )
-        feature_set_spec = schemas.FeatureSetSpec(entities=[], features=[])
-        for feature in feature_set.features:
-            feature_set_spec.features.append(
-                schemas.Feature(
-                    name=feature.name,
-                    value_type=feature.value_type,
-                    labels=transform_label_list_to_dict(feature.labels),
-                )
-            )
-        for entity in feature_set.entities:
-            feature_set_spec.entities.append(
-                schemas.Entity(
-                    name=entity.name,
-                    value_type=entity.value_type,
-                    labels=transform_label_list_to_dict(entity.labels),
-                )
-            )
-
-        feature_set_resp = schemas.FeatureSet(
-            metadata=feature_set_metadata,
-            spec=feature_set_spec,
-            status=feature_set.status,
-        )
+        feature_set_full_dict = feature_set_record.full_object
+        feature_set_resp = schemas.FeatureSet(**feature_set_full_dict)
 
         feature_set_resp.metadata.tag = tag
         return feature_set_resp

--- a/mlrun/api/db/sqldb/models.py
+++ b/mlrun/api/db/sqldb/models.py
@@ -268,7 +268,8 @@ with warnings.catch_warnings():
         updated = Column(TIMESTAMP, default=datetime.now(timezone.utc))
         state = Column(String)
         uid = Column(String)
-        _status = Column("status", JSON)
+
+        _full_object = Column("object", JSON)
 
         Label = make_label(__tablename__)
         Tag = make_tag_v2(__tablename__)
@@ -279,13 +280,13 @@ with warnings.catch_warnings():
         entities = relationship(Entity, cascade="all, delete-orphan")
 
         @property
-        def status(self):
-            if self._status:
-                return json.loads(self._status)
+        def full_object(self):
+            if self._full_object:
+                return json.loads(self._full_object)
 
-        @status.setter
-        def status(self, value):
-            self._status = json.dumps(value)
+        @full_object.setter
+        def full_object(self, value):
+            self._full_object = json.dumps(value)
 
 
 # Must be after all table definitions

--- a/mlrun/api/migrations/versions/863114f0c659_refactoring_feature_set.py
+++ b/mlrun/api/migrations/versions/863114f0c659_refactoring_feature_set.py
@@ -1,0 +1,27 @@
+"""Refactoring feature set
+
+Revision ID: 863114f0c659
+Revises: f7b5a1a03629
+Create Date: 2020-11-11 11:22:36.653049
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "863114f0c659"
+down_revision = "f7b5a1a03629"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("feature_sets") as batch_op:
+        batch_op.add_column(sa.Column("object", sa.JSON(), nullable=True))
+        batch_op.drop_column("status")
+
+
+def downgrade():
+    with op.batch_alter_table("feature_sets") as batch_op:
+        batch_op.add_column(sa.Column("status", sa.JSON(), nullable=True))
+        batch_op.drop_column("object")

--- a/mlrun/api/migrations/versions/863114f0c659_refactoring_feature_set.py
+++ b/mlrun/api/migrations/versions/863114f0c659_refactoring_feature_set.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "863114f0c659"
-down_revision = "f7b5a1a03629"
+down_revision = "1c954f8cb32d"
 branch_labels = None
 depends_on = None
 

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -26,4 +26,4 @@ from .feature_store import (
     FeatureListOutput,
     FeaturesOutput,
 )
-from .object import ObjectMetadata
+from .object import ObjectMetadata, PatchMode

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -18,13 +18,12 @@ from .feature_store import (
     Entity,
     EntityRecord,
     FeatureSetSpec,
-    FeatureSetMetadata,
     FeatureSet,
     FeatureSetRecord,
-    FeatureSetUpdate,
     FeatureSetsOutput,
     FeatureSetDigestOutput,
     FeatureSetDigestSpec,
     FeatureListOutput,
     FeaturesOutput,
 )
+from .object import ObjectMetadata

--- a/mlrun/api/schemas/feature_store.py
+++ b/mlrun/api/schemas/feature_store.py
@@ -31,12 +31,17 @@ class FeatureSetSpec(BaseModel):
         extra = Extra.allow
 
 
-class FeatureSet(BaseModel):
-    metadata: ObjectMetadata
-    spec: FeatureSetSpec
+class FeatureSetStatus(BaseModel):
+    state: Optional[str]
 
     class Config:
         extra = Extra.allow
+
+
+class FeatureSet(BaseModel):
+    metadata: ObjectMetadata
+    spec: FeatureSetSpec
+    status: FeatureSetStatus
 
 
 class LabelRecord(BaseModel):

--- a/mlrun/api/schemas/feature_store.py
+++ b/mlrun/api/schemas/feature_store.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import Optional, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
+from .object import ObjectMetadata
 
 
 class Feature(BaseModel):
@@ -9,37 +10,33 @@ class Feature(BaseModel):
     value_type: str
     labels: Optional[dict]
 
+    class Config:
+        extra = Extra.allow
+
 
 class Entity(BaseModel):
     name: str
     value_type: str
     labels: Optional[dict]
 
-
-class FeatureSetMetadata(BaseModel):
-    name: str
-    tag: Optional[str]
-    labels: Optional[dict]
-    updated: Optional[datetime]
-    uid: Optional[str]
+    class Config:
+        extra = Extra.allow
 
 
 class FeatureSetSpec(BaseModel):
     entities: List[Entity]
     features: List[Feature]
 
+    class Config:
+        extra = Extra.allow
+
 
 class FeatureSet(BaseModel):
-    metadata: FeatureSetMetadata
+    metadata: ObjectMetadata
     spec: FeatureSetSpec
-    status: Optional[dict]
 
-
-class FeatureSetUpdate(BaseModel):
-    features: Optional[List[Feature]]
-    entities: Optional[List[Feature]]
-    status: Optional[dict]
-    labels: Optional[dict]
+    class Config:
+        extra = Extra.allow
 
 
 class LabelRecord(BaseModel):
@@ -80,7 +77,7 @@ class FeatureSetRecord(BaseModel):
     labels: List[LabelRecord]
     # state is extracted from the full status dict to enable queries
     state: Optional[str] = None
-    status: Optional[dict] = None
+    full_object: Optional[dict] = None
 
     class Config:
         orm_mode = True
@@ -95,13 +92,13 @@ class FeatureSetDigestSpec(BaseModel):
 
 
 class FeatureSetDigestOutput(BaseModel):
-    metadata: FeatureSetMetadata
+    metadata: ObjectMetadata
     spec: FeatureSetDigestSpec
 
 
 class FeatureListOutput(BaseModel):
     feature: Feature
-    feature_set_digests: List[FeatureSetDigestOutput]
+    feature_set_digest: FeatureSetDigestOutput
 
 
 class FeaturesOutput(BaseModel):

--- a/mlrun/api/schemas/object.py
+++ b/mlrun/api/schemas/object.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Extra
+
+
+class ObjectMetadata(BaseModel):
+    name: str
+    tag: Optional[str]
+    labels: Optional[dict]
+    updated: Optional[datetime]
+    uid: Optional[str]
+
+    class Config:
+        extra = Extra.allow

--- a/mlrun/api/schemas/object.py
+++ b/mlrun/api/schemas/object.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional
+from enum import Enum
 from pydantic import BaseModel, Extra
 
 
@@ -12,3 +13,8 @@ class ObjectMetadata(BaseModel):
 
     class Config:
         extra = Extra.allow
+
+
+class PatchMode(str, Enum):
+    replace = "replace"
+    additive = "additive"

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -127,7 +127,7 @@ class RunDBInterface(ABC):
         return []
 
     @abstractmethod
-    def add_feature_set(
+    def create_feature_set(
         self, feature_set: Union[dict, schemas.FeatureSet], project="", versioned=True
     ) -> schemas.FeatureSet:
         pass
@@ -176,7 +176,13 @@ class RunDBInterface(ABC):
 
     @abstractmethod
     def update_feature_set(
-        self, name, feature_set: dict, project="", tag=None, uid=None, additive=False
+        self,
+        name,
+        feature_set: dict,
+        project="",
+        tag=None,
+        uid=None,
+        patch_mode: Union[str, schemas.PatchMode] = schemas.PatchMode.replace,
     ):
         pass
 

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -127,7 +127,7 @@ class RunDBInterface(ABC):
         return []
 
     @abstractmethod
-    def create_feature_set(
+    def add_feature_set(
         self, feature_set: Union[dict, schemas.FeatureSet], project="", versioned=True
     ) -> schemas.FeatureSet:
         pass
@@ -163,13 +163,20 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def update_feature_set(
+    def store_feature_set(
         self,
         name,
-        feature_set: Union[dict, schemas.FeatureSetUpdate],
+        feature_set: Union[dict, schemas.FeatureSet],
         project="",
         tag=None,
         uid=None,
+        versioned=True,
+    ):
+        pass
+
+    @abstractmethod
+    def update_feature_set(
+        self, name, feature_set: dict, project="", tag=None, uid=None, additive=False
     ):
         pass
 

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -463,7 +463,7 @@ class FileRunDB(RunDBInterface):
         else:
             raise RunDBError(f"run file is not found or valid ({filepath})")
 
-    def add_feature_set(self, feature_set, project="", versioned=True):
+    def create_feature_set(self, feature_set, project="", versioned=True):
         raise NotImplementedError()
 
     def get_feature_set(
@@ -499,7 +499,7 @@ class FileRunDB(RunDBInterface):
         raise NotImplementedError()
 
     def update_feature_set(
-        self, name, feature_set, project="", tag=None, uid=None, additive=False
+        self, name, feature_set, project="", tag=None, uid=None, patch_mode="replace",
     ):
         raise NotImplementedError()
 

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -463,7 +463,7 @@ class FileRunDB(RunDBInterface):
         else:
             raise RunDBError(f"run file is not found or valid ({filepath})")
 
-    def create_feature_set(self, feature_set, project="", versioned=True):
+    def add_feature_set(self, feature_set, project="", versioned=True):
         raise NotImplementedError()
 
     def get_feature_set(
@@ -493,7 +493,14 @@ class FileRunDB(RunDBInterface):
     ):
         raise NotImplementedError()
 
-    def update_feature_set(self, name, feature_set, project="", tag=None, uid=None):
+    def store_feature_set(
+        self, name, feature_set, project="", tag=None, uid=None, versioned=True
+    ):
+        raise NotImplementedError()
+
+    def update_feature_set(
+        self, name, feature_set, project="", tag=None, uid=None, additive=False
+    ):
         raise NotImplementedError()
 
     def delete_feature_set(self, name, project=""):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -680,11 +680,11 @@ class HTTPRunDB(RunDBInterface):
 
         return resp.json()
 
-    def add_feature_set(
+    def create_feature_set(
         self, feature_set: Union[dict, schemas.FeatureSet], project="", versioned=True
     ) -> schemas.FeatureSet:
         project = project or default_project
-        path = f"projects/{project}/feature_sets"
+        path = f"projects/{project}/feature-sets"
         params = {"versioned": versioned}
 
         if isinstance(feature_set, schemas.FeatureSet):
@@ -705,7 +705,7 @@ class HTTPRunDB(RunDBInterface):
 
         project = project or default_project
         reference = uid or tag or "latest"
-        path = f"projects/{project}/feature_sets/{name}/references/{reference}"
+        path = f"projects/{project}/feature-sets/{name}/references/{reference}"
         error_message = f"Failed retrieving feature-set {project}/{name}"
         resp = self.api_call("GET", path, error_message)
         return schemas.FeatureSet(**resp.json())
@@ -752,7 +752,7 @@ class HTTPRunDB(RunDBInterface):
             "label": labels or [],
         }
 
-        path = f"projects/{project}/feature_sets"
+        path = f"projects/{project}/feature-sets"
 
         error_message = (
             f"Failed listing feature-sets, project: {project}, query: {params}"
@@ -779,7 +779,7 @@ class HTTPRunDB(RunDBInterface):
 
         project = project or default_project
         reference = uid or tag or "latest"
-        path = f"projects/{project}/feature_sets/{name}/references/{reference}"
+        path = f"projects/{project}/feature-sets/{name}/references/{reference}"
         error_message = f"Failed storing feature-set {project}/{name}"
         resp = self.api_call(
             "PUT", path, error_message, params=params, body=json.dumps(feature_set)
@@ -793,15 +793,15 @@ class HTTPRunDB(RunDBInterface):
         project="",
         tag=None,
         uid=None,
-        additive=False,
+        patch_mode: Union[str, schemas.PatchMode] = schemas.PatchMode.replace,
     ):
         if uid and tag:
             raise MLRunInvalidArgumentError("both uid and tag were provided")
 
         project = project or default_project
         reference = uid or tag or "latest"
-        params = {"additive": additive}
-        path = f"projects/{project}/feature_sets/{name}/references/{reference}"
+        params = {"patch-mode": patch_mode}
+        path = f"projects/{project}/feature-sets/{name}/references/{reference}"
         error_message = f"Failed updating feature-set {project}/{name}"
         self.api_call(
             "PATCH",
@@ -813,7 +813,7 @@ class HTTPRunDB(RunDBInterface):
 
     def delete_feature_set(self, name, project=""):
         project = project or default_project
-        path = f"projects/{project}/feature_sets/{name}"
+        path = f"projects/{project}/feature-sets/{name}"
         error_message = f"Failed deleting project {name}"
         self.api_call("DELETE", path, error_message)
 

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -212,9 +212,9 @@ class SQLDB(RunDBInterface):
         except DBError as exc:
             raise RunDBError(exc.args)
 
-    def add_feature_set(self, feature_set, project="", versioned=True):
+    def create_feature_set(self, feature_set, project="", versioned=True):
         return self._transform_db_error(
-            self.db.add_feature_set, self.session, project, feature_set, versioned
+            self.db.create_feature_set, self.session, project, feature_set, versioned
         )
 
     def get_feature_set(
@@ -273,17 +273,17 @@ class SQLDB(RunDBInterface):
         )
 
     def update_feature_set(
-        self, name, feature_set, project="", tag=None, uid=None, additive=False
+        self, name, feature_set, project="", tag=None, uid=None, patch_mode="replace"
     ):
         return self._transform_db_error(
-            self.db.update_feature_set,
+            self.db.patch_feature_set,
             self.session,
             project,
             name,
             feature_set,
             tag,
             uid,
-            additive,
+            patch_mode,
         )
 
     def delete_feature_set(self, name, project=""):

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -212,9 +212,9 @@ class SQLDB(RunDBInterface):
         except DBError as exc:
             raise RunDBError(exc.args)
 
-    def create_feature_set(self, feature_set, project="", versioned=True):
+    def add_feature_set(self, feature_set, project="", versioned=True):
         return self._transform_db_error(
-            self.db.create_feature_set, self.session, project, feature_set, versioned
+            self.db.add_feature_set, self.session, project, feature_set, versioned
         )
 
     def get_feature_set(
@@ -258,7 +258,23 @@ class SQLDB(RunDBInterface):
             labels,
         )
 
-    def update_feature_set(self, name, feature_set, project="", tag=None, uid=None):
+    def store_feature_set(
+        self, name, feature_set, project="", tag=None, uid=None, versioned=True
+    ):
+        return self._transform_db_error(
+            self.db.store_feature_set,
+            self.session,
+            project,
+            name,
+            feature_set,
+            tag,
+            uid,
+            versioned,
+        )
+
+    def update_feature_set(
+        self, name, feature_set, project="", tag=None, uid=None, additive=False
+    ):
         return self._transform_db_error(
             self.db.update_feature_set,
             self.session,
@@ -267,6 +283,7 @@ class SQLDB(RunDBInterface):
             feature_set,
             tag,
             uid,
+            additive,
         )
 
     def delete_feature_set(self, name, project=""):

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -80,9 +80,14 @@ class MLRunInvalidArgumentError(MLRunHTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 
+class MLRunConflictError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.CONFLICT.value
+
+
 STATUS_ERRORS = {
     HTTPStatus.BAD_REQUEST.value: MLRunBadRequestError,
     HTTPStatus.UNAUTHORIZED.value: MLRunUnauthorizedError,
     HTTPStatus.FORBIDDEN.value: MLRunAccessDeniedError,
     HTTPStatus.NOT_FOUND.value: MLRunNotFoundError,
+    HTTPStatus.CONFLICT.value: MLRunConflictError,
 }

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -458,13 +458,13 @@ def pr_comment(repo: str, issue: int, message: str, token=None):
     return resp.json()["id"]
 
 
-def fill_object_hash(object_dict, property_name, tag=""):
+def fill_object_hash(object_dict, uid_property_name, tag=""):
     # remove tag, hash, date from calculation
     object_dict.setdefault("metadata", {})
     tag = tag or object_dict["metadata"].get("tag")
     status = object_dict.setdefault("status", {})
     object_dict["metadata"]["tag"] = ""
-    object_dict["metadata"][property_name] = ""
+    object_dict["metadata"][uid_property_name] = ""
     object_dict["status"] = None
     object_dict["metadata"]["updated"] = None
     data = json.dumps(object_dict, sort_keys=True).encode()
@@ -472,7 +472,7 @@ def fill_object_hash(object_dict, property_name, tag=""):
     h.update(data)
     uid = h.hexdigest()
     object_dict["metadata"]["tag"] = tag
-    object_dict["metadata"][property_name] = uid
+    object_dict["metadata"][uid_property_name] = uid
     object_dict["status"] = status
     return uid
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ pydantic~=1.5
 orjson>=3,<3.4
 importlib-resources; python_version < '3.7'
 alembic~=1.4
-mergedeep
+mergedeep~=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ pydantic~=1.5
 orjson>=3,<3.4
 importlib-resources; python_version < '3.7'
 alembic~=1.4
+mergedeep

--- a/tests/api/api/test_feature_sets.py
+++ b/tests/api/api/test_feature_sets.py
@@ -11,14 +11,28 @@ def _generate_feature_set(name):
             "name": name,
             "labels": {"owner": "saarc", "group": "dev"},
             "tag": "latest",
+            "extra_metadata": 100,
         },
         "spec": {
-            "entities": [{"name": "ticker", "value_type": "str"}],
+            "entities": [
+                {
+                    "name": "ticker",
+                    "value_type": "str",
+                    "labels": {"label1": "value1"},
+                    "extra_entity_field": "here",
+                }
+            ],
             "features": [
-                {"name": "time", "value_type": "datetime"},
+                {
+                    "name": "time",
+                    "value_type": "datetime",
+                    "labels": {"label2": "value2"},
+                    "extra_feature_field": "there",
+                },
                 {"name": "bid", "value_type": "float"},
                 {"name": "ask", "value_type": "time"},
             ],
+            "extra_spec": True,
         },
         "status": {
             "state": "created",
@@ -30,6 +44,7 @@ def _generate_feature_set(name):
                 }
             },
         },
+        "something_else": {"field1": "value1", "field2": "value2"},
     }
 
 
@@ -42,7 +57,7 @@ def _assert_list_objects(
     response = client.get(url)
     assert response.status_code == HTTPStatus.OK.value
     response_body = response.json()
-    assert entity_name in response_body, "no feature sets"
+    assert entity_name in response_body
     assert (
         len(response_body[entity_name]) == expected_number_of_entities
     ), f"wrong number of {entity_name} entities in response"
@@ -55,6 +70,42 @@ def _assert_add_feature_set(client: TestClient, project, feature_set, versioned=
     )
     assert response.status_code == HTTPStatus.OK.value
     return response.json()
+
+
+def _assert_put_feature_set(
+    client: TestClient, project, name, reference, feature_set, versioned=True
+):
+    response = client.put(
+        f"/api/projects/{project}/feature_sets/{name}/references/{reference}?versioned={versioned}",
+        json=feature_set,
+    )
+    assert response
+    return response.json()
+
+
+def _assert_extra_fields_exist(json_response):
+    # Make sure we get all the out-of-schema fields properly
+    assert json_response["metadata"]["extra_metadata"] == 100
+    assert json_response["spec"]["entities"][0]["extra_entity_field"] == "here"
+    assert json_response["spec"]["features"][0]["extra_feature_field"] == "there"
+    assert json_response["spec"]["extra_spec"] is True
+    assert json_response["something_else"]["field1"] == "value1"
+    assert json_response["something_else"]["field2"] == "value2"
+
+
+def test_feature_set_create_extra_fields(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+
+    name = "feature_set1"
+    feature_set = _generate_feature_set(name)
+    _assert_add_feature_set(client, project_name, feature_set)
+
+    response = client.get(
+        f"/api/projects/{project_name}/feature_sets/{name}/references/latest"
+    )
+    assert response.status_code == HTTPStatus.OK.value
+    json_response = response.json()
+    _assert_extra_fields_exist(json_response)
 
 
 def test_feature_set_create_and_list(db: Session, client: TestClient) -> None:
@@ -76,12 +127,18 @@ def test_feature_set_create_and_list(db: Session, client: TestClient) -> None:
 
     name = "feat_3"
     feature_set = _generate_feature_set(name)
-    feature_set["spec"]["entities"] = [{"name": "buyer", "value_type": "str"}]
+    feature_set["spec"]["entities"] = [
+        {"name": "buyer", "value_type": "str", "extra_entity_field": "here"}
+    ]
     feature_set["metadata"]["labels"]["owner"] = "bob"
     feature_set["metadata"]["labels"]["color"] = "blue"
     _assert_add_feature_set(client, project_name, feature_set)
 
-    _assert_list_objects(client, "feature_sets", project_name, None, 3)
+    response = _assert_list_objects(client, "feature_sets", project_name, None, 3)
+    # Verify list query returns full objects, including extra fields
+    for feature_set_json in response["feature_sets"]:
+        _assert_extra_fields_exist(feature_set_json)
+
     _assert_list_objects(client, "feature_sets", project_name, "name=feature", 2)
     _assert_list_objects(client, "feature_sets", project_name, "entity=buyer", 1)
     _assert_list_objects(
@@ -96,26 +153,78 @@ def test_feature_set_create_and_list(db: Session, client: TestClient) -> None:
     # handling multiple label queries has issues right now - needs to fix and re-run this test.
     # _assert_list_objects(client, "feature_sets", project_name, "label=owner=bob&label=color=red", 2)
 
-    # Update a feature-set
-    feature_set_update = {
-        "entities": [{"name": "market_cap", "value_type": "integer"}],
-        "labels": {"new-label": "new-value", "owner": "someone-else"},
-    }
-    response = client.put(
-        f"/api/projects/{project_name}/feature_sets/{name}/references/latest",
+
+def _perform_patch(
+    client: TestClient, project_name, name, feature_set_update, additive=False
+):
+    response = client.patch(
+        f"/api/projects/{project_name}/feature_sets/{name}/references/latest?additive={additive}",
         json=feature_set_update,
     )
     assert response.status_code == HTTPStatus.OK.value
     response = client.get(
         f"/api/projects/{project_name}/feature_sets/{name}/references/latest"
     )
-    assert response.status_code == HTTPStatus.OK.value
-    updated_resp = response.json()
+    return response.json()
+
+
+def test_feature_set_updates(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+
+    name = "feature_set1"
+    feature_set = _generate_feature_set(name)
+    _assert_add_feature_set(client, project_name, feature_set)
+
+    # Update a feature-set
+    feature_set_update = {
+        "spec": {
+            "entities": [
+                {
+                    "name": "market_cap",
+                    "value_type": "integer",
+                    "labels": {},
+                    "extra_field": "val1",
+                }
+            ]
+        },
+        "metadata": {"labels": {"new-label": "new-value", "owner": "someone-else"}},
+        "something_else": {"field3": "new_value3"},
+    }
+
+    updated_resp = _perform_patch(client, project_name, name, feature_set_update)
+    feature_set_metadata = updated_resp["metadata"]
+    assert (
+        # New label should be added
+        len(feature_set_metadata["labels"]) == 3
+        and "new-label" in feature_set_metadata["labels"]
+        and feature_set_metadata["labels"]["owner"] == "someone-else"
+    ), "update corrupted data - got wrong results for labels from DB after update"
+    feature_set_spec = updated_resp["spec"]
+    # Since entities is a list, entity will be replaced, so there should be only one.
+    assert feature_set_spec["entities"] == feature_set_update["spec"]["entities"]
+
+    # update with no labels, ensure labels are not deleted
+    feature_set_update = {
+        "spec": {"features": [{"name": "dividend", "value_type": "float"}]}
+    }
+    updated_resp = _perform_patch(client, project_name, name, feature_set_update)
     feature_set_resp = updated_resp["metadata"]
     assert (
-        len(feature_set_resp["labels"]) == 2
+        len(feature_set_resp["labels"]) == 3
         and "new-label" in feature_set_resp["labels"]
-    ), "update corrupted data - got wrong number of labels from get after update"
+        and feature_set_resp["labels"]["owner"] == "someone-else"
+    ), "update corrupted data - got wrong results for labels from DB after update"
+
+    # use additive strategy, the new feature should be added
+    feature_set_update = {
+        "spec": {
+            "features": [{"name": "looks", "value_type": "str", "description": "good"}],
+        }
+    }
+    updated_resp = _perform_patch(
+        client, project_name, name, feature_set_update, additive=True
+    )
+    assert len(updated_resp["spec"]["features"]) == 2
 
 
 def test_get_feature_set_by_reference(db: Session, client: TestClient) -> None:
@@ -163,6 +272,94 @@ def test_delete_feature_set(db: Session, client: TestClient) -> None:
     _assert_list_objects(client, "feature_sets", project_name, None, count - 2)
 
 
+def test_add_multiple_times_same_uid(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+    name = "feature_set1"
+    feature_set = _generate_feature_set(name)
+
+    _assert_add_feature_set(client, project_name, feature_set, versioned=True)
+
+    response = client.post(
+        f"/api/projects/{project_name}/feature_sets?versioned=True", json=feature_set
+    )
+    assert response.status_code != HTTPStatus.OK.value
+
+    # Now test not-versioned add
+    name = "feature_set2"
+    feature_set = _generate_feature_set(name)
+    added_feature_set = _assert_add_feature_set(
+        client, project_name, feature_set, versioned=False
+    )
+    uid = added_feature_set["metadata"]["uid"]
+    assert uid.startswith("unversioned")
+
+    response = client.post(
+        f"/api/projects/{project_name}/feature_sets?versioned=False", json=feature_set
+    )
+    assert response.status_code != HTTPStatus.OK.value
+
+
+def test_multi_inserts_and_updates(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+    count = 5
+    for i in range(count):
+        name = f"fs_{i}"
+        feature_set = _generate_feature_set(name)
+        _assert_add_feature_set(client, project_name, feature_set)
+
+    feature_set_update = {
+        "metadata": {
+            "labels": {"new-label": "new-value", "owner": "someone-else"},
+        }
+    }
+
+    response = client.patch(
+        f"/api/projects/{project_name}/feature_sets/{name}/references/latest",
+        json=feature_set_update,
+    )
+    assert response.status_code == HTTPStatus.OK.value
+
+    response = _assert_list_objects(client, "feature_sets", project_name, None, count)
+    for feature_set in response["feature_sets"]:
+        if feature_set["metadata"]["name"] == name:
+            labels = feature_set["metadata"]["labels"]
+            assert len(labels) == 3
+            assert labels["new-label"] == "new-value"
+            assert labels["owner"] == "someone-else"
+
+
+def test_put_feature_sets(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+    name = "feature_set1"
+    feature_set = _generate_feature_set(name)
+
+    # Put a new object - verify it's created
+    response = _assert_put_feature_set(
+        client, project_name, name, "latest", feature_set
+    )
+    uid = response["metadata"]["uid"]
+    # Change fields that will not affect the uid, verify object is overwritten
+    feature_set["status"]["state"] = "modified"
+
+    response = _assert_put_feature_set(
+        client, project_name, name, "latest", feature_set
+    )
+    assert response["metadata"]["uid"] == uid
+    assert response["status"]["state"] == "modified"
+
+    _assert_list_objects(client, "feature_sets", project_name, "name=feature_set1", 1)
+
+    # Now modify in a way that will affect uid, add a field to the metadata
+    feature_set["metadata"]["new_metadata"] = True
+    response = _assert_put_feature_set(
+        client, project_name, name, "latest", feature_set
+    )
+    assert response["metadata"]["uid"] != uid
+    assert response["metadata"]["new_metadata"] is True
+
+    _assert_list_objects(client, "feature_sets", project_name, "name=feature_set1", 2)
+
+
 def test_list_features(db: Session, client: TestClient) -> None:
     project_name = f"prj-{uuid4().hex}"
 
@@ -193,18 +390,12 @@ def test_list_features(db: Session, client: TestClient) -> None:
     assert resp.status_code == HTTPStatus.OK.value
     # Now expecting to get 2 objects, one with "latest" tag and one with "my-new-tag"
     features_response = _assert_list_objects(
-        client, "features", project_name, "name=feature3", 1
+        client, "features", project_name, "name=feature3", 2
     )
-    feature_set_digests = features_response["features"][0]["feature_set_digests"]
-    assert len(feature_set_digests) == 2
-
-
-def test_extra_fields(db: Session, client: TestClient) -> None:
-    project_name = f"prj-{uuid4().hex}"
-
-    name = "feature_set1"
-    feature_set = _generate_feature_set(name)
-    feature_set["metadata"]["test1"] = 200
-    feature_set["metadata"]["test2"] = "a test"
-
-    _assert_add_feature_set(client, project_name, feature_set)
+    assert (
+        features_response["features"][0]["feature_set_digest"]["metadata"]["tag"]
+        == "latest"
+    )
+    assert (
+        features_response["features"][1]["feature_set_digest"]["metadata"]["tag"] == tag
+    )

--- a/tests/api/api/test_feature_sets.py
+++ b/tests/api/api/test_feature_sets.py
@@ -308,9 +308,7 @@ def test_multi_inserts_and_updates(db: Session, client: TestClient) -> None:
         _assert_add_feature_set(client, project_name, feature_set)
 
     feature_set_update = {
-        "metadata": {
-            "labels": {"new-label": "new-value", "owner": "someone-else"},
-        }
+        "metadata": {"labels": {"new-label": "new-value", "owner": "someone-else"}}
     }
 
     response = client.patch(

--- a/tests/api/db/test_feature_sets.py
+++ b/tests/api/db/test_feature_sets.py
@@ -41,7 +41,9 @@ def test_create_feature_set(db: DBInterface, db_session: Session):
     project = "proj_test"
 
     feature_set = schemas.FeatureSet(**feature_set)
-    db.create_feature_set(db_session, project, feature_set, versioned=True)
+    db.store_feature_set(
+        db_session, project, name, feature_set, tag="latest", versioned=True
+    )
     db.get_feature_set(db_session, project, name)
 
     feature_set_res = db.list_feature_sets(db_session, project)

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -224,7 +224,7 @@ def _create_resources_of_all_kinds(db: DBInterface, db_session: Session, project
         )
 
     feature_set = schemas.FeatureSet(
-        metadata=schemas.FeatureSetMetadata(
+        metadata=schemas.ObjectMetadata(
             name="dummy", tag="latest", labels={"owner": "nobody"}
         ),
         spec=schemas.FeatureSetSpec(
@@ -237,4 +237,4 @@ def _create_resources_of_all_kinds(db: DBInterface, db_session: Session, project
         ),
         status={},
     )
-    db.create_feature_set(db_session, project, feature_set)
+    db.add_feature_set(db_session, project, feature_set)

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -237,4 +237,4 @@ def _create_resources_of_all_kinds(db: DBInterface, db_session: Session, project
         ),
         status={},
     )
-    db.add_feature_set(db_session, project, feature_set)
+    db.create_feature_set(db_session, project, feature_set)

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -369,7 +369,7 @@ def test_feature_sets(create_server):
     for i in range(count):
         name = f"fs_{i}"
         feature_set = _create_feature_set(name)
-        db.add_feature_set(feature_set, project=project, versioned=True)
+        db.create_feature_set(feature_set, project=project, versioned=True)
 
     # Test store_feature_set, which allows updates as well as inserts
     db.store_feature_set(name, feature_set, project=project, versioned=True)
@@ -382,7 +382,7 @@ def test_feature_sets(create_server):
 
     # additive mode means add the feature to the features-list
     db.update_feature_set(
-        name, feature_set_update, project, tag="latest", additive=True
+        name, feature_set_update, project, tag="latest", patch_mode="additive"
     )
     feature_sets = db.list_feature_sets(project=project)
 


### PR DESCRIPTION
Changing the feature-set API to support the following:
- Schema validation on a (small) subset of fields, allow any other field to be added to the objects, such as FeatureSet
- Added fields will be stored in DB and retrieved on get/list queries. Queries can still use a filter on schema'd fields
- APIs are:
* POST - (add_feature_set) - create a new feature-set. If exists, fail.
* PUT - (store_feature_set) - update or create a feature-set. Can be called multiple times on the same object, even if it has the same UID
* PATCH (updade_feature_set) - apply a set of changes to an existing feature-set, using partial object structure. Supports replace mode (default) that will replace container contents on change, and additive mode which will add entries to containers (for example, add a feature to the list of features in a feature-set). The object structure is exactly the same as the FeatureSet structure, but only modified fields should be provided

Also did the following changes:
- More testing, and separation of the tests to smaller groups per functionality
- Some small DB changes - the FeatureSet object used to only hold a JSON field just for the status, it was replaced with a full_object JSON field that keeps the entire object dictionary. DB migration scripts are included