### PR TITLE
[SDK] Move humanfriendly to SDK requirements

### DIFF
--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -4,4 +4,3 @@ dask-kubernetes~=0.11.0
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes-asyncio~=11.0
 apscheduler~=3.6
-humanfriendly~=8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ semver~=2.13
 dask~=2.12
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0
+humanfriendly~=8.2


### PR DESCRIPTION
From system tests:
```
Run python automation/system_test/prepare.py run \
Warning: -06 21:12:50,405 [warning] Failed resolving version info. Ignoring and using defaults
Traceback (most recent call last):
  File "automation/system_test/prepare.py", line 11, in <module>
    import mlrun.utils
  File "/home/runner/work/mlrun/mlrun/mlrun/__init__.py", line 30, in <module>
    from .db import get_run_db
  File "/home/runner/work/mlrun/mlrun/mlrun/db/__init__.py", line 21, in <module>
    from .sqldb import SQLDB
  File "/home/runner/work/mlrun/mlrun/mlrun/db/sqldb.py", line 19, in <module>
    from mlrun.api.db.sqldb.db import SQLDB as SQLAPIDB
  File "/home/runner/work/mlrun/mlrun/mlrun/api/db/sqldb/db.py", line 37, in <module>
    from mlrun.api.utils.singletons.project_member import get_project_member
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/singletons/project_member.py", line 2, in <module>
    import mlrun.api.utils.projects.leader
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/projects/leader.py", line 4, in <module>
    import humanfriendly
ModuleNotFoundError: No module named 'humanfriendly'
```