### PR TITLE
[Dask] Set distributed min bound to 2.23.0

### DIFF
--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -6,7 +6,7 @@ dask-kubernetes~=0.11.0
 dask-ml~=1.4
 dask[complete]~=2.12
 # see main requirements.txt for reasoning the resrictions
-distributed>=2.5.2, <3
+distributed>=2.23, <3
 kubernetes~=11.0
 lz4~=3.0
 msgpack~=1.0

--- a/dockerfiles/models-gpu/requirements.txt
+++ b/dockerfiles/models-gpu/requirements.txt
@@ -6,7 +6,7 @@ dask-kubernetes~=0.11.0
 dask-ml~=1.4
 dask[complete]~=2.12
 # see main requirements.txt for reasoning the resrictions
-distributed>=2.5.2, <3
+distributed>=2.23, <3
 face_recognition~=1.3
 gnureadline~=8.0
 imutils~=0.5.3

--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -7,7 +7,7 @@ dask-kubernetes~=0.11.0
 dask-ml~=1.4
 dask[complete]~=2.12
 # see main requirements.txt for reasoning the resrictions
-distributed>=2.5.2, <3
+distributed>=2.23, <3
 fsspec~=0.8.0
 gnureadline~=8.0
 kubernetes~=11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,10 @@ dask~=2.12
 # so without our limitation to <3, 2020.12.0 is installed which is incompatible since it has dask>=2020.12.0 while ours
 # is ~=2.12
 # TODO: dask-kubernetes will probably release 0.11.1 with a fix for this soon and this could be removed
-distributed>=2.5.2, <3
+# (19.01.2021) - >=2.5.2, <3 here resolves to 2.30.1, and mlrun/ml-models comes pre-installed with 2.11.0 which is fine
+# for that specifier, but they don't work together (couldn't find why) only 2.23 and up is working, putting down bound
+# of 2.23
+distributed>=2.23, <3
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,9 +33,9 @@ dask~=2.12
 # so without our limitation to <3, 2020.12.0 is installed which is incompatible since it has dask>=2020.12.0 while ours
 # is ~=2.12
 # TODO: dask-kubernetes will probably release 0.11.1 with a fix for this soon and this could be removed
-# (19.01.2021) - >=2.5.2, <3 here resolves to 2.30.1, and mlrun/ml-models comes pre-installed with 2.11.0 which is fine
-# for that specifier, but they don't work together (couldn't find why) only 2.23 and up is working, putting down bound
-# of 2.23
+# (19.01.2021) - >=2.5.2, <3 in the client resolves to 2.30.1, and mlrun/ml-models comes pre-installed with 2.11.0 which
+# is fine for that specifier, but they don't work together (couldn't find why) only 2.23 and up is working, so putting
+# min bound of 2.23
 distributed>=2.23, <3
 # 3.0 iguazio system is running k8s 1.17 so ideally we would use 17.X, but kfp limiting to <12.0
 kubernetes~=11.0


### PR DESCRIPTION
Copying comment from requirements.txt:
```
>=2.5.2, <3 in the client resolves to 2.30.1, and mlrun/ml-models comes pre-installed with 2.11.0 which
# is fine for that specifier, but they don't work together (couldn't find why) only 2.23 and up is working, so putting
# min bound of 2.23
```