### PR TITLE
[Utils] Update Slack run link format used for the RunNotifications

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -847,7 +847,7 @@ class RunNotifications:
                 if config.resolve_ui_url():
                     url = (
                         f"{config.resolve_ui_url()}/{config.ui.projects_prefix}/"
-                        f"{meta.get('project')}/jobs/{meta.get('uid')}/info"
+                        f"{meta.get('project')}/jobs/monitor/{meta.get('uid')}/overview"
                     )
 
                     line = f'<{url}|*{meta.get("name")}*>'


### PR DESCRIPTION
Updated Slack run link format for RunNotifications. Uses new format of "https://dashboard.default-tenant.app.my-cluster.iguazio-cd0.com/mlprojects/PROJECT/jobs/monitor/UID/overview"