### PR TITLE
[Requirements] Fix conflicts [0.5.x Backport]

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: pip install -r automation/requirements.txt && python setup.py develop
+      run: pip install -r automation/requirements.txt && pip install --editable .
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git hash from action mlrun version


### PR DESCRIPTION
*Saw this error in the system tests:
error: chardet 4.0.0 is installed but chardet<4.0,>=2.0 is required by {'aiohttp'}
and reading this I understand this is happening because we `python setup.py develop` which is discouraged, changed to `pip install --editable .`