### PR TITLE
[Doc] Remove preceding "-" in front of mlrun-kit in installation guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -151,7 +151,7 @@ Configurable values are documented in the `values.yaml`, and the `values.yaml` o
 ### Uninstalling the Chart
 
 ```bash
-helm --namespace mlrun uninstall -mlrun-kit
+helm --namespace mlrun uninstall mlrun-kit
 ```
 
 > **Note on terminating pods and hanging resources:**


### PR DESCRIPTION
There seems to be a typo in the documentation in the helm uninstall with a preceding "-" for mlrun-kit