### PR TITLE
[Vault] Fix client to work when url is not configured

### DIFF
--- a/mlrun/api/api/endpoints/secrets.py
+++ b/mlrun/api/api/endpoints/secrets.py
@@ -26,7 +26,10 @@ def initialize_project_secrets(
 
     # Init is idempotent and will do nothing if infra is already in place
     init_project_vault_configuration(project)
-    add_vault_project_secrets(project, secrets.secrets)
+
+    # If no secrets were passed, no need to touch the actual secrets.
+    if secrets.secrets:
+        add_vault_project_secrets(project, secrets.secrets)
     return Response(status_code=HTTPStatus.CREATED.value)
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1233,7 +1233,7 @@ class MlrunProject(ModelObj):
             logger.warning(
                 "get_vault_secrets executed locally. This is not recommended and may become deprecated soon"
             )
-            self._secrets.vault.get_secrets(secrets, project=self.metadata.name)
+            return self._secrets.vault.get_secrets(secrets, project=self.metadata.name)
 
         run_db = get_run_db(secrets=self._secrets)
         project_secrets = run_db.get_project_secrets(

--- a/mlrun/utils/vault.py
+++ b/mlrun/utils/vault.py
@@ -101,6 +101,9 @@ class VaultStore:
         return jwt_token
 
     def _api_call(self, method, url, data=None):
+        if not self.url:
+            return None
+
         self._login()
 
         headers = {"X-Vault-Token": self._token}
@@ -149,6 +152,8 @@ class VaultStore:
 
         response = self._api_call("GET", secret_path)
 
+        # We handle a failure here gracefully, as this may be called on client-side and client doesn't need
+        # to be configured for vault access.
         if not response:
             return secrets
 


### PR DESCRIPTION
Had an issue where if the MLRun configuration on Jupyter didn't include the `mlconf.secret_stores.vault.url` parameter, the code would explode when doing `func.run()` for a function using Vault secrets, since there is no `http://` prefix to the url. 
This is a fatal error on server side, but the `get_secrets()` API is called on client side as well, while not required to return values. Therefore made sure this flow failed gracefully in this case.

Also, added 2 other small fixes found while testing this:
1. Calling `project.get_vault_secrets()` with `local=True` was missing a return statement (this is a rare flow anyway, and is discouraged, but still needs to be handled properly)
2. The `initialize_project_secrets` API endpoint, when called with empty secret list, was deleting all project secrets instead of just doing the configuration work and not touching the secrets. 
