### PR TITLE
[Jupyter image] Fix installations to be done by notebook user

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -4,16 +4,12 @@ ENV PIP_NO_CACHE_DIR=1
 
 RUN python -m pip install --upgrade pip~=20.2.0
 
-# by default COPY creates files with root permissions, so doing all the preparation with root and chown-ing everything
-# in the end
-USER root
-
 WORKDIR $HOME
 
-COPY ./README.md $HOME
-COPY ./docs/quick-start.ipynb $HOME
-COPY ./docs/_static/images/mlrun-quick-start $HOME/_static/images/mlrun-quick-start
-COPY ./examples $HOME/examples/
+COPY --chown=$NB_UID:$NB_GID ./README.md $HOME
+COPY --chown=$NB_UID:$NB_GID ./docs/quick-start.ipynb $HOME
+COPY --chown=$NB_UID:$NB_GID ./docs/_static/images/mlrun-quick-start $HOME/_static/images/mlrun-quick-start
+COPY --chown=$NB_UID:$NB_GID ./examples $HOME/examples/
 
 ARG MLRUN_CACHE_DATE=initial
 RUN git clone --branch release/v0.6.x-latest https://github.com/mlrun/demos.git $HOME/demos
@@ -21,20 +17,16 @@ RUN git clone https://github.com/mlrun/functions.git $HOME/functions
 
 RUN mkdir data
 
-COPY ./dockerfiles/jupyter/requirements.txt /tmp/requirements/jupyter-requirements.txt
-COPY ./dockerfiles/mlrun-api/requirements.txt /tmp/requirements/mlrun-api-requirements.txt
-COPY ./requirements.txt /tmp/requirements/requirement.txt
+COPY --chown=$NB_UID:$NB_GID ./dockerfiles/jupyter/requirements.txt /tmp/requirements/jupyter-requirements.txt
+COPY --chown=$NB_UID:$NB_GID ./dockerfiles/mlrun-api/requirements.txt /tmp/requirements/mlrun-api-requirements.txt
+COPY --chown=$NB_UID:$NB_GID ./requirements.txt /tmp/requirements/requirement.txt
 RUN python -m pip install \
     -r /tmp/requirements/jupyter-requirements.txt \
     -r /tmp/requirements/mlrun-api-requirements.txt \
     -r /tmp/requirements/requirement.txt
 
-COPY . /tmp/mlrun
+COPY --chown=$NB_UID:$NB_GID . /tmp/mlrun
 RUN cd /tmp/mlrun && python -m pip install ".[complete-api]"
-
-RUN chown -R $NB_UID:$NB_GID $HOME
-
-USER $NB_UID
 
 ENV MLRUN_ARTIFACT_PATH=$HOME/data \
     JUPYTER_ENABLE_LAB=yes \


### PR DESCRIPTION
We noticed that when we installing certain packages (like `nuclio-jupyter`) that are already installed pip doesn't remove the old installation
Also when trying to manually uninstall them we got permission errors
It happened because we're running the `pip install` in the docker file under the root user, and not the notebook user
Fixed that