### PR TITLE
[Feature store] Fix store new feature-set or vector not setting tag properly

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1287,6 +1287,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
             session, FeatureSet, project, name, tag, uid
         )
         if not existing_feature_set:
+            feature_set.metadata.tag = tag
             return self.create_feature_set(session, project, feature_set, versioned)
 
         feature_set_dict = feature_set.dict()
@@ -1517,6 +1518,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
             session, FeatureVector, project, name, tag, uid
         )
         if not existing_feature_vector:
+            feature_vector.metadata.tag = tag
             return self.create_feature_vector(
                 session, project, feature_vector, versioned
             )


### PR DESCRIPTION
Scenario:
1. Perform store on object, with `tag != 'latest'`
2. Look for the object - the tag is wrong, and entered as `latest`
3. Perform same store again, with same tag
4. Results in 409 (Conflict)

Issue was in the `store_*` methods which in case the object did not previously exist did not honour the tag parameter, and the object was stored with tag `latest` instead (which is the default tag if none is provided). 