### PR TITLE
[DB migrations] Added downgrade support and AlembicUtil Tests

### DIFF
--- a/mlrun/api/migrations/env.py
+++ b/mlrun/api/migrations/env.py
@@ -28,7 +28,7 @@ target_metadata = models.Base.metadata
 
 # this will overwrite the ini-file sqlalchemy.url path
 # with the path given in the mlconf
-# config.set_main_option("sqlalchemy.url", mlconf.httpdb.dsn)
+config.set_main_option("sqlalchemy.url", mlconf.httpdb.dsn)
 
 
 def run_migrations_offline():

--- a/mlrun/api/migrations/env.py
+++ b/mlrun/api/migrations/env.py
@@ -28,7 +28,7 @@ target_metadata = models.Base.metadata
 
 # this will overwrite the ini-file sqlalchemy.url path
 # with the path given in the mlconf
-config.set_main_option("sqlalchemy.url", mlconf.httpdb.dsn)
+# config.set_main_option("sqlalchemy.url", mlconf.httpdb.dsn)
 
 
 def run_migrations_offline():

--- a/mlrun/api/utils/alembic.py
+++ b/mlrun/api/utils/alembic.py
@@ -30,8 +30,8 @@ class AlembicUtil(object):
             alembic.command.stamp(self._alembic_config, initial_alembic_revision)
 
         elif (
-            not from_scratch
-            and db_path_exists
+            db_path_exists
+            and current_revision
             and current_revision not in revision_history
         ):
             self._downgrade_to_revision(db_file_path, current_revision, latest_revision)
@@ -97,7 +97,9 @@ class AlembicUtil(object):
         shutil.copy2(db_file_path, backup_path)
 
     @staticmethod
-    def _downgrade_to_revision(db_file_path: str, current_revision: str, fallback_version: str):
+    def _downgrade_to_revision(
+        db_file_path: str, current_revision: str, fallback_version: str
+    ):
         db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
         backup_path = db_dir_path / f"{fallback_version}.db"
 

--- a/mlrun/api/utils/alembic.py
+++ b/mlrun/api/utils/alembic.py
@@ -59,6 +59,8 @@ class AlembicUtil(object):
             return self._alembic_output.strip().replace(' (head)', '')
         except Exception as exc:
             if "Can't locate revision identified by" in exc.args[0]:
+
+                # DB has a revision that isn't known to us, extracting it from the exception.
                 return exc.args[0].split('\'')[2]
 
             return None
@@ -97,7 +99,7 @@ class AlembicUtil(object):
 
         shutil.copy2(backup_path, db_file_path)
 
-    def _save_output(self, text, *args):
+    def _save_output(self, text, *_):
         self._alembic_output += f'{text}\n'
 
     def _flush_output(self):

--- a/mlrun/api/utils/alembic.py
+++ b/mlrun/api/utils/alembic.py
@@ -1,33 +1,42 @@
-import os
 import alembic.config
 import alembic.command
+import os
+import pathlib
+import shutil
 
 from mlrun import mlconf
 
 
 class AlembicUtil(object):
-    class Constants(object):
-        initial_alembic_revision = "11f8dd2dc9fe"
-
     def __init__(self, alembic_config_path):
         self._alembic_config_path = str(alembic_config_path)
         self._alembic_config = alembic.config.Config(self._alembic_config_path)
-        self._current_revision = None
+        self._alembic_output = ''
 
     def init_alembic(self, from_scratch: bool = False):
-        if (
-            not from_scratch
-            and os.path.isfile(self._get_db_file_path())
-            and not self._get_current_revision()
-        ):
+        revision_history = self._get_revision_history()
+        latest_revision = revision_history[0]
+        initial_alembic_revision = revision_history[-1]
+        db_file_path = self._get_db_file_path()
+        db_path_exists = os.path.isfile(db_file_path)
+        # this command for some reason creates a dummy db file so it has to be after db_path_exists
+        current_revision = self._get_current_revision()
+
+        if not from_scratch and db_path_exists and not current_revision:
 
             # if database file exists but no alembic version exists, stamp the existing
             # database with the initial alembic version, so we can upgrade it later
-            alembic.command.stamp(
-                self._alembic_config, self.Constants.initial_alembic_revision
-            )
+            alembic.command.stamp(self._alembic_config, initial_alembic_revision)
+
+        elif (
+            not from_scratch
+            and db_path_exists
+            and current_revision not in revision_history
+        ):
+            self._downgrade_to_revision(db_file_path, current_revision, latest_revision)
 
         alembic.command.upgrade(self._alembic_config, "head")
+        self._backup_revision(db_file_path, latest_revision)
 
     @staticmethod
     def _get_db_file_path():
@@ -39,12 +48,57 @@ class AlembicUtil(object):
         return mlconf.httpdb.dsn.split("?")[0].split("sqlite:///")[-1]
 
     def _get_current_revision(self):
-        def print_stdout(text, *arg):
-            self._current_revision = text
 
         # create separate config in order to catch the stdout
         catch_stdout_config = alembic.config.Config(self._alembic_config_path)
-        catch_stdout_config.print_stdout = print_stdout
+        catch_stdout_config.print_stdout = self._save_output
 
-        alembic.command.current(catch_stdout_config)
-        return self._current_revision
+        self._flush_output()
+        try:
+            alembic.command.current(catch_stdout_config)
+            return self._alembic_output.strip().replace(' (head)', '')
+        except Exception as exc:
+            if "Can't locate revision identified by" in exc.args[0]:
+                return exc.args[0].split('\'')[2]
+
+            return None
+
+    def _get_revision_history(self):
+
+        # create separate config in order to catch the stdout
+        catch_stdout_config = alembic.config.Config(self._alembic_config_path)
+        catch_stdout_config.print_stdout = self._save_output
+
+        self._flush_output()
+        alembic.command.history(catch_stdout_config)
+        return self._parse_revision_history(self._alembic_output)
+
+    @staticmethod
+    def _parse_revision_history(output):
+        return [line.split(' ')[2].replace(',', '') for line in output.splitlines()]
+
+    @staticmethod
+    def _backup_revision(db_file_path, latest_revision):
+        db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
+        backup_path = db_dir_path / f'{latest_revision}.db'
+
+        shutil.copy2(db_file_path, backup_path)
+
+    @staticmethod
+    def _downgrade_to_revision(db_file_path, current_revision, latest_revision):
+        db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
+        backup_path = db_dir_path / f'{latest_revision}.db'
+
+        if not os.path.isfile(backup_path):
+            raise RuntimeError(
+                f'Cannot fall back to revision {latest_revision}, '
+                f'no back up exists. Current revision: {current_revision}'
+            )
+
+        shutil.copy2(backup_path, db_file_path)
+
+    def _save_output(self, text, *args):
+        self._alembic_output += f'{text}\n'
+
+    def _flush_output(self):
+        self._alembic_output = ''

--- a/mlrun/api/utils/alembic.py
+++ b/mlrun/api/utils/alembic.py
@@ -109,6 +109,10 @@ class AlembicUtil(object):
                 f"no back up exists. Current revision: {current_revision}"
             )
 
+        # backup the current DB
+        current_backup_path = db_dir_path / f"{current_revision}.db"
+        shutil.copy2(db_file_path, current_backup_path)
+
         shutil.copy2(backup_path, db_file_path)
 
     def _save_output(self, text: str, *_):

--- a/mlrun/api/utils/alembic.py
+++ b/mlrun/api/utils/alembic.py
@@ -81,6 +81,9 @@ class AlembicUtil(object):
 
     @staticmethod
     def _backup_revision(db_file_path, latest_revision):
+        if db_file_path == ":memory:":
+            return
+
         db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
         backup_path = db_dir_path / f"{latest_revision}.db"
 

--- a/mlrun/api/utils/alembic.py
+++ b/mlrun/api/utils/alembic.py
@@ -11,7 +11,7 @@ class AlembicUtil(object):
     def __init__(self, alembic_config_path):
         self._alembic_config_path = str(alembic_config_path)
         self._alembic_config = alembic.config.Config(self._alembic_config_path)
-        self._alembic_output = ''
+        self._alembic_output = ""
 
     def init_alembic(self, from_scratch: bool = False):
         revision_history = self._get_revision_history()
@@ -56,12 +56,12 @@ class AlembicUtil(object):
         self._flush_output()
         try:
             alembic.command.current(catch_stdout_config)
-            return self._alembic_output.strip().replace(' (head)', '')
+            return self._alembic_output.strip().replace(" (head)", "")
         except Exception as exc:
             if "Can't locate revision identified by" in exc.args[0]:
 
                 # DB has a revision that isn't known to us, extracting it from the exception.
-                return exc.args[0].split('\'')[2]
+                return exc.args[0].split("'")[2]
 
             return None
 
@@ -77,30 +77,30 @@ class AlembicUtil(object):
 
     @staticmethod
     def _parse_revision_history(output):
-        return [line.split(' ')[2].replace(',', '') for line in output.splitlines()]
+        return [line.split(" ")[2].replace(",", "") for line in output.splitlines()]
 
     @staticmethod
     def _backup_revision(db_file_path, latest_revision):
         db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
-        backup_path = db_dir_path / f'{latest_revision}.db'
+        backup_path = db_dir_path / f"{latest_revision}.db"
 
         shutil.copy2(db_file_path, backup_path)
 
     @staticmethod
     def _downgrade_to_revision(db_file_path, current_revision, latest_revision):
         db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
-        backup_path = db_dir_path / f'{latest_revision}.db'
+        backup_path = db_dir_path / f"{latest_revision}.db"
 
         if not os.path.isfile(backup_path):
             raise RuntimeError(
-                f'Cannot fall back to revision {latest_revision}, '
-                f'no back up exists. Current revision: {current_revision}'
+                f"Cannot fall back to revision {latest_revision}, "
+                f"no back up exists. Current revision: {current_revision}"
             )
 
         shutil.copy2(backup_path, db_file_path)
 
     def _save_output(self, text, *_):
-        self._alembic_output += f'{text}\n'
+        self._alembic_output += f"{text}\n"
 
     def _flush_output(self):
-        self._alembic_output = ''
+        self._alembic_output = ""

--- a/tests/api/utils/test_alembic_util.py
+++ b/tests/api/utils/test_alembic_util.py
@@ -1,0 +1,176 @@
+import alembic
+import alembic.config
+import os.path
+import pathlib
+import pytest
+import shutil
+import typing
+import unittest.mock
+
+import mlrun.api.utils.alembic
+from mlrun import mlconf
+
+
+class Constants(object):
+    revision_history = ["revision2", "revision1"]
+    initial_revision = "revision1"
+    latest_revision = "revision2"
+    unknown_revision = "revision3"
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_no_database_exists(
+    mock_alembic, mock_database, mock_shutil_copy, from_scratch
+):
+    mock_database(db_file_exists=False)
+    alembic_util = mlrun.api.utils.alembic.AlembicUtil(pathlib.Path(""))
+    alembic_util.init_alembic(from_scratch=from_scratch)
+    assert mock_alembic.stamp_calls == []
+    assert mock_alembic.upgrade_calls == ["head"]
+    mock_shutil_copy.assert_not_called()
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_database_exists_no_revision(
+    mock_alembic, mock_database, mock_shutil_copy, from_scratch
+):
+    mock_database()
+    alembic_util = mlrun.api.utils.alembic.AlembicUtil(pathlib.Path(""))
+    alembic_util.init_alembic(from_scratch=from_scratch)
+
+    # from scratch should skip stamp even if no revision exists
+    expected_stamp_calls = ["revision1"] if not from_scratch else []
+    assert mock_alembic.stamp_calls == expected_stamp_calls
+    assert mock_alembic.upgrade_calls == ["head"]
+    mock_shutil_copy.assert_not_called()
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_database_exists_known_revision(
+    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name, from_scratch
+):
+    mock_database(current_revision=Constants.initial_revision)
+    alembic_util = mlrun.api.utils.alembic.AlembicUtil(pathlib.Path(""))
+    alembic_util.init_alembic(from_scratch=from_scratch)
+    assert mock_alembic.stamp_calls == []
+    assert mock_alembic.upgrade_calls == ["head"]
+    mock_shutil_copy.assert_called_once_with(
+        mock_db_file_name, pathlib.Path(f"{Constants.initial_revision}.db")
+    )
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_database_exists_unknown_revision_successful_downgrade(
+    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name, from_scratch
+):
+    mock_database(current_revision=Constants.unknown_revision)
+    alembic_util = mlrun.api.utils.alembic.AlembicUtil(pathlib.Path(""))
+    alembic_util.init_alembic(from_scratch=from_scratch)
+    assert mock_alembic.stamp_calls == []
+    assert mock_alembic.upgrade_calls == ["head"]
+    copy_calls = [
+        # first copy - to downgrade to the old db file
+        unittest.mock.call(
+            pathlib.Path(f"{Constants.latest_revision}.db"), mock_db_file_name
+        ),
+        # second copy - to back up the db file. In a real scenario the backup would be {latest_revision}.db
+        # as the revision should change during the last copy, but changing a mock during the init_alembic function
+        # is cumbersome and might make the test unreadable - so the current revision stays unknown_revision.
+        unittest.mock.call(
+            mock_db_file_name, pathlib.Path(f"{Constants.unknown_revision}.db")
+        ),
+    ]
+    mock_shutil_copy.assert_has_calls(copy_calls)
+
+
+@pytest.mark.parametrize("from_scratch", [True, False])
+def test_database_exists_unknown_revision_failed_downgrade(
+    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name, from_scratch
+):
+    mock_database(
+        current_revision=Constants.unknown_revision, db_backup_exists=False,
+    )
+    alembic_util = mlrun.api.utils.alembic.AlembicUtil(pathlib.Path(""))
+    with pytest.raises(
+        RuntimeError,
+        match=f"Cannot fall back to revision {Constants.latest_revision}, "
+        f"no back up exists. Current revision: {Constants.unknown_revision}",
+    ):
+        alembic_util.init_alembic(from_scratch=from_scratch)
+
+    assert mock_alembic.stamp_calls == []
+    assert mock_alembic.upgrade_calls == []
+    mock_shutil_copy.assert_not_called()
+
+
+@pytest.fixture()
+def mock_database(
+    monkeypatch, mock_alembic, mock_db_file_name
+) -> typing.Callable[[typing.List[str], str, bool, bool], None]:
+    def _mock_database(
+        revision_history: typing.List[str] = None,
+        current_revision: str = "",
+        db_file_exists: bool = True,
+        db_backup_exists: bool = True,
+    ):
+        revision_history = revision_history or Constants.revision_history
+
+        def _db_file_exists(file_name: str) -> bool:
+            if file_name == mock_db_file_name:
+                return db_file_exists
+            else:
+                return db_backup_exists
+
+        monkeypatch.setattr(os.path, "isfile", _db_file_exists)
+
+        def _current_revision(alembic_config: typing.Any):
+            if current_revision != "" and current_revision not in revision_history:
+                raise Exception(
+                    f"Can't locate revision identified by '{current_revision}'"
+                )
+
+            alembic_config.print_stdout(current_revision)
+
+        mock_alembic.current = _current_revision
+
+        def _revision_history(alembic_config: typing.Any):
+            for revision in revision_history:
+                alembic_config.print_stdout(f"none -> {revision}, revision name")
+
+        mock_alembic.history = _revision_history
+
+    return _mock_database
+
+
+@pytest.fixture()
+def mock_db_file_name(monkeypatch) -> str:
+    db_file_name = "test.db"
+    monkeypatch.setattr(mlconf.httpdb, "dsn", db_file_name)
+    return db_file_name
+
+
+@pytest.fixture()
+def mock_shutil_copy(monkeypatch) -> unittest.mock.Mock:
+    copy = unittest.mock.Mock()
+    monkeypatch.setattr(shutil, "copy2", copy)
+    return copy
+
+
+class MockAlembicCommand(object):
+    def __init__(self):
+        self.stamp_calls = []
+        self.upgrade_calls = []
+
+    def stamp(self, alembic_config: typing.Any, revision: str):
+        self.stamp_calls.append(revision)
+
+    def upgrade(self, alembic_config: typing.Any, revision: str):
+        self.upgrade_calls.append(revision)
+
+
+@pytest.fixture()
+def mock_alembic(monkeypatch) -> MockAlembicCommand:
+    mocked_alembic_command = MockAlembicCommand()
+    monkeypatch.setattr(alembic, "command", mocked_alembic_command)
+    monkeypatch.setattr(alembic.config, "Config", unittest.mock.Mock())
+    return mocked_alembic_command

--- a/tests/api/utils/test_alembic_util.py
+++ b/tests/api/utils/test_alembic_util.py
@@ -69,11 +69,15 @@ def test_database_exists_unknown_revision_successful_downgrade(
     assert mock_alembic.stamp_calls == []
     assert mock_alembic.upgrade_calls == ["head"]
     copy_calls = [
-        # first copy - to downgrade to the old db file
+        # first copy - backup the current database before downgrading
+        unittest.mock.call(
+            mock_db_file_name, pathlib.Path(f"{Constants.unknown_revision}.db")
+        ),
+        # second copy - to downgrade to the old db file
         unittest.mock.call(
             pathlib.Path(f"{Constants.latest_revision}.db"), mock_db_file_name
         ),
-        # second copy - to back up the db file. In a real scenario the backup would be {latest_revision}.db
+        # third copy - to back up the db file. In a real scenario the backup would be {latest_revision}.db
         # as the revision should change during the last copy, but changing a mock during the init_alembic function
         # is cumbersome and might make the test unreadable - so the current revision stays unknown_revision.
         unittest.mock.call(


### PR DESCRIPTION
When initializing the database:
- On db initialization a backup of the DB is made before the upgrade to the latest schema revision, with its previous alembic revision as its name (Any new backup overrides the old backup if it is the same revision)
- If the current DB revision doesn't exist in the known revision history, this means the DB is too new for the code, and we will try to fall back to the backup of the latest know revision.
- If no such backup exists - raise a RuntimeError and fail initializing the DB.

In addition - completely unit-tested the AlembicUtil