### PR TITLE
[Scheduler] Configure `misfire_grace_time` to None by default

### DIFF
--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import copy
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -21,7 +22,8 @@ from mlrun.utils import logger
 
 class Scheduler:
     def __init__(self):
-        self._scheduler = AsyncIOScheduler()
+        scheduler_config = json.loads(config.httpdb.scheduling.scheduler_config)
+        self._scheduler = AsyncIOScheduler(gconfig=scheduler_config)
         # this should be something that does not make any sense to be inside project name or job name
         self._job_id_separator = "-_-"
         # we don't allow to schedule a job to run more then one time per X

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -1,6 +1,6 @@
 import asyncio
-import json
 import copy
+import json
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -23,7 +23,7 @@ from mlrun.utils import logger
 class Scheduler:
     def __init__(self):
         scheduler_config = json.loads(config.httpdb.scheduling.scheduler_config)
-        self._scheduler = AsyncIOScheduler(gconfig=scheduler_config)
+        self._scheduler = AsyncIOScheduler(gconfig=scheduler_config, prefix=None)
         # this should be something that does not make any sense to be inside project name or job name
         self._job_id_separator = "-_-"
         # we don't allow to schedule a job to run more then one time per X

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -119,6 +119,7 @@ default_config = {
             # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute, "0" to disable
             "min_allowed_interval": "10 minutes",
             "default_concurrency_limit": 1,
+            "scheduler_config": '{"misfire_grace_time": null, "coalesce": true}',
         },
         "projects": {
             "leader": "mlrun",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -119,7 +119,7 @@ default_config = {
             # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute, "0" to disable
             "min_allowed_interval": "10 minutes",
             "default_concurrency_limit": 1,
-            "scheduler_config": '{"misfire_grace_time": null, "coalesce": true}',
+            "scheduler_config": '{"job_defaults": {"misfire_grace_time": null, "coalesce": true}}',
         },
         "projects": {
             "leader": "mlrun",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -119,6 +119,10 @@ default_config = {
             # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute, "0" to disable
             "min_allowed_interval": "10 minutes",
             "default_concurrency_limit": 1,
+            # Firing our jobs include things like creating pods which might not be instant, therefore in the case of
+            # multiple schedules scheduled to the same time, there might be delays, the default of the scheduler for
+            # misfire_grace_time is 1 second, we do not want jobs not being scheduled because of the delays so setting
+            # it to None. the default for coalesce it True just adding it here to be explicit
             "scheduler_config": '{"job_defaults": {"misfire_grace_time": null, "coalesce": true}}',
         },
         "projects": {


### PR DESCRIPTION
Firing our jobs include things like creating pods which might not be instant, therefore in the case of multiple schedules scheduled to the same time, there might be delays, the default of the scheduler for misfire_grace_time is 1 second, we do not want jobs not being scheduled because of the delays so setting it to None.
Fixes https://jira.iguazeng.com/browse/ML-524