### PR TITLE
[Projects] Cache ensured project owners to allow permissions until OPA manifest published

### DIFF
--- a/mlrun/api/crud/artifacts.py
+++ b/mlrun/api/crud/artifacts.py
@@ -26,7 +26,7 @@ class Artifacts(metaclass=mlrun.utils.singleton.Singleton,):
     ):
         project = project or mlrun.mlconf.default_project
         mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session
+            db_session, project, auth_info=auth_info
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.artifact,

--- a/mlrun/api/crud/feature_store.py
+++ b/mlrun/api/crud/feature_store.py
@@ -325,7 +325,7 @@ class FeatureStore(metaclass=mlrun.utils.singleton.Singleton,):
         project = project or mlrun.mlconf.default_project
         self._validate_and_enrich_identity_for_object_creation(project, object_)
         mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session
+            db_session, project, auth_info=auth_info
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             object_.get_authorization_resource_type(),
@@ -365,7 +365,7 @@ class FeatureStore(metaclass=mlrun.utils.singleton.Singleton,):
             object_, project, name, tag, uid
         )
         mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session
+            db_session, project, auth_info=auth_info
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             object_.get_authorization_resource_type(),

--- a/mlrun/api/crud/functions.py
+++ b/mlrun/api/crud/functions.py
@@ -25,7 +25,7 @@ class Functions(metaclass=mlrun.utils.singleton.Singleton,):
     ) -> str:
         project = project or mlrun.mlconf.default_project
         mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session
+            db_session, project, auth_info=auth_info
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.function,

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -28,7 +28,7 @@ class Runs(metaclass=mlrun.utils.singleton.Singleton,):
     ):
         project = project or mlrun.mlconf.default_project
         mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session
+            db_session, project, auth_info=auth_info
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.run,

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -14,7 +14,7 @@
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mlrun.api import schemas
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -166,7 +166,6 @@ class DBInterface(ABC):
         labels: Dict = None,
         last_run_uri: str = None,
         concurrency_limit: int = None,
-        leader_session: Optional[str] = None,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from mlrun.api import schemas
 from mlrun.api.db.base import DBError, DBInterface

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -348,7 +348,6 @@ class FileDB(DBInterface):
         labels: Dict = None,
         last_run_uri: str = None,
         concurrency_limit: int = None,
-        leader_session: Optional[str] = None,
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -3,7 +3,7 @@ import re
 import typing
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import humanfriendly
 import mergedeep
@@ -39,7 +39,6 @@ from mlrun.api.db.sqldb.models import (
     _labeled,
     _tagged,
 )
-from mlrun.api.utils.singletons.project_member import get_project_member
 from mlrun.config import config
 from mlrun.lists import ArtifactList, FunctionList, RunList
 from mlrun.model import RunObject

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -639,11 +639,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
         labels: Dict = None,
         last_run_uri: str = None,
         concurrency_limit: int = None,
-        leader_session: Optional[str] = None,
     ):
-        get_project_member().ensure_project(
-            session, project, leader_session=leader_session
-        )
         schedule = self._get_schedule_record(session, project, name)
 
         # explicitly ensure the updated fields are not None, as they can be empty strings/dictionaries etc.

--- a/mlrun/api/schemas/auth.py
+++ b/mlrun/api/schemas/auth.py
@@ -58,3 +58,11 @@ class AuthInfo(pydantic.BaseModel):
         if self.session != "":
             return NuclioAuthInfo(password=self.session, mode=NuclioAuthKinds.iguazio)
         return None
+
+    def get_member_ids(self) -> typing.List[str]:
+        member_ids = []
+        if self.user_id:
+            member_ids.append(self.user_id)
+        if self.user_group_ids:
+            member_ids.extend(self.user_group_ids)
+        return member_ids

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -50,7 +50,7 @@ class Handler(metaclass=mlrun.utils.singleton.Singleton):
         auth_info: mlrun.api.schemas.AuthInfo = mlrun.api.schemas.AuthInfo(),
     ):
         mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session,
+            db_session, project, auth_info=auth_info,
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.background_task,

--- a/mlrun/api/utils/clients/opa.py
+++ b/mlrun/api/utils/clients/opa.py
@@ -1,4 +1,6 @@
 import copy
+import humanfriendly
+import datetime
 import typing
 
 import requests.adapters
@@ -29,6 +31,10 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         )
         self._log_level = int(mlrun.mlconf.httpdb.authorization.opa.log_level)
         self._leader_name = mlrun.mlconf.httpdb.projects.leader
+        self._allowed_project_owners_cache_ttl_seconds = humanfriendly.parse_timespan(mlrun.mlconf.httpdb.projects.leader.project_owners_cache_ttl)
+
+        # owner id -> [(allowed project, ttl)]
+        self._allowed_project_owners_cache: typing.Dict[str, typing.List[typing.Tuple[str, datetime]]] = {}
 
     def filter_resources_by_permissions(
         self,
@@ -124,6 +130,8 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
             or mlrun.mlconf.httpdb.authorization.mode == "none"
         ):
             return True
+        if self._check_allowed_projects_cache(resource, auth_info):
+            return True
         body = self._generate_permission_request_body(resource, action, auth_info)
         if self._log_level > 5:
             logger.debug("Sending request to OPA", body=body)
@@ -139,6 +147,44 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
                 f"Not allowed to {action} resource {resource}"
             )
         return allowed
+
+    def _check_allowed_projects_cache(self, resource: str, auth_info: mlrun.api.schemas.AuthInfo):
+        # Cache shouldn't be big, simply clean it on get instead of scheduling it
+        self._clean_expired_records_from_cache()
+        if auth_info.user_id not in self._allowed_project_owners_cache:
+            return False
+        allowed_projects = [project_name for project_name, _ in self._allowed_project_owners_cache[auth_info.user_id]]
+        for allowed_project in allowed_projects:
+            if f"/projects/{allowed_project}" in resource:
+                return True
+        return False
+
+    def _clean_expired_records_from_cache(self):
+        now = datetime.datetime.now()
+        user_ids_to_remove = []
+        for user_id in self._allowed_project_owners_cache.keys():
+            allowed_projects = self._allowed_project_owners_cache[user_id]
+            updated_allowed_projects = []
+            for allowed_project_name, ttl in allowed_projects:
+                if now > ttl:
+                    continue
+                updated_allowed_projects.append((allowed_project_name, ttl))
+            self._allowed_project_owners_cache[user_id] = updated_allowed_projects
+            if not updated_allowed_projects:
+                user_ids_to_remove.append(user_id)
+        for user_id in user_ids_to_remove:
+            del self._allowed_project_owners_cache[user_id]
+
+    def add_allowed_project(self, project_name: str, auth_info: mlrun.api.schemas.AuthInfo):
+        if not auth_info.user_id or not project_name or not self._allowed_project_owners_cache_ttl_seconds:
+            # Simply won't be cached, no need to explode
+            return
+        allowed_projects = []
+        if auth_info.user_id in self._allowed_project_owners_cache:
+                allowed_projects = self._allowed_project_owners_cache[auth_info.user_id][0]
+        ttl = datetime.datetime.now() + datetime.timedelta(seconds=self._allowed_project_owners_cache_ttl_seconds)
+        allowed_projects.append((project_name, ttl))
+        self._allowed_project_owners_cache[auth_info.user_id] = allowed_projects
 
     def _generate_resource_string(
         self,

--- a/mlrun/api/utils/clients/opa.py
+++ b/mlrun/api/utils/clients/opa.py
@@ -1,8 +1,8 @@
 import copy
-import humanfriendly
 import datetime
 import typing
 
+import humanfriendly
 import requests.adapters
 import urllib3
 
@@ -31,10 +31,14 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         )
         self._log_level = int(mlrun.mlconf.httpdb.authorization.opa.log_level)
         self._leader_name = mlrun.mlconf.httpdb.projects.leader
-        self._allowed_project_owners_cache_ttl_seconds = humanfriendly.parse_timespan(mlrun.mlconf.httpdb.projects.project_owners_cache_ttl)
+        self._allowed_project_owners_cache_ttl_seconds = humanfriendly.parse_timespan(
+            mlrun.mlconf.httpdb.projects.project_owners_cache_ttl
+        )
 
         # owner id -> allowed project -> ttl
-        self._allowed_project_owners_cache: typing.Dict[str, typing.Dict[str, datetime]] = {}
+        self._allowed_project_owners_cache: typing.Dict[
+            str, typing.Dict[str, datetime]
+        ] = {}
 
     def filter_resources_by_permissions(
         self,
@@ -148,12 +152,16 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
             )
         return allowed
 
-    def _check_allowed_project_owners_cache(self, resource: str, auth_info: mlrun.api.schemas.AuthInfo):
+    def _check_allowed_project_owners_cache(
+        self, resource: str, auth_info: mlrun.api.schemas.AuthInfo
+    ):
         # Cache shouldn't be big, simply clean it on get instead of scheduling it
         self._clean_expired_records_from_cache()
         if auth_info.user_id not in self._allowed_project_owners_cache:
             return False
-        allowed_projects = list(self._allowed_project_owners_cache[auth_info.user_id].keys())
+        allowed_projects = list(
+            self._allowed_project_owners_cache[auth_info.user_id].keys()
+        )
         for allowed_project in allowed_projects:
             if f"/projects/{allowed_project}/" in resource:
                 return True
@@ -175,14 +183,22 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         for user_id in user_ids_to_remove:
             del self._allowed_project_owners_cache[user_id]
 
-    def add_allowed_project_for_owner(self, project_name: str, auth_info: mlrun.api.schemas.AuthInfo):
-        if not auth_info.user_id or not project_name or not self._allowed_project_owners_cache_ttl_seconds:
+    def add_allowed_project_for_owner(
+        self, project_name: str, auth_info: mlrun.api.schemas.AuthInfo
+    ):
+        if (
+            not auth_info.user_id
+            or not project_name
+            or not self._allowed_project_owners_cache_ttl_seconds
+        ):
             # Simply won't be cached, no need to explode
             return
         allowed_projects = {}
         if auth_info.user_id in self._allowed_project_owners_cache:
-                allowed_projects = self._allowed_project_owners_cache[auth_info.user_id]
-        ttl = datetime.datetime.now() + datetime.timedelta(seconds=self._allowed_project_owners_cache_ttl_seconds)
+            allowed_projects = self._allowed_project_owners_cache[auth_info.user_id]
+        ttl = datetime.datetime.now() + datetime.timedelta(
+            seconds=self._allowed_project_owners_cache_ttl_seconds
+        )
         allowed_projects[project_name] = ttl
         self._allowed_project_owners_cache[auth_info.user_id] = allowed_projects
 
@@ -247,6 +263,10 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         auth_info: mlrun.api.schemas.AuthInfo,
     ) -> dict:
         body = {
-            "input": {"resource": resource, "action": action, "ids": auth_info.get_member_ids()},
+            "input": {
+                "resource": resource,
+                "action": action,
+                "ids": auth_info.get_member_ids(),
+            },
         }
         return body

--- a/mlrun/api/utils/clients/opa.py
+++ b/mlrun/api/utils/clients/opa.py
@@ -200,12 +200,7 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
     ) -> dict:
-        member_ids = []
-        if auth_info.user_id:
-            member_ids.append(auth_info.user_id)
-        if auth_info.user_group_ids:
-            member_ids.extend(auth_info.user_group_ids)
         body = {
-            "input": {"resource": resource, "action": action, "ids": member_ids},
+            "input": {"resource": resource, "action": action, "ids": auth_info.get_member_ids()},
         }
         return body

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -7,6 +7,7 @@ import mlrun.api.db.session
 import mlrun.api.schemas
 import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.clients.nuclio
+import mlrun.api.utils.clients.opa
 import mlrun.api.utils.periodic
 import mlrun.api.utils.projects.member
 import mlrun.api.utils.projects.remotes.nop_leader
@@ -16,7 +17,6 @@ import mlrun.utils
 import mlrun.utils.helpers
 import mlrun.utils.regex
 import mlrun.utils.singleton
-import mlrun.api.utils.clients.opa
 from mlrun.utils import logger
 
 
@@ -118,17 +118,18 @@ class Member(
         self._stop_periodic_sync()
 
     def ensure_project(
-            self,
-            db_session: sqlalchemy.orm.Session,
-            name: str,
-            wait_for_completion: bool = True,
-            auth_info: mlrun.api.schemas.AuthInfo = mlrun.api.schemas.AuthInfo(),
+        self,
+        db_session: sqlalchemy.orm.Session,
+        name: str,
+        wait_for_completion: bool = True,
+        auth_info: mlrun.api.schemas.AuthInfo = mlrun.api.schemas.AuthInfo(),
     ) -> bool:
-        is_project_created = super().ensure_project(db_session, name, wait_for_completion, auth_info)
+        is_project_created = super().ensure_project(
+            db_session, name, wait_for_completion, auth_info
+        )
         if is_project_created:
             mlrun.api.utils.clients.opa.Client().add_allowed_project_for_owner(
-                name,
-                auth_info,
+                name, auth_info,
             )
         return is_project_created
 

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -16,6 +16,7 @@ import mlrun.utils
 import mlrun.utils.helpers
 import mlrun.utils.regex
 import mlrun.utils.singleton
+import mlrun.api.utils.clients.opa
 from mlrun.utils import logger
 
 
@@ -115,6 +116,21 @@ class Member(
     def shutdown(self):
         logger.info("Shutting down projects leader")
         self._stop_periodic_sync()
+
+    def ensure_project(
+            self,
+            db_session: sqlalchemy.orm.Session,
+            name: str,
+            wait_for_completion: bool = True,
+            auth_info: mlrun.api.schemas.AuthInfo = mlrun.api.schemas.AuthInfo(),
+    ) -> bool:
+        is_project_created = super().ensure_project(db_session, name, wait_for_completion, auth_info)
+        if is_project_created:
+            mlrun.api.utils.clients.opa.Client().add_allowed_project(
+                name,
+                auth_info,
+            )
+        return is_project_created
 
     def create_project(
         self,

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -126,7 +126,7 @@ class Member(
     ) -> bool:
         is_project_created = super().ensure_project(db_session, name, wait_for_completion, auth_info)
         if is_project_created:
-            mlrun.api.utils.clients.opa.Client().add_allowed_project(
+            mlrun.api.utils.clients.opa.Client().add_allowed_project_for_owner(
                 name,
                 auth_info,
             )

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -23,12 +23,12 @@ class Member(abc.ABC):
         db_session: sqlalchemy.orm.Session,
         name: str,
         wait_for_completion: bool = True,
-        leader_session: typing.Optional[str] = None,
+        auth_info: mlrun.api.schemas.AuthInfo = mlrun.api.schemas.AuthInfo(),
     ) -> bool:
         project_names = self.list_projects(
             db_session,
             format_=mlrun.api.schemas.ProjectsFormat.name_only,
-            leader_session=leader_session,
+            leader_session=auth_info.session,
         )
         if name in project_names.projects:
             return False
@@ -41,7 +41,7 @@ class Member(abc.ABC):
         self.create_project(
             db_session,
             project,
-            leader_session=leader_session,
+            leader_session=auth_info.session,
             wait_for_completion=wait_for_completion,
         )
         return True

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -24,14 +24,14 @@ class Member(abc.ABC):
         name: str,
         wait_for_completion: bool = True,
         leader_session: typing.Optional[str] = None,
-    ):
+    ) -> bool:
         project_names = self.list_projects(
             db_session,
             format_=mlrun.api.schemas.ProjectsFormat.name_only,
             leader_session=leader_session,
         )
         if name in project_names.projects:
-            return
+            return False
         logger.info(
             "Ensure project called, but project does not exist. Creating", name=name
         )
@@ -44,6 +44,7 @@ class Member(abc.ABC):
             leader_session=leader_session,
             wait_for_completion=wait_for_completion,
         )
+        return True
 
     @abc.abstractmethod
     def create_project(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -66,7 +66,7 @@ class Scheduler:
         concurrency_limit: int = config.httpdb.scheduling.default_concurrency_limit,
     ):
         get_project_member().ensure_project(
-            db_session, project, leader_session=auth_info.session
+            db_session, project, auth_info=auth_info
         )
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.schedule,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -65,9 +65,7 @@ class Scheduler:
         labels: Dict = None,
         concurrency_limit: int = config.httpdb.scheduling.default_concurrency_limit,
     ):
-        get_project_member().ensure_project(
-            db_session, project, auth_info=auth_info
-        )
+        get_project_member().ensure_project(db_session, project, auth_info=auth_info)
         mlrun.api.utils.clients.opa.Client().query_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.schedule,
             project,
@@ -526,10 +524,7 @@ class Scheduler:
             run_metadata["project"], run_metadata["uid"], run_metadata["iteration"]
         )
         get_db().update_schedule(
-            db_session,
-            run_metadata["project"],
-            schedule_name,
-            last_run_uri=run_uri,
+            db_session, run_metadata["project"], schedule_name, last_run_uri=run_uri,
         )
 
         close_session(db_session)

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -151,7 +151,6 @@ class Scheduler:
             cron_trigger,
             labels,
             concurrency_limit,
-            auth_info.session,
         )
         db_schedule = get_db().get_schedule(db_session, project, name)
         updated_schedule = self._transform_and_enrich_db_schedule(
@@ -531,7 +530,6 @@ class Scheduler:
             run_metadata["project"],
             schedule_name,
             last_run_uri=run_uri,
-            leader_session=auth_info.session,
         )
 
         close_session(db_session)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -165,7 +165,7 @@ default_config = {
             # better performance wise, so made it a mode
             # one of: cache, none
             "follower_projects_store_mode": "none",
-            "project_owners_cache_ttl": "30 seconds"
+            "project_owners_cache_ttl": "30 seconds",
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -165,6 +165,7 @@ default_config = {
             # better performance wise, so made it a mode
             # one of: cache, none
             "follower_projects_store_mode": "none",
+            "project_owners_cache_ttl": "30 seconds"
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1062,6 +1062,7 @@ class BaseRuntimeHandler(ABC):
                     runtime_resource_name=runtime_resource["metadata"]["name"],
                     namespace=namespace,
                     exc=str(exc),
+                    traceback=traceback.format_exc(),
                 )
 
     def _enrich_list_resources_response(

--- a/tests/api/utils/clients/test_opa.py
+++ b/tests/api/utils/clients/test_opa.py
@@ -107,54 +107,71 @@ def test_query_permissions_failure(
 
 
 def test_allowed_project_owners_cache(
-        api_url: str,
-        permission_query_path: str,
-        opa_client: mlrun.api.utils.clients.opa.Client,
+    api_url: str,
+    permission_query_path: str,
+    opa_client: mlrun.api.utils.clients.opa.Client,
 ):
-    auth_info = mlrun.api.schemas.AuthInfo(
-        user_id="user-id"
-    )
+    auth_info = mlrun.api.schemas.AuthInfo(user_id="user-id")
     project_name = "project-name"
     opa_client.add_allowed_project_for_owner(project_name, auth_info)
     # ensure nothing is wrong with adding the same project twice
     opa_client.add_allowed_project_for_owner(project_name, auth_info)
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
-    assert opa_client._check_allowed_project_owners_cache(f"/some-non-project-resource", auth_info) is False
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource",
-                                                          mlrun.api.schemas.AuthInfo(user_id="other-user-id")) is False
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info
+        )
+        is True
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            "/some-non-project-resource", auth_info
+        )
+        is False
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource",
+            mlrun.api.schemas.AuthInfo(user_id="other-user-id"),
+        )
+        is False
+    )
 
 
 def test_allowed_project_owners_cache_ttl_refresh(
-        api_url: str,
-        permission_query_path: str,
-        opa_client: mlrun.api.utils.clients.opa.Client,
+    api_url: str,
+    permission_query_path: str,
+    opa_client: mlrun.api.utils.clients.opa.Client,
 ):
-    auth_info = mlrun.api.schemas.AuthInfo(
-        user_id="user-id"
-    )
+    auth_info = mlrun.api.schemas.AuthInfo(user_id="user-id")
     opa_client._allowed_project_owners_cache_ttl_seconds = 1
     project_name = "project-name"
     opa_client.add_allowed_project_for_owner(project_name, auth_info)
     time.sleep(0.3)
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info
+        )
+        is True
+    )
     # This will refresh the ttl
     opa_client.add_allowed_project_for_owner(project_name, auth_info)
     time.sleep(0.7)
     # by now, more than the first 1 second surely passed, so if it works, ttl refreshed
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info
+        )
+        is True
+    )
 
 
 def test_allowed_project_owners_cache_clean_expired(
-        api_url: str,
-        permission_query_path: str,
-        opa_client: mlrun.api.utils.clients.opa.Client,
+    api_url: str,
+    permission_query_path: str,
+    opa_client: mlrun.api.utils.clients.opa.Client,
 ):
-    auth_info = mlrun.api.schemas.AuthInfo(
-        user_id="user-id"
-    )
-    auth_info_2 = mlrun.api.schemas.AuthInfo(
-        user_id="user-id-2"
-    )
+    auth_info = mlrun.api.schemas.AuthInfo(user_id="user-id")
+    auth_info_2 = mlrun.api.schemas.AuthInfo(user_id="user-id-2")
     opa_client._allowed_project_owners_cache_ttl_seconds = 2
     project_name = "project-name"
     project_name_2 = "project-name-2"
@@ -163,21 +180,81 @@ def test_allowed_project_owners_cache_clean_expired(
     time.sleep(1)
     # Note that the _check_allowed_project_owners_cache method calls the clean method so no need to call the clean
     # method explicitly
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info_2) is False
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info
+        )
+        is True
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info_2
+        )
+        is False
+    )
     opa_client.add_allowed_project_for_owner(project_name_2, auth_info)
     opa_client.add_allowed_project_for_owner(project_name, auth_info_2)
     time.sleep(1)
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is False
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info_2) is True
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info) is True
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info_2) is False
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info
+        )
+        is False
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info_2
+        )
+        is True
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name_2}/resource", auth_info
+        )
+        is True
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name_2}/resource", auth_info_2
+        )
+        is False
+    )
     opa_client.add_allowed_project_for_owner(project_name_3, auth_info)
     opa_client.add_allowed_project_for_owner(project_name_2, auth_info_2)
     time.sleep(1)
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is False
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info_2) is False
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info) is False
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info_2) is True
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_3}/resource", auth_info) is True
-    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_3}/resource", auth_info_2) is False
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info
+        )
+        is False
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name}/resource", auth_info_2
+        )
+        is False
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name_2}/resource", auth_info
+        )
+        is False
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name_2}/resource", auth_info_2
+        )
+        is True
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name_3}/resource", auth_info
+        )
+        is True
+    )
+    assert (
+        opa_client._check_allowed_project_owners_cache(
+            f"/projects/{project_name_3}/resource", auth_info_2
+        )
+        is False
+    )

--- a/tests/api/utils/clients/test_opa.py
+++ b/tests/api/utils/clients/test_opa.py
@@ -106,6 +106,27 @@ def test_query_permissions_failure(
         opa_client.query_permissions(resource, action, auth_info)
 
 
+def test_query_permissions_use_cache(
+    api_url: str,
+    permission_query_path: str,
+    opa_client: mlrun.api.utils.clients.opa.Client,
+    requests_mock: requests_mock_package.Mocker,
+):
+    auth_info = mlrun.api.schemas.AuthInfo(user_id="user-id")
+    project_name = "project-name"
+    opa_client.add_allowed_project_for_owner(project_name, auth_info)
+    mocker = requests_mock.post(f"{api_url}{permission_query_path}", json={})
+    assert (
+        opa_client.query_permissions(
+            f"/projects/{project_name}/resource",
+            mlrun.api.schemas.AuthorizationAction.create,
+            auth_info,
+        )
+        is True
+    )
+    assert mocker.call_count == 0
+
+
 def test_allowed_project_owners_cache(
     api_url: str,
     permission_query_path: str,

--- a/tests/api/utils/clients/test_opa.py
+++ b/tests/api/utils/clients/test_opa.py
@@ -1,4 +1,5 @@
 import http
+import time
 
 import deepdiff
 import pytest
@@ -103,3 +104,80 @@ def test_query_permissions_failure(
         match=f"Not allowed to {action} resource {resource}",
     ):
         opa_client.query_permissions(resource, action, auth_info)
+
+
+def test_allowed_project_owners_cache(
+        api_url: str,
+        permission_query_path: str,
+        opa_client: mlrun.api.utils.clients.opa.Client,
+):
+    auth_info = mlrun.api.schemas.AuthInfo(
+        user_id="user-id"
+    )
+    project_name = "project-name"
+    opa_client.add_allowed_project_for_owner(project_name, auth_info)
+    # ensure nothing is wrong with adding the same project twice
+    opa_client.add_allowed_project_for_owner(project_name, auth_info)
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
+    assert opa_client._check_allowed_project_owners_cache(f"/some-non-project-resource", auth_info) is False
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource",
+                                                          mlrun.api.schemas.AuthInfo(user_id="other-user-id")) is False
+
+
+def test_allowed_project_owners_cache_ttl_refresh(
+        api_url: str,
+        permission_query_path: str,
+        opa_client: mlrun.api.utils.clients.opa.Client,
+):
+    auth_info = mlrun.api.schemas.AuthInfo(
+        user_id="user-id"
+    )
+    opa_client._allowed_project_owners_cache_ttl_seconds = 1
+    project_name = "project-name"
+    opa_client.add_allowed_project_for_owner(project_name, auth_info)
+    time.sleep(0.3)
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
+    # This will refresh the ttl
+    opa_client.add_allowed_project_for_owner(project_name, auth_info)
+    time.sleep(0.7)
+    # by now, more than the first 1 second surely passed, so if it works, ttl refreshed
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
+
+
+def test_allowed_project_owners_cache_clean_expired(
+        api_url: str,
+        permission_query_path: str,
+        opa_client: mlrun.api.utils.clients.opa.Client,
+):
+    auth_info = mlrun.api.schemas.AuthInfo(
+        user_id="user-id"
+    )
+    auth_info_2 = mlrun.api.schemas.AuthInfo(
+        user_id="user-id-2"
+    )
+    opa_client._allowed_project_owners_cache_ttl_seconds = 2
+    project_name = "project-name"
+    project_name_2 = "project-name-2"
+    project_name_3 = "project-name-3"
+    opa_client.add_allowed_project_for_owner(project_name, auth_info)
+    time.sleep(1)
+    # Note that the _check_allowed_project_owners_cache method calls the clean method so no need to call the clean
+    # method explicitly
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is True
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info_2) is False
+    opa_client.add_allowed_project_for_owner(project_name_2, auth_info)
+    opa_client.add_allowed_project_for_owner(project_name, auth_info_2)
+    time.sleep(1)
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is False
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info_2) is True
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info) is True
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info_2) is False
+    opa_client.add_allowed_project_for_owner(project_name_3, auth_info)
+    opa_client.add_allowed_project_for_owner(project_name_2, auth_info_2)
+    time.sleep(1)
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info) is False
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name}/resource", auth_info_2) is False
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info) is False
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_2}/resource", auth_info_2) is True
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_3}/resource", auth_info) is True
+    assert opa_client._check_allowed_project_owners_cache(f"/projects/{project_name_3}/resource", auth_info_2) is False


### PR DESCRIPTION
When a project is being ensured if the project is actually created, it may take some time for the OPA manifest to be updated, until then, requests may fail, to reduce the noice, we cache the project owner and allow him all actions on the project for a configurable (by default 30 seconds) ttl

Also:
1. Removed unneeded `ensure_project` call in `update_schedule` logic
2. Improved `monitor_run` error log