### PR TITLE
[Images] Pin pip version and use legacy resolver + install storey package only on python 3.7 or above

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,8 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r dev-requirements.txt
+        python -m pip install --upgrade pip==20.3
+        pip install -r dev-requirements.txt --use-deprecated=legacy-resolver
     - name: Lint
       run: make lint
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip~=20.3.0
+        python -m pip install --upgrade pip~=20.2.0
         pip install -r dev-requirements.txt --use-deprecated=legacy-resolver
     - name: Lint
       run: make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip~=20.2.0
-        pip install -r dev-requirements.txt --use-deprecated=legacy-resolver
+        pip install -r dev-requirements.txt
     - name: Lint
       run: make lint
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip==20.3
+        python -m pip install --upgrade pip~=20.3.0
         pip install -r dev-requirements.txt --use-deprecated=legacy-resolver
     - name: Lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ all:
 
 .PHONY: install-requirements
 install-requirements: ## Install all requirements needed for development
+	python -m pip install --upgrade pip~=20.2.0
 	python -m pip install \
 		-r requirements.txt \
 		-r dev-requirements.txt \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,4 @@ requests-mock~=1.8
 # needed for system tests
 matplotlib~=3.0
 graphviz~=0.16.0
-storey @ git+https://github.com/mlrun/storey.git
+storey @ git+https://github.com/mlrun/storey.git ; python_version >= '3.7'

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -21,7 +21,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -3,6 +3,7 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim-buster
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -20,7 +21,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -3,7 +3,6 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim-buster
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -21,7 +20,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -1,8 +1,9 @@
 FROM jupyter/scipy-notebook
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 # by default COPY creates files with root permissions, so doing all the preparation with root and chown-ing everything
 # in the end

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/scipy-notebook
 ENV PIP_NO_CACHE_DIR=1
 ENV PIP_USE_DEPRECATED="legacy-resolver"
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 # by default COPY creates files with root permissions, so doing all the preparation with root and chown-ing everything
 # in the end

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -1,9 +1,8 @@
 FROM jupyter/scipy-notebook
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 # by default COPY creates files with root permissions, so doing all the preparation with root and chown-ing everything
 # in the end

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -16,6 +16,7 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
@@ -28,7 +29,7 @@ RUN apt-get update && apt-get install -y \
   vim \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 WORKDIR /mlrun
 

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -16,8 +16,6 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
-
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
 
@@ -29,7 +27,7 @@ RUN apt-get update && apt-get install -y \
   vim \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 WORKDIR /mlrun
 

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
   vim \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 WORKDIR /mlrun
 

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -16,6 +16,7 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
+
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
 

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -17,6 +17,7 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 RUN apt-get update && apt-get install -y \
   gcc \
@@ -25,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /mlrun
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 COPY ./dockerfiles/mlrun/requirements.txt ./mlrun-image-requirements.txt
 COPY ./requirements.txt ./
 RUN python -m pip install \

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -17,7 +17,6 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 RUN apt-get update && apt-get install -y \
   gcc \
@@ -26,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /mlrun
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 COPY ./dockerfiles/mlrun/requirements.txt ./mlrun-image-requirements.txt
 COPY ./requirements.txt ./
 RUN python -m pip install \

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /mlrun
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 COPY ./dockerfiles/mlrun/requirements.txt ./mlrun-image-requirements.txt
 COPY ./requirements.txt ./
 RUN python -m pip install \

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -16,6 +16,7 @@ ARG CUDA_VER=10.1
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -125,7 +126,7 @@ RUN conda install -n base -c rapidsai -c nvidia \
 
 RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 # TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
     #   possible (should be safe to remove if it works ~5 times without it)

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -126,7 +126,7 @@ RUN conda install -n base -c rapidsai -c nvidia \
 
 RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 # TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
     #   possible (should be safe to remove if it works ~5 times without it)

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -16,7 +16,6 @@ ARG CUDA_VER=10.1
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -126,7 +125,7 @@ RUN conda install -n base -c rapidsai -c nvidia \
 
 RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 # TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
     #   possible (should be safe to remove if it works ~5 times without it)

--- a/dockerfiles/models-gpu/py36/Dockerfile
+++ b/dockerfiles/models-gpu/py36/Dockerfile
@@ -121,7 +121,7 @@ RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
 RUN conda clean -aqy
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 # TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
     #   possible (should be safe to remove if it works ~5 times without it)

--- a/dockerfiles/models-gpu/py36/Dockerfile
+++ b/dockerfiles/models-gpu/py36/Dockerfile
@@ -3,6 +3,7 @@ ARG CUDA_VER=10.1
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -120,7 +121,7 @@ RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
 RUN conda clean -aqy
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 # TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
     #   possible (should be safe to remove if it works ~5 times without it)

--- a/dockerfiles/models-gpu/py36/Dockerfile
+++ b/dockerfiles/models-gpu/py36/Dockerfile
@@ -3,7 +3,6 @@ ARG CUDA_VER=10.1
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -121,7 +120,7 @@ RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
 RUN conda clean -aqy
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 # TODO: MAKEFLAGS="-j1" work around some transient concurrency problem with installing horovod remove it when
     #   possible (should be safe to remove if it works ~5 times without it)

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -1,6 +1,7 @@
 FROM continuumio/anaconda3:2020.02
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -26,7 +27,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -27,7 +27,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -1,7 +1,6 @@
 FROM continuumio/anaconda3:2020.02
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -27,7 +26,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -1,6 +1,7 @@
 FROM continuumio/anaconda3:2020.02
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -26,7 +27,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -27,7 +27,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/models/py36/Dockerfile
+++ b/dockerfiles/models/py36/Dockerfile
@@ -1,7 +1,6 @@
 FROM continuumio/anaconda3:2020.02
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yashab@iguazio.com"
 LABEL org="iguazio.com"
@@ -27,7 +26,7 @@ RUN apt update -qqq \
     && apt autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 ENV SSL_CERT_DIR /etc/ssl/certs
 

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -16,13 +16,14 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 RUN apt-get update && apt-get install -y \
   gcc \
   git-core \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 COPY ./dockerfiles/test-system/requirements.txt /tmp
 RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -16,14 +16,13 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 RUN apt-get update && apt-get install -y \
   gcc \
   git-core \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 COPY ./dockerfiles/test-system/requirements.txt /tmp
 RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
   git-core \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 COPY ./dockerfiles/test-system/requirements.txt /tmp
 RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -16,6 +16,7 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
+ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
@@ -37,7 +38,7 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debia
 
 RUN apt update && apt-get install -y docker-ce-cli
 
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip==20.3
 
 WORKDIR /mlrun
 

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -38,7 +38,7 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debia
 
 RUN apt update && apt-get install -y docker-ce-cli
 
-RUN python -m pip install --upgrade pip==20.3
+RUN python -m pip install --upgrade pip~=20.3.0
 
 WORKDIR /mlrun
 

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -16,7 +16,6 @@ ARG MLRUN_PYTHON_VERSION=3.7
 FROM python:${MLRUN_PYTHON_VERSION}-slim
 
 ENV PIP_NO_CACHE_DIR=1
-ENV PIP_USE_DEPRECATED="legacy-resolver"
 
 LABEL maintainer="yaronh@iguazio.com"
 LABEL org="iguazio.com"
@@ -38,7 +37,7 @@ RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debia
 
 RUN apt update && apt-get install -y docker-ce-cli
 
-RUN python -m pip install --upgrade pip~=20.3.0
+RUN python -m pip install --upgrade pip~=20.2.0
 
 WORKDIR /mlrun
 


### PR DESCRIPTION
* Storey added `s3fs` to their requirement in https://github.com/mlrun/storey/pull/124, and `s3fs` is compatible only on python 3.7 and above, so not installing storey on python 3.6
* (I think this is also because of some sub-dependancy of storey) pip installing start taking ages (I stopped waiting after an hour) I saw this one https://github.com/pypa/pip/issues/9215 and decided that for now we'll go back to use the legacy resolver.
Ideally I could keep using latest pip and just add `--use-deprecated=legacy-resolver` but they are planning to deprecate it in `21.0` (could work around by pinning pip to `~=20.3.0`) + since we're doing installation as part of our business logic (people using MLRun to build images with custom packages for them) I feel like this new resolver is still no stable enough to be used. so bottomline pinned pip to `~=20.2.0` in which the old resolver is still the default
Attaching the never ending pip install log (they are part of logs for building the test image) in case it would be useful:
[pip-too-much-time.log](https://github.com/mlrun/mlrun/files/5754984/pip-too-much-time.log)

