### PR TITLE
[Images] Pin and align tensorflow in models and models-gpu images

### DIFF
--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -118,15 +118,12 @@ RUN conda config --add channels conda-forge && \
         scipy \
         seaborn \
         tensorflow-gpu \
-        wrapt \
-    && conda clean -aqy
+        wrapt
 
 RUN conda install -n base -c rapidsai -c nvidia \
-    -c anaconda -c conda-forge -c defaults rapids=0.12 python=3.7 \
-    && conda clean -aqy
+    -c anaconda -c conda-forge -c defaults rapids=0.12 python=3.7
 
-RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1 \
-    && conda clean -aqy
+RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
 
 RUN python -m pip install --upgrade pip~=20.2.0
 

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -117,13 +117,16 @@ RUN conda config --add channels conda-forge && \
         scikit-plot \
         scipy \
         seaborn \
-        tensorflow-gpu \
-        wrapt
+        tensorflow-gpu=2.3 \
+        wrapt \
+    && conda clean -aqy
 
 RUN conda install -n base -c rapidsai -c nvidia \
-    -c anaconda -c conda-forge -c defaults rapids=0.12 python=3.7
+    -c anaconda -c conda-forge -c defaults rapids=0.12 python=3.7 \
+    && conda clean -aqy
 
-RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1
+RUN conda install -n base -c pytorch pytorch torchvision cudatoolkit=10.1 \
+    && conda clean -aqy
 
 RUN python -m pip install --upgrade pip~=20.2.0
 

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -117,7 +117,7 @@ RUN conda config --add channels conda-forge && \
         scikit-plot \
         scipy \
         seaborn \
-        tensorflow-gpu=2.3.0 \
+        tensorflow-gpu=2.2.0 \
         wrapt \
     && conda clean -aqy
 

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -117,7 +117,7 @@ RUN conda config --add channels conda-forge && \
         scikit-plot \
         scipy \
         seaborn \
-        tensorflow-gpu=2.3 \
+        tensorflow-gpu=2.3.0 \
         wrapt \
     && conda clean -aqy
 

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -60,7 +60,7 @@ RUN conda install -y -c plotly plotly-orca && \
 RUN python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN python -m pip install -U 'intel-tensorflow==2.3.0' mxnet
+RUN python -m pip install -U 'intel-tensorflow==2.2.0' mxnet
 
 RUN HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1 \
     python -m pip install 'horovod~=0.20.0'


### PR DESCRIPTION
I started seeing a failure when building the `models-gpu` image, full log is attached.
The error happened at the layer that installs horovod and the message is:
```
Could NOT find Tensorflow: Found unsuitable version "1.14.0", but required
    is at least "1.15.0" (found
    -L/opt/conda/lib/python3.7/site-packages/tensorflow;-l:libtensorflow_framework.so.1)
```
I tried going back in the code to 0.6.1 (which when we released it, the models-gpu image was built successfully) and trying to build produced the same error, so I understood the problem is not a change in code that we did.
I found [here](https://anaconda.org/anaconda/tensorflow-gpu/files) that a new version of `tensorflow-gpu` 2.4.1 - was released recently (8/3)
Looking on the build logs I saw that we install the `tensorflow-gpu` two layers before the horovod installation, and that there it indeed resolved to 2.4.1, but a the middle layer, when it tries to install `rapids=0.12` it eventually (after trying different dependency resolution strategies) find that it needs to downgrade tensorflow to 1.14.0
My theory (didn't verify it) is that the installation of tensorflow 2.4.1 caused to resolve some other packages versions, that does not comply with `rapids=0.12` and when it do the resolution here, it first "picks" some older versions of certain packages, but the only tensorflow version that comply with these packages versions is 1.14.0
Bottomline what solved it was to pin `tensorflow-gpu` to 2.2.0 (there is also 2.3.0 but it's only for windows, see [here](https://anaconda.org/anaconda/tensorflow-gpu/files))
I noticed that in the models image [we pinned](https://github.com/mlrun/mlrun/pull/699) 'intel-tensorflow==2.3.0' so aligned it to be 2.2.0 as well
[models-gpu-failure-log.txt](https://github.com/mlrun/mlrun/files/6124934/models-gpu-failure-log.txt)
