### PR TITLE
[SDK] Fix SDK to not import API requirements

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -99,10 +99,20 @@ class PackageTester:
         self._logger.debug(
             "Testing extra imports", extra=extra,
         )
+        test_command = f"python -c '{self._extras_tests_data[extra]['import_test_command']}'"
         self._run_command(
-            f"python -c '{self._extras_tests_data[extra]['import_test_command']}'",
+            test_command,
             run_in_venv=True,
         )
+        if 'api' not in extra:
+            # When api is not in the extra it's an extra purposed for the client usage
+            # Usually it will be used with a remote server - meaning httpdb as the run db, to test that (will cause
+            # different imports to be done) we're setting the DB path
+            self._run_command(
+                test_command,
+                run_in_venv=True,
+                env={'MLRUN_DBPATH': 'http://mock-server'}
+            )
 
     def _test_requirements_conflicts(self, extra):
         self._logger.debug(
@@ -135,12 +145,13 @@ class PackageTester:
             f"pip install '.{extra}'", run_in_venv=True,
         )
 
-    def _run_command(self, command, run_in_venv=False):
+    def _run_command(self, command, run_in_venv=False, env=None):
         if run_in_venv:
             command = f". test-venv/bin/activate && {command}"
         try:
             process = subprocess.run(
                 command,
+                env=env,
                 shell=True,
                 check=True,
                 stdout=subprocess.PIPE,

--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -99,19 +99,20 @@ class PackageTester:
         self._logger.debug(
             "Testing extra imports", extra=extra,
         )
-        test_command = f"python -c '{self._extras_tests_data[extra]['import_test_command']}'"
-        self._run_command(
-            test_command,
-            run_in_venv=True,
+        test_command = (
+            f"python -c '{self._extras_tests_data[extra]['import_test_command']}'"
         )
-        if 'api' not in extra:
+        self._run_command(
+            test_command, run_in_venv=True,
+        )
+        if "api" not in extra:
             # When api is not in the extra it's an extra purposed for the client usage
             # Usually it will be used with a remote server - meaning httpdb as the run db, to test that (will cause
             # different imports to be done) we're setting the DB path
             self._run_command(
                 test_command,
                 run_in_venv=True,
-                env={'MLRUN_DBPATH': 'http://mock-server'}
+                env={"MLRUN_DBPATH": "http://mock-server"},
             )
 
     def _test_requirements_conflicts(self, extra):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -200,7 +200,9 @@ class HTTPRunDB(RunDBInterface):
             mlconf.dbpath = mlconf.dbpath or 'http://mlrun-api:8080'
             db = get_run_db().connect()
         """
-
+        # hack to allow unit tests to instantiate HTTPRunDB without a real server behind
+        if "mock-server" in self.base_url:
+            return
         resp = self.api_call("GET", "healthz", timeout=5)
         try:
             server_cfg = resp.json()

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from datetime import datetime
 from os import path, remove
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import kfp
 import requests
@@ -33,13 +33,7 @@ from mlrun.errors import MLRunInvalidArgumentError
 
 from ..api.schemas import ModelEndpoint
 from ..config import config
-
-# Storey is not compatible with Python 3.6, and is imported inside feature store module
-# So in order to make the code here runnable in Python 3.6 we're adding this condition which means the import won't be
-# executed on runtime
-if TYPE_CHECKING:
-    from ..feature_store import FeatureSet, FeatureVector
-
+from ..feature_store import FeatureSet, FeatureVector
 from ..lists import ArtifactList, RunList
 from ..utils import datetime_to_iso, dict_to_json, logger, new_pipe_meta
 from .base import RunDBError, RunDBInterface

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from datetime import datetime
 from os import path, remove
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import kfp
 import requests
@@ -33,7 +33,13 @@ from mlrun.errors import MLRunInvalidArgumentError
 
 from ..api.schemas import ModelEndpoint
 from ..config import config
-from ..feature_store import FeatureSet, FeatureVector
+
+# Storey is not compatible with Python 3.6, and is imported inside feature store module
+# So in order to make the code here runnable in Python 3.6 we're adding this condition which means the import won't be
+# executed on runtime
+if TYPE_CHECKING:
+    from ..feature_store import FeatureSet, FeatureVector
+
 from ..lists import ArtifactList, RunList
 from ..utils import datetime_to_iso, dict_to_json, logger, new_pipe_meta
 from .base import RunDBError, RunDBInterface

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -17,8 +17,8 @@ from typing import List, Optional, Union
 import pandas as pd
 
 import mlrun
+import mlrun.errors
 
-from ..api.api.utils import log_and_raise
 from ..data_types import InferOptions, get_infer_interface
 from ..datastore.store_resources import parse_store_uri
 from ..datastore.targets import get_default_targets, get_target_driver
@@ -210,8 +210,8 @@ def ingest(
                 # TODO: this handling is needed because the generic httpdb error handling doesn't raise the correct
                 #  error class and doesn't propagate the correct message, until it solved we're manually handling this
                 #  case to give better user experience, remove this when the error handling is fixed.
-                log_and_raise(
-                    reason=f"{exc}. Make sure the feature set is saved in DB (call feature_set.save())"
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"{exc}. Make sure the feature set is saved in DB (call feature_set.save())"
                 )
 
         # feature-set spec always has a source property that is not None. It may be default-constructed, in which

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import pandas as pd
-from storey import EmitPolicy
+
+# Storey is not compatible with Python 3.6. We have to import this module in httpdb.
+# So in order to make the code here runnable in Python 3.6 we're adding this condition which means the import won't be
+# executed in runtime
+if TYPE_CHECKING:
+    from storey import EmitPolicy
 
 import mlrun
 
@@ -354,7 +359,7 @@ class FeatureSet(ModelObj):
         state_name=None,
         after=None,
         before=None,
-        emit_policy: Optional[EmitPolicy] = None,
+        emit_policy: Optional["EmitPolicy"] = None,
     ):
         """add feature aggregation rule
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -531,7 +531,7 @@ class MlrunProject(ModelObj):
             "This is a property of the metadata, use project.metadata.name instead"
             "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
             # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            DeprecationWarning,
+            PendingDeprecationWarning,
         )
         return self.metadata.name
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -531,7 +531,7 @@ class MlrunProject(ModelObj):
             "This is a property of the metadata, use project.metadata.name instead"
             "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
             # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            DeprecationWarning,
         )
         return self.metadata.name
 


### PR DESCRIPTION
Fixed bug originated in https://github.com/mlrun/mlrun/pull/946 importing API code path in SDK context causing this error to be raised:
```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-9be87cd72dd7> in <module>
----> 1 import mlrun
      2 from os import getenv
      3 
      4 mlrun.set_environment(project='fsdemo', user_project=True)
      5 # location of the output data files
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/__init__.py in <module>
     20 from os import environ, path
     21 
---> 22 from .config import config as mlconf
     23 from .datastore import DataItem, store_manager
     24 from .db import get_run_db
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/config.py in <module>
    467 
    468 
--> 469 _populate()
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/config.py in _populate()
    349 
    350     with _load_lock:
--> 351         _do_populate()
    352 
    353 
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/config.py in _do_populate(env)
    371     data = read_env(env)
    372     if data:
--> 373         config.update(data)
    374 
    375     # HACK to enable config property to both have dynamic default and to use the value from dict/env like other
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/config.py in update(self, cfg)
    216                     getattr(self, key).update(value)
    217                 else:
--> 218                     setattr(self, key, value)
    219 
    220     def dump_yaml(self, stream=None):
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/config.py in __setattr__(self, attr, value)
    199         # in order for the dbpath setter to work
    200         if attr == "dbpath":
--> 201             super().__setattr__(attr, value)
    202         else:
    203             self._cfg[attr] = value
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/config.py in dbpath(self, value)
    303 
    304             # when dbpath is set we want to connect to it which will sync configuration from it to the client
--> 305             mlrun.db.get_run_db(value)
    306 
    307     @property
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/db/__init__.py in get_run_db(url, secrets, force_reconnect)
     71     elif scheme in ("http", "https"):
     72         # import here to avoid circular imports
---> 73         from .httpdb import HTTPRunDB
     74 
     75         cls = HTTPRunDB
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/db/httpdb.py in <module>
     34 from ..api.schemas import ModelEndpoint
     35 from ..config import config
---> 36 from ..feature_store import FeatureSet, FeatureVector
     37 from ..lists import ArtifactList, RunList
     38 from ..utils import datetime_to_iso, dict_to_json, logger, new_pipe_meta
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/feature_store/__init__.py in <module>
     38 from ..data_types import InferOptions, ValueType
     39 from ..features import Entity, Feature
---> 40 from .api import (
     41     delete_feature_set,
     42     delete_feature_vector,
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/feature_store/api.py in <module>
     19 import mlrun
     20 
---> 21 from ..api.api.utils import log_and_raise
     22 from ..data_types import InferOptions, get_infer_interface
     23 from ..datastore.store_resources import parse_store_uri
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/api/api/utils.py in <module>
     16 from mlrun.api.utils.singletons.db import get_db
     17 from mlrun.api.utils.singletons.logs_dir import get_logs_dir
---> 18 from mlrun.api.utils.singletons.scheduler import get_scheduler
     19 from mlrun.config import config
     20 from mlrun.db.sqldb import SQLDB as SQLRunDB
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/api/utils/singletons/scheduler.py in <module>
      1 from mlrun.api.db.sqldb.session import create_session
----> 2 from mlrun.api.utils.scheduler import Scheduler
      3 
      4 # TODO: something nicer
      5 scheduler: Scheduler = None
~/.pythonlibs/jupyter/lib/python3.7/site-packages/mlrun/api/utils/scheduler.py in <module>
      6 import fastapi.concurrency
      7 import humanfriendly
----> 8 from apscheduler.schedulers.asyncio import AsyncIOScheduler
      9 from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
     10 from sqlalchemy.orm import Session
ModuleNotFoundError: No module named 'apscheduler'
```