### PR TITLE
[CI] Fixing release branch automation to include file deletions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,4 +22,4 @@ jobs:
         export tag=$(echo ${GITHUB_REF#refs/tags/})
         git config user.name "mlrun-iguazio"
         git config user.email "mlrun.iguazio@gmail.com"
-        MLRUN_VERSION=$tag make release
+        MLRUN_GIT_ORG=${{ github.repository_owner }} MLRUN_VERSION=$tag make release

--- a/Makefile
+++ b/Makefile
@@ -476,9 +476,10 @@ endif
 		then \
 			echo "Branch $$BRANCH_NAME exists. Adding changes"; \
 			git checkout $$BRANCH_NAME; \
-			git replace --graft $(MLRUN_VERSION) HEAD; \
-			git merge $(MLRUN_VERSION) --allow-unrelated-histories --squash -X theirs; \
-			git replace --delete $(MLRUN_VERSION); \
+			rm -rf /tmp/mlrun; \
+			git clone --branch $(MLRUN_VERSION) git@github.com:mlrun/mlrun.git /tmp/mlrun; \
+			find . -path ./.git -prune -o -exec rm -rf {} \; 2> /dev/null; \
+			rsync -avr --exclude='.git/' /tmp/mlrun/ .; \
 			git add -A; \
 		else \
 			echo "Creating new branch: $$BRANCH_NAME"; \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ MLRUN_CACHE_DATE ?= $(shell date +%s)
 # 2. add the --cache-from falg to the docker build
 # 3. docker tag and push (also) the (updated) cache image
 MLRUN_DOCKER_CACHE_FROM_TAG ?=
+MLRUN_GIT_ORG ?= mlrun
 
 
 MLRUN_DOCKER_IMAGE_PREFIX := $(if $(MLRUN_DOCKER_REGISTRY),$(strip $(MLRUN_DOCKER_REGISTRY))$(MLRUN_DOCKER_REPO),$(MLRUN_DOCKER_REPO))
@@ -477,7 +478,7 @@ endif
 			echo "Branch $$BRANCH_NAME exists. Adding changes"; \
 			git checkout $$BRANCH_NAME; \
 			rm -rf /tmp/mlrun; \
-			git clone --branch $(MLRUN_VERSION) git@github.com:mlrun/mlrun.git /tmp/mlrun; \
+			git clone --branch $(MLRUN_VERSION) https://github.com/$(MLRUN_GIT_ORG)/mlrun.git /tmp/mlrun; \
 			find . -path ./.git -prune -o -exec rm -rf {} \; 2> /dev/null; \
 			rsync -avr --exclude='.git/' /tmp/mlrun/ .; \
 			git add -A; \

--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,9 @@ endif
 		then \
 			echo "Branch $$BRANCH_NAME exists. Adding changes"; \
 			git checkout $$BRANCH_NAME; \
-			git checkout $(MLRUN_TAG) .; \
+			git replace --graft $(MLRUN_VERSION) HEAD; \
+			git merge $(MLRUN_VERSION) --allow-unrelated-histories --squash -X theirs; \
+			git replace --delete $(MLRUN_VERSION); \
 			git add -A; \
 		else \
 			echo "Creating new branch: $$BRANCH_NAME"; \


### PR DESCRIPTION
**What do we want to do ?**
we basically want that this CI will use the `MLRUN_VERSION` it got (representing some git tag), take all of its contents, and put them "as is" in the relevant release branch, as one commit.

What I've done before this PR is:
`git checkout $(MLRUN_TAG) .` - the problem with it was that it was only adding changes and file additions, but don't do file deletions

I've tried going to the `git merge` direction, I ended up with:
```
git replace --graft $(MLRUN_VERSION) HEAD; \
git merge $(MLRUN_VERSION) --allow-unrelated-histories --squash -X theirs; \
git replace --delete $(MLRUN_VERSION); \
```
* `--allow-unrelated-histories` - we're basically trying to merge from the release tag, which its history is like the dev branch history, to the release branch, which its history is unrelated - it has a per tag commit. therefore we must explicitly allow it.
* `--squash` - we want all the tag content added as one commit
* `-X theirs` - there might be conflicts, we just want whatever on that tag, we don't care about local
* `replace --graft $(MLRUN_VERSION) HEAD` - https://stackoverflow.com/questions/49120631/git-merge-does-not-deleting-files-from-another-repository
* `replace --delete $(MLRUN_VERSION)` - just clean the hacks that we do

The problem with this is that first commit we're giving to the `git replace` should be the place where changes starting, so `$(MLRUN_VERSION)` is incorrect, it should be the previous tag, or the first commit after it in order to work, but that's information I don't have

I decided to go with a more simple approach:
* clone what I want to other dir
* delete everything in current dir (except `.git`)
* copy from other dir to current dir
that simply do what I want - "take X branch contents and put them in Y branch contents"