### PR TITLE
[Jupyter image] Pin base image tag

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook
+FROM jupyter/scipy-notebook:python-3.8.8
 
 ENV PIP_NO_CACHE_DIR=1
 


### PR DESCRIPTION
The image building started failing with the attached failure, not sure what exactly happened, seems like another package changed for us "under the hood" (or a python version ?) and anyways it's not "healthy" that we use `latest` tag as the base image, it all happened just when we released 0.6.3, failing the release, pinning the image tag to `:python-3.8.8` mainly because it works, will re-visit the whole thing after 0.6.3 is out
[Jupyter-image-failure-log.txt](https://github.com/mlrun/mlrun/files/6448714/Jupyter-image-failure-log.txt)
