### PR TITLE
[Projects] Remove runtime resources on project deletion

### DIFF
--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -4,38 +4,21 @@ from fastapi import APIRouter, Depends
 from fastapi import Response
 from sqlalchemy.orm import Session
 
+import mlrun.api.crud
 from mlrun.api.api import deps
-from mlrun.api.api.utils import log_and_raise
-from mlrun.api.utils.singletons.db import get_db
 from mlrun.config import config
-from mlrun.runtimes import RuntimeKinds
-from mlrun.runtimes import get_runtime_handler
 
 router = APIRouter()
 
 
 @router.get("/runtimes")
 def list_runtimes(label_selector: str = None):
-    runtimes = []
-    for kind in RuntimeKinds.runtime_with_handlers():
-        runtime_handler = get_runtime_handler(kind)
-        resources = runtime_handler.list_resources(label_selector)
-        runtimes.append({"kind": kind, "resources": resources})
-    return runtimes
+    return mlrun.api.crud.Runtimes().list_runtimes(label_selector)
 
 
 @router.get("/runtimes/{kind}")
 def get_runtime(kind: str, label_selector: str = None):
-    if kind not in RuntimeKinds.runtime_with_handlers():
-        log_and_raise(
-            HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
-        )
-    runtime_handler = get_runtime_handler(kind)
-    resources = runtime_handler.list_resources(label_selector)
-    return {
-        "kind": kind,
-        "resources": resources,
-    }
+    return mlrun.api.crud.Runtimes().get_runtime(kind, label_selector)
 
 
 @router.delete("/runtimes", status_code=HTTPStatus.NO_CONTENT.value)
@@ -45,11 +28,7 @@ def delete_runtimes(
     grace_period: int = config.runtime_resources_deletion_grace_period,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    for kind in RuntimeKinds.runtime_with_handlers():
-        runtime_handler = get_runtime_handler(kind)
-        runtime_handler.delete_resources(
-            get_db(), db_session, label_selector, force, grace_period
-        )
+    mlrun.api.crud.Runtimes().delete_runtimes(db_session, label_selector, force, grace_period)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
@@ -61,14 +40,7 @@ def delete_runtime(
     grace_period: int = config.runtime_resources_deletion_grace_period,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    if kind not in RuntimeKinds.runtime_with_handlers():
-        log_and_raise(
-            HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
-        )
-    runtime_handler = get_runtime_handler(kind)
-    runtime_handler.delete_resources(
-        get_db(), db_session, label_selector, force, grace_period
-    )
+    mlrun.api.crud.Runtimes().delete_runtime(db_session, kind, label_selector, force, grace_period)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
@@ -82,12 +54,5 @@ def delete_runtime_object(
     grace_period: int = config.runtime_resources_deletion_grace_period,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    if kind not in RuntimeKinds.runtime_with_handlers():
-        log_and_raise(
-            HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
-        )
-    runtime_handler = get_runtime_handler(kind)
-    runtime_handler.delete_runtime_object_resources(
-        get_db(), db_session, object_id, label_selector, force, grace_period
-    )
+    mlrun.api.crud.Runtimes().delete_runtime_object(db_session, kind, object_id, label_selector, force, grace_period)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -28,7 +28,9 @@ def delete_runtimes(
     grace_period: int = config.runtime_resources_deletion_grace_period,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.crud.Runtimes().delete_runtimes(db_session, label_selector, force, grace_period)
+    mlrun.api.crud.Runtimes().delete_runtimes(
+        db_session, label_selector, force, grace_period
+    )
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
@@ -40,7 +42,9 @@ def delete_runtime(
     grace_period: int = config.runtime_resources_deletion_grace_period,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.crud.Runtimes().delete_runtime(db_session, kind, label_selector, force, grace_period)
+    mlrun.api.crud.Runtimes().delete_runtime(
+        db_session, kind, label_selector, force, grace_period
+    )
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
@@ -54,5 +58,7 @@ def delete_runtime_object(
     grace_period: int = config.runtime_resources_deletion_grace_period,
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.crud.Runtimes().delete_runtime_object(db_session, kind, object_id, label_selector, force, grace_period)
+    mlrun.api.crud.Runtimes().delete_runtime_object(
+        db_session, kind, object_id, label_selector, force, grace_period
+    )
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/crud/__init__.py
+++ b/mlrun/api/crud/__init__.py
@@ -1,3 +1,4 @@
 from .logs import Logs  # noqa: F401
 from .projects import Projects  # noqa: F401
+from .runtimes import Runtimes  # noqa: F401
 from .pipelines import list_pipelines  # noqa: F401

--- a/mlrun/api/crud/__init__.py
+++ b/mlrun/api/crud/__init__.py
@@ -1,2 +1,3 @@
 from .logs import Logs  # noqa: F401
+from .projects import Projects  # noqa: F401
 from .pipelines import list_pipelines  # noqa: F401

--- a/mlrun/api/crud/logs.py
+++ b/mlrun/api/crud/logs.py
@@ -10,6 +10,7 @@ from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.runtimes.constants import PodPhases
 
 
+# TODO: changed to be under a singleton like projects and runtimes
 class Logs:
     @staticmethod
     def store_log(body: bytes, project: str, uid: str, append: bool = True):

--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -11,6 +11,7 @@ import mlrun.utils.helpers
 from mlrun.utils import logger
 
 
+# TODO: changed to be under a singleton like projects and runtimes
 def list_pipelines(
     project: str,
     namespace: str = "",

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -2,6 +2,7 @@ import typing
 
 import sqlalchemy.orm
 
+import mlrun.api.crud
 import mlrun.api.schemas
 import mlrun.api.utils.projects.remotes.member
 import mlrun.api.utils.singletons.db
@@ -49,6 +50,10 @@ class Projects(
         logger.debug(
             "Deleting project", name=name, deletion_strategy=deletion_strategy
         )
+        if deletion_strategy == mlrun.api.schemas.DeletionStrategy.cascade:
+            # delete runtime resources
+            mlrun.api.crud.Runtimes().delete_runtimes(session, label_selector=f'mlrun/project={name}', force=True)
+        mlrun.api.utils.singletons.db.get_db().delete_project(session, name, deletion_strategy)
 
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -1,0 +1,66 @@
+import typing
+
+import sqlalchemy.orm
+
+import mlrun.api.schemas
+import mlrun.api.utils.projects.remotes.member
+import mlrun.api.utils.singletons.db
+import mlrun.errors
+import mlrun.utils.singleton
+from mlrun.utils import logger
+
+
+class Projects(
+    mlrun.api.utils.projects.remotes.member.Member,
+    metaclass=mlrun.utils.singleton.AbstractSingleton,
+):
+
+    def create_project(
+        self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
+    ):
+        logger.debug("Creating project", project=project)
+        mlrun.api.utils.singletons.db.get_db().create_project(session, project)
+
+    def store_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: mlrun.api.schemas.Project,
+    ):
+        logger.debug("Storing project", name=name, project=project)
+        mlrun.api.utils.singletons.db.get_db().store_project(session, name, project)
+
+    def patch_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: dict,
+        patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
+    ):
+        logger.debug("Patching project", name=name, project=project, patch_mode=patch_mode)
+        mlrun.api.utils.singletons.db.get_db().patch_project(session, name, project, patch_mode)
+
+    def delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
+    ):
+        logger.debug(
+            "Deleting project", name=name, deletion_strategy=deletion_strategy
+        )
+
+    def get_project(
+        self, session: sqlalchemy.orm.Session, name: str
+    ) -> mlrun.api.schemas.Project:
+        return mlrun.api.utils.singletons.db.get_db().get_project(session, name)
+
+    def list_projects(
+        self,
+        session: sqlalchemy.orm.Session,
+        owner: str = None,
+        format_: mlrun.api.schemas.Format = mlrun.api.schemas.Format.full,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+    ) -> mlrun.api.schemas.ProjectsOutput:
+        return mlrun.api.utils.singletons.db.get_db().list_projects(session, owner, format_, labels, state)

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -15,7 +15,6 @@ class Projects(
     mlrun.api.utils.projects.remotes.member.Member,
     metaclass=mlrun.utils.singleton.AbstractSingleton,
 ):
-
     def create_project(
         self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
     ):
@@ -38,8 +37,12 @@ class Projects(
         project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
-        logger.debug("Patching project", name=name, project=project, patch_mode=patch_mode)
-        mlrun.api.utils.singletons.db.get_db().patch_project(session, name, project, patch_mode)
+        logger.debug(
+            "Patching project", name=name, project=project, patch_mode=patch_mode
+        )
+        mlrun.api.utils.singletons.db.get_db().patch_project(
+            session, name, project, patch_mode
+        )
 
     def delete_project(
         self,
@@ -47,13 +50,15 @@ class Projects(
         name: str,
         deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
     ):
-        logger.debug(
-            "Deleting project", name=name, deletion_strategy=deletion_strategy
-        )
+        logger.debug("Deleting project", name=name, deletion_strategy=deletion_strategy)
         if deletion_strategy == mlrun.api.schemas.DeletionStrategy.cascade:
             # delete runtime resources
-            mlrun.api.crud.Runtimes().delete_runtimes(session, label_selector=f'mlrun/project={name}', force=True)
-        mlrun.api.utils.singletons.db.get_db().delete_project(session, name, deletion_strategy)
+            mlrun.api.crud.Runtimes().delete_runtimes(
+                session, label_selector=f"mlrun/project={name}", force=True
+            )
+        mlrun.api.utils.singletons.db.get_db().delete_project(
+            session, name, deletion_strategy
+        )
 
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str
@@ -68,4 +73,6 @@ class Projects(
         labels: typing.List[str] = None,
         state: mlrun.api.schemas.ProjectState = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
-        return mlrun.api.utils.singletons.db.get_db().list_projects(session, owner, format_, labels, state)
+        return mlrun.api.utils.singletons.db.get_db().list_projects(
+            session, owner, format_, labels, state
+        )

--- a/mlrun/api/crud/runtimes.py
+++ b/mlrun/api/crud/runtimes.py
@@ -12,10 +12,7 @@ import mlrun.runtimes
 import mlrun.utils.singleton
 
 
-class Runtimes(
-    metaclass=mlrun.utils.singleton.Singleton,
-):
-
+class Runtimes(metaclass=mlrun.utils.singleton.Singleton,):
     def list_runtimes(self, label_selector: str = None):
         runtimes = []
         for kind in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
@@ -37,25 +34,29 @@ class Runtimes(
         }
 
     def delete_runtimes(
-            self,
-            db_session: sqlalchemy.orm.Session,
-            label_selector: str = None,
-            force: bool = False,
-            grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
+        self,
+        db_session: sqlalchemy.orm.Session,
+        label_selector: str = None,
+        force: bool = False,
+        grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
     ):
         for kind in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
             runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
             runtime_handler.delete_resources(
-                mlrun.api.utils.singletons.db.get_db(), db_session, label_selector, force, grace_period
+                mlrun.api.utils.singletons.db.get_db(),
+                db_session,
+                label_selector,
+                force,
+                grace_period,
             )
 
     def delete_runtime(
-            self,
-            db_session: sqlalchemy.orm.Session,
-            kind: str,
-            label_selector: str = None,
-            force: bool = False,
-            grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
+        self,
+        db_session: sqlalchemy.orm.Session,
+        kind: str,
+        label_selector: str = None,
+        force: bool = False,
+        grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
     ):
         if kind not in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
             mlrun.api.api.utils.log_and_raise(
@@ -63,17 +64,21 @@ class Runtimes(
             )
         runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
         runtime_handler.delete_resources(
-            mlrun.api.utils.singletons.db.get_db(), db_session, label_selector, force, grace_period
+            mlrun.api.utils.singletons.db.get_db(),
+            db_session,
+            label_selector,
+            force,
+            grace_period,
         )
 
     def delete_runtime_object(
-            self,
-            db_session: sqlalchemy.orm.Session,
-            kind: str,
-            object_id: str,
-            label_selector: str = None,
-            force: bool = False,
-            grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
+        self,
+        db_session: sqlalchemy.orm.Session,
+        kind: str,
+        object_id: str,
+        label_selector: str = None,
+        force: bool = False,
+        grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
     ):
         if kind not in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
             mlrun.api.api.utils.log_and_raise(
@@ -81,5 +86,10 @@ class Runtimes(
             )
         runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
         runtime_handler.delete_runtime_object_resources(
-            mlrun.api.utils.singletons.db.get_db(), db_session, object_id, label_selector, force, grace_period
+            mlrun.api.utils.singletons.db.get_db(),
+            db_session,
+            object_id,
+            label_selector,
+            force,
+            grace_period,
         )

--- a/mlrun/api/crud/runtimes.py
+++ b/mlrun/api/crud/runtimes.py
@@ -1,0 +1,85 @@
+import http
+
+import sqlalchemy.orm
+
+import mlrun.api.api.utils
+import mlrun.api.schemas
+import mlrun.api.utils.projects.remotes.member
+import mlrun.api.utils.singletons.db
+import mlrun.config
+import mlrun.errors
+import mlrun.runtimes
+import mlrun.utils.singleton
+
+
+class Runtimes(
+    metaclass=mlrun.utils.singleton.Singleton,
+):
+
+    def list_runtimes(self, label_selector: str = None):
+        runtimes = []
+        for kind in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
+            runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
+            resources = runtime_handler.list_resources(label_selector)
+            runtimes.append({"kind": kind, "resources": resources})
+        return runtimes
+
+    def get_runtime(self, kind: str, label_selector: str = None):
+        if kind not in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
+            mlrun.api.api.utils.log_and_raise(
+                http.HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
+            )
+        runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
+        resources = runtime_handler.list_resources(label_selector)
+        return {
+            "kind": kind,
+            "resources": resources,
+        }
+
+    def delete_runtimes(
+            self,
+            db_session: sqlalchemy.orm.Session,
+            label_selector: str = None,
+            force: bool = False,
+            grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
+    ):
+        for kind in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
+            runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
+            runtime_handler.delete_resources(
+                mlrun.api.utils.singletons.db.get_db(), db_session, label_selector, force, grace_period
+            )
+
+    def delete_runtime(
+            self,
+            db_session: sqlalchemy.orm.Session,
+            kind: str,
+            label_selector: str = None,
+            force: bool = False,
+            grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
+    ):
+        if kind not in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
+            mlrun.api.api.utils.log_and_raise(
+                http.HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
+            )
+        runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
+        runtime_handler.delete_resources(
+            mlrun.api.utils.singletons.db.get_db(), db_session, label_selector, force, grace_period
+        )
+
+    def delete_runtime_object(
+            self,
+            db_session: sqlalchemy.orm.Session,
+            kind: str,
+            object_id: str,
+            label_selector: str = None,
+            force: bool = False,
+            grace_period: int = mlrun.config.config.runtime_resources_deletion_grace_period,
+    ):
+        if kind not in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
+            mlrun.api.api.utils.log_and_raise(
+                http.HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
+            )
+        runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
+        runtime_handler.delete_runtime_object_resources(
+            mlrun.api.utils.singletons.db.get_db(), db_session, object_id, label_selector, force, grace_period
+        )

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -57,7 +57,12 @@ class Client(
         project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
-        logger.debug("Patching project in Nuclio", name=name, project=project, patch_mode=patch_mode)
+        logger.debug(
+            "Patching project in Nuclio",
+            name=name,
+            project=project,
+            patch_mode=patch_mode,
+        )
         response = self._get_project_from_nuclio(name)
         response_body = response.json()
         if project.get("metadata", {}).get("labels") is not None:

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -57,6 +57,7 @@ class Client(
         project: dict,
         patch_mode: mlrun.api.schemas.PatchMode = mlrun.api.schemas.PatchMode.replace,
     ):
+        logger.debug("Patching project in Nuclio", name=name, project=project, patch_mode=patch_mode)
         response = self._get_project_from_nuclio(name)
         response_body = response.json()
         if project.get("metadata", {}).get("labels") is not None:

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -285,10 +285,10 @@ class Member(
         self, name: str
     ) -> mlrun.api.utils.projects.remotes.member.Member:
         # importing here to avoid circular import (db using project member using mlrun follower using db)
-        import mlrun.api.utils.singletons.db
+        import mlrun.api.crud
 
         followers_classes_map = {
-            "mlrun": mlrun.api.utils.singletons.db.get_db(),
+            "mlrun": mlrun.api.crud.Projects(),
             "nuclio": mlrun.api.utils.clients.nuclio.Client(),
             # for tests
             "nop": mlrun.api.utils.projects.remotes.nop.Member(),

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1285,13 +1285,16 @@ class BaseRuntimeHandler(ABC):
     ):
         project, uid = self._resolve_runtime_resource_run(runtime_resource)
         if not project or not uid:
-            logger.warning(
-                "Could not resolve run project or uid from runtime resource, can not monitor run. Continuing",
-                project=project,
-                uid=uid,
-                runtime_resource_name=runtime_resource["metadata"]["name"],
-                namespace=namespace,
-            )
+            # Currently any build pod won't have UID and therefore will cause this log message to be printed which
+            # spams the log
+            # TODO: uncomment the log message when builder become a kind / starts having a UID
+            # logger.warning(
+            #     "Could not resolve run project or uid from runtime resource, can not monitor run. Continuing",
+            #     project=project,
+            #     uid=uid,
+            #     runtime_resource_name=runtime_resource["metadata"]["name"],
+            #     namespace=namespace,
+            # )
             return
         run = project_run_uid_map.get(project, {}).get(uid)
         if runtime_resource_is_crd:

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -1,4 +1,5 @@
 import typing
+import unittest.mock
 import mergedeep
 import copy
 from http import HTTPStatus
@@ -9,6 +10,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 import mlrun.api.schemas
+import mlrun.api.crud
 import mlrun.errors
 
 
@@ -141,6 +143,9 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
         },
     )
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
+
+    # mock runtime resources deletion
+    mlrun.api.crud.Runtimes().delete_runtimes = unittest.mock.Mock()
 
     # delete - cascade strategy, will succeed and delete function
     response = client.delete(


### PR DESCRIPTION
Fixes IG-17647

A project deletion wasn't removing the runtime resources of the jobs (a bug)
That caused to the next cycle of jobs monitoring to find out that a Run doesn't exist for the job, and therefore to create one, that caused ensured project to be called, and that caused to project to be re-created after it deleted already