### PR TITLE
[Projects] Skip old invalid project syncing + name validation fix

### DIFF
--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -211,7 +211,9 @@ class Member(
                 # if it was created prior to 0.6.0, and the version was upgraded
                 # we do not want to sync these projects since it will anyways fail (Nuclio doesn't allow these names
                 # as well)
-                if not self._validate_project_name(project_name, raise_on_failure=False):
+                if not self._validate_project_name(
+                    project_name, raise_on_failure=False
+                ):
                     return
                 for missing_follower in missing_followers:
                     logger.debug(
@@ -291,7 +293,6 @@ class Member(
                 raise
             return False
         return True
-
 
     @staticmethod
     def _validate_body_and_path_names_matches(

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -62,6 +62,7 @@ class Member(
         name: str,
         project: mlrun.api.schemas.Project,
     ):
+        self._validate_project_name(name)
         self._validate_body_and_path_names_matches(name, project)
         self._run_on_all_followers("store_project", session, name, project)
         return self.get_project(session, name)

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -177,7 +177,7 @@ def test_create_project(
     )
 
 
-def test_create_project_failure_invalid_name(
+def test_create_and_store_project_failure_invalid_name(
     db: sqlalchemy.orm.Session,
     projects_leader: mlrun.api.utils.projects.leader.Member,
     leader_follower: mlrun.api.utils.projects.remotes.member.Member,
@@ -223,10 +223,18 @@ def test_create_project_failure_invalid_name(
                 None, mlrun.api.schemas.Project(name=project_name),
             )
             _assert_project_in_followers([leader_follower], project_name)
+            projects_leader.store_project(
+                None, project_name, mlrun.api.schemas.Project(name=project_name),
+            )
+            _assert_project_in_followers([leader_follower], project_name)
         else:
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
                 projects_leader.create_project(
                     None, mlrun.api.schemas.Project(name=project_name),
+                )
+            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                projects_leader.store_project(
+                    None, project_name, mlrun.api.schemas.Project(name=project_name),
                 )
             _assert_project_not_in_followers([leader_follower], project_name)
 

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -85,7 +85,13 @@ def test_projects_sync_leader_project_syncing(
         None,
         mlrun.api.schemas.Project(name=project_name, description=project_description),
     )
+    invalid_project_name = "invalid_name"
+    leader_follower.create_project(
+        None,
+        mlrun.api.schemas.Project(name=invalid_project_name),
+    )
     _assert_project_in_followers([leader_follower], project_name, project_description)
+    _assert_project_in_followers([leader_follower], invalid_project_name)
     _assert_no_projects_in_followers([nop_follower, second_nop_follower])
 
     projects_leader._sync_projects()
@@ -93,6 +99,10 @@ def test_projects_sync_leader_project_syncing(
         [leader_follower, nop_follower, second_nop_follower],
         project_name,
         project_description,
+    )
+    _assert_project_not_in_followers(
+        [nop_follower, second_nop_follower],
+        invalid_project_name,
     )
 
 

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -87,8 +87,7 @@ def test_projects_sync_leader_project_syncing(
     )
     invalid_project_name = "invalid_name"
     leader_follower.create_project(
-        None,
-        mlrun.api.schemas.Project(name=invalid_project_name),
+        None, mlrun.api.schemas.Project(name=invalid_project_name),
     )
     _assert_project_in_followers([leader_follower], project_name, project_description)
     _assert_project_in_followers([leader_follower], invalid_project_name)
@@ -101,8 +100,7 @@ def test_projects_sync_leader_project_syncing(
         project_description,
     )
     _assert_project_not_in_followers(
-        [nop_follower, second_nop_follower],
-        invalid_project_name,
+        [nop_follower, second_nop_follower], invalid_project_name,
     )
 
 


### PR DESCRIPTION
* Added the name validation also on store project (which creates when doesn't exist)
* Added logic to skip syncing project with wrong names, since this will fail anyway and just spam the logs. these projects with wrong names can't be created now, but can come from old DBs