### PR TITLE
[Serving] Set current_function to all functions by default

### DIFF
--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -468,7 +468,7 @@ class ServingRuntime(RemoteRuntime):
         return env
 
     def to_mock_server(
-        self, namespace=None, current_function='*', **kwargs
+        self, namespace=None, current_function="*", **kwargs
     ) -> GraphServer:
         """create mock server object for local testing/emulation
 

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -468,13 +468,13 @@ class ServingRuntime(RemoteRuntime):
         return env
 
     def to_mock_server(
-        self, namespace=None, current_function=None, **kwargs
+        self, namespace=None, current_function='*', **kwargs
     ) -> GraphServer:
         """create mock server object for local testing/emulation
 
         :param namespace: classes search namespace, use globals() for current notebook
         :param log_level: log level (error | info | debug)
-        :param current_function: specify if you want to simulate a child function
+        :param current_function: specify if you want to simulate a child function, * for all functions
         """
 
         server = create_graph_server(


### PR DESCRIPTION
Most times, the best option is to execute the entire pipeline rather than any step individually. This allows users to use multi-function syntax without changing anything when running the mock server.