### PR TITLE
[Requirements] Upbound numpy to 1.20

### DIFF
--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -10,7 +10,8 @@ distributed>=2.23, <3
 kubernetes~=11.0
 lz4~=3.0
 msgpack~=1.0
-numpy~=1.18
+# see main requirements.txt for reasoning the resrictions
+numpy>=1.16.5, <1.20.0
 scikit-learn~=0.23.0
 scikit-plot~=0.3.7
 tornado~=6.0

--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -15,7 +15,8 @@ lifelines~=0.25.0
 lightgbm~=3.0
 lz4~=3.0
 msgpack~=1.0
-numpy~=1.18
+# see main requirements.txt for reasoning the resrictions
+numpy>=1.16.5, <1.20.0
 plotly~=4.7
 pyarrow~=1.0
 pyod~=0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
 nuclio-jupyter>=0.8.9
+# >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
+# https://github.com/Azure/MachineLearningNotebooks/issues/1314
+numpy>=1.16.5, <1.20.0
 pandas~=1.0
 # used as a the engine for parquet files by pandas
 pyarrow~=1.0

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -1,6 +1,8 @@
 import numpy
 import pandas
 import pandas.io.json
+import pathlib
+import tests.conftest
 
 import mlrun.artifacts.dataset
 
@@ -47,3 +49,15 @@ def test_dataset_preview_size_limit():
     )
     artifact = mlrun.artifacts.dataset.DatasetArtifact(df=data_frame)
     assert artifact.stats is None
+
+
+def test_dataset_upload():
+    """
+    This test fails when we use numpy>=1.20 and is here to reproduce the scenario that didn't work
+    which caused us to upbound numpy to 1.20
+    see https://github.com/Azure/MachineLearningNotebooks/issues/1314
+    """
+    data_frame = pandas.DataFrame({'x': [1, 2]})
+    target_path = pathlib.Path(tests.conftest.results) / "dataset"
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(df=data_frame, target_path=str(target_path))
+    artifact.upload()

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -57,7 +57,9 @@ def test_dataset_upload():
     which caused us to upbound numpy to 1.20
     see https://github.com/Azure/MachineLearningNotebooks/issues/1314
     """
-    data_frame = pandas.DataFrame({'x': [1, 2]})
+    data_frame = pandas.DataFrame({"x": [1, 2]})
     target_path = pathlib.Path(tests.conftest.results) / "dataset"
-    artifact = mlrun.artifacts.dataset.DatasetArtifact(df=data_frame, target_path=str(target_path))
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(
+        df=data_frame, target_path=str(target_path)
+    )
     artifact.upload()


### PR DESCRIPTION
When we upload a dataset we turn it into a file, be default we use the parquet format, we recently started hitting this error:
```
> 2021-02-02 22:14:14,111 [error] Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/mlrun/runtimes/local.py", line 217, in exec_from_params
    val = handler(*args_list)
  File "main.py", line 15, in vwvtwewczd
    context.log_dataset('mydf', df=df)
  File "/usr/local/lib/python3.7/site-packages/mlrun/execution.py", line 526, in log_dataset
    labels=labels,
  File "/usr/local/lib/python3.7/site-packages/mlrun/artifacts/manager.py", line 155, in log_artifact
    item.upload()
  File "/usr/local/lib/python3.7/site-packages/mlrun/artifacts/dataset.py", line 140, in upload
    **self._kw,
  File "/usr/local/lib/python3.7/site-packages/mlrun/artifacts/dataset.py", line 307, in upload_dataframe
    saving_func(target, **kw)
  File "/usr/local/lib/python3.7/site-packages/pandas/util/_decorators.py", line 199, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/frame.py", line 2463, in to_parquet
    **kwargs,
  File "/usr/local/lib/python3.7/site-packages/pandas/io/parquet.py", line 397, in to_parquet
    **kwargs,
  File "/usr/local/lib/python3.7/site-packages/pandas/io/parquet.py", line 152, in write
    table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
  File "pyarrow/table.pxi", line 1376, in pyarrow.lib.Table.from_pandas
  File "/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py", line 579, in dataframe_to_arrays
    for c, f in zip(columns_to_convert, convert_fields)]
  File "/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py", line 579, in <listcomp>
    for c, f in zip(columns_to_convert, convert_fields)]
  File "/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py", line 565, in convert_column
    raise e
  File "/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py", line 559, in convert_column
    result = pa.array(col, type=type_, from_pandas=True, safe=safe)
  File "pyarrow/array.pxi", line 265, in pyarrow.lib.array
  File "pyarrow/array.pxi", line 76, in pyarrow.lib._ndarray_to_array
  File "pyarrow/array.pxi", line 64, in pyarrow.lib._ndarray_to_type
  File "pyarrow/error.pxi", line 107, in pyarrow.lib.check_status
pyarrow.lib.ArrowTypeError: ('Did not pass numpy.dtype object', 'Conversion failed for column A with type int64')
```
Looking on https://github.com/Azure/MachineLearningNotebooks/issues/1314 I decided to simply add `<1.20.0` for numpy requirement

This fixes https://jira.iguazeng.com/browse/ML-129