### PR TITLE
[Models image] Pinning intel-tensorflow to 2.3.0

### DIFF
--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -61,7 +61,7 @@ RUN conda clean -ayq
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN python -m pip install -U intel-tensorflow mxnet
+RUN python -m pip install -U 'intel-tensorflow==2.3.0' mxnet
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install 'horovod~=0.20.0'


### PR DESCRIPTION
`mlrun/ml-models` started failed building in the horovod installation step, I noticed that it started when `intel-tensorflow` 2.4.0 released, so pinned it back to 2.3.0. attaching the failure log:
[intel-tensorflow.log](https://github.com/mlrun/mlrun/files/5900490/intel-tensorflow.log)
