### PR TITLE
[Feature Store] Making features/entities optional in feature-set spec

### DIFF
--- a/mlrun/api/api/endpoints/feature_sets.py
+++ b/mlrun/api/api/endpoints/feature_sets.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Header, Query, Request, Response
 from sqlalchemy.orm import Session
@@ -178,7 +178,9 @@ def ingest_feature_set(
     project: str,
     name: str,
     reference: str,
-    ingest_parameters: schemas.FeatureSetIngestInput,
+    ingest_parameters: Optional[
+        schemas.FeatureSetIngestInput
+    ] = schemas.FeatureSetIngestInput(),
     username: str = Header(None, alias="x-remote-user"),
     db_session: Session = Depends(deps.get_db_session),
 ):

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1546,7 +1546,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
             session, FeatureSet, project, name, tag, uid
         )
 
-        feature_set_dict = feature_set.dict()
+        feature_set_dict = feature_set.dict(exclude_none=True)
 
         if not existing_feature_set:
             # Check if this is a re-tag of existing object - search by uid only
@@ -1600,7 +1600,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         get_project_member().ensure_project(session, project)
         tag = new_object.metadata.tag or "latest"
 
-        object_dict = new_object.dict()
+        object_dict = new_object.dict(exclude_none=True)
         hash_key = fill_object_hash(object_dict, "uid", tag)
 
         if versioned:
@@ -1654,7 +1654,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
                 f"Feature-set not found {feature_set_uri}"
             )
 
-        feature_set_struct = feature_set_record.dict()
+        feature_set_struct = feature_set_record.dict(exclude_none=True)
         # using mergedeep for merging the patch content into the existing dictionary
         strategy = patch_mode.to_mergedeep_strategy()
         mergedeep.merge(feature_set_struct, feature_set_update, strategy=strategy)
@@ -1832,7 +1832,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
             session, FeatureVector, project, name, tag, uid
         )
 
-        feature_vector_dict = feature_vector.dict()
+        feature_vector_dict = feature_vector.dict(exclude_none=True)
 
         if not existing_feature_vector:
             # Check if this is a re-tag of existing object - search by uid only
@@ -1886,7 +1886,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
                 f"Feature-vector not found {feature_vector_uri}"
             )
 
-        feature_vector_struct = feature_vector_record.dict()
+        feature_vector_struct = feature_vector_record.dict(exclude_none=True)
         # using mergedeep for merging the patch content into the existing dictionary
         strategy = patch_mode.to_mergedeep_strategy()
         mergedeep.merge(feature_vector_struct, feature_vector_update, strategy=strategy)

--- a/mlrun/api/schemas/feature_store.py
+++ b/mlrun/api/schemas/feature_store.py
@@ -31,8 +31,8 @@ class Entity(BaseModel):
 
 
 class FeatureSetSpec(ObjectSpec):
-    entities: List[Entity]
-    features: List[Feature]
+    entities: Optional[List[Entity]]
+    features: Optional[List[Feature]]
 
 
 class FeatureSet(BaseModel):

--- a/mlrun/api/schemas/feature_store.py
+++ b/mlrun/api/schemas/feature_store.py
@@ -31,8 +31,8 @@ class Entity(BaseModel):
 
 
 class FeatureSetSpec(ObjectSpec):
-    entities: Optional[List[Entity]]
-    features: Optional[List[Feature]]
+    entities: List[Entity] = []
+    features: List[Feature] = []
 
 
 class FeatureSet(BaseModel):


### PR DESCRIPTION
The code in `FeatureSetSpec` had features and entities as mandatory lists. This means that if a user does `feature_set.save()` on an object without them, it will cause failures. This is not the expected behavior.
As a side effect, once they became optional, had to change the way `feature_set.dict()` behaves and add `exclude_none=True`, because otherwise the dictionary created would have (for example) `{"entities": None}`, and various get calls such as `entities = feature_set_spec.pop("entities", [])` would return `None` rather than the expected `[]` since the default value is only used when the key does not exist in the dictionary, not when it is None. Using `exclude_none` fixes this behaviour.