### PR TITLE
[API] Fix get tagged objects API serialization 

### DIFF
--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 from mlrun.api.api import deps
 from mlrun.api.api.utils import log_and_raise
 from mlrun.api.db.sqldb.helpers import table2cls
-from mlrun.api.db.sqldb.helpers import to_dict as db2dict
 from mlrun.api.utils.singletons.db import get_db
 
 router = APIRouter()
@@ -63,7 +62,7 @@ def get_tagged(
     return {
         "project": project,
         "tag": name,
-        "objects": [db2dict(obj) for obj in objs],
+        "objects": [obj.to_dict() for obj in objs],
     }
 
 


### PR DESCRIPTION
The `get_tagged()` API would use a version of `to_dict` that used Python introspection. In SQLAlchemy 1.4, a new attribute `registry` was added to the `base_declarative` class as part of a major change done to support declarative mapping. When calling `get_tagged()` it attempts to serialize the `registry` attribute for the HTTP response, and it fails.
To fix, switched to using the `BaseModel.to_dict()` function instead, which extracts just the DB columns and ignores other Python attributes. Note that this is only done for tags APIs, as these are the only APIs currently exposing DB objects externally (and not going through `from_orm` or something similar).