### PR TITLE
[Secrets] Add kubernetes secrets provider

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -177,7 +177,10 @@ default_config = {
             "default_secret_name": None,
             "secret_path": "~/.mlrun/azure_vault",
         },
-        "kubernetes": {"project_secret_name": "mlrun-project-secrets-{project}"},
+        "kubernetes": {
+            "project_secret_name": "mlrun-project-secrets-{project}",
+            "env_variable_prefix": "MLRUN_K8S_SECRET__",
+        },
     },
     "feature_store": {
         "data_prefixes": {

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -325,13 +325,13 @@ class K8sHelper:
 
         return service_account.secrets[0].name
 
-    def _get_project_secret_name(self, project):
+    def get_project_secret_name(self, project):
         return mlconfig.secret_stores.kubernetes.project_secret_name.format(
             project=project
         )
 
     def store_project_secrets(self, project, secrets, namespace=""):
-        secret_name = self._get_project_secret_name(project)
+        secret_name = self.get_project_secret_name(project)
         namespace = self.resolve_namespace(namespace)
         try:
             k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
@@ -356,7 +356,7 @@ class K8sHelper:
         self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
 
     def delete_project_secrets(self, project, secrets, namespace=""):
-        secret_name = self._get_project_secret_name(project)
+        secret_name = self.get_project_secret_name(project)
         namespace = self.resolve_namespace(namespace)
 
         try:
@@ -383,7 +383,7 @@ class K8sHelper:
             self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
 
     def get_project_secret_keys(self, project, namespace=""):
-        secret_name = self._get_project_secret_name(project)
+        secret_name = self.get_project_secret_name(project)
         namespace = self.resolve_namespace(namespace)
 
         try:

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -639,6 +639,10 @@ class RunTemplate(ModelObj):
 
             task.with_secrets('vault', ['secret1', 'secret2'...])
 
+            # If using with k8s secrets, the k8s secret is managed by MLRun, through the project-secrets
+            # mechanism. The secrets will be attached to the running pod as environment variables.
+            task.with_secrets('kubernetes', ['secret1', 'secret2'])
+
             # If using an empty secrets list [] then all accessible secrets will be available.
             task.with_secrets('vault', [])
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -364,7 +364,7 @@ class RemoteRuntime(KubeResource):
         self.spec.min_replicas = shards
         self.spec.max_replicas = shards
 
-    def add_vault_config_to_spec(self):
+    def add_secrets_config_to_spec(self):
         # Currently secrets are only handled in Serving runtime.
         pass
 
@@ -719,7 +719,7 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
 
     # Add vault configurations to function's pod spec, if vault secret source was added.
     # Needs to be here, since it adds env params, which are handled in the next lines.
-    function.add_vault_config_to_spec()
+    function.add_secrets_config_to_spec()
 
     env_dict = {get_item_name(v): get_item_name(v, "value") for v in function.spec.env}
     for key, value in function._get_runtime_env().items():

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -252,6 +252,9 @@ class KubejobRuntime(KubeResource):
                 self._add_azure_vault_params_to_spec(
                     self._secrets.get_azure_vault_k8s_secret()
                 )
+            k8s_secrets = self._secrets.get_k8s_secrets()
+            if k8s_secrets:
+                self._add_project_k8s_secrets_to_spec(k8s_secrets, runobj)
 
         pod_spec = func_to_pod(
             self.full_image_path(), self, extra_env, command, args, self.spec.workdir

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -366,6 +366,20 @@ class KubeResource(BaseRuntime):
         volume_mounts = [{"name": "azure-vault-secret", "mountPath": secret_path}]
         self.spec.update_vols_and_mounts(volumes, volume_mounts)
 
+    def _add_project_k8s_secrets_to_spec(self, secrets, runobj=None, project=None):
+        project_name = project or runobj.metadata.project
+        if project_name is None:
+            logger.warning("No project provided. Cannot add k8s secrets")
+            return
+
+        secret_name = self._get_k8s().get_project_secret_name(project_name)
+        existing_secret_keys = (
+            self._get_k8s().get_project_secret_keys(project_name) or {}
+        )
+        for key, env_var_name in secrets.items():
+            if key in existing_secret_keys:
+                self.set_env_from_secret(env_var_name, secret_name, key)
+
     def _add_vault_params_to_spec(self, runobj=None, project=None):
         project_name = project or runobj.metadata.project
         if project_name is None:

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -400,7 +400,7 @@ class ServingRuntime(RemoteRuntime):
         self.spec.secret_sources.append({"kind": kind, "source": source})
         return self
 
-    def add_vault_config_to_spec(self):
+    def add_secrets_config_to_spec(self):
         if self.spec.secret_sources:
             self._secrets = SecretsStore.from_list(self.spec.secret_sources)
             if self._secrets.has_vault_source():
@@ -408,6 +408,11 @@ class ServingRuntime(RemoteRuntime):
             if self._secrets.has_azure_vault_source():
                 self._add_azure_vault_params_to_spec(
                     self._secrets.get_azure_vault_k8s_secret()
+                )
+            k8s_secrets = self._secrets.get_k8s_secrets()
+            if k8s_secrets:
+                self._add_project_k8s_secrets_to_spec(
+                    k8s_secrets, project=self.metadata.project
                 )
 
     def deploy(self, dashboard="", project="", tag="", verbose=False):

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -15,6 +15,8 @@
 from ast import literal_eval
 from os import environ
 
+from mlrun.config import config
+
 from .utils import AzureVaultStore, VaultStore, list2dict
 
 
@@ -129,7 +131,7 @@ class SecretsStore:
 
     @staticmethod
     def _k8s_env_variable_name_for_secret(secret_name):
-        return "MLRUN_K8S_SECRET__" + secret_name.upper()
+        return config.secret_stores.kubernetes.env_variable_prefix + secret_name.upper()
 
     def get_k8s_secrets(self):
         for source in self._hidden_sources:

--- a/tests/system/api/assets/function.py
+++ b/tests/system/api/assets/function.py
@@ -1,0 +1,12 @@
+def secret_test_function(context, secrets: list = []):
+    """Validate that given secrets exists
+
+    :param context: the MLRun context
+    :param secrets: name of the secrets that we want to look at
+    """
+    context.logger.info("running function")
+    for sec_name in secrets:
+        sec_value = context.get_secret(sec_name)
+        context.logger.info("Secret: {} ==> {}".format(sec_name, sec_value))
+        context.log_result(sec_name, sec_value)
+    return True


### PR DESCRIPTION
Completing the MLRun k8s project-secrets functionality. This adds a `kubernetes` secret provider. Now if a function is created, its `RunConfig` can have this secret source configured. This will cause the Pod created to have environment variables attached to it that will get their value from the k8s project secret managed by MLRun. 
The user can still use `context.get_secret()` as usual to retrieve the value of these secrets. An example for an end-to-end flow can be seen in the `test_k8s_project_secrets_with_runtime` system-test added.