### PR TITLE
[Serving] Add base runtime env

### DIFF
--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -375,7 +375,7 @@ class ServingRuntime(RemoteRuntime):
             "graph_initializer": self.spec.graph_initializer,
             "error_stream": self.spec.error_stream,
         }
-        env['SERVING_SPEC_ENV'] = json.dumps(serving_spec)
+        env["SERVING_SPEC_ENV"] = json.dumps(serving_spec)
         return env
 
     def to_mock_server(

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -363,7 +363,7 @@ class ServingRuntime(RemoteRuntime):
         return super().deploy(dashboard, project, tag, verbose=verbose)
 
     def _get_runtime_env(self):
-
+        env = super()._get_runtime_env()
         function_name_uri_map = {f.name: f.uri(self) for f in self.spec.function_refs}
         serving_spec = {
             "function_uri": self._function_uri(),
@@ -375,7 +375,8 @@ class ServingRuntime(RemoteRuntime):
             "graph_initializer": self.spec.graph_initializer,
             "error_stream": self.spec.error_stream,
         }
-        return {"SERVING_SPEC_ENV": json.dumps(serving_spec)}
+        env['SERVING_SPEC_ENV'] = json.dumps(serving_spec)
+        return env
 
     def to_mock_server(
         self, namespace=None, current_function=None, **kwargs


### PR DESCRIPTION
The serving function was overriding the `_get_runtime_env` method but wasn't calling the super (and extending its value) that caused the `MLRUN_DBPATH` to not be configured on the serving pod, which caused the pod to not being able to communicate with the API in cases where it's not named `mlrun-api` (covered by the sane default)