### PR TITLE
[Projects] Don't sync projects while mid deletion

### DIFF
--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -30,6 +30,7 @@ class Member(
         self._periodic_sync_interval_seconds = humanfriendly.parse_timespan(
             mlrun.config.config.httpdb.projects.periodic_sync_interval
         )
+        self._projects_in_deletion = set()
         # run one sync to start off on the right foot
         self._sync_projects()
         self._start_periodic_sync()
@@ -91,9 +92,13 @@ class Member(
         name: str,
         deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
     ):
-        self._run_on_all_followers(
-            False, "delete_project", session, name, deletion_strategy
-        )
+        self._projects_in_deletion.add(name)
+        try:
+            self._run_on_all_followers(
+                False, "delete_project", session, name, deletion_strategy
+            )
+        finally:
+            self._projects_in_deletion.remove(name)
 
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str
@@ -167,6 +172,8 @@ class Member(
             all_project.update(project_follower_names_map.keys())
 
             for project in all_project:
+                if project in self._projects_in_deletion:
+                    continue
                 self._ensure_project_synced(
                     session,
                     leader_project_names,

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -98,6 +98,7 @@ def test_projects_sync_mid_deletion(
         [leader_follower, nop_follower, second_nop_follower], project
     )
     original_leader_follower_delete_project = leader_follower.delete_project
+
     def mock_sync_projects_mid_deletion(*args, **kwargs):
         projects_leader._sync_projects()
         original_leader_follower_delete_project(*args, **kwargs)
@@ -105,10 +106,14 @@ def test_projects_sync_mid_deletion(
     leader_follower.delete_project = mock_sync_projects_mid_deletion
     projects_leader.delete_project(db, project_name)
 
-    _assert_no_projects_in_followers([leader_follower, nop_follower, second_nop_follower])
+    _assert_no_projects_in_followers(
+        [leader_follower, nop_follower, second_nop_follower]
+    )
 
     projects_leader._sync_projects()
-    _assert_no_projects_in_followers([leader_follower, nop_follower, second_nop_follower])
+    _assert_no_projects_in_followers(
+        [leader_follower, nop_follower, second_nop_follower]
+    )
 
 
 def test_projects_sync_leader_project_syncing(

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -81,7 +81,7 @@ def test_projects_sync_mid_deletion(
     leader_follower: mlrun.api.utils.projects.remotes.member.Member,
 ):
     """
-    This reproduce a bug in which projects sync is running mid deletion
+    This reproduces a bug in which projects sync is running mid deletion
     The sync starts after the project was removed from followers, but before it was removed from the leader, meaning the
     sync will recognize the project is missing in the followers, and create it in them, so finally after the delete
     process ends, the project exists in the followers, and not in the leader, on the next sync, the project will be


### PR DESCRIPTION
This thing happened several times in system tests causing transient failures, copying the reproducement test docstring:
```
    This reproduce a bug in which projects sync is running mid deletion
    The sync starts after the project was removed from followers, but before it was removed from the leader, meaning the
    sync will recognize the project is missing in the followers, and create it in them, so finally after the delete
    process ends, the project exists in the followers, and not in the leader, on the next sync, the project will be
    created back in the leader causing the the project to practically not being deleted.
```