### PR TITLE
[Projects] Support listing projects from DB in leader format for upgrade scenarios

### DIFF
--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -155,5 +155,11 @@ def list_projects(
     db_session: Session = fastapi.Depends(deps.get_db_session),
 ):
     return get_project_member().list_projects(
-        db_session, owner, format_, labels, state, auth_verifier.auth_info.projects_role, auth_verifier.auth_info.session
+        db_session,
+        owner,
+        format_,
+        labels,
+        state,
+        auth_verifier.auth_info.projects_role,
+        auth_verifier.auth_info.session,
     )

--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -155,5 +155,5 @@ def list_projects(
     db_session: Session = fastapi.Depends(deps.get_db_session),
 ):
     return get_project_member().list_projects(
-        db_session, owner, format_, labels, state, auth_verifier.auth_info.session
+        db_session, owner, format_, labels, state, auth_verifier.auth_info.projects_role, auth_verifier.auth_info.session
     )

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -927,7 +927,10 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
                 if format_ == mlrun.api.schemas.Format.name_only:
                     projects = project_names
                 # leader format is only for follower mode which will format the projects returned from here
-                elif format_ in [mlrun.api.schemas.Format.full, mlrun.api.schemas.Format.leader]:
+                elif format_ in [
+                    mlrun.api.schemas.Format.full,
+                    mlrun.api.schemas.Format.leader,
+                ]:
                     projects.append(
                         self._transform_project_record_to_schema(
                             session, project_record

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -926,7 +926,8 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
             for project_record in project_records:
                 if format_ == mlrun.api.schemas.Format.name_only:
                     projects = project_names
-                elif format_ == mlrun.api.schemas.Format.full:
+                # leader format is only for follower mode which will format the projects returned from here
+                elif format_ in [mlrun.api.schemas.Format.full, mlrun.api.schemas.Format.leader]:
                     projects.append(
                         self._transform_project_record_to_schema(
                             session, project_record

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -60,13 +60,13 @@ from .model_endpoints import (
 from .object import ObjectKind, ObjectMetadata, ObjectSpec, ObjectStatus
 from .pipeline import PipelinesOutput, PipelinesPagination
 from .project import (
+    IguazioProject,
     Project,
     ProjectDesiredState,
     ProjectMetadata,
     ProjectsOutput,
     ProjectSpec,
     ProjectState,
-IguazioProject,
     ProjectStatus,
     ProjectSummary,
 )

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -66,6 +66,7 @@ from .project import (
     ProjectsOutput,
     ProjectSpec,
     ProjectState,
+IguazioProject,
     ProjectStatus,
     ProjectSummary,
 )

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -10,6 +10,8 @@ class Format(str, Enum):
     name_only = "name_only"
     metadata_only = "metadata_only"
     summary = "summary"
+    # internal - allowed only in follower mode, only for the leader for upgrade purposes
+    leader = "leader"
 
 
 class PatchMode(str, Enum):

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -78,10 +78,18 @@ class ProjectSummary(pydantic.BaseModel):
     runs_running_count: int
 
 
+class IguazioProject(pydantic.BaseModel):
+    data: dict
+
+
 class ProjectsOutput(pydantic.BaseModel):
     # The format query param controls the project type used:
     # full - Project
     # name_only - str
     # summary - ProjectSummary
-    # leader - dict
-    projects: typing.List[typing.Union[Project, str, ProjectSummary, dict]]
+    # leader - currently only IguazioProject supported
+    # The way pydantic handles typing.Union is that it takes the object and tries to coerce it to be the types of the
+    # union by the definition order. Therefore we can't currently add generic dict for all leader formats, but we need
+    # to add a specific classes for them. it's frustrating but couldn't find other workaround, see:
+    # https://github.com/samuelcolvin/pydantic/issues/1423, https://github.com/samuelcolvin/pydantic/issues/619
+    projects: typing.List[typing.Union[Project, str, ProjectSummary, IguazioProject]]

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -79,5 +79,9 @@ class ProjectSummary(pydantic.BaseModel):
 
 
 class ProjectsOutput(pydantic.BaseModel):
-    # use the format query param to control whether the full object will be returned or only the names
-    projects: typing.List[typing.Union[Project, str, ProjectSummary]]
+    # The format query param controls the project type used:
+    # full - Project
+    # name_only - str
+    # summary - ProjectSummary
+    # leader - dict
+    projects: typing.List[typing.Union[Project, str, ProjectSummary, dict]]

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -178,8 +178,12 @@ class Client(
     def get_project(self, session: str, name: str,) -> mlrun.api.schemas.Project:
         return self._get_project_from_iguazio(session, name)
 
-    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> mlrun.api.schemas.IguazioProject:
-        return mlrun.api.schemas.IguazioProject(data=self._transform_mlrun_project_to_iguazio_project(project)["data"])
+    def format_as_leader_project(
+        self, project: mlrun.api.schemas.Project
+    ) -> mlrun.api.schemas.IguazioProject:
+        return mlrun.api.schemas.IguazioProject(
+            data=self._transform_mlrun_project_to_iguazio_project(project)["data"]
+        )
 
     def _find_latest_updated_at(
         self, response_body: dict
@@ -293,7 +297,9 @@ class Client(
         return response
 
     @staticmethod
-    def _transform_mlrun_project_to_iguazio_project(project: mlrun.api.schemas.Project) -> dict:
+    def _transform_mlrun_project_to_iguazio_project(
+        project: mlrun.api.schemas.Project,
+    ) -> dict:
         body = {
             "data": {
                 "type": "project",

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -95,7 +95,7 @@ class Client(
         wait_for_completion: bool = True,
     ) -> typing.Tuple[mlrun.api.schemas.Project, bool]:
         logger.debug("Creating project in Iguazio", project=project)
-        body = self._generate_request_body(project)
+        body = self._transform_mlrun_project_to_iguazio_project(project)
         return self._create_project_in_iguazio(session, body, wait_for_completion)
 
     def store_project(
@@ -106,7 +106,7 @@ class Client(
         wait_for_completion: bool = True,
     ) -> typing.Tuple[mlrun.api.schemas.Project, bool]:
         logger.debug("Storing project in Iguazio", name=name, project=project)
-        body = self._generate_request_body(project)
+        body = self._transform_mlrun_project_to_iguazio_project(project)
         try:
             self._get_project_from_iguazio(session, name)
         except requests.HTTPError as exc:
@@ -128,7 +128,7 @@ class Client(
             name=name,
             deletion_strategy=deletion_strategy,
         )
-        body = self._generate_request_body(
+        body = self._transform_mlrun_project_to_iguazio_project(
             mlrun.api.schemas.Project(
                 metadata=mlrun.api.schemas.ProjectMetadata(name=name)
             )
@@ -177,6 +177,9 @@ class Client(
 
     def get_project(self, session: str, name: str,) -> mlrun.api.schemas.Project:
         return self._get_project_from_iguazio(session, name)
+
+    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> dict:
+        return self._transform_mlrun_project_to_iguazio_project(project)
 
     def _find_latest_updated_at(
         self, response_body: dict
@@ -290,7 +293,7 @@ class Client(
         return response
 
     @staticmethod
-    def _generate_request_body(project: mlrun.api.schemas.Project) -> dict:
+    def _transform_mlrun_project_to_iguazio_project(project: mlrun.api.schemas.Project) -> dict:
         body = {
             "data": {
                 "type": "project",

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -178,8 +178,8 @@ class Client(
     def get_project(self, session: str, name: str,) -> mlrun.api.schemas.Project:
         return self._get_project_from_iguazio(session, name)
 
-    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> dict:
-        return self._transform_mlrun_project_to_iguazio_project(project)
+    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> mlrun.api.schemas.IguazioProject:
+        return mlrun.api.schemas.IguazioProject(data=self._transform_mlrun_project_to_iguazio_project(project)["data"])
 
     def _find_latest_updated_at(
         self, response_body: dict

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -224,7 +224,9 @@ class Member(
         projects = []
         if format_ == mlrun.api.schemas.Format.leader:
             if not self._is_request_from_leader(projects_role):
-                raise mlrun.errors.MLRunAccessDeniedError("Leader format is allowed only to the leader")
+                raise mlrun.errors.MLRunAccessDeniedError(
+                    "Leader format is allowed only to the leader"
+                )
             # importing here to avoid circular import (db using project member using mlrun follower using db)
             from mlrun.api.utils.singletons.db import get_db
 
@@ -234,7 +236,10 @@ class Member(
             # to be aware of the already existing projects so we're allowing only to the leader, to read from the DB,
             # and return it in the leader's format
             projects = get_db().list_projects(db_session, owner, format_, labels, state)
-            leader_projects = [self._leader_client.format_as_leader_project(project) for project in projects.projects]
+            leader_projects = [
+                self._leader_client.format_as_leader_project(project)
+                for project in projects.projects
+            ]
             return mlrun.api.schemas.ProjectsOutput(projects=leader_projects)
 
         if self.projects_store_mode == self.ProjectsStoreMode.cache:

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -217,9 +217,26 @@ class Member(
         format_: mlrun.api.schemas.Format = mlrun.api.schemas.Format.full,
         labels: typing.List[str] = None,
         state: mlrun.api.schemas.ProjectState = None,
+        # needed only for external usage when requesting leader format
+        projects_role: typing.Optional[mlrun.api.schemas.ProjectsRole] = None,
         leader_session: typing.Optional[str] = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
         projects = []
+        if format_ == mlrun.api.schemas.Format.leader:
+            if not self._is_request_from_leader(projects_role):
+                raise mlrun.errors.MLRunAccessDeniedError("Leader format is allowed only to the leader")
+            # importing here to avoid circular import (db using project member using mlrun follower using db)
+            from mlrun.api.utils.singletons.db import get_db
+
+            # Basically in follower mode our projects source of truth is the leader and the data in the DB is not
+            # relevant or maintained. The leader format purpose is a specific upgrade scenario where we're moving from
+            # leader mode (in which the projects are maintained in the DB) to follower mode in which the leader needs
+            # to be aware of the already existing projects so we're allowing only to the leader, to read from the DB,
+            # and return it in the leader's format
+            projects = get_db().list_projects(db_session, owner, format_, labels, state)
+            leader_projects = [self._leader_client.format_as_leader_project(project) for project in projects.projects]
+            return mlrun.api.schemas.ProjectsOutput(projects=leader_projects)
+
         if self.projects_store_mode == self.ProjectsStoreMode.cache:
             projects = list(self._projects.values())
         elif self.projects_store_mode == self.ProjectsStoreMode.none:

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -116,6 +116,7 @@ class Member(
         format_: mlrun.api.schemas.Format = mlrun.api.schemas.Format.full,
         labels: typing.List[str] = None,
         state: mlrun.api.schemas.ProjectState = None,
+        projects_role: typing.Optional[mlrun.api.schemas.ProjectsRole] = None,
         leader_session: typing.Optional[str] = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
         return self._leader_follower.list_projects(

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -110,6 +110,7 @@ class Member(abc.ABC):
         format_: mlrun.api.schemas.Format = mlrun.api.schemas.Format.full,
         labels: typing.List[str] = None,
         state: mlrun.api.schemas.ProjectState = None,
+        projects_role: typing.Optional[mlrun.api.schemas.ProjectsRole] = None,
         leader_session: typing.Optional[str] = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
         pass

--- a/mlrun/api/utils/projects/remotes/leader.py
+++ b/mlrun/api/utils/projects/remotes/leader.py
@@ -50,6 +50,10 @@ class Member(abc.ABC):
     def get_project(self, session: str, name: str,) -> mlrun.api.schemas.Project:
         pass
 
+    @abc.abstractmethod
+    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> dict:
+        pass
+
     def patch_project(
         self,
         session: str,

--- a/mlrun/api/utils/projects/remotes/leader.py
+++ b/mlrun/api/utils/projects/remotes/leader.py
@@ -51,7 +51,9 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> mlrun.api.schemas.IguazioProject:
+    def format_as_leader_project(
+        self, project: mlrun.api.schemas.Project
+    ) -> mlrun.api.schemas.IguazioProject:
         pass
 
     def patch_project(

--- a/mlrun/api/utils/projects/remotes/leader.py
+++ b/mlrun/api/utils/projects/remotes/leader.py
@@ -51,7 +51,7 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> dict:
+    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> mlrun.api.schemas.IguazioProject:
         pass
 
     def patch_project(

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -61,5 +61,7 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
             session, name
         )
 
-    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> mlrun.api.schemas.IguazioProject:
+    def format_as_leader_project(
+        self, project: mlrun.api.schemas.Project
+    ) -> mlrun.api.schemas.IguazioProject:
         return mlrun.api.schemas.IguazioProject(data=project.dict())

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -61,5 +61,5 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
             session, name
         )
 
-    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> dict:
-        return project
+    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> mlrun.api.schemas.IguazioProject:
+        return mlrun.api.schemas.IguazioProject(data=project.dict())

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -60,3 +60,6 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
         return mlrun.api.utils.singletons.project_member.get_project_member().get_project(
             session, name
         )
+
+    def format_as_leader_project(self, project: mlrun.api.schemas.Project) -> dict:
+        return project

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -513,22 +513,21 @@ def test_delete_project_without_wait(
 
 
 def test_format_as_leader_project(
-        api_url: str,
-        iguazio_client: mlrun.api.utils.clients.iguazio.Client,
+    api_url: str, iguazio_client: mlrun.api.utils.clients.iguazio.Client,
 ):
     project = _generate_project()
     iguazio_project = iguazio_client.format_as_leader_project(project)
     assert (
-            deepdiff.DeepDiff(
-                _build_project_response(
-                        iguazio_client, project
-                    )
-                ,
-                iguazio_project.data,
-                ignore_order=True,
-                exclude_paths=["root['attributes']['updated_at']", "root['attributes']['operational_status']"],
-            )
-            == {}
+        deepdiff.DeepDiff(
+            _build_project_response(iguazio_client, project),
+            iguazio_project.data,
+            ignore_order=True,
+            exclude_paths=[
+                "root['attributes']['updated_at']",
+                "root['attributes']['operational_status']",
+            ],
+        )
+        == {}
     )
 
 

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -512,6 +512,26 @@ def test_delete_project_without_wait(
     assert is_running_in_background is True
 
 
+def test_format_as_leader_project(
+        api_url: str,
+        iguazio_client: mlrun.api.utils.clients.iguazio.Client,
+):
+    project = _generate_project()
+    iguazio_project = iguazio_client.format_as_leader_project(project)
+    assert (
+            deepdiff.DeepDiff(
+                _build_project_response(
+                        iguazio_client, project
+                    )
+                ,
+                iguazio_project.data,
+                ignore_order=True,
+                exclude_paths=["root['attributes']['updated_at']", "root['attributes']['operational_status']"],
+            )
+            == {}
+    )
+
+
 def _create_project_and_assert(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -282,6 +282,26 @@ def test_list_project_format_summary(
     )
 
 
+def test_list_project_leader_format(
+        db: sqlalchemy.orm.Session,
+        projects_follower: mlrun.api.utils.projects.follower.Member,
+        nop_leader: mlrun.api.utils.projects.remotes.leader.Member,
+):
+    project = _generate_project(name="name-1")
+    mlrun.api.utils.singletons.db.get_db().list_projects = unittest.mock.Mock(
+        return_value=mlrun.api.schemas.ProjectsOutput(projects=[project])
+    )
+    projects = projects_follower.list_projects(
+        None, format_=mlrun.api.schemas.Format.leader, projects_role=mlrun.api.schemas.ProjectsRole.nop
+    )
+    assert (
+            deepdiff.DeepDiff(
+                projects.projects[0].data, project.dict(), ignore_order=True,
+            )
+            == {}
+    )
+
+
 def _assert_list_projects(
     projects_follower: mlrun.api.utils.projects.follower.Member,
     expected_projects: typing.List[mlrun.api.schemas.Project],

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -283,22 +283,22 @@ def test_list_project_format_summary(
 
 
 def test_list_project_leader_format(
-        db: sqlalchemy.orm.Session,
-        projects_follower: mlrun.api.utils.projects.follower.Member,
-        nop_leader: mlrun.api.utils.projects.remotes.leader.Member,
+    db: sqlalchemy.orm.Session,
+    projects_follower: mlrun.api.utils.projects.follower.Member,
+    nop_leader: mlrun.api.utils.projects.remotes.leader.Member,
 ):
     project = _generate_project(name="name-1")
     mlrun.api.utils.singletons.db.get_db().list_projects = unittest.mock.Mock(
         return_value=mlrun.api.schemas.ProjectsOutput(projects=[project])
     )
     projects = projects_follower.list_projects(
-        None, format_=mlrun.api.schemas.Format.leader, projects_role=mlrun.api.schemas.ProjectsRole.nop
+        None,
+        format_=mlrun.api.schemas.Format.leader,
+        projects_role=mlrun.api.schemas.ProjectsRole.nop,
     )
     assert (
-            deepdiff.DeepDiff(
-                projects.projects[0].data, project.dict(), ignore_order=True,
-            )
-            == {}
+        deepdiff.DeepDiff(projects.projects[0].data, project.dict(), ignore_order=True,)
+        == {}
     )
 
 


### PR DESCRIPTION
Basically in follower mode our projects source of truth is the leader and the data in the DB is not relevant or maintained. The leader format purpose is a specific upgrade scenario where we're moving from leader mode (in which the projects are maintained in the DB) to follower mode in which the leader needs to be aware of the already existing projects so we're allowing only to the leader, to read from the DB, and return it in the leader's format