### PR TITLE
Added a Snowflake data source 

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -21,6 +21,7 @@ from ..model import DataSource
 from ..utils import get_class
 from .utils import store_path_to_spark
 
+import os
 
 def get_source_from_dict(source):
     kind = source.get("kind", "")

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -446,6 +446,10 @@ def _ingest_with_spark(
     mlrun_context=None,
     namespace=None,
 ):
+    spark_conf = None
+    if hasattr(source, "get_spark_conf"):
+        spark_conf = source.get_spark_conf()
+
     try:
         if spark is None or spark is True:
             # create spark context
@@ -457,8 +461,15 @@ def _ingest_with_spark(
                 session_name = (
                     f"{featureset.metadata.project}-{featureset.metadata.name}"
                 )
-
-            spark = SparkSession.builder.appName(session_name).getOrCreate()
+            if spark_conf is not None:
+                conf = (
+                    SparkConf()
+                )
+                for key in spark_conf:
+                    conf.set(key, spark_conf[key])
+                spark = SparkSession.builder.config(conf=conf).appName(session_name).getOrCreate()
+            else:
+                spark = SparkSession.builder.appName(session_name).getOrCreate()
 
         df = source.to_spark_df(spark)
         if featureset.spec.graph and featureset.spec.graph.steps:

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -454,6 +454,7 @@ def _ingest_with_spark(
         if spark is None or spark is True:
             # create spark context
             from pyspark.sql import SparkSession
+            from pyspark import SparkConf
 
             if mlrun_context:
                 session_name = f"{mlrun_context.name}-{mlrun_context.uid}"


### PR DESCRIPTION
Added a feature store data source to handle Snowflake queries using Spark. I also made a change to api.py to handle Spark config parameters. The spark config is expected to be data source-specific. In the case of Snowflake, it requires jar packages to access Snowflake. The data source supports only local ingest although it can be deployed as a remote-spark job to execute as a job.

This release enables password authentication only.