### PR TITLE
[API] Reject request to abort dask run

### DIFF
--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -38,7 +38,10 @@ class Runs(metaclass=mlrun.utils.singleton.Singleton,):
                 raise mlrun.errors.MLRunConflictError(
                     "Run is already in terminal state, can not be aborted"
                 )
-            if current_run.get("metadata", {}).get("labels", {}).get("kind") == mlrun.runtimes.RuntimeKinds.dask:
+            if (
+                current_run.get("metadata", {}).get("labels", {}).get("kind")
+                == mlrun.runtimes.RuntimeKinds.dask
+            ):
                 raise mlrun.errors.MLRunBadRequestError(
                     "Run of a dask function can not be aborted"
                 )

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -38,6 +38,10 @@ class Runs(metaclass=mlrun.utils.singleton.Singleton,):
                 raise mlrun.errors.MLRunConflictError(
                     "Run is already in terminal state, can not be aborted"
                 )
+            if current_run.get("metadata", {}).get("labels", {}).get("kind") == mlrun.runtimes.RuntimeKinds.dask:
+                raise mlrun.errors.MLRunBadRequestError(
+                    "Run of a dask function can not be aborted"
+                )
             # aborting the run meaning deleting its runtime resources
             # TODO: runtimes crud interface should ideally expose some better API that will hold inside itself the
             #  "knowledge" on the label selector


### PR DESCRIPTION
Our current way for aborting runs is removing their runtimes resources (pods/crds) which practically stops their execution.
In Dask runtime the runtime resources - pods - are per function, meaning several runs can use the same pods - meaning killing the pod is not an option - so we don't really have a way to abort dask runs - so we're rejecting requests to do so
Fixes https://jira.iguazeng.com/browse/ML-409