### PR TITLE
[Runtime resources] Support grouping by job

### DIFF
--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,9 +1,11 @@
 from http import HTTPStatus
+import typing
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Response, Query
 from sqlalchemy.orm import Session
 
 import mlrun.api.crud
+import mlrun.api.schemas
 from mlrun.api.api import deps
 from mlrun.config import config
 
@@ -12,7 +14,14 @@ router = APIRouter()
 
 @router.get("/runtimes")
 def list_runtimes(label_selector: str = None):
-    return mlrun.api.crud.Runtimes().list_runtimes(label_selector)
+    return mlrun.api.crud.Runtimes().list_runtimes("*", label_selector)
+
+
+# TODO: move everything to use this endpoint instead of list_runtimes and deprecate it
+@router.get("/projects/{project}/runtime-resources")
+def list_runtime_resources(project: str, label_selector: str = None,
+                           group_by: typing.Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = Query(None, alias="group-by"),):
+    return mlrun.api.crud.Runtimes().list_runtimes(project, label_selector, group_by)
 
 
 @router.get("/runtimes/{kind}")

--- a/mlrun/api/api/endpoints/runtimes.py
+++ b/mlrun/api/api/endpoints/runtimes.py
@@ -1,7 +1,7 @@
-from http import HTTPStatus
 import typing
+from http import HTTPStatus
 
-from fastapi import APIRouter, Depends, Response, Query
+from fastapi import APIRouter, Depends, Query, Response
 from sqlalchemy.orm import Session
 
 import mlrun.api.crud
@@ -19,8 +19,13 @@ def list_runtimes(label_selector: str = None):
 
 # TODO: move everything to use this endpoint instead of list_runtimes and deprecate it
 @router.get("/projects/{project}/runtime-resources")
-def list_runtime_resources(project: str, label_selector: str = None,
-                           group_by: typing.Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = Query(None, alias="group-by"),):
+def list_runtime_resources(
+    project: str,
+    label_selector: str = None,
+    group_by: typing.Optional[
+        mlrun.api.schemas.ListRuntimeResourcesGroupByField
+    ] = Query(None, alias="group-by"),
+):
     return mlrun.api.crud.Runtimes().list_runtimes(project, label_selector, group_by)
 
 

--- a/mlrun/api/crud/runtimes.py
+++ b/mlrun/api/crud/runtimes.py
@@ -1,7 +1,7 @@
 import http
 import typing
-import mergedeep
 
+import mergedeep
 import sqlalchemy.orm
 
 import mlrun.api.api.utils
@@ -12,16 +12,23 @@ import mlrun.config
 import mlrun.errors
 import mlrun.runtimes
 import mlrun.utils.singleton
-from mlrun.utils import logger
 
 
 class Runtimes(metaclass=mlrun.utils.singleton.Singleton,):
-    def list_runtimes(self, project: str, label_selector: str = None,
-                      group_by: typing.Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None) -> typing.Union[typing.Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
+    def list_runtimes(
+        self,
+        project: str,
+        label_selector: str = None,
+        group_by: typing.Optional[
+            mlrun.api.schemas.ListRuntimeResourcesGroupByField
+        ] = None,
+    ) -> typing.Union[typing.Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         runtimes = [] if group_by is None else {}
         for kind in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
             runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
-            resources = runtime_handler.list_resources(project, label_selector, group_by)
+            resources = runtime_handler.list_resources(
+                project, label_selector, group_by
+            )
             if group_by is None:
                 runtimes.append({"kind": kind, "resources": resources})
             else:

--- a/mlrun/api/crud/runtimes.py
+++ b/mlrun/api/crud/runtimes.py
@@ -1,4 +1,6 @@
 import http
+import typing
+import mergedeep
 
 import sqlalchemy.orm
 
@@ -10,15 +12,20 @@ import mlrun.config
 import mlrun.errors
 import mlrun.runtimes
 import mlrun.utils.singleton
+from mlrun.utils import logger
 
 
 class Runtimes(metaclass=mlrun.utils.singleton.Singleton,):
-    def list_runtimes(self, label_selector: str = None):
-        runtimes = []
+    def list_runtimes(self, project: str, label_selector: str = None,
+                      group_by: typing.Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None) -> typing.Union[typing.Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
+        runtimes = [] if group_by is None else {}
         for kind in mlrun.runtimes.RuntimeKinds.runtime_with_handlers():
             runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
-            resources = runtime_handler.list_resources(label_selector)
-            runtimes.append({"kind": kind, "resources": resources})
+            resources = runtime_handler.list_resources(project, label_selector, group_by)
+            if group_by is None:
+                runtimes.append({"kind": kind, "resources": resources})
+            else:
+                mergedeep.merge(runtimes, resources)
         return runtimes
 
     def get_runtime(self, kind: str, label_selector: str = None):
@@ -27,7 +34,7 @@ class Runtimes(metaclass=mlrun.utils.singleton.Singleton,):
                 http.HTTPStatus.BAD_REQUEST.value, kind=kind, err="Invalid runtime kind"
             )
         runtime_handler = mlrun.runtimes.get_runtime_handler(kind)
-        resources = runtime_handler.list_resources(label_selector)
+        resources = runtime_handler.list_resources("*", label_selector)
         return {
             "kind": kind,
             "resources": resources,

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -8,7 +8,6 @@ from .background_task import (
     BackgroundTaskState,
     BackgroundTaskStatus,
 )
-from .runtime_resource import ListRuntimeResourcesGroupByField, GroupedRuntimeResourcesOutput, RuntimeResourcesOutput
 from .constants import DeletionStrategy, Format, HeaderNames, PatchMode
 from .feature_store import (
     EntitiesOutput,
@@ -52,6 +51,11 @@ from .project import (
     ProjectSpec,
     ProjectState,
     ProjectStatus,
+)
+from .runtime_resource import (
+    GroupedRuntimeResourcesOutput,
+    ListRuntimeResourcesGroupByField,
+    RuntimeResourcesOutput,
 )
 from .schedule import (
     ScheduleCronTrigger,

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -8,6 +8,7 @@ from .background_task import (
     BackgroundTaskState,
     BackgroundTaskStatus,
 )
+from .runtime_resource import ListRuntimeResourcesGroupByField, GroupedRuntimeResourcesOutput, RuntimeResourcesOutput
 from .constants import DeletionStrategy, Format, HeaderNames, PatchMode
 from .feature_store import (
     EntitiesOutput,

--- a/mlrun/api/schemas/runtime_resource.py
+++ b/mlrun/api/schemas/runtime_resource.py
@@ -1,0 +1,19 @@
+
+import enum
+import typing
+import pydantic
+
+
+class ListRuntimeResourcesGroupByField(str, enum.Enum):
+    job = "job"
+
+
+class RuntimeResourcesOutput(pydantic.BaseModel):
+    crd_resources: typing.List[typing.Dict]
+    pod_resources: typing.List[typing.Dict]
+
+    class Config:
+        extra = pydantic.Extra.allow
+
+
+GroupedRuntimeResourcesOutput = typing.Dict[str, RuntimeResourcesOutput]

--- a/mlrun/api/schemas/runtime_resource.py
+++ b/mlrun/api/schemas/runtime_resource.py
@@ -1,6 +1,6 @@
-
 import enum
 import typing
+
 import pydantic
 
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -893,10 +893,16 @@ class BaseRuntimeHandler(ABC):
         """
         pass
 
-    def list_resources(self, project: str, label_selector: str = None,
-                       group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
+    def list_resources(
+        self,
+        project: str,
+        label_selector: str = None,
+        group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
+    ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         if project and project != "*" and group_by is not None:
-            raise mlrun.errors.MLRunInvalidArgumentError("Group by can not be used across projects")
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Group by can not be used across projects"
+            )
         k8s_helper = get_k8s_helper()
         namespace = k8s_helper.resolve_namespace()
         label_selector = self._resolve_label_selector(project, label_selector)
@@ -904,7 +910,9 @@ class BaseRuntimeHandler(ABC):
         pod_resources = self._build_pod_resources(pods)
         crd_objects = self._list_crd_objects(namespace, label_selector)
         crd_resources = self._build_crd_resources(crd_objects)
-        response = self._build_list_resources_response(pod_resources, crd_resources, group_by)
+        response = self._build_list_resources_response(
+            pod_resources, crd_resources, group_by
+        )
         response = self._enrich_list_resources_response(
             response, namespace, label_selector, group_by
         )
@@ -989,8 +997,11 @@ class BaseRuntimeHandler(ABC):
                 )
 
     def _enrich_list_resources_response(
-        self, response: Dict, namespace: str, label_selector: str = None,
-            group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None
+        self,
+        response: Dict,
+        namespace: str,
+        label_selector: str = None,
+        group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         """
         Override this to list resources other then pods or CRDs (which are handled by the base class)
@@ -1385,10 +1396,12 @@ class BaseRuntimeHandler(ABC):
         if updated_run_state in RunStates.terminal_states():
             self._ensure_run_logs_collected(db, db_session, project, uid)
 
-    def _build_list_resources_response(self,
-                                       pod_resources: List = None, crd_resources: List = None,
-                                       group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None
-                                       ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
+    def _build_list_resources_response(
+        self,
+        pod_resources: List = None,
+        crd_resources: List = None,
+        group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
+    ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         if crd_resources is None:
             crd_resources = []
         if pod_resources is None:
@@ -1401,26 +1414,39 @@ class BaseRuntimeHandler(ABC):
             }
         else:
             if group_by == mlrun.api.schemas.ListRuntimeResourcesGroupByField.job:
-                return self._build_grouped_by_job_list_resources_response(pod_resources, crd_resources)
+                return self._build_grouped_by_job_list_resources_response(
+                    pod_resources, crd_resources
+                )
             else:
                 raise NotImplementedError(
                     f"Provided format is not supported. group_by={group_by}"
                 )
 
-    def _build_grouped_by_job_list_resources_response(self, pod_resources: List = None, crd_resources: List = None) -> mlrun.api.schemas.GroupedRuntimeResourcesOutput:
+    def _build_grouped_by_job_list_resources_response(
+        self, pod_resources: List = None, crd_resources: List = None
+    ) -> mlrun.api.schemas.GroupedRuntimeResourcesOutput:
         resources = {}
         for pod_resource in pod_resources:
-            self._add_resource_to_grouped_by_job_resources_response(resources, "pod_resources", pod_resource)
+            self._add_resource_to_grouped_by_job_resources_response(
+                resources, "pod_resources", pod_resource
+            )
         for crd_resource in crd_resources:
-            self._add_resource_to_grouped_by_job_resources_response(resources, "crd_resources", crd_resource)
+            self._add_resource_to_grouped_by_job_resources_response(
+                resources, "crd_resources", crd_resource
+            )
 
     @staticmethod
-    def _add_resource_to_grouped_by_job_resources_response(resources: mlrun.api.schemas.GroupedRuntimeResourcesOutput,
-                                                           resource_field_name: str, resource: dict):
+    def _add_resource_to_grouped_by_job_resources_response(
+        resources: mlrun.api.schemas.GroupedRuntimeResourcesOutput,
+        resource_field_name: str,
+        resource: dict,
+    ):
         if "mlrun/uid" in resource["labels"]:
             uid = resource["labels"]["mlrun/uid"]
             if uid not in resources:
-                resources[uid] = mlrun.api.schemas.RuntimeResourcesOutput(pod_resources=[], crd_resources=[])
+                resources[uid] = mlrun.api.schemas.RuntimeResourcesOutput(
+                    pod_resources=[], crd_resources=[]
+                )
             getattr(resources[uid], resource_field_name).append(resource)
 
     @staticmethod

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -899,7 +899,7 @@ class BaseRuntimeHandler(ABC):
         label_selector: str = None,
         group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
-        if project and project != "*" and group_by is not None:
+        if project and project == "*" and group_by is not None:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Group by can not be used across projects"
             )
@@ -1434,6 +1434,7 @@ class BaseRuntimeHandler(ABC):
             self._add_resource_to_grouped_by_job_resources_response(
                 resources, "crd_resources", crd_resource
             )
+        return resources
 
     @staticmethod
     def _add_resource_to_grouped_by_job_resources_response(

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -488,8 +488,11 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         return "mlrun/class=dask"
 
     def _enrich_list_resources_response(
-        self, response: Dict, namespace: str, label_selector: str = None,
-            group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None
+        self,
+        response: Dict,
+        namespace: str,
+        label_selector: str = None,
+        group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         """
         Handling listing service resources

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -16,7 +16,7 @@ import inspect
 import socket
 import time
 from os import environ
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 
 from kubernetes.client.rest import ApiException
 from sqlalchemy.orm import Session
@@ -488,11 +488,15 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         return "mlrun/class=dask"
 
     def _enrich_list_resources_response(
-        self, response: Dict, namespace: str, label_selector: str = None
-    ) -> Dict:
+        self, response: Dict, namespace: str, label_selector: str = None,
+            group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None
+    ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         """
         Handling listing service resources
         """
+        # TODO: add support for enrichment also with group by
+        if group_by is not None:
+            return response
         k8s_helper = get_k8s_helper()
         services = k8s_helper.v1api.list_namespaced_service(
             namespace, label_selector=label_selector

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -1,14 +1,14 @@
 import unittest.mock
-import deepdiff
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
+import deepdiff
 import pytest
 from kubernetes import client
 from sqlalchemy.orm import Session
 
-import mlrun.api.schemas
 import mlrun.api.crud as crud
+import mlrun.api.schemas
 from mlrun.api.constants import LogSources
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
@@ -85,7 +85,11 @@ class TestRuntimeHandlerBase:
         return pod
 
     def _assert_runtime_handler_list_resources(
-        self, runtime_kind, expected_crds=None, expected_pods=None, expected_services=None,
+        self,
+        runtime_kind,
+        expected_crds=None,
+        expected_pods=None,
+        expected_services=None,
         group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ):
         runtime_handler = get_runtime_handler(runtime_kind)
@@ -95,15 +99,21 @@ class TestRuntimeHandlerBase:
             assertion_func = TestRuntimeHandlerBase._assert_list_resources_response
         elif group_by == mlrun.api.schemas.ListRuntimeResourcesGroupByField.job:
             project = self.project
-            label_selector = ",".join([runtime_handler._get_default_label_selector(), f"mlrun/project={self.project}"])
-            assertion_func = TestRuntimeHandlerBase._assert_list_resources_grouped_response
+            label_selector = ",".join(
+                [
+                    runtime_handler._get_default_label_selector(),
+                    f"mlrun/project={self.project}",
+                ]
+            )
+            assertion_func = (
+                TestRuntimeHandlerBase._assert_list_resources_grouped_response
+            )
         else:
             raise NotImplementedError("Unsupported group by value")
         resources = runtime_handler.list_resources(project, group_by=group_by)
         crd_group, crd_version, crd_plural = runtime_handler._get_crd_info()
         get_k8s().v1api.list_namespaced_pod.assert_called_once_with(
-            get_k8s().resolve_namespace(),
-            label_selector=label_selector,
+            get_k8s().resolve_namespace(), label_selector=label_selector,
         )
         if expected_crds:
             get_k8s().crdapi.list_namespaced_custom_object.assert_called_once_with(
@@ -115,8 +125,7 @@ class TestRuntimeHandlerBase:
             )
         if expected_services:
             get_k8s().v1api.list_namespaced_service.assert_called_once_with(
-                get_k8s().resolve_namespace(),
-                label_selector=label_selector,
+                get_k8s().resolve_namespace(), label_selector=label_selector,
             )
         assertion_func(
             resources,
@@ -127,7 +136,10 @@ class TestRuntimeHandlerBase:
 
     @staticmethod
     def _assert_list_resources_grouped_response(
-            resources: mlrun.api.schemas.GroupedRuntimeResourcesOutput, expected_crds=None, expected_pods=None, expected_services=None
+        resources: mlrun.api.schemas.GroupedRuntimeResourcesOutput,
+        expected_crds=None,
+        expected_pods=None,
+        expected_services=None,
     ):
         expected_crds = expected_crds or []
         expected_pods = expected_pods or []
@@ -138,8 +150,20 @@ class TestRuntimeHandlerBase:
             for crd_resource in resources[job_uid].crd_resources:
                 if crd_resource["name"] == crd["metadata"]["name"]:
                     found = True
-                    assert deepdiff.DeepDiff(crd_resource["labels"], crd["metadata"]["labels"], ignore_order=True, ) == {}
-                    assert deepdiff.DeepDiff(crd_resource["status"], crd["status"], ignore_order=True, ) == {}
+                    assert (
+                        deepdiff.DeepDiff(
+                            crd_resource["labels"],
+                            crd["metadata"]["labels"],
+                            ignore_order=True,
+                        )
+                        == {}
+                    )
+                    assert (
+                        deepdiff.DeepDiff(
+                            crd_resource["status"], crd["status"], ignore_order=True,
+                        )
+                        == {}
+                    )
             if not found:
                 pytest.fail("Expected crd was not found in response resources")
         for index, pod in enumerate(expected_pods):
@@ -149,8 +173,22 @@ class TestRuntimeHandlerBase:
             for pod_resource in resources[job_uid].pod_resources:
                 if pod_resource["name"] == pod_dict["metadata"]["name"]:
                     found = True
-                    assert deepdiff.DeepDiff(pod_resource["labels"], pod_dict["metadata"]["labels"], ignore_order=True, ) == {}
-                    assert deepdiff.DeepDiff(pod_resource["status"], pod_dict["status"], ignore_order=True, ) == {}
+                    assert (
+                        deepdiff.DeepDiff(
+                            pod_resource["labels"],
+                            pod_dict["metadata"]["labels"],
+                            ignore_order=True,
+                        )
+                        == {}
+                    )
+                    assert (
+                        deepdiff.DeepDiff(
+                            pod_resource["status"],
+                            pod_dict["status"],
+                            ignore_order=True,
+                        )
+                        == {}
+                    )
             if not found:
                 pytest.fail("Expected pod was not found in response resources")
         for index, service in enumerate(expected_services):
@@ -159,8 +197,22 @@ class TestRuntimeHandlerBase:
             for service_resource in resources[job_uid].service_resources:
                 if service_resource["name"] == service.metadata.name:
                     found = True
-                    assert deepdiff.DeepDiff(service_resource["labels"], service.metadata.labels, ignore_order=True, ) == {}
-                    assert deepdiff.DeepDiff(service_resource["status"], service.metadata.status, ignore_order=True, ) == {}
+                    assert (
+                        deepdiff.DeepDiff(
+                            service_resource["labels"],
+                            service.metadata.labels,
+                            ignore_order=True,
+                        )
+                        == {}
+                    )
+                    assert (
+                        deepdiff.DeepDiff(
+                            service_resource["status"],
+                            service.metadata.status,
+                            ignore_order=True,
+                        )
+                        == {}
+                    )
             if not found:
                 pytest.fail("Expected service was not found in response resources")
 

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -84,6 +84,12 @@ class TestRuntimeHandlerBase:
         pod = client.V1Pod(metadata=metadata, status=status)
         return pod
 
+    def _generate_get_logger_pods_label_selector(self, runtime_handler):
+        run_label_selector = runtime_handler._get_run_label_selector(
+            self.project, self.run_uid
+        )
+        return f"mlrun/class,{run_label_selector}"
+
     def _assert_runtime_handler_list_resources(
         self,
         runtime_kind,

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -87,7 +87,7 @@ class TestRuntimeHandlerBase:
         runtime_kind, expected_crds=None, expected_pods=None, expected_services=None,
     ):
         runtime_handler = get_runtime_handler(runtime_kind)
-        resources = runtime_handler.list_resources()
+        resources = runtime_handler.list_resources("*")
         crd_group, crd_version, crd_plural = runtime_handler._get_crd_info()
         get_k8s().v1api.list_namespaced_pod.assert_called_once_with(
             get_k8s().resolve_namespace(),

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -1,11 +1,13 @@
 import unittest.mock
+import deepdiff
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pytest
 from kubernetes import client
 from sqlalchemy.orm import Session
 
+import mlrun.api.schemas
 import mlrun.api.crud as crud
 from mlrun.api.constants import LogSources
 from mlrun.api.utils.singletons.db import get_db
@@ -82,16 +84,26 @@ class TestRuntimeHandlerBase:
         pod = client.V1Pod(metadata=metadata, status=status)
         return pod
 
-    @staticmethod
     def _assert_runtime_handler_list_resources(
-        runtime_kind, expected_crds=None, expected_pods=None, expected_services=None,
+        self, runtime_kind, expected_crds=None, expected_pods=None, expected_services=None,
+        group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ):
         runtime_handler = get_runtime_handler(runtime_kind)
-        resources = runtime_handler.list_resources("*")
+        if group_by is None:
+            project = "*"
+            label_selector = runtime_handler._get_default_label_selector()
+            assertion_func = TestRuntimeHandlerBase._assert_list_resources_response
+        elif group_by == mlrun.api.schemas.ListRuntimeResourcesGroupByField.job:
+            project = self.project
+            label_selector = ",".join([runtime_handler._get_default_label_selector(), f"mlrun/project={self.project}"])
+            assertion_func = TestRuntimeHandlerBase._assert_list_resources_grouped_response
+        else:
+            raise NotImplementedError("Unsupported group by value")
+        resources = runtime_handler.list_resources(project, group_by=group_by)
         crd_group, crd_version, crd_plural = runtime_handler._get_crd_info()
         get_k8s().v1api.list_namespaced_pod.assert_called_once_with(
             get_k8s().resolve_namespace(),
-            label_selector=runtime_handler._get_default_label_selector(),
+            label_selector=label_selector,
         )
         if expected_crds:
             get_k8s().crdapi.list_namespaced_custom_object.assert_called_once_with(
@@ -99,19 +111,58 @@ class TestRuntimeHandlerBase:
                 crd_version,
                 get_k8s().resolve_namespace(),
                 crd_plural,
-                label_selector=runtime_handler._get_default_label_selector(),
+                label_selector=label_selector,
             )
         if expected_services:
             get_k8s().v1api.list_namespaced_service.assert_called_once_with(
                 get_k8s().resolve_namespace(),
-                label_selector=runtime_handler._get_default_label_selector(),
+                label_selector=label_selector,
             )
-        TestRuntimeHandlerBase._assert_list_resources_response(
+        assertion_func(
             resources,
             expected_crds=expected_crds,
             expected_pods=expected_pods,
             expected_services=expected_services,
         )
+
+    @staticmethod
+    def _assert_list_resources_grouped_response(
+            resources: mlrun.api.schemas.GroupedRuntimeResourcesOutput, expected_crds=None, expected_pods=None, expected_services=None
+    ):
+        expected_crds = expected_crds or []
+        expected_pods = expected_pods or []
+        expected_services = expected_services or []
+        for index, crd in enumerate(expected_crds):
+            job_uid = crd["metadata"]["labels"]["mlrun/uid"]
+            found = False
+            for crd_resource in resources[job_uid].crd_resources:
+                if crd_resource["name"] == crd["metadata"]["name"]:
+                    found = True
+                    assert deepdiff.DeepDiff(crd_resource["labels"], crd["metadata"]["labels"], ignore_order=True, ) == {}
+                    assert deepdiff.DeepDiff(crd_resource["status"], crd["status"], ignore_order=True, ) == {}
+            if not found:
+                pytest.fail("Expected crd was not found in response resources")
+        for index, pod in enumerate(expected_pods):
+            pod_dict = pod.to_dict()
+            job_uid = pod_dict["metadata"]["labels"]["mlrun/uid"]
+            found = False
+            for pod_resource in resources[job_uid].pod_resources:
+                if pod_resource["name"] == pod_dict["metadata"]["name"]:
+                    found = True
+                    assert deepdiff.DeepDiff(pod_resource["labels"], pod_dict["metadata"]["labels"], ignore_order=True, ) == {}
+                    assert deepdiff.DeepDiff(pod_resource["status"], pod_dict["status"], ignore_order=True, ) == {}
+            if not found:
+                pytest.fail("Expected pod was not found in response resources")
+        for index, service in enumerate(expected_services):
+            job_uid = service["metadata"]["labels"]["mlrun/uid"]
+            found = False
+            for service_resource in resources[job_uid].service_resources:
+                if service_resource["name"] == service.metadata.name:
+                    found = True
+                    assert deepdiff.DeepDiff(service_resource["labels"], service.metadata.labels, ignore_order=True, ) == {}
+                    assert deepdiff.DeepDiff(service_resource["status"], service.metadata.status, ignore_order=True, ) == {}
+            if not found:
+                pytest.fail("Expected service was not found in response resources")
 
     @staticmethod
     def _assert_list_resources_response(

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from mlrun.api.utils.singletons.db import get_db
 import mlrun.api.schemas
+from mlrun.api.utils.singletons.db import get_db
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
 from mlrun.runtimes.constants import PodPhases, RunStates
@@ -45,7 +45,9 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     def test_list_resources_grouped_by_job(self, db: Session, client: TestClient):
         pods = self._mock_list_resources_pods()
         self._assert_runtime_handler_list_resources(
-            RuntimeKinds.job, expected_pods=pods, group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job
+            RuntimeKinds.job,
+            expected_pods=pods,
+            group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job,
         )
 
     def test_delete_resources_completed_pod(self, db: Session, client: TestClient):

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from mlrun.api.utils.singletons.db import get_db
+import mlrun.api.schemas
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
 from mlrun.runtimes.constants import PodPhases, RunStates
@@ -39,6 +40,12 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         pods = self._mock_list_resources_pods()
         self._assert_runtime_handler_list_resources(
             RuntimeKinds.job, expected_pods=pods
+        )
+
+    def test_list_resources_grouped_by_job(self, db: Session, client: TestClient):
+        pods = self._mock_list_resources_pods()
+        self._assert_runtime_handler_list_resources(
+            RuntimeKinds.job, expected_pods=pods, group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job
         )
 
     def test_delete_resources_completed_pod(self, db: Session, client: TestClient):

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -8,7 +8,7 @@ from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
-from mlrun.runtimes.constants import MPIJobCRDVersions, RunStates, PodPhases
+from mlrun.runtimes.constants import MPIJobCRDVersions, PodPhases, RunStates
 from tests.api.runtime_handlers.base import TestRuntimeHandlerBase
 
 
@@ -40,7 +40,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             "mlrun/tag": "latest",
             "mlrun/uid": self.run_uid,
             "mpi-job-name": "trainer-1b019005",
-            "mpi-job-role": "launcher"
+            "mpi-job-role": "launcher",
         }
         launcher_pod_name = "trainer-1b019005-launcher"
 
@@ -50,17 +50,17 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
 
         worker_pod_labels = {
             "group-name": "kubeflow.org",
-                    "mlrun/class": "mpijob",
-                    "mlrun/function": "trainer",
-                    "mlrun/job": "trainer-1b019005",
-                    "mlrun/name": "trainer",
-                    "mlrun/owner": "iguazio",
-                    "mlrun/project": self.project,
-                    "mlrun/scrape-metrics": "True",
-                    "mlrun/tag": "latest",
-                    "mlrun/uid": self.run_uid,
-                    "mpi-job-name": "trainer-1b019005",
-                    "mpi-job-role": "worker"
+            "mlrun/class": "mpijob",
+            "mlrun/function": "trainer",
+            "mlrun/job": "trainer-1b019005",
+            "mlrun/name": "trainer",
+            "mlrun/owner": "iguazio",
+            "mlrun/project": self.project,
+            "mlrun/scrape-metrics": "True",
+            "mlrun/tag": "latest",
+            "mlrun/uid": self.run_uid,
+            "mpi-job-name": "trainer-1b019005",
+            "mpi-job-role": "worker",
         }
         worker_pod_name = "trainer-1b019005-worker-0"
 
@@ -68,13 +68,17 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             worker_pod_name, worker_pod_labels, PodPhases.running,
         )
 
-        self.pod_label_selector = self._generate_get_logger_pods_label_selector(self.runtime_handler)
+        self.pod_label_selector = self._generate_get_logger_pods_label_selector(
+            self.runtime_handler
+        )
 
     def test_list_resources(self):
         mocked_responses = self._mock_list_namespaced_crds([[self.succeeded_crd_dict]])
         pods = self._mock_list_resources_pods()
         self._assert_runtime_handler_list_resources(
-            RuntimeKinds.mpijob, expected_crds=mocked_responses[0]["items"], expected_pods=pods
+            RuntimeKinds.mpijob,
+            expected_crds=mocked_responses[0]["items"],
+            expected_pods=pods,
         )
 
     def test_list_resources_grouped_by_job(self, db: Session, client: TestClient):

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from mlrun.api.utils.singletons.db import get_db
+import mlrun.api.schemas
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
@@ -32,10 +33,16 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         # from finding the pods, so we're simulating the same thing here
         self._mock_list_namespaced_pods([[]])
 
-    def test_list_mpijob_resources(self):
+    def test_list_resources(self):
         mocked_responses = self._mock_list_namespaced_crds([[self.succeeded_crd_dict]])
         self._assert_runtime_handler_list_resources(
             RuntimeKinds.mpijob, expected_crds=mocked_responses[0]["items"]
+        )
+
+    def test_list_resources_grouped_by_job(self, db: Session, client: TestClient):
+        mocked_responses = self._mock_list_namespaced_crds([[self.succeeded_crd_dict]])
+        self._assert_runtime_handler_list_resources(
+            RuntimeKinds.mpijob, expected_crds=mocked_responses[0]["items"], group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job
         )
 
     def test_delete_resources_succeeded_crd(self, db: Session, client: TestClient):

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from mlrun.api.utils.singletons.db import get_db
 import mlrun.api.schemas
+from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
@@ -42,7 +42,9 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
     def test_list_resources_grouped_by_job(self, db: Session, client: TestClient):
         mocked_responses = self._mock_list_namespaced_crds([[self.succeeded_crd_dict]])
         self._assert_runtime_handler_list_resources(
-            RuntimeKinds.mpijob, expected_crds=mocked_responses[0]["items"], group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job
+            RuntimeKinds.mpijob,
+            expected_crds=mocked_responses[0]["items"],
+            group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job,
         )
 
     def test_delete_resources_succeeded_crd(self, db: Session, client: TestClient):

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from mlrun.api.utils.singletons.db import get_db
 import mlrun.api.schemas
+from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
 from mlrun.runtimes.constants import PodPhases, RunStates

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from mlrun.api.utils.singletons.db import get_db
+import mlrun.api.schemas
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
 from mlrun.runtimes.constants import PodPhases, RunStates
@@ -73,13 +74,23 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self.pod_label_selector = f"mlrun/class,{run_label_selector}"
 
-    def test_list_sparkjob_resources(self):
+    def test_list_resources(self):
         mocked_responses = self._mock_list_namespaced_crds([[self.completed_crd_dict]])
         pods = self._mock_list_resources_pods()
         self._assert_runtime_handler_list_resources(
             RuntimeKinds.spark,
             expected_crds=mocked_responses[0]["items"],
             expected_pods=pods,
+        )
+
+    def test_list_resources_grouped_by_job(self):
+        mocked_responses = self._mock_list_namespaced_crds([[self.completed_crd_dict]])
+        pods = self._mock_list_resources_pods()
+        self._assert_runtime_handler_list_resources(
+            RuntimeKinds.spark,
+            expected_crds=mocked_responses[0]["items"],
+            expected_pods=pods,
+            group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.job,
         )
 
     def test_delete_resources_completed_crd(self, db: Session, client: TestClient):

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -69,10 +69,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             driver_pod_name, driver_pod_labels, PodPhases.running,
         )
 
-        run_label_selector = self.runtime_handler._get_run_label_selector(
-            self.project, self.run_uid
-        )
-        self.pod_label_selector = f"mlrun/class,{run_label_selector}"
+        self.pod_label_selector = self._generate_get_logger_pods_label_selector(self.runtime_handler)
 
     def test_list_resources(self):
         mocked_responses = self._mock_list_namespaced_crds([[self.completed_crd_dict]])

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -69,7 +69,9 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             driver_pod_name, driver_pod_labels, PodPhases.running,
         )
 
-        self.pod_label_selector = self._generate_get_logger_pods_label_selector(self.runtime_handler)
+        self.pod_label_selector = self._generate_get_logger_pods_label_selector(
+            self.runtime_handler
+        )
 
     def test_list_resources(self):
         mocked_responses = self._mock_list_namespaced_crds([[self.completed_crd_dict]])


### PR DESCRIPTION
Due to time restrictions I did some non-consistent stuff here/broke the existing terminology, hopefully I'll be able to align it soon
Added a `GET /projects/{project}/runtime-resources` endpoint (Added TODO to replace to old `GET /runtimes` with this one)
which supports giving `group-by` query param, currently only possible value (beside empty) is `job` which will return the runtime resources grouped by job

Implements https://jira.iguazeng.com/browse/ML-29