### PR TITLE
[SDK] Read kfp image from server + make dask kfp image configurable

### DIFF
--- a/mlrun/api/api/endpoints/healthz.py
+++ b/mlrun/api/api/endpoints/healthz.py
@@ -21,4 +21,5 @@ def health():
         "spark_app_image": config.spark_app_image,
         "spark_app_image_tag": config.spark_app_image_tag,
         "kfp_image": config.kfp_image,
+        "dask_kfp_image": config.dask_kfp_image,
     }

--- a/mlrun/api/api/endpoints/healthz.py
+++ b/mlrun/api/api/endpoints/healthz.py
@@ -20,4 +20,5 @@ def health():
         "artifact_path": config.artifact_path,
         "spark_app_image": config.spark_app_image,
         "spark_app_image_tag": config.spark_app_image_tag,
+        "kfp_image": config.kfp_image,
     }

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -228,6 +228,10 @@ class Config:
             return mlrun.utils.helpers.enrich_image_url("mlrun/mlrun")
         return self._kfp_image
 
+    @kfp_image.setter
+    def kfp_image(self, value):
+        self._kfp_image = value
+
     @staticmethod
     def resolve_ui_url():
         # ui_url is deprecated in favor of the ui.url (we created the ui block)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -50,6 +50,7 @@ default_config = {
     "images_registry": "",  # registry to use with mlrun images e.g. quay.io/ (defaults to empty, for dockerhub)
     "kfp_ttl": "14400",  # KFP ttl in sec, after that completed PODs will be deleted
     "kfp_image": "",  # image to use for KFP runner (defaults to mlrun/mlrun)
+    "dask_kfp_image": "",  # image to use for dask KFP runner (defaults to mlrun/ml-base)
     "igz_version": "",  # the version of the iguazio system the API is running on
     "spark_app_image": "",  # image to use for spark operator app runtime
     "spark_app_image_tag": "",  # image tag to use for spark opeartor app runtime
@@ -232,6 +233,22 @@ class Config:
     def kfp_image(self, value):
         self._kfp_image = value
 
+    @property
+    def dask_kfp_image(self):
+        """
+        See kfp_image property docstring for why we're defining this property
+        """
+        if not self._dask_kfp_image:
+            # importing here to avoid circular dependency
+            import mlrun.utils.helpers
+
+            return mlrun.utils.helpers.enrich_image_url("mlrun/ml-base")
+        return self._dask_kfp_image
+
+    @dask_kfp_image.setter
+    def dask_kfp_image(self, value):
+        self._dask_kfp_image = value
+
     @staticmethod
     def resolve_ui_url():
         # ui_url is deprecated in favor of the ui.url (we created the ui block)
@@ -291,10 +308,12 @@ def _do_populate(env=None):
     if data:
         config.update(data)
 
-    # HACK to enable kfp_image property to both have dynamic default and to use the value from dict/env like
-    # other configurations
+    # HACK to enable kfp_image and dask_kfp_image property to both have dynamic default and to use the value from
+    # dict/env like other configurations
     config._cfg["_kfp_image"] = config._cfg["kfp_image"]
     del config._cfg["kfp_image"]
+    config._cfg["_dask_kfp_image"] = config._cfg["dask_kfp_image"]
+    del config._cfg["dask_kfp_image"]
 
 
 def _convert_str(value, typ):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -217,11 +217,6 @@ class HTTPRunDB(RunDBInterface):
                 "mpijob_crd_version"
             )
             config.ui.url = config.resolve_ui_url() or server_cfg.get("ui_url")
-            # This is has a default value, therefore config.ui.projects_prefix will always have a value, prioritize the
-            # API value first
-            config.ui.projects_prefix = (
-                server_cfg.get("ui_projects_prefix") or config.ui.projects_prefix
-            )
             config.artifact_path = config.artifact_path or server_cfg.get(
                 "artifact_path"
             )
@@ -234,6 +229,14 @@ class HTTPRunDB(RunDBInterface):
             config.httpdb.builder.docker_registry = (
                 config.httpdb.builder.docker_registry
                 or server_cfg.get("docker_registry")
+            )
+            # These have a default value, therefore local config will always have a value, prioritize the
+            # API value first
+            config.ui.projects_prefix = (
+                server_cfg.get("ui_projects_prefix") or config.ui.projects_prefix
+            )
+            config.kfp_image = (
+                    server_cfg.get("kfp_image") or config.kfp_image
             )
         except Exception:
             pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -235,11 +235,9 @@ class HTTPRunDB(RunDBInterface):
             config.ui.projects_prefix = (
                 server_cfg.get("ui_projects_prefix") or config.ui.projects_prefix
             )
-            config.kfp_image = (
-                    server_cfg.get("kfp_image") or config.kfp_image
-            )
+            config.kfp_image = server_cfg.get("kfp_image") or config.kfp_image
             config.dask_kfp_image = (
-                    server_cfg.get("dask_kfp_image") or config.dask_kfp_image
+                server_cfg.get("dask_kfp_image") or config.dask_kfp_image
             )
         except Exception:
             pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -238,6 +238,9 @@ class HTTPRunDB(RunDBInterface):
             config.kfp_image = (
                     server_cfg.get("kfp_image") or config.kfp_image
             )
+            config.dask_kfp_image = (
+                    server_cfg.get("dask_kfp_image") or config.dask_kfp_image
+            )
         except Exception:
             pass
         return self

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -272,11 +272,7 @@ def mlrun_op(
 
         function_name = function.metadata.name
         if function.kind == "dask":
-            image = (
-                image
-                or function.spec.kfp_image
-                or config.dask_kfp_image
-            )
+            image = image or function.spec.kfp_image or config.dask_kfp_image
 
     image = image or config.kfp_image
 

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -275,7 +275,7 @@ def mlrun_op(
             image = (
                 image
                 or function.spec.kfp_image
-                or "mlrun/ml-base:{}".format(config.version)
+                or config.dask_kfp_image
             )
 
     image = image or config.kfp_image


### PR DESCRIPTION
* Make the client get the `kfp_image` from the server
Since the pipelines yaml is currently being rendered in the client side, the kfp image is "taken" from config in client side, so if we want to be able to actually control it, we want to sync this config value from server to client.
(This is also the reason in our system tests the pipelines pods are using `mlrun/mlrun:unstable` and not the tested version)
* Add a `dask_kfp_image` config value (because.. we need a way to configure it, we don't want it to be hardcoded)
and for the same reasons as the above, we made the client sync it from the server