### PR TITLE
[Spark] Don't use igz version for spark image tag

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -51,7 +51,7 @@ default_config = {
     "kfp_image": "",  # image to use for KFP runner (defaults to mlrun/mlrun)
     "igz_version": "",  # the version of the iguazio system the API is running on
     "spark_app_image": "iguazio/spark-app",  # image to use for spark operator app runtime
-    "spark_app_image_tag": "",  # image tag to use for spark opeartor app runtime (default taken from igz_version)
+    "spark_app_image_tag": "",  # image tag to use for spark opeartor app runtime
     "kaniko_version": "v0.19.0",  # kaniko builder version
     "package_path": "mlrun",  # mlrun pip package
     "default_image": "python:3.6-jessie",

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -177,9 +177,7 @@ class SparkRuntime(KubejobRuntime):
             update_in(
                 job,
                 "spec.image",
-                config.spark_app_image
-                + ":"
-                + config.spark_app_image_tag,
+                config.spark_app_image + ":" + config.spark_app_image_tag,
             )
         update_in(job, "spec.volumes", self.spec.volumes)
 

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -173,13 +173,13 @@ class SparkRuntime(KubejobRuntime):
         update_in(job, "spec.executor.instances", self.spec.replicas or 1)
         if self.spec.image:
             update_in(job, "spec.image", self.spec.image)
-        elif config.spark_app_image_tag or config.igz_version:
+        elif config.spark_app_image_tag and config.spark_app_image:
             update_in(
                 job,
                 "spec.image",
                 config.spark_app_image
                 + ":"
-                + (config.spark_app_image_tag or config.igz_version),
+                + config.spark_app_image_tag,
             )
         update_in(job, "spec.volumes", self.spec.volumes)
 


### PR DESCRIPTION
Spark image tag has it's own config value `spark_app_image_tag`, no need to default it to the `igz_version`