### PR TITLE
[Scheduler] Fix concurrency limit check + schedule label name

### DIFF
--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -54,5 +54,8 @@ class HeaderNames:
     secret_store_token = f"{headers_prefix}secret-store-token"
 
 
+labels_prefix = "mlrun/"
+
+
 class LabelNames:
-    schedule_name = "schedule-name"
+    schedule_name = f"{labels_prefix}schedule-name"

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -421,7 +421,7 @@ class Scheduler:
             project=project_name,
             labels=f"{schemas.constants.LabelNames.schedule_name}={schedule_name}",
         )
-        if len(active_runs) > schedule_concurrency_limit:
+        if len(active_runs) >= schedule_concurrency_limit:
             logger.warn(
                 "Schedule exceeded concurrency limit, skipping this run",
                 project=project_name,


### PR DESCRIPTION
* Fixed schedule name label from `schedule-name` to `mlrun/schedule-name"`
* The condition for checking if we passed the limit was `if len(active_runs) > schedule_concurrency_limit:` instead of `if len(active_runs) >= schedule_concurrency_limit:`