### PR TITLE
[Feature Store] Don't remove entity timestamp column when `vector.spec.with_indexes` is `True`

### DIFF
--- a/mlrun/feature_store/retrieval/local_merger.py
+++ b/mlrun/feature_store/retrieval/local_merger.py
@@ -44,7 +44,7 @@ class LocalFeatureMerger:
             if drop_indexes and key and key not in index_columns:
                 index_columns.append(key)
 
-        if entity_timestamp_column:
+        if entity_timestamp_column and drop_indexes:
             index_columns.append(entity_timestamp_column)
         feature_set_objects, feature_set_fields = self.vector.parse_features()
         self.vector.save()

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -685,13 +685,28 @@ class TestFeatureStore(TestMLRunSystem):
         fs.ingest(data_set1, data, infer_options=fs.InferOptions.default())
         features = ["fs1.*"]
         vector = fs.FeatureVector("vector", features)
+        vector.spec.with_indexes = True
+
         resp = fs.get_offline_features(
             vector,
             entity_timestamp_column="time_stamp",
             start_time=datetime(2021, 6, 9, 9, 30),
             end_time=datetime(2021, 6, 9, 10, 30),
         )
-        assert len(resp.to_dataframe()) == 2
+
+        expected = pd.DataFrame(
+            {
+                "time_stamp": [
+                    pd.Timestamp("2021-06-09 09:30:06.008"),
+                    pd.Timestamp("2021-06-09 10:29:07.009"),
+                ],
+                "data": [10, 20],
+                "string": ["ab", "cd"],
+            }
+        )
+        expected.set_index(keys="string", inplace=True)
+
+        assert expected.equals(resp.to_dataframe())
 
     def test_unaggregated_columns(self):
         test_base_time = datetime(2020, 12, 1, 17, 33, 15)


### PR DESCRIPTION
… entity_timestamp_column