### PR TITLE
[Usability] Support auto mount for MLRun runtimes

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -240,6 +240,13 @@ default_config = {
             "channel": "master",
         },
     },
+    "storage": {
+        # What type of auto-mount to use for functions. Can be one of: none, auto, v3io_cred, v3io_fuse, pvc.
+        # Default is auto - which is v3io_cred when running on Iguazio and none otherwise
+        "auto_mount_type": "auto",
+        # Extra parameters to pass to the mount call (will be passed as kwargs)
+        "auto_mount_params": {},
+    },
 }
 
 

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -301,12 +301,16 @@ def v3io_cred(api="", user="", access_key=""):
         web_api = api or environ.get("V3IO_API") or mlconf.v3io_api
         _user = user or environ.get("V3IO_USERNAME")
         _access_key = access_key or environ.get("V3IO_ACCESS_KEY")
+        v3io_framesd = mlconf.v3io_framesd or environ.get("V3IO_FRAMESD")
 
         return (
             task.add_env_variable(k8s_client.V1EnvVar(name="V3IO_API", value=web_api))
             .add_env_variable(k8s_client.V1EnvVar(name="V3IO_USERNAME", value=_user))
             .add_env_variable(
                 k8s_client.V1EnvVar(name="V3IO_ACCESS_KEY", value=_access_key)
+            )
+            .add_env_variable(
+                k8s_client.V1EnvVar(name="V3IO_FRAMESD", value=v3io_framesd)
             )
         )
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -90,6 +90,7 @@ class FunctionSpec(ModelObj):
         workdir=None,
         default_handler=None,
         pythonpath=None,
+        mount_applied=False,
     ):
 
         self.command = command or ""
@@ -106,6 +107,7 @@ class FunctionSpec(ModelObj):
         self.default_handler = default_handler
         # TODO: type verification (FunctionEntrypoint dict)
         self.entry_points = entry_points or {}
+        self.mount_applied = mount_applied or False
 
     @property
     def build(self) -> ImageBuilder:
@@ -216,6 +218,9 @@ class BaseRuntime(ModelObj):
                 self._db_conn = get_run_db(self.spec.rundb, secrets=self._secrets)
         return self._db_conn
 
+    def auto_mount_based_on_config(self):
+        pass
+
     def run(
         self,
         runspec: RunObject = None,
@@ -267,6 +272,9 @@ class BaseRuntime(ModelObj):
 
         if self.spec.mode and self.spec.mode not in run_modes:
             raise ValueError(f'run mode can only be {",".join(run_modes)}')
+
+        # Perform auto-mount if necessary
+        self.auto_mount_based_on_config()
 
         if local:
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -218,7 +218,7 @@ class BaseRuntime(ModelObj):
                 self._db_conn = get_run_db(self.spec.rundb, secrets=self._secrets)
         return self._db_conn
 
-    def auto_mount_based_on_config(self):
+    def try_auto_mount_based_on_config(self):
         pass
 
     def run(
@@ -274,7 +274,7 @@ class BaseRuntime(ModelObj):
             raise ValueError(f'run mode can only be {",".join(run_modes)}')
 
         # Perform auto-mount if necessary
-        self.auto_mount_based_on_config()
+        self.try_auto_mount_based_on_config()
 
         if local:
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -936,7 +936,7 @@ def compile_function_config(function: RemoteRuntime):
     # Needs to be here, since it adds env params, which are handled in the next lines.
     function.add_secrets_config_to_spec()
     # Perform auto-mount to function, if needed
-    function.auto_mount_based_on_config()
+    function.try_auto_mount_based_on_config()
 
     env_dict = {get_item_name(v): get_item_name(v, "value") for v in function.spec.env}
     for key, value in function._get_runtime_env().items():

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -187,16 +187,16 @@ class AutoMountType(str, Enum):
 
     @classmethod
     def _missing_(cls, value):
-        is_iguazio = mlconf.igz_version != ""
-        return AutoMountType.v3io_cred if is_iguazio else AutoMountType.auto
+        return AutoMountType.auto
 
     def get_modifier(self):
+        is_iguazio = mlconf.igz_version != ""
         return {
             AutoMountType.none: None,
             AutoMountType.v3io_cred: mlrun.v3io_cred,
             AutoMountType.v3io_fuse: mlrun.mount_v3io,
             AutoMountType.pvc: mlrun.platforms.other.mount_pvc,
-            AutoMountType.auto: mlrun.platforms.auto_mount,
+            AutoMountType.auto: mlrun.v3io_cred if is_iguazio else None,
         }[self]
 
 
@@ -459,7 +459,7 @@ class KubeResource(BaseRuntime):
             {"name": "MLRUN_SECRET_STORES__VAULT__URL", "value": vault_url}
         )
 
-    def auto_mount_based_on_config(self):
+    def try_auto_mount_based_on_config(self):
         if self.spec.mount_applied:
             logger.info("Mount already applied - not performing auto-mount")
             return

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -315,6 +315,7 @@ def apply_kfp(modify, cop, runtime):
         cop.volumes.clear()
         cop.container.volume_mounts.clear()
 
+    runtime.spec.mount_applied = True
     return runtime
 
 

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -354,7 +354,9 @@ class TestRuntimeBase:
         args, _ = get_k8s().v1api.create_namespaced_pod.call_args
         return args[0]
 
-    def _assert_v3io_mount_configured(self, v3io_user, v3io_access_key):
+    def _assert_v3io_mount_or_creds_configured(
+        self, v3io_user, v3io_access_key, cred_only=False
+    ):
         args = self._get_pod_creation_args()
         pod_spec = args.spec
         container_spec = pod_spec.containers[0]
@@ -368,6 +370,11 @@ class TestRuntimeBase:
                 "V3IO_ACCESS_KEY": v3io_access_key,
             },
         )
+
+        if cred_only:
+            assert len(pod_spec.volumes) == 0
+            assert len(container_spec.volume_mounts) == 0
+            return
 
         expected_volume = {
             "flexVolume": {

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -123,7 +123,9 @@ class TestDaskRuntime(TestRuntimeBase):
             assert_create_pod_called=False,
             assert_namespace_env_variable=False,
         )
-        self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
+        self._assert_v3io_mount_or_creds_configured(
+            self.v3io_user, self.v3io_access_key
+        )
         self._assert_scheduler_pod_args()
 
     def test_dask_runtime_with_resources(self, db: Session, client: TestClient):
@@ -158,7 +160,9 @@ class TestDaskRuntime(TestRuntimeBase):
             assert_create_pod_called=False,
             assert_namespace_env_variable=False,
         )
-        self._assert_v3io_mount_configured(self.v3io_user, self.v3io_access_key)
+        self._assert_v3io_mount_or_creds_configured(
+            self.v3io_user, self.v3io_access_key
+        )
         self._assert_pods_resources(
             expected_requests,
             expected_worker_limits,

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -28,6 +28,9 @@ from tests.api.runtimes.base import TestRuntimeBase
 class TestNuclioRuntime(TestRuntimeBase):
     def custom_setup_after_fixtures(self):
         self._mock_nuclio_deploy_config()
+        # Clear any auto-config params (some tests modify them)
+        mlconf.storage.auto_mount_type = "auto"
+        mlconf.storage.auto_mount_params = {}
 
     def custom_setup(self):
         self.image_name = "test/image:latest"

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -29,6 +29,7 @@ def test_new_function_from_runtime():
             "description": "",
             "build": {"commands": []},
             "affinity": None,
+            "mount_applied": False,
         },
         "verbose": False,
     }
@@ -63,6 +64,7 @@ def test_new_function_args_without_command():
             "description": "",
             "build": {"commands": []},
             "affinity": None,
+            "mount_applied": False,
         },
         "verbose": False,
     }


### PR DESCRIPTION
Support the requirements in https://jira.iguazeng.com/browse/ML-867 - perform auto-mount on runtimes, saving the user the need to use `func.apply(auto_mount())` for every function deployed remotely (and actually not using `auto_mount` as it will default to fuse mount on every function, which is usually not needed).
Two configuration parameters were added:

- `storage.auto_mount_type` - based on the values in the `AutoMountType` enum. By default this is `auto`, and will also be the case if the parameter is empty. Possible values are:
  - `none` - self explanatory
  - `v3io_cred` - add v3io credentials to the deployed runtime (applies `v3io_cred`)
  - `v3io_fuse` - mount v3io fuse driver (applies `mount_v3io`)
  - `pvc` - configure PVC parameters (applies `mount_pvc`)
  - `auto` - for Iguazio system will use `v3io_cred`, else will be `none`
- `storage.auto_mount_params` - a dictionary of kwargs to be passed to the mount function. The exact kwargs to use depend on the type of the auto mount in use and the function it invokes.

Auto mount is activated on `func.run`, except for Nuclio (`RemoteRuntime`) where it's applied in `compile_function_config`, which is part of the deploy flow.
Auto mount is disabled if someone called `apply` on the runtime with any other modifier. Of course, this also means that if auto-mount was already applied, it won't be applied again.

There are 2 other work-items which are related and are not part of this PR:
1. Documentation fixes - given that current docs always apply auto-mount to functions prior to their deployment, this will have no effect on the existing docs/demos. However, the docs need to reflect this change.
2. Properly configure these parameters when deploying MLRun kit - ideally the auto-mount parameters automatically point at the NFS mount. Possibly modify the Helm chart so that the user can control that as part of the values passed to it.