### PR TITLE
[API] Fix endpoints running sync code on the reactor

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -139,7 +139,8 @@ async def start_function(
 
     function = await run_in_threadpool(_parse_start_function_body, db_session, data)
 
-    background_task = await run_in_threadpool(mlrun.api.utils.background_tasks.Handler().create_background_task,
+    background_task = await run_in_threadpool(
+        mlrun.api.utils.background_tasks.Handler().create_background_task,
         db_session,
         function.metadata.project,
         background_tasks,

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -137,9 +137,9 @@ async def start_function(
 
     logger.info("Got request to start function", body=data)
 
-    function = _parse_start_function_body(db_session, data)
+    function = await run_in_threadpool(_parse_start_function_body, db_session, data)
 
-    background_task = mlrun.api.utils.background_tasks.Handler().create_background_task(
+    background_task = await run_in_threadpool(mlrun.api.utils.background_tasks.Handler().create_background_task,
         db_session,
         function.metadata.project,
         background_tasks,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -3,8 +3,8 @@ import copy
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import humanfriendly
 import fastapi.concurrency
+import humanfriendly
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
 from sqlalchemy.orm import Session
@@ -182,7 +182,9 @@ class Scheduler:
 
     async def invoke_schedule(self, db_session: Session, project: str, name: str):
         logger.debug("Invoking schedule", project=project, name=name)
-        db_schedule = await fastapi.concurrency.run_in_threadpool(get_db().get_schedule, db_session, project, name)
+        db_schedule = await fastapi.concurrency.run_in_threadpool(
+            get_db().get_schedule, db_session, project, name
+        )
         function, args, kwargs = self._resolve_job_function(
             db_schedule.kind,
             db_schedule.scheduled_object,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import humanfriendly
+import fastapi.concurrency
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
 from sqlalchemy.orm import Session
@@ -181,7 +182,7 @@ class Scheduler:
 
     async def invoke_schedule(self, db_session: Session, project: str, name: str):
         logger.debug("Invoking schedule", project=project, name=name)
-        db_schedule = get_db().get_schedule(db_session, project, name)
+        db_schedule = await fastapi.concurrency.run_in_threadpool(get_db().get_schedule, db_session, project, name)
         function, args, kwargs = self._resolve_job_function(
             db_schedule.kind,
             db_schedule.scheduled_object,


### PR DESCRIPTION
There were several endpoints defined as `async def` meaning they are [running on the reactor](https://fastapi.tiangolo.com/async/#in-a-hurry) meaning any call to sync code should be wrapped with `run_in_threadpool` - the wrapping was missing