### PR TITLE
[API] Adding APIs to delete specific versions of feature-store objects

### DIFF
--- a/mlrun/api/api/endpoints/feature_sets.py
+++ b/mlrun/api/api/endpoints/feature_sets.py
@@ -86,10 +86,17 @@ def get_feature_set(
 
 
 @router.delete("/projects/{project}/feature-sets/{name}")
+@router.delete("/projects/{project}/feature-sets/{name}/references/{reference}")
 def delete_feature_set(
-    project: str, name: str, db_session: Session = Depends(deps.get_db_session),
+    project: str,
+    name: str,
+    reference: str = None,
+    db_session: Session = Depends(deps.get_db_session),
 ):
-    get_db().delete_feature_set(db_session, project, name)
+    tag = uid = None
+    if reference:
+        tag, uid = parse_reference(reference)
+    get_db().delete_feature_set(db_session, project, name, tag, uid)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
@@ -231,8 +238,15 @@ def patch_feature_vector(
 
 
 @router.delete("/projects/{project}/feature-vectors/{name}")
+@router.delete("/projects/{project}/feature-vectors/{name}/references/{reference}")
 def delete_feature_vector(
-    project: str, name: str, db_session: Session = Depends(deps.get_db_session),
+    project: str,
+    name: str,
+    reference: str = None,
+    db_session: Session = Depends(deps.get_db_session),
 ):
-    get_db().delete_feature_vector(db_session, project, name)
+    tag = uid = None
+    if reference:
+        tag, uid = parse_reference(reference)
+    get_db().delete_feature_vector(db_session, project, name, tag, uid)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -301,7 +301,7 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def delete_feature_set(self, session, project, name):
+    def delete_feature_set(self, session, project, name, tag=None, uid=None):
         pass
 
     @abstractmethod
@@ -356,7 +356,9 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def delete_feature_vector(self, session, project, name):
+    def delete_feature_vector(
+        self, session, project, name, tag=None, uid=None,
+    ):
         pass
 
     def list_artifact_tags(self, session, project):

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -242,7 +242,7 @@ class FileDB(DBInterface):
     ):
         raise NotImplementedError()
 
-    def delete_feature_set(self, session, project, name):
+    def delete_feature_set(self, session, project, name, tag=None, uid=None):
         raise NotImplementedError()
 
     def create_feature_vector(
@@ -291,7 +291,7 @@ class FileDB(DBInterface):
     ):
         raise NotImplementedError()
 
-    def delete_feature_vector(self, session, project, name):
+    def delete_feature_vector(self, session, project, name, tag=None, uid=None):
         raise NotImplementedError()
 
     def list_artifact_tags(self, session, project):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -227,7 +227,7 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def delete_feature_set(self, name, project=""):
+    def delete_feature_set(self, name, project="", tag=None, uid=None):
         pass
 
     @abstractmethod
@@ -281,7 +281,7 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def delete_feature_vector(self, name, project=""):
+    def delete_feature_vector(self, name, project="", tag=None, uid=None):
         pass
 
     @abstractmethod

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -561,7 +561,7 @@ class FileRunDB(RunDBInterface):
     ):
         raise NotImplementedError()
 
-    def delete_feature_set(self, name, project=""):
+    def delete_feature_set(self, name, project="", tag=None, uid=None):
         raise NotImplementedError()
 
     def create_feature_vector(self, feature_vector, project="", versioned=True) -> dict:
@@ -598,7 +598,7 @@ class FileRunDB(RunDBInterface):
     ):
         raise NotImplementedError()
 
-    def delete_feature_vector(self, name, project=""):
+    def delete_feature_vector(self, name, project="", tag=None, uid=None):
         raise NotImplementedError()
 
     def list_pipelines(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1353,10 +1353,19 @@ class HTTPRunDB(RunDBInterface):
             headers=headers,
         )
 
-    def delete_feature_set(self, name, project=""):
-        """ Delete a :py:class:`~mlrun.feature_store.FeatureSet` object from the DB. """
+    def delete_feature_set(self, name, project="", tag=None, uid=None):
+        """ Delete a :py:class:`~mlrun.feature_store.FeatureSet` object from the DB.
+        If ``tag`` or ``uid`` are specified, then just the version referenced by them will be deleted. Using both
+        is not allowed.
+        If none are specified, then all instances of the object whose name is ``name`` will be deleted.
+        """
         project = project or default_project
         path = f"projects/{project}/feature-sets/{name}"
+
+        if tag or uid:
+            reference = self._resolve_reference(tag, uid)
+            path = path + f"/references/{reference}"
+
         error_message = f"Failed deleting feature-set {name}"
         self.api_call("DELETE", path, error_message)
 
@@ -1523,11 +1532,18 @@ class HTTPRunDB(RunDBInterface):
             headers=headers,
         )
 
-    def delete_feature_vector(self, name, project=""):
-        """ Delete a :py:class:`~mlrun.feature_store.FeatureVector` object from the DB. """
-
+    def delete_feature_vector(self, name, project="", tag=None, uid=None):
+        """ Delete a :py:class:`~mlrun.feature_store.FeatureVector` object from the DB.
+        If ``tag`` or ``uid`` are specified, then just the version referenced by them will be deleted. Using both
+        is not allowed.
+        If none are specified, then all instances of the object whose name is ``name`` will be deleted.
+        """
         project = project or default_project
         path = f"projects/{project}/feature-vectors/{name}"
+        if tag or uid:
+            reference = self._resolve_reference(tag, uid)
+            path = path + f"/references/{reference}"
+
         error_message = f"Failed deleting feature-vector {name}"
         self.api_call("DELETE", path, error_message)
 

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -316,9 +316,9 @@ class SQLDB(RunDBInterface):
             patch_mode,
         )
 
-    def delete_feature_set(self, name, project=""):
+    def delete_feature_set(self, name, project="", tag=None, uid=None):
         return self._transform_db_error(
-            self.db.delete_feature_set, self.session, project, name
+            self.db.delete_feature_set, self.session, project, name, tag, uid
         )
 
     def create_feature_vector(self, feature_vector, project="", versioned=True):
@@ -389,9 +389,9 @@ class SQLDB(RunDBInterface):
             patch_mode,
         )
 
-    def delete_feature_vector(self, name, project=""):
+    def delete_feature_vector(self, name, project="", tag=None, uid=None):
         return self._transform_db_error(
-            self.db.delete_feature_vector, self.session, project, name,
+            self.db.delete_feature_vector, self.session, project, name, tag, uid
         )
 
     def list_pipelines(

--- a/tests/api/api/feature_store/test_feature_sets.py
+++ b/tests/api/api/feature_store/test_feature_sets.py
@@ -272,6 +272,54 @@ def test_feature_set_delete(db: Session, client: TestClient) -> None:
     _list_and_assert_objects(client, "feature_sets", project_name, None, count - 2)
 
 
+def test_feature_set_delete_version(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+
+    name = "feature_set"
+    feature_set = _generate_feature_set(name)
+
+    count = 5
+    uids = {}
+    for i in range(count):
+        # Store different copies of the feature set with different uids and tags
+        feature_set["metadata"]["extra_metadata"] = i * 100
+        tag = f"tag{i}"
+        result = _store_and_assert_feature_set(
+            client, project_name, name, f"tag{i}", feature_set
+        )
+        uids[result["metadata"]["uid"]] = tag
+
+    _list_and_assert_objects(
+        client, "feature_sets", project_name, f"name={name}", count
+    )
+
+    delete_by_tag = True
+    objects_left = count
+    for uid, tag in uids.items():
+        reference = tag if delete_by_tag else uid
+        delete_by_tag = not delete_by_tag
+
+        response = client.delete(
+            f"/api/projects/{project_name}/feature-sets/{name}/references/{reference}"
+        )
+        assert response.status_code == HTTPStatus.NO_CONTENT.value
+        objects_left = objects_left - 1
+        _list_and_assert_objects(
+            client, "feature_sets", project_name, f"name={name}", objects_left
+        )
+
+    for i in range(count):
+        feature_set["metadata"]["extra_metadata"] = i * 100
+        _store_and_assert_feature_set(
+            client, project_name, name, f"tag{i}", feature_set
+        )
+
+    # Now delete by name
+    response = client.delete(f"/api/projects/{project_name}/feature-sets/{name}")
+    assert response.status_code == HTTPStatus.NO_CONTENT.value
+    _list_and_assert_objects(client, "feature_sets", project_name, f"name={name}", 0)
+
+
 def test_feature_set_create_failure_already_exists(
     db: Session, client: TestClient
 ) -> None:


### PR DESCRIPTION
Added REST API and DB implementation for deleting specific versions of feature-set and feature-vector objects. Versions are identified by a reference (either `uid` or `tag`), as usual.
APIs are also supported through the httpdb interface in `delete_feature_vector` and `delete_feature_set`.

Delete REST APIs supported now are:
```
DELETE /projects/{project}/feature-sets/{name}
DELETE /projects/{project}/feature-sets/{name}/references/{reference}
```
(and of course, same for feature-vectors)