### PR TITLE
[Builder] Use `python -m pip` instead of `pip` (best practice)

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -44,7 +44,7 @@ def make_dockerfile(
         dock += "ADD {src_dir} {workdir}\n"
         dock += f"ENV PYTHONPATH {workdir}\n"
     if requirements:
-        dock += f"RUN pip install -r {requirements}\n"
+        dock += f"RUN python -m pip install -r {requirements}\n"
     if commands:
         dock += "".join([f"RUN {command}\n" for command in commands])
     if extra:
@@ -249,7 +249,7 @@ def _resolve_mlrun_install_command(mlrun_version_specifier):
             mlrun_version_specifier = (
                 f"{config.package_path}[complete]=={config.version}"
             )
-    return f'pip install "{mlrun_version_specifier}"'
+    return f'python -m pip install "{mlrun_version_specifier}"'
 
 
 def build_runtime(runtime, with_mlrun, mlrun_version_specifier, interactive=False):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -104,7 +104,7 @@ default_config = {
         "max_workers": "",
         "scheduling": {
             # the minimum interval that will be allowed between two scheduled jobs - e.g. a job wouldn't be
-            # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute
+            # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute, "0" to disable
             "min_allowed_interval": "10 minutes",
             "default_concurrency_limit": 1,
         },


### PR DESCRIPTION
Also - document the way to disable the scheduler min interval validation in a comment in `config.py`