### PR TITLE
[System tests enterprise] Fix failure on pulling provctl while provazio is mid release

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -26,6 +26,7 @@ class SystemTestPreparer:
 
         git_url = "https://github.com/mlrun/mlrun.git"
         provctl_releases = "https://api.github.com/repos/iguazio/provazio/releases"
+        provctl_release_search_amount = 3
         provctl_binary_format = "provctl-{release_name}-linux-amd64"
 
     def __init__(
@@ -252,20 +253,25 @@ class SystemTestPreparer:
         stable_provazio_releases = list(
             filter(lambda release: release["tag_name"] != "unstable", provazio_releases)
         )
-        latest_provazio_release = stable_provazio_releases[0]
-        for asset in latest_provazio_release["assets"]:
-            if asset["name"] == self.Constants.provctl_binary_format.format(
-                release_name=latest_provazio_release["name"]
-            ):
-                self._logger.debug(
-                    "Got provctl release url",
-                    release=latest_provazio_release["name"],
-                    name=asset["name"],
-                    url=asset["url"],
-                )
-                return asset["name"], asset["url"]
+        latest_provazio_releases = stable_provazio_releases[
+            : self.Constants.provctl_release_search_amount
+        ]
+        for provazio_release in latest_provazio_releases:
+            for asset in provazio_release["assets"]:
+                if asset["name"] == self.Constants.provctl_binary_format.format(
+                    release_name=provazio_release["name"]
+                ):
+                    self._logger.debug(
+                        "Got provctl release url",
+                        release=provazio_release["name"],
+                        name=asset["name"],
+                        url=asset["url"],
+                    )
+                    return asset["name"], asset["url"]
 
-        raise RuntimeError("provctl binary not found")
+        raise RuntimeError(
+            f"provctl binary not found in {self.Constants.provctl_release_search_amount} latest releases"
+        )
 
     def _prepare_test_env(self):
 


### PR DESCRIPTION
If the system tests run at during a provazio release. The system tests' preparer can fail because the latest release of provazio hasn't yet a built provctl binary.

Made the preparer loop over the latest 3 releases to look for the binary in each release before failing. 
(It should never exceed the second release, but added a third for safety)