### PR TITLE
[Requirements] Bump nuclio-jupyter to 0.8.15 and use its jupyter-server extra in jupyter image

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,3 +6,4 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.16.0
 python-dotenv~=0.17.0
+nuclio-jupyter[jupyter-server]~=0.8.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,7 @@ kfp~=1.0.1
 nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
-# Temporarly locked
-nuclio-jupyter==0.8.13
+nuclio-jupyter~=0.8.15
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0


### PR DESCRIPTION
See https://github.com/nuclio/nuclio-jupyter/pull/115 for full explanation