### PR TITLE
[Images] Ensuring mlrun/mlrun and mlrun/jupyter has mlutils dependencies

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,5 +1,7 @@
-xgboost~=1.1
-scikit-plot~=0.3.0
 matplotlib~=3.0
-scikit-learn~=0.20.0
+scipy~=1.0
+scikit-learn~=0.23.0
 seaborn~=0.11.0
+scikit-plot~=0.3.0
+xgboost~=1.1
+

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,3 +1,5 @@
 matplotlib~=3.0
+scipy~=1.0
 scikit-learn~=0.23.0
 seaborn~=0.11.0
+scikit-plot~=0.3.0


### PR DESCRIPTION
The `mlutils` module is used as a "helpers module" for our functions in the [function hub](https://github.com/mlrun/functions)
This module requires several dependencies that are not part of the package dependencies but we still want to be able to use it on the `mlrun/mlrun` image (otherwise it will require using the `mlrun/ml-models` image which is very big)
So aligned the `mlrun/mlrun` requirements to settle `mlutils` requirements
Also aligned `mlrun/jupyter` requirements
