### PR TITLE
[CI] Enable using several system tests systems

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -93,15 +93,15 @@ jobs:
       run: |
         python automation/system_test/prepare.py run \
           ${{ steps.computed_params.outputs.mlrun_version }} \
-          ${{ secrets.06_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-          ${{ secrets.06_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
-          ${{ secrets.06_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.V06_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          ${{ secrets.V06_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.V06_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
           ${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }} \
-          ${{ secrets.06_SYSTEM_TEST_MLRUN_DB_PATH }} \
-          ${{ secrets.06_SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
-          ${{ secrets.06_SYSTEM_TEST_USERNAME }} \
-          ${{ secrets.06_SYSTEM_TEST_ACCESS_KEY }} \
-          ${{ secrets.06_SYSTEM_TEST_PASSWORD }} \
+          ${{ secrets.V06_SYSTEM_TEST_MLRUN_DB_PATH }} \
+          ${{ secrets.V06_SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
+          ${{ secrets.V06_SYSTEM_TEST_USERNAME }} \
+          ${{ secrets.V06_SYSTEM_TEST_ACCESS_KEY }} \
+          ${{ secrets.V06_SYSTEM_TEST_PASSWORD }} \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
           --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
           --override-mlrun-images \
@@ -112,15 +112,15 @@ jobs:
       run: |
         python automation/system_test/prepare.py run \
           ${{ steps.computed_params.outputs.mlrun_version }} \
-          ${{ secrets.05_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-          ${{ secrets.05_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
-          ${{ secrets.05_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.V05_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          ${{ secrets.V05_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.V05_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
           ${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }} \
-          ${{ secrets.05_SYSTEM_TEST_MLRUN_DB_PATH }} \
-          ${{ secrets.05_SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
-          ${{ secrets.05_SYSTEM_TEST_USERNAME }} \
-          ${{ secrets.05_SYSTEM_TEST_ACCESS_KEY }} \
-          ${{ secrets.05_SYSTEM_TEST_PASSWORD }} \
+          ${{ secrets.V05_SYSTEM_TEST_MLRUN_DB_PATH }} \
+          ${{ secrets.V05_SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
+          ${{ secrets.V05_SYSTEM_TEST_USERNAME }} \
+          ${{ secrets.V05_SYSTEM_TEST_ACCESS_KEY }} \
+          ${{ secrets.V05_SYSTEM_TEST_PASSWORD }} \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
           --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
           --override-mlrun-images \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -88,19 +88,39 @@ jobs:
         poll-interval-seconds: 20s
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Prepare System Test env.yaml and system
+    - name: Prepare System Test env.yaml and 06 system
+      if: ${{ github.ref != 'refs/*/0.5.*' }}
       run: |
         python automation/system_test/prepare.py run \
           ${{ steps.computed_params.outputs.mlrun_version }} \
-          ${{ secrets.SYSTEM_TEST_DATA_CLUSTER_IP }} \
-          ${{ secrets.SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
-          ${{ secrets.SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.06_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          ${{ secrets.06_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.06_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
           ${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }} \
-          ${{ secrets.SYSTEM_TEST_MLRUN_DB_PATH }} \
-          ${{ secrets.SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
-          ${{ secrets.SYSTEM_TEST_USERNAME }} \
-          ${{ secrets.SYSTEM_TEST_ACCESS_KEY }} \
-          ${{ secrets.SYSTEM_TEST_PASSWORD }} \
+          ${{ secrets.06_SYSTEM_TEST_MLRUN_DB_PATH }} \
+          ${{ secrets.06_SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
+          ${{ secrets.06_SYSTEM_TEST_USERNAME }} \
+          ${{ secrets.06_SYSTEM_TEST_ACCESS_KEY }} \
+          ${{ secrets.06_SYSTEM_TEST_PASSWORD }} \
+          --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
+          --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
+          --override-mlrun-images \
+          "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_version }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}"
+
+    - name: Prepare System Test env.yaml and 0.5.x system
+      if: ${{ github.ref == 'refs/*/0.5.*' }}
+      run: |
+        python automation/system_test/prepare.py run \
+          ${{ steps.computed_params.outputs.mlrun_version }} \
+          ${{ secrets.05_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          ${{ secrets.05_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.05_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }} \
+          ${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }} \
+          ${{ secrets.05_SYSTEM_TEST_MLRUN_DB_PATH }} \
+          ${{ secrets.05_SYSTEM_TEST_WEBAPI_DIRECT_URL }} \
+          ${{ secrets.05_SYSTEM_TEST_USERNAME }} \
+          ${{ secrets.05_SYSTEM_TEST_ACCESS_KEY }} \
+          ${{ secrets.05_SYSTEM_TEST_PASSWORD }} \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
           --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
           --override-mlrun-images \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -88,8 +88,8 @@ jobs:
         poll-interval-seconds: 20s
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Prepare System Test env.yaml and 06 system
-      if: ${{ github.ref != 'refs/*/0.5.*' }}
+    - name: Prepare System Test env.yaml and 0.6.x system
+      if: ${{ github.ref != 'refs/heads/0.5.x' }}
       run: |
         python automation/system_test/prepare.py run \
           ${{ steps.computed_params.outputs.mlrun_version }} \
@@ -108,7 +108,7 @@ jobs:
           "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_version }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}"
 
     - name: Prepare System Test env.yaml and 0.5.x system
-      if: ${{ github.ref == 'refs/*/0.5.*' }}
+      if: ${{ github.ref == 'refs/heads/0.5.x' }}
       run: |
         python automation/system_test/prepare.py run \
           ${{ steps.computed_params.outputs.mlrun_version }} \


### PR DESCRIPTION
We need to be able to use one system tests system for 0.5.x and one for development (0.6.x)