### PR TITLE
[System tests] Add matplotlib as requirement

### DIFF
--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -26,6 +26,9 @@ RUN python -m pip install --upgrade pip
 
 COPY . /tmp/mlrun
 RUN pip install --upgrade pytest
+COPY ./requirements.txt ./
+RUN python -m pip install \
+    -r requirements.txt
 RUN cd /tmp/mlrun && python -m pip install ".[api]" && mv tests /tests && cd /tmp && rm -rf mlrun
 
 CMD ["pytest",  "--capture=no", "-rf",  "-v",  "--disable-warnings", "/tests/system"]

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib~=3.0
+scikit-learn~=0.23.0
+seaborn~=0.11.0

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,3 +1,1 @@
 matplotlib~=3.0
-scikit-learn~=0.23.0
-seaborn~=0.11.0


### PR DESCRIPTION
```
==================================== ERRORS ====================================
_______________ ERROR collecting examples/basics/test_basics.py ________________
ImportError while importing test module '/tests/system/examples/basics/test_basics.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
usr/local/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/system/examples/basics/test_basics.py:3: in <module>
    import matplotlib.pyplot as plt
E   ModuleNotFoundError: No module named 'matplotlib'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```