### PR TITLE
[Jupyter image] Use hackathon mlrun/demos branch, add graphviz & python-dotenv, remove examples

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -15,7 +15,6 @@ WORKDIR $HOME
 COPY --chown=$NB_UID:$NB_GID ./README.md $HOME
 COPY --chown=$NB_UID:$NB_GID ./docs/quick-start.ipynb $HOME
 COPY --chown=$NB_UID:$NB_GID ./docs/_static/images/mlrun-quick-start $HOME/_static/images/mlrun-quick-start
-COPY --chown=$NB_UID:$NB_GID ./examples $HOME/examples/
 
 ARG MLRUN_CACHE_DATE=initial
 RUN git clone --branch hackathon https://github.com/mlrun/demos.git $HOME/demos

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -16,7 +16,7 @@ COPY --chown=$NB_UID:$NB_GID ./docs/_static/images/mlrun-quick-start $HOME/_stat
 COPY --chown=$NB_UID:$NB_GID ./examples $HOME/examples/
 
 ARG MLRUN_CACHE_DATE=initial
-RUN git clone --branch release/v0.6.x-latest https://github.com/mlrun/demos.git $HOME/demos
+RUN git clone --branch hackathon https://github.com/mlrun/demos.git $HOME/demos
 RUN git clone https://github.com/mlrun/functions.git $HOME/functions
 
 RUN mkdir data

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -1,12 +1,14 @@
 FROM jupyter/scipy-notebook:python-3.8.8
 
-ENV PIP_NO_CACHE_DIR=1
-
-RUN python -m pip install --upgrade pip~=20.2.0
-
+USER root
 RUN apt-get update && apt-get install --no-install-recommends -y \
   graphviz \
  && rm -rf /var/lib/apt/lists/*
+USER $NB_UID
+
+ENV PIP_NO_CACHE_DIR=1
+
+RUN python -m pip install --upgrade pip~=20.2.0
 
 WORKDIR $HOME
 

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -4,6 +4,10 @@ ENV PIP_NO_CACHE_DIR=1
 
 RUN python -m pip install --upgrade pip~=20.2.0
 
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  graphviz \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR $HOME
 
 COPY --chown=$NB_UID:$NB_GID ./README.md $HOME

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -5,3 +5,4 @@ seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.16.0
+python-dotenv~=0.17.0

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -4,4 +4,4 @@ scikit-learn~=0.23.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1
-
+graphviz~=0.16.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -52,6 +52,9 @@ def test_requirement_specifiers_inconsistencies():
         "scipy": ["~=1.0", "==1.4.1", "~=1.0"],
         # It's ok we have 2 different versions cause they are for different python versions
         "pandas": ["~=1.2; python_version >= '3.7'", "~=1.0; python_version < '3.7'"],
+        # The empty specifier is from tests/runtimes/assets/requirements.txt which is there specifically to test the
+        # scenario of requirements without version specifiers
+        "python-dotenv": ["", "~=0.17.0"],
     }
 
     for (


### PR DESCRIPTION
* Pull `mlrun/demos` hackathon branch - which is suited for the mlrun-kit
* Adding the `graphviz` and `python-dotenv` package
* Removing the examples from since not all of them are mlrun-kit compatible