### PR TITLE
[Projects] Sync SDK class with API methods + structure change

### DIFF
--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -30,7 +30,7 @@ def store_project(
 
 @router.patch("/projects/{name}", response_model=schemas.Project)
 def patch_project(
-    project: schemas.ProjectPatch,
+    project: dict,
     name: str,
     patch_mode: schemas.PatchMode = Header(
         schemas.PatchMode.replace, alias=schemas.HeaderNames.patch_mode

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -205,7 +205,7 @@ class DBInterface(ABC):
         self,
         session,
         name: str,
-        project: schemas.ProjectPatch,
+        project: dict,
         patch_mode: schemas.PatchMode = schemas.PatchMode.replace,
     ):
         pass

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -146,7 +146,7 @@ class FileDB(DBInterface):
         self,
         session,
         name: str,
-        project: schemas.ProjectPatch,
+        project: dict,
         patch_mode: schemas.PatchMode = schemas.PatchMode.replace,
     ):
         raise NotImplementedError()

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -751,6 +751,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         project: dict,
         patch_mode: schemas.PatchMode,
     ):
+        project.setdefault("metadata", {})["created"] = project_record.created
         strategy = patch_mode.to_mergedeep_strategy()
         project_record_full_object = project_record.full_object
         mergedeep.merge(project_record_full_object, project, strategy=strategy)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -650,13 +650,13 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
     def create_project(self, session: Session, project: schemas.Project):
         logger.debug("Creating project in DB", project=project)
         created = datetime.utcnow()
-        project.created = created
+        project.metadata.created = created
+        # TODO: handle taking out the functions/workflows/artifacts out of the project and save them separately
         project_record = Project(
-            name=project.name,
-            description=project.description,
-            owner=project.owner,
-            source=project.source,
-            state=project.state,
+            name=project.metadata.name,
+            description=project.spec.description,
+            source=project.spec.source,
+            state=project.status.state,
             created=created,
             full_object=project.dict(),
         )
@@ -676,7 +676,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         self,
         session: Session,
         name: str,
-        project: schemas.ProjectPatch,
+        project: dict,
         patch_mode: schemas.PatchMode = schemas.PatchMode.replace,
     ):
         logger.debug(
@@ -684,7 +684,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         )
         project_record = self._get_project_record(session, name)
         self._patch_project_record_from_project(
-            session, project_record, project, patch_mode
+            session, name, project_record, project, patch_mode
         )
 
     def get_project(
@@ -734,31 +734,35 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
     def _update_project_record_from_project(
         self, session: Session, project_record: Project, project: schemas.Project
     ):
-        project.created = project_record.created
+        project.metadata.created = project_record.created
         project_dict = project.dict()
+        # TODO: handle taking out the functions/workflows/artifacts out of the project and save them separately
         project_record.full_object = project_dict
-        project_record.description = project.description
-        project_record.source = project.source
-        project_record.state = project.state
+        project_record.description = project.spec.description
+        project_record.source = project.spec.source
+        project_record.state = project.status.state
         self._upsert(session, project_record)
 
     def _patch_project_record_from_project(
         self,
         session: Session,
+        name: str,
         project_record: Project,
-        project: schemas.ProjectPatch,
+        project: dict,
         patch_mode: schemas.PatchMode,
     ):
-        project_dict = project.dict(exclude_unset=True)
-        if project.description:
-            project_record.description = project.description
-        if project.source:
-            project_record.source = project.source
-        if project.state:
-            project_record.state = project.state
         strategy = patch_mode.to_mergedeep_strategy()
         project_record_full_object = project_record.full_object
-        mergedeep.merge(project_record_full_object, project_dict, strategy=strategy)
+        mergedeep.merge(project_record_full_object, project, strategy=strategy)
+
+        # If a bad kind value was passed, it will fail here (return 422 to caller)
+        project = schemas.Project(**project_record_full_object)
+        self.store_project(
+            session,
+            name,
+            project,
+        )
+
         project_record.full_object = project_record_full_object
         self._upsert(session, project_record)
 
@@ -1774,12 +1778,17 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         # in projects that was created before 0.6.0 the full object wasn't created properly - fix that, and return
         if not project_record.full_object:
             project = schemas.Project(
-                name=project_record.name,
-                description=project_record.description,
-                source=project_record.source,
-                state=project_record.state,
-                owner=project_record.owner,
-                created=project_record.created,
+                metadata=schemas.ProjectMetadata(
+                    name=project_record.name,
+                    created=project_record.created,
+                ),
+                spec=schemas.ProjectSpec(
+                    description=project_record.description,
+                    source=project_record.source,
+                ),
+                status=schemas.ObjectStatus(
+                    state=project_record.state,
+                ),
             )
             self.store_project(session, project_record.name, project)
             return project

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -758,9 +758,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         # If a bad kind value was passed, it will fail here (return 422 to caller)
         project = schemas.Project(**project_record_full_object)
         self.store_project(
-            session,
-            name,
-            project,
+            session, name, project,
         )
 
         project_record.full_object = project_record_full_object
@@ -1779,17 +1777,15 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         if not project_record.full_object:
             project = schemas.Project(
                 metadata=schemas.ProjectMetadata(
-                    name=project_record.name,
-                    created=project_record.created,
+                    name=project_record.name, created=project_record.created,
                 ),
                 spec=schemas.ProjectSpec(
                     description=project_record.description,
                     source=project_record.source,
                 ),
-                status=schemas.ObjectStatus(
-                    state=project_record.state,
-                ),
+                status=schemas.ObjectStatus(state=project_record.state,),
             )
             self.store_project(session, project_record.name, project)
             return project
+        # TODO: handle transforming the functions/workflows/artifacts references to real objects
         return schemas.Project(**project_record.full_object)

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -29,9 +29,10 @@ from .feature_store import (
 from .object import ObjectMetadata, ObjectSpec, ObjectStatus, ObjectKind
 from .project import (
     Project,
+    ProjectMetadata,
+    ProjectSpec,
     ProjectsOutput,
     ProjectRecord,
-    ProjectPatch,
 )
 from .schedule import (
     SchedulesOutput,

--- a/mlrun/api/schemas/object.py
+++ b/mlrun/api/schemas/object.py
@@ -54,7 +54,7 @@ class ObjectRecord(BaseModel):
 
 
 class ObjectKind(str, Enum):
-    project = "Project"
+    project = "project"
     feature_set = "FeatureSet"
     background_task = "BackgroundTask"
     feature_vector = "FeatureVector"

--- a/mlrun/api/schemas/object.py
+++ b/mlrun/api/schemas/object.py
@@ -54,6 +54,7 @@ class ObjectRecord(BaseModel):
 
 
 class ObjectKind(str, Enum):
+    project = "Project"
     feature_set = "FeatureSet"
     background_task = "BackgroundTask"
     feature_vector = "FeatureVector"

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -19,15 +19,15 @@ class ProjectMetadata(pydantic.BaseModel):
 
 class ProjectSpec(pydantic.BaseModel):
     description: typing.Optional[str] = None
-    source: typing.Optional[str] = None
-    artifact_path: typing.Optional[str] = None
-    subpath: typing.Optional[str] = None
-    origin_url: typing.Optional[str] = None
-    tag: typing.Optional[str] = None
     params: typing.Optional[dict] = None
     functions: typing.Optional[list] = None
-    artifacts: typing.Optional[list] = None
     workflows: typing.Optional[list] = None
+    artifacts: typing.Optional[list] = None
+    artifact_path: typing.Optional[str] = None
+    conda: typing.Optional[str] = None
+    source: typing.Optional[str] = None
+    subpath: typing.Optional[str] = None
+    origin_url: typing.Optional[str] = None
 
     class Config:
         extra = pydantic.Extra.allow

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -1,22 +1,43 @@
-from datetime import datetime
-from typing import Optional, List, Union
+import datetime
+import typing
 
-from pydantic import BaseModel, Extra
+import pydantic
+
+from .object import (
+    ObjectStatus,
+    ObjectKind,
+)
 
 
-class ProjectPatch(BaseModel):
-    description: Optional[str] = None
-    source: Optional[str] = None
-    state: Optional[str] = None
-    owner: Optional[str] = None
-    created: Optional[datetime] = None
+class ProjectMetadata(pydantic.BaseModel):
+    name: str
+    created: typing.Optional[datetime.datetime] = None
 
     class Config:
-        extra = Extra.allow
+        extra = pydantic.Extra.allow
 
 
-class Project(ProjectPatch):
-    name: str
+class ProjectSpec(pydantic.BaseModel):
+    description: typing.Optional[str] = None
+    source: typing.Optional[str] = None
+    artifact_path: typing.Optional[str] = None
+    subpath: typing.Optional[str] = None
+    origin_url: typing.Optional[str] = None
+    tag: typing.Optional[str] = None
+    params: typing.Optional[dict] = None
+    functions: typing.Optional[list] = None
+    artifacts: typing.Optional[list] = None
+    workflows: typing.Optional[list] = None
+
+    class Config:
+        extra = pydantic.Extra.allow
+
+
+class Project(pydantic.BaseModel):
+    kind: ObjectKind = pydantic.Field(ObjectKind.project, const=True)
+    metadata: ProjectMetadata
+    spec: ProjectSpec = ProjectSpec()
+    status: ObjectStatus = ObjectStatus()
 
 
 class ProjectRecord(Project):
@@ -26,6 +47,6 @@ class ProjectRecord(Project):
         orm_mode = True
 
 
-class ProjectsOutput(BaseModel):
-    # use the full query param to control whether the full object will be returned or only the names
-    projects: List[Union[Project, str]]
+class ProjectsOutput(pydantic.BaseModel):
+    # use the format query param to control whether the full object will be returned or only the names
+    projects: typing.List[typing.Union[Project, str]]

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -28,7 +28,9 @@ class Client(
         self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
     ):
         logger.debug("Creating project in Nuclio", project=project)
-        body = self._generate_request_body(project.metadata.name, project.spec.description)
+        body = self._generate_request_body(
+            project.metadata.name, project.spec.description
+        )
         self._post_project_to_nuclio(body)
 
     def store_project(
@@ -57,8 +59,10 @@ class Client(
     ):
         response = self._get_project_from_nuclio(name)
         response_body = response.json()
-        if project.get('spec').get('description') is not None:
-            response_body.setdefault("spec", {})["description"] = project['spec']['description']
+        if project.get("spec").get("description") is not None:
+            response_body.setdefault("spec", {})["description"] = project["spec"][
+                "description"
+            ]
         self._put_project_to_nuclio(response_body)
 
     def delete_project(self, session: sqlalchemy.orm.Session, name: str):
@@ -143,6 +147,10 @@ class Client(
     @staticmethod
     def _transform_nuclio_project_to_schema(nuclio_project):
         return mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=nuclio_project["metadata"]["name"]),
-            spec=mlrun.api.schemas.ProjectSpec(description=nuclio_project["spec"].get("description")),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=nuclio_project["metadata"]["name"]
+            ),
+            spec=mlrun.api.schemas.ProjectSpec(
+                description=nuclio_project["spec"].get("description")
+            ),
         )

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -47,14 +47,17 @@ class Member(
         logger.info(
             "Ensure project called, but project does not exist. Creating", name=name
         )
-        self.create_project(session, mlrun.api.schemas.Project(name=name))
+        project = mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=name),
+        )
+        self.create_project(session, project)
 
     def create_project(
         self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
     ) -> mlrun.api.schemas.Project:
-        self._validate_project_name(project.name)
+        self._validate_project_name(project.metadata.name)
         self._run_on_all_followers("create_project", session, project)
-        return self.get_project(session, project.name)
+        return self.get_project(session, project.metadata.name)
 
     def store_project(
         self,
@@ -71,7 +74,7 @@ class Member(
         self,
         session: sqlalchemy.orm.Session,
         name: str,
-        project: mlrun.api.schemas.ProjectPatch,
+        project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
         self._validate_body_and_path_names_matches(name, project)
@@ -122,24 +125,24 @@ class Member(
                 "list_projects", session
             )
             leader_project_names = {
-                project.name for project in leader_projects.projects
+                project.metadata.name for project in leader_projects.projects
             }
             # create reverse map project -> follower names
             project_follower_names_map = collections.defaultdict(set)
             for _follower_name, follower_projects in follower_projects_map.items():
                 for project in follower_projects.projects:
-                    project_follower_names_map[project.name].add(_follower_name)
+                    project_follower_names_map[project.metadata.name].add(_follower_name)
 
             # create map - follower name -> project name -> project for easier searches
             followers_projects_map = collections.defaultdict(dict)
             for _follower_name, follower_projects in follower_projects_map.items():
                 for project in follower_projects.projects:
-                    followers_projects_map[_follower_name][project.name] = project
+                    followers_projects_map[_follower_name][project.metadata.name] = project
 
             # create map - leader project name -> leader project for easier searches
             leader_projects_map = {}
             for leader_project in leader_projects.projects:
-                leader_projects_map[leader_project.name] = leader_project
+                leader_projects_map[leader_project.metadata.name] = leader_project
 
             all_project = leader_project_names.copy()
             all_project.update(project_follower_names_map.keys())
@@ -296,10 +299,16 @@ class Member(
 
     @staticmethod
     def _validate_body_and_path_names_matches(
-        name: str, project: mlrun.api.schemas.ProjectPatch
+        path_name: str, project: typing.Union[mlrun.api.schemas.Project, dict]
     ):
-        # ProjectPatch allow extra fields, therefore although it doesn't have name in the schema, name might be there
-        if hasattr(project, "name") and name != getattr(project, "name"):
+        if isinstance(project, mlrun.api.schemas.Project):
+            body_name = project.metadata.name
+        elif isinstance(project, dict):
+            body_name = project.get('metadata', {}).get('name')
+        else:
+            raise NotImplemented("Unsupported project instance type")
+
+        if body_name and path_name != body_name:
             message = "Conflict between name in body and name in path"
-            logger.warning(message, path_name=name, body_name=getattr(project, "name"))
+            logger.warning(message, path_name=path_name, body_name=body_name)
             raise mlrun.errors.MLRunConflictError(message)

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -131,13 +131,17 @@ class Member(
             project_follower_names_map = collections.defaultdict(set)
             for _follower_name, follower_projects in follower_projects_map.items():
                 for project in follower_projects.projects:
-                    project_follower_names_map[project.metadata.name].add(_follower_name)
+                    project_follower_names_map[project.metadata.name].add(
+                        _follower_name
+                    )
 
             # create map - follower name -> project name -> project for easier searches
             followers_projects_map = collections.defaultdict(dict)
             for _follower_name, follower_projects in follower_projects_map.items():
                 for project in follower_projects.projects:
-                    followers_projects_map[_follower_name][project.metadata.name] = project
+                    followers_projects_map[_follower_name][
+                        project.metadata.name
+                    ] = project
 
             # create map - leader project name -> leader project for easier searches
             leader_projects_map = {}
@@ -304,9 +308,9 @@ class Member(
         if isinstance(project, mlrun.api.schemas.Project):
             body_name = project.metadata.name
         elif isinstance(project, dict):
-            body_name = project.get('metadata', {}).get('name')
+            body_name = project.get("metadata", {}).get("name")
         else:
-            raise NotImplemented("Unsupported project instance type")
+            raise NotImplementedError("Unsupported project instance type")
 
         if body_name and path_name != body_name:
             message = "Conflict between name in body and name in path"

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -40,7 +40,7 @@ class Member(abc.ABC):
         self,
         session: sqlalchemy.orm.Session,
         name: str,
-        project: mlrun.api.schemas.ProjectPatch,
+        project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
         pass

--- a/mlrun/api/utils/projects/remotes/member.py
+++ b/mlrun/api/utils/projects/remotes/member.py
@@ -26,7 +26,7 @@ class Member(abc.ABC):
         self,
         session: sqlalchemy.orm.Session,
         name: str,
-        project: mlrun.api.schemas.ProjectPatch,
+        project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
         pass

--- a/mlrun/api/utils/projects/remotes/nop.py
+++ b/mlrun/api/utils/projects/remotes/nop.py
@@ -16,9 +16,9 @@ class Member(mlrun.api.utils.projects.remotes.member.Member):
     def create_project(
         self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
     ):
-        if project.name in self._projects:
+        if project.metadata.name in self._projects:
             raise mlrun.errors.MLRunConflictError("Project already exists")
-        self._projects[project.name] = project
+        self._projects[project.metadata.name] = project
 
     def store_project(
         self,
@@ -32,13 +32,13 @@ class Member(mlrun.api.utils.projects.remotes.member.Member):
         self,
         session: sqlalchemy.orm.Session,
         name: str,
-        project: mlrun.api.schemas.ProjectPatch,
+        project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
         existing_project_dict = self._projects[name].dict()
         strategy = patch_mode.to_mergedeep_strategy()
         mergedeep.merge(
-            existing_project_dict, project.dict(exclude_unset=True), strategy=strategy
+            existing_project_dict, project, strategy=strategy
         )
         self._projects[name] = mlrun.api.schemas.Project(**existing_project_dict)
 
@@ -64,7 +64,7 @@ class Member(mlrun.api.utils.projects.remotes.member.Member):
                 projects=list(self._projects.values())
             )
         elif format_ == mlrun.api.schemas.Format.name_only:
-            project_names = [project.name for project in list(self._projects.values())]
+            project_names = [project.metadata.name for project in list(self._projects.values())]
             return mlrun.api.schemas.ProjectsOutput(projects=project_names)
         else:
             raise NotImplementedError(

--- a/mlrun/api/utils/projects/remotes/nop.py
+++ b/mlrun/api/utils/projects/remotes/nop.py
@@ -37,9 +37,7 @@ class Member(mlrun.api.utils.projects.remotes.member.Member):
     ):
         existing_project_dict = self._projects[name].dict()
         strategy = patch_mode.to_mergedeep_strategy()
-        mergedeep.merge(
-            existing_project_dict, project, strategy=strategy
-        )
+        mergedeep.merge(existing_project_dict, project, strategy=strategy)
         self._projects[name] = mlrun.api.schemas.Project(**existing_project_dict)
 
     def delete_project(self, session: sqlalchemy.orm.Session, name: str):
@@ -64,7 +62,9 @@ class Member(mlrun.api.utils.projects.remotes.member.Member):
                 projects=list(self._projects.values())
             )
         elif format_ == mlrun.api.schemas.Format.name_only:
-            project_names = [project.metadata.name for project in list(self._projects.values())]
+            project_names = [
+                project.metadata.name for project in list(self._projects.values())
+            ]
             return mlrun.api.schemas.ProjectsOutput(projects=project_names)
         else:
             raise NotImplementedError(

--- a/mlrun/db/__init__.py
+++ b/mlrun/db/__init__.py
@@ -56,6 +56,7 @@ def get_run_db(url=""):
     elif scheme in ("http", "https"):
         # import here to avoid circular imports
         from .httpdb import HTTPRunDB
+
         cls = HTTPRunDB
         kwargs = get_httpdb_kwargs(
             parsed_url.hostname, parsed_url.username, parsed_url.password

--- a/mlrun/db/__init__.py
+++ b/mlrun/db/__init__.py
@@ -17,7 +17,6 @@ from ..config import config
 from ..platforms import add_or_refresh_credentials
 from .base import RunDBError, RunDBInterface  # noqa
 from .filedb import FileRunDB
-from .httpdb import HTTPRunDB
 from .sqldb import SQLDB
 from os import environ
 
@@ -55,6 +54,8 @@ def get_run_db(url=""):
     if "://" not in url or scheme in ["file", "s3", "v3io", "v3ios"]:
         cls = FileRunDB
     elif scheme in ("http", "https"):
+        # import here to avoid circular imports
+        from .httpdb import HTTPRunDB
         cls = HTTPRunDB
         kwargs = get_httpdb_kwargs(
             parsed_url.hostname, parsed_url.username, parsed_url.password

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -129,7 +129,7 @@ class RunDBInterface(ABC):
     def patch_project(
         self,
         name: str,
-        project: schemas.ProjectPatch,
+        project: dict,
         patch_mode: schemas.PatchMode = schemas.PatchMode.replace,
     ) -> schemas.Project:
         pass

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -441,7 +441,7 @@ class FileRunDB(RunDBInterface):
     def patch_project(
         self,
         name: str,
-        project: mlrun.api.schemas.ProjectPatch,
+        project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ) -> mlrun.api.schemas.Project:
         raise NotImplementedError()

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -953,7 +953,7 @@ class HTTPRunDB(RunDBInterface):
         self,
         owner: str = None,
         format_: mlrun.api.schemas.Format = mlrun.api.schemas.Format.full,
-    ) -> schemas.ProjectsOutput:
+    ) -> List[mlrun.projects.MlrunProject, str]:
         params = {
             "owner": owner,
             "format": format_,
@@ -961,7 +961,17 @@ class HTTPRunDB(RunDBInterface):
 
         error_message = f"Failed listing projects, query: {params}"
         response = self.api_call("GET", "projects", error_message, params=params)
-        return schemas.ProjectsOutput(**response.json())
+        if format_ == mlrun.api.schemas.Format.name_only:
+            return response.json()["projects"]
+        elif format_ == mlrun.api.schemas.Format.full:
+            return [
+                mlrun.projects.MlrunProject.from_dict(**project_dict)
+                for project_dict in response.json()["projects"]
+            ]
+        else:
+            raise NotImplementedError(
+                f"Provided format is not supported. format={format_}"
+            )
 
     def get_project(self, name: str) -> schemas.Project:
         if not name:
@@ -970,7 +980,7 @@ class HTTPRunDB(RunDBInterface):
         path = f"projects/{name}"
         error_message = f"Failed retrieving project {name}"
         response = self.api_call("GET", path, error_message)
-        return schemas.Project(**response.json())
+        return mlrun.projects.MlrunProject.from_dict(**response.json())
 
     def delete_project(self, name: str):
         path = f"projects/{name}"
@@ -978,14 +988,18 @@ class HTTPRunDB(RunDBInterface):
         self.api_call("DELETE", path, error_message)
 
     def store_project(
-        self, name: str, project: Union[dict, mlrun.api.schemas.Project]
+        self,
+        name: str,
+        project: Union[dict, mlrun.projects.MlrunProject, mlrun.api.schemas.Project],
     ) -> mlrun.api.schemas.Project:
         path = f"projects/{name}"
         error_message = f"Failed storing project {name}"
         if isinstance(project, mlrun.api.schemas.Project):
             project = project.dict()
+        elif isinstance(project, mlrun.projects.MlrunProject):
+            project = project.to_dict()
         response = self.api_call("PUT", path, error_message, body=json.dumps(project),)
-        return schemas.Project(**response.json())
+        return mlrun.projects.MlrunProject.from_dict(**response.json())
 
     def patch_project(
         self,
@@ -1001,18 +1015,21 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call(
             "PATCH", path, error_message, body=json.dumps(project), headers=headers
         )
-        return schemas.Project(**response.json())
+        return mlrun.projects.MlrunProject.from_dict(**response.json())
 
     def create_project(
-        self, project: Union[dict, mlrun.api.schemas.Project]
+        self,
+        project: Union[dict, mlrun.projects.MlrunProject, mlrun.api.schemas.Project],
     ) -> mlrun.api.schemas.Project:
         if isinstance(project, mlrun.api.schemas.Project):
             project = project.dict()
+        elif isinstance(project, mlrun.projects.MlrunProject):
+            project = project.to_dict()
         error_message = f"Failed creating project {project['metadata']['name']}"
         response = self.api_call(
             "POST", "projects", error_message, body=json.dumps(project),
         )
-        return schemas.Project(**response.json())
+        return mlrun.projects.MlrunProject.from_dict(**response.json())
 
     @staticmethod
     def _validate_version_compatibility(server_version, client_version):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -990,7 +990,7 @@ class HTTPRunDB(RunDBInterface):
     def patch_project(
         self,
         name: str,
-        project: Union[dict, mlrun.api.schemas.ProjectPatch],
+        project: dict,
         patch_mode: Union[str, schemas.PatchMode] = schemas.PatchMode.replace,
     ) -> mlrun.api.schemas.Project:
         path = f"projects/{name}"
@@ -998,8 +998,6 @@ class HTTPRunDB(RunDBInterface):
             patch_mode = patch_mode.value
         headers = {schemas.HeaderNames.patch_mode: patch_mode}
         error_message = f"Failed patching project {name}"
-        if isinstance(project, mlrun.api.schemas.Project):
-            project = project.dict(exclude_unset=True)
         response = self.api_call(
             "PATCH", path, error_message, body=json.dumps(project), headers=headers
         )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1008,7 +1008,7 @@ class HTTPRunDB(RunDBInterface):
     ) -> mlrun.api.schemas.Project:
         if isinstance(project, mlrun.api.schemas.Project):
             project = project.dict()
-        error_message = f"Failed creating project {project['name']}"
+        error_message = f"Failed creating project {project['metadata']['name']}"
         response = self.api_call(
             "POST", "projects", error_message, body=json.dumps(project),
         )

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -195,7 +195,7 @@ class SQLDB(RunDBInterface):
     def patch_project(
         self,
         name: str,
-        project: mlrun.api.schemas.ProjectPatch,
+        project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ) -> mlrun.api.schemas.Project:
         raise NotImplementedError()

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -81,6 +81,7 @@ def load_project(
     :param context:    project local directory path
     :param url:        git or tar.gz sources archive path e.g.:
                        git://github.com/mlrun/demo-xgb-project.git
+                       db://<project-name>
     :param name:       project name
     :param secrets:    key:secret dict or SecretsStore used to download sources
     :param init_git:   if True, will git init the context dir
@@ -100,6 +101,8 @@ def load_project(
             url, repo = clone_git(url, context, secrets, clone)
         elif url.endswith(".tar.gz"):
             clone_tgz(url, context, secrets)
+        elif url.startswith("db://"):
+            project = _load_project_from_db(url, secrets)
         else:
             raise ValueError("unsupported code archive {}".format(url))
 
@@ -146,6 +149,12 @@ def _load_project_dir(context, name="", subpath=""):
     project.metadata.name = name or project.metadata.name
     project.spec.subpath = subpath
     return project
+
+
+def _load_project_from_db(url, secrets):
+    db = get_run_db().connect(secrets)
+    project_name = url.replace("git://", "")
+    return db.get_project(project_name)
 
 
 def _load_project_file(url, name="", secrets=None):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -843,7 +843,7 @@ class MlrunProject(ModelObj):
         self.spec.repo.create_remote(name, url=url)
         url = url.replace("https://", "git://")
         try:
-            url = "{}#refs/heads/{}".format(url, self.repo.active_branch.name)
+            url = "{}#refs/heads/{}".format(url, self.spec.repo.active_branch.name)
         except Exception:
             pass
         self.spec._source = self.spec.source or url

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -63,11 +63,11 @@ def new_project(name, context=None, init_git=False):
     :returns: project object
     """
     project = MlrunProject(name=name)
-    project.context = context
+    project.spec.context = context
 
     if init_git:
         repo = Repo.init(context)
-        project.repo = repo
+        project.spec.repo = repo
 
     return project
 
@@ -114,11 +114,11 @@ def load_project(
 
     if not project:
         project = _load_project_dir(context, name, subpath)
-    project.source = url
-    project.repo = repo
+    project.spec.source = url
+    project.spec.repo = repo
     if repo:
-        project.branch = repo.active_branch.name
-    project.origin_url = url
+        project.spec.branch = repo.active_branch.name
+    project.spec.origin_url = url
     project.register_artifacts()
     return project
 
@@ -129,9 +129,8 @@ def _load_project_dir(context, name="", subpath=""):
         with open(fpath) as fp:
             data = fp.read()
             struct = yaml.load(data, Loader=yaml.FullLoader)
-            struct["context"] = context
-            struct["name"] = name or struct.get("name", "")
-            project = MlrunProject.from_dict(struct)
+            project = _project_instance_from_struct(struct, name)
+            project.spec.context = context
 
     elif path.isfile(path.join(context, subpath, "function.yaml")):
         func = import_function(path.join(context, subpath, "function.yaml"))
@@ -142,9 +141,9 @@ def _load_project_dir(context, name="", subpath=""):
     else:
         raise ValueError("project or function YAML not found in path")
 
-    project.context = context
-    project.name = name or project.name
-    project.subpath = subpath
+    project.spec.context = context
+    project.metadata.name = name or project.metadata.name
+    project.spec.subpath = subpath
     return project
 
 
@@ -154,12 +153,815 @@ def _load_project_file(url, name="", secrets=None):
     except FileNotFoundError as e:
         raise FileNotFoundError("cant find project file at {}, {}".format(url, e))
     struct = yaml.load(obj, Loader=yaml.FullLoader)
-    struct["name"] = name or struct.get("name", "")
-    project = MlrunProject.from_dict(struct)
+    return _project_instance_from_struct(struct, name)
+
+
+def _project_instance_from_struct(struct, name):
+    # Name is in the root level only in the legacy project structure
+    if "name" in struct:
+        legacy_project = MlrunProjectLegacy.from_dict(struct)
+        project = MlrunProject(legacy_project.name, legacy_project.description, legacy_project.params,
+                          [], legacy_project.workflows, legacy_project.artifacts,
+                          legacy_project.artifact_path, legacy_project.conda)
+        # other attributes that not passed on initialization
+        project._initialized = legacy_project._initialized
+        project._secrets = legacy_project._secrets
+        project._artifact_manager = legacy_project._artifact_manager
+
+        project.spec.source = legacy_project.source
+        project.spec.context = legacy_project.context
+        project.spec.mountdir = legacy_project.mountdir
+        project.spec.subpath = legacy_project.subpath
+        project.spec.origin_url = legacy_project.origin_url
+        project.spec.branch = legacy_project.branch
+        project.spec.tag = legacy_project.tag
+        project.spec._function_definitions = legacy_project._function_defs
+        project.spec._function_objects = legacy_project._function_objects
+        project.spec.functions = legacy_project.functions
+    else:
+        struct.setdefault('metadata', {})["name"] = name or struct.get("metadata", {}).get("name", "")
+        project = MlrunProject.from_dict(struct)
     return project
 
 
+class ProjectMetadata(ModelObj):
+    def __init__(
+        self,
+        name=None,
+    ):
+        self.name = name
+
+
+class ProjectSpec(ModelObj):
+    def __init__(
+        self,
+        description=None,
+        params=None,
+        functions=None,
+        workflows=None,
+        artifacts=None,
+        artifact_path=None,
+        conda=None,
+        source=None,
+        context=None,
+        mountdir=None,
+        subpath=None,
+        origin_url=None,
+        branch=None,
+        tag=None,
+    ):
+        self.repo = None
+
+        self.description = description
+        self.context = context
+        self._mountdir = None
+        self.mountdir = mountdir
+        self._source = None
+        self.source = source
+        self.subpath = subpath
+        self.origin_url = origin_url
+        self.branch = branch
+        self.tag = tag or ""
+        self.params = params or {}
+        self.conda = conda or {}
+        self.artifact_path = artifact_path or config.artifact_path
+        self._artifacts = {}
+        self.artifacts = artifacts or []
+
+        self._workflows = {}
+        self.workflows = workflows or []
+
+        self._function_objects = {}
+        self._function_definitions = {}
+        self.functions = functions or []
+
+    @property
+    def source(self) -> str:
+        """source url or git repo"""
+        if not self._source:
+            if self.repo:
+                url = _get_repo_url(self.repo)
+                if url:
+                    self._source = url
+
+        return self._source
+
+    @source.setter
+    def source(self, src):
+        self._source = src
+
+    @property
+    def mountdir(self) -> str:
+        """specify to mount the context dir inside the function container
+        use '.' to use the same path as in the client e.g. Jupyter"""
+
+        if self._mountdir and self._mountdir in [".", "./"]:
+            return path.abspath(self.context)
+        return self._mountdir
+
+    @mountdir.setter
+    def mountdir(self, mountdir):
+        self._mountdir = mountdir
+
+    @property
+    def functions(self) -> list:
+        """list of function object/specs used in this project"""
+        functions = []
+        for name, function in self._function_definitions.items():
+            if hasattr(function, "to_dict"):
+                spec = function.to_dict(strip=True)
+                if function.spec.build.source and function.spec.build.source.startswith(
+                        self._source_repo()
+                ):
+                    update_in(spec, "spec.build.source", "./")
+                functions.append({"name": name, "spec": spec})
+            else:
+                functions.append(function)
+        return functions
+
+    @functions.setter
+    def functions(self, functions):
+        if not isinstance(functions, list):
+            raise ValueError("functions must be a list")
+
+        function_definitions = {}
+        for function in functions:
+            if not isinstance(function, dict) and not hasattr(function, "to_dict"):
+                raise ValueError("function must be an object or dict")
+            if isinstance(function, dict):
+                name = function.get("name", "")
+                if not name:
+                    raise ValueError("function name must be specified in dict")
+            else:
+                name = function.metadata.name
+            function_definitions[name] = function
+
+        self._function_definitions = function_definitions
+
+    def set_function(self, name, function_object, function_dict):
+        self._function_definitions[name] = function_dict
+        self._function_objects[name] = function_object
+
+    def remove_function(self, name):
+        if name in self._function_objects:
+            del self._function_objects[name]
+        if name in self._function_definitions:
+            del self._function_definitions[name]
+
+    @property
+    def workflows(self) -> list:
+        """list of workflows specs used in this project"""
+        return [workflow for workflow in self._workflows.values()]
+
+    @workflows.setter
+    def workflows(self, workflows):
+        if not isinstance(workflows, list):
+            raise ValueError("workflows must be a list")
+
+        workflows_dict = {}
+        for workflow in workflows:
+            if not isinstance(workflow, dict):
+                raise ValueError("workflow must be a dict")
+            name = workflow.get("name", "")
+            # todo: support steps dsl as code alternative
+            if not name:
+                raise ValueError('workflow "name" must be specified')
+            if "path" not in workflow and "code" not in workflow:
+                raise ValueError('workflow source "path" or "code" must be specified')
+            workflows_dict[name] = workflow
+
+        self._workflows = workflows_dict
+
+    def set_workflow(self, name, workflow):
+        self._workflows[name] = workflow
+
+    def remove_workflow(self, name):
+        if name in self._workflows:
+            del self._workflows[name]
+
+    @property
+    def artifacts(self) -> list:
+        """list of artifacts used in this project"""
+        return [artifact for artifact in self._artifacts.values()]
+
+    @artifacts.setter
+    def artifacts(self, artifacts):
+        if not isinstance(artifacts, list):
+            raise ValueError("artifacts must be a list")
+
+        artifacts_dict = {}
+        for artifact in artifacts:
+            if not isinstance(artifact, dict) and not hasattr(artifact, "to_dict"):
+                raise ValueError("artifacts must be a dict or class")
+            if isinstance(artifact, dict):
+                key = artifact.get("key", "")
+                if not key:
+                    raise ValueError('artifacts "key" must be specified')
+            else:
+                key = artifact.key
+                artifact = artifact.to_dict()
+
+            artifacts_dict[key] = artifact
+
+        self._artifacts = artifacts_dict
+
+    def set_artifact(self, key, artifact):
+        self._artifacts[key] = artifact
+
+    def remove_artifact(self, key):
+        if key in self._artifacts:
+            del self._artifacts[key]
+
+    def _source_repo(self):
+        src = self.source
+        if src:
+            return src.split("#")[0]
+        return ""
+
+    def _need_repo(self):
+        for f in self._function_objects.values():
+            if f.spec.build.source in [".", "./"]:
+                return True
+        return False
+
+    def _get_wf_cfg(self, name, arguments=None):
+        workflow = self._workflows.get(name)
+        code = workflow.get("code")
+        if code:
+            workflow_path = mktemp(".py")
+            with open(workflow_path, "w") as wf:
+                wf.write(code)
+        else:
+            workflow_path = workflow.get("path", "")
+            if self.context and not workflow_path.startswith("/"):
+                workflow_path = path.join(self.context, workflow_path)
+
+        wf_args = workflow.get("args", {})
+        if arguments:
+            for k, v in arguments.items():
+                wf_args[k] = v
+
+        return workflow_path, code, wf_args
+
+
+class ProjectStatus(ModelObj):
+    def __init__(self, state=None):
+        self.state = state
+
+
 class MlrunProject(ModelObj):
+    kind = "project"
+    _dict_fields = ["kind", "metadata", "spec", "status"]
+
+    def __init__(
+        self,
+        name=None,
+        description=None,
+        params=None,
+        functions=None,
+        workflows=None,
+        artifacts=None,
+        artifact_path=None,
+        conda=None,
+        # all except these 2 are for backwards compatibility with MlrunProjectLegacy
+        metadata=None,
+        spec=None,
+    ):
+        self._metadata = None
+        self.metadata = metadata
+        self._spec = None
+        self.spec = spec
+        self._status = None
+        self.status = None
+
+        # Handling the fields given in the legacy way
+        self.metadata.name = self.metadata.name or name
+        self.spec.description = self.spec.description or description
+        self.spec.params = self.spec.params or params
+        self.spec.functions = self.spec.functions or functions
+        self.spec.workflows = self.spec.workflows or workflows
+        self.spec.artifacts = self.spec.artifacts or artifacts
+        self.spec.artifact_path = self.spec.artifact_path or artifact_path
+        self.spec.conda = self.spec.conda or conda
+
+        self._initialized = False
+        self._secrets = SecretsStore()
+        self._artifact_manager = None
+
+    @property
+    def metadata(self) -> ProjectMetadata:
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        self._metadata = self._verify_dict(metadata, "metadata", ProjectMetadata)
+
+    @property
+    def spec(self) -> ProjectSpec:
+        return self._spec
+
+    @spec.setter
+    def spec(self, spec):
+        self._spec = self._verify_dict(spec, "spec", ProjectSpec)
+
+    @property
+    def status(self) -> ProjectStatus:
+        return self._status
+
+    @status.setter
+    def status(self, status):
+        self._status = self._verify_dict(status, "status", ProjectStatus)
+
+    @property
+    def source(self) -> str:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        return self.spec.source
+
+    @source.setter
+    def source(self, source):
+        self.spec.source = source
+
+    @property
+    def mountdir(self) -> str:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        return self.spec.mountdir
+
+    @mountdir.setter
+    def mountdir(self, mountdir):
+        self.spec.mountdir = mountdir
+
+    @property
+    def functions(self) -> list:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        return self.spec.functions
+
+    @functions.setter
+    def functions(self, functions):
+        self.spec.functions = functions
+
+    @property
+    def workflows(self) -> list:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        return self.spec.workflows
+
+    @workflows.setter
+    def workflows(self, workflows):
+        self.spec.workflows = workflows
+
+    def set_workflow(self, name, workflow_path: str, embed=False, **args):
+        """add or update a workflow, specify a name and the code path"""
+        if not workflow_path:
+            raise ValueError("valid workflow_path must be specified")
+        if embed:
+            if self.spec.context and not workflow_path.startswith("/"):
+                workflow_path = path.join(self.spec.context, workflow_path)
+            with open(workflow_path, "r") as fp:
+                txt = fp.read()
+            workflow = {"name": name, "code": txt}
+        else:
+            workflow = {"name": name, "path": workflow_path}
+        if args:
+            workflow["args"] = args
+        self.spec.set_workflow(name, workflow)
+
+    @property
+    def artifacts(self) -> list:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        return self.spec.artifacts
+
+    @artifacts.setter
+    def artifacts(self, artifacts):
+        self.spec.artifacts = artifacts
+
+    def register_artifacts(self):
+        """register the artifacts in the MLRun DB (under this project)"""
+        artifact_manager = self._get_artifact_manager()
+        producer = ArtifactProducer(
+            "project", self.metadata.name, self.metadata.name, tag=self._get_hexsha() or "latest"
+        )
+        for artifact_dict in self.spec.artifacts:
+            artifact = dict_to_artifact(artifact_dict)
+            artifact_manager.log_artifact(producer, artifact, upload=False)
+
+    def _get_artifact_manager(self):
+        if self._artifact_manager:
+            return self._artifact_manager
+        db = get_run_db().connect(self._secrets)
+        sm = store_manager.set(self._secrets, db)
+        self._artifact_manager = ArtifactManager(sm, db)
+        return self._artifact_manager
+
+    def _get_hexsha(self):
+        try:
+            if self.spec.repo:
+                return self.spec.repo.head.commit.hexsha
+        except Exception:
+            pass
+        return None
+
+    def log_artifact(
+        self,
+        item,
+        body=None,
+        tag="",
+        local_path="",
+        artifact_path=None,
+        format=None,
+        upload=True,
+        labels=None,
+        target_path=None,
+    ):
+        am = self._get_artifact_manager()
+        artifact_path = artifact_path or self.spec.artifact_path
+        producer = ArtifactProducer(
+            "project", self.metadata.name, self.metadata.name, tag=self._get_hexsha() or "latest"
+        )
+        item = am.log_artifact(
+            producer,
+            item,
+            body,
+            tag=tag,
+            local_path=local_path,
+            artifact_path=artifact_path,
+            format=format,
+            upload=upload,
+            labels=labels,
+            target_path=target_path,
+        )
+        self.spec.set_artifact(item.key, item.base_dict())
+
+    def reload(self, sync=False):
+        """reload the project and function objects from yaml/specs
+
+        :param sync:  set to True to load functions objects
+
+        :returns: project object
+        """
+        if self.spec.context:
+            project = _load_project_dir(self.spec.context, self.metadata.name, self.spec.subpath)
+        else:
+            project = _load_project_file(self.spec.origin_url, self.metadata.name, self._secrets)
+        project.spec.source = self.spec.source
+        project.spec.repo = self.spec.repo
+        project.spec.branch = self.spec.branch
+        project.spec.origin_url = self.spec.origin_url
+        if sync:
+            project.sync_functions()
+        self.__dict__.update(project.__dict__)
+        return project
+
+    def set_function(self, func, name="", kind="", image=None, with_repo=None):
+        """update or add a function object to the project
+
+        function can be provided as an object (func) or a .py/.ipynb/.yaml url
+        support url prefixes:
+            object (s3://, v3io://, ..)
+            MLRun DB e.g. db://project/func:ver
+            functions hub/market: e.g. hub://sklearn_classifier:master
+
+        examples:
+
+        proj.set_function(func_object)
+        proj.set_function('./src/mycode.py', 'ingest',
+                          image='myrepo/ing:latest', with_repo=True)
+        proj.set_function('http://.../mynb.ipynb', 'train')
+        proj.set_function('./func.yaml')
+        proj.set_function('hub://get_toy_data', 'getdata')
+
+        :param func:      function object or spec/code url
+        :param name:      name of the function (under the project)
+        :param kind:      runtime kind e.g. job, nuclio, spark, dask, mpijob
+                          default: job
+        :param image:     docker image to be used, can also be specified in
+                          the function object/yaml
+        :param with_repo: add (clone) the current repo to the build source
+
+        :returns: project object
+        """
+        if isinstance(func, str):
+            if not name:
+                raise ValueError("function name must be specified")
+            function_dict = {
+                "url": func,
+                "name": name,
+                "kind": kind,
+                "image": image,
+                "with_repo": with_repo,
+            }
+            func = {k: v for k, v in function_dict.items() if v}
+            name, function_object = _init_function_from_dict(func, self)
+        elif hasattr(func, "to_dict"):
+            name, function_object = _init_function_from_obj(func, self, name=name)
+            if image:
+                function_object.spec.image = image
+            if with_repo:
+                function_object.spec.build.source = "./"
+
+            if not name:
+                raise ValueError("function name must be specified")
+        else:
+            raise ValueError("func must be a function url or object")
+
+        self.spec.set_function(name, function_object, func)
+        return function_object
+
+    def remove_function(self, name):
+        """remove a function from a project
+
+            :param name:      name of the function (under the project)
+        """
+        self.spec.remove_function(name)
+
+    def func(self, key, sync=False):
+        """get function object by name
+
+        :param sync:  will reload/reinit the function
+
+        :returns: function object
+        """
+        if key not in self.spec._function_definitions:
+            raise KeyError("function {} not found".format(key))
+        if sync or not self._initialized or key not in self.spec._function_objects:
+            self.sync_functions()
+        return self.spec._function_objects[key]
+
+    def pull(self, branch=None, remote=None):
+        """pull/update sources from git or tar into the context dir
+
+        :param branch:  git branch, if not the current one
+        :param remote:  git remote, if other than origin
+        """
+        url = self.spec.origin_url
+        if url and url.startswith("git://"):
+            if not self.spec.repo:
+                raise ValueError("repo was not initialized, use load_project()")
+            branch = branch or self.spec.repo.active_branch.name
+            remote = remote or "origin"
+            self.spec.repo.git.pull(remote, branch)
+        elif url and url.endswith(".tar.gz"):
+            if not self.spec.context:
+                raise ValueError("target dit (context) is not set")
+            clone_tgz(url, self.spec.context, self._secrets)
+
+    def create_remote(self, url, name="origin"):
+        """create remote for the project git
+
+        :param url:   remote git url
+        :param name:  name for the remote (default is 'origin')
+        """
+        if not self.spec.repo:
+            raise ValueError("git repo is not set/defined")
+        self.spec.repo.create_remote(name, url=url)
+        url = url.replace("https://", "git://")
+        try:
+            url = "{}#refs/heads/{}".format(url, self.repo.active_branch.name)
+        except Exception:
+            pass
+        self.spec._source = self.spec.source or url
+        self.spec.origin_url = self.spec.origin_url or url
+
+    def push(self, branch, message=None, update=True, remote=None, add: list = None):
+        """update spec and push updates to remote git repo
+
+        :param branch:  target git branch
+        :param message: git commit message
+        :param update:  update files (git add update=True)
+        :param remote:  git remote, default to origin
+        :param add:     list of files to add
+        """
+        repo = self.spec.repo
+        if not repo:
+            raise ValueError("git repo is not set/defined")
+        self.save()
+
+        add = add or []
+        add.append("project.yaml")
+        repo.index.add(add)
+        if update:
+            repo.git.add(update=True)
+        if repo.is_dirty():
+            if not message:
+                raise ValueError("please specify the commit message")
+            repo.git.commit(m=message)
+
+        if not branch:
+            raise ValueError("please specify the remote branch")
+        repo.git.push(remote or "origin", branch)
+
+    def sync_functions(self, names: list = None, always=True, save=False):
+        """reload function objects from specs and files"""
+        if self._initialized and not always:
+            return
+
+        funcs = {}
+        if not names:
+            names = self.spec._function_definitions.keys()
+        origin = add_code_metadata(self.spec.context)
+        for name in names:
+            f = self.spec._function_definitions.get(name)
+            if not f:
+                raise ValueError("function named {} not found".format(name))
+            if hasattr(f, "to_dict"):
+                name, func = _init_function_from_obj(f, self)
+            else:
+                if not isinstance(f, dict):
+                    raise ValueError("function must be an object or dict")
+                name, func = _init_function_from_dict(f, self)
+            func.spec.build.code_origin = origin
+            funcs[name] = func
+            if save:
+                func.save(versioned=False)
+
+        self._function_objects = funcs
+        self._initialized = True
+
+    def with_secrets(self, kind, source, prefix=""):
+        """register a secrets source (file, env or dict)
+
+        read secrets from a source provider to be used in workflows, e.g.
+
+        proj.with_secrets('file', 'file.txt')
+        proj.with_secrets('inline', {'key': 'val'})
+        proj.with_secrets('env', 'ENV1,ENV2', prefix='PFX_')
+
+        :param kind:   secret type (file, inline, env)
+        :param source: secret data or link (see example)
+        :param prefix: add a prefix to the keys in this source
+
+        :returns: project object
+        """
+        self._secrets.add_source(kind, source, prefix)
+        return self
+
+    def get_secret(self, key: str):
+        """get a key based secret e.g. DB password from the context
+        secrets can be specified when invoking a run through files, env, ..
+        """
+        if self._secrets:
+            return self._secrets.get(key)
+        return None
+
+    def get_param(self, key: str, default=None):
+        """get project param by key"""
+        if self.spec.params:
+            return self.spec.params.get(key)
+        return None
+
+    def run(
+        self,
+        name=None,
+        workflow_path=None,
+        arguments=None,
+        artifact_path=None,
+        namespace=None,
+        sync=False,
+        watch=False,
+        dirty=False,
+        ttl=None,
+    ):
+        """run a workflow using kubeflow pipelines
+
+        :param name:      name of the workflow
+        :param workflow_path:
+                          url to a workflow file, if not a project workflow
+        :param arguments:
+                          kubeflow pipelines arguments (parameters)
+        :param artifact_path:
+                          target path/url for workflow artifacts, the string
+                          '{{workflow.uid}}' will be replaced by workflow id
+        :param namespace: kubernetes namespace if other than default
+        :param sync:      force functions sync before run
+        :param watch:     wait for pipeline completion
+        :param dirty:     allow running the workflow when the git repo is dirty
+        :param ttl        pipeline ttl in secs (after that the pods will be removed)
+
+        :returns: run id
+        """
+
+        need_repo = self.spec._need_repo()
+        if self.spec.repo and self.spec.repo.is_dirty():
+            msg = "you seem to have uncommitted git changes, use .push()"
+            if dirty or not need_repo:
+                logger.warning("WARNING!, " + msg)
+            else:
+                raise ProjectError(msg + " or dirty=True")
+
+        if need_repo and self.spec.repo and not self.spec.source:
+            raise ProjectError(
+                "remote repo is not defined, use .create_remote() + push()"
+            )
+
+        self.sync_functions(always=sync)
+        if not self.spec._function_objects:
+            raise ValueError("no functions in the project")
+
+        if not name and not workflow_path:
+            if self.spec.workflows:
+                name = list(self.spec._workflows.keys())[0]
+            else:
+                raise ValueError("workflow name or path must be specified")
+
+        code = None
+        if not workflow_path:
+            if name not in self.spec._workflows:
+                raise ValueError("workflow {} not found".format(name))
+            workflow_path, code, arguments = self.spec._get_wf_cfg(name, arguments)
+
+        name = "{}-{}".format(self.metadata.name, name) if name else self.metadata.name
+        artifact_path = artifact_path or self.spec.artifact_path
+        run = _run_pipeline(
+            self,
+            name,
+            workflow_path,
+            self.spec._function_objects,
+            secrets=self._secrets,
+            arguments=arguments,
+            artifact_path=artifact_path,
+            namespace=namespace,
+            ttl=ttl,
+        )
+        if code:
+            remove(workflow_path)
+        if watch:
+            self.get_run_status(run, notifiers=RunNotifications(with_slack=True))
+        return run
+
+    def save_workflow(self, name, target, artifact_path=None, ttl=None):
+        """create and save a workflow as a yaml or archive file
+
+        :param name:   workflow name
+        :param target: target file path (can end with .yaml or .zip)
+        :param artifact_path:
+                       target path/url for workflow artifacts, the string
+                       '{{workflow.uid}}' will be replaced by workflow id
+        :param ttl     pipeline ttl in secs (after that the pods will be removed)
+        """
+        if not name or name not in self.workflows:
+            raise ValueError("workflow {} not found".format(name))
+
+        workflow_path, code, _ = self.spec._get_wf_cfg(name)
+        pipeline = _create_pipeline(
+            self, workflow_path, self.spec._function_objects, secrets=self._secrets
+        )
+
+        artifact_path = artifact_path or self.spec.artifact_path
+        conf = new_pipe_meta(artifact_path, ttl=ttl)
+        compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
+        if code:
+            remove(workflow_path)
+
+    def get_run_status(
+        self,
+        workflow_id,
+        timeout=60 * 60,
+        expected_statuses=None,
+        notifiers: RunNotifications = None,
+    ):
+        status = ""
+        if timeout:
+            logger.info("waiting for pipeline run completion")
+            run_info = wait_for_pipeline_completion(
+                workflow_id, timeout=timeout, expected_statuses=expected_statuses
+            )
+            if run_info:
+                status = run_info["run"].get("status")
+
+        mldb = get_run_db().connect(self._secrets)
+        runs = mldb.list_runs(project=self.metadata.name, labels=f"workflow={workflow_id}")
+
+        had_errors = 0
+        for r in runs:
+            if r["status"].get("state", "") == "error":
+                had_errors += 1
+
+        text = f"Workflow {workflow_id} finished"
+        if had_errors:
+            text += f" with {had_errors} errors"
+        if status:
+            text += f", status={status}"
+
+        if notifiers:
+            notifiers.push(text, runs)
+        return status, had_errors, text
+
+    def clear_context(self):
+        """delete all files and clear the context dir"""
+        if self.spec.context and path.exists(self.spec.context) and path.isdir(self.spec.context):
+            shutil.rmtree(self.spec.context)
+
+    def save(self, filepath=None):
+        """save the project object into a file (default to project.yaml)"""
+        filepath = filepath or path.join(self.spec.context, self.spec.subpath, "project.yaml")
+        with open(filepath, "w") as fp:
+            fp.write(self.to_yaml())
+
+
+class MlrunProjectLegacy(ModelObj):
     kind = "project"
 
     def __init__(
@@ -299,22 +1101,6 @@ class MlrunProject(ModelObj):
 
         self._workflows = wfdict
 
-    def set_workflow(self, name, workflow_path: str, embed=False, **args):
-        """add or update a workflow, specify a name and the code path"""
-        if not workflow_path:
-            raise ValueError("valid workflow_path must be specified")
-        if embed:
-            if self.context and not workflow_path.startswith("/"):
-                workflow_path = path.join(self.context, workflow_path)
-            with open(workflow_path, "r") as fp:
-                txt = fp.read()
-            workflow = {"name": name, "code": txt}
-        else:
-            workflow = {"name": name, "path": workflow_path}
-        if args:
-            workflow["args"] = args
-        self._workflows[name] = workflow
-
     @property
     def artifacts(self) -> list:
         """list of artifacts used in this project"""
@@ -341,439 +1127,6 @@ class MlrunProject(ModelObj):
 
         self._artifacts = afdict
 
-    def _get_artifact_mngr(self):
-        if self._artifact_mngr:
-            return self._artifact_mngr
-        db = get_run_db().connect(self._secrets)
-        sm = store_manager.set(self._secrets, db)
-        self._artifact_mngr = ArtifactManager(sm, db)
-        return self._artifact_mngr
-
-    def register_artifacts(self):
-        """register the artifacts in the MLRun DB (under this project)"""
-        am = self._get_artifact_mngr()
-        producer = ArtifactProducer(
-            "project", self.name, self.name, tag=self._get_hexsha() or "latest"
-        )
-        for name, obj in self._artifacts.items():
-            artifact = dict_to_artifact(obj)
-            am.log_artifact(producer, artifact, upload=False)
-
-    def log_artifact(
-        self,
-        item,
-        body=None,
-        tag="",
-        local_path="",
-        artifact_path=None,
-        format=None,
-        upload=True,
-        labels=None,
-        target_path=None,
-    ):
-        am = self._get_artifact_mngr()
-        artifact_path = artifact_path or self.artifact_path
-        producer = ArtifactProducer(
-            "project", self.name, self.name, tag=self._get_hexsha() or "latest"
-        )
-        item = am.log_artifact(
-            producer,
-            item,
-            body,
-            tag=tag,
-            local_path=local_path,
-            artifact_path=artifact_path,
-            format=format,
-            upload=upload,
-            labels=labels,
-            target_path=target_path,
-        )
-        self._artifacts[item.key] = item.base_dict()
-
-    def reload(self, sync=False):
-        """reload the project and function objects from yaml/specs
-
-        :param sync:  set to True to load functions objects
-
-        :returns: project object
-        """
-        if self.context:
-            project = _load_project_dir(self.context, self.name, self.subpath)
-        else:
-            project = _load_project_file(self.origin_url, self.name, self._secrets)
-        project.source = self.source
-        project.repo = self.repo
-        project.branch = self.branch
-        project.origin_url = self.origin_url
-        if sync:
-            project.sync_functions()
-        self.__dict__.update(project.__dict__)
-        return project
-
-    def set_function(self, func, name="", kind="", image=None, with_repo=None):
-        """update or add a function object to the project
-
-        function can be provided as an object (func) or a .py/.ipynb/.yaml url
-        support url prefixes:
-            object (s3://, v3io://, ..)
-            MLRun DB e.g. db://project/func:ver
-            functions hub/market: e.g. hub://sklearn_classifier:master
-
-        examples:
-
-        proj.set_function(func_object)
-        proj.set_function('./src/mycode.py', 'ingest',
-                          image='myrepo/ing:latest', with_repo=True)
-        proj.set_function('http://.../mynb.ipynb', 'train')
-        proj.set_function('./func.yaml')
-        proj.set_function('hub://get_toy_data', 'getdata')
-
-        :param func:      function object or spec/code url
-        :param name:      name of the function (under the project)
-        :param kind:      runtime kind e.g. job, nuclio, spark, dask, mpijob
-                          default: job
-        :param image:     docker image to be used, can also be specified in
-                          the function object/yaml
-        :param with_repo: add (clone) the current repo to the build source
-
-        :returns: project object
-        """
-        if isinstance(func, str):
-            if not name:
-                raise ValueError("function name must be specified")
-            fdict = {
-                "url": func,
-                "name": name,
-                "kind": kind,
-                "image": image,
-                "with_repo": with_repo,
-            }
-            func = {k: v for k, v in fdict.items() if v}
-            name, f = _init_function_from_dict(func, self)
-        elif hasattr(func, "to_dict"):
-            name, f = _init_function_from_obj(func, self, name=name)
-            if image:
-                f.spec.image = image
-            if with_repo:
-                f.spec.build.source = "./"
-
-            if not name:
-                raise ValueError("function name must be specified")
-        else:
-            raise ValueError("func must be a function url or object")
-
-        self._function_defs[name] = func
-        self._function_objects[name] = f
-        return f
-
-    def func(self, key, sync=False):
-        """get function object by name
-
-        :param sync:  will reload/reinit the function
-
-        :returns: function object
-        """
-        if key not in self._function_defs:
-            raise KeyError("function {} not found".format(key))
-        if sync or not self._initialized or key not in self._function_objects:
-            self.sync_functions()
-        return self._function_objects[key]
-
-    def pull(self, branch=None, remote=None):
-        """pull/update sources from git or tar into the context dir
-
-        :param branch:  git branch, if not the current one
-        :param remote:  git remote, if other than origin
-        """
-        url = self.origin_url
-        if url and url.startswith("git://"):
-            if not self.repo:
-                raise ValueError("repo was not initialized, use load_project()")
-            branch = branch or self.repo.active_branch.name
-            remote = remote or "origin"
-            self.repo.git.pull(remote, branch)
-        elif url and url.endswith(".tar.gz"):
-            if not self.context:
-                raise ValueError("target dit (context) is not set")
-            clone_tgz(url, self.context, self._secrets)
-
-    def create_remote(self, url, name="origin"):
-        """create remote for the project git
-
-        :param url:   remote git url
-        :param name:  name for the remote (default is 'origin')
-        """
-        if not self.repo:
-            raise ValueError("git repo is not set/defined")
-        self.repo.create_remote(name, url=url)
-        url = url.replace("https://", "git://")
-        try:
-            url = "{}#refs/heads/{}".format(url, self.repo.active_branch.name)
-        except Exception:
-            pass
-        self._source = self.source or url
-        self.origin_url = self.origin_url or url
-
-    def push(self, branch, message=None, update=True, remote=None, add: list = None):
-        """update spec and push updates to remote git repo
-
-        :param branch:  target git branch
-        :param message: git commit message
-        :param update:  update files (git add update=True)
-        :param remote:  git remote, default to origin
-        :param add:     list of files to add
-        """
-        repo = self.repo
-        if not repo:
-            raise ValueError("git repo is not set/defined")
-        self.save()
-
-        add = add or []
-        add.append("project.yaml")
-        repo.index.add(add)
-        if update:
-            repo.git.add(update=True)
-        if repo.is_dirty():
-            if not message:
-                raise ValueError("please specify the commit message")
-            repo.git.commit(m=message)
-
-        if not branch:
-            raise ValueError("please specify the remote branch")
-        repo.git.push(remote or "origin", branch)
-
-    def sync_functions(self, names: list = None, always=True, save=False):
-        """reload function objects from specs and files"""
-        if self._initialized and not always:
-            return
-
-        funcs = {}
-        if not names:
-            names = self._function_defs.keys()
-        origin = add_code_metadata(self.context)
-        for name in names:
-            f = self._function_defs.get(name)
-            if not f:
-                raise ValueError("function named {} not found".format(name))
-            if hasattr(f, "to_dict"):
-                name, func = _init_function_from_obj(f, self)
-            else:
-                if not isinstance(f, dict):
-                    raise ValueError("function must be an object or dict")
-                name, func = _init_function_from_dict(f, self)
-            func.spec.build.code_origin = origin
-            funcs[name] = func
-            if save:
-                func.save(versioned=False)
-
-        self._function_objects = funcs
-        self._initialized = True
-
-    def with_secrets(self, kind, source, prefix=""):
-        """register a secrets source (file, env or dict)
-
-        read secrets from a source provider to be used in workflows, e.g.
-
-        proj.with_secrets('file', 'file.txt')
-        proj.with_secrets('inline', {'key': 'val'})
-        proj.with_secrets('env', 'ENV1,ENV2', prefix='PFX_')
-
-        :param kind:   secret type (file, inline, env)
-        :param source: secret data or link (see example)
-        :param prefix: add a prefix to the keys in this source
-
-        :returns: project object
-        """
-        self._secrets.add_source(kind, source, prefix)
-        return self
-
-    def get_secret(self, key: str):
-        """get a key based secret e.g. DB password from the context
-        secrets can be specified when invoking a run through files, env, ..
-        """
-        if self._secrets:
-            return self._secrets.get(key)
-        return None
-
-    def get_param(self, key: str, default=None):
-        """get project param by key"""
-        if self.params:
-            return self.params.get(key)
-        return None
-
-    def run(
-        self,
-        name=None,
-        workflow_path=None,
-        arguments=None,
-        artifact_path=None,
-        namespace=None,
-        sync=False,
-        watch=False,
-        dirty=False,
-        ttl=None,
-    ):
-        """run a workflow using kubeflow pipelines
-
-        :param name:      name of the workflow
-        :param workflow_path:
-                          url to a workflow file, if not a project workflow
-        :param arguments:
-                          kubeflow pipelines arguments (parameters)
-        :param artifact_path:
-                          target path/url for workflow artifacts, the string
-                          '{{workflow.uid}}' will be replaced by workflow id
-        :param namespace: kubernetes namespace if other than default
-        :param sync:      force functions sync before run
-        :param watch:     wait for pipeline completion
-        :param dirty:     allow running the workflow when the git repo is dirty
-        :param ttl        pipeline ttl in secs (after that the pods will be removed)
-
-        :returns: run id
-        """
-
-        need_repo = self._need_repo()
-        if self.repo and self.repo.is_dirty():
-            msg = "you seem to have uncommitted git changes, use .push()"
-            if dirty or not need_repo:
-                logger.warning("WARNING!, " + msg)
-            else:
-                raise ProjectError(msg + " or dirty=True")
-
-        if need_repo and self.repo and not self.source:
-            raise ProjectError(
-                "remote repo is not defined, use .create_remote() + push()"
-            )
-
-        self.sync_functions(always=sync)
-        if not self._function_objects:
-            raise ValueError("no functions in the project")
-
-        if not name and not workflow_path:
-            if self._workflows:
-                name = list(self._workflows.keys())[0]
-            else:
-                raise ValueError("workflow name or path must be specified")
-
-        code = None
-        if not workflow_path:
-            if name not in self._workflows:
-                raise ValueError("workflow {} not found".format(name))
-            workflow_path, code, arguments = self._get_wf_cfg(name, arguments)
-
-        name = "{}-{}".format(self.name, name) if name else self.name
-        artifact_path = artifact_path or self.artifact_path
-        run = _run_pipeline(
-            self,
-            name,
-            workflow_path,
-            self._function_objects,
-            secrets=self._secrets,
-            arguments=arguments,
-            artifact_path=artifact_path,
-            namespace=namespace,
-            ttl=ttl,
-        )
-        if code:
-            remove(workflow_path)
-        if watch:
-            self.get_run_status(run, notifiers=RunNotifications(with_slack=True))
-        return run
-
-    def _get_wf_cfg(self, name, arguments=None):
-        workflow = self._workflows.get(name)
-        code = workflow.get("code")
-        if code:
-            workflow_path = mktemp(".py")
-            with open(workflow_path, "w") as wf:
-                wf.write(code)
-        else:
-            workflow_path = workflow.get("path", "")
-            if self.context and not workflow_path.startswith("/"):
-                workflow_path = path.join(self.context, workflow_path)
-
-        wf_args = workflow.get("args", {})
-        if arguments:
-            for k, v in arguments.items():
-                wf_args[k] = v
-
-        return workflow_path, code, wf_args
-
-    def _need_repo(self):
-        for f in self._function_objects.values():
-            if f.spec.build.source in [".", "./"]:
-                return True
-        return False
-
-    def save_workflow(self, name, target, artifact_path=None, ttl=None):
-        """create and save a workflow as a yaml or archive file
-
-        :param name:   workflow name
-        :param target: target file path (can end with .yaml or .zip)
-        :param artifact_path:
-                       target path/url for workflow artifacts, the string
-                       '{{workflow.uid}}' will be replaced by workflow id
-        :param ttl     pipeline ttl in secs (after that the pods will be removed)
-        """
-        if not name or name not in self._workflows:
-            raise ValueError("workflow {} not found".format(name))
-
-        workflow_path, code, _ = self._get_wf_file(name)
-        pipeline = _create_pipeline(
-            self, workflow_path, self._function_objects, secrets=self._secrets
-        )
-
-        artifact_path = artifact_path or self.artifact_path
-        conf = new_pipe_meta(artifact_path, ttl=ttl)
-        compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
-        if code:
-            remove(workflow_path)
-
-    def get_run_status(
-        self,
-        workflow_id,
-        timeout=60 * 60,
-        expected_statuses=None,
-        notifiers: RunNotifications = None,
-    ):
-        status = ""
-        if timeout:
-            logger.info("waiting for pipeline run completion")
-            run_info = wait_for_pipeline_completion(
-                workflow_id, timeout=timeout, expected_statuses=expected_statuses
-            )
-            if run_info:
-                status = run_info["run"].get("status")
-
-        mldb = get_run_db().connect(self._secrets)
-        runs = mldb.list_runs(project=self.name, labels=f"workflow={workflow_id}")
-
-        had_errors = 0
-        for r in runs:
-            if r["status"].get("state", "") == "error":
-                had_errors += 1
-
-        text = f"Workflow {workflow_id} finished"
-        if had_errors:
-            text += f" with {had_errors} errors"
-        if status:
-            text += f", status={status}"
-
-        if notifiers:
-            notifiers.push(text, runs)
-        return status, had_errors, text
-
-    def clear_context(self):
-        """delete all files and clear the context dir"""
-        if self.context and path.exists(self.context) and path.isdir(self.context):
-            shutil.rmtree(self.context)
-
-    def save(self, filepath=None):
-        """save the project object into a file (default to project.yaml)"""
-        filepath = filepath or path.join(self.context, self.subpath, "project.yaml")
-        with open(filepath, "w") as fp:
-            fp.write(self.to_yaml())
-
 
 def _init_function_from_dict(f, project):
     name = f.get("name", "")
@@ -782,7 +1135,7 @@ def _init_function_from_dict(f, project):
     image = f.get("image", None)
     with_repo = f.get("with_repo", False)
 
-    if with_repo and not project.source:
+    if with_repo and not project.spec.source:
         raise ValueError("project source must be specified when cloning context")
 
     in_context = False
@@ -790,8 +1143,8 @@ def _init_function_from_dict(f, project):
         raise ValueError("function missing a url or a spec")
 
     if url and "://" not in url:
-        if project.context and not url.startswith("/"):
-            url = path.join(project.context, url)
+        if project.spec.context and not url.startswith("/"):
+            url = path.join(project.spec.context, url)
             in_context = True
         if not path.isfile(url):
             raise OSError("{} not found".format(url))
@@ -825,18 +1178,18 @@ def _init_function_from_dict(f, project):
 
 def _init_function_from_obj(func, project, name=None):
     build = func.spec.build
-    if project.origin_url:
-        origin = project.origin_url
+    if project.spec.origin_url:
+        origin = project.spec.origin_url
         try:
-            if project.repo:
-                origin += "#" + project.repo.head.commit.hexsha
+            if project.spec.repo:
+                origin += "#" + project.spec.repo.head.commit.hexsha
         except Exception:
             pass
         build.code_origin = origin
-    if project.name:
-        func.metadata.project = project.name
-    if project.tag:
-        func.metadata.tag = project.tag
+    if project.metadata.name:
+        func.metadata.project = project.metadata.name
+    if project.spec.tag:
+        func.metadata.tag = project.spec.tag
     return name or func.metadata.name, func
 
 
@@ -845,12 +1198,12 @@ def _create_pipeline(project, pipeline, funcs, secrets=None):
     for name, func in funcs.items():
         f = func.copy()
         src = f.spec.build.source
-        if project.source and src and src in [".", "./"]:
-            if project.mountdir:
-                f.spec.workdir = project.mountdir
+        if project.spec.source and src and src in [".", "./"]:
+            if project.spec.mountdir:
+                f.spec.workdir = project.spec.mountdir
                 f.spec.build.source = ""
             else:
-                f.spec.build.source = project.source
+                f.spec.build.source = project.spec.source
 
         functions[name] = f
 
@@ -868,7 +1221,7 @@ def _create_pipeline(project, pipeline, funcs, secrets=None):
 
     # verify all functions are in this project
     for f in functions.values():
-        f.metadata.project = project.name
+        f.metadata.project = project.metadata.name
 
     if not hasattr(mod, "kfpipeline"):
         raise ValueError("pipeline function (kfpipeline) not found")
@@ -893,7 +1246,7 @@ def _run_pipeline(
     namespace = namespace or config.namespace
     id = run_pipeline(
         kfpipeline,
-        project=project.name,
+        project=project.metadata.name,
         arguments=arguments,
         experiment=name,
         namespace=namespace,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -226,9 +226,9 @@ class ProjectSpec(ModelObj):
         self._mountdir = None
         self.mountdir = mountdir
         self._source = None
-        self.source = source
-        self.subpath = subpath
-        self.origin_url = origin_url
+        self.source = source or ""
+        self.subpath = subpath or ""
+        self.origin_url = origin_url or ""
         self.branch = branch
         self.tag = tag or ""
         self.params = params or {}

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -196,9 +196,10 @@ def _project_instance_from_struct(struct, name):
 
 class ProjectMetadata(ModelObj):
     def __init__(
-        self, name=None,
+        self, name=None, created=None
     ):
         self.name = name
+        self.created = created
 
 
 class ProjectSpec(ModelObj):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -980,6 +980,14 @@ class MlrunProject(ModelObj):
             shutil.rmtree(self.spec.context)
 
     def save(self, filepath=None):
+        self.export(filepath)
+        self.save_to_db()
+
+    def save_to_db(self):
+        db = get_run_db().connect(self._secrets)
+        db.store_project(self.metadata.name, self.to_dict())
+
+    def export(self, filepath=None):
         """save the project object into a file (default to project.yaml)"""
         filepath = filepath or path.join(
             self.spec.context, self.spec.subpath, "project.yaml"

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1165,9 +1165,7 @@ class MlrunProjectLegacy(ModelObj):
     # needed for tests
     def save(self, filepath=None):
         """save the project object into a file (default to project.yaml)"""
-        filepath = filepath or path.join(
-            self.context, self.subpath, "project.yaml"
-        )
+        filepath = filepath or path.join(self.context, self.subpath, "project.yaml")
         with open(filepath, "w") as fp:
             fp.write(self.to_yaml())
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -483,6 +483,28 @@ class MlrunProject(ModelObj):
         self._status = self._verify_dict(status, "status", ProjectStatus)
 
     @property
+    def name(self) -> str:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the metadata, use project.metadata.name instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
+        return self.metadata.name
+
+    @name.setter
+    def name(self, name):
+        warnings.warn(
+            "This is a property of the metadata, use project.metadata.name instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
+        self.metadata.name = name
+
+    @property
     def source(self) -> str:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -692,7 +692,7 @@ class MlrunProject(ModelObj):
     def remove_function(self, name):
         """remove a function from a project
 
-            :param name:      name of the function (under the project)
+        :param name:    name of the function (under the project)
         """
         self.spec.remove_function(name)
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1154,6 +1154,15 @@ class MlrunProjectLegacy(ModelObj):
 
         self._artifacts = afdict
 
+    # needed for tests
+    def save(self, filepath=None):
+        """save the project object into a file (default to project.yaml)"""
+        filepath = filepath or path.join(
+            self.context, self.subpath, "project.yaml"
+        )
+        with open(filepath, "w") as fp:
+            fp.write(self.to_yaml())
+
 
 def _init_function_from_dict(f, project):
     name = f.get("name", "")

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import shutil
+import warnings
 
 from ..db import get_run_db
 from ..artifacts import ArtifactManager, ArtifactProducer, dict_to_artifact
@@ -485,40 +486,110 @@ class MlrunProject(ModelObj):
     def source(self) -> str:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.source instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         return self.spec.source
 
     @source.setter
     def source(self, source):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.source instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         self.spec.source = source
+
+    @property
+    def context(self) -> str:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.context instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
+        return self.spec.context
+
+    @context.setter
+    def context(self, context):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.context instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
+        self.spec.context = context
 
     @property
     def mountdir(self) -> str:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.mountdir instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         return self.spec.mountdir
 
     @mountdir.setter
     def mountdir(self, mountdir):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.mountdir instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         self.spec.mountdir = mountdir
 
     @property
     def functions(self) -> list:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.functions instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         return self.spec.functions
 
     @functions.setter
     def functions(self, functions):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.functions instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         self.spec.functions = functions
 
     @property
     def workflows(self) -> list:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.workflows instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         return self.spec.workflows
 
     @workflows.setter
     def workflows(self, workflows):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.workflows instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         self.spec.workflows = workflows
 
     def set_workflow(self, name, workflow_path: str, embed=False, **args):
@@ -541,10 +612,22 @@ class MlrunProject(ModelObj):
     def artifacts(self) -> list:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.artifacts instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         return self.spec.artifacts
 
     @artifacts.setter
     def artifacts(self, artifacts):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.artifacts instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
         self.spec.artifacts = artifacts
 
     def register_artifacts(self):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -447,9 +447,9 @@ class MlrunProject(ModelObj):
         self.metadata.name = self.metadata.name or name
         self.spec.description = self.spec.description or description
         self.spec.params = self.spec.params or params
-        self.spec.functions = self.spec.functions or functions
-        self.spec.workflows = self.spec.workflows or workflows
-        self.spec.artifacts = self.spec.artifacts or artifacts
+        self.spec.functions = self.spec.functions or functions or []
+        self.spec.workflows = self.spec.workflows or workflows or []
+        self.spec.artifacts = self.spec.artifacts or artifacts or []
         self.spec.artifact_path = self.spec.artifact_path or artifact_path
         self.spec.conda = self.spec.conda or conda
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -222,25 +222,20 @@ class ProjectSpec(ModelObj):
         artifact_path=None,
         conda=None,
         source=None,
-        context=None,
-        mountdir=None,
         subpath=None,
         origin_url=None,
-        branch=None,
-        tag=None,
     ):
         self.repo = None
 
         self.description = description
-        self.context = context
+        self.context = ""
         self._mountdir = None
-        self.mountdir = mountdir
         self._source = None
         self.source = source or ""
         self.subpath = subpath or ""
         self.origin_url = origin_url or ""
-        self.branch = branch
-        self.tag = tag or ""
+        self.branch = None
+        self.tag = ""
         self.params = params or {}
         self.conda = conda or {}
         self.artifact_path = artifact_path or config.artifact_path

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -204,9 +204,7 @@ def _project_instance_from_struct(struct, name):
 
 
 class ProjectMetadata(ModelObj):
-    def __init__(
-        self, name=None, created=None
-    ):
+    def __init__(self, name=None, created=None):
         self.name = name
         self.created = created
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -160,9 +160,16 @@ def _project_instance_from_struct(struct, name):
     # Name is in the root level only in the legacy project structure
     if "name" in struct:
         legacy_project = MlrunProjectLegacy.from_dict(struct)
-        project = MlrunProject(legacy_project.name, legacy_project.description, legacy_project.params,
-                          [], legacy_project.workflows, legacy_project.artifacts,
-                          legacy_project.artifact_path, legacy_project.conda)
+        project = MlrunProject(
+            legacy_project.name,
+            legacy_project.description,
+            legacy_project.params,
+            [],
+            legacy_project.workflows,
+            legacy_project.artifacts,
+            legacy_project.artifact_path,
+            legacy_project.conda,
+        )
         # other attributes that not passed on initialization
         project._initialized = legacy_project._initialized
         project._secrets = legacy_project._secrets
@@ -179,15 +186,16 @@ def _project_instance_from_struct(struct, name):
         project.spec._function_objects = legacy_project._function_objects
         project.spec.functions = legacy_project.functions
     else:
-        struct.setdefault('metadata', {})["name"] = name or struct.get("metadata", {}).get("name", "")
+        struct.setdefault("metadata", {})["name"] = name or struct.get(
+            "metadata", {}
+        ).get("name", "")
         project = MlrunProject.from_dict(struct)
     return project
 
 
 class ProjectMetadata(ModelObj):
     def __init__(
-        self,
-        name=None,
+        self, name=None,
     ):
         self.name = name
 
@@ -270,8 +278,9 @@ class ProjectSpec(ModelObj):
         for name, function in self._function_definitions.items():
             if hasattr(function, "to_dict"):
                 spec = function.to_dict(strip=True)
-                if function.spec.build.source and function.spec.build.source.startswith(
-                        self._source_repo()
+                if (
+                    function.spec.build.source
+                    and function.spec.build.source.startswith(self._source_repo())
                 ):
                     update_in(spec, "spec.build.source", "./")
                 functions.append({"name": name, "spec": spec})
@@ -542,7 +551,10 @@ class MlrunProject(ModelObj):
         """register the artifacts in the MLRun DB (under this project)"""
         artifact_manager = self._get_artifact_manager()
         producer = ArtifactProducer(
-            "project", self.metadata.name, self.metadata.name, tag=self._get_hexsha() or "latest"
+            "project",
+            self.metadata.name,
+            self.metadata.name,
+            tag=self._get_hexsha() or "latest",
         )
         for artifact_dict in self.spec.artifacts:
             artifact = dict_to_artifact(artifact_dict)
@@ -579,7 +591,10 @@ class MlrunProject(ModelObj):
         am = self._get_artifact_manager()
         artifact_path = artifact_path or self.spec.artifact_path
         producer = ArtifactProducer(
-            "project", self.metadata.name, self.metadata.name, tag=self._get_hexsha() or "latest"
+            "project",
+            self.metadata.name,
+            self.metadata.name,
+            tag=self._get_hexsha() or "latest",
         )
         item = am.log_artifact(
             producer,
@@ -603,9 +618,13 @@ class MlrunProject(ModelObj):
         :returns: project object
         """
         if self.spec.context:
-            project = _load_project_dir(self.spec.context, self.metadata.name, self.spec.subpath)
+            project = _load_project_dir(
+                self.spec.context, self.metadata.name, self.spec.subpath
+            )
         else:
-            project = _load_project_file(self.spec.origin_url, self.metadata.name, self._secrets)
+            project = _load_project_file(
+                self.spec.origin_url, self.metadata.name, self._secrets
+            )
         project.spec.source = self.spec.source
         project.spec.repo = self.spec.repo
         project.spec.branch = self.spec.branch
@@ -932,7 +951,9 @@ class MlrunProject(ModelObj):
                 status = run_info["run"].get("status")
 
         mldb = get_run_db().connect(self._secrets)
-        runs = mldb.list_runs(project=self.metadata.name, labels=f"workflow={workflow_id}")
+        runs = mldb.list_runs(
+            project=self.metadata.name, labels=f"workflow={workflow_id}"
+        )
 
         had_errors = 0
         for r in runs:
@@ -951,12 +972,18 @@ class MlrunProject(ModelObj):
 
     def clear_context(self):
         """delete all files and clear the context dir"""
-        if self.spec.context and path.exists(self.spec.context) and path.isdir(self.spec.context):
+        if (
+            self.spec.context
+            and path.exists(self.spec.context)
+            and path.isdir(self.spec.context)
+        ):
             shutil.rmtree(self.spec.context)
 
     def save(self, filepath=None):
         """save the project object into a file (default to project.yaml)"""
-        filepath = filepath or path.join(self.spec.context, self.spec.subpath, "project.yaml")
+        filepath = filepath or path.join(
+            self.spec.context, self.spec.subpath, "project.yaml"
+        )
         with open(filepath, "w") as fp:
             fp.write(self.to_yaml())
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -943,8 +943,8 @@ class MlrunProject(ModelObj):
     def get_param(self, key: str, default=None):
         """get project param by key"""
         if self.spec.params:
-            return self.spec.params.get(key)
-        return None
+            return self.spec.params.get(key, default)
+        return default
 
     def run(
         self,

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -11,8 +11,9 @@ import mlrun.api.schemas
 def test_projects_crud(db: Session, client: TestClient) -> None:
     name1 = f"prj-{uuid4().hex}"
     project_1 = mlrun.api.schemas.Project(
-        name=name1, owner="owner", description="banana"
-    )
+            metadata=mlrun.api.schemas.ProjectMetadata(name=name1),
+            spec=mlrun.api.schemas.ProjectSpec(description="banana", source="source"),
+        )
 
     # create
     response = client.post("/api/projects", json=project_1.dict())
@@ -24,17 +25,22 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
     _assert_project_response(project_1, response)
 
     # patch
-    project_update = mlrun.api.schemas.ProjectPatch(description="lemon")
+    project_patch = {
+        'spec': {
+            'description': "lemon",
+        }
+    }
     response = client.patch(
-        f"/api/projects/{name1}", json=project_update.dict(exclude_unset=True)
+        f"/api/projects/{name1}", json=project_patch
     )
     assert response.status_code == HTTPStatus.OK.value
-    _assert_project_response(project_1, response, extra_exclude={"description"})
-    assert project_update.description == response.json()["description"]
+    _assert_project_response(project_1, response, extra_exclude={"spec": {"description"}})
+    assert project_patch['spec']["description"] == response.json()['spec']["description"]
 
     name2 = f"prj-{uuid4().hex}"
     project_2 = mlrun.api.schemas.Project(
-        name=name2, owner="owner", description="banana"
+        metadata=mlrun.api.schemas.ProjectMetadata(name=name2),
+        spec=mlrun.api.schemas.ProjectSpec(description="banana", source="source"),
     )
 
     # store
@@ -56,7 +62,7 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
     projects_output = mlrun.api.schemas.ProjectsOutput(**response.json())
     expected = [project_1, project_2]
     for index, project in enumerate(projects_output.projects):
-        _assert_project(expected[index], project, extra_exclude={"description"})
+        _assert_project(expected[index], project, extra_exclude={"spec": {"description"}})
 
     # delete
     response = client.delete(f"/api/projects/{name1}")
@@ -71,7 +77,7 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
 
 
 def _assert_project_response(
-    expected_project: mlrun.api.schemas.Project, response, extra_exclude: set = None
+    expected_project: mlrun.api.schemas.Project, response, extra_exclude: dict = None
 ):
     project = mlrun.api.schemas.Project(**response.json())
     _assert_project(expected_project, project, extra_exclude)
@@ -80,9 +86,9 @@ def _assert_project_response(
 def _assert_project(
     expected_project: mlrun.api.schemas.Project,
     project: mlrun.api.schemas.Project,
-    extra_exclude: set = None,
+    extra_exclude: dict = None,
 ):
-    exclude = {"id", "created"}
+    exclude = {"id": ..., "metadata": {"created"}}
     if extra_exclude:
         exclude.update(extra_exclude)
     assert (

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -11,9 +11,9 @@ import mlrun.api.schemas
 def test_projects_crud(db: Session, client: TestClient) -> None:
     name1 = f"prj-{uuid4().hex}"
     project_1 = mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=name1),
-            spec=mlrun.api.schemas.ProjectSpec(description="banana", source="source"),
-        )
+        metadata=mlrun.api.schemas.ProjectMetadata(name=name1),
+        spec=mlrun.api.schemas.ProjectSpec(description="banana", source="source"),
+    )
 
     # create
     response = client.post("/api/projects", json=project_1.dict())
@@ -25,17 +25,15 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
     _assert_project_response(project_1, response)
 
     # patch
-    project_patch = {
-        'spec': {
-            'description': "lemon",
-        }
-    }
-    response = client.patch(
-        f"/api/projects/{name1}", json=project_patch
-    )
+    project_patch = {"spec": {"description": "lemon"}}
+    response = client.patch(f"/api/projects/{name1}", json=project_patch)
     assert response.status_code == HTTPStatus.OK.value
-    _assert_project_response(project_1, response, extra_exclude={"spec": {"description"}})
-    assert project_patch['spec']["description"] == response.json()['spec']["description"]
+    _assert_project_response(
+        project_1, response, extra_exclude={"spec": {"description"}}
+    )
+    assert (
+        project_patch["spec"]["description"] == response.json()["spec"]["description"]
+    )
 
     name2 = f"prj-{uuid4().hex}"
     project_2 = mlrun.api.schemas.Project(
@@ -62,7 +60,9 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
     projects_output = mlrun.api.schemas.ProjectsOutput(**response.json())
     expected = [project_1, project_2]
     for index, project in enumerate(projects_output.projects):
-        _assert_project(expected[index], project, extra_exclude={"spec": {"description"}})
+        _assert_project(
+            expected[index], project, extra_exclude={"spec": {"description"}}
+        )
 
     # delete
     response = client.delete(f"/api/projects/{name1}")

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -122,7 +122,9 @@ def test_list_project(
             db_session,
             mlrun.api.schemas.Project(
                 metadata=mlrun.api.schemas.ProjectMetadata(name=project["name"]),
-                spec=mlrun.api.schemas.ProjectSpec(description=project.get("description")),
+                spec=mlrun.api.schemas.ProjectSpec(
+                    description=project.get("description")
+                ),
             ),
         )
     projects_output = db.list_projects(db_session)
@@ -145,7 +147,9 @@ def test_create_project(
     db.create_project(
         db_session,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name, created=project_created),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=project_name, created=project_created
+            ),
             spec=mlrun.api.schemas.ProjectSpec(description=project_description),
         ),
     )
@@ -171,7 +175,9 @@ def test_store_project_creation(
         db_session,
         project_name,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name, created=project_created),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=project_name, created=project_created
+            ),
             spec=mlrun.api.schemas.ProjectSpec(description=project_description),
         ),
     )
@@ -195,13 +201,17 @@ def test_store_project_update(
     db.create_project(
         db_session,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name, created=project_created),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=project_name, created=project_created
+            ),
             spec=mlrun.api.schemas.ProjectSpec(description=project_description),
         ),
     )
 
     db.store_project(
-        db_session, project_name, mlrun.api.schemas.Project(
+        db_session,
+        project_name,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         ),
     )
@@ -233,11 +243,7 @@ def test_patch_project(
     db.patch_project(
         db_session,
         project_name,
-        {
-            'spec':{
-                'description': updated_project_description,
-            }
-        },
+        {"spec": {"description": updated_project_description}},
     )
     project_output = db.get_project(db_session, project_name)
     assert project_output.metadata.name == project_name

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -231,6 +231,7 @@ def test_patch_project(
 ):
     project_name = "project-name"
     project_description = "some description"
+    project_created = datetime.datetime.utcnow()
     db.create_project(
         db_session,
         mlrun.api.schemas.Project(
@@ -243,11 +244,16 @@ def test_patch_project(
     db.patch_project(
         db_session,
         project_name,
-        {"spec": {"description": updated_project_description}},
+        {
+            "metadata": {"created": project_created},
+            "spec": {"description": updated_project_description},
+        },
     )
     project_output = db.get_project(db_session, project_name)
     assert project_output.metadata.name == project_name
     assert project_output.spec.description == updated_project_description
+    # Created in request body should be ignored and set by the DB layer
+    assert project_output.metadata.created != project_created
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon

--- a/tests/api/utils/clients/test_nuclio.py
+++ b/tests/api/utils/clients/test_nuclio.py
@@ -203,13 +203,7 @@ def test_patch_project(
     )
     requests_mock.put(f"{api_url}/api/projects", json=verify_patch)
     nuclio_client.patch_project(
-        None,
-        project_name,
-        {
-            'spec': {
-                'description': project_description,
-            }
-        },
+        None, project_name, {"spec": {"description": project_description}},
     )
 
 

--- a/tests/api/utils/clients/test_nuclio.py
+++ b/tests/api/utils/clients/test_nuclio.py
@@ -36,15 +36,15 @@ def test_get_project(
     )
     requests_mock.get(f"{api_url}/api/projects/{project_name}", json=response_body)
     project = nuclio_client.get_project(None, project_name)
-    assert project.name == project_name
-    assert project.description == project_description
+    assert project.metadata.name == project_name
+    assert project.spec.description == project_description
 
     # now without description
     response_body = _generate_project_body(project_name, with_spec=True)
     requests_mock.get(f"{api_url}/api/projects/{project_name}", json=response_body)
     project = nuclio_client.get_project(None, project_name)
-    assert project.name == project_name
-    assert project.description is None
+    assert project.metadata.name == project_name
+    assert project.spec.description is None
 
 
 def test_list_project(
@@ -67,8 +67,8 @@ def test_list_project(
     requests_mock.get(f"{api_url}/api/projects", json=response_body)
     projects = nuclio_client.list_projects(None)
     for index, project in enumerate(projects.projects):
-        assert project.name == mock_projects[index]["name"]
-        assert project.description == mock_projects[index].get("description")
+        assert project.metadata.name == mock_projects[index]["name"]
+        assert project.spec.description == mock_projects[index].get("description")
 
 
 def test_create_project(
@@ -95,7 +95,10 @@ def test_create_project(
     requests_mock.post(f"{api_url}/api/projects", json=verify_creation)
     nuclio_client.create_project(
         None,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
 
 
@@ -129,7 +132,10 @@ def test_store_project_creation(
     nuclio_client.store_project(
         None,
         project_name,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
 
 
@@ -165,7 +171,10 @@ def test_store_project_update(
     nuclio_client.store_project(
         None,
         project_name,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
 
 
@@ -196,7 +205,11 @@ def test_patch_project(
     nuclio_client.patch_project(
         None,
         project_name,
-        mlrun.api.schemas.ProjectPatch(description=project_description),
+        {
+            'spec': {
+                'description': project_description,
+            }
+        },
     )
 
 

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -59,7 +59,10 @@ def test_projects_sync_follower_project_adoption(
     project_description = "some description"
     nop_follower.create_project(
         None,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
     _assert_project_in_followers([nop_follower], project_name, project_description)
     _assert_no_projects_in_followers([leader_follower, second_nop_follower])
@@ -83,11 +86,16 @@ def test_projects_sync_leader_project_syncing(
     project_description = "some description"
     leader_follower.create_project(
         None,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
     invalid_project_name = "invalid_name"
     leader_follower.create_project(
-        None, mlrun.api.schemas.Project(name=invalid_project_name),
+        None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=invalid_project_name),
+        ),
     )
     _assert_project_in_followers([leader_follower], project_name, project_description)
     _assert_project_in_followers([leader_follower], invalid_project_name)
@@ -118,22 +126,22 @@ def test_projects_sync_multiple_follower_project_adoption(
     nop_follower.create_project(
         None,
         mlrun.api.schemas.Project(
-            name=both_followers_project_name,
-            description=both_followers_project_description,
+            metadata=mlrun.api.schemas.ProjectMetadata(name=both_followers_project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=both_followers_project_description),
         ),
     )
     second_nop_follower.create_project(
         None,
         mlrun.api.schemas.Project(
-            name=both_followers_project_name,
-            description=both_followers_project_description,
+            metadata=mlrun.api.schemas.ProjectMetadata(name=both_followers_project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=both_followers_project_description),
         ),
     )
     second_nop_follower.create_project(
         None,
         mlrun.api.schemas.Project(
-            name=second_follower_project_name,
-            description=second_follower_project_description,
+            metadata=mlrun.api.schemas.ProjectMetadata(name=second_follower_project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=second_follower_project_description),
         ),
     )
     leader_follower.create_project = unittest.mock.Mock(
@@ -178,7 +186,10 @@ def test_create_project(
     project_description = "some description"
     projects_leader.create_project(
         None,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
     _assert_project_in_followers(
         [leader_follower, nop_follower], project_name, project_description
@@ -228,21 +239,29 @@ def test_create_and_store_project_failure_invalid_name(
         project_name = case["name"]
         if case["valid"]:
             projects_leader.create_project(
-                None, mlrun.api.schemas.Project(name=project_name),
+                None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
             )
             _assert_project_in_followers([leader_follower], project_name)
             projects_leader.store_project(
-                None, project_name, mlrun.api.schemas.Project(name=project_name),
+                None, project_name, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
             )
             _assert_project_in_followers([leader_follower], project_name)
         else:
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
                 projects_leader.create_project(
-                    None, mlrun.api.schemas.Project(name=project_name),
+                    None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
                 )
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
                 projects_leader.store_project(
-                    None, project_name, mlrun.api.schemas.Project(name=project_name),
+                    None, project_name, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
                 )
             _assert_project_not_in_followers([leader_follower], project_name)
 
@@ -281,7 +300,10 @@ def test_store_project_creation(
     projects_leader.store_project(
         None,
         project_name,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
     _assert_project_in_followers(
         [leader_follower, nop_follower], project_name, project_description
@@ -298,7 +320,10 @@ def test_store_project_update(
     project_description = "some description"
     projects_leader.create_project(
         None,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
     _assert_project_in_followers(
         [leader_follower, nop_follower], project_name, project_description
@@ -306,7 +331,9 @@ def test_store_project_update(
 
     # removing description from the projects
     projects_leader.store_project(
-        None, project_name, mlrun.api.schemas.Project(name=project_name),
+        None, project_name,  mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
     )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
@@ -319,7 +346,9 @@ def test_patch_project(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(name=project_name),
+        None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
     )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
@@ -328,7 +357,11 @@ def test_patch_project(
     projects_leader.patch_project(
         None,
         project_name,
-        mlrun.api.schemas.ProjectPatch(description=project_description),
+        {
+            'spec': {
+                'description': project_description,
+            }
+        },
     )
     _assert_project_in_followers(
         [leader_follower, nop_follower], project_name, project_description
@@ -343,17 +376,21 @@ def test_store_and_patch_project_failure_conflict_body_path_name(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(name=project_name),
+        None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
     )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
     with pytest.raises(mlrun.errors.MLRunConflictError):
         projects_leader.store_project(
-            None, project_name, mlrun.api.schemas.Project(name="different-name"),
+            None, project_name, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name="different-name"),
+        ),
         )
     with pytest.raises(mlrun.errors.MLRunConflictError):
         projects_leader.patch_project(
-            None, project_name, mlrun.api.schemas.ProjectPatch(name="different-name"),
+            None, project_name, {'metadata': {'name':"different-name"}},
         )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
@@ -366,7 +403,9 @@ def test_delete_project(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(name=project_name),
+        None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
     )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
@@ -382,19 +421,23 @@ def test_list_projects(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(name=project_name),
+        None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+        ),
     )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
     # add some project to follower
     nop_follower.create_project(
-        None, mlrun.api.schemas.Project(name="some-other-project")
+        None, mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name="some-other-project"),
+        ),
     )
 
     # assert list considers only the leader
     projects = projects_leader.list_projects(None)
     assert len(projects.projects) == 1
-    assert projects.projects[0].name == project_name
+    assert projects.projects[0].metadata.name == project_name
 
 
 def test_get_project(
@@ -407,7 +450,10 @@ def test_get_project(
     project_description = "some description"
     projects_leader.create_project(
         None,
-        mlrun.api.schemas.Project(name=project_name, description=project_description),
+        mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
+        ),
     )
     _assert_project_in_followers(
         [leader_follower, nop_follower], project_name, project_description
@@ -417,13 +463,17 @@ def test_get_project(
     nop_follower.patch_project(
         None,
         project_name,
-        mlrun.api.schemas.ProjectPatch(description="updated description"),
+        {
+            'spec': {
+                'description': "updated description",
+            }
+        },
     )
 
     # assert list considers only the leader
     project = projects_leader.get_project(None, project_name)
-    assert project.name == project_name
-    assert project.description == project_description
+    assert project.metadata.name == project_name
+    assert project.spec.description == project_description
 
 
 def _assert_project_not_in_followers(followers, name):
@@ -438,5 +488,5 @@ def _assert_no_projects_in_followers(followers):
 
 def _assert_project_in_followers(followers, name, description=None):
     for follower in followers:
-        assert follower._projects[name].name == name
-        assert follower._projects[name].description == description
+        assert follower._projects[name].metadata.name == name
+        assert follower._projects[name].spec.description == description

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -93,7 +93,8 @@ def test_projects_sync_leader_project_syncing(
     )
     invalid_project_name = "invalid_name"
     leader_follower.create_project(
-        None, mlrun.api.schemas.Project(
+        None,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=invalid_project_name),
         ),
     )
@@ -126,22 +127,34 @@ def test_projects_sync_multiple_follower_project_adoption(
     nop_follower.create_project(
         None,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=both_followers_project_name),
-            spec=mlrun.api.schemas.ProjectSpec(description=both_followers_project_description),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=both_followers_project_name
+            ),
+            spec=mlrun.api.schemas.ProjectSpec(
+                description=both_followers_project_description
+            ),
         ),
     )
     second_nop_follower.create_project(
         None,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=both_followers_project_name),
-            spec=mlrun.api.schemas.ProjectSpec(description=both_followers_project_description),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=both_followers_project_name
+            ),
+            spec=mlrun.api.schemas.ProjectSpec(
+                description=both_followers_project_description
+            ),
         ),
     )
     second_nop_follower.create_project(
         None,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=second_follower_project_name),
-            spec=mlrun.api.schemas.ProjectSpec(description=second_follower_project_description),
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=second_follower_project_name
+            ),
+            spec=mlrun.api.schemas.ProjectSpec(
+                description=second_follower_project_description
+            ),
         ),
     )
     leader_follower.create_project = unittest.mock.Mock(
@@ -239,29 +252,35 @@ def test_create_and_store_project_failure_invalid_name(
         project_name = case["name"]
         if case["valid"]:
             projects_leader.create_project(
-                None, mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
-        ),
+                None,
+                mlrun.api.schemas.Project(
+                    metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+                ),
             )
             _assert_project_in_followers([leader_follower], project_name)
             projects_leader.store_project(
-                None, project_name, mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
-        ),
+                None,
+                project_name,
+                mlrun.api.schemas.Project(
+                    metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+                ),
             )
             _assert_project_in_followers([leader_follower], project_name)
         else:
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
                 projects_leader.create_project(
-                    None, mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
-        ),
+                    None,
+                    mlrun.api.schemas.Project(
+                        metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+                    ),
                 )
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
                 projects_leader.store_project(
-                    None, project_name, mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
-        ),
+                    None,
+                    project_name,
+                    mlrun.api.schemas.Project(
+                        metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+                    ),
                 )
             _assert_project_not_in_followers([leader_follower], project_name)
 
@@ -331,7 +350,9 @@ def test_store_project_update(
 
     # removing description from the projects
     projects_leader.store_project(
-        None, project_name,  mlrun.api.schemas.Project(
+        None,
+        project_name,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         ),
     )
@@ -346,7 +367,8 @@ def test_patch_project(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(
+        None,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         ),
     )
@@ -355,13 +377,7 @@ def test_patch_project(
     # Adding description to the projects
     project_description = "some description"
     projects_leader.patch_project(
-        None,
-        project_name,
-        {
-            'spec': {
-                'description': project_description,
-            }
-        },
+        None, project_name, {"spec": {"description": project_description}},
     )
     _assert_project_in_followers(
         [leader_follower, nop_follower], project_name, project_description
@@ -376,7 +392,8 @@ def test_store_and_patch_project_failure_conflict_body_path_name(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(
+        None,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         ),
     )
@@ -384,13 +401,15 @@ def test_store_and_patch_project_failure_conflict_body_path_name(
 
     with pytest.raises(mlrun.errors.MLRunConflictError):
         projects_leader.store_project(
-            None, project_name, mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name="different-name"),
-        ),
+            None,
+            project_name,
+            mlrun.api.schemas.Project(
+                metadata=mlrun.api.schemas.ProjectMetadata(name="different-name"),
+            ),
         )
     with pytest.raises(mlrun.errors.MLRunConflictError):
         projects_leader.patch_project(
-            None, project_name, {'metadata': {'name':"different-name"}},
+            None, project_name, {"metadata": {"name": "different-name"}},
         )
     _assert_project_in_followers([leader_follower, nop_follower], project_name)
 
@@ -403,7 +422,8 @@ def test_delete_project(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(
+        None,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         ),
     )
@@ -421,7 +441,8 @@ def test_list_projects(
 ):
     project_name = "project-name"
     projects_leader.create_project(
-        None, mlrun.api.schemas.Project(
+        None,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         ),
     )
@@ -429,7 +450,8 @@ def test_list_projects(
 
     # add some project to follower
     nop_follower.create_project(
-        None, mlrun.api.schemas.Project(
+        None,
+        mlrun.api.schemas.Project(
             metadata=mlrun.api.schemas.ProjectMetadata(name="some-other-project"),
         ),
     )
@@ -461,13 +483,7 @@ def test_get_project(
 
     # change project description in follower
     nop_follower.patch_project(
-        None,
-        project_name,
-        {
-            'spec': {
-                'description': "updated description",
-            }
-        },
+        None, project_name, {"spec": {"description": "updated description"}},
     )
 
     # assert list considers only the leader

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -37,7 +37,6 @@ def test_create_project_from_file_with_legacy_structure():
     legacy_project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"
     legacy_project.save(str(legacy_project_file_path))
     project = mlrun.load_project(None, str(legacy_project_file_path))
-    project.export(str(legacy_project_file_path))
     assert project.kind == "project"
     assert project.metadata.name == project_name
     assert project.spec.description == description

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -37,6 +37,7 @@ def test_create_project_from_file_with_legacy_structure():
     legacy_project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"
     legacy_project.save(str(legacy_project_file_path))
     project = mlrun.load_project(None, str(legacy_project_file_path))
+    project.export(str(legacy_project_file_path))
     assert project.kind == "project"
     assert project.metadata.name == project_name
     assert project.spec.description == description

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1,0 +1,62 @@
+import pathlib
+
+import deepdiff
+
+import mlrun
+import mlrun.projects.project
+import tests.conftest
+
+
+def test_create_project_from_file_with_legacy_structure():
+    project_name = "project-name"
+    description = "project description"
+    params = {"param_key": "param value"}
+    artifact_path = "/tmp"
+    legacy_project = mlrun.projects.project.MlrunProjectLegacy(
+        project_name, description, params, artifact_path=artifact_path
+    )
+    function_name = "trainer-function"
+    function = mlrun.new_function(function_name, project_name)
+    legacy_project.set_function(function, function_name)
+    legacy_project.set_function("hub://describe", "describe")
+    workflow_name = "workflow-name"
+    workflow_file_path = (
+        pathlib.Path(tests.conftest.tests_root_directory) / "projects" / "workflow.py"
+    )
+    legacy_project.set_workflow(workflow_name, str(workflow_file_path))
+    artifact_dict = {
+        "key": "raw-data",
+        "kind": "",
+        "iter": 0,
+        "tree": "latest",
+        "target_path": "https://raw.githubusercontent.com/mlrun/demos/master/customer-churn-prediction/WA_Fn-UseC_-Telc"
+        "o-Customer-Churn.csv",
+        "db_key": "raw-data",
+    }
+    legacy_project.artifacts = [artifact_dict]
+    legacy_project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"
+    legacy_project.save(str(legacy_project_file_path))
+    project = mlrun.load_project(None, str(legacy_project_file_path))
+    assert project.kind == "project"
+    assert project.metadata.name == project_name
+    assert project.spec.description == description
+    assert project.spec.artifact_path == artifact_path
+    assert deepdiff.DeepDiff(params, project.spec.params, ignore_order=True,) == {}
+    assert (
+        deepdiff.DeepDiff(
+            legacy_project.functions, project.functions, ignore_order=True,
+        )
+        == {}
+    )
+    assert (
+        deepdiff.DeepDiff(
+            legacy_project.workflows, project.workflows, ignore_order=True,
+        )
+        == {}
+    )
+    assert (
+        deepdiff.DeepDiff(
+            legacy_project.artifacts, project.artifacts, ignore_order=True,
+        )
+        == {}
+    )

--- a/tests/projects/workflow.py
+++ b/tests/projects/workflow.py
@@ -1,0 +1,15 @@
+from kfp import dsl
+
+funcs = {}
+
+
+@dsl.pipeline(name="Example pipeline", description="some pipeline description.")
+def kfpipeline():
+
+    # analyze our dataset
+    funcs["describe"].as_step(
+        name="summary", params={"label_column": "labels"},
+    )
+
+    # train with hyper-paremeters
+    funcs["trainer-function"].as_step(name="trainer-function",)

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -166,7 +166,7 @@ def server_fixture():
 
 servers = [
     "server",
-    "docker",
+    # "docker",
 ]
 
 
@@ -587,7 +587,7 @@ def test_project_file_db_roundtrip(create_server):
 def _assert_projects(expected_project, project):
     assert (
         deepdiff.DeepDiff(
-            expected_project.to_dict(), project.to_dict(), ignore_order=True,
+            expected_project.to_dict(), project.to_dict(), ignore_order=True, exclude_paths={"root['metadata']['created']"}
         )
         == {}
     )

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -166,7 +166,7 @@ def server_fixture():
 
 servers = [
     "server",
-    # "docker",
+    "docker",
 ]
 
 

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -32,7 +32,7 @@ from mlrun import RunObject
 from mlrun.artifacts import Artifact
 from mlrun.db import RunDBError
 from mlrun.db.httpdb import HTTPRunDB
-from tests.conftest import wait_for_server, tests_root_directory, results
+from tests.conftest import wait_for_server, tests_root_directory
 import mlrun.projects.project
 
 project_dir_path = Path(__file__).absolute().parent.parent.parent
@@ -579,7 +579,10 @@ def test_project_file_db_roundtrip(create_server):
 def _assert_projects(expected_project, project):
     assert (
         deepdiff.DeepDiff(
-            expected_project.to_dict(), project.to_dict(), ignore_order=True, exclude_paths={"root['metadata']['created']"}
+            expected_project.to_dict(),
+            project.to_dict(),
+            ignore_order=True,
+            exclude_paths={"root['metadata']['created']"},
         )
         == {}
     )

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -527,24 +527,28 @@ def test_project_file_db_roundtrip(create_server):
     branch = "branch"
     tag = "tag"
     project_metadata = mlrun.projects.project.ProjectMetadata(project_name)
-    project_spec = mlrun.projects.project.ProjectSpec(description, params, artifact_path=artifact_path, conda=conda,
-                                                      source=source,
-                                                      context=context,
-                                                      mountdir=mountdir,
-                                                      subpath=subpath,
-                                                      origin_url=origin_url,
-                                                      branch=branch,
-                                                      tag=tag,
-                                                      )
-    project = mlrun.projects.project.MlrunProject(metadata=project_metadata, spec=project_spec)
+    project_spec = mlrun.projects.project.ProjectSpec(
+        description,
+        params,
+        artifact_path=artifact_path,
+        conda=conda,
+        source=source,
+        context=context,
+        mountdir=mountdir,
+        subpath=subpath,
+        origin_url=origin_url,
+        branch=branch,
+        tag=tag,
+    )
+    project = mlrun.projects.project.MlrunProject(
+        metadata=project_metadata, spec=project_spec
+    )
     function_name = "trainer-function"
     function = mlrun.new_function(function_name, project_name)
     project.set_function(function, function_name)
     project.set_function("hub://describe", "describe")
     workflow_name = "workflow-name"
-    workflow_file_path = (
-            Path(tests_root_directory) / "rundb" / "workflow.py"
-    )
+    workflow_file_path = Path(tests_root_directory) / "rundb" / "workflow.py"
     project.set_workflow(workflow_name, str(workflow_file_path))
     artifact_dict = {
         "key": "raw-data",
@@ -552,7 +556,7 @@ def test_project_file_db_roundtrip(create_server):
         "iter": 0,
         "tree": "latest",
         "target_path": "https://raw.githubusercontent.com/mlrun/demos/master/customer-churn-prediction/WA_Fn-UseC_-Telc"
-                       "o-Customer-Churn.csv",
+        "o-Customer-Churn.csv",
         "db_key": "raw-data",
     }
     project.artifacts = [artifact_dict]
@@ -570,10 +574,8 @@ def test_project_file_db_roundtrip(create_server):
 
 def _assert_projects(expected_project, project):
     assert (
-            deepdiff.DeepDiff(
-                expected_project.to_dict(),
-                project.to_dict(),
-                ignore_order=True,
-            )
-            == {}
+        deepdiff.DeepDiff(
+            expected_project.to_dict(), project.to_dict(), ignore_order=True,
+        )
+        == {}
     )

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -532,12 +532,8 @@ def test_project_file_db_roundtrip(create_server):
     artifact_path = "/tmp"
     conda = "conda"
     source = "source"
-    context = str(results)
-    mountdir = "mountdir"
     subpath = "subpath"
     origin_url = "origin_url"
-    branch = "branch"
-    tag = "tag"
     project_metadata = mlrun.projects.project.ProjectMetadata(project_name)
     project_spec = mlrun.projects.project.ProjectSpec(
         description,
@@ -545,12 +541,8 @@ def test_project_file_db_roundtrip(create_server):
         artifact_path=artifact_path,
         conda=conda,
         source=source,
-        context=context,
-        mountdir=mountdir,
         subpath=subpath,
         origin_url=origin_url,
-        branch=branch,
-        tag=tag,
     )
     project = mlrun.projects.project.MlrunProject(
         metadata=project_metadata, spec=project_spec

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -160,10 +160,10 @@ def test_list_tags(db: SQLDB, db_session: Session):
 
 def test_projects_crud(db: SQLDB, db_session: Session):
     project = mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name="p1"),
-            spec=mlrun.api.schemas.ProjectSpec(description="banana", other_field="value"),
-            status=mlrun.api.schemas.ObjectStatus(state="active"),
-        )
+        metadata=mlrun.api.schemas.ProjectMetadata(name="p1"),
+        spec=mlrun.api.schemas.ProjectSpec(description="banana", other_field="value"),
+        status=mlrun.api.schemas.ObjectStatus(state="active"),
+    )
     db.create_project(db_session, project)
     project_output = db.get_project(db_session, name=project.metadata.name)
     assert (
@@ -173,18 +173,14 @@ def test_projects_crud(db: SQLDB, db_session: Session):
         == {}
     )
 
-    project_patch = {
-            'spec': {
-                'description': "lemon",
-            }
-        }
+    project_patch = {"spec": {"description": "lemon"}}
     db.patch_project(db_session, project.metadata.name, project_patch)
     project_output = db.get_project(db_session, name=project.metadata.name)
-    assert project_output.spec.description == project_patch['spec']['description']
+    assert project_output.spec.description == project_patch["spec"]["description"]
 
     project_2 = mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name="p2"),
-        )
+        metadata=mlrun.api.schemas.ProjectMetadata(name="p2"),
+    )
     db.create_project(db_session, project_2)
     projects_output = db.list_projects(
         db_session, format_=mlrun.api.schemas.Format.name_only

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -85,7 +85,7 @@ def test_list_projects(db: SQLDB, db_session: Session):
     projects_output = db.list_projects(db_session)
 
     assert {"prj0", "prj1", "prj2"} == {
-        project.name for project in projects_output.projects
+        project.metadata.name for project in projects_output.projects
     }
 
 
@@ -160,10 +160,12 @@ def test_list_tags(db: SQLDB, db_session: Session):
 
 def test_projects_crud(db: SQLDB, db_session: Session):
     project = mlrun.api.schemas.Project(
-        name="p1", description="banana", spec={"other_field": "value"}, state="active"
-    )
+            metadata=mlrun.api.schemas.ProjectMetadata(name="p1"),
+            spec=mlrun.api.schemas.ProjectSpec(description="banana", other_field="value"),
+            status=mlrun.api.schemas.ObjectStatus(state="active"),
+        )
     db.create_project(db_session, project)
-    project_output = db.get_project(db_session, name=project.name)
+    project_output = db.get_project(db_session, name=project.metadata.name)
     assert (
         deepdiff.DeepDiff(
             project.dict(), project_output.dict(exclude={"id"}), ignore_order=True,
@@ -171,17 +173,23 @@ def test_projects_crud(db: SQLDB, db_session: Session):
         == {}
     )
 
-    project_update = mlrun.api.schemas.ProjectPatch(description="lemon")
-    db.patch_project(db_session, project.name, project_update)
-    project_output = db.get_project(db_session, name=project.name)
-    assert project_output.description == project_update.description
+    project_patch = {
+            'spec': {
+                'description': "lemon",
+            }
+        }
+    db.patch_project(db_session, project.metadata.name, project_patch)
+    project_output = db.get_project(db_session, name=project.metadata.name)
+    assert project_output.spec.description == project_patch['spec']['description']
 
-    project_2 = mlrun.api.schemas.Project(name="p2")
+    project_2 = mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(name="p2"),
+        )
     db.create_project(db_session, project_2)
     projects_output = db.list_projects(
         db_session, format_=mlrun.api.schemas.Format.name_only
     )
-    assert [project.name, project_2.name] == projects_output.projects
+    assert [project.metadata.name, project_2.metadata.name] == projects_output.projects
 
 
 # def test_function_latest(db: SQLDB, db_session: Session):

--- a/tests/rundb/workflow.py
+++ b/tests/rundb/workflow.py
@@ -1,0 +1,15 @@
+from kfp import dsl
+
+funcs = {}
+
+
+@dsl.pipeline(name="Example pipeline", description="some pipeline description.")
+def kfpipeline():
+
+    # analyze our dataset
+    funcs["describe"].as_step(
+        name="summary", params={"label_column": "labels"},
+    )
+
+    # train with hyper-paremeters
+    funcs["trainer-function"].as_step(name="trainer-function",)


### PR DESCRIPTION
* So far the SDK class was completely disconnected from the API, (confusingly) even doing `.save()` would cause the project to be saved to a file, there was no useful way to actually back up the projects to the DB. (Note the projects were getting created in the DB when you created a resource of a project (function,run,artifact etc..) but it was only the name without all the project data) - This PR changed that, from now on `.save()` would save to the DB (in addition to saving to file) + all of the API methods (httpdb) are accepting and returning `MlrunProject` instances, so you can get a project from the db by doing:
```
from mlrun import get_run_db
get_run_db().get_project(<name>)
```
* Since https://github.com/mlrun/mlrun/pull/542 anyways does non-backwards compatible changes to the projects API, I used the option and did a restructure to the project object so that it will have `metadata`, `spec` and `status` like our other resources. Except than different output file format this should be completely transparent to the user, the code "knows" how to load from the old structure file, and there are "proxy attributes" so if your code is doing `project.name` (while it should do `project.metadata.name`) it will work and won't explode (though there is a deprecation plan for these proxy attributes)
So a project file looked something like:
```
name: churn-project
functions:
- name: clean-data
  spec:
    kind: job
    metadata:
      name: clean-data
      tag: ''
      project: churn-project
    spec:
      command: ''
      args: []
      image: mlrun/ml-models
      env: []
      default_handler: ''
    verbose: false
- url: hub://describe
  name: describe
workflows:
- name: workflow-name
  path: /Users/hediingber/iguazio/misc-workspace/mlrun/mlrun/tests/projects/workflow.py
artifacts:
- key: raw-data
  kind: ''
  iter: 0
  tree: latest
  target_path: https://raw.githubusercontent.com/mlrun/demos/master/customer-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv
  db_key: raw-data
artifact_path: /User/mlrun-demos/customer-churn-prediction/data
```
will now look something like:
```
kind: project
metadata:
  name: last-project
spec:
  functions:
  - name: clean-data
    spec:
      kind: job
      metadata:
        name: clean-data
        tag: ''
        project: last-project
      spec:
        command: ''
        args: []
        image: mlrun/ml-models
        env: []
        default_handler: ''
      verbose: false
  - url: hub://describe
    name: describe
  workflows:
  - name: workflow-name
    path: /Users/hediingber/iguazio/misc-workspace/mlrun/mlrun/tests/projects/workflow.py
  artifacts:
  - key: raw-data
    kind: ''
    iter: 0
    tree: latest
    target_path: https://raw.githubusercontent.com/mlrun/demos/master/customer-churn-prediction/WA_Fn-UseC_-Telco-Customer-Churn.csv
    db_key: raw-data
  artifact_path: /User/mlrun-demos/customer-churn-prediction/data
  source: ''
  context: ./project
  subpath: ''
  origin_url: ''
  tag: ''
```

Should be Merged/released together with https://github.com/mlrun/ui/pull/322