### PR TITLE
[Runtimes] Support running with non default API name and namespace

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -93,13 +93,14 @@ class FunctionSpec(ModelObj):
         workdir=None,
         default_handler=None,
         pythonpath=None,
+        rundb=None,
     ):
 
         self.command = command or ""
         self.image = image or ""
         self.mode = mode
         self.args = args or []
-        self.rundb = None
+        self.rundb = rundb
         self.description = description or ""
         self.workdir = workdir
         self.pythonpath = pythonpath
@@ -506,7 +507,7 @@ class BaseRuntime(ModelObj):
             runtime_env["MLRUN_LOG_LEVEL"] = "debug"
         if self.spec.rundb:
             runtime_env["MLRUN_DBPATH"] = self.spec.rundb
-        if self.spec.rundb:
+        if self.metadata.namespace or config.namespace:
             runtime_env["MLRUN_NAMESPACE"] = self.metadata.namespace or config.namespace
         return runtime_env
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -299,9 +299,8 @@ class DaskCluster(KubejobRuntime):
         handler = runobj.spec.handler
         self._force_handler(handler)
 
-        environ["MLRUN_EXEC_CONFIG"] = runobj.to_json()
-        if self.spec.rundb:
-            environ["MLRUN_DBPATH"] = self.spec.rundb
+        extra_env = self._generate_runtime_env(runobj)
+        environ.update(extra_env)
 
         if not inspect.isfunction(handler):
             if not self.spec.command:

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -70,6 +70,7 @@ class DaskSpec(KubeResourceSpec):
         min_replicas=None,
         max_replicas=None,
         scheduler_timeout=None,
+        rundb=None,
     ):
 
         super().__init__(
@@ -89,6 +90,7 @@ class DaskSpec(KubeResourceSpec):
             entry_points=entry_points,
             description=description,
             image_pull_secret=image_pull_secret,
+            rundb=rundb,
         )
         self.args = args
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -253,6 +253,7 @@ class RemoteRuntime(KubeResource):
             self.metadata.project = project
         if tag:
             self.metadata.tag = tag
+        self._ensure_run_db()
         state = ""
         last_log_timestamp = 1
 
@@ -330,7 +331,12 @@ class RemoteRuntime(KubeResource):
 
     def _get_runtime_env(self):
         # for runtime specific env var enrichment (before deploy)
-        return {}
+        runtime_env = {}
+        if self.spec.rundb:
+            runtime_env["MLRUN_DBPATH"] = self.spec.rundb
+        if mlconf.namespace:
+            runtime_env["MLRUN_NAMESPACE"] = mlconf.namespace
+        return runtime_env
 
     def deploy_step(
         self,

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -104,9 +104,7 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
             self._update_container(
                 pod_template, "volumeMounts", self.spec.volume_mounts
             )
-            extra_env = {"MLRUN_EXEC_CONFIG": runobj.to_json()}
-            if runobj.spec.verbose:
-                extra_env["MLRUN_LOG_LEVEL"] = "debug"
+            extra_env = self._generate_runtime_env(runobj)
             extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]
             self._update_container(pod_template, "env", extra_env + self.spec.env)
             if self.spec.image_pull_policy:

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -76,9 +76,7 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
         update_in(job, "spec.template.spec.volumes", self.spec.volumes)
         self._update_container(job, "volumeMounts", self.spec.volume_mounts)
 
-        extra_env = {"MLRUN_EXEC_CONFIG": runobj.to_json()}
-        if runobj.spec.verbose:
-            extra_env["MLRUN_LOG_LEVEL"] = "debug"
+        extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]
         self._update_container(job, "env", extra_env + self.spec.env)
         if self.spec.image_pull_policy:

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -49,6 +49,7 @@ class KubeResourceSpec(FunctionSpec):
         service_account=None,
         build=None,
         image_pull_secret=None,
+        rundb=None,
     ):
         super().__init__(
             command=command,
@@ -60,6 +61,7 @@ class KubeResourceSpec(FunctionSpec):
             description=description,
             workdir=workdir,
             default_handler=default_handler,
+            rundb=rundb,
         )
         self._volumes = {}
         self._volume_mounts = {}

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -113,6 +113,7 @@ class SparkJobSpec(KubeResourceSpec):
         description=None,
         workdir=None,
         build=None,
+        rundb=None,
     ):
 
         super().__init__(
@@ -133,6 +134,7 @@ class SparkJobSpec(KubeResourceSpec):
             description=description,
             workdir=workdir,
             build=build,
+            rundb=rundb,
         )
 
         self.driver_resources = driver_resources or {}

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -181,9 +181,7 @@ class SparkRuntime(KubejobRuntime):
             )
         update_in(job, "spec.volumes", self.spec.volumes)
 
-        extra_env = {"MLRUN_EXEC_CONFIG": runobj.to_json()}
-        if runobj.spec.verbose:
-            extra_env["MLRUN_LOG_LEVEL"] = "debug"
+        extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]
 
         update_in(job, "spec.driver.env", extra_env + self.spec.env)


### PR DESCRIPTION
If the the API's svc name was not `mlrun-api` or it wasn't deployed in the `default-tenant` namespace, things gone wrong, this fixes it