### PR TITLE
[Model Monitoring] Add endpoint registration to v2 serving + config changes

### DIFF
--- a/mlrun/api/crud/model_endpoints.py
+++ b/mlrun/api/crud/model_endpoints.py
@@ -23,20 +23,19 @@ from mlrun.errors import (
 from mlrun.utils.helpers import logger
 from mlrun.utils.v3io_clients import get_frames_client, get_v3io_client
 
-ENDPOINTS_TABLE_PATH = "model-endpoints/endpoints"
-ENDPOINT_EVENTS_TABLE_PATH = "model-endpoints/events"
+ENDPOINTS = "endpoints"
+EVENTS = "events"
 
 
 class ModelEndpoints:
     @staticmethod
     async def create_or_patch(access_key: str, model_endpoint: ModelEndpoint):
         """
-        Creates or updates a KV record with the given model_endpoint record
+        Creates or patch a KV record with the given model_endpoint record
 
         :param access_key: V3IO access key for managing user permissions
         :param model_endpoint: An object representing a model endpoint
         """
-
         if model_endpoint.spec.model_uri or model_endpoint.status.feature_stats:
             logger.info(
                 "Getting feature metadata",
@@ -116,10 +115,15 @@ class ModelEndpoints:
         logger.info("Clearing model endpoint table", endpoint_id=endpoint_id)
         client = get_v3io_client(endpoint=config.v3io_api)
 
+        path = config.model_endpoint_monitoring.store_prefixes.default.format(
+            project=project, kind=ENDPOINTS
+        )
+        _, container, path = parse_store_prefix(path)
+
         await run_in_threadpool(
             client.kv.delete,
-            container=config.model_endpoint_monitoring.container,
-            table_path=f"{project}/{ENDPOINTS_TABLE_PATH}",
+            container=container,
+            table_path=path,
             key=endpoint_id,
             access_key=access_key,
         )
@@ -172,9 +176,15 @@ class ModelEndpoints:
         )
 
         client = get_v3io_client(endpoint=config.v3io_api)
+
+        path = config.model_endpoint_monitoring.store_prefixes.default.format(
+            project=project, kind=ENDPOINTS
+        )
+        _, container, path = parse_store_prefix(path)
+
         cursor = client.kv.new_cursor(
-            container=config.model_endpoint_monitoring.container,
-            table_path=f"{project}/{ENDPOINTS_TABLE_PATH}",
+            container=container,
+            table_path=path,
             access_key=access_key,
             filter_expression=build_kv_cursor_filter_expression(
                 project, function, model, labels
@@ -227,10 +237,16 @@ class ModelEndpoints:
         )
 
         client = get_v3io_client(endpoint=config.v3io_api)
+
+        path = config.model_endpoint_monitoring.store_prefixes.default.format(
+            project=project, kind=ENDPOINTS
+        )
+        _, container, path = parse_store_prefix(path)
+
         endpoint = await run_in_threadpool(
             client.kv.get,
-            container=config.model_endpoint_monitoring.container,
-            table_path=f"{project}/{ENDPOINTS_TABLE_PATH}",
+            container=container,
+            table_path=path,
             key=endpoint_id,
             access_key=access_key,
             raise_for_status=RaiseForStatus.never,
@@ -327,10 +343,16 @@ async def write_endpoint_to_kv(
 
     client = get_v3io_client(endpoint=config.v3io_api)
     function = client.kv.update if update else client.kv.put
+
+    path = config.model_endpoint_monitoring.store_prefixes.default.format(
+        project=endpoint.metadata.project, kind=ENDPOINTS
+    )
+    _, container, path = parse_store_prefix(path)
+
     await run_in_threadpool(
         function,
-        container=config.model_endpoint_monitoring.container,
-        table_path=f"{endpoint.metadata.project}/{ENDPOINTS_TABLE_PATH}",
+        container=container,
+        table_path=path,
         key=endpoint.metadata.uid,
         access_key=access_key,
         attributes={
@@ -377,16 +399,19 @@ async def get_endpoint_metrics(
     if not metrics:
         raise MLRunInvalidArgumentError("Metric names must be provided")
 
+    path = config.model_endpoint_monitoring.store_prefixes.default.format(
+        project=project, kind=EVENTS
+    )
+    _, container, path = parse_store_prefix(path)
+
     client = get_frames_client(
-        token=access_key,
-        address=config.v3io_framesd,
-        container=config.model_endpoint_monitoring.container,
+        token=access_key, address=config.v3io_framesd, container=container,
     )
 
     data = await run_in_threadpool(
         client.read,
         backend="tsdb",
-        table=f"{project}/{ENDPOINT_EVENTS_TABLE_PATH}",
+        table=path,
         columns=["endpoint_id", *metrics],
         filter=f"endpoint_id=='{endpoint_id}'",
         start=start,
@@ -454,6 +479,12 @@ def build_kv_cursor_filter_expression(
                 filter_expression.append(f"exists({label})")
 
     return " AND ".join(filter_expression)
+
+
+def parse_store_prefix(store_prefix: str):
+    scheme, path = store_prefix.split("///", 1)
+    container, path = path.split("/", 1)
+    return scheme, container, path
 
 
 def get_access_key(request_headers: Mapping):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -134,8 +134,9 @@ default_config = {
         "v3io_framesd": "",
     },
     "model_endpoint_monitoring": {
-        "container": "projects",
-        "stream_url": "v3io:///projects/{project}/model-endpoints/stream",
+        "store_prefixes": {
+            "default": "v3io:///projects/{project}/model-endpoints/{kind}"
+        }
     },
     "secret_stores": {
         "vault": {

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1904,7 +1904,7 @@ class HTTPRunDB(RunDBInterface):
         self.api_call(
             method="PUT",
             path=path,
-            body=model_endpoint.dict(),
+            body=model_endpoint.json(),
             headers={"X-V3io-Session-Key": access_key},
         )
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -39,22 +39,30 @@ class _StreamContext:
     def __init__(self, enabled, parameters, function_uri):
         self.enabled = False
         self.hostname = socket.gethostname()
-        self.output_stream = None
         self.function_uri = function_uri
         self.output_stream = None
+        self.stream_uri = None
 
         log_stream = parameters.get("log_stream", "")
-        stream_url = config.model_endpoint_monitoring.stream_url
-        if ((enabled and stream_url) or log_stream) and function_uri:
+        stream_uri = config.model_endpoint_monitoring.store_prefixes.default
+
+        if ((enabled and stream_uri) or log_stream) and function_uri:
             self.enabled = True
-            log_stream = log_stream or stream_url
+
             project, _, _, _ = parse_versioned_object_uri(
                 function_uri, config.default_project
             )
+
+            if stream_uri:
+                stream_uri = stream_uri.format(project=project, kind="stream")
+            if log_stream:
+                stream_uri = log_stream.format(project=project)
+
             stream_args = parameters.get("stream_args", {})
-            self.output_stream = get_stream_pusher(
-                log_stream.format(project=project), **stream_args
-            )
+
+            self.stream_uri = stream_uri
+
+            self.output_stream = get_stream_pusher(stream_uri, **stream_args)
 
 
 class GraphServer(ModelObj):

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -303,6 +303,7 @@ class _ModelLogPusher:
         self.verbose = context.verbose
         self.hostname = context.stream.hostname
         self.function_uri = context.stream.function_uri
+        self.stream_path = context.stream.stream_uri
         self.stream_batch = int(context.get_param("log_stream_batch", 1))
         self.stream_sample = int(context.get_param("log_stream_sample", 1))
         self.output_stream = output_stream or context.stream.output_stream
@@ -326,7 +327,7 @@ class _ModelLogPusher:
                 model=model,
                 model_class=self.model.__class__.__name__,
                 model_uri=self.model.model_spec.feature_stats,
-                stream_path=self.output_stream.stream_uri,
+                stream_path=self.stream_path,
                 active=True,
             ),
             status=ModelEndpointStatus(),

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -325,7 +325,7 @@ class _ModelLogPusher:
                 function_uri=self.function_uri,
                 model=model,
                 model_class=self.model.__class__.__name__,
-                model_uri=self.model_spec.feature_stats,
+                model_uri=self.model.model_spec.feature_stats,
                 stream_path=self.output_stream.stream_uri,
                 active=True,
             ),

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -326,7 +326,7 @@ class _ModelLogPusher:
                 function_uri=self.function_uri,
                 model=model,
                 model_class=self.model.__class__.__name__,
-                model_uri=self.model.model_spec.feature_stats,
+                model_uri=self.model.model_path,
                 stream_path=self.stream_path,
                 active=True,
             ),

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -16,8 +16,6 @@ import time
 import traceback
 from typing import Dict
 
-from mlrun.datastore import _DummyStream
-
 import mlrun
 from mlrun.api.schemas import (
     ModelEndpoint,
@@ -25,6 +23,7 @@ from mlrun.api.schemas import (
     ModelEndpointSpec,
     ModelEndpointStatus,
 )
+from mlrun.datastore import _DummyStream
 from mlrun.utils import now_date, parse_versioned_object_uri
 
 

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -316,9 +316,9 @@ class _ModelLogPusher:
         project, uri, tag, hash_key = parse_versioned_object_uri(self.function_uri)
 
         if self.model.version:
-            model = f"{self.model.model}:{self.model.version}"
+            model = f"{self.model.name}:{self.model.version}"
         else:
-            model = self.model.model
+            model = self.model.name
 
         model_endpoint = ModelEndpoint(
             metadata=ModelEndpointMetadata(project=project, labels=self.model.labels),

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -16,6 +16,8 @@ import time
 import traceback
 from typing import Dict
 
+from mlrun.datastore import _DummyStream
+
 import mlrun
 from mlrun.api.schemas import (
     ModelEndpoint,
@@ -109,7 +111,9 @@ class V2ModelServer:
             else:
                 self._load_and_update_state()
 
-        if self._model_logger is not None:
+        if self._model_logger is not None and not isinstance(
+            self._model_logger.output_stream, _DummyStream
+        ):
             self._model_logger.init_endpoint_record()
 
     def get_param(self, key: str, default=None):

--- a/tests/api/api/test_grafana_proxy.py
+++ b/tests/api/api/test_grafana_proxy.py
@@ -18,9 +18,10 @@ from mlrun.api.api.endpoints.grafana_proxy import (
     _validate_query_parameters,
 )
 from mlrun.api.crud.model_endpoints import (
-    ENDPOINT_EVENTS_TABLE_PATH,
-    ENDPOINTS_TABLE_PATH,
+    ENDPOINTS,
+    EVENTS,
     ModelEndpoints,
+    parse_store_prefix,
     write_endpoint_to_kv,
 )
 from mlrun.config import config
@@ -29,6 +30,7 @@ from mlrun.utils.v3io_clients import get_frames_client, get_v3io_client
 from tests.api.api.test_model_endpoints import _mock_random_endpoint
 
 ENV_PARAMS = {"V3IO_ACCESS_KEY", "V3IO_API", "V3IO_FRAMESD"}
+TEST_PROJECT = "test3"
 
 
 def _build_skip_message():
@@ -63,7 +65,7 @@ async def test_grafana_list_endpoints(db: Session, client: TestClient):
         client.post,
         url="/api/grafana-proxy/model-endpoints/query",
         headers={"X-V3io-Session-Key": _get_access_key()},
-        json={"targets": [{"target": "project=test;target_endpoint=list_endpoints"}]},
+        json={"targets": [{"target": f"project={TEST_PROJECT};target_endpoint=list_endpoints"}]},
     )
 
     response_json = response.json()
@@ -95,7 +97,7 @@ async def test_grafana_list_endpoints(db: Session, client: TestClient):
 async def test_grafana_individual_feature_analysis(db: Session, client: TestClient):
     endpoint_data = {
         "timestamp": "2021-02-28 21:02:58.642108",
-        "project": "test",
+        "project": TEST_PROJECT,
         "model": "test-model",
         "function": "v2-model-server",
         "tag": "latest",
@@ -118,7 +120,7 @@ async def test_grafana_individual_feature_analysis(db: Session, client: TestClie
     await run_in_threadpool(
         v3io.kv.put,
         container="projects",
-        table_path="test/model-endpoints/endpoints",
+        table_path=f"{TEST_PROJECT}/model-endpoints/endpoints",
         key="test.test_id",
         attributes=endpoint_data,
     )
@@ -130,7 +132,7 @@ async def test_grafana_individual_feature_analysis(db: Session, client: TestClie
         json={
             "targets": [
                 {
-                    "target": "project=test;endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"
+                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"
                 }
             ]
         },
@@ -155,7 +157,7 @@ async def test_grafana_individual_feature_analysis_missing_field_doesnt_fail(
 ):
     endpoint_data = {
         "timestamp": "2021-02-28 21:02:58.642108",
-        "project": "test",
+        "project": TEST_PROJECT,
         "model": "test-model",
         "function": "v2-model-server",
         "tag": "latest",
@@ -177,7 +179,7 @@ async def test_grafana_individual_feature_analysis_missing_field_doesnt_fail(
     await run_in_threadpool(
         v3io.kv.put,
         container="projects",
-        table_path="test/model-endpoints/endpoints",
+        table_path=f"{TEST_PROJECT}/model-endpoints/endpoints",
         key="test.test_id",
         attributes=endpoint_data,
     )
@@ -189,7 +191,7 @@ async def test_grafana_individual_feature_analysis_missing_field_doesnt_fail(
         json={
             "targets": [
                 {
-                    "target": "project=test;endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"
+                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"
                 }
             ]
         },
@@ -217,7 +219,7 @@ async def test_grafana_individual_feature_analysis_missing_field_doesnt_fail(
 async def test_grafana_overall_feature_analysis(db: Session, client: TestClient):
     endpoint_data = {
         "timestamp": "2021-02-28 21:02:58.642108",
-        "project": "test",
+        "project": TEST_PROJECT,
         "model": "test-model",
         "function": "v2-model-server",
         "tag": "latest",
@@ -239,7 +241,7 @@ async def test_grafana_overall_feature_analysis(db: Session, client: TestClient)
     await run_in_threadpool(
         v3io.kv.put,
         container="projects",
-        table_path="test/model-endpoints/endpoints",
+        table_path=f"{TEST_PROJECT}/model-endpoints/endpoints",
         key="test.test_id",
         attributes=endpoint_data,
     )
@@ -251,7 +253,7 @@ async def test_grafana_overall_feature_analysis(db: Session, client: TestClient)
         json={
             "targets": [
                 {
-                    "target": "project=test;endpoint_id=test.test_id;target_endpoint=overall_feature_analysis"
+                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=overall_feature_analysis"
                 }
             ]
         },
@@ -325,15 +327,28 @@ def _get_access_key() -> Optional[str]:
 @pytest.fixture(autouse=True)
 def cleanup_endpoints(db: Session, client: TestClient):
     if not _is_env_params_dont_exist():
+        kv_path = config.model_endpoint_monitoring.store_prefixes.default.format(
+            project=TEST_PROJECT, kind=ENDPOINTS
+        )
+        _, kv_container, kv_path = parse_store_prefix(kv_path)
+
+        tsdb_path = config.model_endpoint_monitoring.store_prefixes.default.format(
+            project=TEST_PROJECT, kind=EVENTS
+        )
+        _, tsdb_container, tsdb_path = parse_store_prefix(tsdb_path)
+
         v3io = get_v3io_client(endpoint=config.v3io_api, access_key=_get_access_key())
 
         frames = get_frames_client(
-            token=_get_access_key(), container="projects", address=config.v3io_framesd,
+            token=_get_access_key(),
+            container=tsdb_container,
+            address=config.v3io_framesd,
         )
+
         try:
             all_records = v3io.kv.new_cursor(
-                container="projects",
-                table_path=f"test/{ENDPOINTS_TABLE_PATH}",
+                container=kv_container,
+                table_path=kv_path,
                 raise_for_status=RaiseForStatus.never,
             ).all()
 
@@ -342,8 +357,8 @@ def cleanup_endpoints(db: Session, client: TestClient):
             # Cleanup KV
             for record in all_records:
                 v3io.kv.delete(
-                    container="projects",
-                    table_path=f"test/{ENDPOINTS_TABLE_PATH}",
+                    container=kv_container,
+                    table_path=kv_path,
                     key=record,
                     raise_for_status=RaiseForStatus.never,
                 )
@@ -353,9 +368,7 @@ def cleanup_endpoints(db: Session, client: TestClient):
         try:
             # Cleanup TSDB
             frames.delete(
-                backend="tsdb",
-                table=f"test/{ENDPOINT_EVENTS_TABLE_PATH}",
-                if_missing=fpb2.IGNORE,
+                backend="tsdb", table=tsdb_path, if_missing=fpb2.IGNORE,
             )
         except CreateError:
             pass
@@ -366,16 +379,17 @@ def cleanup_endpoints(db: Session, client: TestClient):
     _is_env_params_dont_exist(), reason=_build_skip_message(),
 )
 async def test_grafana_incoming_features(db: Session, client: TestClient):
+    path = config.model_endpoint_monitoring.store_prefixes.default.format(
+        project=TEST_PROJECT, kind=EVENTS
+    )
+    _, container, path = parse_store_prefix(path)
+
     frames = get_frames_client(
-        token=_get_access_key(), container="projects", address=config.v3io_framesd,
+        token=_get_access_key(), container=container, address=config.v3io_framesd,
     )
 
     await run_in_threadpool(
-        frames.create,
-        backend="tsdb",
-        table=f"test/{ENDPOINT_EVENTS_TABLE_PATH}",
-        rate="10/m",
-        if_exists=1,
+        frames.create, backend="tsdb", table=path, rate="10/m", if_exists=1,
     )
 
     start = datetime.utcnow()
@@ -407,7 +421,7 @@ async def test_grafana_incoming_features(db: Session, client: TestClient):
         await run_in_threadpool(
             frames.write,
             backend="tsdb",
-            table=f"test/{ENDPOINT_EVENTS_TABLE_PATH}",
+            table=path,
             dfs=dfs,
             index_cols=["timestamp", "endpoint_id"],
         )
@@ -420,7 +434,7 @@ async def test_grafana_incoming_features(db: Session, client: TestClient):
             json={
                 "targets": [
                     {
-                        "target": f"project=test;endpoint_id={endpoint.metadata.uid};target_endpoint=incoming_features"
+                        "target": f"project={TEST_PROJECT};endpoint_id={endpoint.metadata.uid};target_endpoint=incoming_features"
                     }
                 ]
             },

--- a/tests/api/api/test_grafana_proxy.py
+++ b/tests/api/api/test_grafana_proxy.py
@@ -65,7 +65,11 @@ async def test_grafana_list_endpoints(db: Session, client: TestClient):
         client.post,
         url="/api/grafana-proxy/model-endpoints/query",
         headers={"X-V3io-Session-Key": _get_access_key()},
-        json={"targets": [{"target": f"project={TEST_PROJECT};target_endpoint=list_endpoints"}]},
+        json={
+            "targets": [
+                {"target": f"project={TEST_PROJECT};target_endpoint=list_endpoints"}
+            ]
+        },
     )
 
     response_json = response.json()
@@ -132,7 +136,7 @@ async def test_grafana_individual_feature_analysis(db: Session, client: TestClie
         json={
             "targets": [
                 {
-                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"
+                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"  # noqa
                 }
             ]
         },
@@ -191,7 +195,7 @@ async def test_grafana_individual_feature_analysis_missing_field_doesnt_fail(
         json={
             "targets": [
                 {
-                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"
+                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=individual_feature_analysis"  # noqa
                 }
             ]
         },
@@ -253,7 +257,7 @@ async def test_grafana_overall_feature_analysis(db: Session, client: TestClient)
         json={
             "targets": [
                 {
-                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=overall_feature_analysis"
+                    "target": f"project={TEST_PROJECT};endpoint_id=test.test_id;target_endpoint=overall_feature_analysis"  # noqa
                 }
             ]
         },
@@ -434,7 +438,7 @@ async def test_grafana_incoming_features(db: Session, client: TestClient):
             json={
                 "targets": [
                     {
-                        "target": f"project={TEST_PROJECT};endpoint_id={endpoint.metadata.uid};target_endpoint=incoming_features"
+                        "target": f"project={TEST_PROJECT};endpoint_id={endpoint.metadata.uid};target_endpoint=incoming_features"  # noqa
                     }
                 ]
             },

--- a/tests/api/api/test_model_endpoints.py
+++ b/tests/api/api/test_model_endpoints.py
@@ -241,7 +241,7 @@ async def test_get_endpoint_metrics(db: Session, client: TestClient):
 
         response = await run_in_threadpool(
             client.get,
-            url=f"/api/projects/{TEST_PROJECT}/model-endpoints/{endpoint.metadata.uid}?metric=predictions_per_second_count_1s",
+            url=f"/api/projects/{TEST_PROJECT}/model-endpoints/{endpoint.metadata.uid}?metric=predictions_per_second_count_1s",  # noqa
             headers={"X-V3io-Session-Key": _get_access_key()},
         )
 


### PR DESCRIPTION
* Updated model monitoring config to allow a similar functionality to the feature store config, this PR introduces a single template for data store paths instead of individual paths for kv, tsdb and parquets. 
* Implemented endpoint "registration" in v2_model_server.