### PR TITLE
[Secrets] Fix k8s project secrets to support an empty list of secrets in `with_secrets`

### DIFF
--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -253,7 +253,9 @@ class KubejobRuntime(KubeResource):
                     self._secrets.get_azure_vault_k8s_secret()
                 )
             k8s_secrets = self._secrets.get_k8s_secrets()
-            if k8s_secrets:
+            # the get_k8s_secrets function may return an empty dictionary - it's a different case than returning None
+            # (asking for all secrets of that project)
+            if k8s_secrets is not None:
                 self._add_project_k8s_secrets_to_spec(k8s_secrets, runobj)
 
         pod_spec = func_to_pod(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -385,6 +385,13 @@ class KubeResource(BaseRuntime):
         existing_secret_keys = (
             self._get_k8s().get_project_secret_keys(project_name) or {}
         )
+
+        # If no secrets were passed, we need all existing keys
+        if not secrets:
+            secrets = {
+                key: self._secrets.k8s_env_variable_name_for_secret(key) for key in existing_secret_keys
+            }
+
         for key, env_var_name in secrets.items():
             if key in existing_secret_keys:
                 self.set_env_from_secret(env_var_name, secret_name, key)

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -382,7 +382,9 @@ class KubeResource(BaseRuntime):
             return
 
         secret_name = self._get_k8s().get_project_secret_name(project_name)
-        existing_secret_keys = self._get_k8s().get_project_secrets(project_name) or {}
+        existing_secret_keys = (
+            self._get_k8s().get_project_secret_keys(project_name) or {}
+        )
 
         # If no secrets were passed, we need all existing keys
         if not secrets:

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -382,14 +382,13 @@ class KubeResource(BaseRuntime):
             return
 
         secret_name = self._get_k8s().get_project_secret_name(project_name)
-        existing_secret_keys = (
-            self._get_k8s().get_project_secret_keys(project_name) or {}
-        )
+        existing_secret_keys = self._get_k8s().get_project_secrets(project_name) or {}
 
         # If no secrets were passed, we need all existing keys
         if not secrets:
             secrets = {
-                key: self._secrets.k8s_env_variable_name_for_secret(key) for key in existing_secret_keys
+                key: self._secrets.k8s_env_variable_name_for_secret(key)
+                for key in existing_secret_keys
             }
 
         for key, env_var_name in secrets.items():

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -412,7 +412,7 @@ class ServingRuntime(RemoteRuntime):
                     self._secrets.get_azure_vault_k8s_secret()
                 )
             k8s_secrets = self._secrets.get_k8s_secrets()
-            if k8s_secrets:
+            if k8s_secrets is not None:
                 self._add_project_k8s_secrets_to_spec(
                     k8s_secrets, project=self.metadata.project
                 )

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -102,7 +102,12 @@ class SecretsStore:
             self._hidden_sources.append({"kind": kind, "source": source})
 
     def get(self, key, default=None):
-        return self._secrets.get(key) or self._hidden_secrets.get(key) or default
+        return (
+            self._secrets.get(key)
+            or self._hidden_secrets.get(key)
+            or environ.get(self.k8s_env_variable_name_for_secret(key))
+            or default
+        )
 
     def items(self):
         res = self._secrets.copy()

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -96,7 +96,7 @@ class SecretsStore:
             if not isinstance(source, list):
                 raise ValueError("k8s secrets must be of type list")
             for secret in source:
-                env_value = environ.get(self._k8s_env_variable_name_for_secret(secret))
+                env_value = environ.get(self.k8s_env_variable_name_for_secret(secret))
                 if env_value:
                     self._hidden_secrets[prefix + secret] = env_value
             self._hidden_sources.append({"kind": kind, "source": source})
@@ -130,14 +130,14 @@ class SecretsStore:
                 return source["source"].get("k8s_secret", None)
 
     @staticmethod
-    def _k8s_env_variable_name_for_secret(secret_name):
+    def k8s_env_variable_name_for_secret(secret_name):
         return config.secret_stores.kubernetes.env_variable_prefix + secret_name.upper()
 
     def get_k8s_secrets(self):
         for source in self._hidden_sources:
             if source["kind"] == "kubernetes":
                 return {
-                    secret: self._k8s_env_variable_name_for_secret(secret)
+                    secret: self.k8s_env_variable_name_for_secret(secret)
                     for secret in source["source"]
                 }
         return None

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -172,7 +172,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         get_k8s().get_project_secret_name = unittest.mock.Mock(
             return_value=project_secret_name
         )
-        get_k8s().get_project_secrets = unittest.mock.Mock(return_value=secret_keys)
+        get_k8s().get_project_secret_keys = unittest.mock.Mock(return_value=secret_keys)
 
         runtime = self._generate_runtime()
 

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -188,7 +188,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         # value from the k8s secret, using the correct keys.
         expected_env_from_secrets = {}
         for key in secret_keys:
-            env_variable_name = SecretsStore._k8s_env_variable_name_for_secret(key)
+            env_variable_name = SecretsStore.k8s_env_variable_name_for_secret(key)
             expected_env_from_secrets[env_variable_name] = {project_secret_name: key}
 
         self._execute_run(runtime, runspec=task)

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -172,7 +172,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         get_k8s().get_project_secret_name = unittest.mock.Mock(
             return_value=project_secret_name
         )
-        get_k8s().get_project_secret_keys = unittest.mock.Mock(return_value=secret_keys)
+        get_k8s().get_project_secrets = unittest.mock.Mock(return_value=secret_keys)
 
         runtime = self._generate_runtime()
 

--- a/tests/system/api/test_projects.py
+++ b/tests/system/api/test_projects.py
@@ -151,6 +151,13 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
             image="mlrun/mlrun",
         )
 
+        # Test running with an empty list of secrets
+        task = mlrun.new_task().with_secrets("kubernetes", [])
+        run = function.run(task, params={"secrets": list(secrets.keys())})
+        for key, value in secrets.items():
+            assert run.outputs[key] == value
+
+        # And with actual secret keys
         task = mlrun.new_task().with_secrets("kubernetes", list(secrets.keys()))
         run = function.run(task, params={"secrets": list(secrets.keys())})
         for key, value in secrets.items():


### PR DESCRIPTION
Had a bug where passing an empty list of secrets to `with_secrets` would actually expose no secrets to the running job if working with the `kubernetes` provider.
For example:
```
task = mlrun.new_task().with_secrets("kubernetes", [])
function.run(task)
```
Is expected to allow the function access to all project secrets, and it didn't.
Also, fixed another small issue where code was calling `k8s_helper.get_project_secret_keys` even though this name was changed in another PR.