### PR TITLE
[Build] Add gcc to slim images

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -19,6 +19,7 @@ FROM python:${MLRUN_PYTHON_VERSION}-slim
 ENV PIP_NO_CACHE_DIR=1
 
 RUN apt-get update && apt-get install -y \
+  gcc \
   git-core \
  && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -18,6 +18,7 @@ FROM python:${MLRUN_PYTHON_VERSION}-slim
 ENV PIP_NO_CACHE_DIR=1
 
 RUN apt-get update && apt-get install -y \
+  gcc \
   git-core \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This increases the image size from 808MB to 922MB
Without it building the system test image failed cause it's needed for building `psutil` which is a requirement of `dask-kubernetes` (which is our requirement), added to the `mlrun/mlrun` image although it's not a must currently, this was the error:
```
    Running setup.py install for psutil: started
    Running setup.py install for psutil: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-xgvud5xo/psutil/setup.py'"'"'; __file__='"'"'/tmp/pip-install-xgvud5xo/psutil/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-skdgu_p5/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.7m/psutil
         cwd: /tmp/pip-install-xgvud5xo/psutil/
    Complete output (44 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.7
    creating build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psbsd.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_pslinux.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_compat.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_pswindows.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psosx.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/__init__.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psposix.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_common.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psaix.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_pssunos.py -> build/lib.linux-x86_64-3.7/psutil
    creating build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_testutils.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_aix.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_misc.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_posix.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_osx.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_bsd.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_process.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/runner.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/__init__.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_system.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_sunos.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_connections.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/__main__.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_linux.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_windows.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_contracts.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_unicode.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_memleaks.py -> build/lib.linux-x86_64-3.7/psutil/tests
    running build_ext
    building 'psutil._psutil_linux' extension
    creating build/temp.linux-x86_64-3.7
    creating build/temp.linux-x86_64-3.7/psutil
    gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=573 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/usr/local/include/python3.7m -c psutil/_psutil_common.c -o build/temp.linux-x86_64-3.7/psutil/_psutil_common.o
    unable to execute 'gcc': No such file or directory
    C compiler or Python headers are not installed on this system. Try to run:
    sudo apt-get install gcc python3-dev
    error: command 'gcc' failed with exit status 1
```