### PR TITLE
[Requirements] Lock adlfs and s3fs to patch changes only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,9 @@ extras_require = {
     # from 1.16.53 it requires botocore<1.20.0,>=1.19.53 which conflicts with s3fs 0.5.2 that has aiobotocore>=1.0.1
     # which resolves to 1.2.1 which has botocore >=1.19.52,<1.19.53
     # boto3 1.16.53 has botocore<1.20.0, >=1.19.53, so we must add botocore explictly
-    "s3": ["boto3~=1.9, <1.16.53", "botocore>=1.19.52, <1.19.53", "s3fs~=0.5"],
+    "s3": ["boto3~=1.9, <1.16.53", "botocore>=1.19.52, <1.19.53", "s3fs~=0.5.0"],
     # <12.7.0 from adlfs 0.6.3
-    "azure-blob-storage": ["azure-storage-blob~=12.0, <12.7.0", "adlfs~=0.6"],
+    "azure-blob-storage": ["azure-storage-blob~=12.0, <12.7.0", "adlfs~=0.6.0"],
 }
 extras_require["complete"] = sorted(
     {


### PR DESCRIPTION
adlfs requirement was `~0.6`, 0.7.0 was released few days ago, in the version [they upbound fsspec to 0.8.7](https://github.com/dask/adlfs/commit/0db94169b14d3fbfa494dacdaaaf33223dc2956b) which caused conflicts since fsspec is sub-requirement of `v3iofs` in which it's `>=0.6.2` and was practically installing `0.9.0`
For that reason changed adlfs to be `~=0.6.0` i.e. limiting it to patch changes only.
This also our general convention - when packages are 0.x, minor bumps can have backwards incompatible changes so we bound to patch changes only, saw that the same was going in `s3fs` so fix it as well