### PR TITLE
[Runtimes] Set jobs dbpath from configuration instead of client

### DIFF
--- a/docs/mlrun-kit.md
+++ b/docs/mlrun-kit.md
@@ -87,8 +87,8 @@ Refer to the [**Kubeflow documentation**](https://www.kubeflow.org/docs/started/
 Your applications are now available in your local browser:
 
 - Jupyter-Lab - <http://localhost:30040>
-- Nuclio - <http://localhost:30050>
-- MLRun - <http://locahost:30060>
+- MLRun - <http://locahost:30050>
+- Nuclio - <http://localhost:30060>
 
 ### Start Working
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -97,6 +97,8 @@ default_config = {
             "followers": "",
             "periodic_sync_interval": "1 minute",
         },
+        # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
+        "api_url": "",
     },
 }
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -93,14 +93,13 @@ class FunctionSpec(ModelObj):
         workdir=None,
         default_handler=None,
         pythonpath=None,
-        rundb=None,
     ):
 
         self.command = command or ""
         self.image = image or ""
         self.mode = mode
         self.args = args or []
-        self.rundb = rundb
+        self.rundb = None
         self.description = description or ""
         self.workdir = workdir
         self.pythonpath = pythonpath
@@ -505,8 +504,8 @@ class BaseRuntime(ModelObj):
         runtime_env = {"MLRUN_EXEC_CONFIG": runobj.to_json()}
         if runobj.spec.verbose:
             runtime_env["MLRUN_LOG_LEVEL"] = "debug"
-        if self.spec.rundb:
-            runtime_env["MLRUN_DBPATH"] = self.spec.rundb
+        if config.httpdb.api_url:
+            runtime_env["MLRUN_DBPATH"] = config.httpdb.api_url
         if self.metadata.namespace or config.namespace:
             runtime_env["MLRUN_NAMESPACE"] = self.metadata.namespace or config.namespace
         return runtime_env

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -70,7 +70,6 @@ class DaskSpec(KubeResourceSpec):
         min_replicas=None,
         max_replicas=None,
         scheduler_timeout=None,
-        rundb=None,
     ):
 
         super().__init__(
@@ -90,7 +89,6 @@ class DaskSpec(KubeResourceSpec):
             entry_points=entry_points,
             description=description,
             image_pull_secret=image_pull_secret,
-            rundb=rundb,
         )
         self.args = args
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -236,7 +236,6 @@ class RemoteRuntime(KubeResource):
             self.metadata.project = project
         if tag:
             self.metadata.tag = tag
-        self._ensure_run_db()
         state = ""
         last_log_timestamp = 1
 
@@ -315,8 +314,8 @@ class RemoteRuntime(KubeResource):
     def _get_runtime_env(self):
         # for runtime specific env var enrichment (before deploy)
         runtime_env = {}
-        if self.spec.rundb:
-            runtime_env["MLRUN_DBPATH"] = self.spec.rundb
+        if self.spec.rundb or mlconf.httpdb.api_url:
+            runtime_env["MLRUN_DBPATH"] = self.spec.rundb or mlconf.httpdb.api_url
         if mlconf.namespace:
             runtime_env["MLRUN_NAMESPACE"] = mlconf.namespace
         return runtime_env

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -268,6 +268,7 @@ class RemoteRuntime(KubeResource):
 
         else:
             self.save(versioned=False)
+            self._ensure_run_db()
             address = deploy_nuclio_function(self, dashboard=dashboard, watch=True)
             if address:
                 self.spec.command = "http://{}".format(address)

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -49,7 +49,6 @@ class KubeResourceSpec(FunctionSpec):
         service_account=None,
         build=None,
         image_pull_secret=None,
-        rundb=None,
     ):
         super().__init__(
             command=command,
@@ -61,7 +60,6 @@ class KubeResourceSpec(FunctionSpec):
             description=description,
             workdir=workdir,
             default_handler=default_handler,
-            rundb=rundb,
         )
         self._volumes = {}
         self._volume_mounts = {}

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -114,7 +114,6 @@ class SparkJobSpec(KubeResourceSpec):
         description=None,
         workdir=None,
         build=None,
-        rundb=None,
     ):
 
         super().__init__(
@@ -135,7 +134,6 @@ class SparkJobSpec(KubeResourceSpec):
             description=description,
             workdir=workdir,
             build=build,
-            rundb=rundb,
         )
 
         self.driver_resources = driver_resources or {}


### PR DESCRIPTION
before https://github.com/mlrun/mlrun/pull/550 jobs was able to "talk" with the mlrun API only if its svc name was `mlrun-api`, that PR was purposed to solve this by passing the configured DBPATH from the client to the `function.spec.rundb` attribute which will then be set as an env (`MLRUN_DBPATH`) on the job pod itself. While that worked for some of the cases, it caused a new bug:
sometimes the dbpath (api link) configured in the client side is something like https://mlrun-api.default-tenant.app.hedingber-30-1.iguazio-cd2.com which is the API's ingress URL, in order to "talk" through that ingress credentials are needed, and therefore jobs configured with this as their dbpath failed communicating with the API.
This PR revert some of the stuff from the previous PR, and this time tackle it differently, a new config value was added -  `api_url` - this should be set by the component provisioning the API to be to URL of the svc of the API, this is the URL that really should be set on the jobs.

Other:
* did a little fix in mlrun kit doc