### PR TITLE
[Config] Fix typo in config enrichment from server

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -244,7 +244,7 @@ class HTTPRunDB(RunDBInterface):
             config.scrape_metrics = (
                 server_cfg.get("scrape_metrics")
                 if server_cfg.get("scrape_metrics") is not None
-                else config.kfp_image
+                else config.scrape_metrics
             )
         except Exception:
             pass


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/812 I made the scrape metrics configurable, as part of it, I added logic for the client to read this value from the server, when the server don't have value, it defaults to what the client currently have (`config.scrape_metrics`). I had a typo that it default to `config.kfp_image` instead
Practically in every 0.6.2 server this will be configured, but the meaning is that running a 0.6.2 client with 0.6.1 server (which don't have it configured) will cause weird failures (trying to set the scrape metrics to an image name)