### PR TITLE
[Runtimes] Fix `with_priority_class` default param

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -550,9 +550,7 @@ class RemoteRuntime(KubeResource):
         super().with_node_selection(node_name, node_selector, affinity)
 
     @min_nuclio_versions("1.6.18")
-    def with_priority_class(
-        self, name: str = mlconf.default_function_priority_class_name
-    ):
+    def with_priority_class(self, name: str = None):
         super().with_priority_class(name)
 
     def _get_state(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -550,7 +550,7 @@ class RemoteRuntime(KubeResource):
         super().with_node_selection(node_name, node_selector, affinity)
 
     @min_nuclio_versions("1.6.18")
-    def with_priority_class(self, name: str = None):
+    def with_priority_class(self, name: typing.Optional[str] = None):
         super().with_priority_class(name)
 
     def _get_state(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -341,15 +341,15 @@ class KubeResource(BaseRuntime):
         if affinity:
             self.spec.affinity = affinity
 
-    def with_priority_class(
-        self, name: str = mlconf.default_function_priority_class_name
-    ):
+    def with_priority_class(self, name: str = None):
         """
         Enables to control the priority of the pod
         If not passed - will default to mlrun.mlconf.default_function_priority_class_name
 
         :param name:       The name of the priority class
         """
+        if name is None:
+            name = mlconf.default_function_priority_class_name
         valid_priority_class_names = self.list_valid_and_default_priority_class_names()[
             "valid_function_priority_class_names"
         ]

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -341,7 +341,7 @@ class KubeResource(BaseRuntime):
         if affinity:
             self.spec.affinity = affinity
 
-    def with_priority_class(self, name: str = None):
+    def with_priority_class(self, name: typing.Optional[str] = None):
         """
         Enables to control the priority of the pod
         If not passed - will default to mlrun.mlconf.default_function_priority_class_name


### PR DESCRIPTION
Default argument values are evaluated only once per module load, Therefore mlconf.default_function_priority_class_name default argument will never be evaluated again and we always get an empty string.
The convention for achieving the desired result in Python is to provide a default value of None.