### PR TITLE
[System Tests] Add deepdiff to system tests requirements

### DIFF
--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,3 +1,4 @@
 pytest~=5.4
 matplotlib~=3.0
 graphviz~=0.16.0
+deepdiff~=5.0


### PR DESCRIPTION
https://github.com/mlrun/mlrun/pull/1033 added usage of deepdiff to the system tests, and then they started to break, fixing it