### PR TITLE
Use simple lambda function to show pass through

### DIFF
--- a/docs/serving/distributed-graph.ipynb
+++ b/docs/serving/distributed-graph.ipynb
@@ -230,12 +230,12 @@
     "# define the graph steps (DAG)\n",
     "graph.to(name=\"load_url\", handler=\"load_url\")\\\n",
     "     .to(name=\"to_paragraphs\", handler=\"to_paragraphs\")\\\n",
-    "     .to(\"storey.FlatMap\", \"flatten_paragraphs\", _fn=\"(event)\")\\\n",
+    "     .to(\"storey.FlatMap\", \"flatten_paragraphs\", _fn=lambda x: x)\\\n",
     "     .to(\">>\", \"q1\", path=internal_stream)\\\n",
     "     .to(name=\"nlp\", class_name=\"ApplyNLP\", function=\"enrich\")\\\n",
     "     .to(name=\"extract_entities\", handler=\"extract_entities\", function=\"enrich\")\\\n",
     "     .to(name=\"enrich_entities\", handler=\"enrich_entities\", function=\"enrich\")\\\n",
-    "     .to(\"storey.FlatMap\", \"flatten_entities\", _fn=\"(event)\", function=\"enrich\")\\\n",
+    "     .to(\"storey.FlatMap\", \"flatten_entities\", _fn=lambda x: x, function=\"enrich\")\\\n",
     "     .to(name=\"printer\", handler=\"myprint\", function=\"enrich\")\\\n",
     "     .to(\">>\", \"output_stream\", path=out_stream)"
    ]


### PR DESCRIPTION
According to [this function](https://github.com/mlrun/mlrun/blob/1f15e9b37801f2902ffcd14a5b096ef6a8006d60/mlrun/utils/helpers.py#L833), it is perfectly valid to pass in a callable directly. I believe this is more clear and explicit than specifying a string that is mapped into a lambda. It should probably also be in the documentation what the _fn is with respect to storey UnaryFunctionFlow and how that is used for the different transformation flows.