### PR TITLE
[Nuclio] Fix external / internal invocation urls resolution

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,4 +6,4 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.16.0
 python-dotenv~=0.17.0
-nuclio-jupyter[jupyter-server]~=0.8.17
+nuclio-jupyter[jupyter-server]~=0.8.18

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -18,11 +18,7 @@ from mlrun.builder import build_runtime
 from mlrun.config import config
 from mlrun.run import new_function
 from mlrun.runtimes import RuntimeKinds, runtime_resources_map
-from mlrun.runtimes.function import (
-    deploy_nuclio_function,
-    get_nuclio_deploy_status,
-    resolve_function_internal_invocation_url,
-)
+from mlrun.runtimes.function import deploy_nuclio_function, get_nuclio_deploy_status
 from mlrun.utils import get_in, logger, parse_versioned_object_uri, update_in
 
 router = APIRouter()
@@ -225,15 +221,8 @@ def build_status(
         if state in ["error", "unhealthy"]:
             logger.error(f"Nuclio deploy error, {text}", name=name)
 
-        # internal / external invocation urls were added on nuclio 1.6.x
-        # and hence, it might be empty
-        # to backward compatible with older nuclio versions, we use hard-coded default values
-        internal_invocation_urls = status.get(
-            "internalInvocationUrls", [resolve_function_internal_invocation_url(name)]
-        )
-        external_invocation_urls = status.get(
-            "externalInvocationUrls", [address] if address else []
-        )
+        internal_invocation_urls = status.get("internalInvocationUrls", [])
+        external_invocation_urls = status.get("externalInvocationUrls", [])
 
         # on earlier versions of mlrun, address used to represent the nodePort external invocation url
         # now that functions can be not exposed (using service_type clusterIP) this no longer relevant

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1005,16 +1005,6 @@ def enrich_function_with_ingress(config, mode, service_type):
         enrich()
 
 
-def resolve_function_internal_invocation_url(function_name, namespace=""):
-    # hard-coding the internal invocation url
-    # template: nuclio-<function_name>.(<namespace>.)?svc.cluster.local:8080
-
-    # both might be empty
-    templated_namespace = namespace if namespace else mlconf.namespace
-    templated_namespace += "." if templated_namespace else ""
-    return f"nuclio-{function_name}.{templated_namespace}svc.cluster.local:8080"
-
-
 def get_nuclio_deploy_status(
     name,
     project,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ipython>=5.5, <7.17
 # has ipython>=7.23.1 which is incompatible with our ipython specifiers, therefore instsalling ipykernel 5.x before
 # nuclio-jupyter
 ipykernel~=5.0
-nuclio-jupyter~=0.8.17
+nuclio-jupyter~=0.8.18
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.20.0


### PR DESCRIPTION
moved internal / external hardcoding knowledge back to nuclio-jupyter, which has more awareness of compiling the correct internal address