### PR TITLE
[Refactor] Scrubbing mktemp calls (CVE)

### DIFF
--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import tempfile
-import uuid
 from os import path
 from typing import List
 
@@ -232,8 +231,7 @@ def get_model(model_dir, suffix=""):
     if obj.kind == "file":
         return model_file, model_spec, extra_dataitems
 
-    new_uuid = uuid.uuid4()
-    temp_path = path.join(tempfile.gettempdir(), f"{new_uuid}{suffix}")
+    temp_path = tempfile.NamedTemporaryFile(suffix=suffix, delete=False).name
     obj.download(temp_path)
     return temp_path, model_spec, extra_dataitems
 

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import tempfile
+import uuid
 from os import path
-from tempfile import mktemp
 from typing import List
 
 import yaml
@@ -231,13 +232,14 @@ def get_model(model_dir, suffix=""):
     if obj.kind == "file":
         return model_file, model_spec, extra_dataitems
 
-    tmp = mktemp(suffix)
-    obj.download(tmp)
-    return tmp, model_spec, extra_dataitems
+    new_uuid = uuid.uuid4()
+    temp_path = path.join(tempfile.gettempdir(), f"{new_uuid}{suffix}")
+    obj.download(temp_path)
+    return temp_path, model_spec, extra_dataitems
 
 
-def _load_model_spec(specpath):
-    data = store_manager.object(url=specpath).get()
+def _load_model_spec(spec_path):
+    data = store_manager.object(url=spec_path).get()
     spec = yaml.load(data, Loader=yaml.FullLoader)
     return ModelArtifact.from_dict(spec)
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -15,7 +15,7 @@
 import tarfile
 import tempfile
 from base64 import b64decode, b64encode
-from os import path, remove
+from os import path
 from urllib.parse import urlparse
 
 import mlrun.api.schemas
@@ -125,15 +125,14 @@ def make_kaniko_pod(
 
 
 def upload_tarball(source_dir, target, secrets=None):
-    temp_fh = tempfile.TemporaryFile(suffix=".tar.gz", delete=False)
 
-    with tarfile.open(mode="w:gz", fileobj=temp_fh) as tar:
-        tar.add(source_dir, arcname="")
-
-    stores = store_manager.set(secrets)
-    datastore, subpath = stores.get_or_create_store(target)
-    datastore.upload(subpath, temp_fh.name)
-    remove(temp_fh.name)
+    # will delete the temp file
+    with tempfile.TemporaryFile(suffix=".tar.gz") as temp_fh:
+        with tarfile.open(mode="w:gz", fileobj=temp_fh) as tar:
+            tar.add(source_dir, arcname="")
+        stores = store_manager.set(secrets)
+        datastore, subpath = stores.get_or_create_store(target)
+        datastore.upload(subpath, temp_fh.name)
 
 
 def build_image(

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import tarfile
+import tempfile
+import uuid
 from base64 import b64decode, b64encode
 from os import path, remove
-from tempfile import mktemp
 from urllib.parse import urlparse
 
 import mlrun.api.schemas
@@ -125,14 +126,15 @@ def make_kaniko_pod(
 
 
 def upload_tarball(source_dir, target, secrets=None):
-    tmpfile = mktemp(".tar.gz")
-    with tarfile.open(tmpfile, "w:gz") as tar:
+    new_uuid = uuid.uuid4()
+    temp_file = path.join(tempfile.gettempdir(), f"{new_uuid}.tar.gz")
+    with tarfile.open(temp_file, "w:gz") as tar:
         tar.add(source_dir, arcname="")
 
     stores = store_manager.set(secrets)
     datastore, subpath = stores.get_or_create_store(target)
-    datastore.upload(subpath, tmpfile)
-    remove(tmpfile)
+    datastore.upload(subpath, temp_file)
+    remove(temp_file)
 
 
 def build_image(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -16,7 +16,6 @@ import http
 import os
 import tempfile
 import time
-import uuid
 import warnings
 from datetime import datetime
 from os import path, remove
@@ -1228,8 +1227,7 @@ class HTTPRunDB(RunDBInterface):
         if isinstance(pipeline, str):
             pipe_file = pipeline
         else:
-            new_uuid = uuid.uuid4()
-            pipe_file = path.join(tempfile.gettempdir(), f"{new_uuid}.yaml")
+            pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
             conf = new_pipe_meta(artifact_path, ttl, ops)
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -16,6 +16,7 @@ import http
 import os
 import tempfile
 import time
+import uuid
 import warnings
 from datetime import datetime
 from os import path, remove
@@ -1227,7 +1228,8 @@ class HTTPRunDB(RunDBInterface):
         if isinstance(pipeline, str):
             pipe_file = pipeline
         else:
-            pipe_file = tempfile.mktemp(suffix=".yaml")
+            new_uuid = uuid.uuid4()
+            pipe_file = path.join(tempfile.gettempdir(), f"{new_uuid}.yaml")
             conf = new_pipe_meta(artifact_path, ttl, ops)
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -16,7 +16,6 @@ import builtins
 import importlib.util as imputil
 import os
 import tempfile
-import uuid
 
 from kfp.compiler import compiler
 
@@ -65,11 +64,9 @@ class WorkflowSpec(mlrun.model.ModelObj):
                 "workflow must have code or path properties"
             )
         if self.code:
-            new_uuid = uuid.uuid4()
-            workflow_path = os.path.join(tempfile.gettempdir(), f"{new_uuid}.py")
-            with open(workflow_path, "w") as wf:
-                wf.write(self.code)
-            self._tmp_path = workflow_path
+            with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as workflow_fh:
+                workflow_fh.write(self.code)
+                self._tmp_path = workflow_path = workflow_fh.name
         else:
             workflow_path = self.path or ""
             if context and not workflow_path.startswith("/"):

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -15,7 +15,8 @@ import abc
 import builtins
 import importlib.util as imputil
 import os
-from tempfile import mktemp
+import tempfile
+import uuid
 
 from kfp.compiler import compiler
 
@@ -64,7 +65,8 @@ class WorkflowSpec(mlrun.model.ModelObj):
                 "workflow must have code or path properties"
             )
         if self.code:
-            workflow_path = mktemp(".py")
+            new_uuid = uuid.uuid4()
+            workflow_path = os.path.join(tempfile.gettempdir(), f"{new_uuid}.py")
             with open(workflow_path, "w") as wf:
                 wf.write(self.code)
             self._tmp_path = workflow_path

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -19,7 +19,9 @@ import os
 import shlex
 import socket
 import sys
+import tempfile
 import traceback
+import uuid
 from contextlib import redirect_stdout
 from copy import copy
 from io import StringIO
@@ -27,7 +29,6 @@ from os import environ, remove
 from pathlib import Path
 from subprocess import PIPE, Popen
 from sys import executable
-from tempfile import mktemp
 
 from distributed import Client, as_completed
 from nuclio import Event
@@ -136,7 +137,8 @@ class HandlerRuntime(BaseRuntime, ParallelRunner):
     def _run(self, runobj: RunObject, execution: MLClientCtx):
         handler = runobj.spec.handler
         self._force_handler(handler)
-        tmp = mktemp(".json")
+        new_uuid = uuid.uuid4()
+        tmp = os.path.join(tempfile.gettempdir(), f"{new_uuid}.json")
         environ["MLRUN_META_TMPFILE"] = tmp
         set_paths(self.spec.pythonpath)
 
@@ -216,7 +218,8 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
 
     def _run(self, runobj: RunObject, execution: MLClientCtx):
         environ["MLRUN_EXEC_CONFIG"] = runobj.to_json()
-        tmp = mktemp(".json")
+        new_uuid = uuid.uuid4()
+        tmp = os.path.join(tempfile.gettempdir(), f"{new_uuid}.json")
         environ["MLRUN_META_TMPFILE"] = tmp
         if self.spec.rundb:
             environ["MLRUN_DBPATH"] = self.spec.rundb

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -21,7 +21,6 @@ import socket
 import sys
 import tempfile
 import traceback
-import uuid
 from contextlib import redirect_stdout
 from copy import copy
 from io import StringIO
@@ -137,8 +136,7 @@ class HandlerRuntime(BaseRuntime, ParallelRunner):
     def _run(self, runobj: RunObject, execution: MLClientCtx):
         handler = runobj.spec.handler
         self._force_handler(handler)
-        new_uuid = uuid.uuid4()
-        tmp = os.path.join(tempfile.gettempdir(), f"{new_uuid}.json")
+        tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
         environ["MLRUN_META_TMPFILE"] = tmp
         set_paths(self.spec.pythonpath)
 
@@ -218,8 +216,7 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
 
     def _run(self, runobj: RunObject, execution: MLClientCtx):
         environ["MLRUN_EXEC_CONFIG"] = runobj.to_json()
-        new_uuid = uuid.uuid4()
-        tmp = os.path.join(tempfile.gettempdir(), f"{new_uuid}.json")
+        tmp = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
         environ["MLRUN_META_TMPFILE"] = tmp
         if self.spec.rundb:
             environ["MLRUN_DBPATH"] = self.spec.rundb

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import tarfile
 import tempfile
-import uuid
 import zipfile
 from os import path, remove
 from urllib.parse import urlparse
@@ -20,8 +19,7 @@ def _prep_dir(source, target_dir, suffix, secrets, clone):
     if clone and path.exists(target_dir) and path.isdir(target_dir):
         shutil.rmtree(target_dir)
 
-    new_uuid = uuid.uuid4()
-    temp_file = os.path.join(tempfile.gettempdir(), f"{new_uuid}{suffix}")
+    temp_file = tempfile.NamedTemporaryFile(suffix=suffix, delete=False).name
     mlrun.get_dataitem(source, secrets).download(temp_file)
     return temp_file
 

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -1,9 +1,10 @@
 import os
 import shutil
 import tarfile
+import tempfile
+import uuid
 import zipfile
 from os import path, remove
-from tempfile import mktemp
 from urllib.parse import urlparse
 
 from git import Repo
@@ -18,9 +19,11 @@ def _prep_dir(source, target_dir, suffix, secrets, clone):
         raise ValueError("please specify a target (context) directory for clone")
     if clone and path.exists(target_dir) and path.isdir(target_dir):
         shutil.rmtree(target_dir)
-    tmpfile = mktemp(suffix)
-    mlrun.get_dataitem(source, secrets).download(tmpfile)
-    return tmpfile
+
+    new_uuid = uuid.uuid4()
+    temp_file = os.path.join(tempfile.gettempdir(), f"{new_uuid}{suffix}")
+    mlrun.get_dataitem(source, secrets).download(temp_file)
+    return temp_file
 
 
 def clone_zip(source, target_dir, secrets=None, clone=True):


### PR DESCRIPTION
`tempfile.mktemp()` manifests a known vulnerability wrt race condition between setting the path and obtaining the file handle, which is sometimes worrying, and pops up in security scans even when used in a safe context - https://cwe.mitre.org/data/definitions/377
It is hence deemed deprecated and vulnerable: https://docs.python.org/3/library/tempfile.html#deprecated-functions-and-variables

The underlying issue here will still exist in some cases because the use case is valid - however, we will appease the scans