### PR TITLE
[Tests] Dask runtime unit test

### DIFF
--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -289,7 +289,7 @@ class TestRuntimeBase:
             == {}
         )
 
-    def _assert_pod_create_called(
+    def _assert_pod_creation_config(
         self,
         expected_runtime_class_name="job",
         expected_params=None,

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -1,0 +1,91 @@
+import os
+import unittest
+from tests.api.runtimes.base import TestRuntimeBase
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+import mlrun
+from mlrun.platforms import auto_mount
+from dask import distributed
+from mlrun import mlconf
+from mlrun.runtimes.utils import generate_resources
+
+
+class TestDaskRuntime(TestRuntimeBase):
+    def _mock_dask_cluster(self):
+        patcher = unittest.mock.patch('dask_kubernetes.KubeCluster')
+        self.kube_cluster_mock = patcher.start()
+        self.kube_cluster_mock.return_value.name = self.name
+        self.kube_cluster_mock.return_value.scheduler_address = self.scheduler_address
+
+        class MockPort:
+            def __init__(self, port):
+                self.node_port = port
+
+        # 1st port is client port, 2nd port is dashboard port, both apply to the ingress
+        self.kube_cluster_mock.return_value.scheduler.service.spec.ports = [MockPort(1234), MockPort(5678)]
+
+        distributed.Client = unittest.mock.Mock()
+
+    def custom_setup(self):
+        self.name = "test-dask-cluster"
+        # For dask it is /function instead of /name
+        self.function_name_label = "mlrun/function"
+        self.v3io_access_key = "1111-2222-3333-4444"
+        self.v3io_user = "test-user"
+        self.scheduler_address = "http://1.2.3.4"
+
+        self._mock_dask_cluster()
+
+    def custom_teardown(self):
+        unittest.mock.patch.stopall()
+
+    def _get_pod_creation_args(self):
+        args, _ = self.kube_cluster_mock.call_args
+        return args[0]
+
+    def _get_namespace_arg(self):
+        _, kwargs = self.kube_cluster_mock.call_args
+        return kwargs["namespace"]
+
+    def _generate_runtime(self):
+        # This is following the steps in
+        # https://docs.mlrun.org/en/latest/runtimes/dask-mlrun.html#set-up-the-enviroment
+        mlconf.remote_host = "http://remote_host"
+        os.environ["V3IO_USERNAME"] = self.v3io_user
+
+        mlrun.set_environment(project=self.project,
+                              access_key=self.v3io_access_key,
+                              artifact_path=self.artifact_path)
+        dask_cluster = mlrun.new_function(
+            self.name, project=self.project, kind='dask', image=self.image_name
+        )
+
+        dask_cluster.apply(auto_mount())
+
+        dask_cluster.spec.min_replicas = 1
+        dask_cluster.spec.max_replicas = 4
+
+        dask_cluster.spec.remote = True
+        dask_cluster.spec.service_type = "NodePort"
+
+        return dask_cluster
+
+    def test_dask_runtime(self, db: Session, client: TestClient):
+        runtime = self._generate_runtime()
+
+        expected_requests = generate_resources(mem="2G", cpu=3)
+        runtime.with_requests(
+            mem=expected_requests["memory"], cpu=expected_requests["cpu"]
+        )
+        _ = runtime.client
+
+        self.kube_cluster_mock.assert_called_once()
+
+        self._assert_pod_create_called(
+            expected_runtime_class_name="dask",
+            assert_create_pod_called=False,
+            assert_namespace_env_variable=False,
+            expected_requests=expected_requests,
+        )
+        self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
+

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -86,7 +86,7 @@ class TestDaskRuntime(TestRuntimeBase):
 
         self.kube_cluster_mock.assert_called_once()
 
-        self._assert_pod_create_called(
+        self._assert_pod_creation_config(
             expected_runtime_class_name="dask",
             assert_create_pod_called=False,
             assert_namespace_env_variable=False,

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -35,13 +35,13 @@ class TestKubejobRuntime(TestRuntimeBase):
     def test_run_without_runspec(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
         self._execute_run(runtime)
-        self._assert_pod_create_called()
+        self._assert_pod_creation_config()
 
         params = {"p1": "v1", "p2": 20}
         inputs = {"input1": f"{self.artifact_path}/input1.txt"}
 
         self._execute_run(runtime, params=params, inputs=inputs)
-        self._assert_pod_create_called(expected_params=params, expected_inputs=inputs)
+        self._assert_pod_creation_config(expected_params=params, expected_inputs=inputs)
 
     def test_run_with_runspec(self, db: Session, client: TestClient):
         task = self._generate_task()
@@ -63,7 +63,7 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         runtime = self._generate_runtime()
         self._execute_run(runtime, runspec=task)
-        self._assert_pod_create_called(
+        self._assert_pod_creation_config(
             expected_params=params,
             expected_inputs=inputs,
             expected_hyper_params=hyper_params,
@@ -90,7 +90,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         )
 
         self._execute_run(runtime)
-        self._assert_pod_create_called(
+        self._assert_pod_creation_config(
             expected_limits=expected_limits, expected_requests=expected_requests
         )
 
@@ -105,7 +105,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime.apply(auto_mount())
 
         self._execute_run(runtime)
-        self._assert_pod_create_called()
+        self._assert_pod_creation_config()
         self._assert_v3io_mount_configured(v3io_user, v3io_access_key)
 
         # Mount a PVC. Create a new runtime so we don't have both v3io and the PVC mounted
@@ -116,7 +116,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime.apply(auto_mount(pvc_name, pvc_mount_path, volume_name))
 
         self._execute_run(runtime)
-        self._assert_pod_create_called()
+        self._assert_pod_creation_config()
         self._assert_pvc_mount_configured(pvc_name, pvc_mount_path, volume_name)
 
     # For now Vault is only supported in KubeJob, so it's here. Once it's relevant to other runtimes, this can
@@ -156,7 +156,7 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         self._execute_run(runtime, runspec=task)
 
-        self._assert_pod_create_called(
+        self._assert_pod_creation_config(
             expected_secrets=secret_source,
             expected_env={
                 "MLRUN_SECRET_STORES__VAULT__ROLE": f"project:{self.project}",
@@ -178,7 +178,7 @@ def my_func(context):
         runtime.with_code(body=expected_code)
 
         self._execute_run(runtime)
-        self._assert_pod_create_called(expected_code=expected_code)
+        self._assert_pod_creation_config(expected_code=expected_code)
 
     def test_set_env(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
@@ -186,13 +186,13 @@ def my_func(context):
         for env_variable in env:
             runtime.set_env(env_variable, env[env_variable])
         self._execute_run(runtime)
-        self._assert_pod_create_called(expected_env=env)
+        self._assert_pod_creation_config(expected_env=env)
 
         # set the same env key for a different value and check that the updated one is used
         env2 = {"MLRUN_LOG_LEVEL": "ERROR", "IMAGE_HEIGHT": "128"}
         runtime.set_env("MLRUN_LOG_LEVEL", "ERROR")
         self._execute_run(runtime)
-        self._assert_pod_create_called(expected_env=env2)
+        self._assert_pod_creation_config(expected_env=env2)
 
     def test_run_with_code_with_file(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
@@ -200,7 +200,7 @@ def my_func(context):
         runtime.with_code(from_file=self.code_filename)
 
         self._execute_run(runtime)
-        self._assert_pod_create_called(expected_code=open(self.code_filename).read())
+        self._assert_pod_creation_config(expected_code=open(self.code_filename).read())
 
     def test_run_with_code_and_file(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
@@ -230,4 +230,4 @@ def my_func(context):
 
         runtime = self._generate_runtime()
         self._execute_run(runtime, runspec=task)
-        self._assert_pod_create_called(expected_labels=labels)
+        self._assert_pod_creation_config(expected_labels=labels)


### PR DESCRIPTION
Adding framework and initial tests for Dask runtime unit-tests. Currently running through the standard flow of creating a Dask runtime as shown [here](https://docs.mlrun.org/en/latest/runtimes/dask-mlrun.html), and validating that the spec for the Dask runtime pods is correct.
Additional tests may be added in the future with further validations and configurations.