### PR TITLE
[Requirements] Bound boto3 to <1.17.50 and add botocore explicitly 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 extras_require = {
     # from 1.17.50 it requires botocore>=1.20.50,<1.21.0 which conflicts with s3fs 0.5.2 that has aiobotocore>=1.0.1
     # which resolves to 1.3.0 which has botocore>=1.20.49,<1.20.50
-    "s3": ["boto3~=1.9, <1.17.50", "s3fs~=0.5.0"],
+    # boto3 1.17.49 has botocore<1.21.0,>=1.20.49, so we must add botocore explictly
+    "s3": ["boto3~=1.9, <1.17.50", "botocore>=1.20.49,<1.20.50", "s3fs~=0.5.0"],
     # <12.7.0 from adlfs 0.6.3
     "azure-blob-storage": ["azure-storage-blob~=12.0, <12.7.0", "adlfs~=0.7.1"],
     "azure-key-vault": ["azure-identity~=1.5", "azure-keyvault-secrets~=4.2"],

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,9 @@ api_deps = list(load_deps("dockerfiles/mlrun-api/requirements.txt"))
 # NOTE: These are tested in `automation/package_test/test.py` If
 # you modify these, make sure to change the corresponding line there.
 extras_require = {
-    "s3": ["boto3~=1.9", "s3fs~=0.5.0"],
+    # from 1.17.50 it requires botocore>=1.20.50,<1.21.0 which conflicts with s3fs 0.5.2 that has aiobotocore>=1.0.1
+    # which resolves to 1.3.0 which has botocore>=1.20.49,<1.20.50
+    "s3": ["boto3~=1.9, <1.17.50", "s3fs~=0.5.0"],
     # <12.7.0 from adlfs 0.6.3
     "azure-blob-storage": ["azure-storage-blob~=12.0, <12.7.0", "adlfs~=0.7.1"],
     "azure-key-vault": ["azure-identity~=1.5", "azure-keyvault-secrets~=4.2"],


### PR DESCRIPTION
We started seeing packages CI failing with:
```
Warning!!! Possibly conflicting dependencies found:
* aiobotocore==1.3.0
 - botocore [required: >=1.20.49,<1.20.50, installed: 1.20.50]
------------------------------------------------------------------------
```
That is happening since botocore recently released 1.20.50, which is incompatible with the latest aiobotocore (which is a sub requirement of s3fs)
boto3 from 1.17.50 requires botocore>=1.20.50,<1.21.0 which conflicts with s3fs 0.5.2 that has aiobotocore>=1.0.1
which resolves to 1.3.0 which has botocore>=1.20.49,<1.20.50, so added <1.17.50 to boto3
boto3 1.17.49 has botocore<1.21.0,>=1.20.49, so we must add botocore explictly