### PR TITLE
[Functions] Validate k8s resources quantity regex on assignment

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -184,15 +184,21 @@ class KubeResource(BaseRuntime):
         """set pod cpu/memory/gpu limits"""
         if mem:
             verify_field_regex(
-                "function.limits.memory", mem, mlrun.utils.regex.k8s_resource_quantity_regex
+                "function.limits.memory",
+                mem,
+                mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if cpu:
             verify_field_regex(
-                "function.limits.cpu", cpu, mlrun.utils.regex.k8s_resource_quantity_regex
+                "function.limits.cpu",
+                cpu,
+                mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if gpus:
             verify_field_regex(
-                "function.limits.gpus", gpus, mlrun.utils.regex.k8s_resource_quantity_regex
+                "function.limits.gpus",
+                gpus,
+                mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         update_in(
             self.spec.resources,
@@ -204,17 +210,27 @@ class KubeResource(BaseRuntime):
         """set requested (desired) pod cpu/memory/gpu resources"""
         if mem:
             verify_field_regex(
-                "function.requests.memory", mem, mlrun.utils.regex.k8s_resource_quantity_regex
+                "function.requests.memory",
+                mem,
+                mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if cpu:
             verify_field_regex(
-                "function.requests.cpu", cpu, mlrun.utils.regex.k8s_resource_quantity_regex
+                "function.requests.cpu",
+                cpu,
+                mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if gpus:
             verify_field_regex(
-                "function.requests.gpus", gpus, mlrun.utils.regex.k8s_resource_quantity_regex
+                "function.requests.gpus",
+                gpus,
+                mlrun.utils.regex.k8s_resource_quantity_regex,
             )
-        update_in(self.spec.resources, "requests", generate_resources(mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type))
+        update_in(
+            self.spec.resources,
+            "requests",
+            generate_resources(mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type),
+        )
 
     def _get_meta(self, runobj, unique=False):
         namespace = self._get_k8s().resolve_namespace()

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -206,7 +206,7 @@ class KubeResource(BaseRuntime):
             generate_resources(mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type),
         )
 
-    def with_requests(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def with_requests(self, mem=None, cpu=None):
         """set requested (desired) pod cpu/memory/gpu resources"""
         if mem:
             verify_field_regex(
@@ -220,16 +220,8 @@ class KubeResource(BaseRuntime):
                 cpu,
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )
-        if gpus:
-            verify_field_regex(
-                "function.requests.gpus",
-                gpus,
-                mlrun.utils.regex.k8s_resource_quantity_regex,
-            )
         update_in(
-            self.spec.resources,
-            "requests",
-            generate_resources(mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type),
+            self.spec.resources, "requests", generate_resources(mem=mem, cpu=cpu),
         )
 
     def _get_meta(self, runobj, unique=False):

--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -16,6 +16,9 @@ dns_1123_label = [
     r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
 ]
 
+# https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go#L136
+k8s_resource_quantity_regex = [r"^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"]
+
 run_name = label_value
 
 # A project name have the following restrictions:

--- a/tests/api/runtimes/test_pod.py
+++ b/tests/api/runtimes/test_pod.py
@@ -1,0 +1,40 @@
+import pytest
+
+import mlrun
+import mlrun.errors
+
+
+def test_with_limits_regex_validation():
+    cases = [
+        {
+            "cpu": "no-number",
+            "expected_failure": True,
+        },
+        {
+            "memory": "1g",  # common mistake
+            "expected_failure": True,
+        },
+        {
+            "gpus": "1GPU",
+            "expected_failure": True,
+        },
+        {
+            "cpu": "12e6",
+        },
+        {
+            "memory": "12Mi",
+        },
+        {
+            "memory": "12M",
+        },
+    ]
+    for case in cases:
+        function = mlrun.runtimes.KubejobRuntime()
+        if case.get('expected_failure'):
+            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                function.with_limits(case.get('memory'), case.get('cpu'), case.get('gpus'))
+            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                function.with_requests(case.get('memory'), case.get('cpu'), case.get('gpus'))
+        else:
+            function.with_limits(case.get('memory'), case.get('cpu'), case.get('gpus'))
+            function.with_requests(case.get('memory'), case.get('cpu'), case.get('gpus'))

--- a/tests/api/runtimes/test_pod.py
+++ b/tests/api/runtimes/test_pod.py
@@ -20,12 +20,10 @@ def test_with_limits_regex_validation():
                 function.with_limits(
                     case.get("memory"), case.get("cpu"), case.get("gpus")
                 )
-            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-                function.with_requests(
-                    case.get("memory"), case.get("cpu"), case.get("gpus")
-                )
+            if not case.get("gpus"):
+                with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                    function.with_requests(case.get("memory"), case.get("cpu"))
         else:
             function.with_limits(case.get("memory"), case.get("cpu"), case.get("gpus"))
-            function.with_requests(
-                case.get("memory"), case.get("cpu"), case.get("gpus")
-            )
+            if not case.get("gpus"):
+                function.with_requests(case.get("memory"), case.get("cpu"))

--- a/tests/api/runtimes/test_pod.py
+++ b/tests/api/runtimes/test_pod.py
@@ -6,35 +6,26 @@ import mlrun.errors
 
 def test_with_limits_regex_validation():
     cases = [
-        {
-            "cpu": "no-number",
-            "expected_failure": True,
-        },
-        {
-            "memory": "1g",  # common mistake
-            "expected_failure": True,
-        },
-        {
-            "gpus": "1GPU",
-            "expected_failure": True,
-        },
-        {
-            "cpu": "12e6",
-        },
-        {
-            "memory": "12Mi",
-        },
-        {
-            "memory": "12M",
-        },
+        {"cpu": "no-number", "expected_failure": True},
+        {"memory": "1g", "expected_failure": True},  # common mistake
+        {"gpus": "1GPU", "expected_failure": True},
+        {"cpu": "12e6"},
+        {"memory": "12Mi"},
+        {"memory": "12M"},
     ]
     for case in cases:
         function = mlrun.runtimes.KubejobRuntime()
-        if case.get('expected_failure'):
+        if case.get("expected_failure"):
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-                function.with_limits(case.get('memory'), case.get('cpu'), case.get('gpus'))
+                function.with_limits(
+                    case.get("memory"), case.get("cpu"), case.get("gpus")
+                )
             with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-                function.with_requests(case.get('memory'), case.get('cpu'), case.get('gpus'))
+                function.with_requests(
+                    case.get("memory"), case.get("cpu"), case.get("gpus")
+                )
         else:
-            function.with_limits(case.get('memory'), case.get('cpu'), case.get('gpus'))
-            function.with_requests(case.get('memory'), case.get('cpu'), case.get('gpus'))
+            function.with_limits(case.get("memory"), case.get("cpu"), case.get("gpus"))
+            function.with_requests(
+                case.get("memory"), case.get("cpu"), case.get("gpus")
+            )


### PR DESCRIPTION
When calling `with_limits` or `with_requests` we validate that the given quantity is a valid one
This will help prevent common failures like users mistakenly set memory limit to `1g` which is invalid (should be `1G`)
This implements https://jira.iguazeng.com/browse/ML-14