### PR TITLE
[Scheduler] Add concurrency limit

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -24,6 +24,7 @@ def create_schedule(
         schedule.scheduled_object,
         schedule.cron_trigger,
         labels=schedule.labels,
+        concurrency_limit=schedule.concurrency_limit,
     )
     return Response(status_code=HTTPStatus.CREATED.value)
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -144,6 +144,7 @@ class DBInterface(ABC):
         kind: schemas.ScheduleKinds,
         scheduled_object: Any,
         cron_trigger: schemas.ScheduleCronTrigger,
+        concurrency_limit: int,
         labels: Dict = None,
     ):
         pass
@@ -158,6 +159,7 @@ class DBInterface(ABC):
         cron_trigger: schemas.ScheduleCronTrigger = None,
         labels: Dict = None,
         last_run_uri: str = None,
+        concurrency_limit: int = None,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -305,6 +305,7 @@ class FileDB(DBInterface):
         kind: schemas.ScheduleKinds,
         scheduled_object: Any,
         cron_trigger: schemas.ScheduleCronTrigger,
+        concurrency_limit: int,
         labels: Dict = None,
     ):
         raise NotImplementedError()
@@ -318,6 +319,7 @@ class FileDB(DBInterface):
         cron_trigger: schemas.ScheduleCronTrigger = None,
         labels: Dict = None,
         last_run_uri: str = None,
+        concurrency_limit: int = None,
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -39,6 +39,7 @@ from mlrun.config import config
 from mlrun.lists import ArtifactList, FunctionList, RunList
 from mlrun.model import RunObject
 from mlrun.utils import (
+    as_list,
     fill_function_hash,
     fill_object_hash,
     generate_artifact_uri,
@@ -1814,6 +1815,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
                 ):
                     continue
             if state:
+                requested_states = set(as_list(state))
                 record_state = run.state
                 json_state = None
                 if (
@@ -1826,10 +1828,20 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
                     continue
                 # json_state has precedence over record state
                 if json_state:
-                    if state not in json_state:
+                    if all(
+                        [
+                            requested_state not in json_state
+                            for requested_state in requested_states
+                        ]
+                    ):
                         continue
                 else:
-                    if state not in record_state:
+                    if all(
+                        [
+                            requested_state not in record_state
+                            for requested_state in requested_states
+                        ]
+                    ):
                         continue
             if last_update_time_from or last_update_time_to:
                 if not match_times(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1815,7 +1815,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
                 ):
                     continue
             if state:
-                requested_states = set(as_list(state))
+                requested_states = as_list(state)
                 record_state = run.state
                 json_state = None
                 if (

--- a/mlrun/api/db/sqldb/models.py
+++ b/mlrun/api/db/sqldb/models.py
@@ -202,6 +202,7 @@ with warnings.catch_warnings():
         last_run_uri = Column(String)
         struct = Column(BLOB)
         labels = relationship(Label, cascade="all, delete-orphan")
+        concurrency_limit = Column(Integer, nullable=False)
 
         @property
         def scheduled_object(self):

--- a/mlrun/api/migrations/versions/e1dd5983c06b_schedule_concurrency_limit.py
+++ b/mlrun/api/migrations/versions/e1dd5983c06b_schedule_concurrency_limit.py
@@ -1,0 +1,34 @@
+"""Schedule concurrency limit
+
+Revision ID: e1dd5983c06b
+Revises: bcd0c1f9720c
+Create Date: 2021-03-15 13:36:18.703619
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from mlrun.config import config
+
+# revision identifiers, used by Alembic.
+revision = "e1dd5983c06b"
+down_revision = "bcd0c1f9720c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("schedules_v2") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "concurrency_limit",
+                sa.Integer(),
+                nullable=False,
+                server_default=str(config.httpdb.scheduling.default_concurrency_limit),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("schedules_v2") as batch_op:
+        batch_op.drop_column("concurrency_limit")

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -52,3 +52,7 @@ class HeaderNames:
     patch_mode = f"{headers_prefix}patch-mode"
     deletion_strategy = f"{headers_prefix}deletion-strategy"
     secret_store_token = f"{headers_prefix}secret-store-token"
+
+
+class LabelNames:
+    schedule_name = "schedule-name"

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -70,6 +70,7 @@ class ScheduleUpdate(BaseModel):
     cron_trigger: Optional[Union[str, ScheduleCronTrigger]]
     desired_state: Optional[str]
     labels: Optional[dict]
+    concurrency_limit: Optional[int]
 
 
 # Properties to receive via API on creation
@@ -80,6 +81,7 @@ class ScheduleInput(BaseModel):
     cron_trigger: Union[str, ScheduleCronTrigger]
     desired_state: Optional[str]
     labels: Optional[dict]
+    concurrency_limit: Optional[int]
 
 
 # the schedule object returned from the db layer

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -305,7 +305,7 @@ class Scheduler:
                     db_schedule.kind,
                     db_schedule.scheduled_object,
                     db_schedule.cron_trigger,
-                    db_schedule.concurrency_limit
+                    db_schedule.concurrency_limit,
                 )
             except Exception as exc:
                 logger.warn(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -409,6 +409,12 @@ class Scheduler:
             labels=f"{schedule_name_label}={schedule_name}",
         )
         if len(active_runs) > schedule_concurrency_limit:
+            logger.warn(
+                "Schedule exceeded concurrency limit, skipping this run",
+                schedule_name=schedule_name,
+                schedule_concurrency_limit=schedule_concurrency_limit,
+                active_runs=len(active_runs),
+            )
             return
 
         response = await submit_run(db_session, scheduled_object)

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -255,6 +255,10 @@ class Scheduler:
         function, args, kwargs = self._resolve_job_function(
             kind, scheduled_object, name, concurrency_limit,
         )
+
+        # we use max_instances as well as our logic in the run wrapper for concurrent jobs
+        # in order to allow concurrency for triggering the jobs (max_instances), and concurrency
+        # of the jobs themselves (our logic in the run wrapper).
         self._scheduler.add_job(
             function,
             self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
@@ -263,6 +267,7 @@ class Scheduler:
             args,
             kwargs,
             job_id,
+            max_instances=concurrency_limit,
         )
 
     def _update_schedule_in_scheduler(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -403,17 +403,19 @@ class Scheduler:
 
         db_session = create_session()
 
+        schedule_project = (
+            scheduled_object.get("task", {}).get("metadata", {}).get("project", None)
+        )
         active_runs = get_db().list_runs(
             db_session,
             state=RunStates.non_terminal_states(),
-            project=scheduled_object.get("task", {})
-            .get("metadata", {})
-            .get("project", None),
+            project=schedule_project,
             labels=f"{schemas.constants.LabelNames.schedule_name}={schedule_name}",
         )
         if len(active_runs) > schedule_concurrency_limit:
             logger.warn(
                 "Schedule exceeded concurrency limit, skipping this run",
+                project=schedule_project,
                 schedule_name=schedule_name,
                 schedule_concurrency_limit=schedule_concurrency_limit,
                 active_runs=len(active_runs),

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -14,6 +14,7 @@ from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.project_member import get_project_member
 from mlrun.config import config
 from mlrun.model import RunObject
+from mlrun.runtimes.constants import RunStates
 from mlrun.utils import logger
 
 
@@ -55,6 +56,7 @@ class Scheduler:
         scheduled_object: Union[Dict, Callable],
         cron_trigger: Union[str, schemas.ScheduleCronTrigger],
         labels: Dict = None,
+        concurrency_limit: int = config.httpdb.scheduling.default_concurrency_limit,
     ):
         if isinstance(cron_trigger, str):
             cron_trigger = schemas.ScheduleCronTrigger.from_crontab(cron_trigger)
@@ -69,13 +71,21 @@ class Scheduler:
             scheduled_object=scheduled_object,
             cron_trigger=cron_trigger,
             labels=labels,
+            concurrency_limit=concurrency_limit,
         )
         get_project_member().ensure_project(db_session, project)
         get_db().create_schedule(
-            db_session, project, name, kind, scheduled_object, cron_trigger, labels
+            db_session,
+            project,
+            name,
+            kind,
+            scheduled_object,
+            cron_trigger,
+            concurrency_limit,
+            labels,
         )
         self._create_schedule_in_scheduler(
-            project, name, kind, scheduled_object, cron_trigger
+            project, name, kind, scheduled_object, cron_trigger, concurrency_limit,
         )
 
     def update_schedule(
@@ -86,6 +96,7 @@ class Scheduler:
         scheduled_object: Union[Dict, Callable] = None,
         cron_trigger: Union[str, schemas.ScheduleCronTrigger] = None,
         labels: Dict = None,
+        concurrency_limit: int = None,
     ):
         if isinstance(cron_trigger, str):
             cron_trigger = schemas.ScheduleCronTrigger.from_crontab(cron_trigger)
@@ -100,9 +111,16 @@ class Scheduler:
             scheduled_object=scheduled_object,
             cron_trigger=cron_trigger,
             labels=labels,
+            concurrency_limit=concurrency_limit,
         )
         get_db().update_schedule(
-            db_session, project, name, scheduled_object, cron_trigger, labels
+            db_session,
+            project,
+            name,
+            scheduled_object,
+            cron_trigger,
+            labels,
+            concurrency_limit,
         )
         db_schedule = get_db().get_schedule(db_session, project, name)
         updated_schedule = self._transform_and_enrich_db_schedule(
@@ -115,6 +133,7 @@ class Scheduler:
             updated_schedule.kind,
             updated_schedule.scheduled_object,
             updated_schedule.cron_trigger,
+            updated_schedule.concurrency_limit,
         )
 
     def list_schedules(
@@ -164,7 +183,10 @@ class Scheduler:
         logger.debug("Invoking schedule", project=project, name=name)
         db_schedule = get_db().get_schedule(db_session, project, name)
         function, args, kwargs = self._resolve_job_function(
-            db_schedule.kind, db_schedule.scheduled_object, name
+            db_schedule.kind,
+            db_schedule.scheduled_object,
+            name,
+            db_schedule.concurrency_limit,
         )
         return await function(*args, **kwargs)
 
@@ -226,11 +248,12 @@ class Scheduler:
         kind: schemas.ScheduleKinds,
         scheduled_object: Any,
         cron_trigger: schemas.ScheduleCronTrigger,
+        concurrency_limit: int,
     ):
         job_id = self._resolve_job_id(project, name)
         logger.debug("Adding schedule to scheduler", job_id=job_id)
         function, args, kwargs = self._resolve_job_function(
-            kind, scheduled_object, name
+            kind, scheduled_object, name, concurrency_limit,
         )
         self._scheduler.add_job(
             function,
@@ -249,11 +272,12 @@ class Scheduler:
         kind: schemas.ScheduleKinds,
         scheduled_object: Any,
         cron_trigger: schemas.ScheduleCronTrigger,
+        concurrency_limit: int,
     ):
         job_id = self._resolve_job_id(project, name)
         logger.debug("Updating schedule in scheduler", job_id=job_id)
         function, args, kwargs = self._resolve_job_function(
-            kind, scheduled_object, name
+            kind, scheduled_object, name, concurrency_limit,
         )
         trigger = self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
             cron_trigger
@@ -328,6 +352,7 @@ class Scheduler:
         scheduled_kind: schemas.ScheduleKinds,
         scheduled_object: Any,
         schedule_name: str,
+        schedule_concurrency_limit: int,
     ) -> Tuple[Callable, Optional[Union[List, Tuple]], Optional[Dict]]:
         """
         :return: a tuple (function, args, kwargs) to be used with the APScheduler.add_job
@@ -337,7 +362,7 @@ class Scheduler:
             scheduled_object_copy = copy.deepcopy(scheduled_object)
             return (
                 Scheduler.submit_run_wrapper,
-                [scheduled_object_copy, schedule_name],
+                [scheduled_object_copy, schedule_name, schedule_concurrency_limit],
                 {},
             )
         if scheduled_kind == schemas.ScheduleKinds.local_function:
@@ -355,7 +380,9 @@ class Scheduler:
         return self._job_id_separator.join([project, name])
 
     @staticmethod
-    async def submit_run_wrapper(scheduled_object, schedule_name):
+    async def submit_run_wrapper(
+        scheduled_object, schedule_name, schedule_concurrency_limit
+    ):
         # import here to avoid circular imports
         from mlrun.api.api.utils import submit_run
 
@@ -367,7 +394,22 @@ class Scheduler:
         # otherwise all runs will have the same uid
         scheduled_object.get("task", {}).get("metadata", {}).pop("uid", None)
 
+        schedule_name_label = "schedule-name"
+        if "task" in scheduled_object and "metadata" in scheduled_object["task"]:
+            scheduled_object["task"]["metadata"].setdefault("labels", {})
+            scheduled_object["task"]["metadata"]["labels"][
+                schedule_name_label
+            ] = schedule_name
+
         db_session = create_session()
+
+        active_runs = get_db().list_runs(
+            db_session,
+            state=RunStates.running,
+            labels=f"{schedule_name_label}={schedule_name}",
+        )
+        if len(active_runs) > schedule_concurrency_limit:
+            return
 
         response = await submit_run(db_session, scheduled_object)
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -370,7 +370,12 @@ class Scheduler:
             scheduled_object_copy = copy.deepcopy(scheduled_object)
             return (
                 Scheduler.submit_run_wrapper,
-                [scheduled_object_copy, project_name, schedule_name, schedule_concurrency_limit],
+                [
+                    scheduled_object_copy,
+                    project_name,
+                    schedule_name,
+                    schedule_concurrency_limit,
+                ],
                 {},
             )
         if scheduled_kind == schemas.ScheduleKinds.local_function:

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -305,6 +305,7 @@ class Scheduler:
                     db_schedule.kind,
                     db_schedule.scheduled_object,
                     db_schedule.cron_trigger,
+                    db_schedule.concurrency_limit
                 )
             except Exception as exc:
                 logger.warn(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -98,7 +98,8 @@ default_config = {
         "scheduling": {
             # the minimum interval that will be allowed between two scheduled jobs - e.g. a job wouldn't be
             # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute
-            "min_allowed_interval": "10 minutes"
+            "min_allowed_interval": "10 minutes",
+            "default_concurrency_limit": 1,
         },
         "projects": {
             "leader": "mlrun",

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -37,6 +37,7 @@ from ..utils import (
     match_labels,
     match_times,
     match_value,
+    match_value_options,
     update_in,
 )
 from .base import RunDBError, RunDBInterface
@@ -136,7 +137,7 @@ class FileRunDB(RunDBInterface):
             if (
                 match_value(name, run, "metadata.name")
                 and match_labels(get_in(run, "metadata.labels", {}), labels)
-                and match_value(state, run, "status.state")
+                and match_value_options(state, run, "status.state")
                 and match_value(uid, run, "metadata.uid")
                 and match_times(
                     start_time_from, start_time_to, run, "status.start_time",

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -78,6 +78,15 @@ class RunStates(object):
             RunStates.error,
         ]
 
+    @staticmethod
+    def non_terminal_states():
+        return [
+            RunStates.running,
+            RunStates.created,
+            RunStates.pending,
+            RunStates.unknown,
+        ]
+
 
 class SparkApplicationStates:
     """

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -80,12 +80,7 @@ class RunStates(object):
 
     @staticmethod
     def non_terminal_states():
-        return [
-            RunStates.running,
-            RunStates.created,
-            RunStates.pending,
-            RunStates.unknown,
-        ]
+        return list(set(RunStates.all()) - set(RunStates.terminal_states()))
 
 
 class SparkApplicationStates:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 from importlib import import_module
 from os import environ, path
 from types import ModuleType
-from typing import Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import requests
@@ -255,6 +255,13 @@ def match_value(value, obj, key):
     if not value:
         return True
     return get_in(obj, key, _missing) == value
+
+
+def match_value_options(value_options, obj, key):
+    if not value_options:
+        return True
+
+    return get_in(obj, key, _missing) in as_list(value_options)
 
 
 def flatten(df, col, prefix=""):
@@ -839,3 +846,7 @@ def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
     if not time_obj:
         return
     return time_obj.isoformat()
+
+
+def as_list(element: Any) -> List[Any]:
+    return element if isinstance(element, list) else [element]

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -30,6 +30,7 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
         schemas.ScheduleKinds.local_function,
         do_nothing,
         cron_trigger,
+        config.httpdb.scheduling.default_concurrency_limit,
         labels_1,
     )
 
@@ -44,6 +45,7 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
         schemas.ScheduleKinds.local_function,
         do_nothing,
         cron_trigger,
+        config.httpdb.scheduling.default_concurrency_limit,
         labels_2,
     )
 

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -576,6 +576,7 @@ def _create_resources_of_all_kinds(
             schemas.ScheduleKinds.job,
             schedule,
             schedule_cron_trigger,
+            mlrun.config.config.httpdb.scheduling.default_concurrency_limit,
             labels,
         )
 

--- a/tests/api/utils/function.py
+++ b/tests/api/utils/function.py
@@ -1,2 +1,9 @@
+import time
+
+
 def do_nothing():
     pass
+
+
+def sleep_two_seconds():
+    time.sleep(2)

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -666,7 +666,7 @@ async def test_schedule_job_concurrency_limit(
         concurrency_limit=concurrency_limit,
     )
 
-    # wait so one run will complete
+    # wait so all runs will complete
     await asyncio.sleep(5)
     if schedule_kind == schemas.ScheduleKinds.job:
         runs = get_db().list_runs(db, project=project)

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -639,9 +639,10 @@ async def test_schedule_job_concurrency_limit(
     call_counter = 0
 
     now = datetime.now()
-    now_plus_4_seconds = now + timedelta(seconds=4)
+    now_plus_1_seconds = now + timedelta(seconds=1)
+    now_plus_5_seconds = now + timedelta(seconds=5)
     cron_trigger = schemas.ScheduleCronTrigger(
-        second="*", start_date=now, end_date=now_plus_4_seconds
+        second="*/1", start_date=now_plus_1_seconds, end_date=now_plus_5_seconds
     )
     schedule_name = "schedule-name"
     project = config.default_project
@@ -667,7 +668,7 @@ async def test_schedule_job_concurrency_limit(
     )
 
     # wait so all runs will complete
-    await asyncio.sleep(6)
+    await asyncio.sleep(7)
     if schedule_kind == schemas.ScheduleKinds.job:
         runs = get_db().list_runs(db, project=project)
         assert len(runs) == run_amount

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -667,7 +667,7 @@ async def test_schedule_job_concurrency_limit(
     )
 
     # wait so all runs will complete
-    await asyncio.sleep(5)
+    await asyncio.sleep(6)
     if schedule_kind == schemas.ScheduleKinds.job:
         runs = get_db().list_runs(db, project=project)
         assert len(runs) == run_amount

--- a/tests/rundb/test_dbs.py
+++ b/tests/rundb/test_dbs.py
@@ -127,6 +127,9 @@ def test_runs(db: RunDBInterface):
     assert 2 == len(runs), "labels length"
     assert {1, 2} == {r["x"] for r in runs}, "xs labels"
 
+    runs = db.list_runs(state=["s1", "s2"])
+    assert 3 == len(runs), "state length"
+
     runs = db.list_runs(state="s2")
     assert 1 == len(runs), "state length"
     run3["status"] = updates["status"]


### PR DESCRIPTION
Concurrency limit for scheduled jobs and local functions.
Schedule has a concurrency limit integer field which defaults to 1 (no concurrency). The user can set this integer to a larger number in order to allow overlapping scheduled jobs.
Implements: https://jira.iguazeng.com/browse/ML-154