### PR TITLE
[Feature store] BUGFIX: REST API using uid on unversioned objects fail

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -21,6 +21,7 @@ from mlrun.utils import get_in, logger, parse_versioned_object_uri
 
 import re
 from hashlib import sha1
+from mlrun.api.db.sqldb.db import unversioned_tagged_object_uid_prefix
 
 
 def log_and_raise(status=HTTPStatus.BAD_REQUEST.value, **kw):
@@ -216,7 +217,12 @@ def parse_reference(reference: str):
     uid = None
     regex_match = uid_regex.match(reference)
     if not regex_match:
-        tag = reference
+        # If the uid of an unversioned object was used (i.e. "unversioned-latest"), strip
+        # the prefix and remain with the original tag.
+        if reference.startswith(unversioned_tagged_object_uid_prefix):
+            tag = reference.strip(unversioned_tagged_object_uid_prefix)
+        else:
+            tag = reference
     else:
         uid = regex_match.string
     return tag, uid

--- a/tests/api/api/feature_store/base.py
+++ b/tests/api/api/feature_store/base.py
@@ -31,19 +31,20 @@ def _patch_object(
     object_update,
     object_url_path,
     additive=False,
+    reference="latest",
 ):
     patch_mode = "replace"
     if additive:
         patch_mode = "additive"
     headers = {mlrun.api.schemas.HeaderNames.patch_mode: patch_mode}
     response = client.patch(
-        f"/api/projects/{project_name}/{object_url_path}/{name}/references/latest",
+        f"/api/projects/{project_name}/{object_url_path}/{name}/references/{reference}",
         json=object_update,
         headers=headers,
     )
     assert response.status_code == HTTPStatus.OK.value
     response = client.get(
-        f"/api/projects/{project_name}/{object_url_path}/{name}/references/latest"
+        f"/api/projects/{project_name}/{object_url_path}/{name}/references/{reference}"
     )
     return response.json()
 

--- a/tests/api/api/feature_store/test_feature_sets.py
+++ b/tests/api/api/feature_store/test_feature_sets.py
@@ -1,10 +1,10 @@
 from http import HTTPStatus
 from uuid import uuid4
-
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
-
 from .base import _patch_object, _list_and_assert_objects
+from mlrun.api.db.sqldb.db import unversioned_tagged_object_uid_prefix
+from deepdiff import DeepDiff
 
 
 def _generate_feature_set(name, extra_feature_name="extra"):
@@ -563,3 +563,33 @@ def test_no_feature_leftovers_when_storing_feature_sets(
         _list_and_assert_objects(
             client, "features", project_name, None, expected_number_of_features
         )
+
+
+def test_unversioned_feature_set_reference_by_uid(
+    db: Session, client: TestClient
+) -> None:
+    project_name = f"prj-{uuid4().hex}"
+
+    name = "feature_set_1"
+    feature_set = _generate_feature_set(name)
+    feature_set_response = _feature_set_create_and_assert(
+        client, project_name, feature_set, versioned=False
+    )
+
+    feature_set_uid = feature_set_response["metadata"]["uid"]
+    assert feature_set_uid == f"{unversioned_tagged_object_uid_prefix}latest"
+
+    feature_set_patch = {"status": {"patched": "yes"}}
+    # Since the function calls both PATCH and GET on the same reference, it tests both cases
+    patched_feature_set = _patch_object(
+        client,
+        project_name,
+        name,
+        feature_set_patch,
+        "feature-sets",
+        reference=feature_set_uid,
+    )
+
+    expected_diff = {"dictionary_item_added": ["root['status']['patched']"]}
+    diff = DeepDiff(feature_set_response, patched_feature_set, ignore_order=True,)
+    assert diff == expected_diff


### PR DESCRIPTION
Fixing a bug where calling REST APIs using references to uid of unversioned objects fail to find the objects in question.
For example: doing a `PATCH /projects/<project>/feature-sets/feature-set1/references/unversioned-latest` will result in 404 even if the object with the `latest` tag and this uid exists.

This was caused by the reference not matching the uid regex, and hence used as tag. However, there is no such tag `unversioned-latest` for the object (the tag is actually `latest`) and therefore finding the object will fail.

Fix is to handle unversioned references properly and extract the tag from the reference by stripping the `unversioned-` prefix.

A new test is added to verify the fix on feature-set objects - it is the same fix across all objects using the `parse_reference` function, so avoided testing across all object types.