### PR TITLE
[Secrets] Support using key maps for secrets

### DIFF
--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -1,4 +1,6 @@
+import json
 import typing
+import uuid
 
 import mlrun.api.schemas
 import mlrun.api.utils.singletons.k8s
@@ -11,40 +13,60 @@ import mlrun.utils.vault
 
 class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
     internal_secrets_key_prefix = "mlrun."
+    # make it a subset of internal since key map are by definition internal
+    key_map_secrets_key_prefix = f"{internal_secrets_key_prefix}map."
 
     def generate_schedule_secret_key(self, schedule_name: str):
         return f"{self.internal_secrets_key_prefix}schedules.{schedule_name}"
+
+    def generate_schedule_key_map_secret_key(self):
+        return f"{self.key_map_secrets_key_prefix}schedules"
+
+    @staticmethod
+    def validate_secret_key_regex(key: str, raise_on_failure: bool = True) -> bool:
+        return mlrun.utils.helpers.verify_field_regex(
+            "secret.key", key, mlrun.utils.regex.secret_key, raise_on_failure
+        )
+
+    def validate_internal_secret_key_allowed(self, key: str, allow_internal_secrets: bool = False):
+        if (
+                self._is_internal_secret_key(key)
+                and not allow_internal_secrets
+        ):
+            raise mlrun.errors.MLRunAccessDeniedError(
+                f"Not allowed to create/update internal secrets (key starts with "
+                f"{self.internal_secrets_key_prefix})"
+            )
 
     def store_secrets(
         self,
         project: str,
         secrets: mlrun.api.schemas.SecretsData,
         allow_internal_secrets: bool = False,
+        key_map_secret_key: typing.Optional[str] = None,
+        allow_key_maps: bool = False,
     ):
-        if secrets.secrets:
-            for secret_key in secrets.secrets.keys():
-                mlrun.utils.helpers.verify_field_regex(
-                    "secret.key", secret_key, mlrun.utils.regex.secret_key
-                )
-                if (
-                    self._is_internal_secret_key(secret_key)
-                    and not allow_internal_secrets
-                ):
-                    raise mlrun.errors.MLRunAccessDeniedError(
-                        f"Not allowed to create/update internal secrets (key starts with "
-                        f"{self.internal_secrets_key_prefix})"
-                    )
+        """
+        When secret keys are coming from other object identifiers, which may not be valid secret keys, use
+        key_map_secret_key.
+        Note that when it's used you'll need to get and delete secrets using the get_secret and delete_secret
+        list_secrets won't do any operation on the data and delete_secrets won't handle cleaning the key map
+        """
+        secrets_to_store = self._validate_and_enrich_secrets_to_store(
+            project, secrets, allow_internal_secrets, key_map_secret_key, allow_key_maps
+        )
+
         if secrets.provider == mlrun.api.schemas.SecretProviderName.vault:
             # Init is idempotent and will do nothing if infra is already in place
             mlrun.utils.vault.init_project_vault_configuration(project)
 
             # If no secrets were passed, no need to touch the actual secrets.
-            if secrets.secrets:
-                mlrun.utils.vault.store_vault_project_secrets(project, secrets.secrets)
+            if secrets_to_store:
+                mlrun.utils.vault.store_vault_project_secrets(project, secrets_to_store)
         elif secrets.provider == mlrun.api.schemas.SecretProviderName.kubernetes:
             if mlrun.api.utils.singletons.k8s.get_k8s():
                 mlrun.api.utils.singletons.k8s.get_k8s().store_project_secrets(
-                    project, secrets.secrets
+                    project, secrets_to_store
                 )
             else:
                 raise mlrun.errors.MLRunInternalServerError(
@@ -182,5 +204,137 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
             }
         return mlrun.api.schemas.SecretsData(provider=provider, secrets=secrets_data)
 
-    def _is_internal_secret_key(self, key: str):
+    def delete_secret(
+            self,
+            project: str,
+            provider: mlrun.api.schemas.SecretProviderName,
+            secret_key: str,
+            token: typing.Optional[str] = None,
+            allow_secrets_from_k8s: bool = False,
+            allow_internal_secrets: bool = False,
+            key_map_secret_key: typing.Optional[str] = None
+    ):
+        found_key_in_key_map = False
+        secret_key_to_remove = secret_key
+        if key_map_secret_key:
+            if provider != mlrun.api.schemas.SecretProviderName.kubernetes:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Secret using key map is not implemented for provider {provider}"
+                )
+            if self._is_secret_stored_in_key_map(secret_key):
+                secrets_data = self.list_secrets(project, provider, [key_map_secret_key], token, allow_secrets_from_k8s, allow_internal_secrets)
+                if secrets_data.secrets.get(key_map_secret_key):
+                    key_map = json.loads(secrets_data.secrets[key_map_secret_key])
+                    if secret_key in key_map:
+                        found_key_in_key_map = True
+                        secret_key_to_remove = key_map[secret_key]
+        self.delete_secrets(project, provider, [secret_key_to_remove], allow_internal_secrets)
+        if found_key_in_key_map:
+            # clean key from key map
+            key_map = self._get_secret_key_map(project, key_map_secret_key)
+            del key_map[secret_key]
+            self.store_secrets(project,
+                               mlrun.api.schemas.SecretsData(
+                                   provider=provider,
+                                   secrets={key_map_secret_key: json.dumps(key_map)},
+                               ),
+                               allow_internal_secrets=True,
+                               allow_key_maps=True)
+
+    def get_secret(
+        self,
+        project: str,
+        provider: mlrun.api.schemas.SecretProviderName,
+        secret_key: str,
+        token: typing.Optional[str] = None,
+        allow_secrets_from_k8s: bool = False,
+        allow_internal_secrets: bool = False,
+        key_map_secret_key: typing.Optional[str] = None
+    ) -> typing.Optional[str]:
+        if key_map_secret_key:
+            if provider != mlrun.api.schemas.SecretProviderName.kubernetes:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Secret using key map is not implemented for provider {provider}"
+                )
+            if self._is_secret_stored_in_key_map(secret_key):
+                secrets_data = self.list_secrets(project, provider, [key_map_secret_key], token, allow_secrets_from_k8s, allow_internal_secrets)
+                if secrets_data.secrets.get(key_map_secret_key):
+                    key_map = json.loads(secrets_data.secrets[key_map_secret_key])
+                    if secret_key in key_map:
+                        secret_key = key_map[secret_key]
+        secrets_data = self.list_secrets(project, provider, [secret_key], token, allow_secrets_from_k8s, allow_internal_secrets)
+        return secrets_data.secrets.get(secret_key)
+
+    def _validate_and_enrich_secrets_to_store(
+            self,
+            project: str,
+            secrets: mlrun.api.schemas.SecretsData,
+            allow_internal_secrets: bool = False,
+            key_map_secret_key: typing.Optional[str] = None,
+            allow_key_maps: bool = False,
+    ):
+        secrets_to_store = secrets.secrets.copy()
+        if secrets_to_store:
+            for secret_key in secrets_to_store.keys():
+                # key map is there to allow using invalid secret keys
+                if not key_map_secret_key:
+                    self.validate_secret_key_regex(secret_key)
+                self.validate_internal_secret_key_allowed(secret_key, allow_internal_secrets)
+                if self._is_key_map_secret_key(secret_key) and not allow_key_maps:
+                    raise mlrun.errors.MLRunAccessDeniedError(
+                        f"Not allowed to create/update key map (key starts with "
+                        f"{self.key_map_secrets_key_prefix})"
+                    )
+            if key_map_secret_key:
+                if secrets.provider != mlrun.api.schemas.SecretProviderName.kubernetes:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Storing secret using key map is not implemented for provider {secrets.provider}"
+                    )
+                if not self._is_key_map_secret_key(key_map_secret_key):
+                    raise mlrun.errors.MLRunInvalidArgumentError(f"Key map secret key must start with: {self.key_map_secrets_key_prefix}")
+                if not allow_internal_secrets:
+                    raise mlrun.errors.MLRunAccessDeniedError(
+                        f"Not allowed to create/update internal secrets (key starts with "
+                        f"{self.internal_secrets_key_prefix})"
+                    )
+                self.validate_secret_key_regex(key_map_secret_key)
+                secrets_to_store_in_key_map = [secret_key for secret_key in secrets_to_store.keys() if self._is_secret_stored_in_key_map(secret_key)]
+                if secrets_to_store_in_key_map:
+                    key_map = self._get_secret_key_map(project, key_map_secret_key) or {}
+                    key_map.update({secret_key: self._generate_uuid() for secret_key in secrets_to_store_in_key_map if secret_key not in key_map})
+                    updated_secrets_to_store = {}
+                    for key, value in secrets_to_store.items():
+                        if key in secrets_to_store_in_key_map:
+                            updated_secrets_to_store[key_map[key]] = value
+                        else:
+                            updated_secrets_to_store[key] = value
+                    updated_secrets_to_store[key_map_secret_key] = json.dumps(key_map)
+                    secrets_to_store = updated_secrets_to_store
+        return secrets_to_store
+
+    def _get_secret_key_map(
+            self,
+            project: str,
+            key_map_secret_key: str,
+    ) -> typing.Optional[dict]:
+        secrets_data = self.list_secrets(project, mlrun.api.schemas.SecretProviderName.kubernetes,
+                                         [key_map_secret_key], allow_secrets_from_k8s=True,
+                                         allow_internal_secrets=True)
+        value = secrets_data.secrets.get(key_map_secret_key)
+        if value:
+            value = json.loads(value)
+        return value
+
+    def _is_secret_stored_in_key_map(self, key: str) -> bool:
+        # Key map are only used for invalid keys
+        return not self.validate_secret_key_regex(key, raise_on_failure=False)
+
+    def _is_internal_secret_key(self, key: str) -> bool:
         return key.startswith(self.internal_secrets_key_prefix)
+
+    def _is_key_map_secret_key(self, key: str) -> bool:
+        return key.startswith(self.key_map_secrets_key_prefix)
+
+    @staticmethod
+    def _generate_uuid() -> str:
+        return str(uuid.uuid4())

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -43,7 +43,7 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
         secrets: mlrun.api.schemas.SecretsData,
         allow_internal_secrets: bool = False,
         key_map_secret_key: typing.Optional[str] = None,
-        allow_key_maps: bool = False,
+        allow_storing_key_maps: bool = False,
     ):
         """
         When secret keys are coming from other object identifiers, which may not be valid secret keys, use
@@ -52,7 +52,11 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
         list_secrets won't do any operation on the data and delete_secrets won't handle cleaning the key map
         """
         secrets_to_store = self._validate_and_enrich_secrets_to_store(
-            project, secrets, allow_internal_secrets, key_map_secret_key, allow_key_maps
+            project,
+            secrets,
+            allow_internal_secrets,
+            key_map_secret_key,
+            allow_storing_key_maps,
         )
 
         if secrets.provider == mlrun.api.schemas.SecretProviderName.vault:
@@ -237,7 +241,7 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
                         secrets={key_map_secret_key: json.dumps(key_map)},
                     ),
                     allow_internal_secrets=True,
-                    allow_key_maps=True,
+                    allow_storing_key_maps=True,
                 )
             else:
                 self.delete_secrets(
@@ -309,7 +313,7 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
         secrets: mlrun.api.schemas.SecretsData,
         allow_internal_secrets: bool = False,
         key_map_secret_key: typing.Optional[str] = None,
-        allow_key_maps: bool = False,
+        allow_storing_key_maps: bool = False,
     ):
         secrets_to_store = secrets.secrets.copy()
         if secrets_to_store:
@@ -320,7 +324,10 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
                 self.validate_internal_secret_key_allowed(
                     secret_key, allow_internal_secrets
                 )
-                if self._is_key_map_secret_key(secret_key) and not allow_key_maps:
+                if (
+                    self._is_key_map_secret_key(secret_key)
+                    and not allow_storing_key_maps
+                ):
                     raise mlrun.errors.MLRunAccessDeniedError(
                         f"Not allowed to create/update key map (key starts with "
                         f"{self.key_map_secrets_key_prefix})"

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -233,13 +233,16 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
             # clean key from key map
             key_map = self._get_secret_key_map(project, key_map_secret_key)
             del key_map[secret_key]
-            self.store_secrets(project,
-                               mlrun.api.schemas.SecretsData(
-                                   provider=provider,
-                                   secrets={key_map_secret_key: json.dumps(key_map)},
-                               ),
-                               allow_internal_secrets=True,
-                               allow_key_maps=True)
+            if key_map:
+                self.store_secrets(project,
+                                   mlrun.api.schemas.SecretsData(
+                                       provider=provider,
+                                       secrets={key_map_secret_key: json.dumps(key_map)},
+                                   ),
+                                   allow_internal_secrets=True,
+                                   allow_key_maps=True)
+            else:
+                self.delete_secrets(project, provider, [key_map_secret_key], allow_internal_secrets=True)
 
     def get_secret(
         self,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -284,6 +284,7 @@ class Scheduler:
                 project,
                 self._secrets_provider,
                 secret_key,
+                allow_secrets_from_k8s=True,
                 allow_internal_secrets=True,
                 key_map_secret_key=secret_key_map,
             )

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -114,7 +114,7 @@ class run_keys:
     secrets = "secret_sources"
 
 
-def verify_field_regex(field_name, field_value, patterns):
+def verify_field_regex(field_name, field_value, patterns, raise_on_failure:bool = True) -> bool:
     logger.debug(
         "Validating field against patterns",
         field_name=field_name,
@@ -124,15 +124,20 @@ def verify_field_regex(field_name, field_value, patterns):
 
     for pattern in patterns:
         if not re.match(pattern, str(field_value)):
-            logger.warn(
+            log_func = logger.warn if raise_on_failure else logger.debug
+            log_func(
                 "Field is malformed. Does not match required pattern",
                 field_name=field_name,
                 field_value=field_value,
                 pattern=pattern,
             )
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Field '{field_name}' is malformed. Does not match required pattern: {pattern}"
-            )
+            if raise_on_failure:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Field '{field_name}' is malformed. Does not match required pattern: {pattern}"
+                )
+            else:
+                return False
+    return True
 
 
 # Verifying that a field input is of the expected type. If not the method raises a detailed MLRunInvalidArgumentError

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -114,7 +114,9 @@ class run_keys:
     secrets = "secret_sources"
 
 
-def verify_field_regex(field_name, field_value, patterns, raise_on_failure:bool = True) -> bool:
+def verify_field_regex(
+    field_name, field_value, patterns, raise_on_failure: bool = True
+) -> bool:
     logger.debug(
         "Validating field against patterns",
         field_name=field_name,

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -83,12 +83,12 @@ def test_store_secrets_with_key_map_verifications(
             key_map_secret_key=f"{mlrun.api.crud.Secrets().key_map_secrets_key_prefix}invalid/key",
         )
 
-    # internal not allowed
+    # Internal must be allowed when using key maps, verify that without internal allowed we fail
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         mlrun.api.crud.Secrets().store_secrets(
             project,
             mlrun.api.schemas.SecretsData(
-                provider=provider, secrets={"invalid/key": "value"}
+                provider=provider, secrets={"valid-key": "value"}
             ),
             key_map_secret_key=key_map_secret_key,
         )

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -1,8 +1,8 @@
-import json
 import collections
+import json
+import unittest.mock
 
 import deepdiff
-import unittest.mock
 import fastapi.testclient
 import pytest
 import sqlalchemy.orm
@@ -36,9 +36,9 @@ def test_store_secrets_verifications(
 
 
 def test_store_secrets_with_key_map_verifications(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
@@ -57,7 +57,8 @@ def test_store_secrets_with_key_map_verifications(
         mlrun.api.crud.Secrets().store_secrets(
             project,
             mlrun.api.schemas.SecretsData(
-                provider=mlrun.api.schemas.SecretProviderName.vault, secrets={"invalid/key": "value"}
+                provider=mlrun.api.schemas.SecretProviderName.vault,
+                secrets={"invalid/key": "value"},
             ),
         )
 
@@ -68,7 +69,7 @@ def test_store_secrets_with_key_map_verifications(
             mlrun.api.schemas.SecretsData(
                 provider=provider, secrets={"invalid/key": "value"}
             ),
-            key_map_secret_key="invalid-key-map-secret-key"
+            key_map_secret_key="invalid-key-map-secret-key",
         )
 
     # internal not allowed
@@ -78,14 +79,14 @@ def test_store_secrets_with_key_map_verifications(
             mlrun.api.schemas.SecretsData(
                 provider=provider, secrets={"invalid/key": "value"}
             ),
-            key_map_secret_key=key_map_secret_key
+            key_map_secret_key=key_map_secret_key,
         )
 
 
 def test_get_secret_verifications(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
@@ -98,14 +99,18 @@ def test_get_secret_verifications(
 
     # key map with provider other than k8s
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-        mlrun.api.crud.Secrets().get_secret(project, mlrun.api.schemas.SecretProviderName.vault, "does-not-exist-key",
-                                            key_map_secret_key=key_map_secret_key)
+        mlrun.api.crud.Secrets().get_secret(
+            project,
+            mlrun.api.schemas.SecretProviderName.vault,
+            "does-not-exist-key",
+            key_map_secret_key=key_map_secret_key,
+        )
 
 
 def test_get_secret(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
     _mock_secrets_crud_uuid_generation()
     project = "project-name"
@@ -119,31 +124,72 @@ def test_get_secret(
     valid_secret_value = "some-value-5"
 
     # sanity - none returned on keys that does not exist
-    assert mlrun.api.crud.Secrets().get_secret(project, provider, "does-not-exist-key", allow_secrets_from_k8s=True) is None
-    assert mlrun.api.crud.Secrets().get_secret(project, provider, "does-not-exist-key", allow_secrets_from_k8s=True,
-                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key) is None
+    assert (
+        mlrun.api.crud.Secrets().get_secret(
+            project, provider, "does-not-exist-key", allow_secrets_from_k8s=True
+        )
+        is None
+    )
+    assert (
+        mlrun.api.crud.Secrets().get_secret(
+            project,
+            provider,
+            "does-not-exist-key",
+            allow_secrets_from_k8s=True,
+            allow_internal_secrets=True,
+            key_map_secret_key=key_map_secret_key,
+        )
+        is None
+    )
 
     mlrun.api.crud.Secrets().store_secrets(
         project,
         mlrun.api.schemas.SecretsData(
-            provider=provider, secrets={valid_secret_key: valid_secret_value,
-                                        invalid_secret_key: invalid_secret_value,
-                                        invalid_secret_2_key: invalid_secret_2_value}
+            provider=provider,
+            secrets={
+                valid_secret_key: valid_secret_value,
+                invalid_secret_key: invalid_secret_value,
+                invalid_secret_2_key: invalid_secret_2_value,
+            },
         ),
         True,
         key_map_secret_key,
     )
 
-    assert mlrun.api.crud.Secrets().get_secret(project, provider, valid_secret_key, allow_secrets_from_k8s=True) == valid_secret_value
-    assert mlrun.api.crud.Secrets().get_secret(project, provider, invalid_secret_key, allow_secrets_from_k8s=True,
-                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key) == invalid_secret_value
-    assert mlrun.api.crud.Secrets().get_secret(project, provider, invalid_secret_2_key, allow_secrets_from_k8s=True,
-                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key) == invalid_secret_2_value
+    assert (
+        mlrun.api.crud.Secrets().get_secret(
+            project, provider, valid_secret_key, allow_secrets_from_k8s=True
+        )
+        == valid_secret_value
+    )
+    assert (
+        mlrun.api.crud.Secrets().get_secret(
+            project,
+            provider,
+            invalid_secret_key,
+            allow_secrets_from_k8s=True,
+            allow_internal_secrets=True,
+            key_map_secret_key=key_map_secret_key,
+        )
+        == invalid_secret_value
+    )
+    assert (
+        mlrun.api.crud.Secrets().get_secret(
+            project,
+            provider,
+            invalid_secret_2_key,
+            allow_secrets_from_k8s=True,
+            allow_internal_secrets=True,
+            key_map_secret_key=key_map_secret_key,
+        )
+        == invalid_secret_2_value
+    )
+
 
 def test_delete_secret_verifications(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
@@ -157,84 +203,121 @@ def test_delete_secret_verifications(
 
     # vault provider
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-        mlrun.api.crud.Secrets().delete_secret(project, mlrun.api.schemas.SecretProviderName.vault, "valid-key")
+        mlrun.api.crud.Secrets().delete_secret(
+            project, mlrun.api.schemas.SecretProviderName.vault, "valid-key"
+        )
 
     # key map with provider other than k8s
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-        mlrun.api.crud.Secrets().delete_secret(project, mlrun.api.schemas.SecretProviderName.vault, "invalid/key",
-                                            key_map_secret_key=key_map_secret_key)
+        mlrun.api.crud.Secrets().delete_secret(
+            project,
+            mlrun.api.schemas.SecretProviderName.vault,
+            "invalid/key",
+            key_map_secret_key=key_map_secret_key,
+        )
 
     # key map without allow from k8s provider other than k8s
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
-        mlrun.api.crud.Secrets().delete_secret(project, provider, "invalid/key",
-                                               key_map_secret_key=key_map_secret_key)
+        mlrun.api.crud.Secrets().delete_secret(
+            project, provider, "invalid/key", key_map_secret_key=key_map_secret_key
+        )
 
 
 def test_delete_secret(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
-        _mock_secrets_crud_uuid_generation()
-        project = "project-name"
-        provider = mlrun.api.schemas.SecretProviderName.kubernetes
-        key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
-        invalid_secret_key = "invalid/key"
-        invalid_secret_value = "some-value"
-        invalid_secret_2_key = "invalid/key/2"
-        invalid_secret_2_value = "some-value-3"
-        valid_secret_key = "valid-key"
-        valid_secret_value = "some-value-5"
+    _mock_secrets_crud_uuid_generation()
+    project = "project-name"
+    provider = mlrun.api.schemas.SecretProviderName.kubernetes
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    invalid_secret_key = "invalid/key"
+    invalid_secret_value = "some-value"
+    invalid_secret_2_key = "invalid/key/2"
+    invalid_secret_2_value = "some-value-3"
+    valid_secret_key = "valid-key"
+    valid_secret_value = "some-value-5"
 
-        # sanity - do not explode on deleting key that doesn't exist
-        mlrun.api.crud.Secrets().delete_secret(project, provider, "does-not-exist-key", allow_secrets_from_k8s=True)
+    # sanity - do not explode on deleting key that doesn't exist
+    mlrun.api.crud.Secrets().delete_secret(
+        project, provider, "does-not-exist-key", allow_secrets_from_k8s=True
+    )
 
-        mlrun.api.crud.Secrets().store_secrets(
-            project,
-            mlrun.api.schemas.SecretsData(
-                provider=provider, secrets=collections.OrderedDict({valid_secret_key: valid_secret_value,
-                                            invalid_secret_key: invalid_secret_value,
-                                            invalid_secret_2_key: invalid_secret_2_value})
+    mlrun.api.crud.Secrets().store_secrets(
+        project,
+        mlrun.api.schemas.SecretsData(
+            provider=provider,
+            secrets=collections.OrderedDict(
+                {
+                    valid_secret_key: valid_secret_value,
+                    invalid_secret_key: invalid_secret_value,
+                    invalid_secret_2_key: invalid_secret_2_value,
+                }
             ),
-            True,
-            key_map_secret_key,
-        )
+        ),
+        True,
+        key_map_secret_key,
+    )
 
-        k8s_secrets_mock.assert_project_secrets(project,
-                                                {
-                                                    valid_secret_key: valid_secret_value,
-                                                    0: invalid_secret_value,
-                                                    1: invalid_secret_2_value,
-                                                    key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
-                                                })
+    k8s_secrets_mock.assert_project_secrets(
+        project,
+        {
+            valid_secret_key: valid_secret_value,
+            0: invalid_secret_value,
+            1: invalid_secret_2_value,
+            key_map_secret_key: json.dumps(
+                {invalid_secret_key: 0, invalid_secret_2_key: 1}
+            ),
+        },
+    )
 
-        mlrun.api.crud.Secrets().delete_secret(project, provider, valid_secret_key, allow_secrets_from_k8s=True)
+    mlrun.api.crud.Secrets().delete_secret(
+        project, provider, valid_secret_key, allow_secrets_from_k8s=True
+    )
 
-        k8s_secrets_mock.assert_project_secrets(project,
-                                                {
-                                                    0: invalid_secret_value,
-                                                    1: invalid_secret_2_value,
-                                                    key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
-                                                })
+    k8s_secrets_mock.assert_project_secrets(
+        project,
+        {
+            0: invalid_secret_value,
+            1: invalid_secret_2_value,
+            key_map_secret_key: json.dumps(
+                {invalid_secret_key: 0, invalid_secret_2_key: 1}
+            ),
+        },
+    )
 
-        mlrun.api.crud.Secrets().delete_secret(project, provider, invalid_secret_key, allow_secrets_from_k8s=True,
-                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key)
-        k8s_secrets_mock.assert_project_secrets(project,
-                                                {
-                                                    1: invalid_secret_2_value,
-                                                    key_map_secret_key: json.dumps({invalid_secret_2_key: 1})
-                                                })
+    mlrun.api.crud.Secrets().delete_secret(
+        project,
+        provider,
+        invalid_secret_key,
+        allow_secrets_from_k8s=True,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
+    )
+    k8s_secrets_mock.assert_project_secrets(
+        project,
+        {
+            1: invalid_secret_2_value,
+            key_map_secret_key: json.dumps({invalid_secret_2_key: 1}),
+        },
+    )
 
-        mlrun.api.crud.Secrets().delete_secret(project, provider, invalid_secret_2_key, allow_secrets_from_k8s=True,
-                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key)
-        k8s_secrets_mock.assert_project_secrets(project,
-                                                {})
+    mlrun.api.crud.Secrets().delete_secret(
+        project,
+        provider,
+        invalid_secret_2_key,
+        allow_secrets_from_k8s=True,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
+    )
+    k8s_secrets_mock.assert_project_secrets(project, {})
 
 
 def test_store_secrets_with_key_map_success(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
     _mock_secrets_crud_uuid_generation()
     project = "project-name"
@@ -259,7 +342,9 @@ def test_store_secrets_with_key_map_success(
         True,
         key_map_secret_key,
     )
-    k8s_secrets_mock.assert_project_secrets(project, {valid_secret_key: valid_secret_value})
+    k8s_secrets_mock.assert_project_secrets(
+        project, {valid_secret_key: valid_secret_value}
+    )
 
     # store secret with invalid key - map should be used
     mlrun.api.crud.Secrets().store_secrets(
@@ -270,12 +355,14 @@ def test_store_secrets_with_key_map_success(
         True,
         key_map_secret_key,
     )
-    k8s_secrets_mock.assert_project_secrets(project,
-                                            {
-                                                valid_secret_key: valid_secret_value,
-                                                0: invalid_secret_value,
-                                                key_map_secret_key: json.dumps({invalid_secret_key: 0})
-                                            })
+    k8s_secrets_mock.assert_project_secrets(
+        project,
+        {
+            valid_secret_key: valid_secret_value,
+            0: invalid_secret_value,
+            key_map_secret_key: json.dumps({invalid_secret_key: 0}),
+        },
+    )
 
     # store secret with the same invalid key and different value
     mlrun.api.crud.Secrets().store_secrets(
@@ -286,57 +373,76 @@ def test_store_secrets_with_key_map_success(
         True,
         key_map_secret_key,
     )
-    k8s_secrets_mock.assert_project_secrets(project,
-                                            {
-                                                valid_secret_key: valid_secret_value,
-                                                0: invalid_secret_value_2,
-                                                key_map_secret_key: json.dumps({invalid_secret_key: 0})
-                                            })
+    k8s_secrets_mock.assert_project_secrets(
+        project,
+        {
+            valid_secret_key: valid_secret_value,
+            0: invalid_secret_value_2,
+            key_map_secret_key: json.dumps({invalid_secret_key: 0}),
+        },
+    )
 
     # store secret with the different invalid key and value - do it twice - nothing should change
     for _ in range(2):
         mlrun.api.crud.Secrets().store_secrets(
             project,
             mlrun.api.schemas.SecretsData(
-                provider=provider, secrets={invalid_secret_2_key: invalid_secret_2_value}
+                provider=provider,
+                secrets={invalid_secret_2_key: invalid_secret_2_value},
             ),
             True,
             key_map_secret_key,
         )
-        k8s_secrets_mock.assert_project_secrets(project,
-                                                {
-                                                    valid_secret_key: valid_secret_value,
-                                                    0: invalid_secret_value_2,
-                                                    1: invalid_secret_2_value,
-                                                    key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
-                                                })
+        k8s_secrets_mock.assert_project_secrets(
+            project,
+            {
+                valid_secret_key: valid_secret_value,
+                0: invalid_secret_value_2,
+                1: invalid_secret_2_value,
+                key_map_secret_key: json.dumps(
+                    {invalid_secret_key: 0, invalid_secret_2_key: 1}
+                ),
+            },
+        )
 
     # change values to all secrets
     mlrun.api.crud.Secrets().store_secrets(
         project,
         mlrun.api.schemas.SecretsData(
-            provider=provider, secrets={valid_secret_key: valid_secret_value_2,
-                                        invalid_secret_key: invalid_secret_value,
-                                        invalid_secret_2_key: invalid_secret_2_value_2}
+            provider=provider,
+            secrets={
+                valid_secret_key: valid_secret_value_2,
+                invalid_secret_key: invalid_secret_value,
+                invalid_secret_2_key: invalid_secret_2_value_2,
+            },
         ),
         True,
         key_map_secret_key,
     )
-    k8s_secrets_mock.assert_project_secrets(project,
-                                            {
-                                                valid_secret_key: valid_secret_value_2,
-                                                0: invalid_secret_value,
-                                                1: invalid_secret_2_value_2,
-                                                key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
-                                            })
+    k8s_secrets_mock.assert_project_secrets(
+        project,
+        {
+            valid_secret_key: valid_secret_value_2,
+            0: invalid_secret_value,
+            1: invalid_secret_2_value_2,
+            key_map_secret_key: json.dumps(
+                {invalid_secret_key: 0, invalid_secret_2_key: 1}
+            ),
+        },
+    )
+
 
 def _mock_secrets_crud_uuid_generation():
     uuids_list = [i for i in range(10000)]
     uuids_iter = iter(uuids_list)
+
     def _mock_generate_uuid():
         return next(uuids_iter)
 
-    mlrun.api.crud.Secrets()._generate_uuid = unittest.mock.Mock(side_effect=_mock_generate_uuid)
+    mlrun.api.crud.Secrets()._generate_uuid = unittest.mock.Mock(
+        side_effect=_mock_generate_uuid
+    )
+
 
 def test_secrets_crud_internal_secrets(
     db: sqlalchemy.orm.Session,

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -163,8 +163,8 @@ def test_get_secret(
                 invalid_secret_2_key: invalid_secret_2_value,
             },
         ),
-        True,
-        key_map_secret_key,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
     )
 
     assert (
@@ -267,8 +267,8 @@ def test_delete_secret(
                 }
             ),
         ),
-        True,
-        key_map_secret_key,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
     )
 
     k8s_secrets_mock.assert_project_secrets(
@@ -350,8 +350,8 @@ def test_store_secrets_with_key_map_success(
         mlrun.api.schemas.SecretsData(
             provider=provider, secrets={valid_secret_key: valid_secret_value}
         ),
-        True,
-        key_map_secret_key,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
     )
     k8s_secrets_mock.assert_project_secrets(
         project, {valid_secret_key: valid_secret_value}
@@ -363,8 +363,8 @@ def test_store_secrets_with_key_map_success(
         mlrun.api.schemas.SecretsData(
             provider=provider, secrets={invalid_secret_key: invalid_secret_value}
         ),
-        True,
-        key_map_secret_key,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
     )
     k8s_secrets_mock.assert_project_secrets(
         project,
@@ -381,8 +381,8 @@ def test_store_secrets_with_key_map_success(
         mlrun.api.schemas.SecretsData(
             provider=provider, secrets={invalid_secret_key: invalid_secret_value_2}
         ),
-        True,
-        key_map_secret_key,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
     )
     k8s_secrets_mock.assert_project_secrets(
         project,
@@ -401,8 +401,8 @@ def test_store_secrets_with_key_map_success(
                 provider=provider,
                 secrets={invalid_secret_2_key: invalid_secret_2_value},
             ),
-            True,
-            key_map_secret_key,
+            allow_internal_secrets=True,
+            key_map_secret_key=key_map_secret_key,
         )
         k8s_secrets_mock.assert_project_secrets(
             project,
@@ -427,8 +427,8 @@ def test_store_secrets_with_key_map_success(
                 invalid_secret_2_key: invalid_secret_2_value_2,
             },
         ),
-        True,
-        key_map_secret_key,
+        allow_internal_secrets=True,
+        key_map_secret_key=key_map_secret_key,
     )
     k8s_secrets_mock.assert_project_secrets(
         project,

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -227,7 +227,7 @@ def test_delete_secret_verifications(
             key_map_secret_key=key_map_secret_key,
         )
 
-    # key map without allow from k8s provider other than k8s
+    # key map without allow from k8s provider
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         mlrun.api.crud.Secrets().delete_secret(
             project, provider, "invalid/key", key_map_secret_key=key_map_secret_key

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -62,7 +62,7 @@ def test_store_secrets_with_key_map_verifications(
             ),
         )
 
-    # invalid key map name
+    # invalid key map name (wrong prefix)
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
         mlrun.api.crud.Secrets().store_secrets(
             project,
@@ -70,6 +70,17 @@ def test_store_secrets_with_key_map_verifications(
                 provider=provider, secrets={"invalid/key": "value"}
             ),
             key_map_secret_key="invalid-key-map-secret-key",
+        )
+
+    # invalid key map name but with correct prefix
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=provider, secrets={"invalid/key": "value"}
+            ),
+            allow_internal_secrets=True,
+            key_map_secret_key=f"{mlrun.api.crud.Secrets().key_map_secrets_key_prefix}invalid/key",
         )
 
     # internal not allowed

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -1,4 +1,8 @@
+import json
+import collections
+
 import deepdiff
+import unittest.mock
 import fastapi.testclient
 import pytest
 import sqlalchemy.orm
@@ -30,6 +34,309 @@ def test_store_secrets_verifications(
             ),
         )
 
+
+def test_store_secrets_with_key_map_verifications(
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+    project = "project-name"
+    provider = mlrun.api.schemas.SecretProviderName.kubernetes
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    # not allowed to edit key map
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=provider, secrets={key_map_secret_key: "value"}
+            ),
+        )
+
+    # not allowed with provider other than k8s
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=mlrun.api.schemas.SecretProviderName.vault, secrets={"invalid/key": "value"}
+            ),
+        )
+
+    # invalid key map name
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=provider, secrets={"invalid/key": "value"}
+            ),
+            key_map_secret_key="invalid-key-map-secret-key"
+        )
+
+    # internal not allowed
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=provider, secrets={"invalid/key": "value"}
+            ),
+            key_map_secret_key=key_map_secret_key
+        )
+
+
+def test_get_secret_verifications(
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+    project = "project-name"
+    provider = mlrun.api.schemas.SecretProviderName.kubernetes
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+
+    # verifications check
+    # not allowed from k8s
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        mlrun.api.crud.Secrets().get_secret(project, provider, "does-not-exist-key")
+
+    # key map with provider other than k8s
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.api.crud.Secrets().get_secret(project, mlrun.api.schemas.SecretProviderName.vault, "does-not-exist-key",
+                                            key_map_secret_key=key_map_secret_key)
+
+
+def test_get_secret(
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+    _mock_secrets_crud_uuid_generation()
+    project = "project-name"
+    provider = mlrun.api.schemas.SecretProviderName.kubernetes
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    invalid_secret_key = "invalid/key"
+    invalid_secret_value = "some-value"
+    invalid_secret_2_key = "invalid/key/2"
+    invalid_secret_2_value = "some-value-3"
+    valid_secret_key = "valid-key"
+    valid_secret_value = "some-value-5"
+
+    # sanity - none returned on keys that does not exist
+    assert mlrun.api.crud.Secrets().get_secret(project, provider, "does-not-exist-key", allow_secrets_from_k8s=True) is None
+    assert mlrun.api.crud.Secrets().get_secret(project, provider, "does-not-exist-key", allow_secrets_from_k8s=True,
+                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key) is None
+
+    mlrun.api.crud.Secrets().store_secrets(
+        project,
+        mlrun.api.schemas.SecretsData(
+            provider=provider, secrets={valid_secret_key: valid_secret_value,
+                                        invalid_secret_key: invalid_secret_value,
+                                        invalid_secret_2_key: invalid_secret_2_value}
+        ),
+        True,
+        key_map_secret_key,
+    )
+
+    assert mlrun.api.crud.Secrets().get_secret(project, provider, valid_secret_key, allow_secrets_from_k8s=True) == valid_secret_value
+    assert mlrun.api.crud.Secrets().get_secret(project, provider, invalid_secret_key, allow_secrets_from_k8s=True,
+                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key) == invalid_secret_value
+    assert mlrun.api.crud.Secrets().get_secret(project, provider, invalid_secret_2_key, allow_secrets_from_k8s=True,
+                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key) == invalid_secret_2_value
+
+def test_delete_secret_verifications(
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+    project = "project-name"
+    provider = mlrun.api.schemas.SecretProviderName.kubernetes
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    internal_key = mlrun.api.crud.Secrets().generate_schedule_secret_key("some-name")
+
+    # verifications check
+    # internal key without allow
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        mlrun.api.crud.Secrets().delete_secret(project, provider, internal_key)
+
+    # vault provider
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.api.crud.Secrets().delete_secret(project, mlrun.api.schemas.SecretProviderName.vault, "valid-key")
+
+    # key map with provider other than k8s
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.api.crud.Secrets().delete_secret(project, mlrun.api.schemas.SecretProviderName.vault, "invalid/key",
+                                            key_map_secret_key=key_map_secret_key)
+
+    # key map without allow from k8s provider other than k8s
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        mlrun.api.crud.Secrets().delete_secret(project, provider, "invalid/key",
+                                               key_map_secret_key=key_map_secret_key)
+
+
+def test_delete_secret(
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+        _mock_secrets_crud_uuid_generation()
+        project = "project-name"
+        provider = mlrun.api.schemas.SecretProviderName.kubernetes
+        key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+        invalid_secret_key = "invalid/key"
+        invalid_secret_value = "some-value"
+        invalid_secret_2_key = "invalid/key/2"
+        invalid_secret_2_value = "some-value-3"
+        valid_secret_key = "valid-key"
+        valid_secret_value = "some-value-5"
+
+        # sanity - do not explode on deleting key that doesn't exist
+        mlrun.api.crud.Secrets().delete_secret(project, provider, "does-not-exist-key", allow_secrets_from_k8s=True)
+
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=provider, secrets=collections.OrderedDict({valid_secret_key: valid_secret_value,
+                                            invalid_secret_key: invalid_secret_value,
+                                            invalid_secret_2_key: invalid_secret_2_value})
+            ),
+            True,
+            key_map_secret_key,
+        )
+
+        k8s_secrets_mock.assert_project_secrets(project,
+                                                {
+                                                    valid_secret_key: valid_secret_value,
+                                                    0: invalid_secret_value,
+                                                    1: invalid_secret_2_value,
+                                                    key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
+                                                })
+
+        mlrun.api.crud.Secrets().delete_secret(project, provider, valid_secret_key, allow_secrets_from_k8s=True)
+
+        k8s_secrets_mock.assert_project_secrets(project,
+                                                {
+                                                    0: invalid_secret_value,
+                                                    1: invalid_secret_2_value,
+                                                    key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
+                                                })
+
+        mlrun.api.crud.Secrets().delete_secret(project, provider, invalid_secret_key, allow_secrets_from_k8s=True,
+                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key)
+        k8s_secrets_mock.assert_project_secrets(project,
+                                                {
+                                                    1: invalid_secret_2_value,
+                                                    key_map_secret_key: json.dumps({invalid_secret_2_key: 1})
+                                                })
+
+        mlrun.api.crud.Secrets().delete_secret(project, provider, invalid_secret_2_key, allow_secrets_from_k8s=True,
+                                               allow_internal_secrets=True, key_map_secret_key=key_map_secret_key)
+        k8s_secrets_mock.assert_project_secrets(project,
+                                                {})
+
+
+def test_store_secrets_with_key_map_success(
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+        k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+    _mock_secrets_crud_uuid_generation()
+    project = "project-name"
+    provider = mlrun.api.schemas.SecretProviderName.kubernetes
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    invalid_secret_key = "invalid/key"
+    invalid_secret_value = "some-value"
+    invalid_secret_value_2 = "some-value-2"
+    invalid_secret_2_key = "invalid/key/2"
+    invalid_secret_2_value = "some-value-3"
+    invalid_secret_2_value_2 = "some-value-4"
+    valid_secret_key = "valid-key"
+    valid_secret_value = "some-value-5"
+    valid_secret_value_2 = "some-value-6"
+
+    # store secret with valid key - map shouldn't be used
+    mlrun.api.crud.Secrets().store_secrets(
+        project,
+        mlrun.api.schemas.SecretsData(
+            provider=provider, secrets={valid_secret_key: valid_secret_value}
+        ),
+        True,
+        key_map_secret_key,
+    )
+    k8s_secrets_mock.assert_project_secrets(project, {valid_secret_key: valid_secret_value})
+
+    # store secret with invalid key - map should be used
+    mlrun.api.crud.Secrets().store_secrets(
+        project,
+        mlrun.api.schemas.SecretsData(
+            provider=provider, secrets={invalid_secret_key: invalid_secret_value}
+        ),
+        True,
+        key_map_secret_key,
+    )
+    k8s_secrets_mock.assert_project_secrets(project,
+                                            {
+                                                valid_secret_key: valid_secret_value,
+                                                0: invalid_secret_value,
+                                                key_map_secret_key: json.dumps({invalid_secret_key: 0})
+                                            })
+
+    # store secret with the same invalid key and different value
+    mlrun.api.crud.Secrets().store_secrets(
+        project,
+        mlrun.api.schemas.SecretsData(
+            provider=provider, secrets={invalid_secret_key: invalid_secret_value_2}
+        ),
+        True,
+        key_map_secret_key,
+    )
+    k8s_secrets_mock.assert_project_secrets(project,
+                                            {
+                                                valid_secret_key: valid_secret_value,
+                                                0: invalid_secret_value_2,
+                                                key_map_secret_key: json.dumps({invalid_secret_key: 0})
+                                            })
+
+    # store secret with the different invalid key and value - do it twice - nothing should change
+    for _ in range(2):
+        mlrun.api.crud.Secrets().store_secrets(
+            project,
+            mlrun.api.schemas.SecretsData(
+                provider=provider, secrets={invalid_secret_2_key: invalid_secret_2_value}
+            ),
+            True,
+            key_map_secret_key,
+        )
+        k8s_secrets_mock.assert_project_secrets(project,
+                                                {
+                                                    valid_secret_key: valid_secret_value,
+                                                    0: invalid_secret_value_2,
+                                                    1: invalid_secret_2_value,
+                                                    key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
+                                                })
+
+    # change values to all secrets
+    mlrun.api.crud.Secrets().store_secrets(
+        project,
+        mlrun.api.schemas.SecretsData(
+            provider=provider, secrets={valid_secret_key: valid_secret_value_2,
+                                        invalid_secret_key: invalid_secret_value,
+                                        invalid_secret_2_key: invalid_secret_2_value_2}
+        ),
+        True,
+        key_map_secret_key,
+    )
+    k8s_secrets_mock.assert_project_secrets(project,
+                                            {
+                                                valid_secret_key: valid_secret_value_2,
+                                                0: invalid_secret_value,
+                                                1: invalid_secret_2_value_2,
+                                                key_map_secret_key: json.dumps({invalid_secret_key: 0, invalid_secret_2_key: 1})
+                                            })
+
+def _mock_secrets_crud_uuid_generation():
+    uuids_list = [i for i in range(10000)]
+    uuids_iter = iter(uuids_list)
+    def _mock_generate_uuid():
+        return next(uuids_iter)
+
+    mlrun.api.crud.Secrets()._generate_uuid = unittest.mock.Mock(side_effect=_mock_generate_uuid)
 
 def test_secrets_crud_internal_secrets(
     db: sqlalchemy.orm.Session,

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -444,8 +444,7 @@ def test_store_secrets_with_key_map_success(
 
 
 def _mock_secrets_crud_uuid_generation():
-    uuids_list = [i for i in range(10000)]
-    uuids_iter = iter(uuids_list)
+    uuids_iter = iter(range(10000))
 
     def _mock_generate_uuid():
         return next(uuids_iter)


### PR DESCRIPTION
We started saving each schedule credentials in project secrets, so far we used the schedule key to generate the secret key, but secret keys in k8s have restriction which schedule names might not X to.
Therefore I added a mechanism to save a key map in a value of another secret key, that is simply a json dump of a map between the schedule names to generated uuids that are used as the actual secret keys.
Note that we're using the key map only when needed - for schedule names that are invalid secret keys
2 other solutions brought up that we decided not to choose:
1. "Hashing"/base64 encoding the schedule name - hashing is not bidirectional, and base64 has characters that are invalid in a secret key
2. Adding an annotation on the schedule holding the secret key - this makes debugging harder as in order to understand  which secret key relevant to what schedule you need either access to the DB or to the logs (which might rotate)
