### PR TITLE
[Projects] Support different deletion strategies

### DIFF
--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -49,9 +49,13 @@ def get_project(name: str, db_session: Session = Depends(deps.get_db_session)):
 
 @router.delete("/projects/{name}", status_code=HTTPStatus.NO_CONTENT.value)
 def delete_project(
-    name: str, db_session: Session = Depends(deps.get_db_session),
+    name: str,
+    deletion_strategy: schemas.DeletionStrategy = Header(
+        schemas.DeletionStrategy.default(), alias=schemas.HeaderNames.deletion_strategy
+    ),
+    db_session: Session = Depends(deps.get_db_session),
 ):
-    get_project_member().delete_project(db_session, name)
+    get_project_member().delete_project(db_session, name, deletion_strategy)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -216,7 +216,12 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def delete_project(self, session, name: str):
+    def delete_project(
+        self,
+        session,
+        name: str,
+        deletion_strategy: schemas.DeletionStrategy = schemas.DeletionStrategy.default(),
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -166,7 +166,12 @@ class FileDB(DBInterface):
     ) -> schemas.Project:
         raise NotImplementedError()
 
-    def delete_project(self, session, name: str):
+    def delete_project(
+        self,
+        session,
+        name: str,
+        deletion_strategy: schemas.DeletionStrategy = schemas.DeletionStrategy.default(),
+    ):
         raise NotImplementedError()
 
     def create_feature_set(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -718,7 +718,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
             if not project_record:
                 return
             self._verify_project_has_no_related_resources(session, name)
-        elif deletion_strategy == schemas.DeletionStrategy.restrict:
+        elif deletion_strategy == schemas.DeletionStrategy.cascade:
             self._delete_project_related_resources(session, name)
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -8,7 +8,7 @@ from .background_task import (
     BackgroundTaskSpec,
     BackgroundTaskStatus,
 )
-from .constants import Format, PatchMode, HeaderNames
+from .constants import Format, PatchMode, HeaderNames, DeletionStrategy
 from .feature_store import (
     Feature,
     FeatureRecord,

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -25,8 +25,28 @@ class PatchMode(str, Enum):
             )
 
 
+class DeletionStrategy(str, Enum):
+    restrict = "restrict"
+    cascade = "cascade"
+
+    @staticmethod
+    def default():
+        return DeletionStrategy.restrict
+
+    def to_nuclio_deletion_strategy(self) -> str:
+        if self.value == DeletionStrategy.restrict:
+            return "restricted"
+        elif self.value == DeletionStrategy.cascade:
+            return "cascading"
+        else:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Unknown deletion strategy: {self.value}"
+            )
+
+
 headers_prefix = "x-mlrun-"
 
 
 class HeaderNames:
     patch_mode = f"{headers_prefix}patch-mode"
+    deletion_strategy = f"{headers_prefix}deletion-strategy"

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -72,14 +72,33 @@ class Client(
             ]
         self._put_project_to_nuclio(response_body)
 
-    def delete_project(self, session: sqlalchemy.orm.Session, name: str):
-        logger.debug("Deleting project in Nuclio", name=name)
+    def delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
+        logger.debug(
+            "Deleting project in Nuclio", name=name, deletion_strategy=deletion_strategy
+        )
         body = self._generate_request_body(
             mlrun.api.schemas.Project(
                 metadata=mlrun.api.schemas.ProjectMetadata(name=name)
             )
         )
-        self._send_request_to_api("DELETE", "projects", json=body)
+        headers = {
+            "x-nuclio-delete-project-strategy": deletion_strategy.to_nuclio_deletion_strategy(),
+        }
+        try:
+            self._send_request_to_api("DELETE", "projects", json=body, headers=headers)
+        except requests.HTTPError as exc:
+            if exc.response.status_code != http.HTTPStatus.NOT_FOUND.value:
+                raise
+            logger.debug(
+                "Project not found in Nuclio. Considering deletion as successful",
+                name=name,
+                deletion_strategy=deletion_strategy,
+            )
 
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -8,6 +8,7 @@ import urllib3
 
 import mlrun.api.schemas
 import mlrun.api.utils.projects.remotes.member
+import mlrun.errors
 import mlrun.utils.singleton
 from mlrun.utils import logger
 
@@ -172,7 +173,7 @@ class Client(
                         {"error": error, "error_stack_trace": error_stack_trace}
                     )
             logger.warning("Request to nuclio failed", **log_kwargs)
-            response.raise_for_status()
+            mlrun.errors.raise_for_status(response)
         return response
 
     @staticmethod

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -83,7 +83,12 @@ class Member(
         self._run_on_all_followers("patch_project", session, name, project, patch_mode)
         return self.get_project(session, name)
 
-    def delete_project(self, session: sqlalchemy.orm.Session, name: str):
+    def delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         self._run_on_all_followers("delete_project", session, name)
 
     def get_project(

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -89,7 +89,7 @@ class Member(
         name: str,
         deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
     ):
-        self._run_on_all_followers("delete_project", session, name)
+        self._run_on_all_followers("delete_project", session, name, deletion_strategy)
 
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -47,7 +47,12 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_project(self, session: sqlalchemy.orm.Session, name: str):
+    def delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         pass
 
     @abc.abstractmethod

--- a/mlrun/api/utils/projects/remotes/member.py
+++ b/mlrun/api/utils/projects/remotes/member.py
@@ -33,7 +33,12 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_project(self, session: sqlalchemy.orm.Session, name: str):
+    def delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         pass
 
     @abc.abstractmethod

--- a/mlrun/api/utils/projects/remotes/nop.py
+++ b/mlrun/api/utils/projects/remotes/nop.py
@@ -40,7 +40,12 @@ class Member(mlrun.api.utils.projects.remotes.member.Member):
         mergedeep.merge(existing_project_dict, project, strategy=strategy)
         self._projects[name] = mlrun.api.schemas.Project(**existing_project_dict)
 
-    def delete_project(self, session: sqlalchemy.orm.Session, name: str):
+    def delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         if name in self._projects:
             del self._projects[name]
 

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -118,7 +118,11 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def delete_project(self, name: str):
+    def delete_project(
+        self,
+        name: str,
+        deletion_strategy: schemas.DeletionStrategy = schemas.DeletionStrategy.default(),
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -432,7 +432,11 @@ class FileRunDB(RunDBInterface):
     def get_project(self, name: str) -> mlrun.api.schemas.Project:
         raise NotImplementedError()
 
-    def delete_project(self, name: str):
+    def delete_project(
+        self,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         raise NotImplementedError()
 
     def store_project(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1005,10 +1005,19 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", path, error_message)
         return mlrun.projects.MlrunProject.from_dict(response.json())
 
-    def delete_project(self, name: str):
+    def delete_project(
+        self,
+        name: str,
+        deletion_strategy: Union[
+            str, mlrun.api.schemas.DeletionStrategy
+        ] = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         path = f"projects/{name}"
+        if isinstance(deletion_strategy, schemas.DeletionStrategy):
+            deletion_strategy = deletion_strategy.value
+        headers = {schemas.HeaderNames.deletion_strategy: deletion_strategy}
         error_message = f"Failed deleting project {name}"
-        self.api_call("DELETE", path, error_message)
+        self.api_call("DELETE", path, error_message, headers=headers)
 
     def store_project(
         self,

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -205,7 +205,11 @@ class SQLDB(RunDBInterface):
     ) -> mlrun.api.schemas.Project:
         raise NotImplementedError()
 
-    def delete_project(self, name: str):
+    def delete_project(
+        self,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
         raise NotImplementedError()
 
     def get_project(

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -84,6 +84,10 @@ class MLRunConflictError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.CONFLICT.value
 
 
+class MLRunPreconditionFailedError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.PRECONDITION_FAILED.value
+
+
 class MLRunIncompatibleVersionError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
@@ -94,4 +98,5 @@ STATUS_ERRORS = {
     HTTPStatus.FORBIDDEN.value: MLRunAccessDeniedError,
     HTTPStatus.NOT_FOUND.value: MLRunNotFoundError,
     HTTPStatus.CONFLICT.value: MLRunConflictError,
+    HTTPStatus.PRECONDITION_FAILED.value: MLRunPreconditionFailedError,
 }

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -1,4 +1,3 @@
-import pytest
 from http import HTTPStatus
 from uuid import uuid4
 

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -45,9 +45,13 @@ def test_delete_project_with_resources(
     _assert_resources_in_project(db, db_session, project_to_remove)
     # deletion strategy - restrict - should fail because there are resources
     with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
-        db.delete_project(db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.restrict)
+        db.delete_project(
+            db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.restrict
+        )
     # deletion strategy - cascade - should succeed and remove all related resources
-    db.delete_project(db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.cascade)
+    db.delete_project(
+        db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.cascade
+    )
 
     project_to_keep_table_name_records_count_map_after_project_removal = _assert_resources_in_project(
         db, db_session, project_to_keep
@@ -65,7 +69,9 @@ def test_delete_project_with_resources(
     )
 
     # deletion strategy - restrict - should succeed cause no project
-    db.delete_project(db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.restrict)
+    db.delete_project(
+        db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.restrict
+    )
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -43,7 +43,12 @@ def test_delete_project_with_resources(
         db, db_session, project_to_keep
     )
     _assert_resources_in_project(db, db_session, project_to_remove)
-    db.delete_project(db_session, project_to_remove)
+    # deletion strategy - restrict - should fail because there are resources
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        db.delete_project(db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.restrict)
+    # deletion strategy - cascade - should succeed and remove all related resources
+    db.delete_project(db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.cascade)
+
     project_to_keep_table_name_records_count_map_after_project_removal = _assert_resources_in_project(
         db, db_session, project_to_keep
     )
@@ -58,6 +63,9 @@ def test_delete_project_with_resources(
         )
         == {}
     )
+
+    # deletion strategy - restrict - should succeed cause no project
+    db.delete_project(db_session, project_to_remove, mlrun.api.schemas.DeletionStrategy.restrict)
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon

--- a/tests/api/utils/clients/test_nuclio.py
+++ b/tests/api/utils/clients/test_nuclio.py
@@ -7,6 +7,7 @@ import requests_mock as requests_mock_package
 import mlrun.api.schemas
 import mlrun.api.utils.clients.nuclio
 import mlrun.config
+import mlrun.errors
 
 
 @pytest.fixture()
@@ -344,6 +345,13 @@ def test_delete_project(
         f"{api_url}/api/projects", status_code=http.HTTPStatus.NOT_FOUND.value
     )
     nuclio_client.delete_project(None, project_name)
+
+    # assert correctly propagating 412 errors (will be returned when project has functions)
+    requests_mock.delete(
+        f"{api_url}/api/projects", status_code=http.HTTPStatus.PRECONDITION_FAILED.value
+    )
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        nuclio_client.delete_project(None, project_name)
 
 
 def _generate_project_body(

--- a/tests/api/utils/clients/test_nuclio.py
+++ b/tests/api/utils/clients/test_nuclio.py
@@ -330,9 +330,19 @@ def test_delete_project(
             )
             == {}
         )
+        assert (
+            request.headers["x-nuclio-delete-project-strategy"]
+            == mlrun.api.schemas.DeletionStrategy.default().to_nuclio_deletion_strategy()
+        )
         context.status_code = http.HTTPStatus.NO_CONTENT.value
 
     requests_mock.delete(f"{api_url}/api/projects", json=verify_deletion)
+    nuclio_client.delete_project(None, project_name)
+
+    # assert ignoring (and not exploding) on not found
+    requests_mock.delete(
+        f"{api_url}/api/projects", status_code=http.HTTPStatus.NOT_FOUND.value
+    )
     nuclio_client.delete_project(None, project_name)
 
 


### PR DESCRIPTION
Following [Nuclio's PR](https://github.com/nuclio/nuclio/pull/1996), added support in deletion strategies for project deletion:
* `restrict` - will return 412 when project exists and has related resources (won't check related resources if project doesn't exist, will succeed)
* `cascade` - will remove all related resources with the project

strategy is given using the header `x-mlrun-deletion-strategy`