### PR TITLE
[SDK] Save function on deploy success

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -281,6 +281,7 @@ class RemoteRuntime(KubeResource):
 
             if self.status.address:
                 self.spec.command = "http://{}".format(self.status.address)
+                self.save(versioned=False)
 
         else:
             self.save(versioned=False)

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -104,6 +104,7 @@ class KubejobRuntime(KubeResource):
 
         if skip_deployed and self.is_deployed:
             self.status.state = "ready"
+            self.save(versioned=False)
             return True
 
         build = self.spec.build
@@ -114,6 +115,7 @@ class KubejobRuntime(KubeResource):
                     "please set the function image or build args"
                 )
             self.status.state = "ready"
+            self.save(versioned=False)
             return True
 
         if not build.source and not build.commands and with_mlrun:


### PR DESCRIPTION
There were several execution branches in which deployment was successful but function wasn't saved to DB