### PR TITLE
[Requirements] Extras addition followup fixes

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -23,7 +23,7 @@ COPY ./dockerfiles/jupyter/requirements.txt /tmp
 RUN python -m pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
 COPY . /tmp/mlrun
-RUN cd /tmp/mlrun && python -m pip install ".[complete]" && cd /tmp && rm -rf mlrun
+RUN cd /tmp/mlrun && python -m pip install ".[complete-api]" && cd /tmp && rm -rf mlrun
 
 RUN chown -R $NB_UID:$NB_GID $HOME
 

--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -1,9 +1,4 @@
 uvicorn~=0.12.0
-# dask-kubernetes 0.11.0 has distributed>=2.5.2, but after 2.30.1 they moved to CalVer and released 2020.12.0
-# so without our limitation to <3, 2020.12.0 is installed which is incompatible since it has dask>=2020.12.0 while ours
-# is ~=2.12
-# TODO: dask-kubernetes will probably release 0.11.1 with a fix for this soon and this could be removed
-distributed>=2.5.2, <3
 dask-kubernetes~=0.11.0
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes-asyncio~=11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,11 @@ mergedeep~=1.3
 v3io-frames~=0.8.5
 semver~=2.13
 dask~=2.12
+# dask-kubernetes 0.11.0 has distributed>=2.5.2, but after 2.30.1 they moved to CalVer and released 2020.12.0
+# so without our limitation to <3, 2020.12.0 is installed which is incompatible since it has dask>=2020.12.0 while ours
+# is ~=2.12
+# TODO: dask-kubernetes will probably release 0.11.1 with a fix for this soon and this could be removed
+distributed>=2.5.2, <3
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from


### PR DESCRIPTION
* Jupyter is running the api inside so need complete-api flavor
* Distributed moved to SDK requirements (needed to run Dask, it was a breakage from before, the change that revealed it is installing the SDK requirements in the system tests and not the API requirements)