### PR TITLE
[Requirements] Bound alembic to lower than 1.6.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ pydantic~=1.5
 # <3.4 since 3.4 can't be installed on pip 18.1
 orjson>=3,<3.4
 importlib-resources; python_version < '3.7'
-alembic~=1.4
+# 1.6.0 introduced some bug and we were just about to release a version TODO: find the root cause for the problems
+alembic~=1.4,<1.6.0
 mergedeep~=1.3
 # 3.0 iguazio system uses 0.8.x - limiting to only patch changes
 v3io-frames~=0.8.5


### PR DESCRIPTION
Alembic 1.6.0 was released today, after it happened the migration CI started to constantly fail, we are about to release 0.6.3 so for now just bounding to not using this version, and afterwards will actually solve the issue
To reproduce the issue simply remove this bound on alembic an run the migration tests