### PR TITLE
[Tests] Fix httpdb  exception handling integration test

### DIFF
--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -63,7 +63,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         with pytest.raises(
             mlrun.errors.MLRunInternalServerError,
             match=r"500 Server Error: Internal Server Error for url: http:\/\/(.*)\/api\/projects\/some-project\/model-"
-            r"endpoints\?start=now-1h&end=now: details: {'reason': \"gaierror\(-2, 'Name or service not known'\)\"}",
+            r"endpoints\?start=now-1h&end=now: details: {'reason': \"gaierror\((.*)\)\"}",
         ):
             mlrun.get_run_db().list_endpoints(
                 "some-project", access_key="some-access-key"


### PR DESCRIPTION
On my mac `gaierror(-2, 'Name or service not known')` is raised but on my linux machine `gaierror(-3, 'Temporary failure in name resolution')`, change the error message assertion regex to include both