### PR TITLE
[System tests] Remove unneeded re-initialization of rundb

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -60,8 +60,6 @@ class TestMLRunSystem:
         self.custom_teardown()
 
         self._logger.debug("Removing test data from database")
-        # TODO: understand why a single db instantiation isn't enough, and fix the bug in the db
-        self._run_db = mlrun.db.get_run_db()
         self._run_db.delete_project(
             self.project_name,
             deletion_strategy=mlrun.api.schemas.DeletionStrategy.cascade,

--- a/tests/system/demos/base.py
+++ b/tests/system/demos/base.py
@@ -34,8 +34,6 @@ class TestDemo(TestMLRunSystem):
             watch=True,
         )
 
-        # TODO: understand why a single db instantiation isn't enough, and fix the bug in the db
-        self._run_db = mlrun.db.get_run_db()
         runs = self._run_db.list_runs(
             project=self.project_name, labels=f"workflow={run_id}"
         )

--- a/tests/system/examples/basics/test_db.py
+++ b/tests/system/examples/basics/test_db.py
@@ -1,4 +1,4 @@
-from mlrun import get_run_db, run_local, new_task
+from mlrun import run_local, new_task
 
 from tests.system.base import TestMLRunSystem
 

--- a/tests/system/examples/basics/test_db.py
+++ b/tests/system/examples/basics/test_db.py
@@ -33,8 +33,6 @@ class TestDB(TestMLRunSystem):
 
     def test_db_commands(self):
 
-        # TODO: understand why a single db instantiation isn't enough, and fix the bug in the db
-        self._run_db = get_run_db()
         runs = self._run_db.list_runs(project=self.project_name)
         assert len(runs) == 1
 

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -9,7 +9,6 @@ from mlrun import (
     new_task,
     run_pipeline,
     wait_for_pipeline_completion,
-    get_run_db,
 )
 
 from tests.system.base import TestMLRunSystem

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -81,8 +81,6 @@ class TestDask(TestMLRunSystem):
 
         wait_for_pipeline_completion(workflow_run_id)
 
-        # TODO: understand why a single db instantiation isn't enough, and fix the bug in the db
-        self._run_db = get_run_db()
         runs = self._run_db.list_runs(
             project=self.project_name, labels=f"workflow={workflow_run_id}"
         )

--- a/tests/system/examples/jobs/test_jobs.py
+++ b/tests/system/examples/jobs/test_jobs.py
@@ -78,8 +78,6 @@ class TestJobs(TestMLRunSystem):
 
         wait_for_pipeline_completion(workflow_run_id)
 
-        # TODO: understand why a single db instantiation isn't enough, and fix the bug in the db
-        self._run_db = get_run_db()
         runs = self._run_db.list_runs(
             project=self.project_name, labels=f"workflow={workflow_run_id}"
         )

--- a/tests/system/examples/jobs/test_jobs.py
+++ b/tests/system/examples/jobs/test_jobs.py
@@ -8,7 +8,6 @@ from mlrun import (
     new_task,
     run_pipeline,
     wait_for_pipeline_completion,
-    get_run_db,
 )
 from mlrun.platforms.other import mount_v3io
 


### PR DESCRIPTION
The fix to reload the config after changing the env (done as part of this PR - https://github.com/mlrun/mlrun/pull/691) was the reason the re-initialization was needed