### PR TITLE
[Runtimes] Adding option to manually disable auto-mount on a specific run

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1523,6 +1523,7 @@ class MlrunProject(ModelObj):
         dirty=False,
         ttl=None,
         engine=None,
+        disable_auto_mount=False,
     ) -> _PipelineRunStatus:
         """run a workflow using kubeflow pipelines
 
@@ -1539,6 +1540,8 @@ class MlrunProject(ModelObj):
         :param watch:     wait for pipeline completion
         :param dirty:     allow running the workflow when the git repo is dirty
         :param ttl:       pipeline ttl in secs (after that the pods will be removed)
+        :param engine:    workflow engine running the workflow. Only supported value is 'kfp' (also used if None)
+        :param disable_auto_mount: avoid applying auto-mount to workflow functions (default is False)
 
         :returns: run id
         """
@@ -1572,6 +1575,8 @@ class MlrunProject(ModelObj):
             workflow_spec = WorkflowSpec.from_dict(self.spec._workflows[name])
             workflow_spec.merge_args(arguments)
             workflow_spec.ttl = ttl or workflow_spec.ttl
+
+        workflow_spec.merge_args({"disable_auto_mount": disable_auto_mount})
 
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name
         artifact_path = artifact_path or self.spec.artifact_path

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -245,6 +245,7 @@ class BaseRuntime(ModelObj):
         scrape_metrics: bool = None,
         local=False,
         local_code_path=None,
+        disable_auto_mount=False,
     ) -> RunObject:
         """Run a local or remote task.
 
@@ -271,6 +272,7 @@ class BaseRuntime(ModelObj):
         :param scrape_metrics: whether to add the `mlrun/scrape-metrics` label to this run's resources
         :param local:      run the function locally vs on the runtime/cluster
         :param local_code_path: path of the code for local runs & debug
+        :param disable_auto_mount: Do not apply auto-mount prior to running (default is False)
 
         :return: run context object (RunObject) with run metadata, results and status
         """
@@ -279,7 +281,7 @@ class BaseRuntime(ModelObj):
             raise ValueError(f'run mode can only be {",".join(run_modes)}')
 
         # Perform auto-mount if necessary - make sure it only runs on client side (when using remote API)
-        if self._use_remote_api():
+        if self._use_remote_api() and not disable_auto_mount:
             self.try_auto_mount_based_on_config()
 
         if local:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -449,6 +449,7 @@ class RemoteRuntime(KubeResource):
         tag="",
         verbose=False,
         auth_info: AuthInfo = None,
+        disable_auto_mount=False,
     ):
         # todo: verify that the function name is normalized
 
@@ -462,8 +463,9 @@ class RemoteRuntime(KubeResource):
 
         save_record = False
         if not dashboard:
-            # Attempt auto-mounting, before sending to remote build
-            self.try_auto_mount_based_on_config()
+            if not disable_auto_mount:
+                # Attempt auto-mounting, before sending to remote build
+                self.try_auto_mount_based_on_config()
             db = self._get_db()
             logger.info("Starting remote function deploy")
             data = db.remote_builder(self, False)

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -419,13 +419,16 @@ class ServingRuntime(RemoteRuntime):
                     k8s_secrets, project=self.metadata.project
                 )
 
-    def deploy(self, dashboard="", project="", tag="", verbose=False):
+    def deploy(
+        self, dashboard="", project="", tag="", verbose=False, disable_auto_mount=False
+    ):
         """deploy model serving function to a local/remote cluster
 
         :param dashboard: remote nuclio dashboard url (blank for local or auto detection)
         :param project:   optional, override function specified project name
         :param tag:       specify unique function tag (a different function service is created for every tag)
         :param verbose:   verbose logging
+        :param disable_auto_mount: Avoid applying auto-mount to function prior to deployment (default is False)
         """
         load_mode = self.spec.load_mode
         if load_mode and load_mode not in ["sync", "async"]:
@@ -451,7 +454,13 @@ class ServingRuntime(RemoteRuntime):
             self._deploy_function_refs()
             logger.info(f"deploy root function {self.metadata.name} ...")
 
-        return super().deploy(dashboard, project, tag, verbose=verbose)
+        return super().deploy(
+            dashboard,
+            project,
+            tag,
+            verbose=verbose,
+            disable_auto_mount=disable_auto_mount,
+        )
 
     def _get_runtime_env(self):
         env = super()._get_runtime_env()

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -166,6 +166,22 @@ class RunDBMock:
     ):
         return "ready", last_log_timestamp
 
+    def assert_no_mount_or_creds_configured(self):
+        env_list = self._function["spec"]["env"]
+        env_params = [item["name"] for item in env_list]
+        for env_variable in [
+            "V3IO_USERNAME",
+            "V3IO_ACCESS_KEY",
+            "V3IO_FRAMESD",
+            "V3IO_API",
+        ]:
+            assert env_variable not in env_params
+
+        volume_mounts = self._function["spec"]["volume_mounts"]
+        volumes = self._function["spec"]["volumes"]
+        assert len(volumes) == 0
+        assert len(volume_mounts) == 0
+
     def assert_v3io_mount_or_creds_configured(
         self, v3io_user, v3io_access_key, cred_only=False
     ):

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -82,5 +82,5 @@ class TestAutoMountNuclio(TestAutoMount):
         )
         return runtime
 
-    def _execute_run(self, runtime):
-        runtime.deploy(project=self.project)
+    def _execute_run(self, runtime, disable_auto_mount=False):
+        runtime.deploy(project=self.project, disable_auto_mount=disable_auto_mount)


### PR DESCRIPTION
If a user wishes to prevent auto-mount on a specific run or nuclio deployment, can now set the `disable_auto_mount` parameter. This parameter was added to:

* `BaseRuntime.run()` - for any runtime that is not a nuclio function (of course, auto-mount in general only has effect when the runtime is k8s-based)
* `RemoteRuntime.deploy()` and `ServingRuntime.deploy()` - for nuclio-based runtimes.
* `MLRunProject.run()` - for running a workflow.

In all cases the default for this parameter is `False`, executing auto-mount if needed.