### PR TITLE
[System tests] Enable to take UI from action branch name in mlrun/ui

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - development
-#    - '[0-9]+.[0-9]+.x'
+    - '[0-9]+.[0-9]+.x'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -25,6 +25,10 @@ on:
         description: 'Take tested code from action REF (default: false - take from upstream) (note that test code will be taken from the action REF anyways)'
         required: true
         default: 'false'
+      ui_code_from_action:
+        description: 'Take ui code from action branch in mlrun/ui (default: false - take from upstream)'
+        required: true
+        default: 'false'
 
 jobs:
   run-system-tests-ci:
@@ -50,6 +54,17 @@ jobs:
       id: git_action_info
       run: |
         echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+    - name: Extract git hash from action mlrun version
+      if: ${{ github.event.inputs.ui_code_from_action_branch == 'true' }}
+      id: git_action_ui_info
+      run: |
+        echo "::set-output name=ui_hash::$( \
+          cd /tmp && \
+          git clone --single-branch --branch ${{ github.ref }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          cd mlrun-ui && \
+          git rev-parse --short HEAD && \
+          cd .. && \
+          rm -rf mlrun-ui)"
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info
       run: |
@@ -75,8 +90,12 @@ jobs:
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
         export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
         echo "::set-output name=mlrun_hash::$(echo $mlrun_hash)"
+        action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
+        upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
+        export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
+        echo "::set-output name=ui_hash::$(echo $ui_hash)"
         echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
-        echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-${{ steps.git_upstream_info.outputs.ui_hash }}"
+        echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-$ui_hash"
         echo "::set-output name=mlrun_docker_repo::$( \
           input_docker_repo=${{ github.event.inputs.docker_repo }} && \
           echo ${input_docker_repo:-mlrun})"

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -49,19 +49,22 @@ jobs:
       run: pip install -r automation/requirements.txt && pip install -e .
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-    - name: Extract git info from action git ref
+    - name: Extract git branch
+      id: git_info
+      run: |
+        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+    - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.test_code_from_action == 'true' }}
       id: git_action_info
       run: |
         echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
-        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
     - name: Extract git hash from action mlrun version
-      if: ${{ github.event.inputs.ui_code_from_action_branch == 'true' }}
+      if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
       run: |
         echo "::set-output name=ui_hash::$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ steps.git_action_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short HEAD && \
           cd .. && \
@@ -110,7 +113,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare System Test env.yaml and 0.6.x system
-      if: ${{ steps.git_action_info.outputs.branch != '0.5.x' }}
+      if: ${{ steps.git_info.outputs.branch != '0.5.x' }}
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
@@ -130,7 +133,7 @@ jobs:
           "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_version }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}"
 
     - name: Prepare System Test env.yaml and 0.5.x system
-      if: ${{ steps.git_action_info.outputs.branch == '0.5.x' }}
+      if: ${{ steps.git_info.outputs.branch == '0.5.x' }}
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -49,18 +49,19 @@ jobs:
       run: pip install -r automation/requirements.txt && pip install -e .
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-    - name: Extract git hash from action mlrun version
+    - name: Extract git info from action git ref
       if: ${{ github.event.inputs.test_code_from_action == 'true' }}
       id: git_action_info
       run: |
         echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action_branch == 'true' }}
       id: git_action_ui_info
       run: |
         echo "::set-output name=ui_hash::$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ github.ref }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.git_action_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short HEAD && \
           cd .. && \
@@ -109,7 +110,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Prepare System Test env.yaml and 0.6.x system
-      if: ${{ github.ref != 'refs/heads/0.5.x' }}
+      if: ${{ steps.git_action_info.outputs.branch != '0.5.x' }}
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
@@ -129,7 +130,7 @@ jobs:
           "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_version }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}"
 
     - name: Prepare System Test env.yaml and 0.5.x system
-      if: ${{ github.ref == 'refs/heads/0.5.x' }}
+      if: ${{ steps.git_action_info.outputs.branch == '0.5.x' }}
       run: |
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \


### PR DESCRIPTION
+ configure the build workflow (build images) to automatically run on push to branch with name matching this regex: `[0-9]+.[0-9]+.x` (so it will run on `0.5.x`)