### PR TITLE
[Artifacts] Fix data frame artifacts failure to write as csv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,11 @@ jobs:
       run: make lint
 
   tests:
-    name: Run Dockerized Tests
+    name: Run Dockerized Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     # TODO: re-use the next 2 actions instead of duplicating
@@ -55,7 +58,7 @@ jobs:
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
         echo "::set-output name=tag::$(echo $unstable_tag)"
     - name: Run Dockerized tests
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
+      run: MLRUN_PYTHON_VERSION=${{ matrix.python-version }} MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
 
   integration-tests:
     name: Run Dockerized Integration Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,8 @@ jobs:
       run: make lint
 
   tests:
-    name: Run Dockerized Tests (Python ${{ matrix.python-version }})
+    name: Run Dockerized Tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     # TODO: re-use the next 2 actions instead of duplicating
@@ -58,7 +55,7 @@ jobs:
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
         echo "::set-output name=tag::$(echo $unstable_tag)"
     - name: Run Dockerized tests
-      run: MLRUN_PYTHON_VERSION=${{ matrix.python-version }} MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
 
   integration-tests:
     name: Run Dockerized Integration Tests

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -163,7 +163,7 @@ class BaseStoreTarget(DataTargetBase):
                 dir = os.path.dirname(target_path)
                 if dir:
                     os.makedirs(dir, exist_ok=True)
-            with fs.open(target_path, "w") as fp:
+            with fs.open(target_path, "wb") as fp:
                 self._write_dataframe(df, fp, **kwargs)
             try:
                 return fs.size(target_path)

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -163,7 +163,7 @@ class BaseStoreTarget(DataTargetBase):
                 dir = os.path.dirname(target_path)
                 if dir:
                     os.makedirs(dir, exist_ok=True)
-            with fs.open(target_path, "wb") as fp:
+            with fs.open(target_path, "w") as fp:
                 self._write_dataframe(df, fp, **kwargs)
             try:
                 return fs.size(target_path)

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -733,7 +733,7 @@ class MLClientCtx(object):
             feature_weights=feature_weights,
             extra_data=extra_data,
         )
-        if training_set:
+        if training_set is not None:
             model.infer_from_df(training_set, label_column)
 
         item = self._artifacts_manager.log_artifact(

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ nuclio-jupyter>=0.8.9
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0
-pandas~=1.0
+pandas~=1.2
 # used as a the engine for parquet files by pandas
 pyarrow~=1.0
 pyyaml~=5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ nuclio-jupyter>=0.8.9
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0
-pandas~=1.2
+pandas~=1.2; python_version >= '3.7'
+pandas~=1.0; python_version < '3.7'
 # used as a the engine for parquet files by pandas
 pyarrow~=1.0
 pyyaml~=5.1

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -51,15 +51,30 @@ def test_dataset_preview_size_limit():
     assert artifact.stats is None
 
 
-def test_dataset_upload():
+def test_dataset_upload_parquet():
     """
     This test fails when we use numpy>=1.20 and is here to reproduce the scenario that didn't work
     which caused us to upbound numpy to 1.20
     see https://github.com/Azure/MachineLearningNotebooks/issues/1314
     """
+    artifact = _generate_dataset_artifact(format_="parquet")
+    artifact.upload()
+
+
+def test_dataset_upload_csv():
+    """
+    This test fails when we use pandas<1.2 and is here to reproduce the scenario that didn't work
+    which caused us to upbound numpy to 1.20
+    see https://github.com/pandas-dev/pandas/pull/35129
+    """
+    artifact = _generate_dataset_artifact(format_="csv")
+    artifact.upload()
+
+
+def _generate_dataset_artifact(format_):
     data_frame = pandas.DataFrame({"x": [1, 2]})
     target_path = pathlib.Path(tests.conftest.results) / "dataset"
     artifact = mlrun.artifacts.dataset.DatasetArtifact(
-        df=data_frame, target_path=str(target_path)
+        df=data_frame, target_path=str(target_path), format=format_,
     )
-    artifact.upload()
+    return artifact

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -64,8 +64,8 @@ def test_dataset_upload_parquet():
 def test_dataset_upload_csv():
     """
     This test fails when we use pandas<1.2 and is here to reproduce the scenario that didn't work
-    which caused us to upbound numpy to 1.20
-    see https://github.com/pandas-dev/pandas/pull/35129
+    which caused us to downbound pandas to 1.2
+    see https://pandas.pydata.org/docs/whatsnew/v1.2.0.html#support-for-binary-file-handles-in-to-csv
     """
     artifact = _generate_dataset_artifact(format_="csv")
     artifact.upload()


### PR DESCRIPTION
Since this change https://github.com/mlrun/mlrun/pull/752 we started providing pandas the file when writing `to_csv`
The file is open with `wb` and pandas had a bug with that which was solved in 1.2.0, so changed the requirement from `~1.0` to `~1.2`, the problem is that in 1.2.0 pandas dropped support to python 3.6, so only in python 3.6, the requirement will stay the same, and we'll open the file in `wt` mode which might prevent some features

The error we were seeing was:
```
  File "/opt/conda/lib/python3.7/site-packages/mlrun/execution.py", line 651, in log_dataset
    labels=labels,
  File "/opt/conda/lib/python3.7/site-packages/mlrun/artifacts/manager.py", line 155, in log_artifact
    item.upload()
  File "/opt/conda/lib/python3.7/site-packages/mlrun/artifacts/dataset.py", line 136, in upload
    **self._kw,
  File "/opt/conda/lib/python3.7/site-packages/mlrun/artifacts/dataset.py", line 289, in upload_dataframe
    return target_class(path=target_path).write_dataframe(df, **kw)
  File "/opt/conda/lib/python3.7/site-packages/mlrun/datastore/targets.py", line 166, in write_dataframe
    self._write_dataframe(df, fp, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/mlrun/datastore/targets.py", line 275, in _write_dataframe
    df.to_csv(target, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/pandas/core/generic.py", line 3204, in to_csv
    formatter.save()
  File "/opt/conda/lib/python3.7/site-packages/pandas/io/formats/csvs.py", line 204, in save
    self._save()
  File "/opt/conda/lib/python3.7/site-packages/pandas/io/formats/csvs.py", line 309, in _save
    self._save_header()
  File "/opt/conda/lib/python3.7/site-packages/pandas/io/formats/csvs.py", line 278, in _save_header
    writer.writerow(encoded_labels)
TypeError: a bytes-like object is required, not 'str'
```

Some related links we used:
https://duckpond.ch/python/bash/2020/05/07/support-binary-file-objects-with-pandas.dataframe.to_csv.html
https://pandas.pydata.org/docs/whatsnew/v1.2.0.html#support-for-binary-file-handles-in-to-csv
https://github.com/pandas-dev/pandas/issues/19827