### PR TITLE
[System Tests] Use semver-latest Provazio releases

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,2 +1,3 @@
 click~=7.0
 paramiko~=2.7
+semver~=2.13

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -1,5 +1,4 @@
 import json
-import semver
 import pathlib
 import subprocess
 import sys
@@ -8,6 +7,7 @@ import time
 import click
 import paramiko
 import requests
+import semver
 import yaml
 
 import mlrun.utils
@@ -248,11 +248,12 @@ class SystemTestPreparer:
 
     def _get_provctl_version_and_url(self):
         def extract_version_from_release(release):
-            tag = release['tag_name']
+            tag = release["tag_name"]
             version = tag
             # remove prefix v if exists
             version = version.replace("v", "")
             return semver.VersionInfo.parse(version)
+
         response = requests.get(
             self.Constants.provctl_releases,
             headers={"Authorization": f"token {self._github_access_token}"},

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -1,4 +1,5 @@
 import json
+import semver
 import pathlib
 import subprocess
 import sys
@@ -246,6 +247,12 @@ class SystemTestPreparer:
         return stdout, stderr, exit_status
 
     def _get_provctl_version_and_url(self):
+        def extract_version_from_release(release):
+            tag = release['tag_name']
+            version = tag
+            # remove prefix v if exists
+            version = version.replace("v", "")
+            return semver.VersionInfo.parse(version)
         response = requests.get(
             self.Constants.provctl_releases,
             headers={"Authorization": f"token {self._github_access_token}"},
@@ -258,6 +265,9 @@ class SystemTestPreparer:
         latest_provazio_releases = stable_provazio_releases[
             : self.Constants.provctl_release_search_amount
         ]
+        # This should protect us from taking a backport release (assuming there are never
+        # {provctl_release_search_amount} backport releases in a row)
+        latest_provazio_releases.sort(key=extract_version_from_release, reverse=True)
         for provazio_release in latest_provazio_releases:
             for asset in provazio_release["assets"]:
                 if asset["name"] == self.Constants.provctl_binary_format.format(

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -27,7 +27,7 @@ class SystemTestPreparer:
 
         git_url = "https://github.com/mlrun/mlrun.git"
         provctl_releases = "https://api.github.com/repos/iguazio/provazio/releases"
-        provctl_release_search_amount = 3
+        provctl_release_search_amount = 10
         provctl_binary_format = "provctl-{release_name}-linux-amd64"
 
     def __init__(


### PR DESCRIPTION
Before this we were simply picking by the order of the response from github which is done by creation time which caused us to take "backport releases" which caused system tests to fail