### PR TITLE
[Runtimes] Fix skipped deployment to set the right image

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -287,7 +287,7 @@ def build_runtime(runtime, with_mlrun, mlrun_version_specifier, interactive=Fals
     )
     runtime.status.build_pod = None
     if status == "skipped":
-        runtime.spec.image = build.base_image
+        runtime.spec.image = base_image
         runtime.status.state = "ready"
         return True
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -171,7 +171,6 @@ def build_image(
         requirements_list = None
         requirements_path = requirements
 
-    base_image = base_image or config.default_image
     if with_mlrun:
         commands = commands or []
         commands.append(_resolve_mlrun_install_command(mlrun_version_specifier))
@@ -266,7 +265,7 @@ def build_runtime(runtime, with_mlrun, mlrun_version_specifier, interactive=Fals
     logger.info(f"building image ({build.image})")
 
     name = normalize_name(f"mlrun-build-{runtime.metadata.name}")
-    base_image = enrich_image_url(build.base_image or "mlrun/mlrun")
+    base_image = enrich_image_url(build.base_image or config.default_base_image)
     if not build.base_image:
         with_mlrun = False
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -63,7 +63,7 @@ default_config = {
     "spark_app_image_tag": "",  # image tag to use for spark opeartor app runtime
     "builder_alpine_image": "alpine:3.13.1",  # builder alpine image (as kaniko's initContainer)
     "package_path": "mlrun",  # mlrun pip package
-    "default_image": "python:3.6-jessie",
+    "default_image": "python:3.7",
     "default_project": "default",  # default project name
     "default_archive": "",  # default remote archive URL (for build tar.gz)
     "mpijob_crd_version": "",  # mpijob crd version (e.g: "v1alpha1". must be in: mlrun.runtime.MPIJobCRDVersions)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -63,7 +63,7 @@ default_config = {
     "spark_app_image_tag": "",  # image tag to use for spark opeartor app runtime
     "builder_alpine_image": "alpine:3.13.1",  # builder alpine image (as kaniko's initContainer)
     "package_path": "mlrun",  # mlrun pip package
-    "default_image": "python:3.7",
+    "default_base_image": "mlrun/mlrun",  # default base image when doing .deploy()
     "default_project": "default",  # default project name
     "default_archive": "",  # default remote archive URL (for build tar.gz)
     "mpijob_crd_version": "",  # mpijob crd version (e.g: "v1alpha1". must be in: mlrun.runtime.MPIJobCRDVersions)

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -135,7 +135,7 @@ class KubejobRuntime(KubeResource):
             self.status = data["data"].get("status", None)
             self.spec.image = get_in(data, "data.spec.image")
             ready = data.get("ready", False)
-            if watch:
+            if watch and not ready:
                 state = self._build_watch(watch)
                 ready = state == "ready"
                 self.status.state = state


### PR DESCRIPTION
A call to `.deploy()` when nothing specified doesn't really require deploy since the default base image is `mlrun/mlrun` so although by default `with_mlrun` is `True` there's no need to install mlrun on it, since it's already installed.
There was a bug that caused the wrong image to be set on the function's spec + deploy was returning False as if it was failed - Fixed it
Also changed the default base image to be configurable
Fixes https://github.com/mlrun/mlrun/issues/900