### PR TITLE
[Runtimes] Support pods priority

### DIFF
--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -6,6 +6,7 @@ import mlrun.api.api.deps
 import mlrun.api.schemas
 import mlrun.api.utils.clients.iguazio
 import mlrun.runtimes
+from mlrun.config import config
 
 router = fastapi.APIRouter()
 
@@ -28,6 +29,8 @@ def get_frontend_spec(
         jobs_dashboard_url=jobs_dashboard_url,
         abortable_function_kinds=mlrun.runtimes.RuntimeKinds.abortable_runtimes(),
         feature_flags=feature_flags,
+        default_function_priority_class=config.default_function_priority_class,
+        valid_function_priority_class_names=config.get_valid_function_priority_class_names(),
     )
 
 

--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -29,7 +29,7 @@ def get_frontend_spec(
         jobs_dashboard_url=jobs_dashboard_url,
         abortable_function_kinds=mlrun.runtimes.RuntimeKinds.abortable_runtimes(),
         feature_flags=feature_flags,
-        default_function_priority_class=config.default_function_priority_class,
+        default_function_priority_class_name=config.default_function_priority_class_name,
         valid_function_priority_class_names=config.get_valid_function_priority_class_names(),
     )
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -26,6 +26,15 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
+            # These don't have a default value, but we don't send them if they are not set to allow the client to know
+            # when to use server value and when to use client value (server only if set). Since their default value is
+            # empty and not set is also empty we can use the same _get_config_value_if_not_default
+            default_function_priority_class_name=self._get_config_value_if_not_default(
+                "default_function_priority_class_name"
+            ),
+            valid_function_priority_class_names=self._get_config_value_if_not_default(
+                "valid_function_priority_class_names"
+            ),
             # These have a default value, therefore we want to send them only if their value is not the default one
             # (otherwise clients don't know when to use server value and when to use client value)
             ui_projects_prefix=self._get_config_value_if_not_default(
@@ -42,12 +51,6 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             ),
             auto_mount_params=self._get_config_value_if_not_default(
                 "storage.auto_mount_params"
-            ),
-            default_function_priority_class_name=self._get_config_value_if_not_default(
-                "default_function_priority_class_name"
-            ),
-            valid_function_priority_class_names=self._get_config_value_if_not_default(
-                "valid_function_priority_class_names"
             ),
         )
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -28,8 +28,8 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             nuclio_version=self._resolve_nuclio_version(),
             # These don't have a default value, but we don't send them if they are not set
             # because they will be irrelevant
-            default_function_priority_class=self._get_config_value_if_not_default(
-                "default_function_priority_class"
+            default_function_priority_class_name=self._get_config_value_if_not_default(
+                "default_function_priority_class_name"
             ),
             valid_function_priority_class_names=self._get_config_value_if_not_default(
                 "valid_function_priority_class_names"

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -26,7 +26,7 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
-            valid_function_priority_classes=config.valid_function_priority_classes.split(
+            valid_function_priority_class_names=config.valid_function_priority_class_names.split(
                 ","
             ),
             # These have a default value, therefore we want to send them only if their value is not the default one

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -87,19 +87,8 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
 
     def _resolve_valid_function_priority_classes(self):
         if not self._cached_valid_function_priority_classes:
-            k8s = get_k8s_helper(silent=True)
-            if not k8s.is_running_inside_kubernetes_cluster():
-                return []
-
-            available_priority_class_names = k8s.list_priority_class_names()
-            valid_function_priority_classes = []
-            if config.valid_function_priority_classes:
-                valid_function_priority_classes = config.valid_function_priority_classes.split(
-                    ","
-                )
-
-            self._cached_valid_function_priority_classes = set(
-                valid_function_priority_classes
-            ).intersection(set(available_priority_class_names))
+            self._cached_valid_function_priority_classes = config.valid_function_priority_classes.split(
+                ","
+            )
 
         return self._cached_valid_function_priority_classes

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -26,8 +26,12 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
-            valid_function_priority_class_names=config.valid_function_priority_class_names.split(
-                ","
+            # These don't have a default value, but we don't send them if they are not set
+            default_function_node_selector=self._get_config_value_if_not_default(
+                "default_function_node_selector"
+            ),
+            valid_function_priority_class_names=self._get_config_value_if_not_default(
+                "valid_function_priority_class_names"
             ),
             # These have a default value, therefore we want to send them only if their value is not the default one
             # (otherwise clients don't know when to use server value and when to use client value)
@@ -36,9 +40,6 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             ),
             scrape_metrics=self._get_config_value_if_not_default("scrape_metrics"),
             hub_url=self._get_config_value_if_not_default("hub_url"),
-            default_function_node_selector=self._get_config_value_if_not_default(
-                "default_function_node_selector"
-            ),
             igz_version=self._get_config_value_if_not_default("igz_version"),
             auto_mount_type=self._get_config_value_if_not_default(
                 "storage.auto_mount_type"

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -26,8 +26,9 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
-            # These don't have a default value, but we don't send them if they are not set
-            # because they will be irrelevant
+            # These don't have a default value, but we don't send them if they are not set to allow the client to know
+            # when to use server value and when to use client value (server only if set). Since their default value is
+            # empty and not set is also empty we can use the same _get_config_value_if_not_default
             default_function_priority_class_name=self._get_config_value_if_not_default(
                 "default_function_priority_class_name"
             ),

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -27,6 +27,7 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
             # These don't have a default value, but we don't send them if they are not set
+            # because they will be irrelevant
             default_function_priority_class=self._get_config_value_if_not_default(
                 "default_function_priority_class"
             ),

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -9,7 +9,6 @@ from mlrun.utils import logger
 class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
     def __init__(self):
         self._cached_nuclio_version = None
-        self._cached_valid_function_priority_classes = None
 
     def get_client_spec(self):
         mpijob_crd_version = resolve_mpijob_crd_version(api_context=True)
@@ -27,7 +26,9 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
-            valid_function_priority_classes=self._resolve_valid_function_priority_classes(),
+            valid_function_priority_classes=config.valid_function_priority_classes.split(
+                ","
+            ),
             # These have a default value, therefore we want to send them only if their value is not the default one
             # (otherwise clients don't know when to use server value and when to use client value)
             ui_projects_prefix=self._get_config_value_if_not_default(
@@ -83,11 +84,3 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             self._cached_nuclio_version = nuclio_version
 
         return self._cached_nuclio_version
-
-    def _resolve_valid_function_priority_classes(self):
-        if not self._cached_valid_function_priority_classes:
-            self._cached_valid_function_priority_classes = config.valid_function_priority_classes.split(
-                ","
-            )
-
-        return self._cached_valid_function_priority_classes

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -2,7 +2,6 @@ import mlrun.api.schemas
 import mlrun.utils.singleton
 from mlrun.api.utils.clients import nuclio
 from mlrun.config import config, default_config
-from mlrun.k8s_utils import get_k8s_helper
 from mlrun.runtimes.utils import resolve_mpijob_crd_version
 from mlrun.utils import logger
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -26,15 +26,6 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
-            # These don't have a default value, but we don't send them if they are not set to allow the client to know
-            # when to use server value and when to use client value (server only if set). Since their default value is
-            # empty and not set is also empty we can use the same _get_config_value_if_not_default
-            default_function_priority_class_name=self._get_config_value_if_not_default(
-                "default_function_priority_class_name"
-            ),
-            valid_function_priority_class_names=self._get_config_value_if_not_default(
-                "valid_function_priority_class_names"
-            ),
             # These have a default value, therefore we want to send them only if their value is not the default one
             # (otherwise clients don't know when to use server value and when to use client value)
             ui_projects_prefix=self._get_config_value_if_not_default(
@@ -51,6 +42,12 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             ),
             auto_mount_params=self._get_config_value_if_not_default(
                 "storage.auto_mount_params"
+            ),
+            default_function_priority_class_name=self._get_config_value_if_not_default(
+                "default_function_priority_class_name"
+            ),
+            valid_function_priority_class_names=self._get_config_value_if_not_default(
+                "valid_function_priority_class_names"
             ),
         )
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -27,8 +27,8 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             api_url=config.httpdb.api_url,
             nuclio_version=self._resolve_nuclio_version(),
             # These don't have a default value, but we don't send them if they are not set
-            default_function_node_selector=self._get_config_value_if_not_default(
-                "default_function_node_selector"
+            default_function_priority_class=self._get_config_value_if_not_default(
+                "default_function_priority_class"
             ),
             valid_function_priority_class_names=self._get_config_value_if_not_default(
                 "valid_function_priority_class_names"
@@ -40,15 +40,15 @@ class ClientSpec(metaclass=mlrun.utils.singleton.Singleton,):
             ),
             scrape_metrics=self._get_config_value_if_not_default("scrape_metrics"),
             hub_url=self._get_config_value_if_not_default("hub_url"),
+            default_function_node_selector=self._get_config_value_if_not_default(
+                "default_function_node_selector"
+            ),
             igz_version=self._get_config_value_if_not_default("igz_version"),
             auto_mount_type=self._get_config_value_if_not_default(
                 "storage.auto_mount_type"
             ),
             auto_mount_params=self._get_config_value_if_not_default(
                 "storage.auto_mount_params"
-            ),
-            default_function_priority_class=self._get_config_value_if_not_default(
-                "default_function_priority_class"
             ),
         )
 

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -25,4 +25,4 @@ class ClientSpec(pydantic.BaseModel):
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Optional[str]
     default_function_priority_class: typing.Optional[str]
-    valid_function_priority_classes: typing.List[str] = []
+    valid_function_priority_class_names: typing.List[str] = []

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -25,4 +25,4 @@ class ClientSpec(pydantic.BaseModel):
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Optional[str]
     default_function_priority_class: typing.Optional[str]
-    valid_function_priority_class_names: typing.List[str] = []
+    valid_function_priority_class_names: typing.Optional[str]

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -24,3 +24,5 @@ class ClientSpec(pydantic.BaseModel):
     igz_version: typing.Optional[str]
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Optional[str]
+    default_function_priority_class: typing.Optional[str]
+    valid_function_priority_classes: typing.List[str] = []

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -24,5 +24,5 @@ class ClientSpec(pydantic.BaseModel):
     igz_version: typing.Optional[str]
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Optional[str]
-    default_function_priority_class: typing.Optional[str]
+    default_function_priority_class_name: typing.Optional[str]
     valid_function_priority_class_names: typing.Optional[str]

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -17,5 +17,5 @@ class FrontendSpec(pydantic.BaseModel):
     jobs_dashboard_url: typing.Optional[str]
     abortable_function_kinds: typing.List[str] = []
     feature_flags: FeatureFlags
-    default_function_priority_class: typing.Optional[str]
+    default_function_priority_class_name: typing.Optional[str]
     valid_function_priority_class_names: typing.List[str] = []

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -17,3 +17,5 @@ class FrontendSpec(pydantic.BaseModel):
     jobs_dashboard_url: typing.Optional[str]
     abortable_function_kinds: typing.List[str] = []
     feature_flags: FeatureFlags
+    default_function_priority_class: typing.Optional[str]
+    valid_function_priority_class_names: typing.List[str] = []

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -96,9 +96,7 @@ default_config = {
     "default_function_node_selector": "e30=",
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class_name": "",
-    # valid options for priority classes - separated by a comma
-    # empty string means nothing is valid, will use default_function_priority_class_name if present
-    # else will not support pods priority
+    # valid options for priority classes - separated by a comma (default is [""])
     "valid_function_priority_class_names": "",
     "httpdb": {
         "port": 8080,
@@ -340,7 +338,7 @@ class Config:
     @staticmethod
     def get_valid_function_priority_class_names():
         if not config.valid_function_priority_class_names:
-            return []
+            return [""]
         return config.valid_function_priority_class_names.split(",")
 
     @staticmethod

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -97,8 +97,8 @@ default_config = {
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class": "",
     # valid options for priority classes - separated by a comma
-    # empty string means nothing is valid, will use default_function_priority_class if present else
-    # will not support pods priority
+    # empty string means nothing is valid, will use default_function_priority_class if present
+    # else will not support pods priority
     "valid_function_priority_class_names": "",
     "httpdb": {
         "port": 8080,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -96,8 +96,9 @@ default_config = {
     "default_function_node_selector": "e30=",
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class_name": "",
-    # valid options for priority classes - separated by a comma (default is [""])
-    "valid_function_priority_class_names": ",",
+    # valid options for priority classes - separated by a comma
+    # empty string means nothing is valid
+    "valid_function_priority_class_names": "",
     "httpdb": {
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),
@@ -337,6 +338,8 @@ class Config:
 
     @staticmethod
     def get_valid_function_priority_class_names():
+        if not config.valid_function_priority_class_names:
+            return []
         return list(set(config.valid_function_priority_class_names.split(",")))
 
     @staticmethod

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -95,9 +95,9 @@ default_config = {
     # default node selector to be applied to all functions - json string base64 encoded format
     "default_function_node_selector": "e30=",
     # default priority class to be applied to functions running on k8s cluster
-    "default_function_priority_class": "",
+    "default_function_priority_class_name": "",
     # valid options for priority classes - separated by a comma
-    # empty string means nothing is valid, will use default_function_priority_class if present
+    # empty string means nothing is valid, will use default_function_priority_class_name if present
     # else will not support pods priority
     "valid_function_priority_class_names": "",
     "httpdb": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -97,7 +97,7 @@ default_config = {
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class": "",
     # valid options for priority classes - separated by a comma
-    "valid_function_priority_classes": "",
+    "valid_function_priority_class_names": "",
     "httpdb": {
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -94,7 +94,7 @@ default_config = {
     "datastore": {"async_source_mode": "disabled"},
     # default node selector to be applied to all functions - json string base64 encoded format
     "default_function_node_selector": "e30=",
-    # default priority class to be applied to functions running with priority class
+    # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class": "",
     # valid options for priority classes - separated by a comma
     "valid_function_priority_classes": "",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -97,7 +97,7 @@ default_config = {
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class_name": "",
     # valid options for priority classes - separated by a comma (default is [""])
-    "valid_function_priority_class_names": "",
+    "valid_function_priority_class_names": ",",
     "httpdb": {
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),
@@ -337,9 +337,7 @@ class Config:
 
     @staticmethod
     def get_valid_function_priority_class_names():
-        if not config.valid_function_priority_class_names:
-            return [""]
-        return config.valid_function_priority_class_names.split(",")
+        return list(set(config.valid_function_priority_class_names.split(",")))
 
     @staticmethod
     def get_storage_auto_mount_params():

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -94,7 +94,9 @@ default_config = {
     "datastore": {"async_source_mode": "disabled"},
     # default node selector to be applied to all functions - json string base64 encoded format
     "default_function_node_selector": "e30=",
+    # default priority class to be applied to functions running with priority class
     "default_function_priority_class": "",
+    # valid options for priority classes - separated by a comma
     "valid_function_priority_classes": "",
     "httpdb": {
         "port": 8080,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -97,7 +97,6 @@ default_config = {
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class_name": "",
     # valid options for priority classes - separated by a comma
-    # empty string means nothing is valid
     "valid_function_priority_class_names": "",
     "httpdb": {
         "port": 8080,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -94,6 +94,8 @@ default_config = {
     "datastore": {"async_source_mode": "disabled"},
     # default node selector to be applied to all functions - json string base64 encoded format
     "default_function_node_selector": "e30=",
+    "default_function_priority_class": "",
+    "valid_function_priority_classes": "",
     "httpdb": {
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -97,6 +97,8 @@ default_config = {
     # default priority class to be applied to functions running on k8s cluster
     "default_function_priority_class": "",
     # valid options for priority classes - separated by a comma
+    # empty string means nothing is valid, will use default_function_priority_class if present else
+    # will not support pods priority
     "valid_function_priority_class_names": "",
     "httpdb": {
         "port": 8080,
@@ -331,6 +333,12 @@ class Config:
             )
 
         return default_function_node_selector
+
+    @staticmethod
+    def get_valid_function_priority_class_names():
+        if not config.valid_function_priority_class_names:
+            return []
+        return config.valid_function_priority_class_names.split(",")
 
     @staticmethod
     def get_storage_auto_mount_params():

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -278,9 +278,9 @@ class HTTPRunDB(RunDBInterface):
                 server_cfg.get("default_function_priority_class")
                 or config.default_function_priority_class
             )
-            config.valid_function_priority_classes = (
-                server_cfg.get("valid_function_priority_classes")
-                or config.valid_function_priority_classes
+            config.valid_function_priority_class_names = (
+                server_cfg.get("valid_function_priority_class_names")
+                or config.valid_function_priority_class_names
             )
             config.igz_version = server_cfg.get("igz_version") or config.igz_version
             config.storage.auto_mount_type = (

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -256,12 +256,12 @@ class HTTPRunDB(RunDBInterface):
                 "nuclio_version"
             )
             config.default_function_priority_class = (
-                server_cfg.get("default_function_priority_class")
-                or config.default_function_priority_class
+                config.default_function_priority_class
+                or server_cfg.get("default_function_priority_class")
             )
             config.valid_function_priority_class_names = (
-                server_cfg.get("valid_function_priority_class_names")
-                or config.valid_function_priority_class_names
+                config.valid_function_priority_class_names
+                or server_cfg.get("valid_function_priority_class_names")
             )
             # These have a default value, therefore local config will always have a value, prioritize the
             # API value first

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -255,9 +255,9 @@ class HTTPRunDB(RunDBInterface):
             config.nuclio_version = config.nuclio_version or server_cfg.get(
                 "nuclio_version"
             )
-            config.default_function_priority_class = (
-                config.default_function_priority_class
-                or server_cfg.get("default_function_priority_class")
+            config.default_function_priority_class_name = (
+                config.default_function_priority_class_name
+                or server_cfg.get("default_function_priority_class_name")
             )
             config.valid_function_priority_class_names = (
                 config.valid_function_priority_class_names

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -255,6 +255,14 @@ class HTTPRunDB(RunDBInterface):
             config.nuclio_version = config.nuclio_version or server_cfg.get(
                 "nuclio_version"
             )
+            config.default_function_priority_class = (
+                server_cfg.get("default_function_priority_class")
+                or config.default_function_priority_class
+            )
+            config.valid_function_priority_class_names = (
+                server_cfg.get("valid_function_priority_class_names")
+                or config.valid_function_priority_class_names
+            )
             # These have a default value, therefore local config will always have a value, prioritize the
             # API value first
             config.ui.projects_prefix = (
@@ -273,14 +281,6 @@ class HTTPRunDB(RunDBInterface):
             config.default_function_node_selector = (
                 server_cfg.get("default_function_node_selector")
                 or config.default_function_node_selector
-            )
-            config.default_function_priority_class = (
-                server_cfg.get("default_function_priority_class")
-                or config.default_function_priority_class
-            )
-            config.valid_function_priority_class_names = (
-                server_cfg.get("valid_function_priority_class_names")
-                or config.valid_function_priority_class_names
             )
             config.igz_version = server_cfg.get("igz_version") or config.igz_version
             config.storage.auto_mount_type = (

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -274,6 +274,14 @@ class HTTPRunDB(RunDBInterface):
                 server_cfg.get("default_function_node_selector")
                 or config.default_function_node_selector
             )
+            config.default_function_priority_class = (
+                server_cfg.get("default_function_priority_class")
+                or config.default_function_priority_class
+            )
+            config.valid_function_priority_classes = (
+                server_cfg.get("valid_function_priority_classes")
+                or config.valid_function_priority_classes
+            )
             config.igz_version = server_cfg.get("igz_version") or config.igz_version
             config.storage.auto_mount_type = (
                 server_cfg.get("auto_mount_type") or config.storage.auto_mount_type

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -48,7 +48,6 @@ class K8sHelper:
         try:
             self._init_k8s_config(log)
             self.v1api = client.CoreV1Api()
-            self.scheduling_v1api = client.SchedulingV1Api()
             self.crdapi = client.CustomObjectsApi()
         except Exception:
             if not silent:
@@ -417,18 +416,6 @@ class K8sHelper:
                 results[key] = base64.b64decode(secrets_data[key]).decode("utf-8")
 
         return results
-
-    def list_priority_class_names(self):
-        try:
-            v1_priority_class_list = self.scheduling_v1api.list_priority_class()
-        except ApiException as exc:
-            logger.error(f"failed to list priority class: {exc}")
-            raise exc
-
-        names = []
-        for v1_priority_class in v1_priority_class_list:
-            names.append(v1_priority_class.metadata.name)
-        return names
 
 
 class BasePod:

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from sys import stdout
 
 from kubernetes import client, config
+from kubernetes.client import V1PriorityClassList
 from kubernetes.client.rest import ApiException
 
 import mlrun.errors
@@ -48,6 +49,7 @@ class K8sHelper:
         try:
             self._init_k8s_config(log)
             self.v1api = client.CoreV1Api()
+            self.scheduling_v1api = client.SchedulingV1Api()
             self.crdapi = client.CustomObjectsApi()
         except Exception:
             if not silent:
@@ -416,6 +418,18 @@ class K8sHelper:
                 results[key] = base64.b64decode(secrets_data[key]).decode("utf-8")
 
         return results
+
+    def list_priority_class_names(self):
+        try:
+            v1_priority_class_list = self.scheduling_v1api.list_priority_class()
+        except ApiException as exc:
+            logger.error(f"failed to list priority class: {exc}")
+            raise exc
+
+        names = []
+        for v1_priority_class in v1_priority_class_list:
+            names.append(v1_priority_class.metadata.name)
+        return names
 
 
 class BasePod:

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from sys import stdout
 
 from kubernetes import client, config
-from kubernetes.client import V1PriorityClassList
 from kubernetes.client.rest import ApiException
 
 import mlrun.errors

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -83,6 +83,7 @@ class DaskSpec(KubeResourceSpec):
         affinity=None,
         scheduler_resources=None,
         worker_resources=None,
+        priority_class_name=None,
     ):
 
         super().__init__(
@@ -105,6 +106,7 @@ class DaskSpec(KubeResourceSpec):
             node_name=node_name,
             node_selector=node_selector,
             affinity=affinity,
+            priority_class_name=priority_class_name,
         )
         self.args = args
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -549,6 +549,10 @@ class RemoteRuntime(KubeResource):
     ):
         super().with_node_selection(node_name, node_selector, affinity)
 
+    @min_nuclio_versions("1.6.18")
+    def with_priority_class(self, priority_class_name: typing.Optional[str] = None):
+        super().with_priority_class(priority_class_name)
+
     def _get_state(
         self,
         dashboard="",

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -125,6 +125,7 @@ class NuclioSpec(KubeResourceSpec):
         node_selector=None,
         affinity=None,
         mount_applied=False,
+        priority_class_name=None,
     ):
 
         super().__init__(
@@ -147,6 +148,7 @@ class NuclioSpec(KubeResourceSpec):
             node_selector=node_selector,
             affinity=affinity,
             mount_applied=mount_applied,
+            priority_class_name=priority_class_name,
         )
 
         self.base_spec = base_spec or ""

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -969,12 +969,14 @@ def compile_function_config(function: RemoteRuntime):
         spec.set_config(
             "spec.build.functionSourceCode", function.spec.build.functionSourceCode
         )
-    if function.spec.node_selector:
-        spec.set_config("spec.nodeSelector", function.spec.node_selector)
-    if function.spec.node_name:
-        spec.set_config("spec.nodeName", function.spec.node_name)
-    if function.spec.affinity:
-        spec.set_config("spec.affinity", function.spec._get_sanitized_affinity())
+    # don't send node selections if nuclio is not compatible
+    if validate_nuclio_version_compatibility("1.5.20", "1.6.10"):
+        if function.spec.node_selector:
+            spec.set_config("spec.nodeSelector", function.spec.node_selector)
+        if function.spec.node_name:
+            spec.set_config("spec.nodeName", function.spec.node_name)
+        if function.spec.affinity:
+            spec.set_config("spec.affinity", function.spec._get_sanitized_affinity())
     # don't send default or any priority class name if nuclio is not compatible
     if function.spec.priority_class_name and validate_nuclio_version_compatibility(
         "1.6.18"

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -550,7 +550,9 @@ class RemoteRuntime(KubeResource):
         super().with_node_selection(node_name, node_selector, affinity)
 
     @min_nuclio_versions("1.6.18")
-    def with_priority_class(self, name: typing.Optional[str]):
+    def with_priority_class(
+        self, name: str = mlconf.default_function_priority_class_name
+    ):
         super().with_priority_class(name)
 
     def _get_state(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -550,8 +550,8 @@ class RemoteRuntime(KubeResource):
         super().with_node_selection(node_name, node_selector, affinity)
 
     @min_nuclio_versions("1.6.18")
-    def with_priority_class(self, priority_class_name: typing.Optional[str]):
-        super().with_priority_class(priority_class_name)
+    def with_priority_class(self, name: typing.Optional[str]):
+        super().with_priority_class(name)
 
     def _get_state(
         self,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -550,7 +550,7 @@ class RemoteRuntime(KubeResource):
         super().with_node_selection(node_name, node_selector, affinity)
 
     @min_nuclio_versions("1.6.18")
-    def with_priority_class(self, priority_class_name: typing.Optional[str] = None):
+    def with_priority_class(self, priority_class_name: typing.Optional[str]):
         super().with_priority_class(priority_class_name)
 
     def _get_state(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -971,6 +971,8 @@ def compile_function_config(function: RemoteRuntime):
         spec.set_config("spec.nodeName", function.spec.node_name)
     if function.spec.affinity:
         spec.set_config("spec.affinity", function.spec._get_sanitized_affinity())
+    if function.spec.priority_class_name:
+        spec.set_config("spec.priorityClassName", function.spec.priority_class_name)
 
     if function.spec.replicas:
         spec.set_config("spec.minReplicas", function.spec.replicas)

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -978,8 +978,10 @@ def compile_function_config(function: RemoteRuntime):
         if function.spec.affinity:
             spec.set_config("spec.affinity", function.spec._get_sanitized_affinity())
     # don't send default or any priority class name if nuclio is not compatible
-    if function.spec.priority_class_name and validate_nuclio_version_compatibility(
-        "1.6.18"
+    if (
+        function.spec.priority_class_name
+        and validate_nuclio_version_compatibility("1.6.18")
+        and len(mlconf.get_valid_function_priority_class_names())
     ):
         spec.set_config("spec.priorityClassName", function.spec.priority_class_name)
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -975,7 +975,10 @@ def compile_function_config(function: RemoteRuntime):
         spec.set_config("spec.nodeName", function.spec.node_name)
     if function.spec.affinity:
         spec.set_config("spec.affinity", function.spec._get_sanitized_affinity())
-    if function.spec.priority_class_name:
+    # don't send default or any priority class name if nuclio is not compatible
+    if function.spec.priority_class_name and validate_nuclio_version_compatibility(
+        "1.6.18"
+    ):
         spec.set_config("spec.priorityClassName", function.spec.priority_class_name)
 
     if function.spec.replicas:

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -51,6 +51,7 @@ class MPIResourceSpec(KubeResourceSpec):
         node_name=None,
         node_selector=None,
         affinity=None,
+        priority_class_name=None,
     ):
         super().__init__(
             command=command,
@@ -73,6 +74,7 @@ class MPIResourceSpec(KubeResourceSpec):
             node_name=node_name,
             node_selector=node_selector,
             affinity=affinity,
+            priority_class_name=priority_class_name,
         )
         self.mpi_args = mpi_args or [
             "-x",

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -53,6 +53,7 @@ class MPIV1ResourceSpec(MPIResourceSpec):
         node_name=None,
         node_selector=None,
         affinity=None,
+        priority_class_name=None,
     ):
         super().__init__(
             command=command,
@@ -76,6 +77,7 @@ class MPIV1ResourceSpec(MPIResourceSpec):
             node_name=node_name,
             node_selector=node_selector,
             affinity=affinity,
+            priority_class_name=priority_class_name,
         )
         self.clean_pod_policy = clean_pod_policy or MPIJobV1CleanPodPolicies.default()
 
@@ -185,6 +187,9 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
             update_in(pod_template, "spec.nodeSelector", self.spec.node_selector)
             update_in(
                 pod_template, "spec.affinity", self.spec._get_sanitized_affinity()
+            )
+            update_in(
+                pod_template, "spec.priorityClassName", self.spec.priority_class_name
             )
 
         # configuration for workers only

--- a/mlrun/runtimes/mpijob/v1.py
+++ b/mlrun/runtimes/mpijob/v1.py
@@ -20,6 +20,7 @@ from kubernetes import client
 from sqlalchemy.orm import Session
 
 from mlrun.api.db.base import DBInterface
+from mlrun.config import config as mlconf
 from mlrun.execution import MLClientCtx
 from mlrun.model import RunObject
 from mlrun.runtimes.base import BaseRuntimeHandler, RunStates
@@ -188,9 +189,14 @@ class MpiRuntimeV1(AbstractMPIJobRuntime):
             update_in(
                 pod_template, "spec.affinity", self.spec._get_sanitized_affinity()
             )
-            update_in(
-                pod_template, "spec.priorityClassName", self.spec.priority_class_name
-            )
+            if self.spec.priority_class_name and len(
+                mlconf.get_valid_function_priority_class_names()
+            ):
+                update_in(
+                    pod_template,
+                    "spec.priorityClassName",
+                    self.spec.priority_class_name,
+                )
 
         # configuration for workers only
         # update resources only for workers because the launcher

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -80,6 +80,9 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
         update_in(
             job, "spec.template.spec.affinity", self.spec._get_sanitized_affinity()
         )
+        update_in(
+            job, "spec.template.spec.priorityClassName", self.spec.priority_class_name
+        )
 
         extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -19,6 +19,7 @@ from kubernetes import client
 from sqlalchemy.orm import Session
 
 from mlrun.api.db.base import DBInterface
+from mlrun.config import config as mlconf
 from mlrun.execution import MLClientCtx
 from mlrun.model import RunObject
 from mlrun.runtimes.base import BaseRuntimeHandler, RunStates
@@ -80,9 +81,14 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
         update_in(
             job, "spec.template.spec.affinity", self.spec._get_sanitized_affinity()
         )
-        update_in(
-            job, "spec.template.spec.priorityClassName", self.spec.priority_class_name
-        )
+        if self.spec.priority_class_name and len(
+            mlconf.get_valid_function_priority_class_names()
+        ):
+            update_in(
+                job,
+                "spec.template.spec.priorityClassName",
+                self.spec.priority_class_name,
+            )
 
         extra_env = self._generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -360,7 +360,7 @@ class KubeResource(BaseRuntime):
         self.spec.priority_class_name = priority_class_name
 
     def list_valid_priority_class_names(self):
-        return mlconf.valid_function_priority_classes
+        return mlconf.valid_function_priority_class_names
 
     def _verify_and_set_limits(
         self,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -346,14 +346,18 @@ class KubeResource(BaseRuntime):
         if affinity:
             self.spec.affinity = affinity
 
-    def with_priority_class(self, name: typing.Optional[str]):
+    def with_priority_class(
+        self, name: str = mlconf.default_function_priority_class_name
+    ):
         """
         Enables to control the priority of the pod
         If not passed - will default to mlrun.mlconf.default_function_priority_class_name
 
         :param name:       The name of the priority class
         """
-        valid_priority_class_names = self.list_valid_priority_class_names()
+        valid_priority_class_names = self.list_valid_and_default_priority_class_names()[
+            "valid_function_priority_class_names"
+        ]
         if name not in valid_priority_class_names:
             message = "Priority class name not in available priority class names"
             logger.warning(
@@ -364,8 +368,11 @@ class KubeResource(BaseRuntime):
             raise mlrun.errors.MLRunInvalidArgumentError(message)
         self.spec.priority_class_name = name
 
-    def list_valid_priority_class_names(self):
-        return mlconf.get_valid_function_priority_class_names()
+    def list_valid_and_default_priority_class_names(self):
+        return {
+            "default_function_priority_class_name": mlconf.default_function_priority_class_name,
+            "valid_function_priority_class_names": mlconf.get_valid_function_priority_class_names(),
+        }
 
     def _verify_and_set_limits(
         self,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -341,26 +341,26 @@ class KubeResource(BaseRuntime):
         if affinity:
             self.spec.affinity = affinity
 
-    def with_priority_class(self, priority_class_name: typing.Optional[str]):
+    def with_priority_class(self, name: typing.Optional[str]):
         """
         Enables to control the priority of the pod
-        If not passed - will default to the default_function_priority_class passed in config
+        If not passed - will default to mlrun.mlconf.default_function_priority_class
 
-        :param priority_class_name:       The name of the priority class
+        :param name:       The name of the priority class
         """
         valid_priority_class_names = self.list_valid_priority_class_names()
-        if priority_class_name not in valid_priority_class_names:
+        if name not in valid_priority_class_names:
             message = "Priority class name not in available priority class names"
             logger.warning(
                 message,
-                priority_class_name=priority_class_name,
+                priority_class_name=name,
                 valid_priority_class_names=valid_priority_class_names,
             )
             raise mlrun.errors.MLRunInvalidArgumentError(message)
-        self.spec.priority_class_name = priority_class_name
+        self.spec.priority_class_name = name
 
     def list_valid_priority_class_names(self):
-        return mlconf.valid_function_priority_class_names
+        return mlconf.get_valid_function_priority_class_names()
 
     def _verify_and_set_limits(
         self,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -90,7 +90,7 @@ class KubeResourceSpec(FunctionSpec):
         )
         self._affinity = affinity
         self.priority_class_name = (
-            priority_class_name or mlrun.mlconf.default_function_priority_class
+            priority_class_name or mlrun.mlconf.default_function_priority_class_name
         )
 
     @property
@@ -344,7 +344,7 @@ class KubeResource(BaseRuntime):
     def with_priority_class(self, name: typing.Optional[str]):
         """
         Enables to control the priority of the pod
-        If not passed - will default to mlrun.mlconf.default_function_priority_class
+        If not passed - will default to mlrun.mlconf.default_function_priority_class_name
 
         :param name:       The name of the priority class
         """

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -89,9 +89,14 @@ class KubeResourceSpec(FunctionSpec):
             node_selector or mlrun.mlconf.get_default_function_node_selector()
         )
         self._affinity = affinity
-        self.priority_class_name = (
-            priority_class_name or mlrun.mlconf.default_function_priority_class_name
-        )
+        self.priority_class_name = None
+        if priority_class_name:
+            self.priority_class_name = priority_class_name
+        elif (
+            mlconf.default_function_priority_class_name
+            in mlconf.get_valid_function_priority_class_names()
+        ):
+            self.priority_class_name = mlconf.default_function_priority_class_name
 
     @property
     def volumes(self) -> list:

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -89,14 +89,9 @@ class KubeResourceSpec(FunctionSpec):
             node_selector or mlrun.mlconf.get_default_function_node_selector()
         )
         self._affinity = affinity
-        self.priority_class_name = None
-        if priority_class_name:
-            self.priority_class_name = priority_class_name
-        elif (
-            mlconf.default_function_priority_class_name
-            in mlconf.get_valid_function_priority_class_names()
-        ):
-            self.priority_class_name = mlconf.default_function_priority_class_name
+        self.priority_class_name = (
+            priority_class_name or mlrun.mlconf.default_function_priority_class_name
+        )
 
     @property
     def volumes(self) -> list:
@@ -557,5 +552,7 @@ def kube_resource_spec_to_pod_spec(
         node_name=kube_resource_spec.node_name,
         node_selector=kube_resource_spec.node_selector,
         affinity=kube_resource_spec.affinity,
-        priority_class_name=kube_resource_spec.priority_class_name,
+        priority_class_name=kube_resource_spec.priority_class_name
+        if len(mlconf.get_valid_function_priority_class_names())
+        else None,
     )

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -349,14 +349,13 @@ class KubeResource(BaseRuntime):
         if priority_class_name:
             valid_priority_class_names = self.list_valid_priority_class_names()
             if priority_class_name not in valid_priority_class_names:
-                logger.warn(
-                    "Priority class name not in available priority class names",
+                message = "Priority class name not in available priority class names"
+                logger.warning(
+                    message,
                     priority_class_name=priority_class_name,
                     valid_priority_class_names=valid_priority_class_names,
                 )
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Priority class name was not found"
-                )
+                raise mlrun.errors.MLRunInvalidArgumentError(message)
             self.spec.priority_class_name = priority_class_name
         else:
             self.spec.priority_class_name = mlconf.default_function_priority_class

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -59,6 +59,7 @@ class KubeResourceSpec(FunctionSpec):
         node_selector=None,
         affinity=None,
         mount_applied=False,
+        priority_class_name=None,
     ):
         super().__init__(
             command=command,
@@ -88,6 +89,7 @@ class KubeResourceSpec(FunctionSpec):
             node_selector or mlrun.mlconf.get_default_function_node_selector()
         )
         self._affinity = affinity
+        self.priority_class_name = priority_class_name
 
     @property
     def volumes(self) -> list:
@@ -337,6 +339,31 @@ class KubeResource(BaseRuntime):
         if affinity:
             self.spec.affinity = affinity
 
+    def with_priority_class(self, priority_class_name: typing.Optional[str] = None):
+        """
+        Enables to control the priority of the pod
+        If not passed - will default to the default_function_priority_class passed in config
+
+        :param priority_class_name:       The name of the priority class
+        """
+        if priority_class_name:
+            valid_priority_class_names = self.list_valid_priority_class_names()
+            if priority_class_name not in valid_priority_class_names:
+                logger.warn(
+                    "Priority class name not in available priority class names",
+                    priority_class_name=priority_class_name,
+                    valid_priority_class_names=valid_priority_class_names,
+                )
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "Priority class name was not found"
+                )
+            self.spec.priority_class_name = priority_class_name
+        else:
+            self.spec.priority_class_name = mlconf.default_function_priority_class
+
+    def list_valid_priority_class_names(self):
+        return mlconf.valid_function_priority_classes
+
     def _verify_and_set_limits(
         self,
         resources_field_name,
@@ -520,4 +547,5 @@ def kube_resource_spec_to_pod_spec(
         node_name=kube_resource_spec.node_name,
         node_selector=kube_resource_spec.node_selector,
         affinity=kube_resource_spec.affinity,
+        priority_class_name=kube_resource_spec.priority_class_name,
     )

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -47,6 +47,7 @@ class RemoteSparkSpec(KubeResourceSpec):
         node_name=None,
         node_selector=None,
         affinity=None,
+        priority_class_name=None,
     ):
         super().__init__(
             command=command,
@@ -69,6 +70,7 @@ class RemoteSparkSpec(KubeResourceSpec):
             node_name=node_name,
             node_selector=node_selector,
             affinity=affinity,
+            priority_class_name=priority_class_name,
         )
         self.provider = provider
 

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -310,6 +310,8 @@ class SparkRuntime(KubejobRuntime):
                 self.spec.restart_policy["submission_retry_interval"],
                 int,
             )
+        if self.spec.priority_class_name:
+            update_in(job, "spec.priority_class_name", self.spec.priority_class_name)
 
         update_in(job, "metadata", meta.to_dict())
         update_in(job, "spec.driver.labels", pod_labels)

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -311,7 +311,11 @@ class SparkRuntime(KubejobRuntime):
                 int,
             )
         if self.spec.priority_class_name:
-            update_in(job, "spec.priority_class_name", self.spec.priority_class_name)
+            update_in(
+                job,
+                "spec.batchSchedulerOptions.priorityClassName",
+                self.spec.priority_class_name,
+            )
 
         update_in(job, "metadata", meta.to_dict())
         update_in(job, "spec.driver.labels", pod_labels)

--- a/mlrun/runtimes/sparkjob.py
+++ b/mlrun/runtimes/sparkjob.py
@@ -130,6 +130,7 @@ class SparkJobSpec(KubeResourceSpec):
         hadoop_conf=None,
         node_selector=None,
         use_default_image=False,
+        priority_class_name=None,
     ):
 
         super().__init__(
@@ -151,6 +152,7 @@ class SparkJobSpec(KubeResourceSpec):
             workdir=workdir,
             build=build,
             node_selector=node_selector,
+            priority_class_name=priority_class_name,
         )
 
         self.driver_resources = driver_resources or {}

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -442,6 +442,7 @@ def enrich_function_from_dict(function, function_dict):
         "node_name",
         "node_selector",
         "affinity",
+        "priority_class_name",
     ]:
         override_value = getattr(override_function.spec, attribute, None)
         if override_value:

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -469,6 +469,7 @@ class TestRuntimeBase:
         expected_node_name=None,
         expected_node_selector=None,
         expected_affinity=None,
+        expected_priority_class_name=None,
         assert_create_pod_called=True,
         assert_namespace_env_variable=True,
         expected_labels=None,
@@ -540,6 +541,9 @@ class TestRuntimeBase:
                 )
                 == {}
             )
+
+        if expected_priority_class_name:
+            assert pod.spec.priority_class_name == expected_priority_class_name
 
         assert pod.spec.containers[0].image == self.image_name
 

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -213,7 +213,7 @@ class TestDaskRuntime(TestRuntimeBase):
 
         runtime = self._generate_runtime()
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_class_names = [medium_priority_class_name]
+        mlrun.mlconf.valid_function_priority_class_names = medium_priority_class_name
         runtime.with_priority_class(medium_priority_class_name)
 
         _ = runtime.client

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -213,7 +213,7 @@ class TestDaskRuntime(TestRuntimeBase):
 
         runtime = self._generate_runtime()
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_classes = [medium_priority_class_name]
+        mlrun.mlconf.valid_function_priority_class_names = [medium_priority_class_name]
         runtime.with_priority_class(medium_priority_class_name)
 
         _ = runtime.client

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -198,6 +198,7 @@ class TestDaskRuntime(TestRuntimeBase):
     def test_dask_with_priority_class_name(self, db: Session, client: TestClient):
         default_priority_class_name = "default-priority"
         mlrun.mlconf.default_function_priority_class_name = default_priority_class_name
+        mlrun.mlconf.valid_function_priority_class_names = default_priority_class_name
         runtime = self._generate_runtime()
 
         _ = runtime.client
@@ -213,7 +214,9 @@ class TestDaskRuntime(TestRuntimeBase):
 
         runtime = self._generate_runtime()
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_class_names = medium_priority_class_name
+        mlrun.mlconf.valid_function_priority_class_names = ",".join(
+            [default_priority_class_name, medium_priority_class_name]
+        )
         runtime.with_priority_class(medium_priority_class_name)
 
         _ = runtime.client

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -197,7 +197,7 @@ class TestDaskRuntime(TestRuntimeBase):
 
     def test_dask_with_priority_class_name(self, db: Session, client: TestClient):
         default_priority_class_name = "default-priority"
-        mlrun.mlconf.default_function_priority_class = default_priority_class_name
+        mlrun.mlconf.default_function_priority_class_name = default_priority_class_name
         runtime = self._generate_runtime()
 
         _ = runtime.client

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -140,6 +140,34 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_affinity=affinity,
         )
 
+    def test_run_with_priority_class_name(self, db: Session, client: TestClient):
+        runtime = self._generate_runtime()
+
+        medium_priority_class_name = "medium-priority"
+        mlrun.mlconf.valid_function_priority_classes = [medium_priority_class_name]
+        runtime.with_priority_class(medium_priority_class_name)
+        self._execute_run(runtime)
+        self._assert_pod_creation_config(
+            expected_priority_class_name=medium_priority_class_name
+        )
+
+        runtime = self._generate_runtime()
+
+        default_priority_class_name = "default-priority"
+        mlrun.mlconf.default_function_priority_class = default_priority_class_name
+        runtime.with_priority_class()
+        self._execute_run(runtime)
+        self._assert_pod_creation_config(
+            expected_priority_class_name=default_priority_class_name
+        )
+
+        runtime = self._generate_runtime()
+
+        mlrun.mlconf.valid_function_priority_classes = []
+        mlrun.mlconf.default_function_priority_class = medium_priority_class_name
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            runtime.with_priority_class(medium_priority_class_name)
+
     def test_run_with_mounts(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -144,7 +144,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime = self._generate_runtime()
 
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_classes = [medium_priority_class_name]
+        mlrun.mlconf.valid_function_priority_class_names = [medium_priority_class_name]
         runtime.with_priority_class(medium_priority_class_name)
         self._execute_run(runtime)
         self._assert_pod_creation_config(
@@ -162,7 +162,7 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         runtime = self._generate_runtime()
 
-        mlrun.mlconf.valid_function_priority_classes = []
+        mlrun.mlconf.valid_function_priority_class_names = []
         mlrun.mlconf.default_function_priority_class = medium_priority_class_name
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             runtime.with_priority_class(medium_priority_class_name)

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -151,11 +151,10 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_priority_class_name=medium_priority_class_name
         )
 
-        runtime = self._generate_runtime()
-
         default_priority_class_name = "default-priority"
         mlrun.mlconf.default_function_priority_class = default_priority_class_name
-        runtime.with_priority_class()
+        runtime = self._generate_runtime()
+
         self._execute_run(runtime)
         self._assert_pod_creation_config(
             expected_priority_class_name=default_priority_class_name

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -152,7 +152,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         )
 
         default_priority_class_name = "default-priority"
-        mlrun.mlconf.default_function_priority_class = default_priority_class_name
+        mlrun.mlconf.default_function_priority_class_name = default_priority_class_name
         runtime = self._generate_runtime()
 
         self._execute_run(runtime)
@@ -163,7 +163,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime = self._generate_runtime()
 
         mlrun.mlconf.valid_function_priority_class_names = ""
-        mlrun.mlconf.default_function_priority_class = medium_priority_class_name
+        mlrun.mlconf.default_function_priority_class_name = medium_priority_class_name
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             runtime.with_priority_class(medium_priority_class_name)
 

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -153,6 +153,9 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         default_priority_class_name = "default-priority"
         mlrun.mlconf.default_function_priority_class_name = default_priority_class_name
+        mlrun.mlconf.valid_function_priority_class_names = ",".join(
+            [default_priority_class_name, medium_priority_class_name]
+        )
         runtime = self._generate_runtime()
 
         self._execute_run(runtime)
@@ -163,7 +166,6 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime = self._generate_runtime()
 
         mlrun.mlconf.valid_function_priority_class_names = ""
-        mlrun.mlconf.default_function_priority_class_name = medium_priority_class_name
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             runtime.with_priority_class(medium_priority_class_name)
 

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -144,7 +144,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         runtime = self._generate_runtime()
 
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_class_names = [medium_priority_class_name]
+        mlrun.mlconf.valid_function_priority_class_names = medium_priority_class_name
         runtime.with_priority_class(medium_priority_class_name)
         self._execute_run(runtime)
         self._assert_pod_creation_config(
@@ -162,7 +162,7 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         runtime = self._generate_runtime()
 
-        mlrun.mlconf.valid_function_priority_class_names = []
+        mlrun.mlconf.valid_function_priority_class_names = ""
         mlrun.mlconf.default_function_priority_class = medium_priority_class_name
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             runtime.with_priority_class(medium_priority_class_name)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -429,7 +429,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         function = self._generate_runtime()
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_class_names = [medium_priority_class_name]
+        mlrun.mlconf.valid_function_priority_class_names = medium_priority_class_name
         mlconf.nuclio_version = "1.5.20"
         with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
             function.with_priority_class(medium_priority_class_name)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -425,6 +425,16 @@ class TestNuclioRuntime(TestRuntimeBase):
         args, _ = nuclio.deploy.deploy_config.call_args
         deploy_spec = args[0]["spec"]
 
+        assert "priorityClassName" not in deploy_spec
+
+        mlrun.mlconf.valid_function_priority_class_names = default_priority_class_name
+        function = self._generate_runtime("nuclio")
+
+        deploy_nuclio_function(function)
+        self._assert_deploy_called_basic_config(call_count=3)
+        args, _ = nuclio.deploy.deploy_config.call_args
+        deploy_spec = args[0]["spec"]
+
         assert deploy_spec["priorityClassName"] == default_priority_class_name
 
         function = self._generate_runtime()
@@ -442,7 +452,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         function.with_priority_class(medium_priority_class_name)
 
         deploy_nuclio_function(function)
-        self._assert_deploy_called_basic_config(call_count=3)
+        self._assert_deploy_called_basic_config(call_count=4)
         args, _ = nuclio.deploy.deploy_config.call_args
         deploy_spec = args[0]["spec"]
 

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -429,7 +429,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         function = self._generate_runtime()
         medium_priority_class_name = "medium-priority"
-        mlrun.mlconf.valid_function_priority_classes = [medium_priority_class_name]
+        mlrun.mlconf.valid_function_priority_class_names = [medium_priority_class_name]
         mlconf.nuclio_version = "1.5.20"
         with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
             function.with_priority_class(medium_priority_class_name)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -407,7 +407,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         mlconf.nuclio_version = "1.5.20"
         default_priority_class_name = "default-priority"
-        mlrun.mlconf.default_function_priority_class = default_priority_class_name
+        mlrun.mlconf.default_function_priority_class_name = default_priority_class_name
         function = self._generate_runtime("nuclio")
 
         deploy_nuclio_function(function)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -408,6 +408,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         mlconf.nuclio_version = "1.5.20"
         default_priority_class_name = "default-priority"
         mlrun.mlconf.default_function_priority_class_name = default_priority_class_name
+        mlrun.mlconf.valid_function_priority_class_names = default_priority_class_name
         function = self._generate_runtime("nuclio")
 
         deploy_nuclio_function(function)
@@ -418,6 +419,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         assert "priorityClassName" not in deploy_spec
 
         mlconf.nuclio_version = "1.6.18"
+        mlrun.mlconf.valid_function_priority_class_names = ""
         function = self._generate_runtime("nuclio")
 
         deploy_nuclio_function(function)

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -30,7 +30,7 @@ def test_new_function_from_runtime():
             "build": {"commands": []},
             "affinity": None,
             "mount_applied": False,
-            "priority_class_name": False,
+            "priority_class_name": "",
         },
         "verbose": False,
     }
@@ -66,6 +66,7 @@ def test_new_function_args_without_command():
             "build": {"commands": []},
             "affinity": None,
             "mount_applied": False,
+            "priority_class_name": "",
         },
         "verbose": False,
     }

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -30,6 +30,7 @@ def test_new_function_from_runtime():
             "build": {"commands": []},
             "affinity": None,
             "mount_applied": False,
+            "priority_class_name": False,
         },
         "verbose": False,
     }


### PR DESCRIPTION
Config holds default priority class name and valid priority class names.
SDK Exposes:
1. `func.with_priority_class(name=<name>)` to apply priority to job
2. `func.list_valid_and_default_priority_class_names()` to receive available priority class name selections to user and the default selection.