### PR TITLE
[API] Fix bugs when using feature vectors and in real time ingestion

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -277,7 +277,7 @@ class MLClientCtx(object):
         self._init_dbs(rundb)
 
         if spec and not is_api:
-            # init data related objects (require DB & Secrets to be set first)
+            # init data related objects (require DB & Secrets to be set first), skip when running in the api service
             self._data_stores.from_dict(spec)
             if inputs and isinstance(inputs, dict):
                 for k, v in inputs.items():

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -233,7 +233,14 @@ class MLClientCtx(object):
 
     @classmethod
     def from_dict(
-        cls, attrs: dict, rundb="", autocommit=False, tmp="", host=None, log_stream=None
+        cls,
+        attrs: dict,
+        rundb="",
+        autocommit=False,
+        tmp="",
+        host=None,
+        log_stream=None,
+        is_api=False,
     ):
         """create execution context from dict"""
 
@@ -269,7 +276,7 @@ class MLClientCtx(object):
 
         self._init_dbs(rundb)
 
-        if spec:
+        if spec and not is_api:
             # init data related objects (require DB & Secrets to be set first)
             self._data_stores.from_dict(spec)
             if inputs and isinstance(inputs, dict):
@@ -277,7 +284,7 @@ class MLClientCtx(object):
                     if v:
                         self._set_input(k, v)
 
-        if host:
+        if host and not is_api:
             self.set_label("host", host)
 
         start = get_in(attrs, "status.start_time")

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -413,7 +413,7 @@ def deploy_ingestion_service(
         featureset, source, targets, run_config.parameters
     )
 
-    name = name or f"{featureset.metadata.name}_ingest"
+    name = name or f"{featureset.metadata.name}-ingest"
     if not run_config.function:
         function_ref = featureset.spec.function.copy()
         if function_ref.is_empty():

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -432,7 +432,9 @@ class BaseRuntime(ModelObj):
                 "warning!, Api url not set, " "trying to exec remote runtime locally"
             )
 
-        execution = MLClientCtx.from_dict(runspec.to_dict(), db, autocommit=False)
+        execution = MLClientCtx.from_dict(
+            runspec.to_dict(), db, autocommit=False, is_api=self._is_api_server
+        )
         self._pre_run(runspec, execution)  # hook for runtime specific prep
 
         # create task generator (for child runs) from spec

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -746,10 +746,16 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
         spec.set_config("spec.maxReplicas", function.spec.max_replicas)
 
     dashboard = dashboard or mlconf.nuclio_dashboard_url
-    if function.spec.base_spec:
-        config = nuclio.config.extend_config(
-            function.spec.base_spec, spec, tag, function.spec.build.code_origin
-        )
+    if function.spec.base_spec or function.spec.build.functionSourceCode:
+        if function.spec.base_spec:
+            config = nuclio.config.extend_config(
+                function.spec.base_spec, spec, tag, function.spec.build.code_origin
+            )
+        else:
+            config = spec
+            config.set_config(
+                "spec.build.functionSourceCode", function.spec.build.functionSourceCode
+            )
         update_in(config, "metadata.name", function.metadata.name)
         update_in(config, "spec.volumes", function.spec.generate_nuclio_volumes())
         base_image = get_in(config, "spec.build.baseImage") or function.spec.image

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -371,6 +371,8 @@ class RemoteRuntime(KubeResource):
     def deploy(
         self, dashboard="", project="", tag="", verbose=False,
     ):
+        # todo: verify that the function name is normalized
+        
         verbose = verbose or self.verbose
         if verbose:
             self.set_env("MLRUN_LOG_LEVEL", "DEBUG")
@@ -754,6 +756,8 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
     if function.spec.base_spec or function.spec.build.functionSourceCode:
         config = function.spec.base_spec
         if not config:
+            # if base_spec was not set (when not using code_to_function) and we have base64 code
+            # we create the base spec with essential attributes
             config = nuclio.config.new_config()
             update_in(config, "spec.handler", handler or "main:handler")
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -738,6 +738,11 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
         spec.set_config("spec.resources", function.spec.resources)
     if function.spec.no_cache:
         spec.set_config("spec.build.noCache", True)
+    if function.spec.build.functionSourceCode:
+        spec.set_config(
+            "spec.build.functionSourceCode", function.spec.build.functionSourceCode
+        )
+
     if function.spec.replicas:
         spec.set_config("spec.minReplicas", function.spec.replicas)
         spec.set_config("spec.maxReplicas", function.spec.replicas)
@@ -747,15 +752,10 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
 
     dashboard = dashboard or mlconf.nuclio_dashboard_url
     if function.spec.base_spec or function.spec.build.functionSourceCode:
-        if function.spec.base_spec:
-            config = nuclio.config.extend_config(
-                function.spec.base_spec, spec, tag, function.spec.build.code_origin
-            )
-        else:
-            config = spec
-            config.set_config(
-                "spec.build.functionSourceCode", function.spec.build.functionSourceCode
-            )
+        config = function.spec.base_spec or nuclio.config.new_config()
+        config = nuclio.config.extend_config(
+            config, spec, tag, function.spec.build.code_origin
+        )
         update_in(config, "metadata.name", function.metadata.name)
         update_in(config, "spec.volumes", function.spec.generate_nuclio_volumes())
         base_image = get_in(config, "spec.build.baseImage") or function.spec.image

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -372,7 +372,7 @@ class RemoteRuntime(KubeResource):
         self, dashboard="", project="", tag="", verbose=False,
     ):
         # todo: verify that the function name is normalized
-        
+
         verbose = verbose or self.verbose
         if verbose:
             self.set_env("MLRUN_LOG_LEVEL", "DEBUG")

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -752,7 +752,11 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
 
     dashboard = dashboard or mlconf.nuclio_dashboard_url
     if function.spec.base_spec or function.spec.build.functionSourceCode:
-        config = function.spec.base_spec or nuclio.config.new_config()
+        config = function.spec.base_spec
+        if not config:
+            config = nuclio.config.new_config()
+            update_in(config, "spec.handler", handler or "main:handler")
+
         config = nuclio.config.extend_config(
             config, spec, tag, function.spec.build.code_origin
         )


### PR DESCRIPTION
* currently when the API service initializes the client context object (execution) it also try to initialize/fetch the input artifacts this can lead to errors with store artifacts and is not really needed
*  fix deploy of an ingestion service with empty or partial function reference (read Nuclio/serving runtime functionSourceCode from spec.build not just from spec.base_spec)