### PR TITLE
[Nuclio] Allow creating function with ingresses automatically

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -230,9 +230,11 @@ def build_status(
             "externalInvocationUrls", [address] if address else []
         )
 
-        # on nuclio > 1.6.x we get the external invocation url on the status block
-        if external_invocation_urls and not address:
-            address = external_invocation_urls[0]
+        # on earlier versions of mlrun, address used to represent the nodePort external invocation url
+        # now that functions can be not exposed (using service_type clusterIP) this no longer relevant
+        # and hence, for BC it would be filled with the external invocation url first item
+        # or completely empty.
+        address = external_invocation_urls[0] if external_invocation_urls else ""
 
         update_in(fn, "status.nuclio_name", nuclio_name)
         update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -113,7 +113,23 @@ default_config = {
                 "session_verification_endpoint": "data_sessions/verifications/app_service",
             },
         },
-        "nuclio": {"default_service_type": "NodePort"},  # one of ClusterIP | NodePort
+        "nuclio": {
+            # One of ClusterIP | NodePort
+            "default_service_type": "NodePort",
+            # The following modes apply when user did not configure an ingress
+            #
+            #   name        |  description
+            #  ---------------------------------------------------------------------
+            #   never       |  never enrich with an ingress
+            #   always      |  always enrich with an ingress, regardless the service type
+            #   onClusterIP |  enrich with an ingress only when `mlrun.config.httpdb.nuclio.default_service_type`
+            #                  is set to ClusterIP
+            #  ---------------------------------------------------------------------
+            # Note: adding a mode requires special handling on
+            # - mlrun.runtimes.constants.NuclioIngressAddTemplatedIngressModes
+            # - mlrun.runtimes.function.enrich_function_with_ingress
+            "add_templated_ingress_host_mode": "never",
+        },
         "authorization": {"mode": "none"},  # one of none, opa
         "scheduling": {
             # the minimum interval that will be allowed between two scheduled jobs - e.g. a job wouldn't be

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -195,3 +195,9 @@ class MPIJobV1CleanPodPolicies:
     @staticmethod
     def default():
         return MPIJobV1CleanPodPolicies.all
+
+
+class NuclioIngressAddTemplatedIngressModes:
+    always = "always"
+    never = "never"
+    on_cluster_ip = "onClusterIP"

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -626,6 +626,11 @@ class RemoteRuntime(KubeResource):
 
             path = self._resolve_invocation_url(path, force_external_address)
 
+        if headers is None:
+            headers = {}
+
+        # if function is scaled to zero, let the DLX know we want to wake it up
+        headers.setdefault("x-nuclio-target", self.metadata.name)
         kwargs = {}
         if body:
             if isinstance(body, (str, bytes)):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -826,7 +826,7 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
     )
 
     return nuclio.deploy.deploy_config(
-        config=function_config,
+        function_config,
         dashboard_url=dashboard,
         name=function_name,
         project=project_name,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -38,6 +38,7 @@ from ..model import RunObject
 from ..platforms.iguazio import mount_v3io, parse_v3io_path, split_path
 from ..utils import enrich_image_url, get_in, logger, update_in
 from .base import FunctionStatus, RunError
+from .constants import NuclioIngressAddTemplatedIngressModes
 from .pod import KubeResource, KubeResourceSpec
 from .utils import get_item_name, log_std
 
@@ -799,6 +800,50 @@ def get_fullname(name, project, tag):
 
 
 def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
+    dashboard = dashboard or mlconf.nuclio_dashboard_url
+    function_name, project_name, function_config = compile_function_config(function)
+
+    # if mode allows it, enrich function http trigger with an ingress
+    enrich_function_with_ingress(
+        function_config,
+        mlconf.httpdb.nuclio.add_templated_ingress_host_mode,
+        mlconf.httpdb.nuclio.default_service_type,
+    )
+
+    return nuclio.deploy.deploy_config(
+        config=function_config,
+        dashboard_url=dashboard,
+        name=function_name,
+        project=project_name,
+        tag=function.metadata.tag,
+        verbose=function.verbose,
+        create_new=True,
+        watch=watch,
+        return_address_mode=nuclio.deploy.ReturnAddressModes.all,
+    )
+
+
+def resolve_function_ingresses(function_spec):
+    http_trigger = resolve_function_http_trigger(function_spec)
+    if not http_trigger:
+        return []
+
+    ingresses = []
+    for _, ingress_config in (
+        http_trigger.get("attributes", {}).get("ingresses", {}).items()
+    ):
+        ingresses.append(ingress_config)
+    return ingresses
+
+
+def resolve_function_http_trigger(function_spec):
+    for trigger_name, trigger_config in function_spec.get("triggers", {}).items():
+        if trigger_config.get("kind") != "http":
+            continue
+        return trigger_config
+
+
+def compile_function_config(function: RemoteRuntime):
     function.set_config("metadata.labels.mlrun/class", function.kind)
 
     # Add vault configurations to function's pod spec, if vault secret source was added.
@@ -834,7 +879,6 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
         spec.set_config("spec.minReplicas", function.spec.min_replicas)
         spec.set_config("spec.maxReplicas", function.spec.max_replicas)
 
-    dashboard = dashboard or mlconf.nuclio_dashboard_url
     if function.spec.base_spec or function.spec.build.functionSourceCode:
         config = function.spec.base_spec
         if not config:
@@ -879,17 +923,55 @@ def deploy_nuclio_function(function: RemoteRuntime, dashboard="", watch=False):
 
         update_in(config, "metadata.name", name)
 
-    return nuclio.deploy.deploy_config(
-        config,
-        dashboard_url=dashboard,
-        name=name,
-        project=project,
-        tag=tag,
-        verbose=function.verbose,
-        create_new=True,
-        watch=watch,
-        return_address_mode=nuclio.deploy.ReturnAddressModes.all,
-    )
+    return name, project, config
+
+
+def enrich_function_with_ingress(config, mode, service_type):
+
+    # do not enrich with an ingress
+    if mode == NuclioIngressAddTemplatedIngressModes.never:
+        return
+
+    ingresses = resolve_function_ingresses(config["spec"])
+
+    # function has ingresses already, nothing to add / enrich
+    if ingresses:
+        return
+
+    # if exists, get the http trigger the function has
+    # we would enrich it with an ingress
+    http_trigger = resolve_function_http_trigger(config["spec"])
+    if not http_trigger:
+
+        # function has an HTTP trigger without an ingress
+        # TODO: read from nuclio-api frontend-spec
+        http_trigger = {
+            "kind": "http",
+            "name": "http",
+            "maxWorkers": 1,
+            "workerAvailabilityTimeoutMilliseconds": 10000,  # 10 seconds
+            "attributes": {},
+        }
+
+    def enrich():
+        http_trigger.setdefault("attributes", {}).setdefault("ingresses", {})["0"] = {
+            "paths": ["/"],
+            # this would tell Nuclio to use its default ingress host template
+            # and would auto assign a host for the ingress
+            "hostTemplate": "@nuclio.fromDefault",
+        }
+        http_trigger["attributes"]["serviceType"] = service_type
+        config["spec"].setdefault("triggers", {})[http_trigger["name"]] = http_trigger
+
+    if mode == NuclioIngressAddTemplatedIngressModes.always:
+        enrich()
+    elif mode == NuclioIngressAddTemplatedIngressModes.on_cluster_ip:
+
+        # service type is not cluster ip, bail out
+        if service_type and service_type.lower() != "clusterip":
+            return
+
+        enrich()
 
 
 def resolve_function_internal_invocation_url(function_name, namespace=""):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -640,7 +640,10 @@ class RemoteRuntime(KubeResource):
             headers = {}
 
         # if function is scaled to zero, let the DLX know we want to wake it up
-        headers.setdefault("x-nuclio-target", self.metadata.name)
+        full_function_name = get_fullname(
+            self.metadata.name, self.metadata.project, self.metadata.tag
+        )
+        headers.setdefault("x-nuclio-target", full_function_name)
         kwargs = {}
         if body:
             if isinstance(body, (str, bytes)):

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -10,7 +10,13 @@ from sqlalchemy.orm import Session
 
 from mlrun import code_to_function
 from mlrun.platforms.iguazio import split_path
-from mlrun.runtimes.function import deploy_nuclio_function
+from mlrun.runtimes.constants import NuclioIngressAddTemplatedIngressModes
+from mlrun.runtimes.function import (
+    compile_function_config,
+    deploy_nuclio_function,
+    enrich_function_with_ingress,
+    resolve_function_ingresses,
+)
 from tests.api.runtimes.base import TestRuntimeBase
 
 
@@ -192,6 +198,67 @@ class TestNuclioRuntime(TestRuntimeBase):
             "MLRUN_NAMESPACE": self.namespace,
         }
         self._assert_pod_env(env_config, expected_env)
+
+    def test_enrich_with_ingress_no_overriding(self, db: Session, client: TestClient):
+        """
+        Expect no ingress template to be created, thought its mode is "always",
+        since the function already have a pre-configured ingress
+        """
+        function = self._generate_runtime("nuclio")
+
+        # both ingress and node port
+        ingress_host = "something.com"
+        function.with_http(host=ingress_host, paths=["/"], port=30030)
+        function_name, project_name, config = compile_function_config(function)
+        service_type = "NodePort"
+        enrich_function_with_ingress(
+            config, NuclioIngressAddTemplatedIngressModes.always, service_type
+        )
+        ingresses = resolve_function_ingresses(config["spec"])
+        assert len(ingresses) > 0, "Expected one ingress to be created"
+        for ingress in ingresses:
+            assert "hostTemplate" not in ingress, "No host template should be added"
+            assert ingress["host"] == ingress_host
+
+    def test_enrich_with_ingress_always(self, db: Session, client: TestClient):
+        """
+        Expect ingress template to be created as the configuration templated ingress mode is "always"
+        """
+        function = self._generate_runtime("nuclio")
+        function_name, project_name, config = compile_function_config(function)
+        service_type = "NodePort"
+        enrich_function_with_ingress(
+            config, NuclioIngressAddTemplatedIngressModes.always, service_type
+        )
+        ingresses = resolve_function_ingresses(config["spec"])
+        assert ingresses[0]["hostTemplate"] != ""
+
+    def test_enrich_with_ingress_on_cluster_ip(self, db: Session, client: TestClient):
+        """
+        Expect ingress template to be created as the configuration templated ingress mode is "onClusterIP" while the
+        function service type is ClusterIP
+        """
+        function = self._generate_runtime("nuclio")
+        function_name, project_name, config = compile_function_config(function)
+        service_type = "ClusterIP"
+        enrich_function_with_ingress(
+            config, NuclioIngressAddTemplatedIngressModes.on_cluster_ip, service_type,
+        )
+        ingresses = resolve_function_ingresses(config["spec"])
+        assert ingresses[0]["hostTemplate"] != ""
+
+    def test_enrich_with_ingress_never(self, db: Session, client: TestClient):
+        """
+        Expect no ingress to be created automatically as the configuration templated ingress mode is "never"
+        """
+        function = self._generate_runtime("nuclio")
+        function_name, project_name, config = compile_function_config(function)
+        service_type = "DoesNotMatter"
+        enrich_function_with_ingress(
+            config, NuclioIngressAddTemplatedIngressModes.never, service_type
+        )
+        ingresses = resolve_function_ingresses(config["spec"])
+        assert ingresses == []
 
     def test_deploy_basic_function(self, db: Session, client: TestClient):
         function = self._generate_runtime("nuclio")


### PR DESCRIPTION
To allow MLRun working with functions having service type `ClusterIP` and being remotely available, this PR introducing a new working mode where as functions can be assigned with ingresses created by Nuclio ingress host template.

| mode name        |  description
| :--- | :--- |
|never       |  never enrich with an ingress
|always      |  always enrich with an ingress, regardless the service type
|onClusterIP |  enrich with an ingress only when `mlrun.config.httpdb.nuclio.default_service_type` is set to ClusterIP
