### PR TITLE
[Builder] Install specific mlrun version

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -74,6 +74,7 @@ jobs:
         action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
         export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
+        echo "::set-output name=mlrun_hash::$(echo $mlrun_hash)"
         echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
         echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-${{ steps.git_upstream_info.outputs.ui_hash }}"
         echo "::set-output name=mlrun_docker_repo::$( \
@@ -93,6 +94,7 @@ jobs:
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
+          "${{ steps.computed_params.outputs.mlrun_hash }}" \
           "${{ secrets.V06_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
           "${{ secrets.V06_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           "${{ secrets.V06_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }}" \
@@ -112,6 +114,7 @@ jobs:
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
+          "${{ steps.computed_params.outputs.mlrun_hash }}" \
           "${{ secrets.V05_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
           "${{ secrets.V05_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           "${{ secrets.V05_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }}" \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -94,7 +94,6 @@ jobs:
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
-          "${{ steps.computed_params.outputs.mlrun_hash }}" \
           "${{ secrets.V06_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
           "${{ secrets.V06_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           "${{ secrets.V06_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }}" \
@@ -104,6 +103,7 @@ jobs:
           "${{ secrets.V06_SYSTEM_TEST_USERNAME }}" \
           "${{ secrets.V06_SYSTEM_TEST_ACCESS_KEY }}" \
           "${{ secrets.V06_SYSTEM_TEST_PASSWORD }}" \
+          --mlrun-commit "${{ steps.computed_params.outputs.mlrun_hash }}" \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
           --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
           --override-mlrun-images \
@@ -114,7 +114,6 @@ jobs:
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
-          "${{ steps.computed_params.outputs.mlrun_hash }}" \
           "${{ secrets.V05_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
           "${{ secrets.V05_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           "${{ secrets.V05_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }}" \
@@ -124,6 +123,7 @@ jobs:
           "${{ secrets.V05_SYSTEM_TEST_USERNAME }}" \
           "${{ secrets.V05_SYSTEM_TEST_ACCESS_KEY }}" \
           "${{ secrets.V05_SYSTEM_TEST_PASSWORD }}" \
+          --mlrun-commit "${{ steps.computed_params.outputs.mlrun_hash }}" \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
           --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \
           --override-mlrun-images \

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -277,7 +277,11 @@ class SystemTestPreparer:
         )
 
     def _override_mlrun_api_env(self):
-        version_specifier = f"git+https://github.com/mlrun/mlrun@{self._mlrun_commit}" if self._mlrun_commit else "mlrun"
+        version_specifier = (
+            f"git+https://github.com/mlrun/mlrun@{self._mlrun_commit}"
+            if self._mlrun_commit
+            else "mlrun"
+        )
         data = {
             "MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER": version_specifier,
         }

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -86,9 +86,6 @@ class SystemTestPreparer:
 
         self._override_mlrun_api_env()
 
-        if self._override_image_registry:
-            self._override_k8s_mlrun_registry()
-
         provctl_path = self._download_provctl()
         self._patch_mlrun(provctl_path)
 

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -31,6 +31,7 @@ class SystemTestPreparer:
     def __init__(
         self,
         mlrun_version: str,
+        mlrun_commit: str,
         override_image_registry: str,
         override_image_repo: str,
         override_mlrun_images: str,
@@ -48,6 +49,7 @@ class SystemTestPreparer:
         self._logger = logger
         self._debug = debug
         self._mlrun_version = mlrun_version
+        self._mlrun_commit = mlrun_commit
         self._override_image_registry = override_image_registry.strip().strip("/") + "/"
         self._override_image_repo = override_image_repo
         self._override_mlrun_images = override_mlrun_images
@@ -81,6 +83,8 @@ class SystemTestPreparer:
         self.clean_up_remote_workdir(close_ssh_client=False)
 
         self._prepare_test_env()
+
+        self._override_mlrun_api_env()
 
         if self._override_image_registry:
             self._override_k8s_mlrun_registry()
@@ -272,11 +276,16 @@ class SystemTestPreparer:
             "cat > ", args=[filepath], stdin=contents, local=True,
         )
 
-    def _override_k8s_mlrun_registry(self):
-        mlrun_registry_override = self._override_image_registry.strip().strip("/") + "/"
+    def _override_mlrun_api_env(self):
+        version_specifier = f"git+https://github.com/mlrun/mlrun@{self._mlrun_commit}" if self._mlrun_commit else "mlrun"
+        data = {
+            "MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER": version_specifier,
+        }
+        if self._override_image_registry:
+            data["MLRUN_IMAGES_REGISTRY"] = f"{self._override_image_registry}"
         override_mlrun_registry_manifest = {
             "apiVersion": "v1",
-            "data": {"MLRUN_IMAGES_REGISTRY": f"{mlrun_registry_override}"},
+            "data": data,
             "kind": "ConfigMap",
             "metadata": {"name": "mlrun-override-env", "namespace": "default-tenant"},
         }
@@ -377,6 +386,12 @@ def main():
     default=None,
     help="Override default images (comma delimited list).",
 )
+@click.option(
+    "--mlrun-commit",
+    "-mc",
+    default=None,
+    help="The commit (in mlrun/mlrun) of the tested mlrun version.",
+)
 @click.argument("data-cluster-ip", type=str, required=True)
 @click.argument("data-cluster-ssh-password", type=str, required=True)
 @click.argument("app-cluster-ssh-password", type=str, required=True)
@@ -394,6 +409,7 @@ def main():
 )
 def run(
     mlrun_version: str,
+    mlrun_commit: str,
     override_image_registry: str,
     override_image_repo: str,
     override_mlrun_images: str,
@@ -410,6 +426,7 @@ def run(
 ):
     system_test_preparer = SystemTestPreparer(
         mlrun_version,
+        mlrun_commit,
         override_image_registry,
         override_image_repo,
         override_mlrun_images,

--- a/examples/mlrun_jobs.ipynb
+++ b/examples/mlrun_jobs.ipynb
@@ -1016,7 +1016,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer.deploy()"
+    "trainer.deploy(with_mlrun=False)"
    ]
   },
   {

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -108,8 +108,9 @@ async def build_function(
     logger.info("build_function:\n{}".format(data))
     function = data.get("function")
     with_mlrun = strtobool(data.get("with_mlrun", "on"))
+    mlrun_version_specifier = data.get("mlrun_version_specifier")
     fn, ready = await run_in_threadpool(
-        _build_function, db_session, function, with_mlrun
+        _build_function, db_session, function, with_mlrun, mlrun_version_specifier
     )
     return {
         "data": fn.to_dict(),
@@ -259,7 +260,7 @@ def build_status(
     )
 
 
-def _build_function(db_session, function, with_mlrun):
+def _build_function(db_session, function, with_mlrun, mlrun_version_specifier):
     fn = None
     ready = None
     try:
@@ -273,7 +274,7 @@ def _build_function(db_session, function, with_mlrun):
             # deploy only start the process, the get status API is used to check readiness
             ready = False
         else:
-            ready = build_runtime(fn, with_mlrun)
+            ready = build_runtime(fn, with_mlrun, mlrun_version_specifier)
         fn.save(versioned=True)
         logger.info("Fn:\n %s", fn.to_yaml())
     except Exception as err:

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 import tarfile
-import semver
 from base64 import b64decode, b64encode
 from os import path, remove
 from tempfile import mktemp
 from urllib.parse import urlparse
 
+from .config import config
 from .datastore import store_manager
 from .k8s_utils import BasePod, get_k8s_helper
 from .utils import logger, normalize_name, enrich_image_url, get_parsed_docker_registry
-from .config import config
 
 
 def make_dockerfile(
@@ -237,8 +236,8 @@ def _resolve_mlrun_install_command(mlrun_version_specifier):
     if not mlrun_version_specifier:
         if config.httpdb.builder.mlrun_version_specifier:
             mlrun_version_specifier = config.httpdb.builder.mlrun_version_specifier
-        elif config.version == 'unstable':
-            mlrun_version_specifier = 'git+https://github.com/mlrun/mlrun@development'
+        elif config.version == "unstable":
+            mlrun_version_specifier = "git+https://github.com/mlrun/mlrun@development"
         else:
             mlrun_version_specifier = f"{config.package_path}=={config.version}"
     return f"pip install {mlrun_version_specifier}"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -104,6 +104,10 @@ default_config = {
             # index.docker.io/<username>, if not included repository will default to mlrun
             "docker_registry": "",
             "docker_registry_secret": "",
+            # the requirement specifier used by the builder when installing mlrun in images when it runs
+            # pip install <requirement_specifier>, e.g. mlrun==0.5.4, mlrun~=0.5,
+            # git+https://github.com/mlrun/mlrun@development. by default uses the version
+            "mlrun_version_specifier": "",
         },
     },
 }

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -497,9 +497,11 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed invoking schedule {project}/{name}"
         self.api_call("POST", path, error_message)
 
-    def remote_builder(self, func, with_mlrun):
+    def remote_builder(self, func, with_mlrun, mlrun_version_specifier=None):
         try:
             req = {"function": func.to_dict(), "with_mlrun": bool2str(with_mlrun)}
+            if mlrun_version_specifier:
+                req["mlrun_version_specifier"] = mlrun_version_specifier
             resp = self.api_call("POST", "build/function", json=req)
         except OSError as err:
             logger.error("error submitting build task: {}".format(err))

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -107,7 +107,7 @@ class KubejobRuntime(KubeResource):
     def build(self, **kw):
         raise ValueError(".build() is deprecated, use .deploy() instead")
 
-    def deploy(self, watch=True, with_mlrun=True, skip_deployed=False, is_kfp=False):
+    def deploy(self, watch=True, with_mlrun=True, skip_deployed=False, is_kfp=False, mlrun_version_specifier=None):
         """deploy function, build container with dependencies"""
 
         if skip_deployed and self.is_deployed:
@@ -147,7 +147,7 @@ class KubejobRuntime(KubeResource):
             logger.info(
                 "starting remote build, image: {}".format(self.spec.build.image)
             )
-            data = db.remote_builder(self, with_mlrun)
+            data = db.remote_builder(self, with_mlrun, mlrun_version_specifier)
             self.status = data["data"].get("status", None)
             self.spec.image = get_in(data, "data.spec.image")
             ready = data.get("ready", False)
@@ -157,7 +157,7 @@ class KubejobRuntime(KubeResource):
                 self.status.state = state
         else:
             self.save(versioned=False)
-            ready = build_runtime(self, with_mlrun, watch or is_kfp)
+            ready = build_runtime(self, with_mlrun, mlrun_version_specifier, watch or is_kfp)
             self.save(versioned=False)
 
         return ready

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -107,7 +107,14 @@ class KubejobRuntime(KubeResource):
     def build(self, **kw):
         raise ValueError(".build() is deprecated, use .deploy() instead")
 
-    def deploy(self, watch=True, with_mlrun=True, skip_deployed=False, is_kfp=False, mlrun_version_specifier=None):
+    def deploy(
+        self,
+        watch=True,
+        with_mlrun=True,
+        skip_deployed=False,
+        is_kfp=False,
+        mlrun_version_specifier=None,
+    ):
         """deploy function, build container with dependencies"""
 
         if skip_deployed and self.is_deployed:
@@ -157,7 +164,9 @@ class KubejobRuntime(KubeResource):
                 self.status.state = state
         else:
             self.save(versioned=False)
-            ready = build_runtime(self, with_mlrun, mlrun_version_specifier, watch or is_kfp)
+            ready = build_runtime(
+                self, with_mlrun, mlrun_version_specifier, watch or is_kfp
+            )
             self.save(versioned=False)
 
         return ready

--- a/tests/system/examples/jobs/test_jobs.py
+++ b/tests/system/examples/jobs/test_jobs.py
@@ -31,7 +31,7 @@ class TestJobs(TestMLRunSystem):
         self._trainer.apply(mount_v3io())
 
         self._logger.debug("Deploying trainer")
-        self._trainer.deploy()
+        self._trainer.deploy(with_mlrun=False)
 
     def test_run_training_job(self):
         output_path = str(self.results_path / "{{run.uid}}")


### PR DESCRIPTION
So far when `with_mlrun` was true (the default) the builder added `pip install mlrun` command to the dockerfile, but that would install the latest mlrun, which is not surely the mlrun we want.
Add logic in the builder which resolves the version specifier in this precedence:
1. version given from the client
2. default specifier configured on the server
3. `git+https://github.com/mlrun/mlrun@development` if the version is `unstable` else `mlrun==<version>`

Fixed the system tests to use that new option and pass the tested version to be used by the builder
