### PR TITLE
[API] Add basic OPA verification for marketplace APIs

### DIFF
--- a/mlrun/api/api/endpoints/marketplace.py
+++ b/mlrun/api/api/endpoints/marketplace.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from sqlalchemy.orm import Session
 
 import mlrun
+import mlrun.api.utils.clients.opa
 from mlrun.api.api.deps import AuthVerifierDep
 from mlrun.api.crud.marketplace import Marketplace
 from mlrun.api.schemas import AuthorizationAction

--- a/mlrun/api/api/endpoints/marketplace.py
+++ b/mlrun/api/api/endpoints/marketplace.py
@@ -30,7 +30,11 @@ def create_source(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.create)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.create,
+        auth_verifier.auth_info,
+    )
 
     get_db().create_marketplace_source(db_session, source)
     # Handle credentials if they exist
@@ -45,7 +49,11 @@ def list_sources(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.read)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.read,
+        auth_verifier.auth_info,
+    )
 
     return get_db().list_marketplace_sources(db_session)
 
@@ -58,7 +66,11 @@ def delete_source(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.delete)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.delete,
+        auth_verifier.auth_info,
+    )
 
     get_db().delete_marketplace_source(db_session, source_name)
     Marketplace().remove_source(source_name)
@@ -72,7 +84,11 @@ def get_source(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.read)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.read,
+        auth_verifier.auth_info,
+    )
 
     return get_db().get_marketplace_source(db_session, source_name)
 
@@ -86,7 +102,11 @@ def store_source(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.store)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.store,
+        auth_verifier.auth_info,
+    )
 
     get_db().store_marketplace_source(db_session, source_name, source)
     # Handle credentials if they exist
@@ -107,7 +127,11 @@ def get_catalog(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.read)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.read,
+        auth_verifier.auth_info,
+    )
 
     ordered_source = get_db().get_marketplace_source(db_session, source_name)
     return Marketplace().get_source_catalog(
@@ -129,7 +153,11 @@ def get_item(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.read)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.read,
+        auth_verifier.auth_info,
+    )
 
     ordered_source = get_db().get_marketplace_source(db_session, source_name)
     return Marketplace().get_item(
@@ -144,7 +172,11 @@ def get_object(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_verifier: AuthVerifierDep = Depends(AuthVerifierDep),
 ):
-    _verify_action_allowed(auth_verifier, AuthorizationAction.read)
+    mlrun.api.utils.clients.opa.Client().query_global_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
+        AuthorizationAction.read,
+        auth_verifier.auth_info,
+    )
 
     ordered_source = get_db().get_marketplace_source(db_session, source_name)
     object_data = Marketplace().get_item_object_using_source_credentials(
@@ -158,14 +190,3 @@ def get_object(
     if not ctype:
         ctype = "application/octet-stream"
     return Response(content=object_data, media_type=ctype)
-
-
-def _verify_action_allowed(auth_verifier: AuthVerifierDep, action: AuthorizationAction):
-    # We don't pass a project or resource name, since marketplace permissions are global for now.
-    mlrun.api.utils.clients.opa.Client().query_resource_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
-        "",
-        "",
-        action,
-        auth_verifier.auth_info,
-    )

--- a/mlrun/api/schemas/auth.py
+++ b/mlrun/api/schemas/auth.py
@@ -39,6 +39,7 @@ class AuthorizationResourceTypes(str, enum.Enum):
     run = "run"
     model_endpoint = "model-endpoint"
     pipeline = "pipeline"
+    marketplace_source = "marketplace-source"
 
     def to_resource_string(
         self, project_name: str, resource_name: str,
@@ -59,6 +60,8 @@ class AuthorizationResourceTypes(str, enum.Enum):
             AuthorizationResourceTypes.runtime_resource: "/projects/{project_name}/runtime-resources",
             AuthorizationResourceTypes.model_endpoint: "/projects/{project_name}/model-endpoints/{resource_name}",
             AuthorizationResourceTypes.pipeline: "/projects/{project_name}/pipelines/{resource_name}",
+            # Marketplace sources are not project-scoped, and auth is globally on the sources endpoint.
+            AuthorizationResourceTypes.marketplace_source: "/marketplace/sources",
         }[self].format(project_name=project_name, resource_name=resource_name)
 
 

--- a/mlrun/api/utils/clients/opa.py
+++ b/mlrun/api/utils/clients/opa.py
@@ -159,7 +159,8 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ):
+    ) -> bool:
+        logger.error("In query_global_resource_permissions. ", dict=self.__dict__, dir=dir(self))
         return self.query_resource_permissions(
             resource_type,
             project_name="",

--- a/mlrun/api/utils/clients/opa.py
+++ b/mlrun/api/utils/clients/opa.py
@@ -158,7 +158,7 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
         resource_type: mlrun.api.schemas.AuthorizationResourceTypes,
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
-        raise_on_forbidden: bool = True
+        raise_on_forbidden: bool = True,
     ):
         return self.query_resource_permissions(
             resource_type,

--- a/mlrun/api/utils/clients/opa.py
+++ b/mlrun/api/utils/clients/opa.py
@@ -153,6 +153,22 @@ class Client(metaclass=mlrun.utils.singleton.Singleton,):
             )
         return allowed
 
+    def query_global_resource_permissions(
+        self,
+        resource_type: mlrun.api.schemas.AuthorizationResourceTypes,
+        action: mlrun.api.schemas.AuthorizationAction,
+        auth_info: mlrun.api.schemas.AuthInfo,
+        raise_on_forbidden: bool = True
+    ):
+        return self.query_resource_permissions(
+            resource_type,
+            project_name="",
+            resource_name="",
+            action=action,
+            auth_info=auth_info,
+            raise_on_forbidden=raise_on_forbidden,
+        )
+
     def _check_allowed_project_owners_cache(
         self, resource: str, auth_info: mlrun.api.schemas.AuthInfo
     ):


### PR DESCRIPTION
Marketplace APIs are now looking for OPA verification when invoked.
The verification is pretty basic for now - it's not project scoped, and there's no resource name differentiation. Users may have permissions associated with the `/marketplaces/sources` endpoint, and this is what's verified when an API is called.