### PR TITLE
[Build] Add git to mlrun/mlrun image

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -18,6 +18,10 @@ FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
 
+RUN apt-get update && apt-get install -y \
+  git-core \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /mlrun
 
 RUN pip install --upgrade pip

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -17,6 +17,10 @@ FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
 
+RUN apt-get update && apt-get install -y \
+  git-core \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY . /tmp/mlrun
 RUN pip install --upgrade pytest
 RUN cd /tmp/mlrun && python -m pip install ".[api]" && mv tests /tests && cd /tmp && rm -rf mlrun


### PR DESCRIPTION
https://github.com/mlrun/mlrun/pull/555 caused:
```
Traceback (most recent call last):
  File "/usr/local/bin/mlrun", line 5, in <module>
    from mlrun.__main__ import main
  File "/usr/local/lib/python3.7/site-packages/mlrun/__init__.py", line 34, in <module>
    from .projects import load_project, new_project
  File "/usr/local/lib/python3.7/site-packages/mlrun/projects/__init__.py", line 18, in <module>
    from .project import load_project, new_project, MlrunProject
  File "/usr/local/lib/python3.7/site-packages/mlrun/projects/project.py", line 23, in <module>
    from git import Repo
  File "/usr/local/lib/python3.7/site-packages/git/__init__.py", line 85, in <module>
    raise ImportError('Failed to initialize: {0}'.format(exc)) from exc
ImportError: Failed to initialize: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.
```
This adds git to the image which increase the image size from 721MB to 808MB