### PR TITLE
[Datastore] Add fsspec support to all data stores

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,5 @@ requests-mock~=1.8
 # needed for system tests
 matplotlib~=3.0
 graphviz~=0.16.0
-storey~=0.3.3; python_version >= '3.7'
+# temporary until storey 0.3.3 is fixed
+storey==0.3.2; python_version >= '3.7'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,4 @@ requests-mock~=1.8
 # needed for system tests
 matplotlib~=3.0
 graphviz~=0.16.0
-storey~=0.3; python_version >= '3.7'
+storey~=0.3.3; python_version >= '3.7'

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -26,6 +26,12 @@ from ..utils import logger
 store_manager = StoreManager()
 
 
+def store_path_to_spark(path):
+    if path.startswith("v3io:///"):
+        path = "v3io:" + path[len("v3io:/") :]
+    return path
+
+
 def set_in_memory_item(key, value):
     item = store_manager.object(f"memory://{key}")
     item.put(value)

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -34,7 +34,7 @@ class AzureBlobStore(DataStore):
         if self._filesystem:
             return self._filesystem
         try:
-            import adlfs
+            import adlfs  # noqa
         except ImportError as e:
             if not silent:
                 raise ImportError(
@@ -48,7 +48,9 @@ class AzureBlobStore(DataStore):
         return dict(
             account_name=self._get_secret_or_env("AZURE_STORAGE_ACCOUNT_NAME"),
             account_key=self._get_secret_or_env("AZURE_STORAGE_KEY"),
-            connection_string=self._get_secret_or_env("AZURE_STORAGE_CONNECTION_STRING"),
+            connection_string=self._get_secret_or_env(
+                "AZURE_STORAGE_CONNECTION_STRING"
+            ),
         )
 
     def upload(self, key, src_path):

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -31,6 +31,8 @@ class AzureBlobStore(DataStore):
 
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
+        if self._filesystem:
+            return self._filesystem
         try:
             import adlfs
         except ImportError as e:
@@ -39,7 +41,8 @@ class AzureBlobStore(DataStore):
                     f"Azure adlfs not installed, run pip install adlfs, {e}"
                 )
             return None
-        return fsspec.filesystem("az", **self.get_storage_options())
+        self._filesystem = fsspec.filesystem("az", **self.get_storage_options())
+        return self._filesystem
 
     def get_storage_options(self):
         return dict(

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-import os
+import fsspec
 from azure.storage.blob import BlobServiceClient
 from .base import DataStore, FileStats
 
@@ -25,11 +25,28 @@ class AzureBlobStore(DataStore):
     def __init__(self, parent, schema, name, endpoint=""):
         super().__init__(parent, name, schema, endpoint)
 
-        con_string = self._secret("AZURE_STORAGE_CONNECTION_STRING") or os.getenv(
-            "AZURE_STORAGE_CONNECTION_STRING"
-        )
+        con_string = self._get_secret_or_env("AZURE_STORAGE_CONNECTION_STRING")
         if con_string:
             self.bsc = BlobServiceClient.from_connection_string(con_string)
+
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        try:
+            import adlfs
+        except ImportError as e:
+            if not silent:
+                raise ImportError(
+                    f"Azure adlfs not installed, run pip install adlfs, {e}"
+                )
+            return None
+        return fsspec.filesystem("az", **self.get_storage_options())
+
+    def get_storage_options(self):
+        return dict(
+            account_name=self._get_secret_or_env("AZURE_STORAGE_ACCOUNT_NAME"),
+            account_key=self._get_secret_or_env("AZURE_STORAGE_KEY"),
+            connection_string=self._get_secret_or_env("AZURE_STORAGE_CONNECTION_STRING"),
+        )
 
     def upload(self, key, src_path):
         # Need to strip leading / from key

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from base64 import b64encode
-from os import remove, path
+from os import remove, path, getenv
 from tempfile import mktemp
 
+import fsspec
 import requests
 import urllib3
 import pandas as pd
@@ -65,6 +66,17 @@ class DataStore:
     def uri_to_ipython(endpoint, subpath):
         return ""
 
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        return None
+
+    def _get_secret_or_env(self, key, default=None):
+        return self._secret(key) or getenv(key, default)
+
+    def get_storage_options(self):
+        """get fsspec storage options"""
+        return None
+
     def _join(self, key):
         if self.subpath:
             return "{}/{}".format(self.subpath, key)
@@ -104,27 +116,28 @@ class DataStore:
     def upload(self, key, src_path):
         pass
 
-    def as_df(self, key, columns=None, df_module=None, format="", **kwargs):
+    def as_df(self, url, subpath, columns=None, df_module=None, format="", **kwargs):
         df_module = df_module or pd
-        if key.endswith(".csv") or format == "csv":
+        if url.endswith(".csv") or format == "csv":
             if columns:
                 kwargs["usecols"] = columns
             reader = df_module.read_csv
-        elif key.endswith(".parquet") or key.endswith(".pq") or format == "parquet":
+        elif url.endswith(".parquet") or url.endswith(".pq") or format == "parquet":
             if columns:
                 kwargs["columns"] = columns
             reader = df_module.read_parquet
-        elif key.endswith(".json") or format == "json":
+        elif url.endswith(".json") or format == "json":
             reader = df_module.read_json
 
         else:
-            raise Exception(f"file type unhandled {key}")
+            raise Exception(f"file type unhandled {url}")
 
-        if self.kind == "file":
-            return reader(self._join(key), **kwargs)
+        fs = self.get_filesystem()
+        if fs:
+            return reader(fs.open(url), **kwargs)
 
         tmp = mktemp()
-        self.download(self._join(key), tmp)
+        self.download(self._join(subpath), tmp)
         df = reader(tmp, **kwargs)
         remove(tmp)
         return df
@@ -239,7 +252,12 @@ class DataItem:
         :param format:    file format, if not specified it will be deducted from the suffix
         """
         return self._store.as_df(
-            self._path, columns=columns, df_module=df_module, format=format, **kwargs
+            self._url,
+            self._path,
+            columns=columns,
+            df_module=df_module,
+            format=format,
+            **kwargs,
         )
 
     def __str__(self):
@@ -306,6 +324,10 @@ class HttpStore(DataStore):
     def __init__(self, parent, schema, name, endpoint=""):
         super().__init__(parent, name, schema, endpoint)
         self.auth = None
+
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        return fsspec.filesystem("http")
 
     def upload(self, key, src_path):
         raise ValueError("unimplemented")

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -49,6 +49,7 @@ class DataStore:
         self.secret_pfx = ""
         self.options = {}
         self.from_spec = False
+        self._filesystem = None
 
     @property
     def is_structured(self):
@@ -76,6 +77,10 @@ class DataStore:
     def get_storage_options(self):
         """get fsspec storage options"""
         return None
+
+    def open(self, filepath, mode):
+        fs = self.get_filesystem(False)
+        return fs.open(filepath, mode)
 
     def _join(self, key):
         if self.subpath:
@@ -227,6 +232,10 @@ class DataItem:
         """return FileStats class (size, modified, content_type)"""
         return self._store.stat(self._path)
 
+    def open(self, mode):
+        """return fsspec file handler, if supported"""
+        return self._store.open(self._url, mode)
+
     def listdir(self):
         """return a list of child file names"""
         return self._store.listdir(self._path)
@@ -327,7 +336,9 @@ class HttpStore(DataStore):
 
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
-        return fsspec.filesystem("http")
+        if not self._filesystem:
+            self._filesystem = fsspec.filesystem("http")
+        return self._filesystem
 
     def upload(self, key, src_path):
         raise ValueError("unimplemented")

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 
 import mlrun
 import mlrun.errors
-from .base import DataItem, HttpStore
+from .base import DataItem, HttpStore, DataStore
 from .filestore import FileStore
 from .inmem import InMemoryStore
 from .store_resources import get_store_resource, is_store_uri
@@ -135,7 +135,7 @@ class StoreManager:
             raise OSError("artifact {} not found, {}".format(url, e))
         return resource, resource.get_target_path()
 
-    def object(self, url, key="", project=""):
+    def object(self, url, key="", project="") -> DataItem:
         meta = artifact_url = None
         if is_store_uri(url):
             artifact_url = url
@@ -144,7 +144,7 @@ class StoreManager:
         store, subpath = self.get_or_create_store(url)
         return DataItem(key, store, subpath, url, meta=meta, artifact_url=artifact_url)
 
-    def get_or_create_store(self, url):
+    def get_or_create_store(self, url) -> (DataStore, str):
         schema, endpoint, parsed_url = parse_url(url)
         subpath = parsed_url.path
 

--- a/mlrun/datastore/filestore.py
+++ b/mlrun/datastore/filestore.py
@@ -33,7 +33,9 @@ class FileStore(DataStore):
 
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
-        return fsspec.filesystem("file")
+        if not self._filesystem:
+            self._filesystem = fsspec.filesystem("file")
+        return self._filesystem
 
     def get(self, key, size=None, offset=0):
         with open(self._join(key), "rb") as fp:

--- a/mlrun/datastore/filestore.py
+++ b/mlrun/datastore/filestore.py
@@ -15,6 +15,8 @@
 from os import path, makedirs, listdir, stat
 from shutil import copyfile
 
+import fsspec
+
 from .base import DataStore, FileStats
 
 
@@ -28,6 +30,10 @@ class FileStore(DataStore):
 
     def _join(self, key):
         return path.join(self.subpath, key)
+
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        return fsspec.filesystem("file")
 
     def get(self, key, size=None, offset=0):
         with open(self._join(key), "rb") as fp:

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -39,13 +39,16 @@ class S3Store(DataStore):
 
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
+        if self._filesystem:
+            return self._filesystem
         try:
             import s3fs
         except ImportError as e:
             if not silent:
                 raise ImportError(f"AWS s3fs not installed, run pip install s3fs, {e}")
             return None
-        return fsspec.filesystem("s3", **self.get_storage_options())
+        self._filesystem = fsspec.filesystem("s3", **self.get_storage_options())
+        return self._filesystem
 
     def get_storage_options(self):
         return dict(

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -42,7 +42,7 @@ class S3Store(DataStore):
         if self._filesystem:
             return self._filesystem
         try:
-            import s3fs
+            import s3fs  # noqa
         except ImportError as e:
             if not silent:
                 raise ImportError(f"AWS s3fs not installed, run pip install s3fs, {e}")

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -14,7 +14,7 @@
 
 import boto3
 import time
-
+import fsspec
 from .base import DataStore, get_range, FileStats
 
 
@@ -36,6 +36,23 @@ class S3Store(DataStore):
         else:
             # from env variables
             self.s3 = boto3.resource("s3", region_name=region)
+
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        try:
+            import s3fs
+        except ImportError as e:
+            if not silent:
+                raise ImportError(f"AWS s3fs not installed, run pip install s3fs, {e}")
+            return None
+        return fsspec.filesystem("s3", **self.get_storage_options())
+
+    def get_storage_options(self):
+        return dict(
+            anon=False,
+            key=self._get_secret_or_env("AWS_ACCESS_KEY_ID"),
+            secret=self._get_secret_or_env("AWS_SECRET_ACCESS_KEY"),
+        )
 
     def upload(self, key, src_path):
         self.s3.Object(self.endpoint, self._join(key)[1:]).put(

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -68,7 +68,7 @@ class ResourceCache:
 
         if uri in self._tabels:
             return self._tabels[uri]
-        if uri in [".", ""]:
+        if uri in [".", ""] or uri.startswith("$"):  # $.. indicates in-mem table
             self._tabels[uri] = Table("", Driver())
             return self._tabels[uri]
 

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -18,6 +18,7 @@ from os import environ
 import time
 from urllib.parse import urlparse
 
+import fsspec
 import v3io.dataplane
 
 import mlrun
@@ -42,10 +43,6 @@ class V3ioStore(DataStore):
         super().__init__(parent, name, schema, endpoint)
         self.endpoint = self.endpoint or mlrun.mlconf.v3io_api
 
-        token = self._secret("V3IO_ACCESS_KEY") or environ.get("V3IO_ACCESS_KEY")
-        username = self._secret("V3IO_USERNAME") or environ.get("V3IO_USERNAME")
-        password = self._secret("V3IO_PASSWORD") or environ.get("V3IO_PASSWORD")
-
         self.headers = None
         self.secure = self.kind == "v3ios"
         if self.endpoint.startswith("https://"):
@@ -54,6 +51,10 @@ class V3ioStore(DataStore):
         elif self.endpoint.startswith("http://"):
             self.endpoint = self.endpoint[len("http://") :]
             self.secure = False
+
+        token = self._get_secret_or_env("V3IO_ACCESS_KEY")
+        username = self._get_secret_or_env("V3IO_USERNAME")
+        password = self._get_secret_or_env("V3IO_PASSWORD")
 
         self.auth = None
         self.token = token
@@ -70,6 +71,21 @@ class V3ioStore(DataStore):
     def url(self):
         schema = "https" if self.secure else "http"
         return "{}://{}".format(schema, self.endpoint)
+
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        try:
+            import v3iofs
+        except ImportError as e:
+            if not silent:
+                raise ImportError(
+                    f"v3iofs or storey not installed, run pip install storey, {e}"
+                )
+            return None
+        return fsspec.filesystem("v3io", **self.get_storage_options())
+
+    def get_storage_options(self):
+        return dict(v3io_access_key=self._get_secret_or_env("V3IO_ACCESS_KEY"))
 
     def upload(self, key, src_path):
         http_upload(self.url + self._join(key), src_path, self.headers, None)

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -14,7 +14,6 @@
 
 from copy import deepcopy
 from datetime import datetime
-from os import environ
 import time
 from urllib.parse import urlparse
 
@@ -77,7 +76,7 @@ class V3ioStore(DataStore):
         if self._filesystem:
             return self._filesystem
         try:
-            import v3iofs
+            import v3iofs  # noqa
         except ImportError as e:
             if not silent:
                 raise ImportError(

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -74,6 +74,8 @@ class V3ioStore(DataStore):
 
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
+        if self._filesystem:
+            return self._filesystem
         try:
             import v3iofs
         except ImportError as e:
@@ -82,7 +84,8 @@ class V3ioStore(DataStore):
                     f"v3iofs or storey not installed, run pip install storey, {e}"
                 )
             return None
-        return fsspec.filesystem("v3io", **self.get_storage_options())
+        self._filesystem = fsspec.filesystem("v3io", **self.get_storage_options())
+        return self._filesystem
 
     def get_storage_options(self):
         return dict(v3io_access_key=self._get_secret_or_env("V3IO_ACCESS_KEY"))

--- a/mlrun/feature_store/sources.py
+++ b/mlrun/feature_store/sources.py
@@ -78,7 +78,7 @@ class DFSourceDriver:
         import storey
 
         return storey.DataframeSource(
-            dfs=self._df, key_column=key_column, time_column=time_column,
+            dfs=self._df, key_field=key_column, time_field=time_column,
         )
 
 

--- a/mlrun/feature_store/sources.py
+++ b/mlrun/feature_store/sources.py
@@ -78,7 +78,7 @@ class DFSourceDriver:
         import storey
 
         return storey.DataframeSource(
-            dfs=self._df, key_field=key_column, time_field=time_column,
+            dfs=self._df, key_column=key_column, time_column=time_column,
         )
 
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -927,7 +927,7 @@ class FlowState(BaseState):
             resp = self._controller.emit(
                 event, return_awaitable_result=self._wait_for_result
             )
-            if self._wait_for_result:
+            if self._wait_for_result and resp:
                 return resp.await_result()
             event = copy(event)
             event.body = {"id": event.id}

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ kubernetes~=11.0
 #  separating the SDK and API code) (referring to humanfriendly and fastapi)
 humanfriendly~=8.2
 fastapi~=0.62.0
+storey~=0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,4 @@ kubernetes~=11.0
 #  separating the SDK and API code) (referring to humanfriendly and fastapi)
 humanfriendly~=8.2
 fastapi~=0.62.0
-storey~=0.3.3
+v3iofs~=0.1.5

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,8 @@ api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 # NOTE: These are tested in `automation/package_test/test_imports.sh` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-    "s3": ["boto3~=1.9"],
-    "azure-blob-storage": ["azure-storage-blob~=12.0"],
+    "s3": ["boto3~=1.9", "s3fs~=0.5"],
+    "azure-blob-storage": ["azure-storage-blob~=12.0", "adlfs~=0.6"],
 }
 extras_require["complete"] = sorted(
     {

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -210,11 +210,11 @@ def test_fsspec():
         print(tmpdir)
         store, _ = mlrun.store_manager.get_or_create_store(tmpdir)
         fs = store.get_filesystem(False)
-        with store.open(tmpdir + '/1x.txt', 'w') as fp:
-            fp.write('123')
-        with mlrun.get_dataitem(tmpdir + '/2x.txt').open('w') as fp:
-            fp.write('456')
+        with store.open(tmpdir + "/1x.txt", "w") as fp:
+            fp.write("123")
+        with mlrun.get_dataitem(tmpdir + "/2x.txt").open("w") as fp:
+            fp.write("456")
         files = fs.ls(tmpdir)
-        assert len(files) == 2, '2 test files were not written'
-        assert files[0].endswith('x.txt'), 'wrong file name'
-        assert fs.open(tmpdir + '/1x.txt', 'r').read() == '123', 'wrong file content'
+        assert len(files) == 2, "2 test files were not written"
+        assert files[0].endswith("x.txt"), "wrong file name"
+        assert fs.open(tmpdir + "/1x.txt", "r").read() == "123", "wrong file content"

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -203,3 +203,18 @@ def test_forbidden_file_access():
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         obj = store.object("v3io://some-system/some-dir/some-file")
         obj.stat()
+
+
+def test_fsspec():
+    with TemporaryDirectory() as tmpdir:
+        print(tmpdir)
+        store, _ = mlrun.store_manager.get_or_create_store(tmpdir)
+        fs = store.get_filesystem(False)
+        with store.open(tmpdir + '/1x.txt', 'w') as fp:
+            fp.write('123')
+        with mlrun.get_dataitem(tmpdir + '/2x.txt').open('w') as fp:
+            fp.write('456')
+        files = fs.ls(tmpdir)
+        assert len(files) == 2, '2 test files were not written'
+        assert files[0].endswith('x.txt'), 'wrong file name'
+        assert fs.open(tmpdir + '/1x.txt', 'r').read() == '123', 'wrong file content'


### PR DESCRIPTION
* support fsspec filesystem for all stores (file, http, s3, v3io, ..)
* support .as_df() through fsspec fs (eliminate file copy and allow work with dask)
* support get_filesystem and storage_options per type (used by storey and feature store)
* support DataItem.open(), open data item as fsspec file
* support path mapping from dataitem/fsspec paths to spark paths (for feature store) 