### PR TITLE
[Doc] Fix typo in "Quick-Start Guide"

### DIFF
--- a/docs/quick-start.ipynb
+++ b/docs/quick-start.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "source": [
     "MLRun introduces the concept of [functions](./runtimes/functions.md). You can run your own code as functions, or use functions from the function marketplace.\n",
-    "In the example below, we'll use the [`sklearn_classifer`](https://github.com/mlrun/functions/tree/master/sklearn_classifier) from the function marketplace to train a model."
+    "In the example below, we'll use the [`sklearn_classifier`](https://github.com/mlrun/functions/tree/master/sklearn_classifier) from the function marketplace to train a model."
    ]
   },
   {


### PR DESCRIPTION
Fixed a small typo in "Quick-Start Guide" document page.