### PR TITLE
[Monitoring] Change default runs monitoring interval to 30 sec (from 5)

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -72,7 +72,7 @@ default_config = {
     # runtimes cleanup interval in seconds
     "runtimes_cleanup_interval": "300",
     # runs monitoring interval in seconds
-    "runs_monitoring_interval": "5",
+    "runs_monitoring_interval": "30",
     # the grace period (in seconds) that will be given to runtime resources (after they're in terminal state)
     # before deleting them
     "runtime_resources_deletion_grace_period": "14400",


### PR DESCRIPTION
This queries on the DB every 5 sec make too much load, loosening it a bit