### PR TITLE
[Tests] Adding open source MLRun-Kit system tests

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -1,4 +1,4 @@
-name: System Tests
+name: System Tests Enterprise
 
 on:
   push:

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   run-system-tests-enterprise-ci:
     timeout-minutes: 60
-    name: Run System Tests
+    name: Run System Tests Enterprise
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -31,7 +31,7 @@ on:
         default: 'false'
 
 jobs:
-  run-system-tests-ci:
+  run-system-tests-enterprise-ci:
     timeout-minutes: 60
     name: Run System Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -163,7 +163,7 @@ jobs:
             --set mlrun.api.image.repository=${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api \
             --set mlrun.api.image.tag=${{ steps.computed_params.outputs.mlrun_version }} \
             --set mlrun.ui.image.repository=ghcr.io/mlrun/mlrun-ui \
-            --set mlrun.ui.image.tag=${{ steps.computed_params.outputs.mlrun_version }} \
+            --set mlrun.ui.image.tag=${{ steps.computed_params.outputs.mlrun_ui_version }} \
             --set mlrun.api.service.type=NodePort \
             --set mlrun.api.service.nodePort=${MLRUN_API_NODE_PORT} \
             v3io-stable/mlrun-kit

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -37,7 +37,7 @@ on:
 
 env:
   NAMESPACE: mlrun
-  MLRUN_API_PORT: 30070
+  MLRUN_API_NODE_PORT: 30070
 
 jobs:
   run-system-tests-opensource-ci:
@@ -148,10 +148,13 @@ jobs:
             --wait \
             --set global.registry.url=localhost:5000 \
             --set mlrun.api.service.type=NodePort \
-            --set mlrun.api.service.nodePort=${MLRUN_API_PORT} \
+            --set mlrun.api.service.nodePort=${MLRUN_API_NODE_PORT} \
             v3io-stable/mlrun-kit
+
+    - name: Prepare system tests env
+      run: |
+        echo "MLRUN_DBPATH: http://$(minikube ip):${MLRUN_API_NODE_PORT}" > tests/system/env.yml
 
     - name: Run system tests
       run: |
-        echo "MLRUN_DBPATH: http://$(minikube ip):${MLRUN_API_PORT}" > tests/system/env.yml
         make test-system-open-source

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -134,10 +134,11 @@ jobs:
         github token: ${{ github.token }}
         start args: '--addons registry'
 
-    - name: Get mlrun kit charts
+    - name: Get mlrun kit charts and create namespace
       run: |
         helm repo add v3io-stable https://v3io.github.io/helm-charts/stable
         helm repo update
+        kubectl create namespace ${NAMESPACE}
 
     - name: Override MLRun Registry ConfigMap
       run: |
@@ -154,7 +155,6 @@ jobs:
 
     - name: Install MLRun Kit helm chart
       run: |
-        kubectl create namespace ${NAMESPACE}
         helm --namespace ${NAMESPACE} \
             install mlrun-kit \
             --debug \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -1,0 +1,150 @@
+name: System Tests
+
+on:
+  push:
+    branches:
+      - '.+-system-tests'
+
+  schedule:
+
+    # * is a special character in YAML so you have to quote this string
+    # Run the system tests every 3 hours
+    - cron:  '0 */3 * * *'
+
+  workflow_dispatch:
+    inputs:
+      docker_registry:
+        description: 'Docker registry to pull images from (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
+        required: true
+        default: 'ghcr.io/'
+      docker_repo:
+        description: 'Docker repo to pull images from (default: mlrun)'
+        required: true
+        default: 'mlrun'
+      test_code_from_action:
+        description: 'Take tested code from action REF (default: false - take from upstream) (note that test code will be taken from the action REF anyways)'
+        required: true
+        default: 'false'
+      ui_code_from_action:
+        description: 'Take ui code from action branch in mlrun/ui (default: false - take from upstream)'
+        required: true
+        default: 'false'
+
+jobs:
+  run-system-tests-opensource-ci:
+    timeout-minutes: 60
+    name: Run System Tests
+    runs-on: ubuntu-latest
+
+    # let's not run this on every fork, change to your fork when developing
+    if: github.repository == 'quaark/mlrun' || github.event_name == 'workflow_dispatch'
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install automation scripts dependencies and add mlrun to dev packages
+      run: pip install -r automation/requirements.txt && pip install -e .
+#    - name: Install curl and jq
+#      run: sudo apt-get install curl jq
+#    - name: Extract git branch
+#      id: git_info
+#      run: |
+#        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+#    - name: Extract git hash from action mlrun version
+#      if: ${{ github.event.inputs.test_code_from_action == 'true' }}
+#      id: git_action_info
+#      run: |
+#        echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+#    - name: Extract git hash from action mlrun version
+#      if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
+#      id: git_action_ui_info
+#      run: |
+#        echo "::set-output name=ui_hash::$( \
+#          cd /tmp && \
+#          git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+#          cd mlrun-ui && \
+#          git rev-parse --short HEAD && \
+#          cd .. && \
+#          rm -rf mlrun-ui)"
+#    - name: Extract git hashes from upstream and latest version
+#      id: git_upstream_info
+#      run: |
+#        echo "::set-output name=mlrun_hash::$( \
+#          cd /tmp && \
+#          git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
+#          cd mlrun-upstream && \
+#          git rev-parse --short HEAD && \
+#          cd .. && \
+#          rm -rf mlrun-upstream)"
+#        echo "::set-output name=ui_hash::$( \
+#          cd /tmp && \
+#          git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+#          cd mlrun-ui && \
+#          git rev-parse --short HEAD && \
+#          cd .. && \
+#          rm -rf mlrun-ui)"
+#        echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
+#    - name: Set computed versions params
+#      id: computed_params
+#      run: |
+#        action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
+#        upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
+#        export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
+#        echo "::set-output name=mlrun_hash::$(echo $mlrun_hash)"
+#        action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
+#        upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
+#        export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
+#        echo "::set-output name=ui_hash::$(echo $ui_hash)"
+#        echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
+#        echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-$ui_hash"
+#        echo "::set-output name=mlrun_docker_repo::$( \
+#          input_docker_repo=${{ github.event.inputs.docker_repo }} && \
+#          echo ${input_docker_repo:-mlrun})"
+#        echo "::set-output name=mlrun_docker_registry::$( \
+#          input_docker_registry=${{ github.event.inputs.docker_registry }} && \
+#          echo ${input_docker_registry:-ghcr.io/})"
+#    - name: Wait for existing runs to complete
+#      uses: softprops/turnstyle@v1
+#      with:
+#        poll-interval-seconds: 20s
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: azure/setup-helm@v1
+      with:
+        version: "v3.3.4"
+
+    - uses: manusa/actions-setup-minikube@v2.3.0
+      with:
+        minikube version: "v1.15.1"
+        kubernetes version: "v1.17.5"
+        driver: docker
+        github token: ${{ github.token }}
+        start args: '--addons registry'
+
+    - name: Get mlrun kit charts
+      run: |
+        helm repo add v3io-stable https://v3io.github.io/helm-charts/stable
+        helm repo update
+
+    - name: Install MLRun Kit helm chart
+      run: |
+        kubectl create namespace ${NAMESPACE}
+        helm --namespace ${NAMESPACE} \
+            install mlrun-kit \
+            --debug \
+            --wait \
+            --set global.registry.url=localhost:5000 \
+            --set mlrun.api.service.type=NodePort \
+            --set mlrun.api.service.nodePort=${MLRUN_API_PORT} \
+            v3io-stable/mlrun-kit
+
+    - name: Prepare system tests env
+      run: |
+        echo "MLRUN_DBPATH: $(minikube ip):${MLRUN_API_PORT}" > tests/system/env.yml
+
+    - name: Run system tests
+      run: make test-system-open-source

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -153,7 +153,7 @@ jobs:
 
     - name: Prepare system tests env
       run: |
-        echo "MLRUN_DBPATH: $(minikube ip):${MLRUN_API_PORT}" > tests/system/env.yml
+        echo "MLRUN_DBPATH: http://$(minikube ip):${MLRUN_API_PORT}" > tests/system/env.yml
 
     - name: Run system tests
       run: make test-system-open-source

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -157,6 +157,7 @@ jobs:
             --debug \
             --wait \
             --set global.registry.url=localhost:5000 \
+            --set global.externalHostAddress=$(minikube ip) \
             --set mlrun.api.image.repository=${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api \
             --set mlrun.api.image.tag=${{ steps.computed_params.outputs.mlrun_version }} \
             --set mlrun.ui.image.repository=ghcr.io/mlrun/mlrun-ui \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -151,9 +151,7 @@ jobs:
             --set mlrun.api.service.nodePort=${MLRUN_API_PORT} \
             v3io-stable/mlrun-kit
 
-    - name: Prepare system tests env
+    - name: Run system tests
       run: |
         echo "MLRUN_DBPATH: http://$(minikube ip):${MLRUN_API_PORT}" > tests/system/env.yml
-
-    - name: Run system tests
-      run: make test-system-open-source
+        make test-system-open-source

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -56,71 +56,71 @@ jobs:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: pip install -r automation/requirements.txt -r dockerfiles/test-system/requirements.txt && pip install -e .
-#    - name: Install curl and jq
-#      run: sudo apt-get install curl jq
-#    - name: Extract git branch
-#      id: git_info
-#      run: |
-#        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-#    - name: Extract git hash from action mlrun version
-#      if: ${{ github.event.inputs.test_code_from_action == 'true' }}
-#      id: git_action_info
-#      run: |
-#        echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
-#    - name: Extract git hash from action mlrun version
-#      if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
-#      id: git_action_ui_info
-#      run: |
-#        echo "::set-output name=ui_hash::$( \
-#          cd /tmp && \
-#          git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
-#          cd mlrun-ui && \
-#          git rev-parse --short HEAD && \
-#          cd .. && \
-#          rm -rf mlrun-ui)"
-#    - name: Extract git hashes from upstream and latest version
-#      id: git_upstream_info
-#      run: |
-#        echo "::set-output name=mlrun_hash::$( \
-#          cd /tmp && \
-#          git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
-#          cd mlrun-upstream && \
-#          git rev-parse --short HEAD && \
-#          cd .. && \
-#          rm -rf mlrun-upstream)"
-#        echo "::set-output name=ui_hash::$( \
-#          cd /tmp && \
-#          git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
-#          cd mlrun-ui && \
-#          git rev-parse --short HEAD && \
-#          cd .. && \
-#          rm -rf mlrun-ui)"
-#        echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
-#    - name: Set computed versions params
-#      id: computed_params
-#      run: |
-#        action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
-#        upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
-#        export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
-#        echo "::set-output name=mlrun_hash::$(echo $mlrun_hash)"
-#        action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
-#        upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
-#        export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
-#        echo "::set-output name=ui_hash::$(echo $ui_hash)"
-#        echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
-#        echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-$ui_hash"
-#        echo "::set-output name=mlrun_docker_repo::$( \
-#          input_docker_repo=${{ github.event.inputs.docker_repo }} && \
-#          echo ${input_docker_repo:-mlrun})"
-#        echo "::set-output name=mlrun_docker_registry::$( \
-#          input_docker_registry=${{ github.event.inputs.docker_registry }} && \
-#          echo ${input_docker_registry:-ghcr.io/})"
-#    - name: Wait for existing runs to complete
-#      uses: softprops/turnstyle@v1
-#      with:
-#        poll-interval-seconds: 20s
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install curl and jq
+      run: sudo apt-get install curl jq
+    - name: Extract git branch
+      id: git_info
+      run: |
+        echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+    - name: Extract git hash from action mlrun version
+      if: ${{ github.event.inputs.test_code_from_action == 'true' }}
+      id: git_action_info
+      run: |
+        echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+    - name: Extract git hash from action mlrun version
+      if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
+      id: git_action_ui_info
+      run: |
+        echo "::set-output name=ui_hash::$( \
+          cd /tmp && \
+          git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          cd mlrun-ui && \
+          git rev-parse --short HEAD && \
+          cd .. && \
+          rm -rf mlrun-ui)"
+    - name: Extract git hashes from upstream and latest version
+      id: git_upstream_info
+      run: |
+        echo "::set-output name=mlrun_hash::$( \
+          cd /tmp && \
+          git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
+          cd mlrun-upstream && \
+          git rev-parse --short HEAD && \
+          cd .. && \
+          rm -rf mlrun-upstream)"
+        echo "::set-output name=ui_hash::$( \
+          cd /tmp && \
+          git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          cd mlrun-ui && \
+          git rev-parse --short HEAD && \
+          cd .. && \
+          rm -rf mlrun-ui)"
+        echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
+    - name: Set computed versions params
+      id: computed_params
+      run: |
+        action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
+        upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
+        export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
+        echo "::set-output name=mlrun_hash::$(echo $mlrun_hash)"
+        action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
+        upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
+        export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
+        echo "::set-output name=ui_hash::$(echo $ui_hash)"
+        echo "::set-output name=mlrun_version::$(echo ${{ steps.git_upstream_info.outputs.latest_version }}-$mlrun_hash)"
+        echo "::set-output name=mlrun_ui_version::${{ steps.git_upstream_info.outputs.latest_version }}-$ui_hash"
+        echo "::set-output name=mlrun_docker_repo::$( \
+          input_docker_repo=${{ github.event.inputs.docker_repo }} && \
+          echo ${input_docker_repo:-mlrun})"
+        echo "::set-output name=mlrun_docker_registry::$( \
+          input_docker_registry=${{ github.event.inputs.docker_registry }} && \
+          echo ${input_docker_registry:-ghcr.io/})"
+    - name: Wait for existing runs to complete
+      uses: softprops/turnstyle@v1
+      with:
+        poll-interval-seconds: 20s
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: azure/setup-helm@v1
       with:
@@ -139,6 +139,19 @@ jobs:
         helm repo add v3io-stable https://v3io.github.io/helm-charts/stable
         helm repo update
 
+    - name: Override MLRun Registry ConfigMap
+      run: |
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: mlrun-override-env
+          namespace: ${NAMESPACE}
+        data:
+          MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER: mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}
+          MLRUN_IMAGES_REGISTRY: ${{ steps.computed_params.outputs.mlrun_docker_registry }}
+        EOF
+
     - name: Install MLRun Kit helm chart
       run: |
         kubectl create namespace ${NAMESPACE}
@@ -147,6 +160,10 @@ jobs:
             --debug \
             --wait \
             --set global.registry.url=localhost:5000 \
+            --set mlrun.api.image.repository=${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api \
+            --set mlrun.api.image.tag=${{ steps.computed_params.outputs.mlrun_version }} \
+            --set mlrun.ui.image.repository=ghcr.io/mlrun/mlrun-ui \
+            --set mlrun.ui.image.tag=${{ steps.computed_params.outputs.mlrun_version }} \
             --set mlrun.api.service.type=NodePort \
             --set mlrun.api.service.nodePort=${MLRUN_API_NODE_PORT} \
             v3io-stable/mlrun-kit

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -1,4 +1,4 @@
-name: System Tests
+name: System Tests Open Source
 
 on:
   push:

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -35,6 +35,10 @@ on:
         required: true
         default: 'false'
 
+env:
+  NAMESPACE: mlrun
+  MLRUN_API_PORT: 30070
+
 jobs:
   run-system-tests-opensource-ci:
     timeout-minutes: 60

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'quaark/mlrun' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -1,6 +1,11 @@
 name: System Tests Open Source
 
 on:
+  pull_request:
+    branches:
+      - development
+      - '.+-system-tests'
+
   push:
     branches:
       - '.+-system-tests'

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -1,6 +1,11 @@
 name: System Tests Open Source
 
 on:
+  pull_request:
+    branches:
+      - development
+      - '.+-system-tests'
+
   push:
     branches:
       - '.+-system-tests'
@@ -37,7 +42,7 @@ env:
 jobs:
   run-system-tests-opensource-ci:
     timeout-minutes: 60
-    name: Run System Tests
+    name: Run System Tests Open Source
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
@@ -51,6 +56,8 @@ jobs:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: pip install -r automation/requirements.txt -r dockerfiles/test-system/requirements.txt && pip install -e .
+
+      # TODO: How can we avoid these duplicate lines from the enterprise system tests, up until line 120.
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git branch
@@ -159,8 +166,6 @@ jobs:
             --set mlrun.api.image.tag=${{ steps.computed_params.outputs.mlrun_version }} \
             --set mlrun.ui.image.repository=ghcr.io/mlrun/mlrun-ui \
             --set mlrun.ui.image.tag=${{ steps.computed_params.outputs.mlrun_ui_version }} \
-            --set mlrun.api.service.type=NodePort \
-            --set mlrun.api.service.nodePort=${MLRUN_API_NODE_PORT} \
             v3io-stable/mlrun-kit
 
     - name: Prepare system tests env

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -1,11 +1,6 @@
 name: System Tests Open Source
 
 on:
-  pull_request:
-    branches:
-      - development
-      - '.+-system-tests'
-
   push:
     branches:
       - '.+-system-tests'

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: pip install -r automation/requirements.txt && pip install -e .
+      run: pip install -r automation/requirements.txt -r dockerfiles/test-system/requirements.txt && pip install -e .
 #    - name: Install curl and jq
 #      run: sudo apt-get install curl jq
 #    - name: Extract git branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,15 +49,37 @@ In the `tests/system/` directory exist test suites to run against a running syst
 ### Adding More System Tests
 To add more system tests, all that is required is to create a test suite class which inherits the `TestMLRunSystem`
 class from `tests.system.base`. In addition, a special `skip` annotation must be added to the suite, so it won't run 
-if the `env.yml` isn't filled.
+if the `env.yml` isn't filled. If the test can only run on a full iguazio system and not on an MLRun Kit instance, add
+the `enterprise` marker under the `skip` annotation or on the test method itself. If the `enterprise` marker is added
+to a specific test method, the `skip` annotation must be added above it in addition to the annotation over the test 
+suite. This is because enterprise tests and open source tests require different env vars to be set in the `env.yml`.
 
 For example:
 ```python
+import pytest
+from tests.system.base import TestMLRunSystem
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestSomeFunctionality(TestMLRunSystem):
+    def test_the_functionality(self):
+        pass
+```
+
+Example of a suite with two tests, one of them meant for enterprise only
+```python
+import pytest
 from tests.system.base import TestMLRunSystem
 
 @TestMLRunSystem.skip_test_if_env_not_configured
 class TestSomeFunctionality(TestMLRunSystem):
-    def test_the_functionality(self):
+
+    def test_open_source_features(self):
+        pass
+
+    @TestMLRunSystem.skip_test_if_env_not_configured
+    @pytest.mark.enterprise
+    def test_enterprise_features(self):
         pass
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,15 @@ test-system: ## Run mlrun system tests
 		-rf \
 		tests/system
 
+.PHONY: test-system-open-source
+test-system-open-source: ## Run mlrun system tests with opensource configuration
+	python -m pytest -v \
+		--capture=no \
+		--disable-warnings \
+		-rsf \
+		-m "not enterprise" \
+		tests/system
+
 .PHONY: test-package
 test-package: ## Run mlrun package tests
 	python -m pip install --upgrade pip~=20.2.0

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -15,22 +15,22 @@ logger = create_logger(level="debug", name="test-system")
 
 class TestMLRunSystem:
 
-    project_name: str = "system-test-project"
-    root_path: pathlib.Path = pathlib.Path(__file__).absolute().parent.parent.parent
-    env_file_path: pathlib.Path = root_path / "tests" / "system" / "env.yml"
-    results_path: pathlib.Path = root_path / "tests" / "test_results" / "system"
-    enterprise_marker_name: str = "enterprise"
-    mandatory_env_vars: typing.List[str] = [
+    project_name = "system-test-project"
+    root_path = pathlib.Path(__file__).absolute().parent.parent.parent
+    env_file_path = root_path / "tests" / "system" / "env.yml"
+    results_path = root_path / "tests" / "test_results" / "system"
+    enterprise_marker_name = "enterprise"
+    mandatory_env_vars = [
         "MLRUN_DBPATH",
     ]
-    mandatory_enterprise_env_vars: typing.List[str] = mandatory_env_vars + [
+    mandatory_enterprise_env_vars = mandatory_env_vars + [
         "V3IO_API",
         "V3IO_FRAMESD",
         "V3IO_USERNAME",
         "V3IO_ACCESS_KEY",
     ]
 
-    def setup_method(self, method: typing.Callable):
+    def setup_method(self, method):
         self._logger = logger
         self._logger.info(
             f"Setting up test {self.__class__.__name__}::{method.__name__}"
@@ -56,7 +56,7 @@ class TestMLRunSystem:
             f"Finished setting up test {self.__class__.__name__}::{method.__name__}"
         )
 
-    def teardown_method(self, method: typing.Callable):
+    def teardown_method(self, method):
         self._logger.info(
             f"Tearing down test {self.__class__.__name__}::{method.__name__}"
         )
@@ -81,7 +81,7 @@ class TestMLRunSystem:
         pass
 
     @classmethod
-    def skip_test_if_env_not_configured(cls, test: typing.Callable) -> None:
+    def skip_test_if_env_not_configured(cls, test):
         mandatory_env_vars = (
             cls.mandatory_enterprise_env_vars
             if cls._has_marker(test, cls.enterprise_marker_name)
@@ -104,18 +104,18 @@ class TestMLRunSystem:
         )(test)
 
     @property
-    def assets_path(self) -> pathlib.Path:
+    def assets_path(self):
         return (
             pathlib.Path(sys.modules[self.__module__].__file__).absolute().parent
             / "assets"
         )
 
     @classmethod
-    def _get_env_from_file(cls) -> typing.Dict[str, str]:
+    def _get_env_from_file(cls) -> dict:
         with cls.env_file_path.open() as f:
             return yaml.safe_load(f)
 
-    def _setup_env(self, env: typing.Dict[str, str]):
+    def _setup_env(self, env: dict):
         self._logger.debug("Setting up test environment")
         self._test_env.update(env)
 
@@ -149,7 +149,7 @@ class TestMLRunSystem:
 
     def _verify_run_spec(
         self,
-        run_spec: typing.Dict[str, str],
+        run_spec,
         parameters: dict = None,
         inputs: dict = None,
         outputs: list = None,
@@ -179,7 +179,7 @@ class TestMLRunSystem:
 
     def _verify_run_metadata(
         self,
-        run_metadata: typing.Dict[str, str],
+        run_metadata,
         uid: str = None,
         name: str = None,
         project: str = None,
@@ -202,7 +202,7 @@ class TestMLRunSystem:
 
     def _verify_run_outputs(
         self,
-        run_outputs: typing.Dict[str, str],
+        run_outputs,
         uid: str,
         name: str,
         project: str,

--- a/tests/system/demos/churn/test_churn.py
+++ b/tests/system/demos/churn/test_churn.py
@@ -1,3 +1,5 @@
+import pytest
+
 import mlrun
 
 from tests.system.base import TestMLRunSystem
@@ -5,6 +7,7 @@ from tests.system.demos.base import TestDemo
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
 class TestChurn(TestDemo):
 
     project_name = "churn-project"

--- a/tests/system/demos/churn/test_churn.py
+++ b/tests/system/demos/churn/test_churn.py
@@ -6,6 +6,7 @@ from tests.system.base import TestMLRunSystem
 from tests.system.demos.base import TestDemo
 
 
+# Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestChurn(TestDemo):

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -1,4 +1,5 @@
 import pathlib
+import pytest
 
 import mlrun
 
@@ -7,6 +8,7 @@ from tests.system.demos.base import TestDemo
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
 class TestHorovodTFv2(TestDemo):
 
     project_name = "horovod-project"

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -7,6 +7,7 @@ from tests.system.base import TestMLRunSystem
 from tests.system.demos.base import TestDemo
 
 
+# Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestHorovodTFv2(TestDemo):

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -6,6 +6,7 @@ from tests.system.base import TestMLRunSystem
 from tests.system.demos.base import TestDemo
 
 
+# Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestSKLearn(TestDemo):

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -1,3 +1,5 @@
+import pytest
+
 import mlrun
 
 from tests.system.base import TestMLRunSystem
@@ -5,6 +7,7 @@ from tests.system.demos.base import TestDemo
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
 class TestSKLearn(TestDemo):
 
     project_name = "sklearn-project"

--- a/tests/system/examples/basics/test_basics.py
+++ b/tests/system/examples/basics/test_basics.py
@@ -45,9 +45,7 @@ class TestBasics(TestMLRunSystem):
             name="demo",
             project=self.project_name,
             labels={
-                "v3io_user": self._test_env["V3IO_USERNAME"],
                 "kind": "",
-                "owner": self._test_env["V3IO_USERNAME"],
                 "framework": "sklearn",
             },
         )

--- a/tests/system/examples/basics/test_basics.py
+++ b/tests/system/examples/basics/test_basics.py
@@ -44,10 +44,7 @@ class TestBasics(TestMLRunSystem):
             uid=run_uid,
             name="demo",
             project=self.project_name,
-            labels={
-                "kind": "",
-                "framework": "sklearn",
-            },
+            labels={"kind": "", "framework": "sklearn"},
         )
         self._verify_run_spec(
             run_object.to_dict()["spec"],

--- a/tests/system/examples/basics/test_db.py
+++ b/tests/system/examples/basics/test_db.py
@@ -42,9 +42,7 @@ class TestDB(TestMLRunSystem):
             name="demo",
             project=self.project_name,
             labels={
-                "v3io_user": self._test_env["V3IO_USERNAME"],
                 "kind": "",
-                "owner": self._test_env["V3IO_USERNAME"],
                 "framework": "sklearn",
             },
         )

--- a/tests/system/examples/basics/test_db.py
+++ b/tests/system/examples/basics/test_db.py
@@ -41,10 +41,7 @@ class TestDB(TestMLRunSystem):
             uid=self._run_uid,
             name="demo",
             project=self.project_name,
-            labels={
-                "kind": "",
-                "framework": "sklearn",
-            },
+            labels={"kind": "", "framework": "sklearn"},
         )
         self._verify_run_spec(
             runs[0]["spec"],

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 import kfp
 import kfp.compiler
@@ -15,6 +16,7 @@ from tests.system.base import TestMLRunSystem
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
 class TestDask(TestMLRunSystem):
     def custom_setup(self):
         self._logger.debug("Creating dask function")

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -15,6 +15,7 @@ from mlrun import (
 from tests.system.base import TestMLRunSystem
 
 
+# Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestDask(TestMLRunSystem):

--- a/tests/system/examples/jobs/test_jobs.py
+++ b/tests/system/examples/jobs/test_jobs.py
@@ -15,6 +15,7 @@ from mlrun.platforms.other import mount_v3io
 from tests.system.base import TestMLRunSystem
 
 
+# Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestJobs(TestMLRunSystem):

--- a/tests/system/examples/jobs/test_jobs.py
+++ b/tests/system/examples/jobs/test_jobs.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 import kfp.dsl
 import kfp.compiler
@@ -15,6 +16,7 @@ from tests.system.base import TestMLRunSystem
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
 class TestJobs(TestMLRunSystem):
     def custom_setup(self):
         code_path = str(self.assets_path / "jobs_function.py")


### PR DESCRIPTION
- Added facilities for running system tests against MLRun Kit (and not only Iguazio system):
  - Pytest markers for enterprise only tests.
  - Env can only contain `MLRUN_DBPATH` if the test isn't enterprise only.
  - `make test-system-open-source` runs the tests that aren't enterprise.
- Added CI for periodically bringing up the latest MLRun Kit and running system tests against it.
- Updated CONTRIBUTING.md to reflect the new pytest markers