### PR TITLE
[Build] Use python's -slim tag for mlrun/mlrun image

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG MLRUN_PYTHON_VERSION=3.7
 
-FROM python:${MLRUN_PYTHON_VERSION}
+FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
 

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 ARG MLRUN_PYTHON_VERSION=3.7
 
-FROM python:${MLRUN_PYTHON_VERSION}
+FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
 


### PR DESCRIPTION
This shrinks the `mlrun/mlrun` image size from 1.49GB to 721MB (~51% decrease)