### PR TITLE
[DB] Change default identifier query to be exact match and support ~ prefix for doing ilike match

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2174,14 +2174,14 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         # still be a like, but no % in the query string, so a real exact match will be done.
         if name is not None and name != "":
             if name.startswith("~"):
-                query_string = f"{iter_prefix}%{name[1:]}%"
+                query = query.filter(Artifact.key.ilike(f"{iter_prefix}%{name[1:]}%"))
             else:
-                query_string = f"{iter_prefix}{name}"
-            query = query.filter(Artifact.key.ilike(query_string))
+                # Note - case sensitive (like vs. ilike)
+                query = query.filter(Artifact.key.like(f"{iter_prefix}{name}"))
         # In case no name query was asked for, but we do want to query iter, it will be
         # a like query on the iter alone.
         elif iter:
-            query = query.filter(Artifact.key.ilike(f"{iter_prefix}%"))
+            query = query.filter(Artifact.key.like(f"{iter_prefix}%"))
 
         if kind:
             return self._filter_artifacts_by_kinds(query, [kind])

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -16,6 +16,7 @@ import mlrun.errors
 from mlrun.api import schemas
 from mlrun.api.db.base import DBInterface
 from mlrun.api.db.sqldb.helpers import (
+    generate_query_predicate_for_name,
     label_set,
     run_labels,
     run_start_time,
@@ -647,7 +648,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
         query = self._query(session, Schedule, project=project, kind=kind)
         if name is not None:
-            query = query.filter(Schedule.name.ilike(f"%{name}%"))
+            query = query.filter(generate_query_predicate_for_name(Schedule.name, name))
         labels = label_set(labels)
         query = self._add_labels_filter(session, query, Schedule, labels)
 
@@ -1158,7 +1159,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         # Find object IDs by tag, project and feature-set-name (which is a like query)
         tag_query = self._query(session, cls.Tag, project=project, name=tag)
         if name:
-            tag_query = tag_query.filter(cls.Tag.obj_name.ilike(f"%{name}%"))
+            tag_query = tag_query.filter(
+                generate_query_predicate_for_name(cls.Tag.obj_name, name)
+            )
 
         # Generate a mapping from each object id (note: not uid, it's the DB ID) to its associated tags.
         obj_id_tags = {}
@@ -1216,7 +1219,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         )
 
         if name:
-            query = query.filter(query_class.name.ilike(f"%{name}%"))
+            query = query.filter(
+                generate_query_predicate_for_name(query_class.name, name)
+            )
         if labels:
             query = self._add_labels_filter(session, query, query_class, labels)
         if tag:
@@ -1390,7 +1395,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         query = self._query(session, FeatureSet, project=project, state=state)
 
         if name is not None:
-            query = query.filter(FeatureSet.name.ilike(f"%{name}%"))
+            query = query.filter(
+                generate_query_predicate_for_name(FeatureSet.name, name)
+            )
         if tag:
             query = query.filter(FeatureSet.id.in_(obj_id_tags.keys()))
         if entities:
@@ -1784,7 +1791,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         query = self._query(session, FeatureVector, project=project, state=state)
 
         if name is not None:
-            query = query.filter(FeatureVector.name.ilike(f"%{name}%"))
+            query = query.filter(
+                generate_query_predicate_for_name(FeatureVector.name, name)
+            )
         if tag:
             query = query.filter(FeatureVector.id.in_(obj_id_tags.keys()))
         if labels:
@@ -1932,7 +1941,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
 
         query = self._query(session, cls.Tag, project=project, name=tag_name)
         if obj_name:
-            query = query.filter(cls.Tag.obj_name.ilike(f"%{obj_name}%"))
+            query = query.filter(
+                generate_query_predicate_for_name(cls.Tag.obj_name, obj_name)
+            )
 
         for tag in query:
             uids.append(self._query(session, cls).get(tag.obj_id).uid)
@@ -2155,14 +2166,22 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
                 and_(Artifact.updated >= since, Artifact.updated <= until)
             )
 
-        name_query = ""
-        if iter:
-            # Note that this only covers cases where iter>0
-            name_query = f"{iter}-"
-        if name is not None:
-            name_query = name_query + f"%{name}"
-        if name_query != "":
-            query = query.filter(Artifact.key.ilike(f"{name_query}%"))
+        # Note that iter_prefix will be != "" only where iter>0
+        iter_prefix = f"{iter}-" if iter else "%"
+
+        # Name query requires special handling, since even for an exact match we need to account for the
+        # iter prefix, so it's always a like query. In the case where a specific iter and an exact name it will
+        # still be a like, but no % in the query string, so a real exact match will be done.
+        if name is not None and name != "":
+            if name.startswith("~"):
+                query_string = f"{iter_prefix}%{name[1:]}%"
+            else:
+                query_string = f"{iter_prefix}{name}"
+            query = query.filter(Artifact.key.ilike(query_string))
+        # In case no name query was asked for, but we do want to query iter, it will be
+        # a like query on the iter alone.
+        elif iter:
+            query = query.filter(Artifact.key.ilike(f"{iter_prefix}%"))
 
         if kind:
             return self._filter_artifacts_by_kinds(query, [kind])
@@ -2209,7 +2228,9 @@ class SQLDB(mlrun.api.utils.projects.remotes.member.Member, DBInterface):
         return filtered_artifacts
 
     def _find_functions(self, session, name, project, uids=None, labels=None):
-        query = self._query(session, Function, name=name, project=project)
+        query = self._query(session, Function, project=project)
+        if name:
+            query = query.filter(generate_query_predicate_for_name(Function.name, name))
         if uids:
             query = query.filter(Function.uid.in_(uids))
 

--- a/mlrun/api/db/sqldb/helpers.py
+++ b/mlrun/api/db/sqldb/helpers.py
@@ -62,3 +62,10 @@ def is_field(name):
     if name[0] == "_":
         return False
     return name not in ("metadata", "Tag", "Label", "body")
+
+
+def generate_query_predicate_for_name(column, query_string, fixed_prefix=""):
+    if query_string.startswith("~"):
+        return column.ilike(f"{fixed_prefix}%{query_string[1:]}%")
+    else:
+        return column.__eq__(f"{fixed_prefix}{query_string}")

--- a/mlrun/api/db/sqldb/helpers.py
+++ b/mlrun/api/db/sqldb/helpers.py
@@ -64,8 +64,8 @@ def is_field(name):
     return name not in ("metadata", "Tag", "Label", "body")
 
 
-def generate_query_predicate_for_name(column, query_string, fixed_prefix=""):
+def generate_query_predicate_for_name(column, query_string):
     if query_string.startswith("~"):
-        return column.ilike(f"{fixed_prefix}%{query_string[1:]}%")
+        return column.ilike(f"%{query_string[1:]}%")
     else:
-        return column.__eq__(f"{fixed_prefix}{query_string}")
+        return column.__eq__(query_string)

--- a/tests/api/api/feature_store/test_feature_sets.py
+++ b/tests/api/api/feature_store/test_feature_sets.py
@@ -147,13 +147,13 @@ def test_feature_set_create_and_list(db: Session, client: TestClient) -> None:
     for feature_set_json in response["feature_sets"]:
         _assert_extra_fields_exist(feature_set_json)
 
-    _list_and_assert_objects(client, "feature_sets", project_name, "name=feature", 2)
+    _list_and_assert_objects(client, "feature_sets", project_name, "name=~feature", 2)
     _list_and_assert_objects(client, "feature_sets", project_name, "entity=buyer", 1)
     _list_and_assert_objects(
         client, "feature_sets", project_name, "entity=ticker&entity=bid", 2
     )
     _list_and_assert_objects(
-        client, "feature_sets", project_name, "name=feature&entity=buyer", 0
+        client, "feature_sets", project_name, "name=~feature&entity=buyer", 0
     )
     # Test various label filters
     _list_and_assert_objects(
@@ -560,13 +560,13 @@ def test_entities_list(db: Session, client: TestClient) -> None:
 
         _feature_set_create_and_assert(client, project_name, feature_set)
     _list_and_assert_objects(client, "entities", project_name, "name=entity_0", 1)
-    _list_and_assert_objects(client, "entities", project_name, "name=entity", count)
+    _list_and_assert_objects(client, "entities", project_name, "name=~entity", count)
     _list_and_assert_objects(client, "entities", project_name, "label=color", count)
     _list_and_assert_objects(
         client, "entities", project_name, f"label=color={colors[1]}", count // 2
     )
     _list_and_assert_objects(
-        client, "entities", project_name, "name=entity&label=id=id_0", 1
+        client, "entities", project_name, "name=~entity&label=id=id_0", 1
     )
 
     # set a new tag
@@ -607,7 +607,7 @@ def test_features_list(db: Session, client: TestClient) -> None:
 
     _list_and_assert_objects(client, "features", project_name, "name=feature1", 1)
     # name is a like query, so expecting all 4 features to return
-    _list_and_assert_objects(client, "features", project_name, "name=feature", 4)
+    _list_and_assert_objects(client, "features", project_name, "name=~feature", 4)
     _list_and_assert_objects(client, "features", project_name, "label=owner=me", 1)
 
     # set a new tag
@@ -718,6 +718,25 @@ def test_unversioned_feature_set_actions(db: Session, client: TestClient) -> Non
 
     # Verify we still have just 1 object in the DB
     _list_and_assert_objects(client, "feature_sets", project_name, f"name={name}", 1)
+
+
+def test_feature_set_name_exact_and_fuzzy_list(db: Session, client: TestClient) -> None:
+    project_name = f"prj-{uuid4().hex}"
+
+    name = "FeatureSET123"
+    feature_set = _generate_feature_set(name)
+    _feature_set_create_and_assert(client, project_name, feature_set)
+    _list_and_assert_objects(client, "feature_sets", project_name, f"name={name}", 1)
+    _list_and_assert_objects(
+        client, "feature_sets", project_name, f"name={name.lower()}", 0
+    )
+    _list_and_assert_objects(
+        client, "feature_sets", project_name, f"name=~{name.lower()}", 1
+    )
+    _list_and_assert_objects(client, "feature_sets", project_name, "name=~set", 1)
+    _list_and_assert_objects(client, "feature_sets", project_name, "name=~SET", 1)
+    _list_and_assert_objects(client, "feature_sets", project_name, "name=set", 0)
+    _list_and_assert_objects(client, "feature_sets", project_name, "name=SET", 0)
 
 
 def test_multi_label_query(db: Session, client: TestClient) -> None:

--- a/tests/api/api/feature_store/test_feature_vectors.py
+++ b/tests/api/api/feature_store/test_feature_vectors.py
@@ -106,7 +106,7 @@ def test_list_feature_vectors(db: Session, client: TestClient) -> None:
 
     _list_and_assert_objects(client, "feature_vectors", project_name, None, count)
     _list_and_assert_objects(
-        client, "feature_vectors", project_name, "name=ooga", ooga_name_count
+        client, "feature_vectors", project_name, "name=~ooga", ooga_name_count
     )
     _list_and_assert_objects(
         client,
@@ -128,7 +128,7 @@ def test_list_feature_vectors(db: Session, client: TestClient) -> None:
         client,
         "feature_vectors",
         project_name,
-        "state=dead&name=booga",
+        "state=dead&name=~booga",
         ooga_name_count,
     )
     _list_and_assert_objects(client, "feature_vectors", "wrong_project", None, 0)

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -45,7 +45,7 @@ def test_list_artifact_name_filter(db: DBInterface, db_session: Session):
     assert len(artifacts) == 1
     assert artifacts[0]["metadata"]["name"] == artifact_name_2
 
-    artifacts = db.list_artifacts(db_session, name="artifact_name")
+    artifacts = db.list_artifacts(db_session, name="~artifact_name")
     assert len(artifacts) == 2
 
 

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -416,7 +416,7 @@ async def test_list_schedules_name_filter(db: Session, scheduler: Scheduler):
         if should_find:
             expected_schedule_names.append(name)
 
-    schedules = scheduler.list_schedules(db, project, "mlrun")
+    schedules = scheduler.list_schedules(db, project, "~mlrun")
     assert len(schedules.schedules) == len(expected_schedule_names)
     for schedule in schedules.schedules:
         assert schedule.name in expected_schedule_names


### PR DESCRIPTION
Modifying the logic behind how name queries are done in list APIs for all MLRun objects:

- If name starts with `~`, query will be an `ilike %name%` query (also ignore case). For example using: `name=~hello` will return names: `myHello`, `heLLoween` and similar
- Else, name is an exact query, and should match in both content and case

As can be seen, the default is now **exact query**, rather than a like query as was before. To create a like query the `~` prefix must be added.

The only caveat here is around Artifacts, due to how the `iter` is encoded in the `key` field. If you ask for an exact artifact name, but do not provide a specific `iter` to look for, the query will still be a like query on `%name`, since the iter is at the beginning of the string. This means that names with prefixes may still be returned in this case. For example, looking for artifacts named "dead" will also return artifacts named "undead". This can be fixed with additional complexity to the code, but again - the real fix should be to modify the DB structure, separating the iter from the key.