### PR TITLE
[Artifacts] Add tag to artifacts returned in get/list APIs

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -240,6 +240,20 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
             tag = tag or "latest"
             self.tag_artifacts(session, [art], project, tag)
 
+    def _add_tag_to_artifact_struct(
+        self, session, artifact_struct, artifact_id, tag=None
+    ):
+        if tag:
+            artifact_struct["tag"] = tag
+        else:
+            tag_object = self._query(
+                session, Artifact.Tag, obj_id=artifact_id
+            ).one_or_none()
+            if tag_object:
+                artifact_struct["tag"] = tag_object.name
+            else:
+                artifact_struct["tag"] = None
+
     def read_artifact(self, session, key, tag="", iter=None, project=""):
         project = project or config.default_project
         uids = self._resolve_tag(session, Artifact, project, tag)
@@ -248,6 +262,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
 
         query = self._query(session, Artifact, key=key, project=project)
 
+        # This will hold the real tag of the object (if exists). Will be placed in the artifact structure.
+        db_tag = None
+
         # TODO: refactor this
         # tag has 2 meanings:
         # 1. tag - in this case _resolve_tag will find the relevant uids and will return a list
@@ -255,6 +272,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         # represents the uid
         if isinstance(uids, list) and uids:
             query = query.filter(Artifact.uid.in_(uids))
+            db_tag = tag
         elif isinstance(uids, str) and uids:
             query = query.filter(Artifact.uid == uids)
         else:
@@ -267,7 +285,11 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         art = query.one_or_none()
         if not art:
             raise DBError(f"Artifact {key}:{tag}:{project} not found")
-        return art.struct
+
+        artifact_struct = art.struct
+        self._add_tag_to_artifact_struct(session, artifact_struct, art.id, db_tag)
+
+        return artifact_struct
 
     def list_artifacts(
         self,
@@ -290,12 +312,14 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         if tag:
             uids = self._resolve_tag(session, Artifact, project, tag)
 
-        artifacts = ArtifactList(
-            artifact.struct
-            for artifact in self._find_artifacts(
-                session, project, uids, labels, since, until, name, kind, category
-            )
-        )
+        artifacts = ArtifactList()
+        for artifact in self._find_artifacts(
+            session, project, uids, labels, since, until, name, kind, category
+        ):
+            artifact_struct = artifact.struct
+            self._add_tag_to_artifact_struct(session, artifact_struct, artifact.id, tag)
+            artifacts.append(artifact_struct)
+
         return artifacts
 
     def del_artifact(self, session, key, tag="", project=""):

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -364,7 +364,7 @@ def test_data_migration_fix_datasets_large_previews(
             artifact_with_valid_preview_after_migration,
             artifact_with_valid_preview.to_dict(),
             ignore_order=True,
-            exclude_paths=["root['updated']"],
+            exclude_paths=["root['updated']", "root['tag']"],
         )
         == {}
     )
@@ -383,6 +383,7 @@ def test_data_migration_fix_datasets_large_previews(
                 "root['stats']",
                 "root['schema']",
                 "root['preview']",
+                "root['tag']",
             ],
         )
         == {}

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -164,6 +164,15 @@ def test_read_and_list_artifacts_with_tags(db: SQLDB, db_session: Session):
     result = db.list_artifacts(db_session, k1, prj)
     assert deepdiff.DeepDiff(result, expected_results, ignore_order=True) == {}
 
+    db.store_artifact(db_session, k1, art1, u1, iter=1, project=prj, tag="tag3")
+    result = db.read_artifact(db_session, k1, "tag3", iter=1, project=prj)
+    assert result["tag"] == "tag3"
+    expected_results.append(result)
+
+    result = db.list_artifacts(db_session, k1, prj)
+    # We want to ignore the "updated" field, since it changes as we store a new tag.
+    exclude_regex = r"root\[\d+\]\['updated'\]"
+    assert deepdiff.DeepDiff(result, expected_results, ignore_order=True, exclude_regex_paths=exclude_regex) == {}
 
 @pytest.mark.parametrize(
     "cls", [tagged_model for tagged_model in _tagged if tagged_model != Run]

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -172,7 +172,16 @@ def test_read_and_list_artifacts_with_tags(db: SQLDB, db_session: Session):
     result = db.list_artifacts(db_session, k1, prj)
     # We want to ignore the "updated" field, since it changes as we store a new tag.
     exclude_regex = r"root\[\d+\]\['updated'\]"
-    assert deepdiff.DeepDiff(result, expected_results, ignore_order=True, exclude_regex_paths=exclude_regex) == {}
+    assert (
+        deepdiff.DeepDiff(
+            result,
+            expected_results,
+            ignore_order=True,
+            exclude_regex_paths=exclude_regex,
+        )
+        == {}
+    )
+
 
 @pytest.mark.parametrize(
     "cls", [tagged_model for tagged_model in _tagged if tagged_model != Run]

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -131,9 +131,13 @@ def test_read_and_list_artifacts_with_tags(db: SQLDB, db_session: Session):
     result = db.read_artifact(db_session, k1, "tag2", iter=2, project=prj)
     assert result["tag"] == "tag2"
     result = db.read_artifact(db_session, k1, iter=1, project=prj)
-    assert result["tag"] == "tag1"
+    # When doing get without a tag, the returned object must not contain a tag.
+    assert "tag" not in result
     # read_artifact supports a case where the tag is actually the uid.
     result = db.read_artifact(db_session, k1, tag="u2", iter=2, project=prj)
+    assert "tag" not in result
+
+    result = db.read_artifact(db_session, k1, "tag2", iter=2, project=prj)
     assert result["tag"] == "tag2"
 
     result = db.list_artifacts(db_session, k1, project=prj)


### PR DESCRIPTION
When listing or querying artifacts, the returned results will have a `tag` field in them indicating the tag of the object. 
The `tag` field will always be present, even if there's no tag (in which case it will be `None`).
As is the case for every other object in the MLRun DB - if an artifact has multiple tags and a list API requests all of them (i.e. doesn't filter by tag), the same object will be returned multiple times, each with a different tag associated.