### PR TITLE
[Projects] - Support old project records

### DIFF
--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -81,6 +81,29 @@ def test_get_project(
 @pytest.mark.parametrize(
     "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
 )
+def test_get_project_with_pre_060_record(
+    db: DBInterface, db_session: sqlalchemy.orm.Session,
+):
+    project_name = "project_name"
+    pre_060_record = Project(name=project_name)
+    db_session.add(pre_060_record)
+    db_session.commit()
+    pre_060_record = db_session.query(Project).filter(Project.name == project_name).one()
+    assert pre_060_record.full_object is None
+    project = db.get_project(
+        db_session,
+        project_name,
+    )
+    assert project.name == project_name
+    updated_record = db_session.query(Project).filter(Project.name == project_name).one()
+    # when GET performed on a project of the old format - we're upgrading it to the new format - ensuring it happened
+    assert updated_record.full_object is not None
+
+
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
 def test_list_project(
     db: DBInterface, db_session: sqlalchemy.orm.Session,
 ):

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -88,14 +88,15 @@ def test_get_project_with_pre_060_record(
     pre_060_record = Project(name=project_name)
     db_session.add(pre_060_record)
     db_session.commit()
-    pre_060_record = db_session.query(Project).filter(Project.name == project_name).one()
-    assert pre_060_record.full_object is None
-    project = db.get_project(
-        db_session,
-        project_name,
+    pre_060_record = (
+        db_session.query(Project).filter(Project.name == project_name).one()
     )
+    assert pre_060_record.full_object is None
+    project = db.get_project(db_session, project_name,)
     assert project.name == project_name
-    updated_record = db_session.query(Project).filter(Project.name == project_name).one()
+    updated_record = (
+        db_session.query(Project).filter(Project.name == project_name).one()
+    )
     # when GET performed on a project of the old format - we're upgrading it to the new format - ensuring it happened
     assert updated_record.full_object is not None
 


### PR DESCRIPTION
upgrading to `unstable` which has https://github.com/mlrun/mlrun/pull/542 in it with a DB that had projects resulted in failure to list projects since we were not supporting the old record format, this PR add support for it (+test), this was the failure:
```
> 2020-12-03 10:29:27,564 [debug] Initialized leader and followers: {'leader': 'mlrun', 'followers': []}
ERROR:    Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 526, in lifespan
    async for item in self.lifespan_context(app):
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 467, in default_lifespan
    await self.startup()
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 502, in startup
    await handler()
  File "/mlrun/mlrun/api/main.py", line 122, in startup_event
    await _initialize_singletons()
  File "/mlrun/mlrun/api/main.py", line 140, in _initialize_singletons
    initialize_project_member()
  File "/mlrun/mlrun/api/utils/singletons/project_member.py", line 13, in initialize_project_member
    project_member.initialize()
  File "/mlrun/mlrun/api/utils/projects/leader.py", line 32, in initialize
    self._sync_projects()
  File "/mlrun/mlrun/api/utils/projects/leader.py", line 118, in _sync_projects
    "list_projects", session
  File "/mlrun/mlrun/api/utils/projects/leader.py", line 232, in _run_on_all_followers
    leader_response = getattr(self._leader_follower, method)(*args, **kwargs)
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 726, in list_projects
    self._transform_project_record_to_schema(project_record)
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 1774, in _transform_project_record_to_schema
    return schemas.Project(**project_full_dict)
TypeError: ModelMetaclass object argument after ** must be a mapping, not NoneType
ERROR [uvicorn.error] Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 526, in lifespan
    async for item in self.lifespan_context(app):
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 467, in default_lifespan
    await self.startup()
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 502, in startup
    await handler()
  File "/mlrun/mlrun/api/main.py", line 122, in startup_event
    await _initialize_singletons()
  File "/mlrun/mlrun/api/main.py", line 140, in _initialize_singletons
    initialize_project_member()
  File "/mlrun/mlrun/api/utils/singletons/project_member.py", line 13, in initialize_project_member
    project_member.initialize()
  File "/mlrun/mlrun/api/utils/projects/leader.py", line 32, in initialize
    self._sync_projects()
  File "/mlrun/mlrun/api/utils/projects/leader.py", line 118, in _sync_projects
    "list_projects", session
  File "/mlrun/mlrun/api/utils/projects/leader.py", line 232, in _run_on_all_followers
    leader_response = getattr(self._leader_follower, method)(*args, **kwargs)
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 726, in list_projects
    self._transform_project_record_to_schema(project_record)
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 1774, in _transform_project_record_to_schema
    return schemas.Project(**project_full_dict)
TypeError: ModelMetaclass object argument after ** must be a mapping, not NoneType
ERROR:    Application startup failed. Exiting.
ERROR [uvicorn.error] Application startup failed. Exiting.
```