### PR TITLE
[DOC REVIEW] "lifecycle" > "life cycle"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 *The fastest way to develop and deploy your AI application today.*
 
 
-**MLRun** is the first end-to-end open source MLOps solution to manage and automate your entire analytics and machine learning lifecycle, from data ingestion through model development and full pipeline deployment.
+**MLRun** is the first end-to-end open source MLOps solution to manage and automate your entire analytics and machine learning life cycle, from data ingestion through model development and full pipeline deployment.
 
 Benefits <!-- omit in toc -->
 --------
@@ -27,7 +27,7 @@ Components <!-- omit in toc -->
 
 MLRun includes the following components:
 
-* **Project lifecycle management**: experiment management and tracking of jobs, functions and artifacts.
+* **Project life-cycle management**: experiment management and tracking of jobs, functions and artifacts.
 * **Scalable functions**: turn code to scalable microservices in a single command.
 * **Managed Pipelines**: deploy, run and monitor your machine learning execution plan.
 
@@ -140,7 +140,7 @@ MLRun has many code examples and tutorial Jupyter notebooks with embedded docume
   - Serverless model serving with Nuclio &mdash; [**examples/xgb_serving.ipynb**](examples/xgb_serving.ipynb)
   - Dask &mdash; [**examples/mlrun_dask.ipynb**](examples/mlrun_dask.ipynb)
   - Spark &mdash; [**examples/mlrun_sparkk8s.ipynb**](examples/mlrun_sparkk8s.ipynb)
-- MLRun project and Git lifecycle &mdash;
+- MLRun project and Git life cycle &mdash;
   - Load a project from a remote Git location and run pipelines &mdash; [**examples/load-project.ipynb**](examples/load-project.ipynb)
   - Create a new project, functions, and pipelines, and upload to Git &mdash; [**examples/new-project.ipynb**](examples/new-project.ipynb)
 - Import and export functions using different modes &mdash; [**examples/mlrun_export_import.ipynb**](examples/mlrun_export_import.ipynb)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -15,7 +15,7 @@ MLRun has many code examples and tutorial Jupyter notebooks with embedded docume
   - Serverless model serving with Nuclio &mdash; [**xgb_serving.ipynb**](https://github.com/mlrun/mlrun/tree/master/examples/xgb_serving.ipynb)
   - Dask &mdash; [**mlrun_dask.ipynb**](https://github.com/mlrun/mlrun/tree/master/examples/mlrun_dask.ipynb)
   - Spark &mdash; [**mlrun_sparkk8s.ipynb**](https://github.com/mlrun/mlrun/tree/master/examples/mlrun_sparkk8s.ipynb)
-- MLRun project and Git lifecycle &mdash;
+- MLRun project and Git life cycle &mdash;
   - Load a project from a remote Git location and run pipelines &mdash; [**load-project.ipynb**](https://github.com/mlrun/mlrun/tree/master/examples/load-project.ipynb)
   - Create a new project, functions, and pipelines, and upload to Git &mdash; [**new-project.ipynb**](https://github.com/mlrun/mlrun/tree/master/examples/new-project.ipynb)
 - Import and export functions using files or Git &mdash; [**mlrun_export_import.ipynb**](https://github.com/mlrun/mlrun/tree/master/examples/mlrun_export_import.ipynb)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ MLRun Package Documentation
 Introduction
 ************
 
-**MLRun** is the first end-to-end open source MLOps solution to manage and automate your entire analytics and machine learning lifecycle, from data ingestion through model development and full pipeline deployment.
+**MLRun** is the first end-to-end open source MLOps solution to manage and automate your entire analytics and machine learning life cycle, from data ingestion through model development and full pipeline deployment.
 
 Benefits
 --------
@@ -28,7 +28,7 @@ Components
 
 MLRun includes the following components:
 
-* **Project lifecycle management**: experiment management and tracking of jobs, functions and artifacts.
+* **Project life-cycle management**: experiment management and tracking of jobs, functions and artifacts.
 * **Scalable functions**: turn code to scalable microservices in a single command.
 * **Managed Pipelines**: deploy, run and monitor your machine learning execution plan.
 

--- a/mlrun/serving/README.md
+++ b/mlrun/serving/README.md
@@ -5,8 +5,8 @@ Mlrun serving can take MLRun models or standard model files and produce managed 
 
 Simple model serving classes can be written in Python or be taken from a set of pre-developed 
 ML/DL classes, the code can handle complex data, feature preparation, binary data (images/video).
-The serving engine supports the full lifecycle including auto generation of micro-services, APIs, 
-load-balancing, logging, model monitoring, configuration management, etc.  
+The serving engine supports the full life cycle, including auto generation of micro-services, APIs, 
+load-balancing, logging, model monitoring, and configuration management.
 
 The underline Nuclio serverless engine is built on top of a high-performance parallel processing engine 
 which maximize the utilization of CPUs and GPUs, support 13 protocols 


### PR DESCRIPTION
Our convention is to spell "life cycle" as two words (or hyphenated — "life-cycle" — when the phrase modifies subsequent text).
@gilad-shaham FYI. @zilbermanor please merge.