### PR TITLE
[SDK+API] Move deploy enrichment and validation to API

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -114,7 +114,12 @@ async def build_function(
     skip_deployed = data.get("skip_deployed", False)
     mlrun_version_specifier = data.get("mlrun_version_specifier")
     fn, ready = await run_in_threadpool(
-        _build_function, db_session, function, with_mlrun, skip_deployed, mlrun_version_specifier
+        _build_function,
+        db_session,
+        function,
+        with_mlrun,
+        skip_deployed,
+        mlrun_version_specifier,
     )
     return {
         "data": fn.to_dict(),
@@ -275,7 +280,9 @@ def build_status(
     )
 
 
-def _build_function(db_session, function, with_mlrun, skip_deployed, mlrun_version_specifier):
+def _build_function(
+    db_session, function, with_mlrun, skip_deployed, mlrun_version_specifier
+):
     fn = None
     ready = None
     try:
@@ -289,7 +296,9 @@ def _build_function(db_session, function, with_mlrun, skip_deployed, mlrun_versi
             # deploy only start the process, the get status API is used to check readiness
             ready = False
         else:
-            ready = build_runtime(fn, with_mlrun, mlrun_version_specifier, skip_deployed)
+            ready = build_runtime(
+                fn, with_mlrun, mlrun_version_specifier, skip_deployed
+            )
         fn.save(versioned=True)
         logger.info("Fn:\n %s", fn.to_yaml())
     except Exception as err:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -177,13 +177,9 @@ class HTTPRunDB(RunDBInterface):
                     reason = ""
             if reason:
                 error = error or f"{method} {url}, error: {reason}"
-                raise RunDBError(error)
+                mlrun.errors.raise_for_status(resp, error)
 
-            try:
-                resp.raise_for_status()
-            except requests.RequestException as err:
-                error = error or f"{method} {url}, error: {err}"
-                raise RunDBError(error) from err
+            mlrun.errors.raise_for_status(resp)
 
         return resp
 
@@ -849,7 +845,7 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed invoking schedule {project}/{name}"
         self.api_call("POST", path, error_message)
 
-    def remote_builder(self, func, with_mlrun, mlrun_version_specifier=None):
+    def remote_builder(self, func, with_mlrun, mlrun_version_specifier=None, skip_deployed=False):
         """ Build the pod image for a function, for execution on a remote cluster. This is executed by the MLRun
         API server, and creates a Docker image out of the function provided and any specific build
         instructions provided within. This is a pre-requisite for remotely executing a function, unless using
@@ -859,10 +855,11 @@ class HTTPRunDB(RunDBInterface):
         :param with_mlrun: Whether to add MLRun package to the built package. This is not required if using a base
             image that already has MLRun in it.
         :param mlrun_version_specifier: Version of MLRun to include in the buit image.
+        :param skip_deployed: Skip the build if we already have an image for the function.
         """
 
         try:
-            req = {"function": func.to_dict(), "with_mlrun": bool2str(with_mlrun)}
+            req = {"function": func.to_dict(), "with_mlrun": bool2str(with_mlrun), "skip_deployed": skip_deployed}
             if mlrun_version_specifier:
                 req["mlrun_version_specifier"] = mlrun_version_specifier
             resp = self.api_call("POST", "build/function", json=req)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -845,7 +845,9 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed invoking schedule {project}/{name}"
         self.api_call("POST", path, error_message)
 
-    def remote_builder(self, func, with_mlrun, mlrun_version_specifier=None, skip_deployed=False):
+    def remote_builder(
+        self, func, with_mlrun, mlrun_version_specifier=None, skip_deployed=False
+    ):
         """ Build the pod image for a function, for execution on a remote cluster. This is executed by the MLRun
         API server, and creates a Docker image out of the function provided and any specific build
         instructions provided within. This is a pre-requisite for remotely executing a function, unless using
@@ -859,7 +861,11 @@ class HTTPRunDB(RunDBInterface):
         """
 
         try:
-            req = {"function": func.to_dict(), "with_mlrun": bool2str(with_mlrun), "skip_deployed": skip_deployed}
+            req = {
+                "function": func.to_dict(),
+                "with_mlrun": bool2str(with_mlrun),
+                "skip_deployed": skip_deployed,
+            }
             if mlrun_version_specifier:
                 req["mlrun_version_specifier"] = mlrun_version_specifier
             resp = self.api_call("POST", "build/function", json=req)

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -48,7 +48,7 @@ class MLRunHTTPStatusError(MLRunHTTPError):
         )
 
 
-def raise_for_status(response: requests.Response):
+def raise_for_status(response: requests.Response, message: str = None):
     """
     Raise a specific MLRunSDK error depending on the given response status code.
     If no specific error exists, raises an MLRunHTTPError
@@ -56,12 +56,15 @@ def raise_for_status(response: requests.Response):
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
+        error_message = str(exc)
+        if error_message:
+            error_message = f"{str(exc)}: {message}"
         try:
             raise STATUS_ERRORS[response.status_code](
-                str(exc), response=response
+                error_message, response=response
             ) from exc
         except KeyError:
-            raise MLRunHTTPError(str(exc), response=response) from exc
+            raise MLRunHTTPError(error_message, response=response) from exc
 
 
 # Specific Errors

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -17,8 +17,8 @@ import time
 from kubernetes import client
 from kubernetes.client.rest import ApiException
 
-from mlrun.runtimes.base import BaseRuntimeHandler
 import mlrun.errors
+from mlrun.runtimes.base import BaseRuntimeHandler
 
 from ..builder import build_runtime
 from ..db import RunDBError
@@ -27,7 +27,7 @@ from ..model import RunObject
 from ..utils import get_in, logger
 from .base import RunError
 from .pod import KubeResource, kube_resource_spec_to_pod_spec
-from .utils import AsyncLogWriter, generate_function_image_name
+from .utils import AsyncLogWriter
 
 
 class KubejobRuntime(KubeResource):
@@ -141,7 +141,9 @@ class KubejobRuntime(KubeResource):
         if self._is_remote_api():
             db = self._get_db()
             logger.info(f"starting remote build, image: {self.spec.build.image}")
-            data = db.remote_builder(self, with_mlrun, mlrun_version_specifier, skip_deployed)
+            data = db.remote_builder(
+                self, with_mlrun, mlrun_version_specifier, skip_deployed
+            )
             self.status = data["data"].get("status", None)
             self.spec.image = get_in(data, "data.spec.image")
             ready = data.get("ready", False)
@@ -151,7 +153,9 @@ class KubejobRuntime(KubeResource):
                 self.status.state = state
         else:
             self.save(versioned=False)
-            ready = build_runtime(self, with_mlrun, mlrun_version_specifier, skip_deployed, watch)
+            ready = build_runtime(
+                self, with_mlrun, mlrun_version_specifier, skip_deployed, watch
+            )
             self.save(versioned=False)
 
         if watch and not ready:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -31,7 +31,6 @@ import mlrun.projects.project
 from mlrun import RunObject
 from mlrun.api import schemas
 from mlrun.artifacts import Artifact
-from mlrun.db import RunDBError
 from mlrun.db.httpdb import HTTPRunDB
 from tests.conftest import tests_root_directory, wait_for_server
 
@@ -285,7 +284,7 @@ def test_basic_auth(create_server):
 
     db: HTTPRunDB = server.conn
 
-    with pytest.raises(RunDBError):
+    with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
         db.list_runs()
 
     db.user = user
@@ -300,7 +299,7 @@ def test_bearer_auth(create_server):
 
     db: HTTPRunDB = server.conn
 
-    with pytest.raises(RunDBError):
+    with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
         db.list_runs()
 
     db.token = token


### PR DESCRIPTION
Also:
* Fix httpdb to propagate mlrun errors (instead of `RunDBError`)
* Raise when `.deploy()` failed (instead of returning False)

Fixes https://jira.iguazeng.com/browse/ML-566