### PR TITLE
[Feature Store] Fix OPA verification for list features/entities

### DIFF
--- a/mlrun/api/api/endpoints/feature_store.py
+++ b/mlrun/api/api/endpoints/feature_store.py
@@ -382,8 +382,8 @@ def list_features(
         mlrun.api.schemas.AuthorizationResourceTypes.feature,
         features.features,
         lambda feature_list_output: (
-            feature_list_output.feature.name,
             feature_list_output.feature_set_digest.metadata.project,
+            feature_list_output.feature.name,
         ),
         auth_verifier.auth_info,
     )
@@ -409,8 +409,8 @@ def list_entities(
         mlrun.api.schemas.AuthorizationResourceTypes.entity,
         entities.entities,
         lambda entity_list_output: (
-            entity_list_output.entity.name,
             entity_list_output.feature_set_digest.metadata.project,
+            entity_list_output.entity.name,
         ),
         auth_verifier.auth_info,
     )


### PR DESCRIPTION
Lambda functions had wrong order of parameters in them - was `(name, project)` rather than `(project, name)`. Caused feature (and probably entity) lists to return empty. 
Fix for issue - https://jira.iguazeng.com/browse/ML-1075