### PR TITLE
[Runtimes] Keep order in valid pod priority class names list, and rename methods

### DIFF
--- a/mlrun/config/dynamic.py
+++ b/mlrun/config/dynamic.py
@@ -63,9 +63,16 @@ class Config(ConfigBase):
 
     @staticmethod
     def get_valid_function_priority_class_names():
+        valid_function_priority_class_names = []
         if not config.valid_function_priority_class_names:
-            return []
-        return list(set(config.valid_function_priority_class_names.split(",")))
+            return valid_function_priority_class_names
+
+        for priority_class_name in config.valid_function_priority_class_names.split(
+            ","
+        ):
+            if priority_class_name not in valid_function_priority_class_names:
+                valid_function_priority_class_names.append(priority_class_name)
+        return valid_function_priority_class_names
 
     def get_storage_auto_mount_params(self):
         auto_mount_params = {}

--- a/mlrun/config/dynamic.py
+++ b/mlrun/config/dynamic.py
@@ -67,6 +67,7 @@ class Config(ConfigBase):
         if not config.valid_function_priority_class_names:
             return valid_function_priority_class_names
 
+        # Manually ensure we have only unique values because we want to keep the order and using a set would lose it
         for priority_class_name in config.valid_function_priority_class_names.split(
             ","
         ):

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -380,7 +380,7 @@ class KubeResource(BaseRuntime):
     def list_valid_priority_class_names(self):
         return mlconf.get_valid_function_priority_class_names()
 
-    def get_default_priority_class_names(self):
+    def get_default_priority_class_name(self):
         return mlconf.default_function_priority_class_name
 
     def _verify_and_set_limits(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -366,9 +366,7 @@ class KubeResource(BaseRuntime):
         """
         if name is None:
             name = mlconf.default_function_priority_class_name
-        valid_priority_class_names = self.list_valid_and_default_priority_class_names()[
-            "valid_function_priority_class_names"
-        ]
+        valid_priority_class_names = self.list_valid_priority_class_names()
         if name not in valid_priority_class_names:
             message = "Priority class name not in available priority class names"
             logger.warning(
@@ -379,11 +377,11 @@ class KubeResource(BaseRuntime):
             raise mlrun.errors.MLRunInvalidArgumentError(message)
         self.spec.priority_class_name = name
 
-    def list_valid_and_default_priority_class_names(self):
-        return {
-            "default_function_priority_class_name": mlconf.default_function_priority_class_name,
-            "valid_function_priority_class_names": mlconf.get_valid_function_priority_class_names(),
-        }
+    def list_valid_priority_class_names(self):
+        return mlconf.get_valid_function_priority_class_names()
+
+    def get_default_priority_class_names(self):
+        return mlconf.default_function_priority_class_name
 
     def _verify_and_set_limits(
         self,


### PR DESCRIPTION
- split method to get valid priority class names and default priority class name to 2 different methods
- preserve order of valid priority class name received externally