### PR TITLE
[Requirements] Bound ipykernel to 5.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ kfp~=1.0.1
 nest-asyncio~=1.0
 # >=5.5 from nuclio-jupyter, <7.17 cause from 7.17 python 3.6 is not supported (and models-gpu-legacy image build fail)
 ipython>=5.5, <7.17
+# nuclio-jupyter has notebook>=5.2.0 which resolves to 6.4.0 which has ipykernel without specifier, which from 0.6.0
+# has ipython>=7.23.1 which is incompatible with our ipython specifiers, therefore instsalling ipykernel 5.x before
+# nuclio-jupyter
+ipykernel~=5.0
 nuclio-jupyter~=0.8.15
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314


### PR DESCRIPTION
nuclio-jupyter has notebook>=5.2.0 which resolves to 6.4.0 which has ipykernel without specifier, which from 0.6.0 (released several hours ago) has ipython>=7.23.1 which is incompatible with our ipython specifiers, therefore instsalling ipykernel 5.x before nuclio-jupyter