### PR TITLE
[Runtimes] Skip list/delete runtime resources in non k8s env

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -944,6 +944,9 @@ class BaseRuntimeHandler(ABC):
         label_selector: str = None,
         group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
+        # We currently don't support removing runtime resources in non k8s env
+        if not mlrun.k8s_utils.get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+            return {}
         k8s_helper = get_k8s_helper()
         namespace = k8s_helper.resolve_namespace()
         label_selector = self._resolve_label_selector(project, label_selector)
@@ -968,6 +971,9 @@ class BaseRuntimeHandler(ABC):
         grace_period: int = config.runtime_resources_deletion_grace_period,
         leader_session: Optional[str] = None,
     ):
+        # We currently don't support removing runtime resources in non k8s env
+        if not mlrun.k8s_utils.get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+            return
         k8s_helper = get_k8s_helper()
         namespace = k8s_helper.resolve_namespace()
         label_selector = self._resolve_label_selector("*", label_selector)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -945,7 +945,9 @@ class BaseRuntimeHandler(ABC):
         group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ) -> Union[Dict, mlrun.api.schemas.GroupedRuntimeResourcesOutput]:
         # We currently don't support removing runtime resources in non k8s env
-        if not mlrun.k8s_utils.get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+        if not mlrun.k8s_utils.get_k8s_helper(
+            silent=True
+        ).is_running_inside_kubernetes_cluster():
             return {}
         k8s_helper = get_k8s_helper()
         namespace = k8s_helper.resolve_namespace()
@@ -972,7 +974,9 @@ class BaseRuntimeHandler(ABC):
         leader_session: Optional[str] = None,
     ):
         # We currently don't support removing runtime resources in non k8s env
-        if not mlrun.k8s_utils.get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+        if not mlrun.k8s_utils.get_k8s_helper(
+            silent=True
+        ).is_running_inside_kubernetes_cluster():
             return
         k8s_helper = get_k8s_helper()
         namespace = k8s_helper.resolve_namespace()

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -30,6 +30,7 @@ def test_build_status_pod_not_found(db: Session, client: TestClient):
     )
     assert response.status_code == HTTPStatus.OK.value
 
+    mlrun.api.utils.singletons.k8s.get_k8s().v1api = unittest.mock.Mock()
     mlrun.api.utils.singletons.k8s.get_k8s().v1api.read_namespaced_pod = unittest.mock.Mock(
         side_effect=kubernetes.client.rest.ApiException(
             status=HTTPStatus.NOT_FOUND.value

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -48,30 +48,6 @@ def test_create_project_failure_already_exists(db: Session, client: TestClient) 
     assert response.status_code == HTTPStatus.CONFLICT.value
 
 
-def test_delete_project_in_non_k8s_env(db: Session, client: TestClient) -> None:
-    name1 = f"prj-{uuid4().hex}"
-    project_1 = mlrun.api.schemas.Project(
-        metadata=mlrun.api.schemas.ProjectMetadata(name=name1),
-    )
-
-    # create
-    response = client.post("/api/projects", json=project_1.dict())
-    assert response.status_code == HTTPStatus.CREATED.value
-
-    mlrun.api.utils.singletons.k8s.get_k8s().is_running_inside_kubernetes_cluster = unittest.mock.Mock(
-        return_value=False
-    )
-
-    # delete
-    response = client.delete(
-        f"/api/projects/{name1}",
-        headers={
-            mlrun.api.schemas.HeaderNames.deletion_strategy: mlrun.api.schemas.DeletionStrategy.cascading
-        },
-    )
-    assert response.status_code == HTTPStatus.NO_CONTENT.value
-
-
 def test_delete_project_with_resources(db: Session, client: TestClient):
     project_to_keep = "project-to-keep"
     project_to_remove = "project-to-remove"
@@ -91,9 +67,6 @@ def test_delete_project_with_resources(db: Session, client: TestClient):
     )
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
 
-    # mock runtime resources deletion
-    mlrun.api.crud.Runtimes().delete_runtimes = unittest.mock.Mock()
-
     # deletion strategy - cascading - should succeed and remove all related resources
     response = client.delete(
         f"/api/projects/{project_to_remove}",
@@ -102,7 +75,6 @@ def test_delete_project_with_resources(db: Session, client: TestClient):
         },
     )
     assert response.status_code == HTTPStatus.NO_CONTENT.value
-    assert mlrun.api.crud.Runtimes().delete_runtimes.call_count == 1
 
     project_to_keep_table_name_records_count_map_after_project_removal = _assert_resources_in_project(
         db, project_to_keep
@@ -354,9 +326,6 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
     )
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
 
-    # mock runtime resources deletion
-    mlrun.api.crud.Runtimes().delete_runtimes = unittest.mock.Mock()
-
     # delete - cascading strategy, will succeed and delete function
     response = client.delete(
         f"/api/projects/{name1}",
@@ -365,7 +334,6 @@ def test_projects_crud(db: Session, client: TestClient) -> None:
         },
     )
     assert response.status_code == HTTPStatus.NO_CONTENT.value
-    assert mlrun.api.crud.Runtimes().delete_runtimes.call_count == 1
 
     # ensure function is gone
     response = client.get(f"/api/func/{name1}/{function_name}")

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -1,7 +1,6 @@
 import copy
 import datetime
 import typing
-import unittest.mock
 from http import HTTPStatus
 from uuid import uuid4
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,4 +1,3 @@
-import unittest.mock
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Generator
 
@@ -10,7 +9,6 @@ from mlrun.api.db.sqldb.session import _init_engine, create_session
 from mlrun.api.initial_data import init_data
 from mlrun.api.main import app
 from mlrun.api.utils.singletons.db import initialize_db
-from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.api.utils.singletons.project_member import initialize_project_member
 from mlrun.config import config
 from mlrun.utils import logger

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -53,13 +53,5 @@ def client() -> Generator:
         mlconf.runtimes_cleanup_interval = 0
         mlconf.httpdb.projects.periodic_sync_interval = "0 seconds"
 
-        # in case some test setup already mocked them, don't override it
-        if not hasattr(get_k8s(), "v1api"):
-            get_k8s().v1api = unittest.mock.Mock()
-        if not hasattr(get_k8s(), "crdapi"):
-            get_k8s().crdapi = unittest.mock.Mock()
-        get_k8s().is_running_inside_kubernetes_cluster = unittest.mock.Mock(
-            return_value=True
-        )
         with TestClient(app) as c:
             yield c

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -58,5 +58,8 @@ def client() -> Generator:
             get_k8s().v1api = unittest.mock.Mock()
         if not hasattr(get_k8s(), "crdapi"):
             get_k8s().crdapi = unittest.mock.Mock()
+        get_k8s().is_running_inside_kubernetes_cluster = unittest.mock.Mock(
+            return_value=True
+        )
         with TestClient(app) as c:
             yield c

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -1,9 +1,9 @@
 import unittest.mock
-import fastapi.testclient
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import deepdiff
+import fastapi.testclient
 import pytest
 from kubernetes import client
 from sqlalchemy.orm import Session

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -7,6 +7,9 @@ from copy import deepcopy
 from datetime import datetime, timezone
 
 import deepdiff
+import fastapi.testclient
+import pytest
+import sqlalchemy.orm
 from kubernetes import client
 from kubernetes import client as k8s_client
 from kubernetes.client import V1EnvVar
@@ -18,9 +21,6 @@ from mlrun.runtimes.constants import PodPhases
 from mlrun.utils import create_logger
 from mlrun.utils.azure_vault import AzureVaultStore
 from mlrun.utils.vault import VaultStore
-import pytest
-import fastapi.testclient
-import sqlalchemy.orm
 
 logger = create_logger(level="debug", name="test-runtime")
 
@@ -58,7 +58,9 @@ class TestRuntimeBase:
         )
 
     @pytest.fixture(autouse=True)
-    def setup_method_fixture(self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient):
+    def setup_method_fixture(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
         # We want this mock for every test, ideally we would have simply put it in the setup_method
         # but it is happening before the fixtures initialization. We need the client fixture (which needs the db one)
         # in order to be able to mock k8s stuff

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -17,11 +17,7 @@ from tests.api.runtimes.base import TestRuntimeBase
 
 
 class TestKubejobRuntime(TestRuntimeBase):
-    @pytest.fixture(autouse=True)
-    def setup_method_fixture(self, db: Session, client: TestClient):
-        # We want this mock for every test, ideally we would have simply put it in the custom_setup
-        # but this function is called by the base class's setup_method which is happening before the fixtures
-        # initialization. We need the client fixture (which needs the db one) in order to be able to mock k8s stuff
+    def custom_setup_after_fixtures(self):
         self._mock_create_namespaced_pod()
 
     def custom_setup(self):

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -4,7 +4,6 @@ import unittest.mock
 
 import deepdiff
 import nuclio
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -21,11 +21,7 @@ from tests.api.runtimes.base import TestRuntimeBase
 
 
 class TestNuclioRuntime(TestRuntimeBase):
-    @pytest.fixture(autouse=True)
-    def setup_method_fixture(self, db: Session, client: TestClient):
-        # We want this mock for every test, ideally we would have simply put it in the custom_setup
-        # but this function is called by the base class's setup_method which is happening before the fixtures
-        # initialization. We need the client fixture (which needs the db one) in order to be able to mock k8s stuff
+    def custom_setup_after_fixtures(self):
         self._mock_nuclio_deploy_config()
 
     def custom_setup(self):

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -5,7 +5,6 @@ from http import HTTPStatus
 
 import deepdiff
 import nuclio
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -21,11 +21,7 @@ from .test_nuclio import TestNuclioRuntime
 
 
 class TestServingRuntime(TestNuclioRuntime):
-    @pytest.fixture(autouse=True)
-    def setup_method_fixture(self, db: Session, client: TestClient):
-        # We want this mock for every test, ideally we would have simply put it in the custom_setup
-        # but this function is called by the base class's setup_method which is happening before the fixtures
-        # initialization. We need the client fixture (which needs the db one) in order to be able to mock k8s stuff
+    def custom_setup_after_fixtures(self):
         self._mock_nuclio_deploy_config()
         self._mock_vault_functionality()
         # Since most of the Serving runtime handling is done client-side, we'll mock the calls to remote-build


### PR DESCRIPTION
Project deletion was failing in non k8s env on trying to remove runtime resources (trying to list pods and failing):
```
> 2021-07-09 13:52:09,780 [warning] Request handling failed. Sending response: {'status_code': 500, 'request_id': '6bb08a60-20b5-4c3a-be08-d7159a1aa56d', 'uri': '/api/projects/default', 'method': 'DELETE', 'exc': AttributeError("'K8sHelper' object has no attribute 'v1api'")}
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/uvicorn/protocols/http/h11_impl.py", line 394, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/opt/conda/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
    return await self.app(scope, receive, send)
  File "/opt/conda/lib/python3.8/site-packages/fastapi/applications.py", line 190, in __call__
    await super().__call__(scope, receive, send)
  File "/opt/conda/lib/python3.8/site-packages/starlette/applications.py", line 111, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/conda/lib/python3.8/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/opt/conda/lib/python3.8/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/opt/conda/lib/python3.8/site-packages/starlette/middleware/base.py", line 25, in __call__
    response = await self.dispatch_func(request, self.call_next)
  File "/opt/conda/lib/python3.8/site-packages/mlrun/api/main.py", line 92, in log_request_response
    response = await call_next(request)
  File "/opt/conda/lib/python3.8/site-packages/starlette/middleware/base.py", line 45, in call_next
    task.result()
  File "/opt/conda/lib/python3.8/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/opt/conda/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/opt/conda/lib/python3.8/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/opt/conda/lib/python3.8/site-packages/starlette/routing.py", line 566, in __call__
    await route.handle(scope, receive, send)
  File "/opt/conda/lib/python3.8/site-packages/starlette/routing.py", line 227, in handle
    await self.app(scope, receive, send)
  File "/opt/conda/lib/python3.8/site-packages/starlette/routing.py", line 41, in app
    response = await func(request)
  File "/opt/conda/lib/python3.8/site-packages/fastapi/routing.py", line 188, in app
    raw_response = await run_endpoint_function(
  File "/opt/conda/lib/python3.8/site-packages/fastapi/routing.py", line 137, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/opt/conda/lib/python3.8/site-packages/starlette/concurrency.py", line 34, in run_in_threadpool
    return await loop.run_in_executor(None, func, *args)
  File "/opt/conda/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/conda/lib/python3.8/site-packages/mlrun/api/api/endpoints/projects.py", line 109, in delete_project
    is_running_in_background = get_project_member().delete_project(
  File "/opt/conda/lib/python3.8/site-packages/mlrun/api/utils/projects/leader.py", line 93, in delete_project
    self._run_on_all_followers(
  File "/opt/conda/lib/python3.8/site-packages/mlrun/api/utils/projects/leader.py", line 276, in _run_on_all_followers
    leader_response = getattr(self._leader_follower, method)(*args, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/mlrun/api/crud/projects.py", line 56, in delete_project
    mlrun.api.crud.Runtimes().delete_runtimes(
  File "/opt/conda/lib/python3.8/site-packages/mlrun/api/crud/runtimes.py", line 59, in delete_runtimes
    runtime_handler.delete_resources(
  File "/opt/conda/lib/python3.8/site-packages/mlrun/runtimes/base.py", line 959, in delete_resources
    deleted_resources = self._delete_pod_resources(
  File "/opt/conda/lib/python3.8/site-packages/mlrun/runtimes/base.py", line 1278, in _delete_pod_resources
    pods = k8s_helper.v1api.list_namespaced_pod(
AttributeError: 'K8sHelper' object has no attribute 'v1api'
```