### PR TITLE
[Schedules] Fix labels bugs

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -56,7 +56,7 @@ def list_schedules(
     db_session: Session = Depends(deps.get_db_session),
 ):
     return get_scheduler().list_schedules(
-        db_session, project, name, labels, kind, include_last_run=include_last_run
+        db_session, project, name, kind, labels, include_last_run=include_last_run
     )
 
 

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -41,7 +41,7 @@ def update_schedule(
         name,
         schedule.scheduled_object,
         schedule.cron_trigger,
-        labels={label.name: label.value for label in schedule.labels},
+        labels=schedule.labels,
     )
     return Response(status_code=HTTPStatus.OK.value)
 

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -23,7 +23,7 @@ def create_schedule(
         schedule.kind,
         schedule.scheduled_object,
         schedule.cron_trigger,
-        labels={label.name: label.value for label in schedule.labels},
+        labels=schedule.labels,
     )
     return Response(status_code=HTTPStatus.CREATED.value)
 

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Optional, List, Union, Any, Dict
 
 from pydantic import BaseModel
+from mlrun.api.schemas.object import LabelRecord
 
 
 class ScheduleCronTrigger(BaseModel):
@@ -63,14 +64,6 @@ class ScheduleKinds(str, Enum):
 
     # this is mainly for testing purposes
     local_function = "local_function"
-
-
-class LabelRecord(BaseModel):
-    name: str
-    value: str
-
-    class Config:
-        orm_mode = True
 
 
 class ScheduleUpdate(BaseModel):

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -65,7 +65,7 @@ class ScheduleKinds(str, Enum):
     local_function = "local_function"
 
 
-class Label(BaseModel):
+class LabelRecord(BaseModel):
     name: str
     value: str
 
@@ -77,7 +77,7 @@ class ScheduleUpdate(BaseModel):
     scheduled_object: Optional[Any]
     cron_trigger: Optional[Union[str, ScheduleCronTrigger]]
     desired_state: Optional[str]
-    labels: Optional[List[Label]]
+    labels: Optional[List[LabelRecord]]
 
 
 # Properties to receive via API on creation
@@ -96,7 +96,7 @@ class ScheduleRecord(ScheduleInput):
     project: str
     last_run_uri: Optional[str]
     state: Optional[str]
-    labels: Optional[List[Label]]
+    labels: Optional[List[LabelRecord]]
 
     class Config:
         orm_mode = True

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -70,7 +70,7 @@ class ScheduleUpdate(BaseModel):
     scheduled_object: Optional[Any]
     cron_trigger: Optional[Union[str, ScheduleCronTrigger]]
     desired_state: Optional[str]
-    labels: Optional[List[LabelRecord]]
+    labels: Optional[dict]
 
 
 # Properties to receive via API on creation

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -87,7 +87,7 @@ class ScheduleInput(BaseModel):
     scheduled_object: Any
     cron_trigger: Union[str, ScheduleCronTrigger]
     desired_state: Optional[str]
-    labels: Optional[List[Label]]
+    labels: Optional[dict]
 
 
 # the schedule object returned from the db layer
@@ -96,6 +96,7 @@ class ScheduleRecord(ScheduleInput):
     project: str
     last_run_uri: Optional[str]
     state: Optional[str]
+    labels: Optional[List[Label]]
 
     class Config:
         orm_mode = True
@@ -105,6 +106,7 @@ class ScheduleRecord(ScheduleInput):
 class ScheduleOutput(ScheduleRecord):
     next_run_time: Optional[datetime]
     last_run: Optional[Dict]
+    labels: Optional[dict]
 
 
 class SchedulesOutput(BaseModel):

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -294,7 +294,8 @@ class Scheduler:
 
         job_id = self._resolve_job_id(schedule_record.project, schedule_record.name)
         job = self._scheduler.get_job(job_id)
-        schedule.next_run_time = job.next_run_time
+        if job:
+            schedule.next_run_time = job.next_run_time
 
         if include_last_run:
             schedule = self._enrich_schedule_with_last_run(db_session, schedule)

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -291,7 +291,9 @@ class Scheduler:
         include_last_run: bool = False,
     ) -> schemas.ScheduleOutput:
         schedule_dict = schedule_record.dict()
-        schedule_dict['labels'] = {label['name']: label['value'] for label in schedule_dict['labels']}
+        schedule_dict["labels"] = {
+            label["name"]: label["value"] for label in schedule_dict["labels"]
+        }
         schedule = schemas.ScheduleOutput(**schedule_dict)
 
         job_id = self._resolve_job_id(schedule_record.project, schedule_record.name)

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -290,7 +290,9 @@ class Scheduler:
         schedule_record: schemas.ScheduleRecord,
         include_last_run: bool = False,
     ) -> schemas.ScheduleOutput:
-        schedule = schemas.ScheduleOutput(**schedule_record.dict())
+        schedule_dict = schedule_record.dict()
+        schedule_dict['labels'] = {label['name']: label['value'] for label in schedule_dict['labels']}
+        schedule = schemas.ScheduleOutput(**schedule_dict)
 
         job_id = self._resolve_job_id(schedule_record.project, schedule_record.name)
         job = self._scheduler.get_job(job_id)

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -47,15 +47,19 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
         labels_2,
     )
 
-    _get_and_assert_single_schedule(client, {'labels': 'label1'}, schedule_name)
-    _get_and_assert_single_schedule(client, {'labels': 'label2'}, schedule_name_2)
-    _get_and_assert_single_schedule(client, {'labels': 'label1=value1'}, schedule_name)
-    _get_and_assert_single_schedule(client, {'labels': 'label2=value2'}, schedule_name_2)
+    _get_and_assert_single_schedule(client, {"labels": "label1"}, schedule_name)
+    _get_and_assert_single_schedule(client, {"labels": "label2"}, schedule_name_2)
+    _get_and_assert_single_schedule(client, {"labels": "label1=value1"}, schedule_name)
+    _get_and_assert_single_schedule(
+        client, {"labels": "label2=value2"}, schedule_name_2
+    )
 
 
-def _get_and_assert_single_schedule(client: TestClient, get_params: dict, schedule_name: str):
+def _get_and_assert_single_schedule(
+    client: TestClient, get_params: dict, schedule_name: str
+):
     resp = client.get("/api/projects/default/schedules", params=get_params)
     assert resp.status_code == HTTPStatus.OK.value, "status"
-    result = resp.json()['schedules']
+    result = resp.json()["schedules"]
     assert len(result) == 1
-    assert result[0]['name'] == schedule_name
+    assert result[0]["name"] == schedule_name

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -3,8 +3,59 @@ from http import HTTPStatus
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from mlrun.api import schemas
+from mlrun.api.utils.singletons.db import get_db
+from mlrun.config import config
+
+
+async def do_nothing():
+    pass
+
 
 def test_list_schedules(db: Session, client: TestClient) -> None:
     resp = client.get("/api/projects/default/schedules")
     assert resp.status_code == HTTPStatus.OK.value, "status"
     assert "schedules" in resp.json(), "no schedules"
+
+    labels_1 = {
+        "label1": "value1",
+    }
+    cron_trigger = schemas.ScheduleCronTrigger(year="1999")
+    schedule_name = "schedule-name"
+    project = config.default_project
+    get_db().create_schedule(
+        db,
+        project,
+        schedule_name,
+        schemas.ScheduleKinds.local_function,
+        do_nothing,
+        cron_trigger,
+        labels_1,
+    )
+
+    labels_2 = {
+        "label2": "value2",
+    }
+    schedule_name_2 = "schedule-name-2"
+    get_db().create_schedule(
+        db,
+        project,
+        schedule_name_2,
+        schemas.ScheduleKinds.local_function,
+        do_nothing,
+        cron_trigger,
+        labels_2,
+    )
+
+    _get_and_assert_single_schedule(client, {'labels': 'label1'}, schedule_name)
+    _get_and_assert_single_schedule(client, {'labels': 'label2'}, schedule_name_2)
+    _get_and_assert_single_schedule(client, {'labels': 'label1=value1'}, schedule_name)
+    _get_and_assert_single_schedule(client, {'labels': 'label2=value2'}, schedule_name_2)
+
+
+def _get_and_assert_single_schedule(client: TestClient, get_params: dict, schedule_name: str):
+    resp = client.get("/api/projects/default/schedules", params=get_params)
+    assert resp.status_code == HTTPStatus.OK.value, "status"
+    result = resp.json()['schedules']
+    assert len(result) == 1
+    assert result[0]['name'] == schedule_name

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -573,9 +573,7 @@ def _assert_schedule(
     assert schedule.next_run_time == next_run_time
     assert schedule.cron_trigger == cron_trigger
     assert schedule.creation_time is not None
-    assert len(schedule.labels) == len(labels)
-    for label in schedule.labels:
-        assert labels[label.name] == label.value
+    assert DeepDiff(schedule.labels, labels, ignore_order=True) == {}
 
 
 def _create_mlrun_function_and_matching_scheduled_object(db: Session, project: str):


### PR DESCRIPTION
- Schedules Labels and Kind got mixed up in one of the function calls
- Made schedules labels as dict in API(input and output)
- Addressed a situation when the schedule exists but no job exists
- Added Labels filter test in api tests