### PR TITLE
[Schemas] Change `FunctionState` to regular string constants class to enable downgrading to 0.6.4

### DIFF
--- a/mlrun/api/db/sqldb/models.py
+++ b/mlrun/api/db/sqldb/models.py
@@ -139,6 +139,7 @@ with warnings.catch_warnings():
         project = Column(String)
         uid = Column(String)
         updated = Column(TIMESTAMP)
+        # TODO: change to JSON, see mlrun/api/schemas/function.py::FunctionState for reasoning
         body = Column(BLOB)
         labels = relationship(Label)
 
@@ -155,6 +156,7 @@ with warnings.catch_warnings():
         name = Column(String)
         project = Column(String)
         uid = Column(String)
+        # TODO: change to JSON, see mlrun/api/schemas/function.py::FunctionState for reasoning
         body = Column(BLOB)
         updated = Column(TIMESTAMP)
         labels = relationship(Label)
@@ -165,6 +167,7 @@ with warnings.catch_warnings():
         id = Column(Integer, primary_key=True)
         uid = Column(String)
         project = Column(String)
+        # TODO: change to JSON, see mlrun/api/schemas/function.py::FunctionState for reasoning
         body = Column(BLOB)
 
     class Run(Base, HasStruct):
@@ -181,6 +184,7 @@ with warnings.catch_warnings():
         project = Column(String)
         iteration = Column(Integer)
         state = Column(String)
+        # TODO: change to JSON, see mlrun/api/schemas/function.py::FunctionState for reasoning
         body = Column(BLOB)
         start_time = Column(TIMESTAMP)
         labels = relationship(Label)
@@ -200,6 +204,7 @@ with warnings.catch_warnings():
         creation_time = Column(TIMESTAMP)
         cron_trigger_str = Column(String)
         last_run_uri = Column(String)
+        # TODO: change to JSON, see mlrun/api/schemas/function.py::FunctionState for reasoning
         struct = Column(BLOB)
         labels = relationship(Label, cascade="all, delete-orphan")
         concurrency_limit = Column(Integer, nullable=False)
@@ -247,6 +252,7 @@ with warnings.catch_warnings():
         source = Column(String)
         # the attribute name used to be _spec which is just a wrong naming, the attribute was renamed to _full_object
         # leaving the column as is to prevent redundant migration
+        # TODO: change to JSON, see mlrun/api/schemas/function.py::FunctionState for reasoning
         _full_object = Column("spec", BLOB)
         created = Column(TIMESTAMP, default=datetime.utcnow)
         state = Column(String)

--- a/mlrun/api/schemas/function.py
+++ b/mlrun/api/schemas/function.py
@@ -1,7 +1,17 @@
-import enum
-
-
-class FunctionState(str, enum.Enum):
+# Ideally we would want this to be class FunctionState(str, enum.Enum) which is the "FastAPI-compatible" way of creating
+# schemas
+# But, when we save a function to the DB, we pickle the body, which saves the state as an instance of this class (and
+# not just a string), then if for some reason we downgrade to 0.6.4, before we had this class, we fail reading (pickle
+# load) the function from the DB.
+# Note that the problems are happening only if the state is assigned in the API side. When it's in the client side it
+# anyways passes through JSON in the HTTP request body and come up as a string in the API side.
+# For now I'm simply making the class a simple string consts class
+# 2 other solutions I thought of:
+# 1. Changing the places where we set the state in the UI to use set the actual enum value (FunctionState.x.value) - too
+# fragile, tomorrow someone will set the state using the enum
+# 2. Changing the function to be saved into a JSON field instead of pickled inside BLOB field - looks like the ideal we
+# should go to, but too complicated and needed something fast and simple.
+class FunctionState:
     unknown = "unknown"
     ready = "ready"
     error = "error"  # represents deployment error


### PR DESCRIPTION
Saw this error when trying to downgrade from 0.6.5 to 0.6.4:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 394, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.7/site-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/fastapi/applications.py", line 190, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/applications.py", line 111, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 25, in __call__
    response = await self.dispatch_func(request, self.call_next)
  File "/mlrun/mlrun/api/main.py", line 92, in log_request_response
    response = await call_next(request)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 45, in call_next
    task.result()
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 566, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 227, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 41, in app
    response = await func(request)
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 189, in app
    dependant=dependant, values=values, is_coroutine=is_coroutine
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 137, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/usr/local/lib/python3.7/site-packages/starlette/concurrency.py", line 34, in run_in_threadpool
    return await loop.run_in_executor(None, func, *args)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/mlrun/mlrun/api/api/endpoints/functions.py", line 93, in list_functions
    funcs = get_db().list_functions(db_session, name, project, tag, labels)
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 535, in list_functions
    function_dict = function.struct
  File "/mlrun/mlrun/api/db/sqldb/models.py", line 61, in struct
    return pickle.loads(self.body)
ModuleNotFoundError: No module named 'mlrun.api.schemas.function'
```
See comment in code for explanation on what happened and the solution
Note that after merging this PR an existing DB created after 0.6.5-rc6 with functions inside it won't be usable 
but obviously the upgrade compatibility between same version RCs is much less important than the downgrade compatibility between two GA versions (0.6.5->0.6.4)

Fixes https://jira.iguazeng.com/browse/ML-798