### PR TITLE
[Configuration] Duplicated configurations removal + default value fixes

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -127,7 +127,6 @@ default_config = {
     "model_endpoint_monitoring": {
         "container": "projects",
         "stream_url": "v3io:///projects/{project}/model-endpoints/stream",
-        "model_endpoint_monitoring": {"container": "projects"},
     },
     "secret_stores": {
         "vault": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -79,7 +79,7 @@ default_config = {
     "artifact_path": "",  # default artifacts path/url
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to
     #  configure this values on field systems, for newer system this will be configured correctly
-    "v3io_api": "http://v3io-webapi:8080",
+    "v3io_api": "http://v3io-webapi:8081",
     "v3io_framesd": "http://framesd:8080",
     # url template for default model tracking stream
     "httpdb": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -79,8 +79,8 @@ default_config = {
     "artifact_path": "",  # default artifacts path/url
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to
     #  configure this values on field systems, for newer system this will be configured correctly
-    "v3io_api": "http://v3io-webapi:8081",
-    "v3io_framesd": "http://framesd:8081",
+    "v3io_api": "http://v3io-webapi:8080",
+    "v3io_framesd": "http://framesd:8080",
     # url template for default model tracking stream
     "httpdb": {
         "port": 8080,


### PR DESCRIPTION
This PR removes a duplication that was created in the default configuration of mlrun. In addition, this PR changes the default port for v3io framesd