### PR TITLE
[API] Adding metadata.created to feature-store objects

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1544,9 +1544,10 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
         db_object.name = common_object_dict["metadata"]["name"]
         updated_datetime = datetime.now(timezone.utc)
         db_object.updated = updated_datetime
-        db_object.created = common_object_dict["metadata"].pop(
-            "created", None
-        ) or datetime.now(timezone.utc)
+        if not db_object.created:
+            db_object.created = common_object_dict["metadata"].pop(
+                "created", None
+            ) or datetime.now(timezone.utc)
         db_object.state = common_object_dict.get("status", {}).get("state")
         db_object.uid = uid
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1544,10 +1544,14 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
         db_object.name = common_object_dict["metadata"]["name"]
         updated_datetime = datetime.now(timezone.utc)
         db_object.updated = updated_datetime
+        db_object.created = common_object_dict["metadata"].pop(
+            "created", None
+        ) or datetime.now(timezone.utc)
         db_object.state = common_object_dict.get("status", {}).get("state")
         db_object.uid = uid
 
         common_object_dict["metadata"]["updated"] = str(updated_datetime)
+        common_object_dict["metadata"]["created"] = str(db_object.created)
 
         # In case of an unversioned object, we don't want to return uid to user queries. However,
         # the uid DB field has to be set, since it's used for uniqueness in the DB.
@@ -2441,6 +2445,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
         feature_vector_resp = schemas.FeatureVector(**feature_vector_full_dict)
 
         feature_vector_resp.metadata.tag = tag
+        feature_vector_resp.metadata.created = feature_vector_record.created
         return feature_vector_resp
 
     def _transform_project_record_to_schema(

--- a/mlrun/api/schemas/object.py
+++ b/mlrun/api/schemas/object.py
@@ -11,6 +11,7 @@ class ObjectMetadata(BaseModel):
     tag: Optional[str]
     labels: Optional[dict]
     updated: Optional[datetime]
+    created: Optional[datetime]
     uid: Optional[str]
 
     class Config:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -611,6 +611,7 @@ def fill_object_hash(object_dict, uid_property_name, tag=""):
     object_dict["metadata"][uid_property_name] = ""
     object_dict["status"] = None
     object_dict["metadata"]["updated"] = None
+    object_created_timestamp = object_dict["metadata"].pop("created", None)
     data = json.dumps(object_dict, sort_keys=True).encode()
     h = hashlib.sha1()
     h.update(data)
@@ -618,6 +619,8 @@ def fill_object_hash(object_dict, uid_property_name, tag=""):
     object_dict["metadata"]["tag"] = tag
     object_dict["metadata"][uid_property_name] = uid
     object_dict["status"] = status
+    if object_created_timestamp:
+        object_dict["metadata"]["created"] = object_created_timestamp
     return uid
 
 

--- a/tests/api/api/feature_store/test_feature_sets.py
+++ b/tests/api/api/feature_store/test_feature_sets.py
@@ -710,7 +710,7 @@ def test_unversioned_feature_set_actions(db: Session, client: TestClient) -> Non
         client, project_name, feature_set, versioned=False
     )
 
-    allowed_added_fields = ["updated", "tag", "uid", "project"]
+    allowed_added_fields = ["created", "updated", "tag", "uid", "project"]
     _assert_diff_as_expected_except_for_specific_metadata(
         feature_set, feature_set_response, allowed_added_fields
     )

--- a/tests/api/api/feature_store/test_feature_vectors.py
+++ b/tests/api/api/feature_store/test_feature_vectors.py
@@ -55,7 +55,7 @@ def test_feature_vector_create(db: Session, client: TestClient) -> None:
     feature_vector_response = _create_and_assert_feature_vector(
         client, project_name, feature_vector, True
     )
-    allowed_added_fields = ["uid", "updated", "tag"]
+    allowed_added_fields = ["uid", "created", "updated", "tag"]
     assert feature_vector_response["metadata"]["tag"] == "latest"
 
     _assert_diff_as_expected_except_for_specific_metadata(
@@ -348,7 +348,7 @@ def test_unversioned_feature_vector_actions(db: Session, client: TestClient) -> 
         client, project_name, feature_vector, versioned=False
     )
 
-    allowed_added_fields = ["uid", "updated", "tag", "project"]
+    allowed_added_fields = ["uid", "created", "updated", "tag", "project"]
     _assert_diff_as_expected_except_for_specific_metadata(
         feature_vector, feature_vector_response, allowed_added_fields
     )


### PR DESCRIPTION
The `created` field already exists in the DB today, now it's reflected in the objects returned from the APIs in the `metadata.created` field.