### PR TITLE
[Feature Store] Fixing dataframe messy column names

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -213,6 +213,19 @@ def ingest(
     :param overwrite:     delete the targets' data prior to ingestion
                           (default: True. deletes the targets that are about to be ingested)
     """
+    # pandas dataframes rename columns with space with _<attribute #>.
+    # we fix columns prior to manipulations
+    if (
+        source is not None
+        and isinstance(source, pd.DataFrame)
+        and hasattr(source.columns, "str")
+    ):
+        source.columns = (
+            source.columns.str.strip()
+            .str.replace(" ", "_")
+            .str.replace("(", "")
+            .str.replace(")", "")
+        )
     if featureset:
         if isinstance(featureset, str):
             # need to strip store prefix from the uri


### PR DESCRIPTION
Pandas does not have clear DataFrame column naming conventions. Thus there is  internal  forced renaming  of the column names to `_column #` for the "unconventional" names. for example column name  with space  on column 7  is renamed to `_7`.  
snake_case (lower case with underscores) is most common practice  but Pascal (camel) case can also be used.  
Instead of returning an error, `ingest` will strip the enclosing white spaces, replace spaces with underscores and omit parentheses. 
it's recommended to use snake_case convention in order to avoid changes in column names under the hood.  

Fixes https://jira.iguazeng.com/browse/ML-803

Signed-off-by: Eyal Salomon <eyals@iguazio.com>