### PR TITLE
[Projects] Ensure project name regex

### DIFF
--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -14,6 +14,8 @@ import mlrun.api.utils.projects.remotes.nop
 import mlrun.config
 import mlrun.errors
 import mlrun.utils
+import mlrun.utils.helpers
+import mlrun.utils.regex
 import mlrun.utils.singleton
 from mlrun.utils import logger
 
@@ -50,6 +52,7 @@ class Member(
     def create_project(
         self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
     ) -> mlrun.api.schemas.Project:
+        self._validate_project_name(project.name)
         self._run_on_all_followers("create_project", session, project)
         return self.get_project(session, project.name)
 
@@ -269,6 +272,12 @@ class Member(
         if name not in followers_classes_map:
             raise ValueError(f"Unknown follower name: {name}")
         return followers_classes_map[name]
+
+    @staticmethod
+    def _validate_project_name(
+        name: str
+    ):
+        mlrun.utils.helpers.verify_field_regex("project.metadata.name", name, mlrun.utils.regex.project_name)
 
     @staticmethod
     def _validate_body_and_path_names_matches(

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -274,10 +274,10 @@ class Member(
         return followers_classes_map[name]
 
     @staticmethod
-    def _validate_project_name(
-        name: str
-    ):
-        mlrun.utils.helpers.verify_field_regex("project.metadata.name", name, mlrun.utils.regex.project_name)
+    def _validate_project_name(name: str):
+        mlrun.utils.helpers.verify_field_regex(
+            "project.metadata.name", name, mlrun.utils.regex.project_name
+        )
 
     @staticmethod
     def _validate_body_and_path_names_matches(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -32,6 +32,7 @@ from tabulate import tabulate
 from yaml.representer import RepresenterError
 
 import mlrun.utils.version.version
+import mlrun.errors
 from .logger import create_logger
 from ..config import config
 
@@ -89,7 +90,7 @@ def verify_field_regex(field_name, field_value, patterns):
                 field_value=field_value,
                 pattern=pattern,
             )
-            raise ValueError(
+            raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Field {field_name} is malformed. Does not match required pattern: {pattern}"
             )
 

--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -1,7 +1,11 @@
 # k8s label value format
+# https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L161
 label_value = [r"^.{0,63}$", r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"]
 
-# DNS label (RFC 1123) - used by k8s for most resource names format
-dns_1123_label = [r"^.{0,63}$", r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"]
+# DNS Subdomain (RFC 1123) - used by k8s for most resource names format
+# https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L204
+dns_1123_subdomain = [r"^.{0,253}$", r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"]
 
 run_name = label_value
+
+project_name = dns_1123_subdomain

--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -4,7 +4,10 @@ label_value = [r"^.{0,63}$", r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"]
 
 # DNS Subdomain (RFC 1123) - used by k8s for most resource names format
 # https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L204
-dns_1123_subdomain = [r"^.{0,253}$", r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"]
+dns_1123_subdomain = [
+    r"^.{0,253}$",
+    r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+]
 
 run_name = label_value
 

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -9,7 +9,7 @@ from mlrun.api.api.utils import _parse_submit_run_body
 
 def test_parse_submit_job_body_override_values(db: Session, client: TestClient):
     task_name = "task_name"
-    task_project = "task_project"
+    task_project = "task-project"
     project, function_name, function_tag, original_function = _mock_original_function(
         client
     )
@@ -93,7 +93,7 @@ def test_parse_submit_job_body_override_values(db: Session, client: TestClient):
 
 def test_parse_submit_job_body_keep_resources(db: Session, client: TestClient):
     task_name = "task_name"
-    task_project = "task_project"
+    task_project = "task-project"
     project, function_name, function_tag, original_function = _mock_original_function(
         client
     )
@@ -128,7 +128,7 @@ def test_parse_submit_job_body_keep_resources(db: Session, client: TestClient):
 
 def _mock_original_function(client):
     function_name = "function_name"
-    project = "some_project"
+    project = "some-project"
     function_tag = "function_tag"
     original_function = {
         "kind": "job",

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -10,6 +10,7 @@ from mlrun.api.db.sqldb.session import create_session, _init_engine
 from mlrun.api.initial_data import init_data
 from mlrun.api.main import app
 from mlrun.api.utils.singletons.db import initialize_db
+from mlrun.api.utils.singletons.project_member import initialize_project_member
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.utils import logger
@@ -37,6 +38,7 @@ def db() -> Generator:
     # forcing from scratch because we created an empty file for the db
     init_data(from_scratch=True)
     initialize_db()
+    initialize_project_member()
     yield create_session()
     logger.info(f"Removing temp db file: {db_file.name}")
     db_file.close()

--- a/tests/api/db/test_feature_sets.py
+++ b/tests/api/db/test_feature_sets.py
@@ -38,7 +38,7 @@ def test_create_feature_set(db: DBInterface, db_session: Session):
     name = "dummy"
     feature_set = _create_feature_set(name)
 
-    project = "proj_test"
+    project = "proj-test"
 
     feature_set = schemas.FeatureSet(**feature_set)
     db.store_feature_set(

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -33,8 +33,8 @@ from tests.api.db.conftest import dbs
 def test_delete_project_with_resources(
     db: DBInterface, db_session: sqlalchemy.orm.Session
 ):
-    project_to_keep = "project_to_keep"
-    project_to_remove = "project_to_remove"
+    project_to_keep = "project-to-keep"
+    project_to_remove = "project-to-remove"
     _create_resources_of_all_kinds(db, db_session, project_to_keep)
     _create_resources_of_all_kinds(db, db_session, project_to_remove)
     project_to_keep_table_name_records_count_map_before_project_removal = _assert_resources_in_project(

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -24,7 +24,7 @@ class TestRuntimeHandlerBase:
             f"Setting up test {self.__class__.__name__}::{method.__name__}"
         )
 
-        self.project = "test_project"
+        self.project = "test-project"
         self.run_uid = "test_run_uid"
 
         self.custom_setup()

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -210,29 +210,25 @@ def test_create_project_failure_invalid_name(
         },
         {
             # Invalid because it's more than 253 characters
-            "name": "azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfv"
-                    "g-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdc"
-                    "fvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsx",
+            "name": "azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-"
+            "azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-"
+            "azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsxdcfvg-azsx",
             "valid": False,
         },
     ]
     for case in cases:
-        project_name = case['name']
-        if case['valid']:
+        project_name = case["name"]
+        if case["valid"]:
             projects_leader.create_project(
-                None,
-                mlrun.api.schemas.Project(name=project_name),
+                None, mlrun.api.schemas.Project(name=project_name),
             )
             _assert_project_in_followers([leader_follower], project_name)
         else:
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
                 projects_leader.create_project(
-                    None,
-                    mlrun.api.schemas.Project(name=project_name),
+                    None, mlrun.api.schemas.Project(name=project_name),
                 )
-            _assert_project_not_in_followers(
-                [leader_follower], project_name
-            )
+            _assert_project_not_in_followers([leader_follower], project_name)
 
 
 def test_ensure_project(


### PR DESCRIPTION
This ensures that a project name conforms the k8s name regex (which is dns subdomain)
Upgrade concerns - 2 options:
* MLRun will have already existing project names that does not conforms to the regex - the validation happens only on creation, so existing projects are uneffected.
* MLRun will sync projects with invalid names from Nuclio - can't happen, Nuclio projects names pass the same validation