### PR TITLE
[Artifacts] Support {{project}} in artifact path + support template for project's log_x methods

### DIFF
--- a/docs/howto/remote.md
+++ b/docs/howto/remote.md
@@ -46,10 +46,10 @@ Set environment variables to define your MLRun configuration. As a minimum requi
     MLRUN_DBPATH=<API endpoint of the MLRun APIs service engpoint; e.g., "https://mlrun-api.default-tenant.app.mycluster.iguazio.com">
     ```
     
-2. In order to store the artifacts on the remote server, you need to set the `MLRUN_ARTIFACT_PATH` to the desired root folder of your artifact. You can use `{{run.project}}` to include the project name in the path `{{run.uid}}` to include the specific run uid in the artifact path. For example:
+2. In order to store the artifacts on the remote server, you need to set the `MLRUN_ARTIFACT_PATH` to the desired root folder of your artifact. You can use `{{project}}` to include the project name in the path `{{run.uid}}` to include the specific run uid in the artifact path. For example:
 
     ```ini
-    MLRUN_ARTIFACT_PATH=/User/artifacts/{{run.project}}
+    MLRUN_ARTIFACT_PATH=/User/artifacts/{{project}}
     ```
 
 3. If the remote service is on an instance of the Iguazio Data Science Platform (**"the platform"**), set the following environment variables as well; replace the `<...>` placeholders with the information for your specific platform cluster:

--- a/docs/install.md
+++ b/docs/install.md
@@ -128,10 +128,10 @@ Define your MLRun configuration. As a minimum requirement:
     MLRUN_DBPATH=<API endpoint of the MLRun APIs service engpoint; e.g., "https://mlrun-api.default-tenant.app.mycluster.iguazio.com">
     ```
 
-2. In order to store the artifacts on the remote server, you need to set the `MLRUN_ARTIFACT_PATH` to the desired root folder of your artifact. You can use `{{run.project}}` to include the project name in the path `{{run.uid}}` to include the specific run uid in the artifact path. For example:
+2. In order to store the artifacts on the remote server, you need to set the `MLRUN_ARTIFACT_PATH` to the desired root folder of your artifact. You can use `{{project}}` to include the project name in the path `{{run.uid}}` to include the specific run uid in the artifact path. For example:
 
     ```ini
-    MLRUN_ARTIFACT_PATH=/User/artifacts/{{run.project}}
+    MLRUN_ARTIFACT_PATH=/User/artifacts/{{project}}
     ```
 
 3. If the remote service is on an instance of the Iguazio Data Science Platform (**"the platform"**), set the following environment variables as well; replace the `<...>` placeholders with the information for your specific platform cluster:

--- a/docs/store/artifacts.md
+++ b/docs/store/artifacts.md
@@ -41,8 +41,8 @@ You can set the default artifact_path for your environment using the {py:func}`~
 
 You can override the default artifact_path configuration by setting the artifact_path parameter of 
 the {py:func}`~mlrun.set_environment` function. You can use variables in the artifacts path, 
-such as {{run.project}} for the name of the running project or {{run.uid}} for the current job/pipeline run UID. 
-(The default artifacts path uses {{run.project}}.) The following example configures the artifacts path to an 
+such as {{project}} for the name of the running project or {{run.uid}} for the current job/pipeline run UID. 
+(The default artifacts path uses {{project}}.) The following example configures the artifacts path to an 
 artifacts directory in the current active directory (./artifacts)
 
     set_environment(project=project_name, artifact_path='./artifacts')

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -780,6 +780,7 @@ class MlrunProject(ModelObj):
     ):
         am = self._get_artifact_manager()
         artifact_path = artifact_path or self.spec.artifact_path
+        artifact_path = mlrun.utils.helpers.fill_artifact_path_template(artifact_path, self.metadata.name)
         producer = ArtifactProducer(
             "project",
             self.metadata.name,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -780,7 +780,9 @@ class MlrunProject(ModelObj):
     ):
         am = self._get_artifact_manager()
         artifact_path = artifact_path or self.spec.artifact_path
-        artifact_path = mlrun.utils.helpers.fill_artifact_path_template(artifact_path, self.metadata.name)
+        artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
+            artifact_path, self.metadata.name
+        )
         producer = ArtifactProducer(
             "project",
             self.metadata.name,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -29,6 +29,7 @@ from nuclio import build_file
 
 import mlrun.api.schemas
 import mlrun.errors
+import mlrun.utils.helpers
 
 from .config import config as mlconf
 from .datastore import store_manager
@@ -56,7 +57,6 @@ from .utils import (
     retry_until_successful,
     update_in,
 )
-import mlrun.utils.helpers
 
 
 class RunStatuses(object):
@@ -791,7 +791,9 @@ def run_pipeline(
     remote = not get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster()
 
     artifact_path = artifact_path or mlconf.artifact_path
-    artifact_path = mlrun.utils.helpers.fill_artifact_path_template(artifact_path, project)
+    artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
+        artifact_path, project
+    )
     if artifact_path and "{{run.uid}}" in artifact_path:
         artifact_path.replace("{{run.uid}}", "{{workflow.uid}}")
     if not artifact_path:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -56,6 +56,7 @@ from .utils import (
     retry_until_successful,
     update_in,
 )
+import mlrun.utils.helpers
 
 
 class RunStatuses(object):
@@ -790,15 +791,9 @@ def run_pipeline(
     remote = not get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster()
 
     artifact_path = artifact_path or mlconf.artifact_path
+    artifact_path = mlrun.utils.helpers.fill_artifact_path_template(artifact_path, project)
     if artifact_path and "{{run.uid}}" in artifact_path:
         artifact_path.replace("{{run.uid}}", "{{workflow.uid}}")
-    if artifact_path and "{{run.project}}" in artifact_path:
-        if not project:
-            raise ValueError(
-                "project name must be specified with this"
-                + f" artifact_path template {artifact_path}"
-            )
-        artifact_path.replace("{{run.project}}", project)
     if not artifact_path:
         raise ValueError("artifact path was not specified")
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -354,7 +354,9 @@ class BaseRuntime(ModelObj):
             runspec.spec.output_path = runspec.spec.output_path.replace(
                 "{{run.uid}}", meta.uid
             )
-            runspec.spec.output_path = mlrun.utils.helpers.fill_artifact_path_template(runspec.spec.output_path, runspec.metadata.project)
+            runspec.spec.output_path = mlrun.utils.helpers.fill_artifact_path_template(
+                runspec.spec.output_path, runspec.metadata.project
+            )
         if is_local(runspec.spec.output_path):
             logger.warning(
                 "artifact path is not defined or is local,"

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -354,9 +354,7 @@ class BaseRuntime(ModelObj):
             runspec.spec.output_path = runspec.spec.output_path.replace(
                 "{{run.uid}}", meta.uid
             )
-            runspec.spec.output_path = runspec.spec.output_path.replace(
-                "{{run.project}}", runspec.metadata.project
-            )
+            runspec.spec.output_path = mlrun.utils.helpers.fill_artifact_path_template(runspec.spec.output_path, runspec.metadata.project)
         if is_local(runspec.spec.output_path):
             logger.warning(
                 "artifact path is not defined or is local,"

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -850,3 +850,17 @@ def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
 
 def as_list(element: Any) -> List[Any]:
     return element if isinstance(element, list) else [element]
+
+
+def fill_artifact_path_template(artifact_path, project):
+    # Supporting {{project}} is new, in certain setup configuration the default artifact path has the old
+    # {{run.project}} so we're supporting it too for backwards compatibility
+    if artifact_path and ("{{run.project}}" in artifact_path or "{{project}}" in artifact_path):
+        if not project:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "project name must be specified with this"
+                + f" artifact_path template {artifact_path}"
+            )
+        artifact_path.replace("{{run.project}}", project)
+        artifact_path.replace("{{project}}", project)
+    return artifact_path

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -855,12 +855,14 @@ def as_list(element: Any) -> List[Any]:
 def fill_artifact_path_template(artifact_path, project):
     # Supporting {{project}} is new, in certain setup configuration the default artifact path has the old
     # {{run.project}} so we're supporting it too for backwards compatibility
-    if artifact_path and ("{{run.project}}" in artifact_path or "{{project}}" in artifact_path):
+    if artifact_path and (
+        "{{run.project}}" in artifact_path or "{{project}}" in artifact_path
+    ):
         if not project:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "project name must be specified with this"
                 + f" artifact_path template {artifact_path}"
             )
-        artifact_path.replace("{{run.project}}", project)
-        artifact_path.replace("{{project}}", project)
+        artifact_path = artifact_path.replace("{{run.project}}", project)
+        artifact_path = artifact_path.replace("{{project}}", project)
     return artifact_path


### PR DESCRIPTION
In certain setup configuration we configure the default artifact path to have the `{{run.project}}` this was not working with the [recently added](https://github.com/mlrun/mlrun/pull/786) project's log_x methods
To solve that, and for the terminology to make sense, I added support to `{{project}}` for artifact path (while keeping BC with `{{run.project}}`) And added this support in the project's log_x methods as well

Fixes https://jira.iguazeng.com/browse/ML-302