### PR TITLE
[Doc] Add missing docstrings - part I

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,5 +3,5 @@ max-line-length = 120
 extend-ignore = E203, W503
 
 # exclude these dirs
-exclude = .git,venv
+exclude = .git,venv,.venv,docs/_build
 

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -95,7 +95,7 @@ def set_environment(
     """
     mlconf.dbpath = mlconf.dbpath or api_path
     if not mlconf.dbpath:
-        raise ValueError("DB/API path was not detected, please specify its address")
+        raise ValueError("DB/API path not detected. Please specify one of the addresses")
 
     # check connectivity and load remote defaults
     get_run_db()
@@ -112,7 +112,7 @@ def set_environment(
     mlconf.default_project = project or mlconf.default_project
 
     if not mlconf.artifact_path and not artifact_path:
-        raise ValueError("please specify a valid artifact_path")
+        raise ValueError("Artifact path no detected. Please specify a valid artifact_path")
 
     if artifact_path:
         if artifact_path.startswith("./"):

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -95,7 +95,9 @@ def set_environment(
     """
     mlconf.dbpath = mlconf.dbpath or api_path
     if not mlconf.dbpath:
-        raise ValueError("DB/API path not detected. Please specify one of the addresses")
+        raise ValueError(
+            "DB/API path not detected. Please specify one of the addresses"
+        )
 
     # check connectivity and load remote defaults
     get_run_db()
@@ -112,7 +114,9 @@ def set_environment(
     mlconf.default_project = project or mlconf.default_project
 
     if not mlconf.artifact_path and not artifact_path:
-        raise ValueError("Artifact path no detected. Please specify a valid artifact_path")
+        raise ValueError(
+            "Artifact path no detected. Please specify a valid artifact_path"
+        )
 
     if artifact_path:
         if artifact_path.startswith("./"):

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -70,7 +70,7 @@ def set_environment(
     access_key: str = None,
     user_project=False,
 ):
-    """set and test default config for: api path, artifact_path and project
+    """set and test default config for: api path, artifact_path, project, access_key and user_project
 
     this function will try and read the configuration from the environment/api
     and merge it with the user provided project name, artifacts path or api path/access_key.

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -19,9 +19,9 @@ __all__ = ["get_version", "set_environment", "code_to_function", "import_functio
 import getpass
 from os import environ, path
 
+from .db import get_run_db, RunDBInterface
 from .config import config as mlconf
 from .datastore import DataItem, store_manager
-from .db import get_run_db
 from .execution import MLClientCtx
 from .model import RunTemplate, NewTask, new_task, RunObject
 from .platforms import (
@@ -51,8 +51,10 @@ from .utils.version import Version
 __version__ = Version().get()["version"]
 
 
-def get_version():
-    """get current mlrun version"""
+def get_version() -> str:
+    """
+    Get current mlrun version
+    """
     return __version__
 
 
@@ -70,7 +72,8 @@ def set_environment(
     access_key: str = None,
     user_project=False,
 ):
-    """set and test default config for: api path, artifact_path, project, access_key and user_project
+    """
+    Set and test default config for: api path, artifact_path, project, access_key and user_project
 
     this function will try and read the configuration from the environment/api
     and merge it with the user provided project name, artifacts path or api path/access_key.

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -15,12 +15,13 @@ import os
 import pathlib
 from io import StringIO
 
-import mlrun
 import numpy as np
 import pandas as pd
-
 from pandas.io.json import build_table_schema
 
+import mlrun
+import mlrun.errors
+import mlrun.datastore.targets
 from .base import Artifact
 from ..datastore import store_manager, is_store_uri
 

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -171,7 +171,6 @@ def get_model(
     """
     Get model file, model spec object, and list of extra data items
 
-    this function will get the model file, metadata, and extra data
     the returned model file is always local, when using remote urls
     (such as v3io://, s3://, store://, ..) it will be copied locally.
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -151,9 +151,9 @@ default_config = {
         "default_job_image": "mlrun/mlrun",
     },
     "ui": {
-        "projects_prefix": "projects",  # The UI link prefix for projects
-        "url": "",  # remote/external mlrun UI url (for hyperlinks)
-    },
+        "projects_prefix": "projects",
+        "url": "",
+    },  # The UI link prefix for projects  # remote/external mlrun UI url (for hyperlinks)
 }
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -260,9 +260,7 @@ class Config:
     @property
     def version(self) -> str:
         """
-        Return the MLRun version
-
-        :return: version string
+        The MLRun version
         """
         # importing here to avoid circular dependency
         from mlrun.utils.version import Version
@@ -272,7 +270,7 @@ class Config:
     @property
     def kfp_image(self) -> str:
         """
-        Get the kfp image URL.
+        The kfp image URL.
         Note that if not specifically configured it will default to mlrun/mlrun
         """
 
@@ -289,17 +287,12 @@ class Config:
 
     @kfp_image.setter
     def kfp_image(self, value: str):
-        """
-        Set the kfp image
-
-        :param value: kfp image URL
-        """
         self._kfp_image = value
 
     @property
     def dask_kfp_image(self) -> str:
         """
-        Set the dask kfp image URL.
+        Dask kfp image URL.
         See kfp_image property docstring for why we're defining this property
         """
         if not self._dask_kfp_image:
@@ -311,25 +304,17 @@ class Config:
 
     @dask_kfp_image.setter
     def dask_kfp_image(self, value: str):
-        """
-        Set the dask kfp image
-
-        :param value: Dask kfp image full URL
-        """
         self._dask_kfp_image = value
 
     @property
     def dbpath(self) -> str:
         """
-        Get the db path
+        The DB path
         """
         return self._dbpath
 
     @dbpath.setter
     def dbpath(self, value: str):
-        """
-        Set the db path
-        """
         self._dbpath = value
         if value:
             # importing here to avoid circular dependency
@@ -356,7 +341,8 @@ config = Config.from_dict(default_config)
 
 
 def _populate():
-    """Populate configuration from config file (if exists in environment) and
+    """
+    Populate configuration from config file (if exists in environment) and
     from environment variables.
 
     populate will run only once, after first call it does nothing.
@@ -408,7 +394,9 @@ def _convert_str(value, typ):
 
 
 def read_env(env=None, prefix=env_prefix):
-    """Read configuration from environment"""
+    """
+    Read configuration from environment
+    """
     env = os.environ if env is None else env
 
     config = {}

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -158,9 +158,15 @@ default_config = {
 
 
 class Config:
+    """
+    The main configuration object for MLRun
+    """
     _missing = object()
 
     def __init__(self, cfg=None):
+        self._kfp_image = None
+        self._dask_kfp_image = None
+        self._dbpath = None
         cfg = {} if cfg is None else cfg
 
         # Can't use self._cfg = cfg → infinite recursion

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -165,12 +165,9 @@ class Config:
     _missing = object()
 
     def __init__(self, cfg=None) -> None:
-        self._kfp_image = None
-        self._dask_kfp_image = None
-        self._dbpath = None
-        cfg = {} if cfg is None else cfg
 
-        # Can't use self._cfg = cfg → infinite recursion
+        # Can't use normal assignment [e.g. self._cfg = cfg] → infinite recursion
+        cfg = {} if cfg is None else cfg
         object.__setattr__(self, "_cfg", cfg)
 
     def __getattr__(self, attr):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -161,9 +161,10 @@ class Config:
     """
     The main configuration object for MLRun
     """
+
     _missing = object()
 
-    def __init__(self, cfg=None):
+    def __init__(self, cfg=None) -> None:
         self._kfp_image = None
         self._dask_kfp_image = None
         self._dbpath = None
@@ -204,10 +205,18 @@ class Config:
                     setattr(self, key, value)
 
     def dump_yaml(self, stream=None):
+        """
+        Serialize the configuration into YAML stream or string
+        :param stream: IO stream object
+        :return: None or string
+        """
         return yaml.dump(self._cfg, stream, default_flow_style=False)
 
     @classmethod
-    def from_dict(cls, dict_):
+    def from_dict(cls, dict_: dict):
+        """
+        Build Config object from given dict
+        """
         return cls(copy.deepcopy(dict_))
 
     @staticmethod
@@ -222,14 +231,25 @@ class Config:
         return build_args
 
     def to_dict(self):
+        """
+        Dumping a copy of the underlying configuration into a dict
+        :return: dict
+        """
         return copy.copy(self._cfg)
 
     @staticmethod
     def reload():
+        """
+        Reload (re-populate) the configuration object from env file or env vars
+        """
         _populate()
 
     @property
     def version(self):
+        """
+        Return the MLRun version
+        :return: version string
+        """
         # importing here to avoid circular dependency
         from mlrun.utils.version import Version
 
@@ -269,13 +289,6 @@ class Config:
     def dask_kfp_image(self, value):
         self._dask_kfp_image = value
 
-    @staticmethod
-    def resolve_ui_url():
-        # ui_url is deprecated in favor of the ui.url (we created the ui block)
-        # since the config class is used in a "recursive" way, we can't use property like we used in other places
-        # since the property will need to be url, which exists in other structs as well
-        return config.ui.url or config.ui_url
-
     @property
     def dbpath(self):
         return self._dbpath
@@ -289,6 +302,17 @@ class Config:
 
             # when dbpath is set we want to connect to it which will sync configuration from it to the client
             mlrun.db.get_run_db(value)
+
+    @staticmethod
+    def resolve_ui_url():
+        """
+        Returns the MLRun UI URL.
+        Note: config.ui_url is deprecated in favor of the ui.url
+        :return: str - resolved URL
+        """
+        # since the config class is used in a "recursive" way, we can't use a property like we used in other places
+        # since the property will need to be url, which exists in other structs as well
+        return config.ui.url or config.ui_url
 
 
 # Global configuration

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -152,9 +152,9 @@ default_config = {
         "default_job_image": "mlrun/mlrun",
     },
     "ui": {
-        "projects_prefix": "projects",
-        "url": "",
-    },  # The UI link prefix for projects  # remote/external mlrun UI url (for hyperlinks)
+        "projects_prefix": "projects",  # The UI link prefix for projects
+        "url": "",  # remote/external mlrun UI url (for hyperlinks)
+    },
 }
 
 

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -37,7 +37,8 @@ def get_in_memory_items():
 
 
 def get_stream_pusher(stream_path: str, **kwargs):
-    """get a stream pusher object from URL, currently only support v3io stream
+    """
+    Get a stream pusher object from URL, currently only support v3io stream
 
     common kwargs::
 

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -15,6 +15,7 @@
 from base64 import b64encode
 from os import remove, path, getenv
 from tempfile import mktemp
+import typing
 
 import fsspec
 import requests
@@ -30,6 +31,9 @@ if not verify_ssl:
 
 
 class FileStats:
+    """
+    Represents file statistics
+    """
     def __init__(self, size, modified, content_type=None):
         self.size = size
         self.modified = modified
@@ -157,8 +161,9 @@ class DataStore:
 
 
 class DataItem:
-    """Data input/output class abstracting access to various local/remote data sources"""
-
+    """
+    Data input/output class abstracting access to various local/remote data sources
+    """
     def __init__(
         self,
         key: str,
@@ -178,62 +183,93 @@ class DataItem:
 
     @property
     def key(self):
-        """DataItem key"""
+        """
+        DataItem key
+        """
         return self._key
 
     @property
     def suffix(self):
-        """DataItem suffix (file extension) e.g. '.png'"""
+        """
+        DataItem suffix (file extension) e.g. '.png'
+        """
         _, file_ext = path.splitext(self._path)
         return file_ext
 
     @property
     def store(self):
-        """DataItem store object"""
+        """
+        DataItem store object
+        """
         return self._store
 
     @property
     def kind(self):
-        """DataItem store kind (file, s3, v3io, ..)"""
+        """
+        DataItem store kind (file, s3, v3io, ..)
+        """
         return self._store.kind
 
     @property
     def meta(self):
-        """Artifact Metadata, when the DataItem is read from the artifacts store"""
+        """
+        Artifact Metadata, when the DataItem is read from the artifacts store
+        """
         return self._meta
 
     @property
     def artifact_url(self):
-        """DataItem artifact url (when its an artifact) or url for simple dataitems"""
+        """
+        DataItem artifact url (when its an artifact) or url for simple dataitems
+        """
         return self._artifact_url or self._url
 
     @property
     def url(self):
-        """DataItem url e.g. /dir/path, s3://bucket/path"""
+        """
+        DataItem url e.g. /dir/path, s3://bucket/path
+        """
         return self._url
 
     def get(self, size=None, offset=0):
-        """read all or a range and return thge content"""
+        """
+        get/read an object (all of it or a range) and return the contents
+        """
         return self._store.get(self._path, size=size, offset=offset)
 
     def download(self, target_path):
-        """download to the target dir/path"""
+        """
+        download the DataItem to the provided target dir/path
+        :param target_path: str - file path
+        """
         self._store.download(self._path, target_path)
 
     def put(self, data, append=False):
-        """write/upload the data, append is only supported by some datastores"""
+        """
+        write/upload the data to the underlying DataStore
+        :param data: data to store
+        :param append: is only supported by some data stores
+        """
         self._store.put(self._path, data, append=append)
 
     def upload(self, src_path):
-        """upload the source file (src_path) """
+        """
+        upload the source file
+        :param src_path: str - file path for the source file
+        """
         self._store.upload(self._path, src_path)
 
-    def stat(self):
-        """return FileStats class (size, modified, content_type)"""
+    def stat(self) -> typing.Optional[FileStats]:
+        """
+        get file statistics for the DataItem
+        :return FileStats class (size, modified, content_type)
+        """
         return self._store.stat(self._path)
 
     def open(self, mode):
-        """return fsspec file handler, if supported"""
+        """
+        return fsspec file handler, if supported
+        """
         return self._store.open(self._url, mode)
 
     def ls(self):
@@ -241,7 +277,9 @@ class DataItem:
         return self._store.listdir(self._path)
 
     def listdir(self):
-        """return a list of child file names"""
+        """
+        return a list of child file names
+        """
         return self._store.listdir(self._path)
 
     def local(self):

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -34,6 +34,7 @@ class FileStats:
     """
     Represents file statistics
     """
+
     def __init__(self, size, modified, content_type=None):
         self.size = size
         self.modified = modified
@@ -161,9 +162,8 @@ class DataStore:
 
 
 class DataItem:
-    """
-    Data input/output class abstracting access to various local/remote data sources
-    """
+    """Data input/output class abstracting access to various local/remote data sources"""
+
     def __init__(
         self,
         key: str,
@@ -269,6 +269,7 @@ class DataItem:
     def open(self, mode):
         """
         return fsspec file handler, if supported
+        :param mode: str - file open mode
         """
         return self._store.open(self._url, mode)
 
@@ -283,7 +284,10 @@ class DataItem:
         return self._store.listdir(self._path)
 
     def local(self):
-        """get the local path of the file, download to tmp first if its a remote object"""
+        """
+        get the local path of the file, if remote object - download to tmp first
+        :return file path str
+        """
         if self.kind == "file":
             return self._path
         if self._local_path:
@@ -296,7 +300,8 @@ class DataItem:
         return self._local_path
 
     def as_df(self, columns=None, df_module=None, format="", **kwargs):
-        """return a dataframe object (generated from the dataitem).
+        """
+        return a dataframe generated from the DataItem.
 
         :param columns:   optional, list of columns to select
         :param df_module: optional, dataframe class (e.g. pd, dd, cudf, ..)

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -162,7 +162,9 @@ class DataStore:
 
 
 class DataItem:
-    """Data input/output class abstracting access to various local/remote data sources"""
+    """
+    Data input/output class abstracting access to various local/remote data sources
+    """
 
     def __init__(
         self,
@@ -171,7 +173,7 @@ class DataItem:
         subpath: str,
         url: str = "",
         meta=None,
-        artifact_url=None,
+        artifact_url: str = None,
     ):
         self._store = store
         self._key = key
@@ -218,14 +220,14 @@ class DataItem:
         return self._meta
 
     @property
-    def artifact_url(self):
+    def artifact_url(self) -> str:
         """
         DataItem artifact url (when its an artifact) or url for simple dataitems
         """
         return self._artifact_url or self._url
 
     @property
-    def url(self):
+    def url(self) -> str:
         """
         DataItem url e.g. /dir/path, s3://bucket/path
         """
@@ -233,60 +235,62 @@ class DataItem:
 
     def get(self, size=None, offset=0):
         """
-        get/read an object (all of it or a range) and return the contents
+        Get/read an object (all of it or a range) and return the contents
         """
         return self._store.get(self._path, size=size, offset=offset)
 
-    def download(self, target_path):
+    def download(self, target_path: str):
         """
-        download the DataItem to the provided target dir/path
-        :param target_path: str - file path
+        Download the DataItem to the provided target dir/path
+        :param target_path: file path
         """
         self._store.download(self._path, target_path)
 
-    def put(self, data, append=False):
+    def put(self, data, append: bool = False):
         """
-        write/upload the data to the underlying DataStore
+        Write/upload the data to the underlying DataStore
         :param data: data to store
         :param append: is only supported by some data stores
         """
         self._store.put(self._path, data, append=append)
 
-    def upload(self, src_path):
+    def upload(self, src_path: str):
         """
-        upload the source file
+        Upload the source file
         :param src_path: str - file path for the source file
         """
         self._store.upload(self._path, src_path)
 
     def stat(self) -> typing.Optional[FileStats]:
         """
-        get file statistics for the DataItem
-        :return FileStats class (size, modified, content_type)
+        Get file statistics for the DataItem
+        :return: FileStats class (size, modified, content_type)
         """
         return self._store.stat(self._path)
 
-    def open(self, mode):
+    def open(self, mode: str):
         """
         return fsspec file handler, if supported
-        :param mode: str - file open mode
+        :param mode: File open mode
         """
         return self._store.open(self._url, mode)
 
     def ls(self):
-        """return a list of child file names"""
-        return self._store.listdir(self._path)
-
-    def listdir(self):
         """
-        return a list of child file names
+        Get a list of child file names
         """
         return self._store.listdir(self._path)
 
-    def local(self):
+    def listdir(self) -> typing.List[str]:
         """
-        get the local path of the file, if remote object - download to tmp first
-        :return file path str
+        Get a list of child file names
+        """
+        return self._store.listdir(self._path)
+
+    def local(self) -> str:
+        """
+        Get the local path of the file, if remote object - download to tmp first
+        :return: File path
         """
         if self.kind == "file":
             return self._path
@@ -299,9 +303,11 @@ class DataItem:
         self.download(self._local_path)
         return self._local_path
 
-    def as_df(self, columns=None, df_module=None, format="", **kwargs):
+    def as_df(
+        self, columns=None, df_module=None, format: str = "", **kwargs
+    ) -> pd.DataFrame:
         """
-        return a dataframe generated from the DataItem.
+        Return a dataframe generated from the DataItem.
 
         :param columns:   optional, list of columns to select
         :param df_module: optional, dataframe class (e.g. pd, dd, cudf, ..)

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -174,7 +174,15 @@ class DataItem:
         url: str = "",
         meta=None,
         artifact_url: str = None,
-    ):
+    ) -> None:
+        """
+        :param key: DataItem key
+        :param store: Data store
+        :param subpath: subpath of the item in the store
+        :param url: DataItem url e.g. /dir/path, s3://bucket/path
+        :param meta: Metadata for the DataItem, when reading it from the store
+        :param artifact_url: DataItem artifact url (when its an artifact) or url for simple dataitems
+        """
         self._store = store
         self._key = key
         self._url = url

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -39,7 +39,7 @@ def parse_url(url):
         lower_netloc = netloc.lower()
         hostname_index_in_netloc = lower_netloc.index(str(lower_hostname))
         endpoint = netloc[
-            hostname_index_in_netloc : hostname_index_in_netloc + len(lower_hostname)
+            hostname_index_in_netloc: hostname_index_in_netloc + len(lower_hostname)
         ]
     if parsed_url.port:
         endpoint += f":{parsed_url.port}"
@@ -84,7 +84,7 @@ def uri_to_ipython(link):
 
 
 class StoreManager:
-    def __init__(self, secrets=None, db=None):
+    def __init__(self, secrets=None, db=None) -> None:
         self._stores = {}
         self._secrets = secrets or {}
         self._db = db
@@ -103,16 +103,18 @@ class StoreManager:
         return self._db
 
     def from_dict(self, struct: dict):
-        stor_list = struct.get(run_keys.data_stores)
-        if stor_list and isinstance(stor_list, list):
-            for stor in stor_list:
-                schema, endpoint, parsed_url = parse_url(stor.get("url"))
-                new_stor = schema_to_store(schema)(self, schema, stor["name"], endpoint)
-                new_stor.subpath = parsed_url.path
-                new_stor.secret_pfx = stor.get("secret_pfx")
-                new_stor.options = stor.get("options", {})
-                new_stor.from_spec = True
-                self._stores[stor["name"]] = new_stor
+        store_list = struct.get(run_keys.data_stores)
+        if store_list and isinstance(store_list, list):
+            for store in store_list:
+                schema, endpoint, parsed_url = parse_url(store.get("url"))
+                new_store = schema_to_store(schema)(
+                    self, schema, store["name"], endpoint
+                )
+                new_store.subpath = parsed_url.path
+                new_store.secret_pfx = store.get("secret_pfx")
+                new_store.options = store.get("options", {})
+                new_store.from_spec = True
+                self._stores[store["name"]] = new_store
 
     def to_dict(self, struct):
         struct[run_keys.data_stores] = [

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -84,7 +84,7 @@ def uri_to_ipython(link):
 
 
 class StoreManager:
-    def __init__(self, secrets=None, db=None) -> None:
+    def __init__(self, secrets=None, db=None):
         self._stores = {}
         self._secrets = secrets or {}
         self._db = db

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -39,7 +39,7 @@ def parse_url(url):
         lower_netloc = netloc.lower()
         hostname_index_in_netloc = lower_netloc.index(str(lower_hostname))
         endpoint = netloc[
-            hostname_index_in_netloc: hostname_index_in_netloc + len(lower_hostname)
+            hostname_index_in_netloc : hostname_index_in_netloc + len(lower_hostname)
         ]
     if parsed_url.port:
         endpoint += f":{parsed_url.port}"

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -126,7 +126,13 @@ class ResourceCache:
 
 def get_store_resource(
     uri: str, db: RunDBInterface = None, secrets: dict = None, project: str = None
-) -> typing.Union[dict, DataItem, StorePrefix.Artifact, StorePrefix.FeatureSet, StorePrefix.FeatureVector]:
+) -> typing.Union[
+    dict,
+    DataItem,
+    StorePrefix.Artifact,
+    StorePrefix.FeatureSet,
+    StorePrefix.FeatureVector,
+]:
     """
     Get store resource object by uri
 
@@ -174,6 +180,7 @@ def get_store_resource(
             )
         if resource:
             from ..artifacts import dict_to_artifact
+
             return dict_to_artifact(resource)
 
     else:

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -95,7 +95,9 @@ online_lookup_order = [TargetTypes.nosql]
 
 
 def get_offline_target(featureset, start_time=None, name=None):
-    """return an optimal offline feature set target"""
+    """
+    Return an optimal offline feature set target
+    """
     # todo: take status, start_time and lookup order into account
     for target in featureset.status.targets:
         driver = kind_to_driver[target.kind]

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -45,10 +45,10 @@ class V3ioStore(DataStore):
         self.headers = None
         self.secure = self.kind == "v3ios"
         if self.endpoint.startswith("https://"):
-            self.endpoint = self.endpoint[len("https://") :]
+            self.endpoint = self.endpoint[len("https://"):]
             self.secure = True
         elif self.endpoint.startswith("http://"):
-            self.endpoint = self.endpoint[len("http://") :]
+            self.endpoint = self.endpoint[len("http://"):]
             self.secure = False
 
         token = self._get_secret_or_env("V3IO_ACCESS_KEY")

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -45,10 +45,10 @@ class V3ioStore(DataStore):
         self.headers = None
         self.secure = self.kind == "v3ios"
         if self.endpoint.startswith("https://"):
-            self.endpoint = self.endpoint[len("https://"):]
+            self.endpoint = self.endpoint[len("https://") :]
             self.secure = True
         elif self.endpoint.startswith("http://"):
-            self.endpoint = self.endpoint[len("http://"):]
+            self.endpoint = self.endpoint[len("http://") :]
             self.secure = False
 
         token = self._get_secret_or_env("V3IO_ACCESS_KEY")

--- a/mlrun/db/__init__.py
+++ b/mlrun/db/__init__.py
@@ -21,7 +21,7 @@ from .sqldb import SQLDB
 from os import environ
 
 
-def get_or_set_dburl(default=""):
+def get_or_set_db_url(default=""):
     if not config.dbpath and default:
         config.dbpath = default
         environ["MLRUN_DBPATH"] = default
@@ -47,12 +47,22 @@ _run_db = None
 _last_db_url = None
 
 
-def get_run_db(url="", secrets=None, force_reconnect=False):
-    """Returns the runtime database"""
+def get_run_db(
+    url: str = "", secrets: dict = None, force_reconnect: bool = False
+) -> RunDBInterface:
+    """
+    Returns the runtime database
+
+    :param url: optional db URL
+    :param secrets: Optional secrets dict
+    :param force_reconnect: Optional, force reconnection
+
+    :return: The run DB
+    """
     global _run_db, _last_db_url
 
     if not url:
-        url = get_or_set_dburl("./")
+        url = get_or_set_db_url("./")
 
     if (
         _last_db_url is not None

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -169,7 +169,7 @@ class RunDBInterface(ABC):
     @abstractmethod
     def get_feature_set(
         self, name: str, project: str = "", tag: str = None, uid: str = None
-    ) -> dict:
+    ) -> schemas.FeatureSet:
         pass
 
     @abstractmethod
@@ -242,7 +242,7 @@ class RunDBInterface(ABC):
     @abstractmethod
     def get_feature_vector(
         self, name: str, project: str = "", tag: str = None, uid: str = None
-    ) -> dict:
+    ) -> schemas.FeatureVector:
         pass
 
     @abstractmethod

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -186,7 +186,8 @@ class HTTPRunDB(RunDBInterface):
         return f"{prefix}/{project}/{uid}"
 
     def connect(self, secrets=None):
-        """ Connect to the MLRun API server. Must be called prior to executing any other method.
+        """
+        Connect to the MLRun API server. Must be called prior to executing any other method.
         The code utilizes the URL for the API server from the configuration - ``mlconf.dbpath``.
 
         For example::

--- a/mlrun/feature_store/__init__.py
+++ b/mlrun/feature_store/__init__.py
@@ -27,11 +27,9 @@ __all__ = [
     "FeatureVector",
 ]
 
-
+from ..features import Feature, Entity
 from .feature_set import FeatureSet
 from .feature_vector import FeatureVector
-from ..features import Feature, Entity
-from ..data_types import InferOptions, ValueType
 from .api import (
     get_offline_features,
     get_online_feature_service,

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -55,17 +55,17 @@ def _features_to_vector(features):
 def get_offline_features(
     features: typing.Union[str, typing.List[str], FeatureVector],
     entity_rows=None,
-    entity_timestamp_column: str = None,
+    entity_timestamp_column: typing.Optional[str] = None,
     batch: bool = False,
-    store_target: DataTargetBase = None,
+    store_target: typing.Optional[DataTargetBase] = None,
     drop_columns: typing.List[str] = None,
-    engine: str = None,
-    name: str = None,
-    function=None,
-    local=None,
-    watch=False,
-    auto_mount=True,
-    secrets=None,
+    engine: typing.Optional[str] = None,
+    name: typing.Optional[str] = None,
+    function: typing.Optional[BaseRuntime] = None,
+    local: typing.Optional[bool] = None,
+    watch: bool = False,
+    auto_mount: bool = True,
+    secrets: typing.Optional[dict] = None,
 ) -> OfflineVectorResponse:
     """
     Retrieve offline feature vector results

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -20,7 +20,12 @@ import pandas as pd
 from ..db import get_run_db
 from ..features import Feature, Entity
 from ..model import VersionedObjMetadata
-from ..datastore.targets import get_offline_target, default_target_names, TargetTypes, BaseStoreTarget
+from ..datastore.targets import (
+    get_offline_target,
+    default_target_names,
+    TargetTypes,
+    BaseStoreTarget,
+)
 from ..model import ModelObj, ObjectList, DataSource, DataTarget, DataTargetBase
 from ..runtimes.function_reference import FunctionReference
 from ..serving.states import BaseState, RootFlowState, previous_step
@@ -38,11 +43,11 @@ class FeatureAggregation(ModelObj):
 
     def __init__(
         self,
-            name: typing.Optional[str] = None,
-            column: typing.Optional[str] = None,
-            operations: typing.Optional[typing.List[str]] = None,
-            windows: typing.Optional[typing.List[str]] = None,
-            period: typing.Optional[str] = None,
+        name: typing.Optional[str] = None,
+        column: typing.Optional[str] = None,
+        operations: typing.Optional[typing.List[str]] = None,
+        windows: typing.Optional[typing.List[str]] = None,
+        period: typing.Optional[str] = None,
     ) -> None:
         """
         :param name:       Aggregation name/prefix
@@ -62,6 +67,7 @@ class FeatureSetSpec(ModelObj):
     """
     Spec for FeatureSet
     """
+
     def __init__(
         self,
         owner: typing.Optional[str] = None,
@@ -236,6 +242,7 @@ class FeatureSetStatus(ModelObj):
     """
     Status for FeatureSet
     """
+
     def __init__(
         self,
         state: typing.Optional[str] = None,
@@ -279,14 +286,17 @@ class FeatureSet(ModelObj):
     """
     Feature set object, defines a set of features and their data pipeline
     """
+
     kind = mlrun.api.schemas.ObjectKind.feature_set.value
     _dict_fields = ["kind", "metadata", "spec", "status"]
 
-    def __init__(self,
-                 name: str = None,
-                 description: str = None,
-                 entities: typing.Optional[typing.List[Entity]] = None,
-                 timestamp_key: typing.Optional[str] = None):
+    def __init__(
+        self,
+        name: str = None,
+        description: str = None,
+        entities: typing.Optional[typing.List[Entity]] = None,
+        timestamp_key: typing.Optional[str] = None,
+    ):
         """
         :param name: Optional, name
         :param description: Optional, description
@@ -383,9 +393,13 @@ class FeatureSet(ModelObj):
         if target:
             return target.path
 
-    def set_targets(self,
-                    targets: typing.Optional[typing.List[typing.Union[str, BaseStoreTarget]]] = None,
-                    with_defaults: bool = True):
+    def set_targets(
+        self,
+        targets: typing.Optional[
+            typing.List[typing.Union[str, BaseStoreTarget]]
+        ] = None,
+        with_defaults: bool = True,
+    ):
         """
         Set the desired target list or defaults
 
@@ -517,11 +531,13 @@ class FeatureSet(ModelObj):
     def __setitem__(self, key, item):
         self._spec.features.update(item, key)
 
-    def plot(self,
-             filename: typing.Optional[str] = None,
-             format: typing.Optional[str] = None,
-             with_targets: bool = False,
-             **kw):
+    def plot(
+        self,
+        filename: typing.Optional[str] = None,
+        format: typing.Optional[str] = None,
+        with_targets: bool = False,
+        **kw,
+    ):
         """
         Generate graphviz plot
 
@@ -545,10 +561,12 @@ class FeatureSet(ModelObj):
             ]
         return graph.plot(filename, format, targets=targets, **kw)
 
-    def to_dataframe(self,
-                     columns: typing.Optional[typing.List[str]] = None,
-                     df_module:  typing.Optional[typing.Any] = None,
-                     target_name: typing.Optional[str] = None) -> typing.Union[pd.DataFrame, typing.Any]:
+    def to_dataframe(
+        self,
+        columns: typing.Optional[typing.List[str]] = None,
+        df_module: typing.Optional[typing.Any] = None,
+        target_name: typing.Optional[str] = None,
+    ) -> typing.Union[pd.DataFrame, typing.Any]:
         """
         Return featureset (offline) data as dataframe
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -128,111 +128,73 @@ class FeatureSetSpec(ModelObj):
     def entities(self) -> ObjectList:
         """
         Feature set entities (indexes)
-
-        :return: object list of entities
         """
         return self._entities
 
     @entities.setter
     def entities(self, entities: typing.List[Entity]):
-        """
-        Set feature set entities (indexes)
-
-        :param entities: entities to set
-        """
         self._entities = ObjectList.from_list(Entity, entities)
 
     @property
     def features(self) -> ObjectList:
         """
         Feature set features list
-
-        :return: object list of features
         """
         return self._features
 
     @features.setter
     def features(self, features: typing.List[Feature]):
-        """
-        Set the feature set list
-        :param features: list of Feature objects
-        """
         self._features = ObjectList.from_list(Feature, features)
 
     @property
     def targets(self) -> ObjectList:
         """
-        Get list object of desired targets (material storage)
-
-        :return object list of targets
+        List object of desired targets (material storage)
         """
         return self._targets
 
     @targets.setter
     def targets(self, targets: typing.List[DataTargetBase]):
-        """
-        Set targets list
-
-        :param targets: list of DataTarget objects
-        """
         self._targets = ObjectList.from_list(DataTargetBase, targets)
 
     @property
     def graph(self) -> RootFlowState:
         """
-        Get feature set transformation graph/DAG
+        Feature set transformation graph/DAG
         """
         return self._graph
 
     @graph.setter
     def graph(self, graph: typing.Union[dict, RootFlowState]):
-        """
-        Set the transformation graph for the feature set
-
-        :param graph: graph dict or root state object
-        """
         self._graph = self._verify_dict(graph, "graph", RootFlowState)
         self._graph.engine = "async"
 
     @property
     def function(self) -> FunctionReference:
         """
-        Get template graph processing function reference
-
-        :return: function reference
+        The template graph processing function reference
         """
         return self._function
 
     @function.setter
     def function(self, function: typing.Union[dict, FunctionReference]):
-        """
-        Set function reference for template graph processing
-
-        :param function: function reference object
-        """
         self._function = self._verify_dict(function, "function", FunctionReference)
 
     @property
     def source(self) -> DataSource:
         """
-        Get feature set data source definitions
-
-        :return: data source
+        The feature set data source definitions
         """
         return self._source
 
     @source.setter
     def source(self, source: typing.Union[dict, DataSource]):
-        """
-        Set source definition for feature set
-
-        :param source: source definition
-        """
         self._source = self._verify_dict(source, "source", DataSource)
 
     def require_processing(self) -> bool:
         """
         Is processing required on this feature set
+
         :return: bool (true if there are any graph states)
         """
         return len(self._graph.states) > 0
@@ -242,7 +204,6 @@ class FeatureSetStatus(ModelObj):
     """
     Status for FeatureSet
     """
-
     def __init__(
         self,
         state: typing.Optional[str] = None,
@@ -263,9 +224,7 @@ class FeatureSetStatus(ModelObj):
     @property
     def targets(self) -> ObjectList:
         """
-        list of material storage targets + their status/path
-
-        :return: Object list of DataTarget
+        List of material storage targets + their status/path
         """
         return self._targets
 
@@ -317,62 +276,40 @@ class FeatureSet(ModelObj):
     @property
     def spec(self) -> FeatureSetSpec:
         """
-        Get the feature set spec
-
-        :return: Feature set spec
+        The feature set spec
         """
         return self._spec
 
     @spec.setter
     def spec(self, spec: typing.Union[dict, FeatureSetSpec]):
-        """
-        Set feature set spec
-
-        :param spec: Feature set spec to set
-        """
         self._spec = self._verify_dict(spec, "spec", FeatureSetSpec)
 
     @property
     def metadata(self) -> VersionedObjMetadata:
         """
-        Get feature set metadata
-
-        :return: Feature set metadata
+        The feature set metadata
         """
         return self._metadata
 
     @metadata.setter
     def metadata(self, metadata: typing.Union[dict, VersionedObjMetadata]):
-        """
-        Set feature set metadata
-
-        :param metadata: Feature set metadata
-        """
         self._metadata = self._verify_dict(metadata, "metadata", VersionedObjMetadata)
 
     @property
     def status(self) -> FeatureSetStatus:
         """
-        Get feature set status
-
-        :return: feature set status
+        The feature set status
         """
         return self._status
 
     @status.setter
     def status(self, status: typing.Union[dict, FeatureSetStatus]):
-        """
-        Set feature set status
-        :param status: Status to set
-        """
         self._status = self._verify_dict(status, "status", FeatureSetStatus)
 
     @property
     def uri(self) -> str:
         """
-        Get the fully qualified feature set uri
-
-        :return: uri
+        The fully qualified feature set uri
         """
         uri = (
             f"{self._metadata.project or mlconf.default_project}/{self._metadata.name}"
@@ -454,7 +391,7 @@ class FeatureSet(ModelObj):
     @property
     def graph(self) -> RootFlowState:
         """
-        Get feature set transformation graph/DAG
+        The feature set transformation graph/DAG
         """
         return self.spec.graph
 
@@ -568,7 +505,7 @@ class FeatureSet(ModelObj):
         target_name: typing.Optional[str] = None,
     ) -> typing.Union[pd.DataFrame, typing.Any]:
         """
-        Return featureset (offline) data as dataframe
+        Return feature set (offline) data as dataframe
 
         :param columns:   Optional, list of columns to select
         :param df_module: Optional, dataframe class (e.g. pd, dd, cudf, ..)

--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -35,6 +35,7 @@ class FeatureVectorSpec(ModelObj):
     """
     Spec for FeatureVector
     """
+
     def __init__(
         self,
         features: typing.Optional[typing.List[str]] = None,
@@ -166,10 +167,12 @@ class FeatureVector(ModelObj):
     kind = mlrun.api.schemas.ObjectKind.feature_vector.value
     _dict_fields = ["kind", "metadata", "spec", "status"]
 
-    def __init__(self,
-                 name: typing.Optional[str] = None,
-                 features: typing.Optional[typing.List[str]] = None,
-                 description: typing.Optional[str] = None) -> None:
+    def __init__(
+        self,
+        name: typing.Optional[str] = None,
+        features: typing.Optional[typing.List[str]] = None,
+        description: typing.Optional[str] = None,
+    ) -> None:
         """
 
         :param name: Optional, name for the vector
@@ -286,7 +289,9 @@ class FeatureVector(ModelObj):
         if target:
             return target.path
 
-    def to_dataframe(self, df_module=None, target_name=None) -> typing.Union[pd.DataFrame, typing.Any]:
+    def to_dataframe(
+        self, df_module=None, target_name=None
+    ) -> typing.Union[pd.DataFrame, typing.Any]:
         """
         Return feature vector (offline) data as dataframe
 

--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -76,21 +76,20 @@ class FeatureVectorSpec(ModelObj):
 
     @property
     def entity_source(self) -> DataSource:
-        """data source used as entity source (events/keys need to be enriched)"""
+        """
+        Data source used as entity source (events/keys need to be enriched)
+        """
         return self._entity_source
 
     @entity_source.setter
     def entity_source(self, source: typing.Union[dict, DataSource]):
-        """
-        Set entity data source
-        :param source: datasource as dic or DataSource object
-        :return:
-        """
         self._entity_source = self._verify_dict(source, "entity_source", DataSource)
 
     @property
     def entity_fields(self) -> ObjectList:
-        """the schema/metadata for the entity source fields"""
+        """
+        The schema/metadata for the entity source fields
+        """
         return self._entity_fields
 
     @entity_fields.setter
@@ -99,7 +98,9 @@ class FeatureVectorSpec(ModelObj):
 
     @property
     def graph(self) -> RootFlowState:
-        """feature vector transformation graph/DAG"""
+        """
+        Feature vector transformation graph/DAG
+        """
         return self._graph
 
     @graph.setter
@@ -109,7 +110,9 @@ class FeatureVectorSpec(ModelObj):
 
     @property
     def function(self) -> FunctionReference:
-        """reference to template graph processing function"""
+        """
+        Reference to template graph processing function
+        """
         return self._function
 
     @function.setter
@@ -139,7 +142,9 @@ class FeatureVectorStatus(ModelObj):
 
     @property
     def targets(self) -> ObjectList:
-        """list of material storage targets + their status/path"""
+        """
+        List of material storage targets + their status/path
+        """
         return self._targets
 
     @targets.setter
@@ -151,7 +156,9 @@ class FeatureVectorStatus(ModelObj):
 
     @property
     def features(self) -> ObjectList:
-        """list of features (result of joining features from the source feature sets)"""
+        """
+        List of features (result of joining features from the source feature sets)
+        """
         return self._features
 
     @features.setter
@@ -194,63 +201,40 @@ class FeatureVector(ModelObj):
     @property
     def spec(self) -> FeatureVectorSpec:
         """
-        Get the feature vector spec
-
-        :return: Feature vector spec
+        Feature vector spec
         """
         return self._spec
 
     @spec.setter
     def spec(self, spec: typing.Union[dict, FeatureVectorSpec]):
-        """
-        Set the feature vector spec
-
-        :param spec: spec dict or object
-        """
         self._spec = self._verify_dict(spec, "spec", FeatureVectorSpec)
 
     @property
     def metadata(self) -> VersionedObjMetadata:
         """
         Get feature vector metadata
-
-        :return: metadata object
         """
         return self._metadata
 
     @metadata.setter
     def metadata(self, metadata: typing.Union[dict, VersionedObjMetadata]):
-        """
-        Set feature vector metadata from dict or object
-
-        :param metadata: dict or object representing metadata
-        """
         self._metadata = self._verify_dict(metadata, "metadata", VersionedObjMetadata)
 
     @property
     def status(self) -> FeatureVectorStatus:
         """
-        Get the feature vector status
-
-        :return: Feature vector status object
+        The feature vector status
         """
         return self._status
 
     @status.setter
     def status(self, status: typing.Union[dict, FeatureVectorStatus]):
-        """
-        Set feature vector status from dict or status object
-
-        :param status: status as dict or object
-        """
         self._status = self._verify_dict(status, "status", FeatureVectorStatus)
 
     @property
     def uri(self) -> str:
         """
         Get the fully qualified feature vector uri
-
-        :return: uri
         """
         uri = (
             f"{self._metadata.project or mlconf.default_project}/{self._metadata.name}"
@@ -404,9 +388,7 @@ class OnlineVectorService:
     @property
     def status(self) -> str:
         """
-        Get vector prep function status.
-
-        :return: Status - One of [ready, running, error]
+        Vector prep function status.
         """
         return "ready"
 
@@ -432,29 +414,38 @@ class OnlineVectorService:
 
 
 class OfflineVectorResponse:
-    """get_offline_features response object"""
-
+    """
+    Response object for get_offline_features response
+    """
     def __init__(self, merger):
         self._merger = merger
         self.vector = merger.vector
 
     @property
     def status(self):
-        """vector prep job status (ready, running, error)"""
+        """
+        Vector prep job status (ready, running, error)
+        """
         return self._merger.get_status()
 
     def to_dataframe(self):
-        """return result as dataframe"""
+        """
+        Get results as dataframe
+        """
         if self.status != "completed":
             raise mlrun.errors.MLRunTaskNotReady("feature vector dataset is not ready")
         return self._merger.get_df()
 
     def to_parquet(self, target_path, **kw):
-        """return results as parquet file"""
+        """
+        Get results as parquet file
+        """
         return ParquetTarget(path=target_path).write_dataframe(
             self._merger.get_df(), **kw
         )
 
     def to_csv(self, target_path, **kw):
-        """return results as csv file"""
+        """
+        Get results as csv file
+        """
         return CSVTarget(path=target_path).write_dataframe(self._merger.get_df(), **kw)

--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -37,16 +37,27 @@ class FeatureVectorSpec(ModelObj):
     """
     def __init__(
         self,
-        features=None,
-        description=None,
-        entity_source=None,
-        entity_fields=None,
-        timestamp_field=None,
-        graph=None,
-        label_column=None,
-        function=None,
-        analysis=None,
+        features: typing.Optional[typing.List[str]] = None,
+        description: typing.Optional[str] = None,
+        entity_source: typing.Optional[typing.Union[dict, DataSource]] = None,
+        entity_fields: typing.Optional[typing.List[Feature]] = None,
+        timestamp_field: typing.Optional[str] = None,
+        graph: typing.Optional[typing.Union[dict, RootFlowState]] = None,
+        label_column: typing.Optional[str] = None,
+        function: typing.Optional[typing.Union[dict, FunctionReference]] = None,
+        analysis: typing.Optional[dict] = None,
     ):
+        """
+        :param features: Optional, list of features
+        :param description: Optional, description
+        :param entity_source: Optional, name of data source for features
+        :param entity_fields: Optional, the features in the vector
+        :param timestamp_field: Optional, timestamp_field
+        :param graph: Optional, provide graph (root state)
+        :param label_column: Optional, Which column in the is the label (target) column
+        :param function: Optional, template graph processing function reference
+        :param analysis: Optional, linked artifacts/files for analysis
+        """
         self._graph: RootFlowState = None
         self._entity_fields: ObjectList = None
         self._entity_source: DataSource = None
@@ -68,7 +79,12 @@ class FeatureVectorSpec(ModelObj):
         return self._entity_source
 
     @entity_source.setter
-    def entity_source(self, source: DataSource):
+    def entity_source(self, source: typing.Union[dict, DataSource]):
+        """
+        Set entity data source
+        :param source: datasource as dic or DataSource object
+        :return:
+        """
         self._entity_source = self._verify_dict(source, "entity_source", DataSource)
 
     @property
@@ -103,12 +119,12 @@ class FeatureVectorSpec(ModelObj):
 class FeatureVectorStatus(ModelObj):
     def __init__(
         self,
-        state=None,
-        targets=None,
-        features=None,
-        stats=None,
-        preview=None,
-        run_uri=None,
+        state: typing.Optional[str] = None,
+        targets: typing.Optional[typing.List[DataTarget]] = None,
+        features: typing.Optional[typing.List[Feature]] = None,
+        stats: typing.Optional[dict] = None,
+        preview: typing.Optional[list] = None,
+        run_uri: typing.Optional[str] = None,
     ):
         self._targets: ObjectList = None
         self._features: ObjectList = None
@@ -133,7 +149,7 @@ class FeatureVectorStatus(ModelObj):
         self._targets.update(target)
 
     @property
-    def features(self) -> typing.List[Feature]:
+    def features(self) -> ObjectList:
         """list of features (result of joining features from the source feature sets)"""
         return self._features
 
@@ -154,6 +170,12 @@ class FeatureVector(ModelObj):
                  name: typing.Optional[str] = None,
                  features: typing.Optional[typing.List[str]] = None,
                  description: typing.Optional[str] = None) -> None:
+        """
+
+        :param name: Optional, name for the vector
+        :param features: Optional, list of features (strings)
+        :param description: Optional, description of the vector
+        """
         self._spec: FeatureVectorSpec = None
         self._metadata = None
         self._status = None

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -1,69 +1,26 @@
-from typing import Optional, Dict
+import typing
 from .data_types import ValueType
 from .model import ModelObj
 
 
 class Entity(ModelObj):
-    """data entity (index)"""
+    """
+    Data entity (index)
+    """
 
     def __init__(
         self,
         name: str = None,
         value_type: ValueType = None,
         description: str = None,
-        labels: Optional[Dict[str, str]] = None,
-    ):
+        labels: typing.Optional[typing.Dict[str, str]] = None,
+    ) -> None:
         self.name = name
         self.description = description
         self.value_type = value_type
         if name and not value_type:
             self.value_type = ValueType.STRING
         self.labels = labels or {}
-
-
-class Feature(ModelObj):
-    """data feature"""
-
-    _dict_fields = [
-        "name",
-        "description",
-        "value_type",
-        "dims",
-        "default",
-        "labels",
-        "aggregate",
-        "validator",
-    ]
-
-    def __init__(
-        self,
-        value_type: ValueType = None,
-        description=None,
-        aggregate=None,
-        name=None,
-        validator=None,
-        default=None,
-        labels: Dict[str, str] = None,
-    ):
-        self.name = name or ""
-        self.value_type: ValueType = value_type or ""
-        self.dims = None
-        self.description = description
-        self.default = default
-        self.labels = labels or {}
-        self.aggregate = aggregate
-        self._validator = validator
-
-    @property
-    def validator(self):
-        return self._validator
-
-    @validator.setter
-    def validator(self, validator):
-        if isinstance(validator, dict):
-            kind = validator.get("kind")
-            validator = validator_kinds[kind].from_dict(validator)
-        self._validator = validator
 
 
 class Validator(ModelObj):
@@ -125,3 +82,48 @@ validator_kinds = {
     "": Validator,
     "minmax": MinMaxValidator,
 }
+
+
+class Feature(ModelObj):
+    """Data feature"""
+
+    _dict_fields = [
+        "name",
+        "description",
+        "value_type",
+        "dims",
+        "default",
+        "labels",
+        "aggregate",
+        "validator",
+    ]
+
+    def __init__(
+        self,
+        value_type: ValueType = None,
+        description: typing.Optional[str] = None,
+        aggregate: typing.Optional[bool] = None,
+        name: typing.Optional[str] = None,
+        validator: typing.Optional[Validator] = None,
+        default: typing.Optional[typing.Any] = None,
+        labels: typing.Dict[str, str] = None,
+    ) -> None:
+        self.name = name or ""
+        self.value_type: ValueType = value_type or ""
+        self.dims = None
+        self.description = description
+        self.default = default
+        self.labels = labels or {}
+        self.aggregate = aggregate
+        self._validator = validator
+
+    @property
+    def validator(self):
+        return self._validator
+
+    @validator.setter
+    def validator(self, validator):
+        if isinstance(validator, dict):
+            kind = validator.get("kind")
+            validator = validator_kinds[kind].from_dict(validator)
+        self._validator = validator

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -19,7 +19,7 @@ import os.path
 
 
 import mlrun
-from .db import get_or_set_dburl
+from .db import get_or_set_db_url
 from .utils import run_keys, dict_to_yaml, logger, gen_md_table, get_artifact_target
 from .config import config
 
@@ -243,7 +243,7 @@ def mlrun_op(
     outputs = [] if outputs is None else outputs
     labels = {} if labels is None else labels
 
-    rundb = rundb or get_or_set_dburl()
+    rundb = rundb or get_or_set_db_url()
     cmd = [
         "python",
         "-m",

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -344,8 +344,8 @@ class RunSpec(ModelObj):
         secret_sources=None,
         data_stores=None,
         tuning_strategy=None,
-        verbose=None,
-        scrape_metrics=False,
+        verbose: bool = None,
+        scrape_metrics: bool = False,
     ):
 
         self.parameters = parameters or {}

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1427,10 +1427,12 @@ class MlrunProjectLegacy(ModelObj):
             fp.write(self.to_yaml())
 
 
-def new_project(name: str,
-                context: typing.Optional[str] = None,
-                init_git: bool = False,
-                user_project: bool = False) -> MlrunProject:
+def new_project(
+    name: str,
+    context: typing.Optional[str] = None,
+    init_git: bool = False,
+    user_project: bool = False,
+) -> MlrunProject:
     """Create a new MLRun project
 
     :param name:         project name

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -951,8 +951,9 @@ def list_pipelines(
     namespace: str = None,
     project: str = "*",
     format_: mlrun.api.schemas.Format = mlrun.api.schemas.Format.metadata_only,
-) -> Tuple[int, Optional[int], List[dict]]:
-    """List pipelines
+) -> Tuple[int, Optional[str], List[dict]]:
+    """
+    List pipelines
 
     :param full:       Deprecated, use format_ instead. if True will set format_ to full, otherwise format_ will be used
     :param page_token: A page token to request the next page of results. The token is acquried from the nextPageToken
@@ -968,7 +969,9 @@ def list_pipelines(
                        filtering by project can't be used together with pagination, sorting, or custom filter.
     :param format_:    Control what will be returned (full/metadata_only/name_only)
 
-    :return: Tuple of (total_size, next_page_token, runs)
+    :return total_size: Number of runs in the pipeline
+    :return next_page_token: A page token to request the next page of results (kfp)
+    :return runs: List of runs
     """
     if full:
         format_ = mlrun.api.schemas.Format.full

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -93,7 +93,7 @@ class RuntimeKinds(object):
     dask = "dask"
     job = "job"
     spark = "spark"
-    remotespark = "remote-spark"
+    remote_spark = "remote-spark"
     mpijob = "mpijob"
     serving = "serving"
 
@@ -106,7 +106,7 @@ class RuntimeKinds(object):
             RuntimeKinds.dask,
             RuntimeKinds.job,
             RuntimeKinds.spark,
-            RuntimeKinds.remotespark,
+            RuntimeKinds.remote_spark,
             RuntimeKinds.mpijob,
         ]
 
@@ -116,7 +116,7 @@ class RuntimeKinds(object):
             RuntimeKinds.dask,
             RuntimeKinds.job,
             RuntimeKinds.spark,
-            RuntimeKinds.remotespark,
+            RuntimeKinds.remote_spark,
             RuntimeKinds.mpijob,
         ]
 
@@ -154,7 +154,7 @@ def get_runtime_handler(kind: str) -> BaseRuntimeHandler:
     kind_runtime_handler_map = {
         RuntimeKinds.dask: DaskRuntimeHandler,
         RuntimeKinds.spark: SparkRuntimeHandler,
-        RuntimeKinds.remotespark: RemoteSparkRuntimeHandler,
+        RuntimeKinds.remote_spark: RemoteSparkRuntimeHandler,
         RuntimeKinds.job: KubeRuntimeHandler,
     }
     runtime_handler_class = kind_runtime_handler_map[kind]
@@ -179,7 +179,7 @@ def get_runtime_class(kind: str):
         RuntimeKinds.dask: DaskCluster,
         RuntimeKinds.job: KubejobRuntime,
         RuntimeKinds.spark: SparkRuntime,
-        RuntimeKinds.remotespark: RemoteSparkRuntime,
+        RuntimeKinds.remote_spark: RemoteSparkRuntime,
     }
 
     return kind_runtime_map[kind]

--- a/mlrun/runtimes/nuclio.py
+++ b/mlrun/runtimes/nuclio.py
@@ -16,7 +16,7 @@ import json
 import socket
 
 from .serving import serving_subkind
-from ..db import get_or_set_dburl
+from ..db import get_or_set_db_url
 from ..model import RunTemplate
 from ..execution import MLClientCtx
 from ..serving.v1_serving import nuclio_serving_init
@@ -58,7 +58,7 @@ def nuclio_jobs_handler(context, event):
             status_code=400,
         )
 
-    out = get_or_set_dburl()
+    out = get_or_set_db_url()
     if out:
         context.logger.info(f"logging run results to: {out}")
 

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -200,7 +200,7 @@ class ServingRuntime(RemoteRuntime):
         :param exist_ok:     - allow overriding existing topology
         :param class_args:   - optional, router/flow class init args
 
-        :return graph object (fn.spec.graph)
+        :return: graph object (fn.spec.graph)
         """
         topology = topology or StateKinds.router
         if self.spec.graph and not exist_ok:
@@ -301,19 +301,20 @@ class ServingRuntime(RemoteRuntime):
     def add_child_function(
         self, name, url=None, image=None, requirements=None, kind=None
     ):
-        """in a multi-function pipeline add child function
+        """
+        Add a child function in a multi-function pipeline
 
         example::
 
             fn.add_child_function('enrich', './enrich.ipynb', 'mlrun/mlrun')
 
-        :param name:   child function name
-        :param url:    function/code url, support .py, .ipynb, .yaml extensions
-        :param image:  base docker image for the function
+        :param name:   Child function name
+        :param url:    Function/code url, support .py, .ipynb, .yaml extensions
+        :param image:  Base docker image for the function
         :param requirements: py package requirements file path OR list of packages
-        :param kind:   mlrun function/runtime kind
+        :param kind:   MLRun function/runtime kind
 
-        :return function object
+        :return: Function object
         """
         function_reference = FunctionReference(
             url, image, requirements=requirements, kind=kind or "serving"
@@ -357,7 +358,7 @@ class ServingRuntime(RemoteRuntime):
             self.spec.graph.clear_children(keys)
 
     def deploy(self, dashboard="", project="", tag="", verbose=False):
-        """deploy model serving function to a local/remote cluster
+        """Deploy model serving function to a local/remote cluster
 
         :param dashboard: remote nuclio dashboard url (blank for local or auto detection)
         :param project:   optional, overide function specified project name

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -567,7 +567,9 @@ class QueueState(BaseState):
 
 
 class FlowState(BaseState):
-    """flow state, represent a workflow or DAG"""
+    """
+    Flow state, represent a workflow or DAG
+    """
 
     kind = "flow"
     _dict_fields = BaseState._dict_fields + [

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -550,6 +550,7 @@ def retry_until_successful(
     """
     Runs function with given *args and **kwargs.
     Tries to run it until success or timeout reached (timeout is optional)
+
     :param interval: int/float that will be used as interval
     :param timeout: pass None if timeout is not wanted, number of seconds if it is
     :param logger: a logger so we can log the failures
@@ -557,7 +558,8 @@ def retry_until_successful(
     :param _function: function to run
     :param args: functions args
     :param kwargs: functions kwargs
-    :return: function result
+
+    :return: A function result
     """
     start_time = time.time()
     last_exception = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,13 @@
 # please keep this to a minimum - defaults are good
 [tool.black]
+include = '\.pyi?$'
 exclude = '''
-/(
-    \.git
-  | \.venv
-  | \venv
-)/
+(
+   /(   # exclude a few common directories in the root
+      \.git
+     | \.venv
+     | venv
+     | docs/_build
+   )/
+)
 '''


### PR DESCRIPTION
- Docstrings added where missing
- Typying added to the exposed SDK functions and classes as well
- There will be a part II for runtimes (and more?)

Infra:
- Fixed `pyproject.toml` and `.flake8` not ignoriog docs/_build properly which caused lint to fail after generating docs
