### PR TITLE
[Projects] Support accessing artifact path from root

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -525,7 +525,7 @@ class MlrunProject(ModelObj):
 
     @property
     def name(self) -> str:
-        """This is a property of the spec, look there for documentation
+        """This is a property of the metadata, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
         warnings.warn(
             "This is a property of the metadata, use project.metadata.name instead"

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -546,6 +546,28 @@ class MlrunProject(ModelObj):
         self.metadata.name = name
 
     @property
+    def artifact_path(self) -> str:
+        """This is a property of the spec, look there for documentation
+        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
+        warnings.warn(
+            "This is a property of the spec, use project.spec.artifact_path instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
+        return self.spec.artifact_path
+
+    @artifact_path.setter
+    def artifact_path(self, artifact_path):
+        warnings.warn(
+            "This is a property of the spec, use project.spec.artifact_path instead"
+            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
+            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
+            PendingDeprecationWarning,
+        )
+        self.spec.artifact_path = artifact_path
+
+    @property
     def source(self) -> str:
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -76,6 +76,8 @@ def test_create_project_from_file_with_legacy_structure():
     # assert accessible from the project as well
     assert project.description == description
     assert project.spec.artifact_path == artifact_path
+    # assert accessible from the project as well
+    assert project.artifact_path == artifact_path
     assert deepdiff.DeepDiff(params, project.spec.params, ignore_order=True,) == {}
     # assert accessible from the project as well
     assert deepdiff.DeepDiff(params, project.params, ignore_order=True,) == {}


### PR DESCRIPTION
In the legacy project structure users did `project.artifact_path` while now they should do `project.spec.artifact_path`
Added a proxy property to allow still doing `project.artifact_path` to keep backwards compatibility 