### PR TITLE
[API] Add support for query with multiple label values

### DIFF
--- a/tests/api/api/feature_store/test_feature_vectors.py
+++ b/tests/api/api/feature_store/test_feature_vectors.py
@@ -108,7 +108,11 @@ def test_list_feature_vectors(db: Session, client: TestClient) -> None:
         client, "feature_vectors", project_name, "name=ooga", ooga_name_count
     )
     _list_and_assert_objects(
-        client, "feature_vectors", project_name, "label=color=blue", blue_lables_count
+        client,
+        "feature_vectors",
+        project_name,
+        "label=color=blue&label=owner",
+        blue_lables_count,
     )
     _list_and_assert_objects(
         client, "feature_vectors", project_name, "label=owner", count


### PR DESCRIPTION
Fixing a known issue in the SQLDB where a DB query for objects with multiple labels would return nothing. For example, if looking for a feature-set with:
`GET /projects/<proj>/feature-sets?label=label1=value1&label=label2=value2`
This will return nothing, even if an object with both labels and values exist. The reason is the SQL query that was used in the `_add_labels_filter()` method which could not handle this kind of complex query.
The fix allows for multiple labels to be queried, and also takes care of the special (and weird) case of asking for:
`label=label1&label=label1=value1`
In this case it will reduce the query to `label=label1=value1` and ignore the predicate without the value which is redundant.
The fix applies to all objects which use the `_add_label_filter()` method, which are the feature-store objects as well as projects, artifacts and some others.