### PR TITLE
[Dask] Enable to set resources for scheduler/worker separately

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -15,6 +15,7 @@ import datetime
 import inspect
 import socket
 import time
+import warnings
 from os import environ
 from typing import Dict, List, Optional, Union
 
@@ -36,7 +37,9 @@ from .base import FunctionStatus
 from .kubejob import KubejobRuntime
 from .local import exec_from_params, load_module
 from .pod import KubeResourceSpec, kube_resource_spec_to_pod_spec
-from .utils import RunError, get_func_selector, get_resource_labels, log_std
+from .utils import RunError, get_func_selector, get_resource_labels, log_std, generate_resources
+import mlrun.utils
+import mlrun.utils.regex
 
 
 def get_dask_resource():
@@ -78,6 +81,8 @@ class DaskSpec(KubeResourceSpec):
         node_name=None,
         node_selector=None,
         affinity=None,
+        scheduler_resources=None,
+        worker_resources=None,
     ):
 
         super().__init__(
@@ -114,6 +119,8 @@ class DaskSpec(KubeResourceSpec):
         # supported format according to https://github.com/dask/dask/blob/master/dask/utils.py#L1402
         self.scheduler_timeout = scheduler_timeout or "60 minutes"
         self.nthreads = nthreads or 1
+        self.scheduler_resources = scheduler_resources or {}
+        self.worker_resources = worker_resources or {}
 
 
 class DaskStatus(FunctionStatus):
@@ -334,6 +341,46 @@ class DaskCluster(KubejobRuntime):
             mlrun_version_specifier=mlrun_version_specifier,
         )
 
+    def with_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+        warnings.warn(
+            "Dask's with_limits will be deprecated in 0.8.0, and will be removed in 0.10.0, use "
+            "with_scheduler_limits/with_worker_limits instead",
+            # TODO: In 0.8.0 deprecate and replace with_limits to with_worker/scheduler_limits in examples & demos
+            PendingDeprecationWarning,
+        )
+        # the scheduler/worker specific function was introduced after the general one, to keep backwards compatibility
+        # this function just sets the limits for both of them
+        self.with_scheduler_limits(mem, cpu, gpus, gpu_type)
+        self.with_worker_limits(mem, cpu, gpus, gpu_type)
+
+    def with_scheduler_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+        """set scheduler pod resources limits"""
+        self._verify_and_set_limits("scheduler_resources", mem, cpu, gpus, gpu_type)
+
+    def with_worker_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+        """set worker pod resources limits"""
+        self._verify_and_set_limits("worker_resources", mem, cpu, gpus, gpu_type)
+
+    def with_requests(self, mem=None, cpu=None):
+        warnings.warn(
+            "Dask's with_requests will be deprecated in 0.8.0, and will be removed in 0.10.0, use "
+            "with_scheduler_requests/with_worker_requests instead",
+            # TODO: In 0.8.0 deprecate and replace with_requests to with_worker/scheduler_requests in examples & demos
+            PendingDeprecationWarning,
+        )
+        # the scheduler/worker specific function was introduced after the general one, to keep backwards compatibility
+        # this function just sets the requests for both of them
+        self.with_scheduler_requests(mem, cpu)
+        self.with_worker_requests(mem, cpu)
+
+    def with_scheduler_requests(self, mem=None, cpu=None):
+        """set scheduler pod resources requests"""
+        self._verify_and_set_limits("scheduler_resources", mem, cpu)
+
+    def with_worker_requests(self, mem=None, cpu=None):
+        """set worker pod resources requests"""
+        self._verify_and_set_limits("worker_resources", mem, cpu)
+
     def _run(self, runobj: RunObject, execution):
 
         handler = runobj.spec.handler
@@ -396,26 +443,38 @@ def deploy_function(function: DaskCluster, secrets=None):
     if spec.args:
         args.extend(spec.args)
 
-    container = client.V1Container(
-        name="base",
-        image=image,
-        env=env,
-        args=args,
-        image_pull_policy=spec.image_pull_policy,
-        volume_mounts=spec.volume_mounts,
-        resources=spec.resources,
+    container_kwargs = {
+        "name": "base",
+        "image": image,
+        "env": env,
+        "args": args,
+        "image_pull_policy": spec.image_pull_policy,
+        "volume_mounts": spec.volume_mounts,
+    }
+    scheduler_container = client.V1Container(
+        resources=spec.scheduler_resources, **container_kwargs
+    )
+    worker_container = client.V1Container(
+        resources=spec.worker_resources, **container_kwargs
     )
 
-    pod_spec = kube_resource_spec_to_pod_spec(spec, container)
-    if spec.image_pull_secret:
-        pod_spec.image_pull_secrets = [
-            client.V1LocalObjectReference(name=spec.image_pull_secret)
-        ]
+    scheduler_pod_spec = kube_resource_spec_to_pod_spec(spec, scheduler_container)
+    worker_pod_spec = kube_resource_spec_to_pod_spec(spec, worker_container)
+    for pod_spec in [scheduler_pod_spec, worker_pod_spec]:
+        if spec.image_pull_secret:
+            pod_spec.image_pull_secrets = [
+                client.V1LocalObjectReference(name=spec.image_pull_secret)
+            ]
 
-    pod = client.V1Pod(
+    scheduler_pod = client.V1Pod(
         metadata=client.V1ObjectMeta(namespace=namespace, labels=pod_labels),
         # annotations=meta.annotation),
-        spec=pod_spec,
+        spec=scheduler_pod_spec,
+    )
+    worker_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(namespace=namespace, labels=pod_labels),
+        # annotations=meta.annotation),
+        spec=worker_pod_spec,
     )
 
     svc_temp = dask.config.get("kubernetes.scheduler-service-template")
@@ -434,7 +493,8 @@ def deploy_function(function: DaskCluster, secrets=None):
     )
 
     cluster = KubeCluster(
-        pod,
+        worker_pod,
+        scheduler_pod_template=scheduler_pod,
         deploy_mode="remote",
         namespace=namespace,
         idle_timeout=spec.scheduler_timeout,

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -24,6 +24,8 @@ from sqlalchemy.orm import Session
 
 import mlrun.api.schemas
 import mlrun.errors
+import mlrun.utils
+import mlrun.utils.regex
 from mlrun.api.db.base import DBInterface
 from mlrun.runtimes.base import BaseRuntimeHandler
 
@@ -37,9 +39,7 @@ from .base import FunctionStatus
 from .kubejob import KubejobRuntime
 from .local import exec_from_params, load_module
 from .pod import KubeResourceSpec, kube_resource_spec_to_pod_spec
-from .utils import RunError, get_func_selector, get_resource_labels, log_std, generate_resources
-import mlrun.utils
-import mlrun.utils.regex
+from .utils import RunError, get_func_selector, get_resource_labels, log_std
 
 
 def get_dask_resource():
@@ -353,11 +353,15 @@ class DaskCluster(KubejobRuntime):
         self.with_scheduler_limits(mem, cpu, gpus, gpu_type)
         self.with_worker_limits(mem, cpu, gpus, gpu_type)
 
-    def with_scheduler_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def with_scheduler_limits(
+        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"
+    ):
         """set scheduler pod resources limits"""
         self._verify_and_set_limits("scheduler_resources", mem, cpu, gpus, gpu_type)
 
-    def with_worker_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def with_worker_limits(
+        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"
+    ):
         """set worker pod resources limits"""
         self._verify_and_set_limits("worker_resources", mem, cpu, gpus, gpu_type)
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -379,11 +379,11 @@ class DaskCluster(KubejobRuntime):
 
     def with_scheduler_requests(self, mem=None, cpu=None):
         """set scheduler pod resources requests"""
-        self._verify_and_set_limits("scheduler_resources", mem, cpu)
+        self._verify_and_set_requests("scheduler_resources", mem, cpu)
 
     def with_worker_requests(self, mem=None, cpu=None):
         """set worker pod resources requests"""
-        self._verify_and_set_limits("worker_resources", mem, cpu)
+        self._verify_and_set_requests("worker_resources", mem, cpu)
 
     def _run(self, runobj: RunObject, execution):
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -265,7 +265,14 @@ class KubeResource(BaseRuntime):
         if affinity:
             self.spec.affinity = affinity
 
-    def _verify_and_set_limits(self, resources_field_name, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def _verify_and_set_limits(
+        self,
+        resources_field_name,
+        mem=None,
+        cpu=None,
+        gpus=None,
+        gpu_type="nvidia.com/gpu",
+    ):
         if mem:
             verify_field_regex(
                 f"function.spec.{resources_field_name}.limits.memory",
@@ -304,7 +311,9 @@ class KubeResource(BaseRuntime):
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         update_in(
-            getattr(self.spec, resources_field_name), "requests", generate_resources(mem=mem, cpu=cpu),
+            getattr(self.spec, resources_field_name),
+            "requests",
+            generate_resources(mem=mem, cpu=cpu),
         )
 
     def _get_meta(self, runobj, unique=False):

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -239,19 +239,19 @@ class KubeResource(BaseRuntime):
         """set pod cpu/memory/gpu limits"""
         if mem:
             verify_field_regex(
-                "function.limits.memory",
+                "function.spec.resources.limits.memory",
                 mem,
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if cpu:
             verify_field_regex(
-                "function.limits.cpu",
+                "function.spec.resources.limits.cpu",
                 cpu,
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if gpus:
             verify_field_regex(
-                "function.limits.gpus",
+                "function.spec.resources.limits.gpus",
                 gpus,
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )
@@ -265,13 +265,13 @@ class KubeResource(BaseRuntime):
         """set requested (desired) pod cpu/memory/gpu resources"""
         if mem:
             verify_field_regex(
-                "function.requests.memory",
+                "function.spec.resources.requests.memory",
                 mem,
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )
         if cpu:
             verify_field_regex(
-                "function.requests.cpu",
+                "function.spec.resources.requests.cpu",
                 cpu,
                 mlrun.utils.regex.k8s_resource_quantity_regex,
             )

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -428,24 +428,7 @@ class TestRuntimeBase:
 
         container_spec = pod.spec.containers[0]
 
-        if expected_limits:
-            assert (
-                deepdiff.DeepDiff(
-                    container_spec.resources["limits"],
-                    expected_limits,
-                    ignore_order=True,
-                )
-                == {}
-            )
-        if expected_requests:
-            assert (
-                deepdiff.DeepDiff(
-                    container_spec.resources["requests"],
-                    expected_requests,
-                    ignore_order=True,
-                )
-                == {}
-            )
+        self._assert_container_resources(container_spec, expected_limits, expected_requests)
 
         pod_env = container_spec.env
 
@@ -499,3 +482,23 @@ class TestRuntimeBase:
             )
 
         assert pod.spec.containers[0].image == self.image_name
+
+    def _assert_container_resources(self, container_spec, expected_limits, expected_requests):
+        if expected_limits:
+            assert (
+                deepdiff.DeepDiff(
+                    container_spec.resources["limits"],
+                    expected_limits,
+                    ignore_order=True,
+                )
+                == {}
+            )
+        if expected_requests:
+            assert (
+                deepdiff.DeepDiff(
+                    container_spec.resources["requests"],
+                    expected_requests,
+                    ignore_order=True,
+                )
+                == {}
+            )

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -428,7 +428,9 @@ class TestRuntimeBase:
 
         container_spec = pod.spec.containers[0]
 
-        self._assert_container_resources(container_spec, expected_limits, expected_requests)
+        self._assert_container_resources(
+            container_spec, expected_limits, expected_requests
+        )
 
         pod_env = container_spec.env
 
@@ -483,7 +485,9 @@ class TestRuntimeBase:
 
         assert pod.spec.containers[0].image == self.image_name
 
-    def _assert_container_resources(self, container_spec, expected_limits, expected_requests):
+    def _assert_container_resources(
+        self, container_spec, expected_limits, expected_requests
+    ):
         if expected_limits:
             assert (
                 deepdiff.DeepDiff(

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -77,16 +77,26 @@ class TestDaskRuntime(TestRuntimeBase):
 
         return dask_cluster
 
-    def _assert_pods_resources(self, expected_worker_requests, expected_worker_limits, expected_scheduler_requests, expected_scheduler_limits):
+    def _assert_pods_resources(
+        self,
+        expected_worker_requests,
+        expected_worker_limits,
+        expected_scheduler_requests,
+        expected_scheduler_limits,
+    ):
         worker_pod = self._get_pod_creation_args()
         worker_container_spec = worker_pod.spec.containers[0]
-        # self._assert_container_resources(worker_container_spec, expected_worker_limits, expected_worker_requests)
+        self._assert_container_resources(
+            worker_container_spec, expected_worker_limits, expected_worker_requests
+        )
         _, kwargs = self.kube_cluster_mock.call_args
         scheduler_pod = kwargs["scheduler_pod_template"]
         scheduler_container_spec = scheduler_pod.spec.containers[0]
-        self._assert_container_resources(scheduler_container_spec, expected_scheduler_limits, expected_scheduler_requests)
-
-
+        self._assert_container_resources(
+            scheduler_container_spec,
+            expected_scheduler_limits,
+            expected_scheduler_requests,
+        )
 
     def test_dask_runtime(self, db: Session, client: TestClient):
         runtime: mlrun.runtimes.DaskCluster = self._generate_runtime()
@@ -97,12 +107,17 @@ class TestDaskRuntime(TestRuntimeBase):
         )
         expected_scheduler_limits = generate_resources(mem="4G", cpu=5)
         gpu_type = "nvidia.com/gpu"
-        expected_worker_limits = generate_resources(mem="4G", cpu=5, gpus=2, gpu_type=gpu_type)
+        expected_worker_limits = generate_resources(
+            mem="4G", cpu=5, gpus=2, gpu_type=gpu_type
+        )
         runtime.with_scheduler_limits(
-            mem=expected_scheduler_limits["memory"], cpu=expected_scheduler_limits["cpu"]
+            mem=expected_scheduler_limits["memory"],
+            cpu=expected_scheduler_limits["cpu"],
         )
         runtime.with_worker_limits(
-            mem=expected_worker_limits["memory"], cpu=expected_worker_limits["cpu"], gpus=expected_worker_limits[gpu_type]
+            mem=expected_worker_limits["memory"],
+            cpu=expected_worker_limits["cpu"],
+            gpus=expected_worker_limits[gpu_type],
         )
         _ = runtime.client
 
@@ -114,7 +129,12 @@ class TestDaskRuntime(TestRuntimeBase):
             assert_namespace_env_variable=False,
         )
         self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
-        self._assert_pods_resources(expected_requests, expected_worker_limits, expected_requests, expected_scheduler_limits)
+        self._assert_pods_resources(
+            expected_requests,
+            expected_worker_limits,
+            expected_requests,
+            expected_scheduler_limits,
+        )
 
     def test_dask_with_node_selection(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()


### PR DESCRIPTION
When setting resources it doesn't really make much sense to set the same for the workers and scheduler, especially for example when setting a GPU.
This PR is adding new methods: `with_scheduler_limits`, `with_worker_limits`, `with_scheduler_requests` and `with_worker_requests` 
The old methods `with_requests`/`with_limits` are still working to keep backwards compatibility and just assigning requests/limits for both the scheduler and worker. Added deprecation plan for the support of this methods for Dask runtime.
Fixes https://jira.iguazeng.com/browse/ML-475
Implements https://jira.iguazeng.com/browse/ML-446