### PR TITLE
[Runtimes] Support setting node name, node selector and affinity

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -308,12 +308,13 @@ class RemoteRuntime(KubeResource):
         logger.info(f"function deployed, address={self.status.address}")
         return self.spec.command
 
-    def with_node_selection(self, node_name: typing.Optional[str] = None,
-                            node_selector: typing.Optional[typing.Dict[str, str]] = None,
-                            affinity: typing.Optional[client.V1Affinity] = None):
-        raise NotImplementedError(
-            "Node selection is not supported for nuclio runtime"
-        )
+    def with_node_selection(
+        self,
+        node_name: typing.Optional[str] = None,
+        node_selector: typing.Optional[typing.Dict[str, str]] = None,
+        affinity: typing.Optional[client.V1Affinity] = None,
+    ):
+        raise NotImplementedError("Node selection is not supported for nuclio runtime")
 
     def _get_state(
         self,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import asyncio
+from kubernetes import client
 import json
+import typing
 from datetime import datetime
 from os import environ
 from time import sleep
@@ -305,6 +307,21 @@ class RemoteRuntime(KubeResource):
 
         logger.info(f"function deployed, address={self.status.address}")
         return self.spec.command
+
+    def with_node_name(self, node_name: str = None):
+        raise NotImplementedError(
+            "Setting node name is not supported for nuclio runtime"
+        )
+
+    def with_node_selector(self, node_selector: typing.Dict[str, str] = None):
+        raise NotImplementedError(
+            "Setting node selector is not supported for nuclio runtime"
+        )
+
+    def with_affinity(self, affinity: client.V1Affinity = None):
+        raise NotImplementedError(
+            "Setting affinity is not supported for nuclio runtime"
+        )
 
     def _get_state(
         self,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -308,19 +308,11 @@ class RemoteRuntime(KubeResource):
         logger.info(f"function deployed, address={self.status.address}")
         return self.spec.command
 
-    def with_node_name(self, node_name: str = None):
+    def with_node_selection(self, node_name: typing.Optional[str] = None,
+                            node_selector: typing.Optional[typing.Dict[str, str]] = None,
+                            affinity: typing.Optional[client.V1Affinity] = None):
         raise NotImplementedError(
-            "Setting node name is not supported for nuclio runtime"
-        )
-
-    def with_node_selector(self, node_selector: typing.Dict[str, str] = None):
-        raise NotImplementedError(
-            "Setting node selector is not supported for nuclio runtime"
-        )
-
-    def with_affinity(self, affinity: client.V1Affinity = None):
-        raise NotImplementedError(
-            "Setting affinity is not supported for nuclio runtime"
+            "Node selection is not supported for nuclio runtime"
         )
 
     def _get_state(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-from kubernetes import client
 import json
 import typing
 from datetime import datetime
@@ -23,6 +22,7 @@ from time import sleep
 import nuclio
 import requests
 from aiohttp.client import ClientSession
+from kubernetes import client
 from nuclio.deploy import deploy_config, find_dashboard_url, get_deploy_status
 from nuclio.triggers import V3IOStreamTrigger
 

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -25,7 +25,7 @@ from ..kfpops import build_op
 from ..model import RunObject
 from ..utils import get_in, logger
 from .base import RunError
-from .pod import KubeResource
+from .pod import KubeResource, kube_resource_spec_to_pod_spec
 from .utils import AsyncLogWriter, generate_function_image_name
 
 
@@ -268,12 +268,7 @@ def func_to_pod(image, runtime, extra_env, command, args, workdir):
         resources=runtime.spec.resources,
     )
 
-    pod_spec = client.V1PodSpec(
-        containers=[container],
-        restart_policy="Never",
-        volumes=runtime.spec.volumes,
-        service_account=runtime.spec.service_account,
-    )
+    pod_spec = kube_resource_spec_to_pod_spec(runtime.spec, container)
 
     if runtime.spec.image_pull_secret:
         pod_spec.image_pull_secrets = [

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -48,6 +48,9 @@ class MPIResourceSpec(KubeResourceSpec):
         build=None,
         image_pull_secret=None,
         mpi_args=None,
+        node_name=None,
+        node_selector=None,
+        affinity=None,
     ):
         super().__init__(
             command=command,
@@ -67,6 +70,9 @@ class MPIResourceSpec(KubeResourceSpec):
             service_account=service_account,
             image_pull_secret=image_pull_secret,
             args=args,
+            node_name=node_name,
+            node_selector=node_selector,
+            affinity=affinity,
         )
         self.mpi_args = mpi_args or [
             "-x",

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -187,7 +187,9 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
             update_in(pod_template, "spec.volumes", self.spec.volumes)
             update_in(pod_template, "spec.nodeName", self.spec.node_name)
             update_in(pod_template, "spec.nodeSelector", self.spec.node_selector)
-            update_in(pod_template, "spec.affinity", self.spec._get_sanitized_affinity())
+            update_in(
+                pod_template, "spec.affinity", self.spec._get_sanitized_affinity()
+            )
 
         # configuration for workers only
         # update resources only for workers because the launcher

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -187,7 +187,7 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
             update_in(pod_template, "spec.volumes", self.spec.volumes)
             update_in(pod_template, "spec.nodeName", self.spec.node_name)
             update_in(pod_template, "spec.nodeSelector", self.spec.node_selector)
-            update_in(pod_template, "spec.affinity", self.spec.affinity)
+            update_in(pod_template, "spec.affinity", self.spec._get_sanitized_affinity())
 
         # configuration for workers only
         # update resources only for workers because the launcher

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -50,6 +50,9 @@ class MPIV1ResourceSpec(MPIResourceSpec):
         image_pull_secret=None,
         mpi_args=None,
         clean_pod_policy=None,
+        node_name=None,
+        node_selector=None,
+        affinity=None,
     ):
         super().__init__(
             command=command,
@@ -70,6 +73,9 @@ class MPIV1ResourceSpec(MPIResourceSpec):
             image_pull_secret=image_pull_secret,
             args=args,
             mpi_args=mpi_args,
+            node_name=node_name,
+            node_selector=node_selector,
+            affinity=affinity,
         )
         self.clean_pod_policy = clean_pod_policy or MPIJobV1CleanPodPolicies.default()
 

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -185,6 +185,9 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
                 )
             update_in(pod_template, "metadata.labels", pod_labels)
             update_in(pod_template, "spec.volumes", self.spec.volumes)
+            update_in(pod_template, "spec.nodeName", self.spec.node_name)
+            update_in(pod_template, "spec.nodeSelector", self.spec.node_selector)
+            update_in(pod_template, "spec.affinity", self.spec.affinity)
 
         # configuration for workers only
         # update resources only for workers because the launcher

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -77,7 +77,7 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
         self._update_container(job, "volumeMounts", self.spec.volume_mounts)
         update_in(job, "spec.template.spec.nodeName", self.spec.node_name)
         update_in(job, "spec.template.spec.nodeSelector", self.spec.node_selector)
-        update_in(job, "spec.template.spec.affinity", self.spec.affinity)
+        update_in(job, "spec.template.spec.affinity", self.spec._get_sanitized_affinity())
 
         extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -77,7 +77,9 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
         self._update_container(job, "volumeMounts", self.spec.volume_mounts)
         update_in(job, "spec.template.spec.nodeName", self.spec.node_name)
         update_in(job, "spec.template.spec.nodeSelector", self.spec.node_selector)
-        update_in(job, "spec.template.spec.affinity", self.spec._get_sanitized_affinity())
+        update_in(
+            job, "spec.template.spec.affinity", self.spec._get_sanitized_affinity()
+        )
 
         extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -75,6 +75,9 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
             self._update_container(job, "image", self.full_image_path())
         update_in(job, "spec.template.spec.volumes", self.spec.volumes)
         self._update_container(job, "volumeMounts", self.spec.volume_mounts)
+        update_in(job, "spec.template.spec.nodeName", self.spec.node_name)
+        update_in(job, "spec.template.spec.nodeSelector", self.spec.node_selector)
+        update_in(job, "spec.template.spec.affinity", self.spec.affinity)
 
         extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
 import typing
+import uuid
 from copy import deepcopy
 
 from kfp.dsl import ContainerOp
@@ -318,7 +318,9 @@ class KubeResource(BaseRuntime):
         )
 
 
-def kube_resource_spec_to_pod_spec(kube_resource_spec: KubeResourceSpec, container: client.V1Container):
+def kube_resource_spec_to_pod_spec(
+    kube_resource_spec: KubeResourceSpec, container: client.V1Container
+):
     return client.V1PodSpec(
         containers=[container],
         restart_policy="Never",

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -278,9 +278,12 @@ class KubeResource(BaseRuntime):
             self.spec.resources, "requests", generate_resources(mem=mem, cpu=cpu),
         )
 
-    def with_node_selection(self, node_name: typing.Optional[str] = None,
-                            node_selector: typing.Optional[typing.Dict[str, str]] = None,
-                            affinity: typing.Optional[client.V1Affinity] = None):
+    def with_node_selection(
+        self,
+        node_name: typing.Optional[str] = None,
+        node_selector: typing.Optional[typing.Dict[str, str]] = None,
+        affinity: typing.Optional[client.V1Affinity] = None,
+    ):
         """
         Enables to control on which k8s node the job will run
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -279,17 +279,17 @@ class KubeResource(BaseRuntime):
         )
 
     def with_node_name(self, node_name: str = None):
-        """set node_name to schedule the pod on"""
+        """set node_name to schedule the job's pod/s on"""
         if node_name:
             self.spec.node_name = node_name
 
     def with_node_selector(self, node_selector: typing.Dict[str, str] = None):
-        """set node_name to schedule the pod on"""
+        """set a label selector that will be used by k8s scheduler to decide which node to use for the job's pod/s"""
         if node_selector:
             self.spec.node_selector = node_selector
 
     def with_affinity(self, affinity: client.V1Affinity = None):
-        """set node_name to schedule the pod on"""
+        """set affinity to the job's pod/s"""
         if affinity:
             self.spec.affinity = affinity
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -278,18 +278,22 @@ class KubeResource(BaseRuntime):
             self.spec.resources, "requests", generate_resources(mem=mem, cpu=cpu),
         )
 
-    def with_node_name(self, node_name: str = None):
-        """set node_name to schedule the job's pod/s on"""
+    def with_node_selection(self, node_name: typing.Optional[str] = None,
+                            node_selector: typing.Optional[typing.Dict[str, str]] = None,
+                            affinity: typing.Optional[client.V1Affinity] = None):
+        """
+        Enables to control on which k8s node the job will run
+
+        :param node_name:       The name of the k8s node
+        :param node_selector:   Label selector, only nodes with matching labels will be eligible to be picked
+        :param affinity:        Expands the types of constraints you can express - see
+                                https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+                                for details
+        """
         if node_name:
             self.spec.node_name = node_name
-
-    def with_node_selector(self, node_selector: typing.Dict[str, str] = None):
-        """set a label selector that will be used by k8s scheduler to decide which node to use for the job's pod/s"""
         if node_selector:
             self.spec.node_selector = node_selector
-
-    def with_affinity(self, affinity: client.V1Affinity = None):
-        """set affinity to the job's pod/s"""
         if affinity:
             self.spec.affinity = affinity
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -112,6 +112,10 @@ class KubeResourceSpec(FunctionSpec):
             for volume_mount in volume_mounts:
                 self._set_volume_mount(volume_mount)
 
+    def _get_sanitized_affinity(self):
+        api = client.ApiClient()
+        return api.sanitize_for_serialization(self.affinity)
+
     def _set_volume_mount(self, volume_mount):
         # calculate volume mount hash
         volume_name = get_item_name(volume_mount, "name")

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -316,3 +316,15 @@ class KubeResource(BaseRuntime):
         self.spec.env.append(
             {"name": "MLRUN_SECRET_STORES__VAULT__URL", "value": vault_url}
         )
+
+
+def kube_resource_spec_to_pod_spec(kube_resource_spec: KubeResourceSpec, container: client.V1Container):
+    return client.V1PodSpec(
+        containers=[container],
+        restart_policy="Never",
+        volumes=kube_resource_spec.volumes,
+        service_account=kube_resource_spec.service_account,
+        node_name=kube_resource_spec.node_name,
+        node_selector=kube_resource_spec.node_selector,
+        affinity=kube_resource_spec.affinity,
+    )

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -131,6 +131,8 @@ class KubeResourceSpec(FunctionSpec):
         affinity = self.affinity
         if isinstance(affinity, dict):
             api = client.ApiClient()
+            # not ideal to use their private method, but looks like that's the only option
+            # Taken from https://github.com/kubernetes-client/python/issues/977
             affinity = api._ApiClient__deserialize(self.affinity, "V1Affinity")
         return affinity
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -116,7 +116,7 @@ class KubeResourceSpec(FunctionSpec):
         api = client.ApiClient()
         affinity = self.affinity
         if isinstance(self.affinity, dict):
-            affinity = api.__deserialize(self.affinity, "V1Affinity")
+            affinity = api._ApiClient__deserialize(self.affinity, "V1Affinity")
         return affinity
 
     def _get_sanitized_affinity(self):

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -245,7 +245,7 @@ class KubeResource(BaseRuntime):
     def with_affinity(self, affinity: client.V1Affinity = None):
         """set node_name to schedule the pod on"""
         if affinity:
-            self.spec.node_selector = affinity
+            self.spec.affinity = affinity
 
     def _get_meta(self, runobj, unique=False):
         namespace = self._get_k8s().resolve_namespace()
@@ -328,5 +328,5 @@ def kube_resource_spec_to_pod_spec(
         service_account=kube_resource_spec.service_account,
         node_name=kube_resource_spec.node_name,
         node_selector=kube_resource_spec.node_selector,
-        affinity=kube_resource_spec.affinity,
+        affinity=kube_resource_spec.affinity.to_dict(),
     )

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import uuid
+import typing
 from copy import deepcopy
 
 from kfp.dsl import ContainerOp
@@ -51,6 +52,9 @@ class KubeResourceSpec(FunctionSpec):
         service_account=None,
         build=None,
         image_pull_secret=None,
+        node_name=None,
+        node_selector=None,
+        affinity=None,
     ):
         super().__init__(
             command=command,
@@ -73,6 +77,9 @@ class KubeResourceSpec(FunctionSpec):
         self.image_pull_policy = image_pull_policy
         self.service_account = service_account
         self.image_pull_secret = image_pull_secret
+        self.node_name = node_name
+        self.node_selector = node_selector
+        self.affinity = affinity
 
     @property
     def volumes(self) -> list:
@@ -224,6 +231,21 @@ class KubeResource(BaseRuntime):
         update_in(
             self.spec.resources, "requests", generate_resources(mem=mem, cpu=cpu),
         )
+
+    def with_node_name(self, node_name: str = None):
+        """set node_name to schedule the pod on"""
+        if node_name:
+            self.spec.node_name = node_name
+
+    def with_node_selector(self, node_selector: typing.Dict[str, str] = None):
+        """set node_name to schedule the pod on"""
+        if node_selector:
+            self.spec.node_selector = node_selector
+
+    def with_affinity(self, affinity: client.V1Affinity = None):
+        """set node_name to schedule the pod on"""
+        if affinity:
+            self.spec.node_selector = affinity
 
     def _get_meta(self, runobj, unique=False):
         namespace = self._get_k8s().resolve_namespace()

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -332,5 +332,7 @@ def kube_resource_spec_to_pod_spec(
         service_account=kube_resource_spec.service_account,
         node_name=kube_resource_spec.node_name,
         node_selector=kube_resource_spec.node_selector,
-        affinity=kube_resource_spec.affinity.to_dict(),
+        affinity=kube_resource_spec.affinity.to_dict()
+        if kube_resource_spec.affinity
+        else None,
     )

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -42,6 +42,9 @@ class RemoteSparkSpec(KubeResourceSpec):
         build=None,
         image_pull_secret=None,
         provider=None,
+        node_name=None,
+        node_selector=None,
+        affinity=None,
     ):
         super().__init__(
             command=command,
@@ -61,6 +64,9 @@ class RemoteSparkSpec(KubeResourceSpec):
             service_account=service_account,
             build=build,
             image_pull_secret=image_pull_secret,
+            node_name=node_name,
+            node_selector=node_selector,
+            affinity=affinity,
         )
         self.provider = provider
 

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -17,8 +17,8 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Optional, Tuple
 
-from kubernetes.client.rest import ApiException
 from kubernetes import client
+from kubernetes.client.rest import ApiException
 from sqlalchemy.orm import Session
 
 from mlrun.api.db.base import DBInterface
@@ -469,9 +469,7 @@ class SparkRuntime(KubejobRuntime):
         )
 
     def with_affinity(self, affinity: client.V1Affinity = None):
-        raise NotImplementedError(
-            "Setting affinity is not supported for spark runtime"
-        )
+        raise NotImplementedError("Setting affinity is not supported for spark runtime")
 
     def with_executor_requests(
         self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -463,15 +463,20 @@ class SparkRuntime(KubejobRuntime):
             "In spark runtimes, please use with_driver_requests & with_executor_requests"
         )
 
-    def with_node_selection(self, node_name: typing.Optional[str] = None,
-                            node_selector: typing.Optional[typing.Dict[str, str]] = None,
-                            affinity: typing.Optional[client.V1Affinity] = None):
+    def with_node_selection(
+        self,
+        node_name: typing.Optional[str] = None,
+        node_selector: typing.Optional[typing.Dict[str, str]] = None,
+        affinity: typing.Optional[client.V1Affinity] = None,
+    ):
         if node_name:
             raise NotImplementedError(
                 "Setting node name is not supported for spark runtime"
             )
         if affinity:
-            raise NotImplementedError("Setting affinity is not supported for spark runtime")
+            raise NotImplementedError(
+                "Setting affinity is not supported for spark runtime"
+            )
         super().with_node_selection(node_name, node_selector, affinity)
 
     def with_executor_requests(

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -271,7 +271,6 @@ class SparkRuntime(KubejobRuntime):
         update_in(job, "spec.driver.volumeMounts", self.spec.volume_mounts)
         update_in(job, "spec.executor.volumeMounts", self.spec.volume_mounts)
         update_in(job, "spec.deps", self.spec.deps)
-        update_in(job, "spec.deps", self.spec.deps)
 
         if self.spec.spark_conf:
             job["spec"]["sparkConf"] = {}

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import typing
 from copy import deepcopy
 from datetime import datetime
 from typing import Optional, Tuple
@@ -462,13 +463,16 @@ class SparkRuntime(KubejobRuntime):
             "In spark runtimes, please use with_driver_requests & with_executor_requests"
         )
 
-    def with_node_name(self, node_name: str = None):
-        raise NotImplementedError(
-            "Setting node name is not supported for spark runtime"
-        )
-
-    def with_affinity(self, affinity: client.V1Affinity = None):
-        raise NotImplementedError("Setting affinity is not supported for spark runtime")
+    def with_node_selection(self, node_name: typing.Optional[str] = None,
+                            node_selector: typing.Optional[typing.Dict[str, str]] = None,
+                            affinity: typing.Optional[client.V1Affinity] = None):
+        if node_name:
+            raise NotImplementedError(
+                "Setting node name is not supported for spark runtime"
+            )
+        if affinity:
+            raise NotImplementedError("Setting affinity is not supported for spark runtime")
+        super().with_node_selection(node_name, node_selector, affinity)
 
     def with_executor_requests(
         self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -99,7 +99,23 @@ class TestRuntimeBase:
                             ]
                         ),
                     )
-                ]
+                ],
+                required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
+                    node_selector_terms=[
+                        k8s_client.V1NodeSelectorTerm(
+                            match_expressions=[
+                                k8s_client.V1NodeSelectorRequirement(
+                                    key="some_node_label",
+                                    operator="In",
+                                    values=[
+                                        "required-label-value-1",
+                                        "required-label-value-2",
+                                    ],
+                                )
+                            ]
+                        ),
+                    ]
+                ),
             ),
             pod_affinity=k8s_client.V1PodAffinity(
                 required_during_scheduling_ignored_during_execution=[

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -8,10 +8,10 @@ from datetime import datetime, timezone
 
 import deepdiff
 from kubernetes import client
+from kubernetes import client as k8s_client
 from kubernetes.client import V1EnvVar
 
 from mlrun.api.utils.singletons.k8s import get_k8s
-from kubernetes import client as k8s_client
 from mlrun.config import config as mlconf
 from mlrun.model import new_task
 from mlrun.runtimes.constants import PodPhases
@@ -91,10 +91,13 @@ class TestRuntimeBase:
                                 k8s_client.V1NodeSelectorRequirement(
                                     key="some_node_label",
                                     operator="In",
-                                    values=["possible-label-value-1", "possible-label-value-2"],
+                                    values=[
+                                        "possible-label-value-1",
+                                        "possible-label-value-2",
+                                    ],
                                 )
                             ]
-                        )
+                        ),
                     )
                 ]
             ),
@@ -102,15 +105,10 @@ class TestRuntimeBase:
                 required_during_scheduling_ignored_during_execution=[
                     k8s_client.V1PodAffinityTerm(
                         label_selector=k8s_client.V1LabelSelector(
-                            match_labels={
-                                "some-pod-label-key": "some-pod-label-value",
-                            }
+                            match_labels={"some-pod-label-key": "some-pod-label-value"}
                         ),
-                        namespaces=[
-                            "namespace-a",
-                            "namespace-b"
-                        ],
-                        topology_key="key-1"
+                        namespaces=["namespace-a", "namespace-b"],
+                        topology_key="key-1",
                     )
                 ]
             ),
@@ -124,18 +122,19 @@ class TestRuntimeBase:
                                     k8s_client.V1LabelSelectorRequirement(
                                         key="some_pod_label",
                                         operator="NotIn",
-                                        values=["forbidden-label-value-1", "forbidden-label-value-2"],
+                                        values=[
+                                            "forbidden-label-value-1",
+                                            "forbidden-label-value-2",
+                                        ],
                                     )
                                 ]
                             ),
-                            namespaces=[
-                                "namespace-c",
-                            ],
-                            topology_key="key-2"
-                        )
+                            namespaces=["namespace-c"],
+                            topology_key="key-2",
+                        ),
                     )
                 ]
-            )
+            ),
         )
 
     def _mock_create_namespaced_pod(self):
@@ -456,16 +455,18 @@ class TestRuntimeBase:
             assert pod.spec.node_name == expected_node_name
 
         if expected_node_selector:
-            assert deepdiff.DeepDiff(
-                    pod.spec.node_selector,
-                    expected_node_selector,
-                    ignore_order=True,
-                ) == {}
+            assert (
+                deepdiff.DeepDiff(
+                    pod.spec.node_selector, expected_node_selector, ignore_order=True,
+                )
+                == {}
+            )
         if expected_affinity:
-            assert deepdiff.DeepDiff(
-                    pod.spec.affinity,
-                    expected_affinity.to_dict(),
-                    ignore_order=True,
-                ) == {}
+            assert (
+                deepdiff.DeepDiff(
+                    pod.spec.affinity, expected_affinity.to_dict(), ignore_order=True,
+                )
+                == {}
+            )
 
         assert pod.spec.containers[0].image == self.image_name

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -325,6 +325,9 @@ class TestRuntimeBase:
         expected_requests=None,
         expected_code=None,
         expected_env={},
+        expected_node_name=None,
+        expected_node_selector=None,
+        expected_affinity=None,
         assert_create_pod_called=True,
         assert_namespace_env_variable=True,
         expected_labels=None,
@@ -335,10 +338,10 @@ class TestRuntimeBase:
 
         assert self._get_namespace_arg() == self.namespace
 
-        pod_spec = self._get_pod_creation_args()
-        self._assert_labels(pod_spec.metadata.labels, expected_runtime_class_name)
+        pod = self._get_pod_creation_args()
+        self._assert_labels(pod.metadata.labels, expected_runtime_class_name)
 
-        container_spec = pod_spec.spec.containers[0]
+        container_spec = pod.spec.containers[0]
 
         if expected_limits:
             assert (
@@ -390,4 +393,20 @@ class TestRuntimeBase:
         if expected_code:
             assert expected_code_found
 
-        assert pod_spec.spec.containers[0].image == self.image_name
+        if expected_node_name:
+            assert pod.spec.node_name == expected_node_name
+
+        if expected_node_selector:
+            assert deepdiff.DeepDiff(
+                    pod.spec.node_selector,
+                    expected_node_selector,
+                    ignore_order=True,
+                ) == {}
+        if expected_affinity:
+            assert deepdiff.DeepDiff(
+                    pod.spec.affinity,
+                    expected_affinity.to_dict(),
+                    ignore_order=True,
+                ) == {}
+
+        assert pod.spec.containers[0].image == self.image_name

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -464,7 +464,9 @@ class TestRuntimeBase:
         if expected_affinity:
             assert (
                 deepdiff.DeepDiff(
-                    pod.spec.affinity, expected_affinity.to_dict(), ignore_order=True,
+                    pod.spec.affinity.to_dict(),
+                    expected_affinity.to_dict(),
+                    ignore_order=True,
                 )
                 == {}
             )

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -95,3 +95,28 @@ class TestDaskRuntime(TestRuntimeBase):
             expected_requests=expected_requests,
         )
         self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
+
+    def test_dask_with_node_selection_attributes(self, db: Session, client: TestClient):
+        runtime = self._generate_runtime()
+
+        node_name = "some-node-name"
+        runtime.with_node_name(node_name)
+        node_selector = {
+            "label-a": "val1",
+            "label-2": "val2",
+        }
+        runtime.with_node_selector(node_selector)
+        affinity = self._generate_affinity()
+        runtime.with_affinity(affinity)
+        _ = runtime.client
+
+        self.kube_cluster_mock.assert_called_once()
+
+        self._assert_pod_creation_config(
+            expected_runtime_class_name="dask",
+            assert_create_pod_called=False,
+            assert_namespace_env_variable=False,
+            expected_node_name=node_name,
+            expected_node_selector=node_selector,
+            expected_affinity=affinity,
+        )

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -96,18 +96,18 @@ class TestDaskRuntime(TestRuntimeBase):
         )
         self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
 
-    def test_dask_with_node_selection_attributes(self, db: Session, client: TestClient):
+    def test_dask_with_node_selection(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 
         node_name = "some-node-name"
-        runtime.with_node_name(node_name)
+        runtime.with_node_selection(node_name)
         node_selector = {
             "label-a": "val1",
             "label-2": "val2",
         }
-        runtime.with_node_selector(node_selector)
+        runtime.with_node_selection(node_selector=node_selector)
         affinity = self._generate_affinity()
-        runtime.with_affinity(affinity)
+        runtime.with_node_selection(affinity=affinity)
         _ = runtime.client
 
         self.kube_cluster_mock.assert_called_once()

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from kubernetes import client as k8s_client
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -88,6 +89,99 @@ class TestKubejobRuntime(TestRuntimeBase):
         self._execute_run(runtime)
         self._assert_pod_creation_config(
             expected_limits=expected_limits, expected_requests=expected_requests
+        )
+
+    def test_run_with_node_name(
+        self, db: Session, client: TestClient
+    ):
+        runtime = self._generate_runtime()
+
+        node_name = "some-node-name"
+        runtime.with_node_name(node_name)
+        self._execute_run(runtime)
+        self._assert_pod_creation_config(
+            expected_node_name=node_name
+        )
+
+    def test_run_with_node_selector(
+        self, db: Session, client: TestClient
+    ):
+        runtime = self._generate_runtime()
+
+        node_selector = {
+            "label-a": "val1",
+            "label-2": "val2",
+        }
+        runtime.with_node_selector(node_selector)
+        self._execute_run(runtime)
+        self._assert_pod_creation_config(
+            expected_node_selector=node_selector
+        )
+
+    def test_run_with_affinity(
+        self, db: Session, client: TestClient
+    ):
+        runtime = self._generate_runtime()
+        affinity = k8s_client.V1Affinity(
+            node_affinity=k8s_client.V1NodeAffinity(
+                preferred_during_scheduling_ignored_during_execution=[
+                    k8s_client.V1PreferredSchedulingTerm(
+                        weight=1,
+                        preference=k8s_client.V1NodeSelectorTerm(
+                            match_expressions=[
+                                k8s_client.V1NodeSelectorRequirement(
+                                    key="some_node_label",
+                                    operator="In",
+                                    values=["possible-label-value-1", "possible-label-value-2"],
+                                )
+                            ]
+                        )
+                    )
+                ]
+            ),
+            pod_affinity=k8s_client.V1PodAffinity(
+                required_during_scheduling_ignored_during_execution=[
+                    k8s_client.V1PodAffinityTerm(
+                        label_selector=k8s_client.V1LabelSelector(
+                            match_labels={
+                                "some-pod-label-key": "some-pod-label-value",
+                            }
+                        ),
+                        namespaces=[
+                            "namespace-a",
+                            "namespace-b"
+                        ],
+                        topology_key="key-1"
+                    )
+                ]
+            ),
+            pod_anti_affinity=k8s_client.V1PodAntiAffinity(
+                preferred_during_scheduling_ignored_during_execution=[
+                    k8s_client.V1WeightedPodAffinityTerm(
+                        weight=1,
+                        pod_affinity_term=k8s_client.V1PodAffinityTerm(
+                            label_selector=k8s_client.V1LabelSelector(
+                                match_expressions=[
+                                    k8s_client.V1LabelSelectorRequirement(
+                                        key="some_pod_label",
+                                        operator="NotIn",
+                                        values=["forbidden-label-value-1", "forbidden-label-value-2"],
+                                    )
+                                ]
+                            ),
+                            namespaces=[
+                                "namespace-c",
+                            ],
+                            topology_key="key-2"
+                        )
+                    )
+                ]
+            )
+        )
+        runtime.with_affinity(affinity)
+        self._execute_run(runtime)
+        self._assert_pod_creation_config(
+            expected_affinity=affinity
         )
 
     def test_run_with_mounts(self, db: Session, client: TestClient):

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -90,31 +90,34 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_limits=expected_limits, expected_requests=expected_requests
         )
 
-    def test_run_with_node_name(self, db: Session, client: TestClient):
+    def test_run_with_node_selection(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 
         node_name = "some-node-name"
-        runtime.with_node_name(node_name)
+        runtime.with_node_selection(node_name)
         self._execute_run(runtime)
         self._assert_pod_creation_config(expected_node_name=node_name)
 
-    def test_run_with_node_selector(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 
         node_selector = {
             "label-a": "val1",
             "label-2": "val2",
         }
-        runtime.with_node_selector(node_selector)
+        runtime.with_node_selection(node_selector=node_selector)
         self._execute_run(runtime)
         self._assert_pod_creation_config(expected_node_selector=node_selector)
 
-    def test_run_with_affinity(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
         affinity = self._generate_affinity()
-        runtime.with_affinity(affinity)
+        runtime.with_node_selection(affinity=affinity)
         self._execute_run(runtime)
         self._assert_pod_creation_config(expected_affinity=affinity)
+
+        runtime = self._generate_runtime()
+        runtime.with_node_selection(node_name, node_selector, affinity)
+        self._execute_run(runtime)
+        self._assert_pod_creation_config(expected_node_name=node_name, expected_node_selector=node_selector, expected_affinity=affinity)
 
     def test_run_with_mounts(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -117,7 +117,11 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime = self._generate_runtime()
         runtime.with_node_selection(node_name, node_selector, affinity)
         self._execute_run(runtime)
-        self._assert_pod_creation_config(expected_node_name=node_name, expected_node_selector=node_selector, expected_affinity=affinity)
+        self._assert_pod_creation_config(
+            expected_node_name=node_name,
+            expected_node_selector=node_selector,
+            expected_affinity=affinity,
+        )
 
     def test_run_with_mounts(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -90,21 +90,15 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_limits=expected_limits, expected_requests=expected_requests
         )
 
-    def test_run_with_node_name(
-        self, db: Session, client: TestClient
-    ):
+    def test_run_with_node_name(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 
         node_name = "some-node-name"
         runtime.with_node_name(node_name)
         self._execute_run(runtime)
-        self._assert_pod_creation_config(
-            expected_node_name=node_name
-        )
+        self._assert_pod_creation_config(expected_node_name=node_name)
 
-    def test_run_with_node_selector(
-        self, db: Session, client: TestClient
-    ):
+    def test_run_with_node_selector(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 
         node_selector = {
@@ -113,20 +107,14 @@ class TestKubejobRuntime(TestRuntimeBase):
         }
         runtime.with_node_selector(node_selector)
         self._execute_run(runtime)
-        self._assert_pod_creation_config(
-            expected_node_selector=node_selector
-        )
+        self._assert_pod_creation_config(expected_node_selector=node_selector)
 
-    def test_run_with_affinity(
-        self, db: Session, client: TestClient
-    ):
+    def test_run_with_affinity(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
         affinity = self._generate_affinity()
         runtime.with_affinity(affinity)
         self._execute_run(runtime)
-        self._assert_pod_creation_config(
-            expected_affinity=affinity
-        )
+        self._assert_pod_creation_config(expected_affinity=affinity)
 
     def test_run_with_mounts(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()

--- a/tests/api/runtimes/test_pod.py
+++ b/tests/api/runtimes/test_pod.py
@@ -12,7 +12,7 @@ class TestKubeResource(TestRuntimeBase):
         affinity = self._generate_affinity()
         kube_resource = mlrun.runtimes.pod.KubeResource()
         # simulating the client - setting from a class instance
-        kube_resource.with_affinity(affinity)
+        kube_resource.with_node_selection(affinity=affinity)
         # simulating sending to API - serialization through dict
         kube_resource_dict = kube_resource.to_dict()
         kube_resource = kube_resource.from_dict(kube_resource_dict)

--- a/tests/api/runtimes/test_pod.py
+++ b/tests/api/runtimes/test_pod.py
@@ -1,29 +1,52 @@
+import deepdiff
 import pytest
 
 import mlrun
 import mlrun.errors
+import mlrun.runtimes.pod
+from tests.api.runtimes.base import TestRuntimeBase
 
 
-def test_with_limits_regex_validation():
-    cases = [
-        {"cpu": "no-number", "expected_failure": True},
-        {"memory": "1g", "expected_failure": True},  # common mistake
-        {"gpus": "1GPU", "expected_failure": True},
-        {"cpu": "12e6"},
-        {"memory": "12Mi"},
-        {"memory": "12M"},
-    ]
-    for case in cases:
-        function = mlrun.runtimes.KubejobRuntime()
-        if case.get("expected_failure"):
-            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-                function.with_limits(
+class TestKubeResource(TestRuntimeBase):
+    def test_affinity_serialization(self):
+        affinity = self._generate_affinity()
+        kube_resource = mlrun.runtimes.pod.KubeResource()
+        # simulating the client - setting from a class instance
+        kube_resource.with_affinity(affinity)
+        # simulating sending to API - serialization through dict
+        kube_resource_dict = kube_resource.to_dict()
+        kube_resource = kube_resource.from_dict(kube_resource_dict)
+        assert (
+            deepdiff.DeepDiff(
+                kube_resource.spec.affinity.to_dict(),
+                affinity.to_dict(),
+                ignore_order=True,
+            )
+            == {}
+        )
+
+    def test_with_limits_regex_validation(self):
+        cases = [
+            {"cpu": "no-number", "expected_failure": True},
+            {"memory": "1g", "expected_failure": True},  # common mistake
+            {"gpus": "1GPU", "expected_failure": True},
+            {"cpu": "12e6"},
+            {"memory": "12Mi"},
+            {"memory": "12M"},
+        ]
+        for case in cases:
+            kube_resource = mlrun.runtimes.pod.KubeResource()
+            if case.get("expected_failure"):
+                with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                    kube_resource.with_limits(
+                        case.get("memory"), case.get("cpu"), case.get("gpus")
+                    )
+                if not case.get("gpus"):
+                    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                        kube_resource.with_requests(case.get("memory"), case.get("cpu"))
+            else:
+                kube_resource.with_limits(
                     case.get("memory"), case.get("cpu"), case.get("gpus")
                 )
-            if not case.get("gpus"):
-                with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-                    function.with_requests(case.get("memory"), case.get("cpu"))
-        else:
-            function.with_limits(case.get("memory"), case.get("cpu"), case.get("gpus"))
-            if not case.get("gpus"):
-                function.with_requests(case.get("memory"), case.get("cpu"))
+                if not case.get("gpus"):
+                    kube_resource.with_requests(case.get("memory"), case.get("cpu"))

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -28,6 +28,7 @@ def test_new_function_from_runtime():
             "env": [],
             "description": "",
             "build": {"commands": []},
+            "affinity": None,
         },
         "verbose": False,
     }
@@ -61,6 +62,7 @@ def test_new_function_args_without_command():
             "env": [],
             "description": "",
             "build": {"commands": []},
+            "affinity": None,
         },
         "verbose": False,
     }


### PR DESCRIPTION
Exposing [k8s ways](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) to assign jobs to run on specific nodes, shortly there are 3 ways:
* Using node name:
```
function.with_node_selection('k8s-node1')
```
* Using node selector:
```
function.with_node_selection(node_selector={'kubernetes.io/hostname': 'k8s-node2'})
```
* Using affinity:
```
from kubernetes import client as k8s_client
affinity = k8s_client.V1Affinity(
            node_affinity=k8s_client.V1NodeAffinity(
                preferred_during_scheduling_ignored_during_execution=[
                    k8s_client.V1PreferredSchedulingTerm(
                        weight=1,
                        preference=k8s_client.V1NodeSelectorTerm(
                            match_expressions=[
                                k8s_client.V1NodeSelectorRequirement(
                                    key="kubernetes.io/hostname",
                                    operator="In",
                                    values=[
                                        "k8s-node2",
                                        "k8s-node3",
                                    ],
                                )
                            ]
                        ),
                    )
                ],
            ),
        )
function.with_node_selection(affinity=affinity)
```

This PR implements - https://jira.iguazeng.com/browse/ML-27