### PR TITLE
[Builder] Change registry URL configurations

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -7,11 +7,6 @@ RUN python -m pip install --upgrade pip
 # by default COPY creates files with root permissions, so doing all the preparation with root and chown-ing everything
 # in the end
 USER root
-COPY . /tmp/mlrun
-RUN cd /tmp/mlrun && python -m pip install ".[api]" && cd /tmp && rm -rf mlrun
-
-COPY ./dockerfiles/jupyter/requirements.txt /tmp
-RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 WORKDIR $HOME
 
@@ -23,6 +18,12 @@ RUN git clone https://github.com/mlrun/demos.git $HOME/demos
 RUN git clone https://github.com/mlrun/functions.git $HOME/functions
 
 RUN mkdir data
+
+COPY ./dockerfiles/jupyter/requirements.txt /tmp
+RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
+
+COPY . /tmp/mlrun
+RUN cd /tmp/mlrun && python -m pip install ".[api]" && cd /tmp && rm -rf mlrun
 
 RUN chown -R $NB_UID:$NB_GID $HOME
 

--- a/hack/local/README.md
+++ b/hack/local/README.md
@@ -78,7 +78,7 @@ Copy the [**mlrun-local.yaml**](mlrun-local.yaml) file to your cluster, edit the
 
 ```yaml
     - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-      value: "index.docker.io/<username>"
+      value: "default registry url e.g. index.docker.io/<username>, if repository is not set it will default to mlrun"
     - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
       value: my-docker-secret
 ``` 

--- a/hack/local/README.md
+++ b/hack/local/README.md
@@ -77,9 +77,9 @@ kubectl create -n <namespace> secret docker-registry my-docker --docker-server=h
 Copy the [**mlrun-local.yaml**](mlrun-local.yaml) file to your cluster, edit the registry and other attributes as needed, for example:
 
 ```yaml
-    - name: DEFAULT_DOCKER_REGISTRY
+    - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
       value: "https://index.docker.io/v1/"
-    - name: DEFAULT_DOCKER_SECRET
+    - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
       value: my-docker
 ``` 
 

--- a/hack/local/README.md
+++ b/hack/local/README.md
@@ -71,16 +71,16 @@ The following example uses a shared NFS server and a Helm chart for the installa
 If you plan to push containers or use a private registry, you need to first create a secret with your Docker registry information.
 You can do this by running the following command:
 ```sh
-kubectl create -n <namespace> secret docker-registry my-docker --docker-server=https://index.docker.io/v1/ --docker-username=<your-user> --docker-password=<your-password> --docker-email=<your-email>
+kubectl create -n <namespace> secret docker-registry my-docker-secret --docker-server=https://index.docker.io/v1/ --docker-username=<your-user> --docker-password=<your-password> --docker-email=<your-email>
 ```
 
 Copy the [**mlrun-local.yaml**](mlrun-local.yaml) file to your cluster, edit the registry and other attributes as needed, for example:
 
 ```yaml
     - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-      value: "https://index.docker.io/v1/"
+      value: "index.docker.io/<username>"
     - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-      value: my-docker
+      value: my-docker-secret
 ``` 
 
 and run the following command from the directory that contains the file:

--- a/hack/local/mlrun-local.yaml
+++ b/hack/local/mlrun-local.yaml
@@ -24,7 +24,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-          value: "set default registry url e.g. index.docker.io/<username>"
+          value: "default registry url e.g. index.docker.io/<username>, if repository is not set it will default to mlrun"
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
           value: ""
         ports:

--- a/hack/local/mlrun-local.yaml
+++ b/hack/local/mlrun-local.yaml
@@ -24,7 +24,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-          value: "<set default registry url>"
+          value: "set default registry url e.g. index.docker.io/<username>"
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
           value: ""
         ports:

--- a/hack/local/mlrun-local.yaml
+++ b/hack/local/mlrun-local.yaml
@@ -23,6 +23,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: MLRUN_HTTPDB__DB_TYPE
+          value: filedb
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
           value: "default registry url e.g. index.docker.io/<username>, if repository is not set it will default to mlrun"
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET

--- a/hack/local/mlrun-local.yaml
+++ b/hack/local/mlrun-local.yaml
@@ -23,8 +23,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: MLRUN_HTTPDB__DB_TYPE
-          value: filedb
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
           value: "<set default registry url>"
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET

--- a/hack/local/mlrun-local.yaml
+++ b/hack/local/mlrun-local.yaml
@@ -25,9 +25,9 @@ spec:
               fieldPath: metadata.namespace
         - name: MLRUN_HTTPDB__DB_TYPE
           value: filedb
-        - name: DEFAULT_DOCKER_REGISTRY
+        - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
           value: "<set default registry url>"
-        - name: DEFAULT_DOCKER_SECRET
+        - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
           value: ""
         ports:
         - containerPort: 8080

--- a/hack/mlrun-all.yaml
+++ b/hack/mlrun-all.yaml
@@ -24,7 +24,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-          value: "<set default registry url>"
+          value: "set default registry url e.g. index.docker.io/<username>"
         - name: V3IO_ACCESS_KEY
           value: <access-key>
         - name: V3IO_USERNAME

--- a/hack/mlrun-all.yaml
+++ b/hack/mlrun-all.yaml
@@ -24,7 +24,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-          value: "set default registry url e.g. index.docker.io/<username>"
+          value: "default registry url e.g. index.docker.io/<username>, if repository is not set it will default to mlrun"
         - name: V3IO_ACCESS_KEY
           value: <access-key>
         - name: V3IO_USERNAME

--- a/hack/mlrun-all.yaml
+++ b/hack/mlrun-all.yaml
@@ -23,7 +23,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: DEFAULT_DOCKER_REGISTRY
+        - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
           value: "<set default registry url>"
         - name: V3IO_ACCESS_KEY
           value: <access-key>

--- a/hack/mlrunapi.yaml
+++ b/hack/mlrunapi.yaml
@@ -20,7 +20,7 @@ spec:
         image: mlrun/mlrun-api:0.5.4
         env:
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-          value: "set default registry url e.g. index.docker.io/<username>"
+          value: "default registry url e.g. index.docker.io/<username>, if repository is not set it will default to mlrun"
         - name: V3IO_ACCESS_KEY
           value: <access-key>
         - name: V3IO_USERNAME

--- a/hack/mlrunapi.yaml
+++ b/hack/mlrunapi.yaml
@@ -20,7 +20,7 @@ spec:
         image: mlrun/mlrun-api:0.5.4
         env:
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
-          value: "<set default registry url>"
+          value: "set default registry url e.g. index.docker.io/<username>"
         - name: V3IO_ACCESS_KEY
           value: <access-key>
         - name: V3IO_USERNAME

--- a/hack/mlrunapi.yaml
+++ b/hack/mlrunapi.yaml
@@ -19,7 +19,7 @@ spec:
       - name: mlrun-api
         image: mlrun/mlrun-api:0.5.4
         env:
-        - name: DEFAULT_DOCKER_REGISTRY
+        - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
           value: "<set default registry url>"
         - name: V3IO_ACCESS_KEY
           value: <access-key>

--- a/mlrun/api/api/endpoints/healthz.py
+++ b/mlrun/api/api/endpoints/healthz.py
@@ -14,7 +14,7 @@ def health():
     return {
         "version": config.version,
         "namespace": config.namespace,
-        "docker_registry": environ.get("DEFAULT_DOCKER_REGISTRY", ""),
+        "docker_registry": config.httpdb.builder.docker_registry,
         "remote_host": config.remote_host,
         "mpijob_crd_version": mpijob_crd_version,
         "ui_url": config.ui_url,

--- a/mlrun/api/api/endpoints/healthz.py
+++ b/mlrun/api/api/endpoints/healthz.py
@@ -1,5 +1,3 @@
-from os import environ
-
 from fastapi import APIRouter
 
 from mlrun.config import config

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 
 from .datastore import store_manager
 from .k8s_utils import BasePod, get_k8s_helper
-from .utils import logger, normalize_name, enrich_image_url
+from .utils import logger, normalize_name, enrich_image_url, get_parsed_docker_registry
 from .config import config
 
 
@@ -145,7 +145,7 @@ def build_image(
         dest = "{}/{}".format(registry, dest)
     elif dest.startswith("."):
         dest = dest[1:]
-        registry = config.httpdb.builder.docker_registry
+        registry, _ = get_parsed_docker_registry()
         secret_name = secret_name or config.httpdb.builder.docker_registry_secret
         if not registry:
             raise ValueError(

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -14,7 +14,7 @@
 
 import tarfile
 from base64 import b64decode, b64encode
-from os import environ, path, remove
+from os import path, remove
 from tempfile import mktemp
 from urllib.parse import urlparse
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -145,15 +145,12 @@ def build_image(
         dest = "{}/{}".format(registry, dest)
     elif dest.startswith("."):
         dest = dest[1:]
-        if "DOCKER_REGISTRY_PORT" in environ:
-            registry = urlparse(environ.get("DOCKER_REGISTRY_PORT")).netloc
-        else:
-            registry = environ.get("DEFAULT_DOCKER_REGISTRY")
-            secret_name = secret_name or environ.get("DEFAULT_DOCKER_SECRET")
+        registry = config.httpdb.builder.docker_registry
+        secret_name = secret_name or config.httpdb.builder.docker_registry_secret
         if not registry:
             raise ValueError(
-                "local docker registry is not defined, set "
-                "DEFAULT_DOCKER_REGISTRY/SECRET env vars"
+                "Default docker registry is not defined, set "
+                "MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY/MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET env vars"
             )
         dest = "{}/{}".format(registry, dest)
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -38,7 +38,7 @@ _none_type = type(None)
 
 
 default_config = {
-    "namespace": "default-tenant",  # default kubernetes namespace
+    "namespace": "",  # default kubernetes namespace
     "dbpath": "",  # db/api url
     # url to nuclio dashboard api (can be with user & token, e.g. https://username:password@dashboard-url.com)
     "nuclio_dashboard_url": "",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -99,10 +99,7 @@ default_config = {
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",
-        "builder": {
-            "docker_registry": "",
-            "docker_registry_secret": "",
-        },
+        "builder": {"docker_registry": "", "docker_registry_secret": ""},
     },
 }
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -181,6 +181,7 @@ class Config:
         self._dbpath = dbpath
         # importing here to avoid circular dependency
         import mlrun.db
+
         # when dbpath is set we want to connect to it which will sync configuration from it to the client
         mlrun.db.get_run_db(dbpath).connect()
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -99,6 +99,10 @@ default_config = {
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",
+        "builder": {
+            "docker_registry": "",
+            "docker_registry_secret": "",
+        },
     },
 }
 
@@ -256,9 +260,9 @@ def read_env(env=None, prefix=env_prefix):
     uisvc = env.get("MLRUN_UI_SERVICE_HOST")
     igz_domain = env.get("IGZ_NAMESPACE_DOMAIN")
 
-    # workaround to try and detect IGZ domain in 2.8
-    if not igz_domain and "DEFAULT_DOCKER_REGISTRY" in env:
-        registry = env["DEFAULT_DOCKER_REGISTRY"]
+    # workaround to try and detect IGZ domain
+    if not igz_domain and "MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY" in env:
+        registry = env["MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY"]
         if registry.startswith("docker-registry.default-tenant"):
             igz_domain = registry[len("docker-registry.") :]
             if ":" in igz_domain:

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -270,9 +270,12 @@ def read_env(env=None, prefix=env_prefix):
             cfg = cfg.setdefault(name, {})
         cfg[path[0]] = value
 
-    # check for mlrun-api or db kubernetes service
+    # TODO: remove this - and verify dbpath is set correctly in all flows
+    # Here we're just guessing that there is a service named mlrun-api, if there is, there will be an env var for it's
+    # port - MLRUN_API_PORT - so we're using the env var existence to know whether our guess is right.
+    # the existence of config.httpdb.api_url tell that we're running in an API context so no need to set the dbpath
     svc = env.get("MLRUN_API_PORT")
-    if svc and not config.get("dbpath"):
+    if svc and not config.get("dbpath") and not config.get("httpdb", {}).get("api_url"):
         config["dbpath"] = "http://mlrun-api:{}".format(
             default_config["httpdb"]["port"] or 8080
         )

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -128,7 +128,11 @@ class Config:
         return val
 
     def __setattr__(self, attr, value):
-        self._cfg[attr] = value
+        # in order for the dbpath setter to work
+        if attr == 'dbpath':
+            super().__setattr__(attr, value)
+        else:
+            self._cfg[attr] = value
 
     def __dir__(self):
         return list(self._cfg) + dir(self.__class__)
@@ -182,13 +186,14 @@ class Config:
         return self._dbpath
 
     @dbpath.setter
-    def dbpath(self, dbpath):
-        self._dbpath = dbpath
-        # importing here to avoid circular dependency
-        import mlrun.db
+    def dbpath(self, value):
+        self._dbpath = value
+        if value:
+            # importing here to avoid circular dependency
+            import mlrun.db
 
-        # when dbpath is set we want to connect to it which will sync configuration from it to the client
-        mlrun.db.get_run_db(dbpath).connect()
+            # when dbpath is set we want to connect to it which will sync configuration from it to the client
+            mlrun.db.get_run_db(value).connect()
 
 
 # Global configuration

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -99,7 +99,12 @@ default_config = {
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",
-        "builder": {"docker_registry": "", "docker_registry_secret": ""},
+        "builder": {
+            # setting the docker registry to be used for built images, can include the repository as well, e.g.
+            # index.docker.io/<username>, if not included repository will default to mlrun
+            "docker_registry": "",
+            "docker_registry_secret": "",
+        },
     },
 }
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -172,6 +172,18 @@ class Config:
             return mlrun.utils.helpers.enrich_image_url("mlrun/mlrun")
         return self._kfp_image
 
+    @property
+    def dbpath(self):
+        return self._dbpath
+
+    @dbpath.setter
+    def dbpath(self, dbpath):
+        self._dbpath = dbpath
+        # importing here to avoid circular dependency
+        import mlrun.db
+        # when dbpath is set we want to connect to it which will sync configuration from it to the client
+        mlrun.db.get_run_db(dbpath).connect()
+
 
 # Global configuration
 config = Config.from_dict(default_config)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -129,7 +129,7 @@ class Config:
 
     def __setattr__(self, attr, value):
         # in order for the dbpath setter to work
-        if attr == 'dbpath':
+        if attr == "dbpath":
             super().__setattr__(attr, value)
         else:
             self._cfg[attr] = value

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -53,7 +53,7 @@ default_config = {
     "igz_version": "",  # the version of the iguazio system the API is running on
     "spark_app_image": "",  # image to use for spark operator app runtime
     "spark_app_image_tag": "",  # image tag to use for spark opeartor app runtime
-    "kaniko_version": "v0.19.0",  # kaniko builder version
+    "kaniko_version": "v0.24.0",  # kaniko builder version
     "package_path": "mlrun",  # mlrun pip package
     "default_image": "python:3.6-jessie",
     "default_project": "default",  # default project name

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -139,6 +139,7 @@ class HTTPRunDB(RunDBInterface):
             server_cfg = resp.json()
             self.server_version = server_cfg["version"]
             self._validate_version_compatibility(self.server_version, config.version)
+            config.namespace = config.namespace or server_cfg.get("namespace")
             if (
                 "namespace" in server_cfg
                 and server_cfg["namespace"] != config.namespace

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -16,7 +16,7 @@ import json
 import tempfile
 import time
 from datetime import datetime
-from os import path, remove, environ
+from os import path, remove
 from typing import List, Dict, Union
 
 import kfp
@@ -164,8 +164,9 @@ class HTTPRunDB(RunDBInterface):
             config.spark_app_image_tag = config.spark_app_image_tag or server_cfg.get(
                 "spark_app_image_tag"
             )
-            config.httpdb.builder.docker_registry = config.httpdb.builder.docker_registry or server_cfg.get(
-                "docker_registry"
+            config.httpdb.builder.docker_registry = (
+                config.httpdb.builder.docker_registry
+                or server_cfg.get("docker_registry")
             )
         except Exception:
             pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -164,12 +164,9 @@ class HTTPRunDB(RunDBInterface):
             config.spark_app_image_tag = config.spark_app_image_tag or server_cfg.get(
                 "spark_app_image_tag"
             )
-            if (
-                "docker_registry" in server_cfg
-                and "DEFAULT_DOCKER_REGISTRY" not in environ
-            ):
-                environ["DEFAULT_DOCKER_REGISTRY"] = server_cfg["docker_registry"]
-
+            config.httpdb.builder.docker_registry = config.httpdb.builder.docker_registry or server_cfg.get(
+                "docker_registry"
+            )
         except Exception:
             pass
         return self

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -389,7 +389,7 @@ def mlrun_op(
         )
     if registry:
         cop.container.add_env_variable(
-            k8s_client.V1EnvVar(name="DEFAULT_DOCKER_REGISTRY", value=registry)
+            k8s_client.V1EnvVar(name="MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY", value=registry)
         )
     cop.container.add_env_variable(
         k8s_client.V1EnvVar(
@@ -535,11 +535,11 @@ def build_op(
         file_outputs={"state": "/tmp/state", "image": "/tmp/image"},
     )
 
-    if "DEFAULT_DOCKER_REGISTRY" in environ:
+    if config.httpdb.builder.docker_registry:
         cop.container.add_env_variable(
             k8s_client.V1EnvVar(
-                name="DEFAULT_DOCKER_REGISTRY",
-                value=environ.get("DEFAULT_DOCKER_REGISTRY"),
+                name="MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY",
+                value=config.httpdb.builder.docker_registry,
             )
         )
     if "IGZ_NAMESPACE_DOMAIN" in environ:
@@ -573,8 +573,8 @@ def build_op(
 
 
 def get_default_reg():
-    if "DEFAULT_DOCKER_REGISTRY" in environ:
-        return environ.get("DEFAULT_DOCKER_REGISTRY")
+    if config.httpdb.builder.docker_registry:
+        return config.httpdb.builder.docker_registry
     if "IGZ_NAMESPACE_DOMAIN" in environ:
         return "docker-registry.{}:80".format(environ.get("IGZ_NAMESPACE_DOMAIN"))
     return ""

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -389,7 +389,9 @@ def mlrun_op(
         )
     if registry:
         cop.container.add_env_variable(
-            k8s_client.V1EnvVar(name="MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY", value=registry)
+            k8s_client.V1EnvVar(
+                name="MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY", value=registry
+            )
         )
     cop.container.add_env_variable(
         k8s_client.V1EnvVar(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -624,7 +624,7 @@ class BaseRuntime(ModelObj):
         image = enrich_image_url(image)
         if not image.startswith("."):
             return image
-        registry, _ = get_parsed_docker_registry
+        registry, _ = get_parsed_docker_registry()
         if registry:
             return "{}/{}".format(registry, image[1:])
         if "IGZ_NAMESPACE_DOMAIN" in environ:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -54,6 +54,7 @@ from ..utils import (
     enrich_image_url,
     dict_to_yaml,
     dict_to_json,
+    get_parsed_docker_registry,
 )
 
 
@@ -623,8 +624,9 @@ class BaseRuntime(ModelObj):
         image = enrich_image_url(image)
         if not image.startswith("."):
             return image
-        if config.httpdb.builder.docker_registry:
-            return "{}/{}".format(config.httpdb.builder.docker_registry, image[1:])
+        registry, _ = get_parsed_docker_registry
+        if registry:
+            return "{}/{}".format(registry, image[1:])
         if "IGZ_NAMESPACE_DOMAIN" in environ:
             return "docker-registry.{}:80/{}".format(
                 environ.get("IGZ_NAMESPACE_DOMAIN"), image[1:]

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -623,8 +623,8 @@ class BaseRuntime(ModelObj):
         image = enrich_image_url(image)
         if not image.startswith("."):
             return image
-        if "DEFAULT_DOCKER_REGISTRY" in environ:
-            return "{}/{}".format(environ.get("DEFAULT_DOCKER_REGISTRY"), image[1:])
+        if config.httpdb.builder.docker_registry:
+            return "{}/{}".format(config.httpdb.builder.docker_registry, image[1:])
         if "IGZ_NAMESPACE_DOMAIN" in environ:
             return "docker-registry.{}:80/{}".format(
                 environ.get("IGZ_NAMESPACE_DOMAIN"), image[1:]

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -22,7 +22,7 @@ from mlrun.runtimes.base import BaseRuntimeHandler
 from .base import RunError
 from .funcdoc import update_function_entry_points
 from .pod import KubeResource
-from .utils import AsyncLogWriter, default_image_name
+from .utils import AsyncLogWriter, generate_function_image_name
 from ..builder import build_runtime
 from ..db import RunDBError
 from ..kfpops import build_op
@@ -124,7 +124,7 @@ class KubejobRuntime(KubeResource):
                 "with_mlrun=False to skip if its already in the image"
             )
 
-        self.spec.build.image = self.spec.build.image or default_image_name(self)
+        self.spec.build.image = self.spec.build.image or generate_function_image_name(self)
         self.status.state = ""
 
         if self._is_remote_api() and not is_kfp:

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -124,7 +124,9 @@ class KubejobRuntime(KubeResource):
                 "with_mlrun=False to skip if its already in the image"
             )
 
-        self.spec.build.image = self.spec.build.image or generate_function_image_name(self)
+        self.spec.build.image = self.spec.build.image or generate_function_image_name(
+            self
+        )
         self.status.state = ""
 
         if self._is_remote_api() and not is_kfp:

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -29,6 +29,7 @@ from ..artifacts import TableArtifact
 from ..config import config
 from ..utils import get_in
 from ..utils import logger
+from ..utils import helpers
 
 
 class RunError(Exception):
@@ -265,10 +266,13 @@ def results_to_iter(results, runspec, execution):
     execution.commit()
 
 
-def default_image_name(function):
-    meta = function.metadata
-    proj = meta.project or config.default_project
-    return ".mlrun/func-{}-{}-{}".format(proj, meta.name, meta.tag or "latest")
+def generate_function_image_name(function):
+    project = function.metadata.project or config.default_project
+    tag = function.metadata.tag or "latest"
+    _, repository = helpers.get_parsed_docker_registry()
+    if not repository:
+        repository = "mlrun"
+    return f".{repository}/func-{project}-{function.metadata.name}-{tag}"
 
 
 def set_named_item(obj, item):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -451,11 +451,18 @@ def enrich_image_url(image_url: str) -> str:
 def get_parsed_docker_registry() -> Tuple[Optional[str], Tuple[str]]:
     # according to https://stackoverflow.com/questions/37861791/how-are-docker-image-names-parsed
     docker_registry = config.httpdb.builder.docker_registry
-    first_slash_index = docker_registry.find('/')
-    if first_slash_index == -1 or (docker_registry[:first_slash_index].find('.') == -1 and docker_registry[:first_slash_index].find(':') == -1 and docker_registry[:first_slash_index] != 'localhost'):
+    first_slash_index = docker_registry.find("/")
+    if first_slash_index == -1 or (
+        docker_registry[:first_slash_index].find(".") == -1
+        and docker_registry[:first_slash_index].find(":") == -1
+        and docker_registry[:first_slash_index] != "localhost"
+    ):
         return None, docker_registry
     else:
-        return docker_registry[:first_slash_index], docker_registry[first_slash_index + 1:]
+        return (
+            docker_registry[:first_slash_index],
+            docker_registry[first_slash_index + 1 :],
+        )
 
 
 def get_artifact_target(item: dict, project=None):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -448,11 +448,15 @@ def enrich_image_url(image_url: str) -> str:
     return image_url
 
 
-def get_parsed_docker_registry() -> Tuple[Optional[str], Tuple[str]]:
+def get_parsed_docker_registry() -> Tuple[Optional[str], Optional[str]]:
     # according to https://stackoverflow.com/questions/37861791/how-are-docker-image-names-parsed
     docker_registry = config.httpdb.builder.docker_registry
     first_slash_index = docker_registry.find("/")
-    if first_slash_index == -1 or (
+    # this is exception to the rules from the link above, since the config value is called docker_registry we assume
+    # that if someone gave just one component without any slash they gave a registry and not a repository
+    if first_slash_index == -1:
+        return docker_registry, None
+    if (
         docker_registry[:first_slash_index].find(".") == -1
         and docker_registry[:first_slash_index].find(":") == -1
         and docker_registry[:first_slash_index] != "localhost"

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -17,7 +17,7 @@ import json
 import re
 import sys
 import time
-from typing import Optional
+from typing import Optional, Tuple
 from datetime import datetime, timezone
 from dateutil import parser
 from os import path, environ
@@ -446,6 +446,16 @@ def enrich_image_url(image_url: str) -> str:
         if registry and "/mlrun/" not in image_url:
             image_url = f"{registry}{image_url}"
     return image_url
+
+
+def get_parsed_docker_registry() -> Tuple[Optional[str], Tuple[str]]:
+    # according to https://stackoverflow.com/questions/37861791/how-are-docker-image-names-parsed
+    docker_registry = config.httpdb.builder.docker_registry
+    first_slash_index = docker_registry.find('/')
+    if first_slash_index == -1 or (docker_registry[:first_slash_index].find('.') == -1 and docker_registry[:first_slash_index].find(':') == -1 and docker_registry[:first_slash_index] != 'localhost'):
+        return None, docker_registry
+    else:
+        return docker_registry[:first_slash_index], docker_registry[first_slash_index + 1:]
 
 
 def get_artifact_target(item: dict, project=None):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 import yaml
+import requests_mock as requests_mock_package
 
 from mlrun import config as mlconf
 
@@ -116,3 +117,16 @@ def test_overriding_config_not_remain_for_next_tests_tester():
     global old_config_value
     assert old_config_value == mlconf.config.igz_version
     assert old_config_value == mlconf.config.httpdb.data_volume
+
+
+def test_setting_dbpath_trigger_connect(requests_mock: requests_mock_package.Mocker):
+    api_url = 'http://mlrun-api-url:8080'
+    remote_host = 'some-namespace'
+    response_body = {
+        'version': 'some-version',
+        'remote_host': remote_host,
+    }
+    requests_mock.get(f"{api_url}/api/healthz", json=response_body)
+    assert "" == mlconf.config.remote_host
+    mlconf.config.dbpath = api_url
+    assert remote_host == mlconf.config.remote_host

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,8 +17,8 @@ from os import environ
 from tempfile import NamedTemporaryFile
 
 import pytest
-import yaml
 import requests_mock as requests_mock_package
+import yaml
 
 from mlrun import config as mlconf
 
@@ -120,11 +120,11 @@ def test_overriding_config_not_remain_for_next_tests_tester():
 
 
 def test_setting_dbpath_trigger_connect(requests_mock: requests_mock_package.Mocker):
-    api_url = 'http://mlrun-api-url:8080'
-    remote_host = 'some-namespace'
+    api_url = "http://mlrun-api-url:8080"
+    remote_host = "some-namespace"
     response_body = {
-        'version': 'some-version',
-        'remote_host': remote_host,
+        "version": "some-version",
+        "remote_host": remote_host,
     }
     requests_mock.get(f"{api_url}/api/healthz", json=response_body)
     assert "" == mlconf.config.remote_host

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,5 +1,10 @@
 from mlrun.config import config
-from mlrun.utils.helpers import verify_field_regex, extend_hub_uri, enrich_image_url, get_parsed_docker_registry
+from mlrun.utils.helpers import (
+    verify_field_regex,
+    extend_hub_uri,
+    enrich_image_url,
+    get_parsed_docker_registry,
+)
 from mlrun.utils.regex import run_name
 
 
@@ -123,11 +128,7 @@ def test_enrich_image():
 
 def test_get_parsed_docker_registry():
     cases = [
-        {
-            "docker_registry": "",
-            "expected_registry": None,
-            "expected_repository": "",
-        },
+        {"docker_registry": "", "expected_registry": None, "expected_repository": ""},
         {
             "docker_registry": "hedi/ingber",
             "expected_registry": None,
@@ -160,7 +161,7 @@ def test_get_parsed_docker_registry():
         },
     ]
     for case in cases:
-        config.httpdb.builder.docker_registry = case['docker_registry']
+        config.httpdb.builder.docker_registry = case["docker_registry"]
         registry, repository = get_parsed_docker_registry()
         assert case["expected_registry"] == registry
         assert case["expected_repository"] == repository

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,5 +1,5 @@
 from mlrun.config import config
-from mlrun.utils.helpers import verify_field_regex, extend_hub_uri, enrich_image_url
+from mlrun.utils.helpers import verify_field_regex, extend_hub_uri, enrich_image_url, get_parsed_docker_registry
 from mlrun.utils.regex import run_name
 
 
@@ -119,3 +119,48 @@ def test_enrich_image():
         expected_output = case["expected_output"]
         output = enrich_image_url(image)
         assert expected_output == output
+
+
+def test_get_parsed_docker_registry():
+    cases = [
+        {
+            "docker_registry": "",
+            "expected_registry": None,
+            "expected_repository": "",
+        },
+        {
+            "docker_registry": "hedi/ingber",
+            "expected_registry": None,
+            "expected_repository": "hedi/ingber",
+        },
+        {
+            "docker_registry": "localhost/hedingber",
+            "expected_registry": "localhost",
+            "expected_repository": "hedingber",
+        },
+        {
+            "docker_registry": "gcr.io/hedingber",
+            "expected_registry": "gcr.io",
+            "expected_repository": "hedingber",
+        },
+        {
+            "docker_registry": "local-registry:80/hedingber",
+            "expected_registry": "local-registry:80",
+            "expected_repository": "hedingber",
+        },
+        {
+            "docker_registry": "docker-registry.default-tenant.app.hedingber-30-1.iguazio-cd1.com:80/hedingber",
+            "expected_registry": "docker-registry.default-tenant.app.hedingber-30-1.iguazio-cd1.com:80",
+            "expected_repository": "hedingber",
+        },
+        {
+            "docker_registry": "quay.io/",
+            "expected_registry": "quay.io",
+            "expected_repository": "",
+        },
+    ]
+    for case in cases:
+        config.httpdb.builder.docker_registry = case['docker_registry']
+        registry, repository = get_parsed_docker_registry()
+        assert case["expected_registry"] == registry
+        assert case["expected_repository"] == repository

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -128,7 +128,7 @@ def test_enrich_image():
 
 def test_get_parsed_docker_registry():
     cases = [
-        {"docker_registry": "", "expected_registry": None, "expected_repository": ""},
+        {"docker_registry": "", "expected_registry": "", "expected_repository": None},
         {
             "docker_registry": "hedi/ingber",
             "expected_registry": None,
@@ -153,6 +153,11 @@ def test_get_parsed_docker_registry():
             "docker_registry": "docker-registry.default-tenant.app.hedingber-30-1.iguazio-cd1.com:80/hedingber",
             "expected_registry": "docker-registry.default-tenant.app.hedingber-30-1.iguazio-cd1.com:80",
             "expected_repository": "hedingber",
+        },
+        {
+            "docker_registry": "docker-registry.default-tenant.app.hedingber-30-1.iguazio-cd1.com:80",
+            "expected_registry": "docker-registry.default-tenant.app.hedingber-30-1.iguazio-cd1.com:80",
+            "expected_repository": None,
         },
         {
             "docker_registry": "quay.io/",


### PR DESCRIPTION
* Move builder configuration to use the main `config.py` instead of reading from env var directly, this caused a change with the env vars naming: `DEFAULT_DOCKER_REGISTRY` -> `MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY`, `DEFAULT_DOCKER_SECRET` -> `MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET `
* Added support to giving the docker repository inside the registry config value, which will override the default repository (mlrun)
* Added logic in config so that when dbpath is being set we connect to the db (API) which will sync config from it
* Bump kaniko tag - I had a bug similar https://github.com/GoogleContainerTools/kaniko/issues/245 and upgrade solved it
* related docs fixes
* Reordered the jupyter dockerfile to improve caching