### PR TITLE
[Cleanup] Fix crd objects cleanup

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -22,7 +22,6 @@ from datetime import datetime, timedelta, timezone
 from os import environ
 from typing import Dict, List, Tuple, Union, Optional
 
-from kubernetes import client
 from kubernetes.client.rest import ApiException
 from sqlalchemy.orm import Session
 
@@ -1392,11 +1391,7 @@ class BaseRuntimeHandler(ABC):
         name = crd_object["metadata"]["name"]
         try:
             k8s_helper.crdapi.delete_namespaced_custom_object(
-                crd_group,
-                crd_version,
-                namespace,
-                crd_plural,
-                name,
+                crd_group, crd_version, namespace, crd_plural, name,
             )
             logger.info(
                 "Deleted crd object",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1397,7 +1397,6 @@ class BaseRuntimeHandler(ABC):
                 namespace,
                 crd_plural,
                 name,
-                client.V1DeleteOptions(),
             )
             logger.info(
                 "Deleted crd object",

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -200,7 +200,6 @@ class TestRuntimeHandlerBase:
                 expected_custom_object_namespace,
                 crd_plural,
                 expected_custom_object_name,
-                client.V1DeleteOptions(),
             )
             for expected_custom_object_name in expected_custom_object_names
         ]


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/568 I bumped the `kubernetes` package version from `==10.0.0` to `~=11.0` and didn't notice that [version 11.0.0](https://github.com/kubernetes-client/python/blob/release-11.0/CHANGELOG.md#v1100) had this change https://github.com/kubernetes-client/gen/pull/142 which caused our `delete_namespaced_custom_object` to fail with:
```
> 2020-12-15 01:01:32,319 [warning] Cleanup failed processing CRD object train-7f9ca89e: Traceback (most recent call last):
  File "/mlrun/mlrun/runtimes/base.py", line 1144, in _delete_crd_resources
    namespace, crd_group, crd_version, crd_plural, crd_object
  File "/mlrun/mlrun/runtimes/base.py", line 1400, in _delete_crd
    client.V1DeleteOptions(),
TypeError: delete_namespaced_custom_object() takes 6 positional arguments but 7 were given
```