### PR TITLE
[Requirements] Support extras

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,8 +99,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Lint
-      run: make lint
+    - name: Test package
+      run: MLRUN_PYTHON_VERSION=${{ matrix.python-version }} make test-package
 
   docs:
     name: Build Project Documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,10 +95,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
           ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
     - name: Test package
       run: MLRUN_PYTHON_VERSION=${{ matrix.python-version }} make test-package
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,32 @@ jobs:
       - name: Run Dockerized DB Migration tests
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
 
+  package-tests:
+    name: Run package tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint
+      run: make lint
+
   docs:
     name: Build Project Documentation
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,7 @@ test-system: build-test-system ## Run mlrun system tests
 
 .PHONY: test-package
 test-package: ## Run mlrun package tests
-	bash ./automation/package_test/test_imports.sh
+	PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) bash ./automation/package_test/test_imports.sh
 
 .PHONY: run-api-undockerized
 run-api-undockerized: ## Run mlrun api locally (un-dockerized)

--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,10 @@ test-migrations: clean ## Run mlrun db migrations tests
 test-system: build-test-system ## Run mlrun system tests
 	docker run -t --rm $(MLRUN_SYSTEM_TEST_IMAGE_NAME)
 
+.PHONY: test-package
+test-package: ## Run mlrun package tests
+	bash ./automation/package_test/test_imports.sh
+
 .PHONY: run-api-undockerized
 run-api-undockerized: ## Run mlrun api locally (un-dockerized)
 	python -m mlrun db

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -15,7 +15,11 @@ test_import () {
 }
 
 test_import ""                      "import mlrun"
-test_import "[api]"                 "import mlrun.api.main"
+# API works only with python 3.7 and above
+if [ "$PYTHON_VERSION" != "3.6" ]
+  then
+    test_import "[api]"                 "import mlrun.api.main"
+fi
 test_import "[dask]"                "import dask"
 test_import "[v3io]"                "import mlrun.datastore.v3io"
 test_import "[s3]"                  "import mlrun.datastore.s3"

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -o errexit
+
+
+test_import () {
+    echo "Testing import: python=$PYTHON_VERSION extra=$1 import=$2"
+    # Create an empty environment
+    virtualenv venv
+    source venv/bin/activate
+    pip install ."$1"
+    python -c "$2"
+    deactivate
+    rm -rf venv
+}
+
+test_import ""                    "import mlrun"
+test_import "api"                 "import mlrun.api.main"
+test_import "dask"                "from dask.distributed import Client"
+test_import "v3io"                "import mlrun.datastore.v3io"
+test_import "s3"                  "import mlrun.datastore.s3"
+test_import "azure-blob-storage"  "import mlrun.datastore.azure_blob"

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -7,15 +7,15 @@ test_import () {
     # Create an empty environment
     virtualenv venv
     source venv/bin/activate
-    pip install .["$1"]
+    pip install ."$1"
     python -c "$2"
     deactivate
     rm -rf venv
 }
 
-test_import ""                    "import mlrun"
-test_import "api"                 "import mlrun.api.main"
-test_import "dask"                "from dask.distributed import Client"
-test_import "v3io"                "import mlrun.datastore.v3io"
-test_import "s3"                  "import mlrun.datastore.s3"
-test_import "azure-blob-storage"  "import mlrun.datastore.azure_blob"
+test_import ""                      "import mlrun"
+test_import "[api]"                 "import mlrun.api.main"
+test_import "[dask]"                "from dask.distributed import Client"
+test_import "[v3io]"                "import mlrun.datastore.v3io"
+test_import "[s3]"                  "import mlrun.datastore.s3"
+test_import "[azure-blob-storage]"  "import mlrun.datastore.azure_blob"

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -7,7 +7,7 @@ test_import () {
     # Create an empty environment
     virtualenv venv
     source venv/bin/activate
-    pip install ."$1"
+    pip install .["$1"]
     python -c "$2"
     deactivate
     rm -rf venv

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -14,13 +14,18 @@ test_import () {
     rm -rf venv
 }
 
-test_import ""                      "import mlrun"
+basic_test="import mlrun"
+api_test="import mlrun.api.main"
+s3_test="import mlrun.datastore.s3"
+azure_blob_storage_test="import mlrun.datastore.azure_blob"
+
+test_import ""                      "$basic_test"
 # API works only with python 3.7 and above
 if [ "$PYTHON_VERSION" != "3.6" ]
   then
-    test_import "[api]"                 "import mlrun.api.main"
+    test_import "[api]"                 "$basic_test; $api_test"
+    test_import "[complete-api]"        "$basic_test; $api_test; $s3_test; $azure_blob_storage_test"
 fi
-test_import "[dask]"                "import dask"
-test_import "[v3io]"                "import mlrun.datastore.v3io"
-test_import "[s3]"                  "import mlrun.datastore.s3"
-test_import "[azure-blob-storage]"  "import mlrun.datastore.azure_blob"
+test_import "[s3]"                  "$basic_test; $s3_test"
+test_import "[azure-blob-storage]"  "$basic_test; $azure_blob_storage_test"
+test_import "[complete]"  "$basic_test; $s3_test; $azure_blob_storage_test"

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -15,7 +15,7 @@ test_import () {
 
 test_import ""                      "import mlrun"
 test_import "[api]"                 "import mlrun.api.main"
-test_import "[dask]"                "from dask.distributed import Client"
+test_import "[dask]"                "import dask"
 test_import "[v3io]"                "import mlrun.datastore.v3io"
 test_import "[s3]"                  "import mlrun.datastore.s3"
 test_import "[azure-blob-storage]"  "import mlrun.datastore.azure_blob"

--- a/automation/package_test/test_imports.sh
+++ b/automation/package_test/test_imports.sh
@@ -5,6 +5,7 @@ set -o errexit
 test_import () {
     echo "Testing import: python=$PYTHON_VERSION extra=$1 import=$2"
     # Create an empty environment
+    python -m pip install virtualenv
     virtualenv venv
     source venv/bin/activate
     pip install ."$1"

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -279,9 +279,9 @@ class SystemTestPreparer:
 
     def _override_mlrun_api_env(self):
         version_specifier = (
-            f"git+https://github.com/mlrun/mlrun@{self._mlrun_commit}"
+            f"mlrun[complete] @ git+https://github.com/mlrun/mlrun@{self._mlrun_commit}"
             if self._mlrun_commit
-            else "mlrun"
+            else "mlrun[complete]"
         )
         data = {
             "MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER": version_specifier,

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -31,7 +31,7 @@ COPY ./dockerfiles/base/requirements.txt ./
 RUN python -m pip install -r requirements.txt
 
 COPY . .
-RUN python -m pip install .
+RUN python -m pip install .[complete]
 
 ARG MLRUN_MLUTILS_GITHUB_TAG=development
 ARG MLRUN_MLUTILS_CACHE_DATE=initial

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -23,7 +23,7 @@ COPY ./dockerfiles/jupyter/requirements.txt /tmp
 RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 COPY . /tmp/mlrun
-RUN cd /tmp/mlrun && python -m pip install ".[api]" && cd /tmp && rm -rf mlrun
+RUN cd /tmp/mlrun && python -m pip install ".[complete]" && cd /tmp && rm -rf mlrun
 
 RUN chown -R $NB_UID:$NB_GID $HOME
 

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -43,6 +43,8 @@ RUN python -m pip install \
 ENV MLRUN_httpdb__dirpath=/mlrun/db
 ENV MLRUN_httpdb__port=8080
 COPY . .
+
+RUN python -m pip install .[complete]
 VOLUME /mlrun/db
 
 CMD ["python",  "-m",  "mlrun",  "db"]

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -44,7 +44,7 @@ ENV MLRUN_httpdb__dirpath=/mlrun/db
 ENV MLRUN_httpdb__port=8080
 COPY . .
 
-RUN python -m pip install .[complete]
+RUN python -m pip install .[complete-api]
 VOLUME /mlrun/db
 
 CMD ["python",  "-m",  "mlrun",  "db"]

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -33,4 +33,4 @@ RUN python -m pip install \
     -r mlrun-image-requirements.txt
 
 COPY . .
-RUN python -m pip install .
+RUN python -m pip install .[complete]

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -144,7 +144,7 @@ COPY ./dockerfiles/models-gpu/requirements.txt ./
 RUN python -m pip install -r requirements.txt
 
 COPY . .
-RUN python -m pip install .
+RUN python -m pip install .[complete]
 
 ARG MLRUN_MLUTILS_GITHUB_TAG=development
 ARG MLRUN_MLUTILS_CACHE_DATE=initial

--- a/dockerfiles/models-gpu/py36/Dockerfile
+++ b/dockerfiles/models-gpu/py36/Dockerfile
@@ -137,7 +137,7 @@ COPY ./dockerfiles/models-gpu/requirements.txt ./
 RUN python -m pip install -r requirements.txt
 
 COPY . .
-RUN python -m pip install .
+RUN python -m pip install .[complete]
 
 ARG MLRUN_MLUTILS_GITHUB_TAG=development
 ARG MLRUN_MLUTILS_CACHE_DATE=initial

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -73,7 +73,7 @@ COPY ./dockerfiles/models/requirements.txt ./
 RUN python -m pip install -r requirements.txt
 
 COPY . .
-RUN python -m pip install .
+RUN python -m pip install .[complete]
 
 ARG MLRUN_MLUTILS_GITHUB_TAG=development
 ARG MLRUN_MLUTILS_CACHE_DATE=initial

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -76,7 +76,7 @@ COPY ./dockerfiles/models/requirements.txt ./
 RUN python -m pip install -r requirements.txt
 
 COPY . .
-RUN python -m pip install .
+RUN python -m pip install .[complete]
 
 ARG MLRUN_MLUTILS_GITHUB_TAG=development
 ARG MLRUN_MLUTILS_CACHE_DATE=initial

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -27,6 +27,6 @@ RUN python -m pip install --upgrade pip
 COPY ./dockerfiles/test-system/requirements.txt /tmp
 RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 COPY . /tmp/mlrun
-RUN cd /tmp/mlrun && python -m pip install ".[api]" && mv tests /tests && cd /tmp && rm -rf mlrun
+RUN cd /tmp/mlrun && python -m pip install ".[complete]" && mv tests /tests && cd /tmp && rm -rf mlrun
 
 CMD ["pytest",  "--capture=no", "-rf",  "-v",  "--disable-warnings", "/tests/system"]

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -53,4 +53,4 @@ RUN pip install \
 
 COPY . .
 
-RUN pip install -e .
+RUN pip install -e .[complete]

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -237,9 +237,14 @@ def _resolve_mlrun_install_command(mlrun_version_specifier):
         if config.httpdb.builder.mlrun_version_specifier:
             mlrun_version_specifier = config.httpdb.builder.mlrun_version_specifier
         elif config.version == "unstable":
-            mlrun_version_specifier = "git+https://github.com/mlrun/mlrun@development"
+            mlrun_version_specifier = (
+                f"{config.package_path}[complete] @ git+"
+                f"https://github.com/mlrun/mlrun@development"
+            )
         else:
-            mlrun_version_specifier = f"{config.package_path}=={config.version}"
+            mlrun_version_specifier = (
+                f"{config.package_path}[complete]=={config.version}"
+            )
     return f"pip install {mlrun_version_specifier}"
 
 

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -15,6 +15,7 @@
 from urllib.parse import urlparse
 
 import mlrun
+import mlrun.errors
 from .base import DataItem, HttpStore
 from .filestore import FileStore
 from .inmem import InMemoryStore
@@ -50,11 +51,21 @@ def schema_to_store(schema):
     if not schema or schema in ["file", "c", "d"]:
         return FileStore
     elif schema == "s3":
-        from .s3 import S3Store
+        try:
+            from .s3 import S3Store
+        except ImportError:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "s3 packages are missing, use pip install mlrun[s3]"
+            )
 
         return S3Store
     elif schema == "az":
-        from .azure_blob import AzureBlobStore
+        try:
+            from .azure_blob import AzureBlobStore
+        except ImportError:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "azure blob storage packages are missing, use pip install mlrun[azure-blob-storage]"
+            )
 
         return AzureBlobStore
     elif schema in ["v3io", "v3ios"]:

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -18,6 +18,7 @@ import mlrun
 from .base import DataItem, HttpStore
 from .filestore import FileStore
 from .inmem import InMemoryStore
+from .v3io import V3ioStore
 from ..config import config
 from ..utils import run_keys, DB_SCHEMA
 
@@ -57,8 +58,6 @@ def schema_to_store(schema):
 
         return AzureBlobStore
     elif schema in ["v3io", "v3ios"]:
-        from .v3io import V3ioStore
-
         return V3ioStore
     elif schema in ["http", "https"]:
         return HttpStore

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -50,12 +50,15 @@ def schema_to_store(schema):
         return FileStore
     elif schema == "s3":
         from .s3 import S3Store
+
         return S3Store
     elif schema == "az":
         from .azure_blob import AzureBlobStore
+
         return AzureBlobStore
     elif schema in ["v3io", "v3ios"]:
         from .v3io import V3ioStore
+
         return V3ioStore
     elif schema in ["http", "https"]:
         return HttpStore

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -15,12 +15,9 @@
 from urllib.parse import urlparse
 
 import mlrun
-from .azure_blob import AzureBlobStore
 from .base import DataItem, HttpStore
 from .filestore import FileStore
 from .inmem import InMemoryStore
-from .s3 import S3Store
-from .v3io import V3ioStore
 from ..config import config
 from ..utils import run_keys, DB_SCHEMA
 
@@ -48,13 +45,17 @@ def parse_url(url):
 
 
 def schema_to_store(schema):
+    # import store classes inside to enable making their dependencies optional (package extras)
     if not schema or schema in ["file", "c", "d"]:
         return FileStore
     elif schema == "s3":
+        from .s3 import S3Store
         return S3Store
     elif schema == "az":
+        from .azure_blob import AzureBlobStore
         return AzureBlobStore
     elif schema in ["v3io", "v3ios"]:
+        from .v3io import V3ioStore
         return V3ioStore
     elif schema in ["http", "https"]:
         return HttpStore

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -92,6 +92,14 @@ class MLRunIncompatibleVersionError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 
+class MLRunInternalServerError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
+
+
+class MLRunMissingDependencyError(MLRunInternalServerError):
+    pass
+
+
 STATUS_ERRORS = {
     HTTPStatus.BAD_REQUEST.value: MLRunBadRequestError,
     HTTPStatus.UNAUTHORIZED.value: MLRunUnauthorizedError,
@@ -99,4 +107,5 @@ STATUS_ERRORS = {
     HTTPStatus.NOT_FOUND.value: MLRunNotFoundError,
     HTTPStatus.CONFLICT.value: MLRunConflictError,
     HTTPStatus.PRECONDITION_FAILED.value: MLRunPreconditionFailedError,
+    HTTPStatus.INTERNAL_SERVER_ERROR.value: MLRunInternalServerError,
 }

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -353,7 +353,7 @@ def deploy_function(function: DaskCluster, secrets=None):
     except ImportError as e:
         print(
             "missing dask or dask_kubernetes, please run "
-            '"pip install dask distributed dask_kubernetes", %s',
+            '"pip install mlrun[dask]", %s',
             e,
         )
         raise e

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -353,7 +353,7 @@ def deploy_function(function: DaskCluster, secrets=None):
     except ImportError as e:
         print(
             "missing dask or dask_kubernetes, please run "
-            '"pip install mlrun[dask]", %s',
+            '"pip install dask distributed dask_kubernetes", %s',
             e,
         )
         raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ urllib3>=1.25.4, <1.27
 chardet>=3.0.2, <4.0
 GitPython~=3.0
 aiohttp~=3.6
-boto3~=1.9
 click~=7.0
 # 3.0 iguazio system uses 1.0.1, since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
 kfp~=1.0.1
@@ -19,20 +18,13 @@ pyyaml~=5.1
 requests~=2.22
 sqlalchemy~=1.3
 tabulate>=0.8.0, <=0.8.3
-v3io~=0.5.0
-# required by some sub-dependency of a package installed in models-gpu, otherwise building this image fails - TODO: check if still happening
-google-auth<2.0dev,>=1.19.1
-azure-storage-blob~=12.0
 pydantic~=1.5
 # <3.4 since 3.4 can't be installed on pip 18.1
 orjson>=3,<3.4
 importlib-resources; python_version < '3.7'
 alembic~=1.4
 mergedeep~=1.3
-# 3.0 iguazio system uses 0.8.x - limiting to only patch changes
-v3io-frames~=0.8.5
 semver~=2.13
-dask~=2.12
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ dask~=2.12
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from
-#  separating the SDK and API code) (referring to humanfriendly and fastapi
+#  separating the SDK and API code) (referring to humanfriendly and fastapi)
 humanfriendly~=8.2
 fastapi~=0.62.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # >=1.25.4, <1.27 from botocore 1.19.28 inside boto3 1.16.28 inside nuclio-jupyter 0.8.8
 urllib3>=1.25.4, <1.27
+# >=3.0.2 from requests 2.25.1 <4.0 from aiohttp 3.7.3, requests is <5, so without the upbound there's a conflict
+chardet>=3.0.2, <4.0
 GitPython~=3.0
 # required by google-auth - TODO: check if still needed
 aiohttp~=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ urllib3>=1.25.4, <1.27
 # >=3.0.2 from requests 2.25.1 <4.0 from aiohttp 3.7.3, requests is <5, so without the upbound there's a conflict
 chardet>=3.0.2, <4.0
 GitPython~=3.0
-# required by google-auth - TODO: check if still needed
 aiohttp~=3.6
 boto3~=1.9
 click~=7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,13 +18,17 @@ pyyaml~=5.1
 requests~=2.22
 sqlalchemy~=1.3
 tabulate>=0.8.0, <=0.8.3
+v3io~=0.5.0
 pydantic~=1.5
 # <3.4 since 3.4 can't be installed on pip 18.1
 orjson>=3,<3.4
 importlib-resources; python_version < '3.7'
 alembic~=1.4
 mergedeep~=1.3
+# 3.0 iguazio system uses 0.8.x - limiting to only patch changes
+v3io-frames~=0.8.5
 semver~=2.13
+dask~=2.12
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,28 @@ install_requires = list(load_deps("requirements.txt"))
 tests_require = list(load_deps("dev-requirements.txt"))
 api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 
+# NOTE: These are tested in `continuous_integration/travis/test_imports.sh` If
+# you modify these, make sure to change the corresponding line there.
+extras_require = {
+    "api": api_deps,
+    "dask": ['dask~=2.12'],
+    "v3io": [
+        # 3.0 iguazio system uses 0.8.x - limiting to only patch changes
+        'v3io-frames~=0.8.5',
+        'v3io~=0.5.0'
+    ],
+    's3': [
+      'boto3~=1.9',
+    ],
+    'azure-blob-storage': [
+        # required by some sub-dependency of a package installed in models-gpu, otherwise building this image fails -
+        # TODO: check if still happening
+      # 'google-auth<2.0dev,>=1.19.1',
+      'azure-storage-blob~=12.0',
+    ],
+}
+extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
+
 
 setup(
     name="mlrun",
@@ -93,7 +115,7 @@ setup(
         "mlrun.api.utils.projects.remotes",
     ],
     install_requires=install_requires,
-    extras_require={"api": api_deps},
+    extras_require=extras_require,
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,6 @@ extras_require = {
     ],
     "s3": ["boto3~=1.9"],
     "azure-blob-storage": [
-        # required by some sub-dependency of a package installed in models-gpu, otherwise building this image fails -
-        # TODO: check if still happening
-        # 'google-auth<2.0dev,>=1.19.1',
         "azure-storage-blob~=12.0",
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -57,17 +57,20 @@ api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 # NOTE: These are tested in `automation/package_test/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-    "api": api_deps,
-    "dask": ["dask~=2.12"],
-    "v3io": [
-        # 3.0 iguazio system uses 0.8.x - limiting to only patch changes
-        "v3io-frames~=0.8.5",
-        "v3io~=0.5.0",
-    ],
     "s3": ["boto3~=1.9"],
     "azure-blob-storage": ["azure-storage-blob~=12.0"],
 }
-extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
+extras_require["complete"] = sorted(
+    {
+        requirement
+        for requirement_list in extras_require.values()
+        for requirement in requirement_list
+    }
+)
+extras_require["api"] = api_deps
+complete_api_deps = set(api_deps)
+complete_api_deps.update(extras_require["complete"])
+extras_require["complete-api"] = sorted(complete_api_deps)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -58,20 +58,18 @@ api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
     "api": api_deps,
-    "dask": ['dask~=2.12'],
+    "dask": ["dask~=2.12"],
     "v3io": [
         # 3.0 iguazio system uses 0.8.x - limiting to only patch changes
-        'v3io-frames~=0.8.5',
-        'v3io~=0.5.0'
+        "v3io-frames~=0.8.5",
+        "v3io~=0.5.0",
     ],
-    's3': [
-      'boto3~=1.9',
-    ],
-    'azure-blob-storage': [
+    "s3": ["boto3~=1.9"],
+    "azure-blob-storage": [
         # required by some sub-dependency of a package installed in models-gpu, otherwise building this image fails -
         # TODO: check if still happening
-      # 'google-auth<2.0dev,>=1.19.1',
-      'azure-storage-blob~=12.0',
+        # 'google-auth<2.0dev,>=1.19.1',
+        "azure-storage-blob~=12.0",
     ],
 }
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,7 @@ extras_require = {
         "v3io~=0.5.0",
     ],
     "s3": ["boto3~=1.9"],
-    "azure-blob-storage": [
-        "azure-storage-blob~=12.0",
-    ],
+    "azure-blob-storage": ["azure-storage-blob~=12.0"],
 }
 extras_require["complete"] = sorted({v for req in extras_require.values() for v in req})
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = list(load_deps("requirements.txt"))
 tests_require = list(load_deps("dev-requirements.txt"))
 api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 
-# NOTE: These are tested in `continuous_integration/travis/test_imports.sh` If
+# NOTE: These are tested in `automation/package_test/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
     "api": api_deps,

--- a/tests/Dockerfile.test-nb
+++ b/tests/Dockerfile.test-nb
@@ -27,4 +27,4 @@ RUN pip install \
     -r dev-requirements.txt
 COPY . .
 ENV PYTHONPATH=/mlrun
-RUN python -m pip install .
+RUN python -m pip install .[complete]


### PR DESCRIPTION
Fixes https://github.com/mlrun/mlrun/issues/551

This PR leverages setuptools' `extras_require` to enable a user to install only the dependencies they really need. This will give:
* Faster installation
* Less conflicts with local venv
* Don't install un-needed dependencies

The extras we will support are:
* `api` - already existed - needed dependencies to run the API
* `s3` - `boto3~=1.9` - needed dependencies to use s3 as the storage layer
* `azure-blob-storage` - `azure-storage-blob~=12.0` - needed dependencies to use azure blob storage as the storage layer
* `complete` - all of the above excluding `api`
* `complete-api` - all of the above including `api`

For examples on how to install package with extras using `pip` [see this](https://pip.pypa.io/en/latest/reference/pip_install/#examples)

I wanted to evaluate how effective was this change on the downloaded dependencies size. I couldn't find an automatic tool online to do that, so what I did is executing `pip install --no-cache-dir .` which prints output such as:
```
Collecting starlette==0.13.6
  Downloading starlette-0.13.6-py3-none-any.whl (59 kB)
     |████████████████████████████████| 59 kB 2.5 MB/s
```
and parsed its output. I'm uploading here the code I used so we can re-use it in the future:
[package_sizes.tar.gz](https://github.com/mlrun/mlrun/files/5745830/package_sizes.tar.gz)
I also used https://github.com/naiquevin/pipdeptree to easily understand the dependency tree

The old dependencies size was `83.39 MB`, the new size is `81 MB` (2.8% decrease)
The packages we don't install anymore are:
```
cryptography:1.8 MB
azure-storage-blob:328 KB
azure-core:124 KB
msrest:84 KB
isodate:45 KB
```

Notes:
* Unfortunately although `boto3` moved to the `s3` extra, it is still installed by default since it's a sub-requirement of `nuclio-jupyter` (`boto3` and its sub requirements are 7.4MB) - We may be able to remove it, I'm checking it
* Ideally I would want to also make an extra for `kfp` but since its code is not very ordered doing it meaning to add an `import` inside a lot of functions so I decided to skip it for now
* While working on this PR I considered another 2 extras:
1. `v3io` - `v3io-frames~=0.8.5`, `v3io~=0.5.0` - needed dependencies to use v3io as the storage layer, the total size it could save is 5.75MB, but since it's widely used by most of MLRun users decided to keep it as part of the base
2. `dask` - `dask~=2.12` - needed dependencies to run dask functions - the total size it could save is 848 KB, low size + widely used - decided to keep it as well
* Most of our dependencies size is coming from several packages, these are the top:
```
numpy:15.3 MB
pyarrow:13.4 MB
pandas:10.3 MB
notebook:9.5 MB
botocore:7.2 MB
pydantic:2.3 MB
kubernetes:1.5 MB
jedi:1.4 MB
sqlalchemy:1.2 MB
protobuf:1 MB
```
Some analysis:
* `numpy` and `pyarrow` are sub-requirements of `pandas` so practically `pandas` by itself is 39MB, almost half of the size (though most data scientists will already have `pandas` in their venv)
* `notebook` is a sub requirement of `nuclio-jupyter`, we may be able to remove it from there, I'm checking it
* `botocore` is a sub requirement of `boto3` details above

Also:
* Removed `google-auth<2.0dev,>=1.19.1` from requirements, it was added in https://github.com/mlrun/mlrun/pull/373 to fix some conflict which doesn't happen anymore
* Added `chardet>=3.0.2, <4.0` to requirements to fix a conflict