### PR TITLE
[Datastore] Small improvements to Azure blob handling & testing

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -17,6 +17,8 @@ import time
 import fsspec
 from azure.storage.blob import BlobServiceClient
 
+import mlrun.errors
+
 from .base import DataStore, FileStats
 
 # Azure blobs will be represented with the following URL: az://<container name>. The storage account is already
@@ -86,6 +88,11 @@ class AzureBlobStore(DataStore):
             return blob
 
     def put(self, key, data, append=False):
+        if append:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Append mode not supported for Azure blob datastore"
+            )
+
         if self.bsc:
             blob_client = self.bsc.get_blob_client(
                 container=self.endpoint, blob=key[1:]

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -90,7 +90,7 @@ class AzureBlobStore(DataStore):
     def put(self, key, data, append=False):
         if append:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Append mode not supported for Azure blob datastore"
+                "Append mode not supported for Azure blob datastore"
             )
 
         if self.bsc:

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -43,6 +43,7 @@ def config_test_base():
     mlrun.db._run_db = None
     mlrun.db._last_db_url = None
     mlrun.datastore.store_manager._db = None
+    mlrun.datastore.store_manager._stores = {}
 
     # remove singletons in case they were changed (we don't want changes to pass between tests)
     mlrun.utils.singleton.Singleton._instances = {}

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -56,12 +56,6 @@ def prepare_env(auth_method):
     return True
 
 
-def azure_connection_configured():
-    return any(
-        prepare_env(auth_method) for auth_method in AUTH_METHODS_AND_REQUIRED_PARAMS
-    )
-
-
 pytestmark = pytest.mark.parametrize(
     "auth_method",
     [

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -34,7 +34,7 @@ AUTH_METHODS_AND_REQUIRED_PARAMS = {
 }
 
 
-def prepare_env(auth_method):
+def verify_auth_parameters_and_configure_env(auth_method):
     if not config["env"].get("AZURE_CONTAINER"):
         return False
 
@@ -56,22 +56,24 @@ def prepare_env(auth_method):
     return True
 
 
+# Apply parametrization to all tests in this file. Skip test if auth method is not configured.
 pytestmark = pytest.mark.parametrize(
     "auth_method",
     [
         pytest.param(
-            key,
+            auth_method,
             marks=pytest.mark.skipif(
-                not prepare_env(key), reason=f"Auth method {key} not configured."
+                not verify_auth_parameters_and_configure_env(auth_method),
+                reason=f"Auth method {auth_method} not configured.",
             ),
         )
-        for key in AUTH_METHODS_AND_REQUIRED_PARAMS
+        for auth_method in AUTH_METHODS_AND_REQUIRED_PARAMS
     ],
 )
 
 
 def test_azure_blob(auth_method):
-    prepare_env(auth_method)
+    verify_auth_parameters_and_configure_env(auth_method)
     blob_path = "az://" + config["env"].get("AZURE_CONTAINER")
     blob_url = blob_path + "/" + blob_dir + "/" + blob_file
 
@@ -95,7 +97,7 @@ def test_azure_blob(auth_method):
 
 
 def test_list_dir(auth_method):
-    prepare_env(auth_method)
+    verify_auth_parameters_and_configure_env(auth_method)
     blob_container_path = "az://" + config["env"].get("AZURE_CONTAINER")
     blob_url = blob_container_path + "/" + blob_dir + "/" + blob_file
     print(f"\nBlob URL: {blob_url}")
@@ -112,7 +114,7 @@ def test_list_dir(auth_method):
 
 
 def test_blob_upload(auth_method):
-    prepare_env(auth_method)
+    verify_auth_parameters_and_configure_env(auth_method)
     blob_path = "az://" + config["env"].get("AZURE_CONTAINER")
     blob_url = blob_path + "/" + blob_dir + "/" + blob_file
     print(f"\nBlob URL: {blob_url}")

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -56,6 +56,17 @@ def prepare_env(auth_method):
     return True
 
 
+def azure_connection_configured():
+    return any(
+        prepare_env(auth_method) for auth_method in AUTH_METHODS_AND_REQUIRED_PARAMS
+    )
+
+
+@pytest.mark.skipif(
+    not azure_connection_configured(),
+    reason="This is an integration test, add the needed environment variables in test-azure-blob.yml "
+    "to run it",
+)
 def test_azure_blob():
     for auth_method in AUTH_METHODS_AND_REQUIRED_PARAMS:
         if not prepare_env(auth_method):
@@ -83,6 +94,11 @@ def test_azure_blob():
         assert stat.size == len(test_string), "Stat size different than expected"
 
 
+@pytest.mark.skipif(
+    not azure_connection_configured(),
+    reason="This is an integration test, add the needed environment variables in test-azure-blob.yml "
+    "to run it",
+)
 def test_list_dir():
     for auth_method in AUTH_METHODS_AND_REQUIRED_PARAMS:
         if not prepare_env(auth_method):
@@ -105,6 +121,11 @@ def test_list_dir():
         assert blob_file in dir_list, "File not in folder dir-list"
 
 
+@pytest.mark.skipif(
+    not azure_connection_configured(),
+    reason="This is an integration test, add the needed environment variables in test-azure-blob.yml "
+    "to run it",
+)
 def test_blob_upload():
     # Check upload functionality
     for auth_method in AUTH_METHODS_AND_REQUIRED_PARAMS:


### PR DESCRIPTION
Fail if a `put` request was sent with `append=True`.
Modified the integration tests such that they can run on a single auth method (does not need to fill in all the parameters for all methods). Tests will execute according to the auth parameters available in the yml file.