### PR TITLE
[Nuclio] Support internal external invocation urls

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,4 +6,4 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.16.0
 python-dotenv~=0.17.0
-git+git://github.com/liranbg/nuclio-jupyter@use-internal-external-invocation-url#egg=nuclio-jupyter[jupyter-server]
+nuclio-jupyter[jupyter-server]~=0.8.16

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,4 +6,4 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.16.0
 python-dotenv~=0.17.0
-nuclio-jupyter[jupyter-server]~=0.8.15
+git+git://github.com/liranbg/nuclio-jupyter@use-internal-external-invocation-url#egg=nuclio-jupyter[jupyter-server]

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -223,8 +223,9 @@ def build_status(
             logger.info("Nuclio function deployed successfully", name=name)
         if state in ["error", "unhealthy"]:
             logger.error(f"Nuclio deploy error, {text}", name=name)
-        internal_invocation_urls = function_status_.get('externalInvocationUrls', [])
-        external_invocation_urls = function_status_.get('internalInvocationUrls', [])
+
+        internal_invocation_urls = function_status_.get('internalInvocationUrls', [])
+        external_invocation_urls = function_status_.get('externalInvocationUrls', [])
 
         update_in(fn, "status.nuclio_name", nuclio_name)
         update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -215,6 +215,7 @@ def build_status(
             nuclio_name,
             last_log_timestamp,
             text,
+            function_status_,
         ) = get_nuclio_deploy_status(
             name, project, tag, last_log_timestamp=last_log_timestamp, verbose=verbose
         )
@@ -222,7 +223,12 @@ def build_status(
             logger.info("Nuclio function deployed successfully", name=name)
         if state == "error":
             logger.error(f"Nuclio deploy error, {text}", name=name)
+        internal_invocation_urls = function_status_.get('externalInvocationUrls', [])
+        external_invocation_urls = function_status_.get('internalInvocationUrls', [])
+
         update_in(fn, "status.nuclio_name", nuclio_name)
+        update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)
+        update_in(fn, "status.external_invocation_urls", external_invocation_urls)
         update_in(fn, "status.state", state)
         update_in(fn, "status.address", address)
 
@@ -247,6 +253,8 @@ def build_status(
                 "x-mlrun-function-status": state,
                 "x-mlrun-last-timestamp": str(last_log_timestamp),
                 "x-mlrun-address": address,
+                "x-mlrun-internal-invocation-urls": ",".join(internal_invocation_urls),
+                "x-mlrun-external-invocation-urls": ",".join(external_invocation_urls),
                 "x-mlrun-name": nuclio_name,
             },
         )

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -224,8 +224,8 @@ def build_status(
         if state in ["error", "unhealthy"]:
             logger.error(f"Nuclio deploy error, {text}", name=name)
 
-        internal_invocation_urls = function_status_.get('internalInvocationUrls', [])
-        external_invocation_urls = function_status_.get('externalInvocationUrls', [])
+        internal_invocation_urls = function_status_.get("internalInvocationUrls", [])
+        external_invocation_urls = function_status_.get("externalInvocationUrls", [])
 
         update_in(fn, "status.nuclio_name", nuclio_name)
         update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -227,6 +227,10 @@ def build_status(
         internal_invocation_urls = function_status_.get("internalInvocationUrls", [])
         external_invocation_urls = function_status_.get("externalInvocationUrls", [])
 
+        # on nuclio > 1.6.x we get the external invocation url on the status block
+        if external_invocation_urls:
+            address = external_invocation_urls[0]
+
         update_in(fn, "status.nuclio_name", nuclio_name)
         update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)
         update_in(fn, "status.external_invocation_urls", external_invocation_urls)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -215,7 +215,7 @@ def build_status(
             nuclio_name,
             last_log_timestamp,
             text,
-            function_status_,
+            status,
         ) = get_nuclio_deploy_status(
             name, project, tag, last_log_timestamp=last_log_timestamp, verbose=verbose
         )
@@ -224,8 +224,8 @@ def build_status(
         if state in ["error", "unhealthy"]:
             logger.error(f"Nuclio deploy error, {text}", name=name)
 
-        internal_invocation_urls = function_status_.get("internalInvocationUrls", [])
-        external_invocation_urls = function_status_.get("externalInvocationUrls", [])
+        internal_invocation_urls = status.get("internalInvocationUrls", [])
+        external_invocation_urls = status.get("externalInvocationUrls", [])
 
         # on nuclio > 1.6.x we get the external invocation url on the status block
         if external_invocation_urls:

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -221,7 +221,7 @@ def build_status(
         )
         if state == "ready":
             logger.info("Nuclio function deployed successfully", name=name)
-        if state == "error":
+        if state in ["error", "unhealthy"]:
             logger.error(f"Nuclio deploy error, {text}", name=name)
         internal_invocation_urls = function_status_.get('externalInvocationUrls', [])
         external_invocation_urls = function_status_.get('internalInvocationUrls', [])

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -319,7 +319,7 @@ def build_runtime(
         return False
 
     logger.info(f"build completed with {status}")
-    if status in ["failed", "error", "unhealthy"]:
+    if status in ["failed", "error"]:
         runtime.status.state = mlrun.api.schemas.FunctionState.error
         return False
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -319,7 +319,7 @@ def build_runtime(
         return False
 
     logger.info(f"build completed with {status}")
-    if status in ["failed", "error"]:
+    if status in ["failed", "error", "unhealthy"]:
         runtime.status.state = mlrun.api.schemas.FunctionState.error
         return False
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -113,6 +113,7 @@ default_config = {
                 "session_verification_endpoint": "data_sessions/verifications/app_service",
             },
         },
+        "nuclio": {"default_service_type": "NodePort",},  # one of ClusterIP | NodePort
         "authorization": {"mode": "none"},  # one of none, opa
         "scheduling": {
             # the minimum interval that will be allowed between two scheduled jobs - e.g. a job wouldn't be

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -113,7 +113,7 @@ default_config = {
                 "session_verification_endpoint": "data_sessions/verifications/app_service",
             },
         },
-        "nuclio": {"default_service_type": "NodePort",},  # one of ClusterIP | NodePort
+        "nuclio": {"default_service_type": "NodePort"},  # one of ClusterIP | NodePort
         "authorization": {"mode": "none"},  # one of none, opa
         "scheduling": {
             # the minimum interval that will be allowed between two scheduled jobs - e.g. a job wouldn't be

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -880,7 +880,12 @@ class HTTPRunDB(RunDBInterface):
         return resp.json()
 
     def get_builder_status(
-        self, func: BaseRuntime, offset=0, logs=True, last_log_timestamp=0, verbose=False
+        self,
+        func: BaseRuntime,
+        offset=0,
+        logs=True,
+        last_log_timestamp=0,
+        verbose=False,
     ):
         """ Retrieve the status of a build operation currently in progress.
 
@@ -926,9 +931,11 @@ class HTTPRunDB(RunDBInterface):
                 func.status.address = resp.headers.get("x-mlrun-address", "")
                 func.status.nuclio_name = resp.headers.get("x-mlrun-name", "")
                 func.status.internal_invocation_urls = resp.headers.get(
-                    "x-mlrun-internal-invocation-urls", "").split(",")
+                    "x-mlrun-internal-invocation-urls", ""
+                ).split(",")
                 func.status.external_invocation_urls = resp.headers.get(
-                    "x-mlrun-external-invocation-urls", "").split(",")
+                    "x-mlrun-external-invocation-urls", ""
+                ).split(",")
             else:
                 func.status.build_pod = resp.headers.get("builder_pod", "")
                 func.spec.image = resp.headers.get("function_image", "")

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -35,6 +35,7 @@ from ..api.schemas import ModelEndpoint
 from ..config import config
 from ..feature_store import FeatureSet, FeatureVector
 from ..lists import ArtifactList, RunList
+from ..runtimes import BaseRuntime
 from ..utils import datetime_to_iso, dict_to_json, logger, new_pipe_meta
 from .base import RunDBError, RunDBInterface
 
@@ -879,7 +880,7 @@ class HTTPRunDB(RunDBInterface):
         return resp.json()
 
     def get_builder_status(
-        self, func, offset=0, logs=True, last_log_timestamp=0, verbose=False
+        self, func: BaseRuntime, offset=0, logs=True, last_log_timestamp=0, verbose=False
     ):
         """ Retrieve the status of a build operation currently in progress.
 
@@ -924,6 +925,10 @@ class HTTPRunDB(RunDBInterface):
             if func.kind in mlrun.runtimes.RuntimeKinds.nuclio_runtimes():
                 func.status.address = resp.headers.get("x-mlrun-address", "")
                 func.status.nuclio_name = resp.headers.get("x-mlrun-name", "")
+                func.status.internal_invocation_urls = resp.headers.get(
+                    "x-mlrun-internal-invocation-urls", "").split(",")
+                func.status.external_invocation_urls = resp.headers.get(
+                    "x-mlrun-external-invocation-urls", "").split(",")
             else:
                 func.status.build_pod = resp.headers.get("builder_pod", "")
                 func.spec.image = resp.headers.get("function_image", "")

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -28,24 +28,25 @@ from .utils import logger
 _k8s = None
 
 
-def get_k8s_helper(namespace=None, silent=False):
+def get_k8s_helper(namespace=None, silent=False, log=False):
     """
     :param silent: set to true if you're calling this function from a code that might run from remotely (outside of a
     k8s cluster)
+    :param log: sometimes we want to avoid logging when executing init_k8s_config
     """
     global _k8s
     if not _k8s:
-        _k8s = K8sHelper(namespace, silent=silent)
+        _k8s = K8sHelper(namespace, silent=silent, log=log)
     return _k8s
 
 
 class K8sHelper:
-    def __init__(self, namespace=None, config_file=None, silent=False):
+    def __init__(self, namespace=None, config_file=None, silent=False, log=True):
         self.namespace = namespace or mlconfig.namespace
         self.config_file = config_file
         self.running_inside_kubernetes_cluster = False
         try:
-            self._init_k8s_config()
+            self._init_k8s_config(log)
             self.v1api = client.CoreV1Api()
             self.crdapi = client.CustomObjectsApi()
         except Exception:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -440,6 +440,8 @@ class RemoteRuntime(KubeResource):
             # save the (first) function external invocation url
             # this is made for backwards compatability because the user, at this point, may
             # work remotely and need the external invocation url on the spec.command
+            # TODO: when using `ClusterIP`, this block might not fulfilled
+            #       as long as function doesnt have ingresses
             if self.status.external_invocation_urls:
                 address = self.status.external_invocation_urls[0]
                 self.spec.command = f"http://{address}"

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -130,10 +130,24 @@ class NuclioSpec(KubeResourceSpec):
 
 
 class NuclioStatus(FunctionStatus):
-    def __init__(self, state=None, nuclio_name=None, address=None):
+    def __init__(self,
+                 state=None,
+                 nuclio_name=None,
+                 address=None,
+                 internal_invocation_urls=None,
+                 external_invocation_urls=None,
+                 ):
         super().__init__(state)
 
         self.nuclio_name = nuclio_name
+
+        # exists on nuclio >= 1.6.x
+        # infers the function invocation urls
+        self.internal_invocation_urls = internal_invocation_urls or []
+        self.external_invocation_urls = external_invocation_urls or []
+
+        # still exists for backwards compatability reasons.
+        # on latest Nuclio (>= 1.6.x) versions, use external_invocation_urls / internal_invocation_urls instead
         self.address = address
 
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -774,16 +774,6 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
         name = get_fullname(function.metadata.name, project, tag)
         function.status.nuclio_name = name
         update_in(config, "metadata.name", name)
-        return nuclio.deploy.deploy_config(
-            config,
-            dashboard,
-            name=name,
-            project=project,
-            tag=tag,
-            verbose=function.verbose,
-            create_new=True,
-            watch=watch,
-        )
     else:
 
         name, config, code = nuclio.build_file(
@@ -806,16 +796,18 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
         function.status.nuclio_name = name
 
         update_in(config, "metadata.name", name)
-        return deploy_config(
-            config,
-            dashboard_url=dashboard,
-            name=name,
-            project=project,
-            tag=tag,
-            verbose=function.verbose,
-            create_new=True,
-            watch=watch,
-        )
+
+    return deploy_config(
+        config,
+        dashboard_url=dashboard,
+        name=name,
+        project=project,
+        tag=tag,
+        verbose=function.verbose,
+        create_new=True,
+        watch=watch,
+        return_address_mode=nuclio.deploy.ReturnAddressModes.all,
+    )
 
 
 def get_nuclio_deploy_status(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -402,7 +402,7 @@ class RemoteRuntime(KubeResource):
             self.status = data["data"].get("status")
             # ready = data.get("ready", False)
 
-            while state not in ["ready", "error"]:
+            while state not in ["ready", "error", "unhealthy"]:
                 sleep(1)
                 try:
                     text, last_log_timestamp = db.get_builder_status(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -890,6 +890,16 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
     )
 
 
+def resolve_function_internal_invocation_url(function_name, namespace=""):
+    # hard-coding the internal invocation url
+    # template: nuclio-<function_name>.(<namespace>.)?svc.cluster.local:8080
+
+    # both might be empty
+    templated_namespace = namespace if namespace else mlconf.namespace
+    templated_namespace += "." if templated_namespace else ""
+    return f"nuclio-{function_name}.{templated_namespace}svc.cluster.local:8080"
+
+
 def get_nuclio_deploy_status(
     name,
     project,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -644,7 +644,7 @@ class RemoteRuntime(KubeResource):
         if state != "ready":
             if state:
                 raise RunError(f"cannot run, function in state {state}")
-            state = self._get_state(raise_on_exception=True)
+            state, _, _ = self._get_state(raise_on_exception=True)
             if state != "ready":
                 logger.info("starting nuclio build!")
                 self.deploy()

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -617,7 +617,16 @@ class RemoteRuntime(KubeResource):
                     )
             if path.startswith("/"):
                 path = path[1:]
-            path = f"http://{self.status.address}/{path}"
+
+            # internal / external invocation urls is a nuclio >= 1.6.x feature
+            # try to infer the invocation url from the internal and if not exists, use external.
+            # if both not available, fallback to `address` for backwards compatability
+            if self.status.internal_invocation_urls:
+                path = f"http://{self.status.internal_invocation_urls[0]}/{path}"
+            elif self.status.external_invocation_urls:
+                path = f"http://{self.status.external_invocation_urls[0]}/{path}"
+            else:
+                path = f"http://{self.status.address}/{path}"
 
         kwargs = {}
         if body:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -407,6 +407,7 @@ class RemoteRuntime(KubeResource):
             self.status = data["data"].get("status")
             # ready = data.get("ready", False)
 
+            text = ""
             while state not in ["ready", "error", "unhealthy"]:
                 sleep(1)
                 try:
@@ -902,7 +903,12 @@ def get_nuclio_deploy_status(
     name = get_fullname(name, project, tag)
 
     state, address, last_log_timestamp, outputs, function_status = get_deploy_status(
-        api_address, name, last_log_timestamp, verbose, resolve_address, return_function_status=True
+        api_address,
+        name,
+        last_log_timestamp,
+        verbose,
+        resolve_address,
+        return_function_status=True,
     )
 
     text = "\n".join(outputs) if outputs else ""

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -481,21 +481,25 @@ class RemoteRuntime(KubeResource):
         return message
 
     def _get_state(
-        self,
-        dashboard="",
-        last_log_timestamp=None,
-        verbose=False,
-        raise_on_exception=True,
-    ):
+            self,
+            dashboard="",
+            last_log_timestamp=None,
+            verbose=False,
+            raise_on_exception=True,
+            resolve_address=True,
+    ) -> typing.Tuple[str, str, typing.Optional[float]]:
         if dashboard:
-            state, address, name, last_log_timestamp, text = get_nuclio_deploy_status(
+            state, address, name, last_log_timestamp, text, function_status, = get_nuclio_deploy_status(
                 self.metadata.name,
                 self.metadata.project,
                 self.metadata.tag,
                 dashboard,
                 last_log_timestamp=last_log_timestamp,
                 verbose=verbose,
+                resolve_address=resolve_address,
             )
+            self.status.internal_invocation_urls = function_status.get('internalInvocationUrls', [])
+            self.status.external_invocation_urls = function_status.get('externalInvocationUrls', [])
             self.status.state = state
             self.status.nuclio_name = name
             if address:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -848,14 +848,14 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
 
 
 def get_nuclio_deploy_status(
-    name, project, tag, dashboard="", last_log_timestamp=None, verbose=False
+    name, project, tag, dashboard="", last_log_timestamp=None, verbose=False, resolve_address=True
 ):
     api_address = find_dashboard_url(dashboard or mlconf.nuclio_dashboard_url)
     name = get_fullname(name, project, tag)
 
-    state, address, last_log_timestamp, outputs = get_deploy_status(
-        api_address, name, last_log_timestamp, verbose
+    state, address, last_log_timestamp, outputs, function_status = get_deploy_status(
+        api_address, name, last_log_timestamp, verbose, resolve_address
     )
 
     text = "\n".join(outputs) if outputs else ""
-    return state, address, name, last_log_timestamp, text
+    return state, address, name, last_log_timestamp, text, function_status

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -23,7 +23,7 @@ import nuclio
 import requests
 from aiohttp.client import ClientSession
 from kubernetes import client
-from nuclio.deploy import deploy_config, find_dashboard_url, get_deploy_status
+from nuclio.deploy import find_dashboard_url, get_deploy_status
 from nuclio.triggers import V3IOStreamTrigger
 
 import mlrun.errors
@@ -862,7 +862,7 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
 
         update_in(config, "metadata.name", name)
 
-    return deploy_config(
+    return nuclio.deploy.deploy_config(
         config,
         dashboard_url=dashboard,
         name=name,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -619,6 +619,7 @@ class RemoteRuntime(KubeResource):
             else:
                 kwargs["json"] = body
         try:
+            logger.info("invoking function", method=method, path=path)
             resp = requests.request(method, path, headers=headers, **kwargs)
         except OSError as err:
             raise OSError(f"error: cannot run function at url {path}, {err}")

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -902,7 +902,7 @@ def get_nuclio_deploy_status(
     name = get_fullname(name, project, tag)
 
     state, address, last_log_timestamp, outputs, function_status = get_deploy_status(
-        api_address, name, last_log_timestamp, verbose, resolve_address
+        api_address, name, last_log_timestamp, verbose, resolve_address, return_function_status=True
     )
 
     text = "\n".join(outputs) if outputs else ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ kfp~=1.0.1
 nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
-nuclio-jupyter~=0.8.15
+#nuclio-jupyter~=0.8.15
+# TODO: remove and use nuclio-jupter
+git+git://github.com/liranbg/nuclio-jupyter@use-internal-external-invocation-url#egg=nuclio-jupyter
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,7 @@ ipython>=5.5, <7.17
 # has ipython>=7.23.1 which is incompatible with our ipython specifiers, therefore instsalling ipykernel 5.x before
 # nuclio-jupyter
 ipykernel~=5.0
-#nuclio-jupyter~=0.8.15
-# TODO: remove and use nuclio-jupter
-git+git://github.com/liranbg/nuclio-jupyter@use-internal-external-invocation-url#egg=nuclio-jupyter
+nuclio-jupyter~=0.8.16
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -53,11 +53,9 @@ class TestServingRuntime(TestNuclioRuntime):
                     "status": NuclioStatus(
                         state="ready",
                         nuclio_name=f"nuclio-{func.metadata.name}",
-                        internal_invocation_urls=["http://127.0.0.1:1234"],
-                        external_invocation_urls=["http://somewhere-far-away.com"],
-
-                        # deprecated
                         address="http://127.0.0.1:1234",
+                        external_invocation_urls=["http://somewhere-far-away.com"],
+                        internal_invocation_urls=["http://127.0.0.1:1234"],
                     )
                 }
             }

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -53,6 +53,10 @@ class TestServingRuntime(TestNuclioRuntime):
                     "status": NuclioStatus(
                         state="ready",
                         nuclio_name=f"nuclio-{func.metadata.name}",
+                        internal_invocation_urls=["http://127.0.0.1:1234"],
+                        external_invocation_urls=["http://somewhere-far-away.com"],
+
+                        # deprecated
                         address="http://127.0.0.1:1234",
                     )
                 }

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -113,10 +113,7 @@ def _generate_requirement_specifiers_map(requirement_specifiers):
         r"(?P<requirementSpecifier>.*)"
     )
     remote_location_regex = (
-        r"^"
-        r"(?P<requirementSpecifier>.*)"
-        r"#egg="
-        r"(?P<requirementName>[^#]+)"
+        r"^(?P<requirementSpecifier>.*)#egg=(?P<requirementName>[^#]+)"
     )
     requirement_specifiers_map = collections.defaultdict(list)
     for requirement_specifier in requirement_specifiers:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -116,7 +116,7 @@ def _generate_requirement_specifiers_map(requirement_specifiers):
         r"^"
         r"(?P<requirementSpecifier>.*)"
         r"#egg="
-        r"(?P<requirementName>[a-zA-Z\-0-9_]+)"
+        r"(?P<requirementName>[^#]+)"
     )
     requirement_specifiers_map = collections.defaultdict(list)
     for requirement_specifier in requirement_specifiers:


### PR DESCRIPTION
This is a work in progress 🚬 

- added "unhealthy" to the function states when deployment needs to raise an error
- support internal / external invocation urls, this is a Nuclio >= 1.6.x feature. I left the `address` field for backwards compatibility for those working against nuclio 1.5.x


Invoking a function would use the `internal` invocation url if applicable and running within Kubernetes cluster. else will fallback to external url or the good-old address.

deploy function will return the external address, for backwards compatibility. the return address can be used on your jupyter notebook.