### PR TITLE
[Requirements] Fix conflicts

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: pip install -r automation/requirements.txt && python setup.py develop
+      run: pip install -r automation/requirements.txt && pip install -e .
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git hash from action mlrun version

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,3 +1,2 @@
-# ==7.0 from kfp
-click==7.0
+click~=7.0
 paramiko~=2.7

--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -1,4 +1,9 @@
 uvicorn~=0.12.0
+# dask-kubernetes 0.11.0 has distributed>=2.5.2, but after 2.30.1 they moved to CalVer and released 2020.12.0
+# so without our limitation to <3, 2020.12.0 is installed which is incompatible since it has dask>=2020.12.0 while ours
+# is ~=2.12
+# TODO: dask-kubernetes will probably release 0.11.1 with a fix for this soon and this could be removed
+distributed>=2.5.2, <3
 dask-kubernetes~=0.11.0
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes-asyncio~=11.0

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -53,4 +53,4 @@ RUN pip install \
 
 COPY . .
 
-RUN python setup.py develop
+RUN pip install -e .


### PR DESCRIPTION
* Saw this error in the system tests:
`error: chardet 4.0.0 is installed but chardet<4.0,>=2.0 is required by {'aiohttp'}`
and [reading this](https://stackoverflow.com/questions/19048732/python-setup-py-develop-vs-install) I understand this is happening because we `python setup.py develop` which is discouraged, changed to `pip install -e .`
* noticed that in the automation requirements we're still `click==7.0` which was pinned because of kfp, already bumped kfp in https://github.com/mlrun/mlrun/pull/568 so was able to change it to `click~=7.0`
* Found a conflict with new distributed version see detailed explanation in comment