### PR TITLE
[MPIJob] Support configuring clean pod policy and set to All by default

### DIFF
--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -173,3 +173,18 @@ class MPIJobV1Alpha1States:
             SparkApplicationStates.failed: RunStates.error,
             MPIJobV1Alpha1States.active: RunStates.running,
         }[mpijob_state]
+
+
+class MPIJobV1CleanPodPolicies:
+    """
+    https://github.com/kubeflow/common/blob/master/pkg/apis/common/v1/types.go#L137
+    """
+
+    all = "All"
+    running = "Running"
+    none = "None"
+    undefined = ""
+
+    @staticmethod
+    def default():
+        return MPIJobV1CleanPodPolicies.all

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -58,6 +58,7 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
             "metadata": {"name": "", "namespace": "default-tenant"},
             "spec": {
                 "slotsPerWorker": 1,
+                "cleanPodPolicy": "All",
                 "mpiReplicaSpecs": {
                     "Launcher": {"template": launcher_pod_template},
                     "Worker": {"replicas": 1, "template": worker_pod_template},

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -126,6 +126,9 @@ class MpiV1Alpha1RuntimeHandler(BaseRuntimeHandler):
     def _resolve_crd_object_status_info(
         self, db: DBInterface, db_session: Session, crd_object
     ) -> typing.Tuple[bool, typing.Optional[datetime], typing.Optional[str]]:
+        """
+        https://github.com/kubeflow/mpi-operator/blob/master/pkg/apis/kubeflow/v1alpha1/types.go#L115
+        """
         launcher_status = crd_object.get("status", {}).get("launcherStatus", "")
         in_terminal_state = launcher_status in MPIJobV1Alpha1States.terminal_states()
         desired_run_state = MPIJobV1Alpha1States.mpijob_state_to_run_state(


### PR DESCRIPTION
The [clean pod policy](https://github.com/kubeflow/common/blob/master/pkg/apis/common/v1/types.go#L137) describes how to deal with pods when the job is finished (success or failure)
We want to set it to `All` by default, since without it, the operator default is None, that means the worker pods will stay there, which means that if for example GPU was used, it will still be occupied for the worker pods although the job finished.
It is possible to change the policy by doing:
```
import mlrun.runtimes.constants
function.spec.clean_pod_policy = mlrun.runtimes.constants.MPIJobV1CleanPodPolicies.running
```
This resolves https://jira.iguazeng.com/browse/ML-22