### PR TITLE
[API] Adding best-iteration parameter to artifacts list

### DIFF
--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -96,10 +96,19 @@ def list_artifacts(
     category: schemas.ArtifactCategories = None,
     labels: List[str] = Query([], alias="label"),
     iter: int = Query(None, ge=0),
+    best_iteration: bool = Query(False, alias="best-iteration"),
     db_session: Session = Depends(deps.get_db_session),
 ):
     artifacts = get_db().list_artifacts(
-        db_session, name, project, tag, labels, kind=kind, category=category, iter=iter,
+        db_session,
+        name,
+        project,
+        tag,
+        labels,
+        kind=kind,
+        category=category,
+        iter=iter,
+        best_iteration=best_iteration,
     )
     return {
         "artifacts": artifacts,

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -98,6 +98,7 @@ class DBInterface(ABC):
         kind=None,
         category: schemas.ArtifactCategories = None,
         iter: int = None,
+        best_iteration: bool = False,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -98,6 +98,7 @@ class FileDB(DBInterface):
         kind=None,
         category: schemas.ArtifactCategories = None,
         iter: int = None,
+        best_iteration: bool = False,
     ):
         return self._transform_run_db_error(
             self.db.list_artifacts, name, project, tag, labels, since, until

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -95,6 +95,7 @@ class RunDBInterface(ABC):
         since=None,
         until=None,
         iter: int = None,
+        best_iteration: bool = False,
     ):
         pass
 

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -234,6 +234,7 @@ class FileRunDB(RunDBInterface):
         since=None,
         until=None,
         iter: int = None,
+        best_iteration: bool = False,
     ):
         if iter:
             raise NotImplementedError(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -526,6 +526,7 @@ class HTTPRunDB(RunDBInterface):
         since=None,
         until=None,
         iter: int = None,
+        best_iteration: bool = False,
     ):
         """ List artifacts filtered by various parameters.
 
@@ -545,6 +546,9 @@ class HTTPRunDB(RunDBInterface):
         :param until: Not in use in :py:class:`HTTPRunDB`.
         :param iter: Return artifacts from a specific iteration (where ``iter=0`` means the root iteration). If
             ``None`` (default) return artifacts from all iterations.
+        :param best_iteration: Returns the artifact which belongs to the best iteration of a given run, in the case of
+            artifacts generated from a hyper-param run. If only a single iteration exists, will return the artifact
+            from that iteration. If using ``best_iter``, the ``iter`` parameter must not be used.
         """
 
         project = project or default_project
@@ -554,6 +558,7 @@ class HTTPRunDB(RunDBInterface):
             "tag": tag,
             "label": labels or [],
             "iter": iter,
+            "best-iteration": best_iteration,
         }
         error = "list artifacts"
         resp = self.api_call("GET", "artifacts", error, params=params)

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -124,6 +124,7 @@ class SQLDB(RunDBInterface):
         since=None,
         until=None,
         iter: int = None,
+        best_iteration: bool = False,
     ):
         return self._transform_db_error(
             self.db.list_artifacts,
@@ -135,6 +136,7 @@ class SQLDB(RunDBInterface):
             since,
             until,
             iter=iter,
+            best_iteration=best_iteration,
         )
 
     def del_artifact(self, key, tag="", project=""):

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -266,6 +266,10 @@ def test_artifacts(create_server):
     artifacts = db.list_artifacts(project=prj, tag="*", iter=0)
     assert len(artifacts) == 1, "bad number of artifacts"
 
+    # Only 1 will be returned since it's only looking for iter 0
+    artifacts = db.list_artifacts(project=prj, tag="*", best_iteration=True)
+    assert len(artifacts) == 1, "bad number of artifacts"
+
     db.del_artifacts(project=prj, tag="*")
     artifacts = db.list_artifacts(project=prj, tag="*")
     assert len(artifacts) == 0, "bad number of artifacts after del"


### PR DESCRIPTION
Added a new boolean query-param `best-iteration` to the artifacts list API. When using this parameter, the following logic is applied:
- In artifacts resulting from hyper-param (multi-iteration) runs, the artifact at iteration 0 is examined, and the value of `link_iteration` is used to retrieve the artifact from that iteration. That artifact (which is expected to be the best iteration) is returned for that key.
- In artifacts where iteration 0 is a real artifact (not link), that artifact is returned. Artifacts from any other iteration are omitted from the results.

**Notes:**
1. The `best-iteration` parameter cannot co-exist with the `iter` parameter - specifying both will result in an error.
2. The expected usage for this parameter is  with filtering on project/name. Other filters are allowed but should be used with caution - the `best-iteration` logic is applied on the results of the original DB query. This means that if it's used with other query parameters, such as filtering on specific tags or dates, then results will only be constructed from the results of the DB query. So, if a linked artifact points at another artifact not in the original results list (for example, it's tagged differently than the list `tag` parameter), nothing will be returned.

