### PR TITLE
[Runtimes] Set the default project in the runtime context to be the run project

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -268,7 +268,7 @@ def _load_func_code(command="", workdir=None, secrets=None, name="name"):
 
 
 def get_or_create_ctx(
-    name: str, event=None, spec=None, with_env: bool = True, rundb: str = ""
+    name: str, event=None, spec=None, with_env: bool = True, rundb: str = "", project: str = ""
 ):
     """called from within the user program to obtain a run context
 
@@ -284,6 +284,7 @@ def get_or_create_ctx(
     :param spec:     dictionary holding run spec
     :param with_env: look for context in environment vars, default True
     :param rundb:    path/url to the metadata and artifact database
+    :param project:    project to initiate the context in (by default mlrun.mlctx.default_project)
 
     :return: execution context
 
@@ -342,6 +343,7 @@ def get_or_create_ctx(
     if not newspec:
         newspec = {}
 
+    newspec.setdefault("metadata", {})
     update_in(newspec, "metadata.name", name, replace=False)
     autocommit = False
     tmp = environ.get("MLRUN_META_TMPFILE")
@@ -349,6 +351,8 @@ def get_or_create_ctx(
     if out:
         autocommit = True
         logger.info(f"logging run results to: {out}")
+
+    newspec["metadata"]['project'] = project or newspec["metadata"].get('project') or mlconf.default_project
 
     ctx = MLClientCtx.from_dict(
         newspec, rundb=out, autocommit=autocommit, tmp=tmp, host=socket.gethostname()

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -268,7 +268,12 @@ def _load_func_code(command="", workdir=None, secrets=None, name="name"):
 
 
 def get_or_create_ctx(
-    name: str, event=None, spec=None, with_env: bool = True, rundb: str = "", project: str = ""
+    name: str,
+    event=None,
+    spec=None,
+    with_env: bool = True,
+    rundb: str = "",
+    project: str = "",
 ):
     """called from within the user program to obtain a run context
 
@@ -352,7 +357,9 @@ def get_or_create_ctx(
         autocommit = True
         logger.info(f"logging run results to: {out}")
 
-    newspec["metadata"]['project'] = project or newspec["metadata"].get('project') or mlconf.default_project
+    newspec["metadata"]["project"] = (
+        project or newspec["metadata"].get("project") or mlconf.default_project
+    )
 
     ctx = MLClientCtx.from_dict(
         newspec, rundb=out, autocommit=autocommit, tmp=tmp, host=socket.gethostname()

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -289,7 +289,7 @@ def get_or_create_ctx(
     :param spec:     dictionary holding run spec
     :param with_env: look for context in environment vars, default True
     :param rundb:    path/url to the metadata and artifact database
-    :param project:    project to initiate the context in (by default mlrun.mlctx.default_project)
+    :param project:  project to initiate the context in (by default mlrun.mlctx.default_project)
 
     :return: execution context
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -484,7 +484,10 @@ class BaseRuntime(ModelObj):
             return task.to_dict()
 
     def _generate_runtime_env(self, runobj: RunObject):
-        runtime_env = {"MLRUN_EXEC_CONFIG": runobj.to_json()}
+        runtime_env = {
+            "MLRUN_EXEC_CONFIG": runobj.to_json(),
+            "MLRUN_DEFAULT_PROJECT": runobj.metadata.project or self.metadata.project or config.default_project,
+        }
         if runobj.spec.verbose:
             runtime_env["MLRUN_LOG_LEVEL"] = "DEBUG"
         if config.httpdb.api_url:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -486,7 +486,9 @@ class BaseRuntime(ModelObj):
     def _generate_runtime_env(self, runobj: RunObject):
         runtime_env = {
             "MLRUN_EXEC_CONFIG": runobj.to_json(),
-            "MLRUN_DEFAULT_PROJECT": runobj.metadata.project or self.metadata.project or config.default_project,
+            "MLRUN_DEFAULT_PROJECT": runobj.metadata.project
+            or self.metadata.project
+            or config.default_project,
         }
         if runobj.spec.verbose:
             runtime_env["MLRUN_LOG_LEVEL"] = "DEBUG"

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -337,7 +337,9 @@ class RemoteRuntime(KubeResource):
 
     def _get_runtime_env(self):
         # for runtime specific env var enrichment (before deploy)
-        runtime_env = {}
+        runtime_env = {
+            "MLRUN_DEFAULT_PROJECT": self.metadata.project or mlconf.default_project,
+        }
         if self.spec.rundb or mlconf.httpdb.api_url:
             runtime_env["MLRUN_DBPATH"] = self.spec.rundb or mlconf.httpdb.api_url
         if mlconf.namespace:

--- a/tests/integration/sdk_api/run/test_run.py
+++ b/tests/integration/sdk_api/run/test_run.py
@@ -1,0 +1,13 @@
+import mlrun
+import tests.integration.sdk_api.base
+
+
+class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
+    def test_ctx_creation_creates_run_with_project(self):
+        ctx_name = "some-context"
+        mlrun.get_or_create_ctx(ctx_name)
+        runs = mlrun.get_run_db().list_runs(
+            name=ctx_name, project=mlrun.mlconf.default_project
+        )
+        assert len(runs) == 1
+        assert runs[0]["metadata"]["project"] == mlrun.mlconf.default_project


### PR DESCRIPTION
What happened ?
Inside a Nuclio function (i.e. no actual Run context, code inside is of function context), in the init_context part, `get_or_create_ctx` called, that call is generating a Run object, but it was being generated in the `default` project + the Run object itself didn't contain the `project` attribute

This PR do 2 things:
1. Ensure to fill the project attribute in the Run object created in the ctx creation
2. Sets the `MLRUN_DEFAULT_PROJECT` env var on every job/function pod, so that in that job/function context, the default project will be the project of the job/function