### PR TITLE
[Feature store] Fix some typo bugs

### DIFF
--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -14,6 +14,7 @@
 from copy import copy
 
 import mlrun
+import mlrun.errors
 from mlrun.runtimes.function_reference import FunctionReference
 from mlrun.utils import parse_versioned_object_uri
 
@@ -107,8 +108,7 @@ class RunConfig:
     @function.setter
     def function(self, function):
         if function and not (
-            isinstance(function, (str, FunctionReference))
-            or hasattr(self.function, "apply")
+            isinstance(function, (str, FunctionReference)) or hasattr(function, "apply")
         ):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "function must be a uri (string) or mlrun function object/reference"

--- a/mlrun/feature_store/retrieval/local_merger.py
+++ b/mlrun/feature_store/retrieval/local_merger.py
@@ -17,6 +17,7 @@ from typing import List
 import pandas as pd
 
 import mlrun
+import mlrun.errors
 
 from ...utils import logger
 from ..feature_vector import OfflineVectorResponse
@@ -82,7 +83,7 @@ class LocalFeatureMerger:
                 )
             target.name = target.name or target.kind
             target.set_resource(self.vector)
-            size, _ = target.write_dataframe(self._result_df)
+            size = target.write_dataframe(self._result_df)
             if is_persistent_vector:
                 target_status = target.update_resource_status("ready", size=size)
                 logger.info(f"wrote target: {target_status}")


### PR DESCRIPTION
* When I was working on https://github.com/mlrun/mlrun/pull/830 I was changing `write_dataframe` to return tuple (2 values), but then rollback that change, mistakenly leaving the local merger reading 2 values - fixed that
* Noticed that it is using `mlrun.errors` but not importing it so fixed that as well
* Noticed the same in `common.py`
* function setter in the same file was mistakenly doing `self.function` instead of just `function`
