### PR TITLE
[Requirements] Bump nuclio-jupyter minimum to 0.8.14

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,13 +4,13 @@ twine~=3.1
 black<=19.10b0
 flake8~=3.8
 pytest-asyncio~=0.14
-# See jupyter-server for why we're limiting it to a specific version
+# See jupyter-server requirement for why we're limiting it to a specific version and the relation to tornado
 # The jupyter-server that we're using (1.0.8) has a bug (https://github.com/jupyter-server/jupyter_server/issues/337)
 # which makes pytest dependent on pytest-tornasync (when jupyter-server is installed) the bug was fixed
 # (https://github.com/jupyter-server/jupyter_server/pull/339) and released in 1.1.0
 # (https://github.com/jupyter-server/jupyter_server/releases/tag/1.1.0) But the change there require tornado upgrade
 # which we can't make currently
-# TODO: when tornado upgrade is possible, do it, upgrade jupyter-server and remove this
+# TODO: when tornado upgrade is possible, upgrade jupyter-server and remove this
 pytest-tornasync~=0.6.0
 deepdiff~=5.0
 pytest-alembic~=0.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,14 @@ twine~=3.1
 black<=19.10b0
 flake8~=3.8
 pytest-asyncio~=0.14
+# See jupyter-server for why we're limiting it to a specific version
+# The jupyter-server that we're using (1.0.8) has a bug (https://github.com/jupyter-server/jupyter_server/issues/337)
+# which makes pytest dependent on pytest-tornasync (when jupyter-server is installed) the bug was fixed
+# (https://github.com/jupyter-server/jupyter_server/pull/339) and released in 1.1.0
+# (https://github.com/jupyter-server/jupyter_server/releases/tag/1.1.0) But the change there require tornado upgrade
+# which we can't make currently
+# TODO: when tornado upgrade is possible, do it, upgrade jupyter-server and remove this
+pytest-tornasync~=0.6.0
 deepdiff~=5.0
 pytest-alembic~=0.2
 requests-mock~=1.8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,14 +4,6 @@ twine~=3.1
 black<=19.10b0
 flake8~=3.8
 pytest-asyncio~=0.14
-# See jupyter-server requirement for why we're limiting it to a specific version and the relation to tornado
-# The jupyter-server that we're using (1.0.8) has a bug (https://github.com/jupyter-server/jupyter_server/issues/337)
-# which makes pytest dependent on pytest-tornasync (when jupyter-server is installed) the bug was fixed
-# (https://github.com/jupyter-server/jupyter_server/pull/339) and released in 1.1.0
-# (https://github.com/jupyter-server/jupyter_server/releases/tag/1.1.0) But the change there require tornado upgrade
-# which we can't make currently
-# TODO: when tornado upgrade is possible, upgrade jupyter-server and remove this
-pytest-tornasync~=0.6.0
 deepdiff~=5.0
 pytest-alembic~=0.2
 requests-mock~=1.8

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,15 @@ twine~=3.1
 black<=19.10b0
 flake8~=3.8
 pytest-asyncio~=0.14
+# See jupyter-server requirement in nuclio-jupyter (https://github.com/nuclio/nuclio-jupyter/blob/master/Pipfile#L19)
+# for why we're limiting it to a specific version and the relation to tornado
+# The jupyter-server that we're using (1.0.8) has a bug (https://github.com/jupyter-server/jupyter_server/issues/337)
+# which makes pytest dependent on pytest-tornasync (when jupyter-server is installed) the bug was fixed
+# (https://github.com/jupyter-server/jupyter_server/pull/339) and released in 1.1.0
+# (https://github.com/jupyter-server/jupyter_server/releases/tag/1.1.0) But the change there require tornado upgrade
+# which we can't make currently
+# TODO: when tornado upgrade is possible, upgrade jupyter-server and remove this
+pytest-tornasync~=0.6.0
 deepdiff~=5.0
 pytest-alembic~=0.2
 requests-mock~=1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,7 @@ kfp~=1.0.1
 nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
-# ~=1.0 from nuclio-jupyter 0.8.13, <=1.0.8 cause above this version it requires a version of tornado that is
-# incompatible with iguazio system that is <3.2.0
-# TODO: remove in 0.7.0 (which is for 3.2.0)
-jupyter-server~=1.0, <=1.0.8
-nuclio-jupyter~=0.8.13
+nuclio-jupyter~=0.8.14
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ kfp~=1.0.1
 nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
-# ~= from nuclio-jupyter 0.8.13, <=1.0.8 cause above this version it requires a version of tornado that is incompatible
-# with iguazio system that is <3.2.0
+# ~=1.0 from nuclio-jupyter 0.8.13, <=1.0.8 cause above this version it requires a version of tornado that is
+# incompatible with iguazio system that is <3.2.0
 # TODO: remove in 0.7.0 (which is for 3.2.0)
 jupyter-server~=1.0, <=1.0.8
 nuclio-jupyter~=0.8.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ kfp~=1.0.1
 nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
+# ~= from nuclio-jupyter 0.8.13, <=1.0.8 cause above this version it requires a version of tornado that is incompatible
+# with iguazio system that is <3.2.0
+# TODO: remove in 0.7.0 (which is for 3.2.0)
+jupyter-server~=1.0, <=1.0.8
 nuclio-jupyter~=0.8.13
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314


### PR DESCRIPTION
Bumping nuclio-jupyter to 0.8.14 in order to get https://github.com/nuclio/nuclio-jupyter/pull/113