### PR TITLE
[Requirements] Bump adlfs to 0.7.x

### DIFF
--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -8,7 +8,7 @@ dask-ml~=1.4
 dask[complete]~=2.12
 # see main requirements.txt for reasoning the resrictions
 distributed>=2.23, <3
-fsspec~=0.8.0
+fsspec>=0.8.2, <=0.8.7
 gnureadline~=8.0
 kubernetes~=11.0
 lifelines~=0.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,9 @@ kubernetes~=11.0
 #  separating the SDK and API code) (referring to humanfriendly and fastapi)
 humanfriendly~=8.2
 fastapi~=0.62.0
+# adlfs 0.7.0 has fsspec>=0.8.2, <=0.8.7, replicating it here since v3iofs 0.1.6 has fsspec>=0.6.2 which installs 0.9.0
+# which is incompatible
+fsspec>=0.8.2, <=0.8.7
 v3iofs~=0.1.5
 # 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
 cryptography~=3.3.2

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ extras_require = {
     # boto3 1.16.53 has botocore<1.20.0, >=1.19.53, so we must add botocore explictly
     "s3": ["boto3~=1.9, <1.16.53", "botocore>=1.19.52, <1.19.53", "s3fs~=0.5.0"],
     # <12.7.0 from adlfs 0.6.3
-    "azure-blob-storage": ["azure-storage-blob~=12.0, <12.7.0", "adlfs~=0.6.0"],
+    "azure-blob-storage": ["azure-storage-blob~=12.0, <12.7.0", "adlfs~=0.7.0"],
 }
 extras_require["complete"] = sorted(
     {


### PR DESCRIPTION
It seems like the actual right fix for what described in https://github.com/mlrun/mlrun/pull/850 was to bump adlfs and replicate fsspec restrictions since probably adlfs (0.6.x or 0.7.x) is actually not compatible with fsspec bigger than 0.8.7 (they didn't add it for no reason)
Just didn't want to do it then cause it was moments before releasing 0.6.2, and all tests were done with 0.6.x