### PR TITLE
[System tests] Skip chart patching in provctl patch

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -362,6 +362,8 @@ class SystemTestPreparer:
                 "appservice",
                 "mlrun",
                 mlrun_archive,
+                # TODO: remove when 0.6.0 is out
+                "--skip-chart-patching"
             ],
         )
 

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -363,7 +363,7 @@ class SystemTestPreparer:
                 "mlrun",
                 mlrun_archive,
                 # TODO: remove when 0.6.0 is out
-                "--skip-chart-patching"
+                "--skip-chart-patching",
             ],
         )
 


### PR DESCRIPTION
Our CI that builds image tag the images with `<latest-version>-<commit-hash>`
the `<latest-version>` is resolved by `curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version'` which (as of writing this) outputs `0.5.4`.
It means that currently our system tests running on development are patching the system to versions like `0.5.4-daafbed` the problem with this is that since this 0.5.x it makes provctl patch picking 0.4.x chart, while [this PR](https://github.com/mlrun/mlrun/pull/582) that will be only in 0.6.x requires this [chart PR](https://github.com/v3io/helm-charts/pull/532) that will only in 0.5.x charts. 
Bottomline provctl patch gives the wrong chart which is causing these failures in the `TestJobs` suite:
```
E               mlrun.db.base.RunDBError: POST ***/api/build/function, error: runtime error: Default docker registry is not defined, set MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY/MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET env vars

usr/local/lib/python3.7/site-packages/mlrun/db/httpdb.py:122: RunDBError
```