### PR TITLE
[Artifacts] Fix artifacts tagging

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -597,7 +597,10 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
 
     def tag_objects(self, session, objs, project: str, name: str):
         # only artifacts left with this tagging schema
-        self.tag_artifacts(session, objs, project, name)
+        if objs and isinstance(objs[0], Artifact):
+            self.tag_artifacts(session, objs, project, name)
+        else:
+            self.tag_objects_v2(session, objs, project, name)
 
     def tag_artifacts(self, session, artifacts, project: str, name: str):
         for artifact in artifacts:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -597,10 +597,11 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
 
     def tag_objects(self, session, objs, project: str, name: str):
         # only artifacts left with this tagging schema
-        if objs and isinstance(objs[0], Artifact):
-            self.tag_artifacts(session, objs, project, name)
-        else:
-            self.tag_objects_v2(session, objs, project, name)
+        for obj in objs:
+            if isinstance(obj, Artifact):
+                self.tag_artifacts(session, [obj], project, name)
+            else:
+                self.tag_objects_v2(session, [obj], project, name)
 
     def tag_artifacts(self, session, artifacts, project: str, name: str):
         for artifact in artifacts:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -601,9 +601,11 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
 
     def tag_artifacts(self, session, artifacts, project: str, name: str):
         for artifact in artifacts:
-            query = self._query(
-                session, artifact.Tag, project=project, name=name,
-            ).join(Artifact).filter(Artifact.key == artifact.key)
+            query = (
+                self._query(session, artifact.Tag, project=project, name=name,)
+                .join(Artifact)
+                .filter(Artifact.key == artifact.key)
+            )
             tag = query.one_or_none()
             if not tag:
                 tag = artifact.Tag(project=project, name=name)

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -122,6 +122,30 @@ def test_list_artifact_category_filter(db: DBInterface, db_session: Session):
     assert artifacts[1]["metadata"]["name"] == artifact_name_2
 
 
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
+def test_store_artifact_tagging(db: DBInterface, db_session: Session):
+    artifact_1_key = "artifact_key_1"
+    artifact_1_body = _generate_artifact(artifact_1_key)
+    artifact_1_kind = ChartArtifact.kind
+    artifact_1_with_kind_body = _generate_artifact(artifact_1_key, kind=artifact_1_kind)
+    artifact_1_uid = "artifact_uid"
+    artifact_1_with_kind_uid = "artifact_uid_2"
+
+    db.store_artifact(
+        db_session, artifact_1_key, artifact_1_body, artifact_1_uid,
+    )
+    db.store_artifact(
+        db_session, artifact_1_key, artifact_1_with_kind_body, artifact_1_with_kind_uid,
+    )
+    artifact = db.read_artifact(db_session, artifact_1_key, tag="latest")
+    assert artifact['kind'] == artifact_1_kind
+    artifact = db.read_artifact(db_session, artifact_1_key, tag=artifact_1_uid)
+    assert artifact.get('kind') is None
+
+
 def _generate_artifact(name, kind=None):
     artifact = {
         "metadata": {"name": name},

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -141,9 +141,9 @@ def test_store_artifact_tagging(db: DBInterface, db_session: Session):
         db_session, artifact_1_key, artifact_1_with_kind_body, artifact_1_with_kind_uid,
     )
     artifact = db.read_artifact(db_session, artifact_1_key, tag="latest")
-    assert artifact['kind'] == artifact_1_kind
+    assert artifact["kind"] == artifact_1_kind
     artifact = db.read_artifact(db_session, artifact_1_key, tag=artifact_1_uid)
-    assert artifact.get('kind') is None
+    assert artifact.get("kind") is None
 
 
 def _generate_artifact(name, kind=None):

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -118,7 +118,9 @@ def test_artifacts_latest(db: SQLDB, db_session: Session):
     assert {17, 99} == set(art["a"] for art in arts), "latest"
 
 
-@pytest.mark.parametrize("cls", [tagged_model for tagged_model in _tagged if tagged_model != Run])
+@pytest.mark.parametrize(
+    "cls", [tagged_model for tagged_model in _tagged if tagged_model != Run]
+)
 def test_tags(db: SQLDB, db_session: Session, cls):
     p1, n1 = "prj1", "name1"
     object_identifier = "name"

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -142,9 +142,10 @@ def test_tags(db: SQLDB, db_session: Session, cls):
 
 
 def _tag_objs(db: SQLDB, db_session: Session, count, project, tags):
+    tagged = [tagged_model for tagged_model in _tagged if tagged_model != Run]
     by_tag = defaultdict(list)
     for i in range(count):
-        cls = _tagged[i % len(_tagged)]
+        cls = tagged[i % len(tagged)]
         obj = cls()
         by_tag[tags[i % len(tags)]].append(obj)
         db_session.add(obj)

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 
 import mlrun.api.schemas
 from mlrun.api.db.sqldb.db import SQLDB
-from mlrun.api.db.sqldb.models import _tagged
+from mlrun.api.db.sqldb.models import _tagged, Artifact, Run
 from tests.conftest import new_run
 
 
@@ -118,10 +118,15 @@ def test_artifacts_latest(db: SQLDB, db_session: Session):
     assert {17, 99} == set(art["a"] for art in arts), "latest"
 
 
-@pytest.mark.parametrize("cls", _tagged)
+@pytest.mark.parametrize("cls", [tagged_model for tagged_model in _tagged if tagged_model != Run])
 def test_tags(db: SQLDB, db_session: Session, cls):
     p1, n1 = "prj1", "name1"
+    object_identifier = "name"
+    if cls == Artifact:
+        object_identifier = "key"
     obj1, obj2, obj3 = cls(), cls(), cls()
+    for index, obj in enumerate([obj1, obj2, obj3]):
+        setattr(obj, object_identifier, f"obj-identifier-{index}")
     db_session.add(obj1)
     db_session.add(obj2)
     db_session.add(obj3)

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -108,14 +108,14 @@ def test_artifacts_latest(db: SQLDB, db_session: Session):
     u2, art2 = "u2", {"a": 17}
     db.store_artifact(db_session, k1, art2, u2, project=prj)
     arts = db.list_artifacts(db_session, project=prj, tag="latest")
-    assert 2 == len(arts), "count"
-    assert art2["a"] == arts[1]["a"], "bad artifact"
+    assert 1 == len(arts), "count"
+    assert art2["a"] == arts[0]["a"], "bad artifact"
 
     k2, u3, art3 = "k2", "u3", {"a": 99}
     db.store_artifact(db_session, k2, art3, u3, project=prj)
     arts = db.list_artifacts(db_session, project=prj, tag="latest")
-    assert 3 == len(arts), "number"
-    assert {1, 17, 99} == set(art["a"] for art in arts), "latest"
+    assert 2 == len(arts), "number"
+    assert {17, 99} == set(art["a"] for art in arts), "latest"
 
 
 @pytest.mark.parametrize("cls", _tagged)
@@ -129,11 +129,11 @@ def test_tags(db: SQLDB, db_session: Session, cls):
 
     db.tag_objects(db_session, [obj1, obj2], p1, n1)
     objs = db.find_tagged(db_session, p1, n1)
-    assert {obj1, obj2} == set(objs), "find tags"
+    assert {obj1, obj2} == set(objs)
 
     db.del_tag(db_session, p1, n1)
     objs = db.find_tagged(db_session, p1, n1)
-    assert [] == objs, "find tags after del"
+    assert [] == objs
 
 
 def _tag_objs(db: SQLDB, db_session: Session, count, project, tags):


### PR DESCRIPTION
There was a problem in the tagging logic that caused each `store_artifact` call to create a new Tag record, therefore when trying to get a specific artifact's `latest` version, `one_or_none` would explode.
Fixed that - in a followup PR will add logic that will fix DBs with duplicated tags