### PR TITLE
[Feature store] Added list entities endpoint

### DIFF
--- a/mlrun/api/api/endpoints/feature_sets.py
+++ b/mlrun/api/api/endpoints/feature_sets.py
@@ -126,6 +126,18 @@ def list_features(
     return features
 
 
+@router.get("/projects/{project}/entities", response_model=schemas.EntitiesOutput)
+def list_entities(
+    project: str,
+    name: str = None,
+    tag: str = None,
+    labels: List[str] = Query(None, alias="label"),
+    db_session: Session = Depends(deps.get_db_session),
+):
+    features = get_db().list_entities(db_session, project, name, tag, labels)
+    return features
+
+
 @router.post(
     "/projects/{project}/feature-vectors", response_model=schemas.FeatureVector
 )

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -253,6 +253,17 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
+    def list_entities(
+        self,
+        session,
+        project: str,
+        name: str = None,
+        tag: str = None,
+        labels: List[str] = None,
+    ) -> schemas.EntitiesOutput:
+        pass
+
+    @abstractmethod
     def list_feature_sets(
         self,
         session,

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -196,6 +196,16 @@ class FileDB(DBInterface):
     ) -> schemas.FeaturesOutput:
         raise NotImplementedError()
 
+    def list_entities(
+        self,
+        session,
+        project: str,
+        name: str = None,
+        tag: str = None,
+        labels: List[str] = None,
+    ) -> schemas.EntitiesOutput:
+        pass
+
     def list_feature_sets(
         self,
         session,

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -22,6 +22,8 @@ from .feature_store import (
     FeatureSetDigestSpec,
     FeatureListOutput,
     FeaturesOutput,
+    EntityListOutput,
+    EntitiesOutput,
     FeatureVector,
     FeatureVectorRecord,
     FeatureVectorsOutput,

--- a/mlrun/api/schemas/feature_store.py
+++ b/mlrun/api/schemas/feature_store.py
@@ -73,6 +73,7 @@ class FeatureSetsOutput(BaseModel):
 
 class FeatureSetDigestSpec(BaseModel):
     entities: List[Entity]
+    features: List[Feature]
 
 
 class FeatureSetDigestOutput(BaseModel):
@@ -87,6 +88,15 @@ class FeatureListOutput(BaseModel):
 
 class FeaturesOutput(BaseModel):
     features: List[FeatureListOutput]
+
+
+class EntityListOutput(BaseModel):
+    entity: Entity
+    feature_set_digest: FeatureSetDigestOutput
+
+
+class EntitiesOutput(BaseModel):
+    entities: List[EntityListOutput]
 
 
 class FeatureVector(BaseModel):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -175,6 +175,12 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
+    def list_entities(
+        self, project: str, name: str = None, tag: str = None, labels: List[str] = None,
+    ) -> schemas.EntitiesOutput:
+        pass
+
+    @abstractmethod
     def list_feature_sets(
         self,
         project: str = "",

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -524,6 +524,11 @@ class FileRunDB(RunDBInterface):
     ):
         raise NotImplementedError()
 
+    def list_entities(
+        self, project: str, name: str = None, tag: str = None, labels: List[str] = None,
+    ):
+        raise NotImplementedError()
+
     def list_feature_sets(
         self,
         project: str = "",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -738,7 +738,7 @@ class HTTPRunDB(RunDBInterface):
         tag: str = None,
         entities: List[str] = None,
         labels: List[str] = None,
-    ) -> schemas.FeaturesOutput:
+    ) -> List[dict]:
         project = project or default_project
         params = {
             "name": name,
@@ -751,7 +751,23 @@ class HTTPRunDB(RunDBInterface):
 
         error_message = f"Failed listing features, project: {project}, query: {params}"
         resp = self.api_call("GET", path, error_message, params=params)
-        return schemas.FeaturesOutput(**resp.json())
+        return resp.json()["features"]
+
+    def list_entities(
+        self, project: str, name: str = None, tag: str = None, labels: List[str] = None,
+    ) -> List[dict]:
+        project = project or default_project
+        params = {
+            "name": name,
+            "tag": tag,
+            "label": labels or [],
+        }
+
+        path = f"projects/{project}/entities"
+
+        error_message = f"Failed listing entities, project: {project}, query: {params}"
+        resp = self.api_call("GET", path, error_message, params=params)
+        return resp.json()["entities"]
 
     def list_feature_sets(
         self,

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -251,6 +251,13 @@ class SQLDB(RunDBInterface):
             self.db.list_features, self.session, project, name, tag, entities, labels,
         )
 
+    def list_entities(
+        self, project: str, name: str = None, tag: str = None, labels: List[str] = None,
+    ):
+        return self._transform_db_error(
+            self.db.list_entities, self.session, project, name, tag, labels,
+        )
+
     def list_feature_sets(
         self,
         project: str = "",

--- a/tests/api/api/feature_store/base.py
+++ b/tests/api/api/feature_store/base.py
@@ -17,10 +17,10 @@ def _list_and_assert_objects(
     assert response.status_code == HTTPStatus.OK.value
     response_body = response.json()
     assert entity_name in response_body
-    actual_result = len(response_body[entity_name])
+    number_of_entities = len(response_body[entity_name])
     assert (
-        actual_result == expected_number_of_entities
-    ), f"wrong number of {entity_name} in response - {actual_result} instead of {expected_number_of_entities}"
+        number_of_entities == expected_number_of_entities
+    ), f"wrong number of {entity_name} in response - {number_of_entities} instead of {expected_number_of_entities}"
     return response_body
 
 

--- a/tests/api/api/feature_store/base.py
+++ b/tests/api/api/feature_store/base.py
@@ -17,9 +17,10 @@ def _list_and_assert_objects(
     assert response.status_code == HTTPStatus.OK.value
     response_body = response.json()
     assert entity_name in response_body
+    actual_result = len(response_body[entity_name])
     assert (
-        len(response_body[entity_name]) == expected_number_of_entities
-    ), f"wrong number of {entity_name} entities in response"
+        actual_result == expected_number_of_entities
+    ), f"wrong number of {entity_name} in response - {actual_result} instead of {expected_number_of_entities}"
     return response_body
 
 

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -433,11 +433,23 @@ def test_feature_sets(create_server):
     feature_set_without_labels["metadata"]["project"] = project
     db.store_feature_set(feature_set_without_labels)
     feature_set_update = {
-        "metadata": {"labels": {"label1": "value1", "label2": "value2"}}
+        "spec": {"entities": [{"name": "nothing", "value_type": "bool"}]},
+        "metadata": {"labels": {"label1": "value1", "label2": "value2"}},
     }
     db.patch_feature_set(name, feature_set_update, project)
     feature_set = db.get_feature_set(name, project)
     assert len(feature_set["metadata"]["labels"]) == 2, "Labels didn't get updated"
+
+    features = db.list_features(project, "time")
+    # The feature-set with different labels also counts here
+    assert len(features) == count + 1
+    # Only count, since we modified the entity of the last feature-set - other name, no labels
+    entities = db.list_entities(project, "ticker")
+    assert len(entities) == count
+    entities = db.list_entities(project, labels=["type"])
+    assert len(entities) == count
+    entities = db.list_entities(project, labels=["type=prod"])
+    assert len(entities) == count
 
 
 def _create_feature_vector(name):


### PR DESCRIPTION
Added a REST API that allows to list feature-set entities. This is needed for the UI. API is very similar to the list-features API, except there's no filter on entities (obviously).