### PR TITLE
[Dask] Change start cluster endpoint to be async 

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -50,7 +50,11 @@ class SystemTestPreparer:
         self._debug = debug
         self._mlrun_version = mlrun_version
         self._mlrun_commit = mlrun_commit
-        self._override_image_registry = override_image_registry.strip().strip("/") + "/" if override_image_registry is not None else override_image_registry
+        self._override_image_registry = (
+            override_image_registry.strip().strip("/") + "/"
+            if override_image_registry is not None
+            else override_image_registry
+        )
         self._override_image_repo = override_image_repo
         self._override_mlrun_images = override_mlrun_images
         self._data_cluster_ip = data_cluster_ip

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -50,7 +50,7 @@ class SystemTestPreparer:
         self._debug = debug
         self._mlrun_version = mlrun_version
         self._mlrun_commit = mlrun_commit
-        self._override_image_registry = override_image_registry.strip().strip("/") + "/"
+        self._override_image_registry = override_image_registry.strip().strip("/") + "/" if override_image_registry is not None else override_image_registry
         self._override_image_repo = override_image_repo
         self._override_mlrun_images = override_mlrun_images
         self._data_cluster_ip = data_cluster_ip

--- a/mlrun/api/api/api.py
+++ b/mlrun/api/api/api.py
@@ -24,7 +24,9 @@ api_router.include_router(
     artifacts.router, tags=["artifacts"], dependencies=[Depends(deps.AuthVerifier)]
 )
 api_router.include_router(
-    background_tasks.router, tags=["background-tasks"], dependencies=[Depends(deps.AuthVerifier)]
+    background_tasks.router,
+    tags=["background-tasks"],
+    dependencies=[Depends(deps.AuthVerifier)],
 )
 api_router.include_router(
     files.router, tags=["files"], dependencies=[Depends(deps.AuthVerifier)]

--- a/mlrun/api/api/api.py
+++ b/mlrun/api/api/api.py
@@ -62,6 +62,6 @@ api_router.include_router(
 )
 api_router.include_router(
     feature_sets.router,
-    tags=["feature_sets"],
+    tags=["feature-sets"],
     dependencies=[Depends(deps.AuthVerifier)],
 )

--- a/mlrun/api/api/api.py
+++ b/mlrun/api/api/api.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from mlrun.api.api import deps
 from mlrun.api.api.endpoints import (
     artifacts,
+    background_tasks,
     files,
     functions,
     healthz,
@@ -21,6 +22,9 @@ from mlrun.api.api.endpoints import (
 api_router = APIRouter()
 api_router.include_router(
     artifacts.router, tags=["artifacts"], dependencies=[Depends(deps.AuthVerifier)]
+)
+api_router.include_router(
+    background_tasks.router, tags=["background-tasks"], dependencies=[Depends(deps.AuthVerifier)]
 )
 api_router.include_router(
     files.router, tags=["files"], dependencies=[Depends(deps.AuthVerifier)]

--- a/mlrun/api/api/endpoints/background_tasks.py
+++ b/mlrun/api/api/endpoints/background_tasks.py
@@ -1,0 +1,14 @@
+import fastapi
+
+import mlrun.api.schemas
+import mlrun.api.utils.background_tasks
+
+router = fastapi.APIRouter()
+
+
+@router.get("/projects/{project}/background-tasks/{name}", response_model=mlrun.api.schemas.BackgroundTask)
+def get_background_task(
+    project: str,
+    name: str,
+):
+    return mlrun.api.utils.background_tasks.Handler().get_background_task(project, name)

--- a/mlrun/api/api/endpoints/background_tasks.py
+++ b/mlrun/api/api/endpoints/background_tasks.py
@@ -6,9 +6,11 @@ import mlrun.api.utils.background_tasks
 router = fastapi.APIRouter()
 
 
-@router.get("/projects/{project}/background-tasks/{name}", response_model=mlrun.api.schemas.BackgroundTask)
+@router.get(
+    "/projects/{project}/background-tasks/{name}",
+    response_model=mlrun.api.schemas.BackgroundTask,
+)
 def get_background_task(
-    project: str,
-    name: str,
+    project: str, name: str,
 ):
     return mlrun.api.utils.background_tasks.Handler().get_background_task(project, name)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -3,12 +3,15 @@ from distutils.util import strtobool
 from http import HTTPStatus
 from typing import List
 
-from fastapi import APIRouter, Depends, Request, Query, Response
+from fastapi import APIRouter, Depends, Request, Query, Response, BackgroundTasks
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 from mlrun.api.api import deps
 from mlrun.api.api.utils import log_and_raise, get_run_db_instance
+import mlrun.api.utils.background_tasks
+import mlrun.api.db.session
+import mlrun.api.schemas
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.builder import build_runtime
@@ -119,10 +122,10 @@ async def build_function(
 
 
 # curl -d@/path/to/job.json http://localhost:8080/start/function
-@router.post("/start/function")
-@router.post("/start/function/")
+@router.post("/start/function", response_model=mlrun.api.schemas.BackgroundTask)
+@router.post("/start/function/", response_model=mlrun.api.schemas.BackgroundTask)
 async def start_function(
-    request: Request, db_session: Session = Depends(deps.get_db_session)
+    request: Request, background_tasks: BackgroundTasks, db_session: Session = Depends(deps.get_db_session),
 ):
     data = None
     try:
@@ -130,11 +133,13 @@ async def start_function(
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
-    fn = await run_in_threadpool(_start_function, db_session, data)
+    logger.info("Got request to start function", body=data)
 
-    return {
-        "data": fn.to_dict(),
-    }
+    function = _parse_start_function_body(db_session, data)
+
+    background_task = mlrun.api.utils.background_tasks.Handler().create_background_task(db_session, function.metadata.project, background_tasks, _start_function, function)
+
+    return background_task
 
 
 # curl -d@/path/to/job.json http://localhost:8080/status/function
@@ -285,8 +290,7 @@ def _build_function(db_session, function, with_mlrun, mlrun_version_specifier):
     return fn, ready
 
 
-def _start_function(db_session, data):
-    logger.info("start_function:\n{}".format(data))
+def _parse_start_function_body(db_session, data):
     url = data.get("functionUrl")
     if not url:
         log_and_raise(
@@ -302,29 +306,32 @@ def _start_function(db_session, data):
             reason="runtime error: function {} not found".format(url),
         )
 
-    fn = new_function(runtime=runtime)
-    resource = runtime_resources_map.get(fn.kind)
-    if "start" not in resource:
-        log_and_raise(
-            HTTPStatus.BAD_REQUEST.value,
-            reason="runtime error: 'start' not supported by this runtime",
-        )
+    return new_function(runtime=runtime)
 
+
+def _start_function(function):
+    db_session = mlrun.api.db.session.create_session()
     try:
-
-        run_db = get_run_db_instance(db_session)
-        fn.set_db_connection(run_db)
-        #  resp = resource["start"](fn)  # TODO: handle resp?
-        resource["start"](fn)
-        fn.save(versioned=False)
-        logger.info("Fn:\n %s", fn.to_yaml())
-    except Exception as err:
-        logger.error(traceback.format_exc())
-        log_and_raise(
-            HTTPStatus.BAD_REQUEST.value, reason="runtime error: {}".format(err)
-        )
-
-    return fn
+        resource = runtime_resources_map.get(function.kind)
+        if "start" not in resource:
+            log_and_raise(
+                HTTPStatus.BAD_REQUEST.value,
+                reason="runtime error: 'start' not supported by this runtime",
+            )
+        try:
+            run_db = get_run_db_instance(db_session)
+            function.set_db_connection(run_db)
+            #  resp = resource["start"](fn)  # TODO: handle resp?
+            resource["start"](function)
+            function.save(versioned=False)
+            logger.info("Fn:\n %s", function.to_yaml())
+        except Exception as err:
+            logger.error(traceback.format_exc())
+            log_and_raise(
+                HTTPStatus.BAD_REQUEST.value, reason="runtime error: {}".format(err)
+            )
+    finally:
+        mlrun.api.db.session.close_session(db_session)
 
 
 def _get_function_status(data):

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -7,11 +7,11 @@ from fastapi import APIRouter, Depends, Request, Query, Response, BackgroundTask
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
-from mlrun.api.api import deps
-from mlrun.api.api.utils import log_and_raise, get_run_db_instance
-import mlrun.api.utils.background_tasks
 import mlrun.api.db.session
 import mlrun.api.schemas
+import mlrun.api.utils.background_tasks
+from mlrun.api.api import deps
+from mlrun.api.api.utils import log_and_raise, get_run_db_instance
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.builder import build_runtime
@@ -125,7 +125,9 @@ async def build_function(
 @router.post("/start/function", response_model=mlrun.api.schemas.BackgroundTask)
 @router.post("/start/function/", response_model=mlrun.api.schemas.BackgroundTask)
 async def start_function(
-    request: Request, background_tasks: BackgroundTasks, db_session: Session = Depends(deps.get_db_session),
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db_session: Session = Depends(deps.get_db_session),
 ):
     data = None
     try:
@@ -137,7 +139,13 @@ async def start_function(
 
     function = _parse_start_function_body(db_session, data)
 
-    background_task = mlrun.api.utils.background_tasks.Handler().create_background_task(db_session, function.metadata.project, background_tasks, _start_function, function)
+    background_task = mlrun.api.utils.background_tasks.Handler().create_background_task(
+        db_session,
+        function.metadata.project,
+        background_tasks,
+        _start_function,
+        function,
+    )
 
     return background_task
 

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -1,7 +1,13 @@
 # flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
 from .artifact import ArtifactCategories
-from .background_task import BackgroundTaskState, BackgroundTask, BackgroundTaskMetadata, BackgroundTaskSpec, BackgroundTaskStatus
+from .background_task import (
+    BackgroundTaskState,
+    BackgroundTask,
+    BackgroundTaskMetadata,
+    BackgroundTaskSpec,
+    BackgroundTaskStatus,
+)
 from .constants import Format, PatchMode, HeaderNames
 from .feature_store import (
     Feature,

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
 from .artifact import ArtifactCategories
+from .background_task import BackgroundTaskState, BackgroundTask, BackgroundTaskMetadata, BackgroundTaskSpec, BackgroundTaskStatus
 from .constants import Format, PatchMode, HeaderNames
 from .feature_store import (
     Feature,

--- a/mlrun/api/schemas/background_task.py
+++ b/mlrun/api/schemas/background_task.py
@@ -12,6 +12,13 @@ class BackgroundTaskState(str, enum.Enum):
     failed = "failed"
     running = "running"
 
+    @staticmethod
+    def terminal_states():
+        return [
+            BackgroundTaskState.succeeded,
+            BackgroundTaskState.failed,
+        ]
+
 
 class BackgroundTaskMetadata(pydantic.BaseModel):
     name: str

--- a/mlrun/api/schemas/background_task.py
+++ b/mlrun/api/schemas/background_task.py
@@ -1,0 +1,34 @@
+import datetime
+import enum
+import typing
+
+import pydantic
+
+import mlrun.api.schemas.object
+
+
+class BackgroundTaskState(str, enum.Enum):
+    succeeded = "succeeded"
+    failed = "failed"
+    running = "running"
+
+
+class BackgroundTaskMetadata(pydantic.BaseModel):
+    name: str
+    created: typing.Optional[datetime.datetime]
+    updated: typing.Optional[datetime.datetime]
+
+
+class BackgroundTaskSpec(pydantic.BaseModel):
+    pass
+
+
+class BackgroundTaskStatus(pydantic.BaseModel):
+    state: BackgroundTaskState
+
+
+class BackgroundTask(pydantic.BaseModel):
+    kind: mlrun.api.schemas.object.ObjectKind = pydantic.Field(mlrun.api.schemas.object.ObjectKind.feature_set, const=True)
+    metadata: BackgroundTaskMetadata
+    spec: BackgroundTaskSpec
+    status: BackgroundTaskStatus

--- a/mlrun/api/schemas/background_task.py
+++ b/mlrun/api/schemas/background_task.py
@@ -28,7 +28,9 @@ class BackgroundTaskStatus(pydantic.BaseModel):
 
 
 class BackgroundTask(pydantic.BaseModel):
-    kind: mlrun.api.schemas.object.ObjectKind = pydantic.Field(mlrun.api.schemas.object.ObjectKind.feature_set, const=True)
+    kind: mlrun.api.schemas.object.ObjectKind = pydantic.Field(
+        mlrun.api.schemas.object.ObjectKind.feature_set, const=True
+    )
     metadata: BackgroundTaskMetadata
     spec: BackgroundTaskSpec
     status: BackgroundTaskStatus

--- a/mlrun/api/schemas/background_task.py
+++ b/mlrun/api/schemas/background_task.py
@@ -15,6 +15,7 @@ class BackgroundTaskState(str, enum.Enum):
 
 class BackgroundTaskMetadata(pydantic.BaseModel):
     name: str
+    project: str
     created: typing.Optional[datetime.datetime]
     updated: typing.Optional[datetime.datetime]
 

--- a/mlrun/api/schemas/background_task.py
+++ b/mlrun/api/schemas/background_task.py
@@ -4,7 +4,7 @@ import typing
 
 import pydantic
 
-import mlrun.api.schemas.object
+from .object import ObjectKind
 
 
 class BackgroundTaskState(str, enum.Enum):
@@ -36,8 +36,8 @@ class BackgroundTaskStatus(pydantic.BaseModel):
 
 
 class BackgroundTask(pydantic.BaseModel):
-    kind: mlrun.api.schemas.object.ObjectKind = pydantic.Field(
-        mlrun.api.schemas.object.ObjectKind.feature_set, const=True
+    kind: ObjectKind = pydantic.Field(
+        ObjectKind.background_task, const=True
     )
     metadata: BackgroundTaskMetadata
     spec: BackgroundTaskSpec

--- a/mlrun/api/schemas/background_task.py
+++ b/mlrun/api/schemas/background_task.py
@@ -36,9 +36,7 @@ class BackgroundTaskStatus(pydantic.BaseModel):
 
 
 class BackgroundTask(pydantic.BaseModel):
-    kind: ObjectKind = pydantic.Field(
-        ObjectKind.background_task, const=True
-    )
+    kind: ObjectKind = pydantic.Field(ObjectKind.background_task, const=True)
     metadata: BackgroundTaskMetadata
     spec: BackgroundTaskSpec
     status: BackgroundTaskStatus

--- a/mlrun/api/schemas/object.py
+++ b/mlrun/api/schemas/object.py
@@ -55,4 +55,5 @@ class ObjectRecord(BaseModel):
 
 class ObjectKind(str, Enum):
     feature_set = "FeatureSet"
+    background_task = "BackgroundTask"
     feature_vector = "FeatureVector"

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -36,7 +36,7 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
             raise RuntimeError("Background task name already exists")
         self._save_background_task(db_session, project, name)
         background_tasks.add_task(
-            self.background_task_wrapper, name, function, *args, **kwargs
+            self.background_task_wrapper, project, name, function, *args, **kwargs
         )
         return self.get_background_task(project, name)
 
@@ -49,12 +49,13 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
         metadata = mlrun.api.schemas.BackgroundTaskMetadata(
             name=name, project=project, created=datetime.datetime.utcnow()
         )
+        spec = mlrun.api.schemas.BackgroundTaskSpec()
         status = mlrun.api.schemas.BackgroundTaskStatus(
             state=mlrun.api.schemas.BackgroundTaskState.running
         )
         self._background_tasks.setdefault(project, {})[
             name
-        ] = mlrun.api.schemas.BackgroundTask(metadata=metadata, status=status)
+        ] = mlrun.api.schemas.BackgroundTask(metadata=metadata, spec=spec, status=status)
 
     def get_background_task(
         self, project: str, name: str
@@ -72,6 +73,7 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
                 metadata=mlrun.api.schemas.BackgroundTaskMetadata(
                     name=name, project=project
                 ),
+                spec=mlrun.api.schemas.BackgroundTaskSpec(),
                 status=mlrun.api.schemas.BackgroundTaskStatus(
                     state=mlrun.api.schemas.BackgroundTaskState.failed
                 ),

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -1,33 +1,45 @@
 import asyncio
 import datetime
+import traceback
 import typing
-from mlrun.utils import logger
-import mlrun.utils.singleton
+import uuid
+
 import fastapi
 import fastapi.concurrency
-import uuid
-import mlrun.errors
-import traceback
+
 import mlrun.api.schemas
+import mlrun.errors
+import mlrun.utils.singleton
+from mlrun.utils import logger
 
 
 class Handler(metaclass=mlrun.utils.singleton.Singleton):
     def __init__(self):
         self._background_tasks: typing.Dict[str, mlrun.api.schemas.BackgroundTask] = {}
 
-    def create_background_task(self, background_tasks: fastapi.BackgroundTasks, function, *args, **kwargs) -> mlrun.api.schemas.BackgroundTask:
+    def create_background_task(
+        self, background_tasks: fastapi.BackgroundTasks, function, *args, **kwargs
+    ) -> mlrun.api.schemas.BackgroundTask:
         name = str(uuid.uuid4())
         # sanity
         if name in self._background_tasks:
             raise RuntimeError("Background task name already exists")
-        self._create_background_task(name)
-        background_tasks.add_task(self.background_task_wrapper, name, function, *args, **kwargs)
+        self._save_background_task(name)
+        background_tasks.add_task(
+            self.background_task_wrapper, name, function, *args, **kwargs
+        )
         return self.get_background_task(name)
 
-    def _create_background_task(self, name: str):
-        metadata = mlrun.api.schemas.BackgroundTaskMetadata(name=name, created=datetime.datetime.utcnow())
-        status = mlrun.api.schemas.BackgroundTaskStatus(state=mlrun.api.schemas.BackgroundTaskState.running)
-        self._background_tasks[name] = mlrun.api.schemas.BackgroundTask(metadata=metadata, status=status)
+    def _save_background_task(self, name: str):
+        metadata = mlrun.api.schemas.BackgroundTaskMetadata(
+            name=name, created=datetime.datetime.utcnow()
+        )
+        status = mlrun.api.schemas.BackgroundTaskStatus(
+            state=mlrun.api.schemas.BackgroundTaskState.running
+        )
+        self._background_tasks[name] = mlrun.api.schemas.BackgroundTask(
+            metadata=metadata, status=status
+        )
 
     def get_background_task(self, name: str) -> mlrun.api.schemas.BackgroundTask:
         if name in self._background_tasks:
@@ -36,9 +48,16 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
             # in order to keep things simple we don't persist the background tasks to the DB
             # If for some reason get is called and the background task doesn't exist, it means that probably we got
             # restarted, therefore we want to return a failed background task so the client will retry (if needed)
-            return mlrun.api.schemas.BackgroundTask(metadata=mlrun.api.schemas.BackgroundTaskMetadata(name=name), status=mlrun.api.schemas.BackgroundTaskStatus(state=mlrun.api.schemas.BackgroundTaskState.failed))
+            return mlrun.api.schemas.BackgroundTask(
+                metadata=mlrun.api.schemas.BackgroundTaskMetadata(name=name),
+                status=mlrun.api.schemas.BackgroundTaskStatus(
+                    state=mlrun.api.schemas.BackgroundTaskState.failed
+                ),
+            )
 
-    async def background_task_wrapper(self, background_task_name: str, function, *args, **kwargs):
+    async def background_task_wrapper(
+        self, background_task_name: str, function, *args, **kwargs
+    ):
         try:
             if asyncio.iscoroutinefunction(function):
                 await function(*args, **kwargs)
@@ -48,11 +67,17 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
             logger.warning(
                 f"Failed during background task execution: {function.__name__}, exc: {traceback.format_exc()}"
             )
-            self._update_background_task(background_task_name, mlrun.api.schemas.BackgroundTaskState.failed)
+            self._update_background_task(
+                background_task_name, mlrun.api.schemas.BackgroundTaskState.failed
+            )
         finally:
-            self._update_background_task(background_task_name, mlrun.api.schemas.BackgroundTaskState.succeeded)
+            self._update_background_task(
+                background_task_name, mlrun.api.schemas.BackgroundTaskState.succeeded
+            )
 
-    def _update_background_task(self, name: str, state: mlrun.api.schemas.BackgroundTaskState):
+    def _update_background_task(
+        self, name: str, state: mlrun.api.schemas.BackgroundTaskState
+    ):
         background_task = self._background_tasks[name]
         background_task.status.state = state
         background_task.metadata.updated = datetime.datetime.utcnow()

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -96,7 +96,7 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
             self._update_background_task(
                 project, name, mlrun.api.schemas.BackgroundTaskState.failed
             )
-        finally:
+        else:
             self._update_background_task(
                 project, name, mlrun.api.schemas.BackgroundTaskState.succeeded
             )

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -55,7 +55,9 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
         )
         self._background_tasks.setdefault(project, {})[
             name
-        ] = mlrun.api.schemas.BackgroundTask(metadata=metadata, spec=spec, status=status)
+        ] = mlrun.api.schemas.BackgroundTask(
+            metadata=metadata, spec=spec, status=status
+        )
 
     def get_background_task(
         self, project: str, name: str

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -1,0 +1,58 @@
+import asyncio
+import datetime
+import typing
+from mlrun.utils import logger
+import mlrun.utils.singleton
+import fastapi
+import fastapi.concurrency
+import uuid
+import mlrun.errors
+import traceback
+import mlrun.api.schemas
+
+
+class Handler(metaclass=mlrun.utils.singleton.Singleton):
+    def __init__(self):
+        self._background_tasks: typing.Dict[str, mlrun.api.schemas.BackgroundTask] = {}
+
+    def create_background_task(self, background_tasks: fastapi.BackgroundTasks, function, *args, **kwargs) -> mlrun.api.schemas.BackgroundTask:
+        name = str(uuid.uuid4())
+        # sanity
+        if name in self._background_tasks:
+            raise RuntimeError("Background task name already exists")
+        self._create_background_task(name)
+        background_tasks.add_task(self.background_task_wrapper, name, function, *args, **kwargs)
+        return self.get_background_task(name)
+
+    def _create_background_task(self, name: str):
+        metadata = mlrun.api.schemas.BackgroundTaskMetadata(name=name, created=datetime.datetime.utcnow())
+        status = mlrun.api.schemas.BackgroundTaskStatus(state=mlrun.api.schemas.BackgroundTaskState.running)
+        self._background_tasks[name] = mlrun.api.schemas.BackgroundTask(metadata=metadata, status=status)
+
+    def get_background_task(self, name: str) -> mlrun.api.schemas.BackgroundTask:
+        if name in self._background_tasks:
+            return self._background_tasks[name]
+        else:
+            # in order to keep things simple we don't persist the background tasks to the DB
+            # If for some reason get is called and the background task doesn't exist, it means that probably we got
+            # restarted, therefore we want to return a failed background task so the client will retry (if needed)
+            return mlrun.api.schemas.BackgroundTask(metadata=mlrun.api.schemas.BackgroundTaskMetadata(name=name), status=mlrun.api.schemas.BackgroundTaskStatus(state=mlrun.api.schemas.BackgroundTaskState.failed))
+
+    async def background_task_wrapper(self, background_task_name: str, function, *args, **kwargs):
+        try:
+            if asyncio.iscoroutinefunction(function):
+                await function(*args, **kwargs)
+            else:
+                await fastapi.concurrency.run_in_threadpool(function, *args, **kwargs)
+        except Exception:
+            logger.warning(
+                f"Failed during background task execution: {function.__name__}, exc: {traceback.format_exc()}"
+            )
+            self._update_background_task(background_task_name, mlrun.api.schemas.BackgroundTaskState.failed)
+        finally:
+            self._update_background_task(background_task_name, mlrun.api.schemas.BackgroundTaskState.succeeded)
+
+    def _update_background_task(self, name: str, state: mlrun.api.schemas.BackgroundTaskState):
+        background_task = self._background_tasks[name]
+        background_task.status.state = state
+        background_task.metadata.updated = datetime.datetime.utcnow()

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -69,7 +69,9 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
             # If for some reason get is called and the background task doesn't exist, it means that probably we got
             # restarted, therefore we want to return a failed background task so the client will retry (if needed)
             return mlrun.api.schemas.BackgroundTask(
-                metadata=mlrun.api.schemas.BackgroundTaskMetadata(name=name),
+                metadata=mlrun.api.schemas.BackgroundTaskMetadata(
+                    name=name, project=project
+                ),
                 status=mlrun.api.schemas.BackgroundTaskStatus(
                     state=mlrun.api.schemas.BackgroundTaskState.failed
                 ),

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -552,7 +552,7 @@ class HTTPRunDB(RunDBInterface):
             text = resp.content.decode()
         return text, last_log_timestamp
 
-    def remote_start(self, func_url):
+    def remote_start(self, func_url) -> schemas.BackgroundTask:
         try:
             req = {"functionUrl": func_url}
             resp = self.api_call(
@@ -569,7 +569,16 @@ class HTTPRunDB(RunDBInterface):
             logger.error("bad resp!!\n{}".format(resp.text))
             raise ValueError("bad function start response")
 
-        return resp.json()["data"]
+        return schemas.BackgroundTask(**resp.json())
+
+    def get_background_task(self, project: str, name: str,) -> schemas.BackgroundTask:
+        project = project or default_project
+        path = f"projects/{project}/background-tasks/{name}"
+        error_message = (
+            f"Failed getting background task. project={project}, name={name}"
+        )
+        response = self.api_call("GET", path, error_message)
+        return schemas.BackgroundTask(**response.json())
 
     def remote_status(self, kind, selector):
         try:

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -102,6 +102,7 @@ class DaskSpec(KubeResourceSpec):
         self.node_port = node_port
         self.min_replicas = min_replicas or 0
         self.max_replicas = max_replicas or 16
+        # supported format according to https://github.com/dask/dask/blob/master/dask/utils.py#L1402
         self.scheduler_timeout = scheduler_timeout or "60 minutes"
         self.nthreads = nthreads or 1
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -208,9 +208,9 @@ class DaskCluster(KubejobRuntime):
                         return
                     time.sleep(5)
                     now = datetime.datetime.utcnow()
-
-        self._cluster = deploy_function(self)
-        self.save(versioned=False)
+        else:
+            self._cluster = deploy_function(self)
+            self.save(versioned=False)
 
     def close(self, running=True):
         from dask.distributed import default_client

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -205,14 +205,14 @@ class DaskCluster(KubejobRuntime):
                         background_task.status.state
                         in mlrun.api.schemas.BackgroundTaskState.terminal_states()
                     ):
+                        function = db.get_function(
+                            self.metadata.name, self.metadata.project, self.metadata.tag
+                        )
+                        if function and function.get("status"):
+                            self.status = function.get("status")
                         return
                     time.sleep(5)
                     now = datetime.datetime.utcnow()
-                function = db.get_function(
-                    self.metadata.name, self.metadata.project, self.metadata.tag
-                )
-                if function and function.get("status"):
-                    self.status = function.get("status")
         else:
             self._cluster = deploy_function(self)
             self.save(versioned=False)

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -208,7 +208,9 @@ class DaskCluster(KubejobRuntime):
                         return
                     time.sleep(5)
                     now = datetime.datetime.utcnow()
-                function = db.get_function(self.metadata.name, self.metadata.project, self.metadata.tag)
+                function = db.get_function(
+                    self.metadata.name, self.metadata.project, self.metadata.tag
+                )
                 if function and function.get("status"):
                     self.status = function.get("status")
         else:

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -208,6 +208,9 @@ class DaskCluster(KubejobRuntime):
                         return
                     time.sleep(5)
                     now = datetime.datetime.utcnow()
+                function = db.get_function(self.metadata.name, self.metadata.project, self.metadata.tag)
+                if function and function.get("status"):
+                    self.status = function.get("status")
         else:
             self._cluster = deploy_function(self)
             self.save(versioned=False)

--- a/tests/api/api/test_background_tasks.py
+++ b/tests/api/api/test_background_tasks.py
@@ -1,0 +1,109 @@
+import http
+import typing
+
+import fastapi
+import fastapi.testclient
+import pytest
+import sqlalchemy.orm
+
+import mlrun.api.api.deps
+import mlrun.api.main
+import mlrun.api.schemas
+import mlrun.api.utils.background_tasks
+
+test_router = fastapi.APIRouter()
+
+
+@test_router.post(
+    "/projects/{project}/background-tasks",
+    response_model=mlrun.api.schemas.BackgroundTask,
+)
+def create_background_task(
+    project: str,
+    background_tasks: fastapi.BackgroundTasks,
+    failed_task: bool = False,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        mlrun.api.api.deps.get_db_session
+    ),
+):
+    function = bump_counter
+    if failed_task:
+        function = failing_function
+    return mlrun.api.utils.background_tasks.Handler().create_background_task(
+        db_session, project, background_tasks, function
+    )
+
+
+call_counter: int = 0
+
+
+async def bump_counter():
+    global call_counter
+    call_counter += 1
+
+
+def failing_function():
+    raise RuntimeError("I am a failure")
+
+
+# must add it here since we're adding routes
+@pytest.fixture()
+def client() -> typing.Generator:
+    mlrun.api.main.app.include_router(test_router, prefix="/test")
+    with fastapi.testclient.TestClient(mlrun.api.main.app) as client:
+        yield client
+
+
+def test_create_background_task_success(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+):
+    project = "project"
+    assert call_counter == 0
+    response = client.post(f"/test/projects/{project}/background-tasks")
+    assert response.status_code == http.HTTPStatus.OK.value
+    background_task = mlrun.api.schemas.BackgroundTask(**response.json())
+    assert background_task.kind == mlrun.api.schemas.ObjectKind.background_task
+    assert background_task.metadata.project == project
+    assert background_task.status.state == mlrun.api.schemas.BackgroundTaskState.running
+    response = client.get(
+        f"/api/projects/{project}/background-tasks/{background_task.metadata.name}"
+    )
+    assert response.status_code == http.HTTPStatus.OK.value
+    background_task = mlrun.api.schemas.BackgroundTask(**response.json())
+    assert (
+        background_task.status.state == mlrun.api.schemas.BackgroundTaskState.succeeded
+    )
+    assert call_counter == 1
+
+
+def test_create_background_task_failure(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+):
+    project = "project"
+    response = client.post(
+        f"/test/projects/{project}/background-tasks", params={"failed_task": True}
+    )
+    assert response.status_code == http.HTTPStatus.OK.value
+    background_task = mlrun.api.schemas.BackgroundTask(**response.json())
+    assert background_task.kind == mlrun.api.schemas.ObjectKind.background_task
+    assert background_task.metadata.project == project
+    assert background_task.status.state == mlrun.api.schemas.BackgroundTaskState.running
+    response = client.get(
+        f"/api/projects/{project}/background-tasks/{background_task.metadata.name}"
+    )
+    assert response.status_code == http.HTTPStatus.OK.value
+    background_task = mlrun.api.schemas.BackgroundTask(**response.json())
+    assert background_task.status.state == mlrun.api.schemas.BackgroundTaskState.failed
+
+
+def test_get_background_task_not_exists(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+):
+    project = "project"
+    name = "task-name"
+    response = client.get(f"/api/projects/{project}/background-tasks/{name}")
+    assert response.status_code == http.HTTPStatus.OK.value
+    background_task = mlrun.api.schemas.BackgroundTask(**response.json())
+    assert background_task.metadata.project == project
+    assert background_task.metadata.name == name
+    assert background_task.status.state == mlrun.api.schemas.BackgroundTaskState.failed


### PR DESCRIPTION
I saw several failures recently running our [dask example notebook](https://github.com/mlrun/mlrun/blob/development/examples/mlrun_dask.ipynb)
The image used for the dask cluster is `mlrun/ml-models` which is a pretty big image.
Before this PR the start cluster endpoint was waiting for the cluster to actually come up, which could take long time since just pulling the image can take several minutes, and in Iguazio system the ingress timeout is 2 minutes.
Added a new resource `BackgroundTask` that the endpoint will return, then the client query the background tasks endpoint to determine when the task is finished

Unrelated:
* fix in system tests prepare
* fix feature sets router tag