### PR TITLE
[Runtimes] Explode when invalid auto-mount is configured

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -190,6 +190,10 @@ class AutoMountType(str, Enum):
 
     @classmethod
     def _missing_(cls, value):
+        logger.warning(
+            "Invalid or missing value for auto_mount_type - will use default",
+            value=value,
+        )
         return AutoMountType.default()
 
     @staticmethod

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -190,10 +190,10 @@ class AutoMountType(str, Enum):
 
     @classmethod
     def _missing_(cls, value):
-        logger.warning(
-            "Invalid or missing value for auto_mount_type - will use default",
-            value=value,
-        )
+        if value:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Invalid value for auto_mount_type - '{value}'"
+            )
         return AutoMountType.default()
 
     @staticmethod

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+import mlrun.errors
 from mlrun.config import config as mlconf
 from mlrun.runtimes import KubejobRuntime
 from mlrun.runtimes.pod import AutoMountType
@@ -58,8 +59,13 @@ class TestAutoMount:
         rundb_mock.assert_no_mount_or_creds_configured()
 
     def test_auto_mount_invalid_value(self):
-        # When invalid value is used, auto mode will be used
+        # When invalid value is used, we explode
         mlconf.storage.auto_mount_type = "something_wrong"
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            auto_mount_type = AutoMountType(mlconf.storage.auto_mount_type)
+
+        # When it's missing, we just use auto
+        mlconf.storage.auto_mount_type = None
         auto_mount_type = AutoMountType(mlconf.storage.auto_mount_type)
         assert auto_mount_type == AutoMountType.auto
 


### PR DESCRIPTION
Explode when an invalid auto-mount mode is provided. If it's missing, continue doing as before - using `auto` mode.
Also fixed test that was using an invalid mode (`v3io_cred` was used instead of `v3io_credentials`)