### PR TITLE
[SDK] Make auto_mount importable from root

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -26,6 +26,7 @@ from .execution import MLClientCtx
 from .model import NewTask, RunObject, RunTemplate, new_task
 from .platforms import (
     VolumeMount,
+    auto_mount,
     mount_v3io,
     mount_v3io_extended,
     mount_v3io_legacy,


### PR DESCRIPTION
make `auto_mount` importable by `import mlrun` only (instead of `import mlrun.platforms`)