### PR TITLE
[Doc] - MLRun - kit fixes

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,8 @@ This guide outlines the steps for installing and running MLRun locally.
   - [Prerequisites](#prerequisites)
   - [Chart Details](#chart-details)
   - [Installing the Chart](#installing-the-chart)
+    - [Basic Installation](#basic-installation)
+    - [Installing on Minikube/VM](#minikube-vm-installation)
   - [Install Kubeflow](#install-kubeflow)
   - [Usage](#usage)
   - [Start Working](#start-working)
@@ -37,7 +39,11 @@ The MLRun Kit chart includes the following stack:
 - NFS: <https://github.com/kubernetes-retired/external-storage/tree/master/nfs>
 - MPI Operator: <https://github.com/kubeflow/mpi-operator>
 
+<a id="installing-the-chart"></a>
 ### Installing the Chart
+
+<a id="basic-installation"></a>
+#### Basic installation
 
 Create a namespace for the deployed components:
 
@@ -81,8 +87,29 @@ helm --namespace mlrun \
 ```
 
 Where:
-
 - `<registry-url` is the registry URL which can be authenticated by the `registry-credentials` secret (e.g., `index.docker.io/<your-username>` for Docker Hub>).
+
+<a id="minikube-vm-installation"></a>
+#### Installing on Minikube/VM
+The Open source MLRun kit uses node ports for simplicity. If your kubernetes cluster is running inside a VM, 
+as is usually the case when using minikube, the kubernetes services exposed over node ports would not be available on 
+your local host interface, but instead, on the virtual machine's interface.
+To accommodate for this, use the `global.externalHostAddress` value on the chart. For example, if you're using 
+the kit inside a minikube cluster (with some non-empty `vm-driver`), pass the VM address in the chart installation 
+command like so:
+
+```bash
+$ helm --namespace mlrun \
+    install my-mlrun \
+    --wait \
+    --set global.registry.url=<registry URL e.g. index.docker.io/iguazio > \
+    --set global.registry.secretName=registry-credentials \
+    --set global.externalHostAddress=$(minikube ip) \
+    v3io-stable/mlrun-kit
+```
+
+Where:
+- `$(minikube ip)` shell command resolving the external node address of the k8s node VM
 
 ### Install Kubeflow
 
@@ -94,9 +121,14 @@ Refer to the [**Kubeflow documentation**](https://www.kubeflow.org/docs/started/
 
 Your applications are now available in your local browser:
 
-- Jupyter-Lab - <http://localhost:30040>
-- MLRun - <http://localhost:30050>
-- Nuclio - <http://localhost:30060>
+- Jupyter-notebook - http://localhost:30040
+- Nuclio - http://localhost:30050
+- MLRun UI - http://locahost:30060
+- MLRun API (external) - http://locahost:30070
+> **Note:**
+> The above links assume your Kubernetes cluster is exposed on localhost.
+> If that's not the case, the different components will be available on the provided `externalHostAddress`
+
 
 ### Start Working
 
@@ -205,7 +237,7 @@ To use MLRun with your local Docker registry, run the MLRun API service, dashboa
 
 > **Note:**
 > - Using Docker is limited to local runtimes.
-> - By default the MLRun API service will run inside the Jupyter server, set the MLRUN_DBPATH env var in Jupyter to point to an alternative service address.
+> - By default, the MLRun API service will run inside the Jupyter server, set the MLRUN_DBPATH env var in Jupyter to point to an alternative service address.
 > - The artifacts and DB will be stored under **/home/jovyan/data**, use docker -v option to persist the content on the host (e.g. `-v $(SHARED_DIR}:/home/jovyan/data`)
 
 ```sh


### PR DESCRIPTION
- Fixing ports - addresses https://github.com/mlrun/mlrun/issues/827
- Adding references from original chart [README](https://github.com/v3io/helm-charts/blob/development/stable/mlrun-kit/README.md) referring to minikube/VM installation and `externalHostAddress` value, with slight edits to fit the local doc structure