### PR TITLE
[Dask] Handle gpus method correctly

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -341,11 +341,25 @@ class DaskCluster(KubejobRuntime):
             mlrun_version_specifier=mlrun_version_specifier,
         )
 
+    def gpus(self, gpus, gpu_type="nvidia.com/gpu"):
+        warnings.warn(
+            "Dask's gpus will be deprecated in 0.8.0, and will be removed in 0.10.0, use "
+            "with_scheduler_limits/with_worker_limits instead",
+            # TODO: In 0.8.0 deprecate and replace gpus to with_worker/scheduler_limits in examples & demos (or maybe
+            #  just change behavior ?)
+            PendingDeprecationWarning,
+        )
+        # the scheduler/worker specific functions was introduced after the general one, to keep backwards compatibility
+        # this function just sets the gpus for both of them
+        update_in(self.spec.scheduler_resources, ["limits", gpu_type], gpus)
+        update_in(self.spec.worker_resources, ["limits", gpu_type], gpus)
+
     def with_limits(self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
         warnings.warn(
             "Dask's with_limits will be deprecated in 0.8.0, and will be removed in 0.10.0, use "
             "with_scheduler_limits/with_worker_limits instead",
-            # TODO: In 0.8.0 deprecate and replace with_limits to with_worker/scheduler_limits in examples & demos
+            # TODO: In 0.8.0 deprecate and replace with_limits to with_worker/scheduler_limits in examples & demos (or
+            #  maybe just change behavior ?)
             PendingDeprecationWarning,
         )
         # the scheduler/worker specific function was introduced after the general one, to keep backwards compatibility
@@ -370,6 +384,7 @@ class DaskCluster(KubejobRuntime):
             "Dask's with_requests will be deprecated in 0.8.0, and will be removed in 0.10.0, use "
             "with_scheduler_requests/with_worker_requests instead",
             # TODO: In 0.8.0 deprecate and replace with_requests to with_worker/scheduler_requests in examples & demos
+            #  (or maybe just change behavior ?)
             PendingDeprecationWarning,
         )
         # the scheduler/worker specific function was introduced after the general one, to keep backwards compatibility

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -133,7 +133,9 @@ class TestDaskRuntime(TestRuntimeBase):
         )
         gpu_type = "nvidia.com/gpu"
         expected_gpus = 2
-        expected_scheduler_limits = generate_resources(mem="4G", cpu=5, gpus=expected_gpus, gpu_type=gpu_type)
+        expected_scheduler_limits = generate_resources(
+            mem="4G", cpu=5, gpus=expected_gpus, gpu_type=gpu_type
+        )
         expected_worker_limits = generate_resources(
             mem="4G", cpu=5, gpus=expected_gpus, gpu_type=gpu_type
         )
@@ -142,8 +144,7 @@ class TestDaskRuntime(TestRuntimeBase):
             cpu=expected_scheduler_limits["cpu"],
         )
         runtime.with_worker_limits(
-            mem=expected_worker_limits["memory"],
-            cpu=expected_worker_limits["cpu"],
+            mem=expected_worker_limits["memory"], cpu=expected_worker_limits["cpu"],
         )
         runtime.gpus(expected_gpus, gpu_type)
         _ = runtime.client

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -112,14 +112,30 @@ class TestDaskRuntime(TestRuntimeBase):
     def test_dask_runtime(self, db: Session, client: TestClient):
         runtime: mlrun.runtimes.DaskCluster = self._generate_runtime()
 
+        _ = runtime.client
+
+        self.kube_cluster_mock.assert_called_once()
+
+        self._assert_pod_creation_config(
+            expected_runtime_class_name="dask",
+            assert_create_pod_called=False,
+            assert_namespace_env_variable=False,
+        )
+        self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
+        self._assert_scheduler_pod_args()
+
+    def test_dask_runtime_with_resources(self, db: Session, client: TestClient):
+        runtime: mlrun.runtimes.DaskCluster = self._generate_runtime()
+
         expected_requests = generate_resources(mem="2G", cpu=3)
         runtime.with_requests(
             mem=expected_requests["memory"], cpu=expected_requests["cpu"]
         )
-        expected_scheduler_limits = generate_resources(mem="4G", cpu=5)
         gpu_type = "nvidia.com/gpu"
+        expected_gpus = 2
+        expected_scheduler_limits = generate_resources(mem="4G", cpu=5, gpus=expected_gpus, gpu_type=gpu_type)
         expected_worker_limits = generate_resources(
-            mem="4G", cpu=5, gpus=2, gpu_type=gpu_type
+            mem="4G", cpu=5, gpus=expected_gpus, gpu_type=gpu_type
         )
         runtime.with_scheduler_limits(
             mem=expected_scheduler_limits["memory"],
@@ -128,8 +144,8 @@ class TestDaskRuntime(TestRuntimeBase):
         runtime.with_worker_limits(
             mem=expected_worker_limits["memory"],
             cpu=expected_worker_limits["cpu"],
-            gpus=expected_worker_limits[gpu_type],
         )
+        runtime.gpus(expected_gpus, gpu_type)
         _ = runtime.client
 
         self.kube_cluster_mock.assert_called_once()
@@ -146,7 +162,6 @@ class TestDaskRuntime(TestRuntimeBase):
             expected_requests,
             expected_scheduler_limits,
         )
-        self._assert_scheduler_pod_args()
 
     def test_dask_with_node_selection(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()


### PR DESCRIPTION
In https://github.com/mlrun/mlrun/pull/914 we changed the resources to be saved in the `scheduler_resources` and `worker_resources` attribute but didn't handle the `gpus` method which was still saving in the `resources` attribute and therefore nothing is happening when using it