### PR TITLE
[Requirements] Allow install dependencies from remote endpoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,12 +48,12 @@ def load_deps(path):
         for line in fp:
             if is_ignored(line):
                 continue
-            stripped_line = line.strip()
+            line = line.strip()
 
             # e.g.: git+https://github.com/nuclio/nuclio-jupyter.git@some-branch#egg=nuclio-jupyter
-            if "#egg=" in stripped_line:
-                _, package = stripped_line.split("#egg=")
-                deps.append(f"{package} @ {stripped_line}")
+            if "#egg=" in line:
+                _, package = line.split("#egg=")
+                deps.append(f"{package} @ {line}")
                 continue
 
             # append package

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,21 @@ def is_ignored(line):
 def load_deps(path):
     """Load dependencies from requirements file"""
     with open(path) as fp:
-        return [line.strip() for line in fp if not is_ignored(line)]
+        deps = []
+        for line in fp:
+            if is_ignored(line):
+                continue
+            stripped_line = line.strip()
+
+            # e.g.: git+https://github.com/nuclio/nuclio-jupyter.git@some-branch#egg=nuclio-jupyter
+            if "#egg=" in stripped_line:
+                _, package = stripped_line.split("#egg=")
+                deps.append(f"{package} @ {stripped_line}")
+                continue
+
+            # append package
+            deps.append(line)
+        return deps
 
 
 with open("README.md") as fp:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -86,11 +86,13 @@ def test_requirement_specifiers_inconsistencies():
 
 
 def test_requirement_from_remote():
-    requirement_specifiers_map = _generate_requirement_specifiers_map([
-        "some-package~=1.9, <1.17.50",
-        "other-package==0.1",
-        "git+https://github.com/mlrun/something.git@some-branch#egg=more-package",
-    ])
+    requirement_specifiers_map = _generate_requirement_specifiers_map(
+        [
+            "some-package~=1.9, <1.17.50",
+            "other-package==0.1",
+            "git+https://github.com/mlrun/something.git@some-branch#egg=more-package",
+        ]
+    )
     assert len(requirement_specifiers_map) > 0
     assert requirement_specifiers_map["some-package"] == [
         "~=1.9, <1.17.50",
@@ -118,7 +120,11 @@ def _generate_requirement_specifiers_map(requirement_specifiers):
     )
     requirement_specifiers_map = collections.defaultdict(list)
     for requirement_specifier in requirement_specifiers:
-        regex = remote_location_regex if "#egg=" in requirement_specifier else specific_module_regex
+        regex = (
+            remote_location_regex
+            if "#egg=" in requirement_specifier
+            else specific_module_regex
+        )
         match = re.fullmatch(regex, requirement_specifier)
         assert (
             match is not None

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -85,15 +85,40 @@ def test_requirement_specifiers_inconsistencies():
     assert inconsistent_specifiers_map == {}
 
 
+def test_requirement_from_remote():
+    requirement_specifiers_map = _generate_requirement_specifiers_map([
+        "some-package~=1.9, <1.17.50",
+        "other-package==0.1",
+        "git+https://github.com/mlrun/something.git@some-branch#egg=more-package",
+    ])
+    assert len(requirement_specifiers_map) > 0
+    assert requirement_specifiers_map["some-package"] == [
+        "~=1.9, <1.17.50",
+    ]
+    assert requirement_specifiers_map["other-package"] == [
+        "==0.1",
+    ]
+    assert requirement_specifiers_map["more-package"] == [
+        "git+https://github.com/mlrun/something.git@some-branch",
+    ]
+
+
 def _generate_requirement_specifiers_map(requirement_specifiers):
-    regex = (
+    specific_module_regex = (
         r"^"
         r"(?P<requirementName>[a-zA-Z\-0-9_]+)"
         r"(?P<requirementExtra>\[[a-zA-Z\-0-9_]+\])?"
         r"(?P<requirementSpecifier>.*)"
     )
+    remote_location_regex = (
+        r"^"
+        r"(?P<requirementSpecifier>.*)"
+        r"#egg="
+        r"(?P<requirementName>[a-zA-Z\-0-9_]+)"
+    )
     requirement_specifiers_map = collections.defaultdict(list)
     for requirement_specifier in requirement_specifiers:
+        regex = remote_location_regex if "#egg=" in requirement_specifier else specific_module_regex
         match = re.fullmatch(regex, requirement_specifier)
         assert (
             match is not None
@@ -143,5 +168,22 @@ def _is_ignored_requirement_line(line):
 
 
 def _load_requirements(path):
-    with open(path) as file:
-        return [line.strip() for line in file if not _is_ignored_requirement_line(line)]
+    """
+    Load dependencies from requirements file, exactly like `setup.py`
+    """
+    with open(path) as fp:
+        deps = []
+        for line in fp:
+            if _is_ignored_requirement_line(line):
+                continue
+            line = line.strip()
+
+            # e.g.: git+https://github.com/nuclio/nuclio-jupyter.git@some-branch#egg=nuclio-jupyter
+            if "#egg=" in line:
+                _, package = line.split("#egg=")
+                deps.append(f"{package} @ {line}")
+                continue
+
+            # append package
+            deps.append(line)
+        return deps


### PR DESCRIPTION
This will allow to use `git+https://github.com/nuclio/nuclio-jupyter.git@some-branch#egg=nuclio-jupyter` on the `requirements.txt`