### PR TITLE
[Runtimes] Fix `auto_mount` precedence to PVC->V3IO

### DIFF
--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -56,8 +56,6 @@ def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
             volume_mount_path=volume_mount_path,
             volume_name=volume_name or "pvc",
         )
-    if "V3IO_ACCESS_KEY" in os.environ:
-        return mount_v3io(name=volume_name or "v3io")
     if "MLRUN_PVC_MOUNT" in os.environ:
         mount = os.environ.get("MLRUN_PVC_MOUNT")
         items = mount.split(":")
@@ -68,6 +66,8 @@ def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
             volume_mount_path=items[1],
             volume_name=volume_name or "pvc",
         )
+    if "V3IO_ACCESS_KEY" in os.environ:
+        return mount_v3io(name=volume_name or "v3io")
     raise ValueError("failed to auto mount, need to set env vars")
 
 


### PR DESCRIPTION
In `auto_mount` to detect whether we should use `mount_pvc` we check for the `MLRUN_PVC_MOUNT` env var existence which is a clear cut - if someone set it they wanted us to use it. in contrast, the detection for `mount_v3io` is done by checking the `V3IO_ACCESS_KEY` env var existence, which is a heuristic.
So generally, makes sense to prefer pvc when both are defined.
Specifically, it happened to us that someone tried to use the mlrun-kit which uses pvc mounts, but they also had a v3io access (but no mount support) so they set the `V3IO_ACCESS_KEY` and the `auto_mount` tried to mount v3io which failed.
Fixes https://jira.iguazeng.com/browse/ML-555
 