### PR TITLE
[Requirements] Upbound cryptography version and pin storey

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,4 @@ requests-mock~=1.8
 # needed for system tests
 matplotlib~=3.0
 graphviz~=0.16.0
-storey~=0.3; python_version >= '3.7'
+storey==0.3.2; python_version >= '3.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ kubernetes~=11.0
 #  separating the SDK and API code) (referring to humanfriendly and fastapi)
 humanfriendly~=8.2
 fastapi~=0.62.0
+# 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
+cryptography~=3.3.2


### PR DESCRIPTION
Upbound cryptography to `cryptography~=3.3.2` since 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
Also pinning storey to 0.3.2 since 0.3.3 breaks CI for some reason
