### PR TITLE
[API] Making payload of ingest API optional

### DIFF
--- a/mlrun/api/api/endpoints/feature_sets.py
+++ b/mlrun/api/api/endpoints/feature_sets.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Header, Query, Request, Response
 from sqlalchemy.orm import Session
@@ -178,7 +178,9 @@ def ingest_feature_set(
     project: str,
     name: str,
     reference: str,
-    ingest_parameters: schemas.FeatureSetIngestInput,
+    ingest_parameters: Optional[
+        schemas.FeatureSetIngestInput
+    ] = schemas.FeatureSetIngestInput(),
     username: str = Header(None, alias="x-remote-user"),
     db_session: Session = Depends(deps.get_db_session),
 ):


### PR DESCRIPTION
After this fix, ingest API can be called without any payload. Until now, body was mandatory, so an empty body was required or else 422 was returned.