### PR TITLE
[Serving] Fix and enhance remote graph steps

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ flake8~=3.8
 pytest-asyncio~=0.15.0
 deepdiff~=5.0
 pytest-alembic~=0.4.0
+pytest-httpserver~=1.0.1
 requests-mock~=1.8
 # needed for system tests
 matplotlib~=3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ flake8~=3.8
 pytest-asyncio~=0.15.0
 deepdiff~=5.0
 pytest-alembic~=0.4.0
-pytest-httpserver~=1.0.1
+pytest-httpserver~=1.0
 requests-mock~=1.8
 # needed for system tests
 matplotlib~=3.0

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -356,7 +356,9 @@ class ServingRuntime(RemoteRuntime):
             function_object.metadata.tag = self.metadata.tag
 
             function_object.metadata.labels = function_object.metadata.labels or {}
-            function_object.metadata.labels["mlrun/parent-function"] = self._function_uri()
+            function_object.metadata.labels[
+                "mlrun/parent-function"
+            ] = self._function_uri()
             if not function_object.spec.graph:
                 # copy the current graph only if the child doesnt have a graph of his own
                 function_object.set_env("SERVING_CURRENT_FUNCTION", function_ref.name)

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -357,7 +357,7 @@ class ServingRuntime(RemoteRuntime):
 
             function_object.metadata.labels = function_object.metadata.labels or {}
             function_object.metadata.labels["parent-function"] = self._function_uri()
-            if function_object.spec.graph.is_empty():
+            if not function_object.spec.graph:
                 # copy the current graph only if the child doesnt have a graph of his own
                 function_object.set_env("SERVING_CURRENT_FUNCTION", function_ref.name)
                 function_object.spec.graph = self.spec.graph

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -329,7 +329,6 @@ class ServingRuntime(RemoteRuntime):
         )
         self._spec.function_refs.update(function_reference, name)
         func = function_reference.to_function(self.kind)
-        func.set_env("SERVING_CURRENT_FUNCTION", function_reference.name)
         return func
 
     def _add_ref_triggers(self):
@@ -350,13 +349,18 @@ class ServingRuntime(RemoteRuntime):
         for function_ref in self._spec.function_refs.values():
             logger.info(f"deploy child function {function_ref.name} ...")
             function_object = function_ref.function_object
+            if not function_object:
+                function_object = function_ref.to_function(self.kind)
             function_object.metadata.name = function_ref.fullname(self)
             function_object.metadata.project = self.metadata.project
             function_object.metadata.tag = self.metadata.tag
-            function_object.spec.graph = self.spec.graph
-            # todo: may want to copy parent volumes to child functions
-            function_object.apply(mlrun.v3io_cred())
-            function_ref.db_uri = function_object._function_uri()
+
+            function_object.metadata.labels["parent-function"] = self._function_uri()
+            if function_object.spec.graph.is_empty():
+                # copy the current graph only if the child doesnt have a graph of his own
+                function_object.set_env("SERVING_CURRENT_FUNCTION", function_ref.name)
+                function_object.spec.graph = self.spec.graph
+
             function_object.verbose = self.verbose
             function_object.spec.secret_sources = self.spec.secret_sources
             function_object.deploy()
@@ -480,13 +484,14 @@ class ServingRuntime(RemoteRuntime):
         return env
 
     def to_mock_server(
-        self, namespace=None, current_function="*", **kwargs
+        self, namespace=None, current_function="*", track_models=False, **kwargs
     ) -> GraphServer:
         """create mock server object for local testing/emulation
 
         :param namespace: classes search namespace, use globals() for current notebook
         :param log_level: log level (error | info | debug)
         :param current_function: specify if you want to simulate a child function, * for all functions
+        :param track_models: allow model tracking (disabled by default in the mock server)
         """
 
         server = create_graph_server(
@@ -496,7 +501,7 @@ class ServingRuntime(RemoteRuntime):
             verbose=self.verbose,
             current_function=current_function,
             graph_initializer=self.spec.graph_initializer,
-            track_models=self.spec.track_models,
+            track_models=track_models and self.spec.track_models,
             function_uri=self._function_uri(),
             secret_sources=self.spec.secret_sources,
             default_content_type=self.spec.default_content_type,

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -356,7 +356,7 @@ class ServingRuntime(RemoteRuntime):
             function_object.metadata.tag = self.metadata.tag
 
             function_object.metadata.labels = function_object.metadata.labels or {}
-            function_object.metadata.labels["parent-function"] = self._function_uri()
+            function_object.metadata.labels["mlrun/parent-function"] = self._function_uri()
             if not function_object.spec.graph:
                 # copy the current graph only if the child doesnt have a graph of his own
                 function_object.set_env("SERVING_CURRENT_FUNCTION", function_ref.name)

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -355,6 +355,7 @@ class ServingRuntime(RemoteRuntime):
             function_object.metadata.project = self.metadata.project
             function_object.metadata.tag = self.metadata.tag
 
+            function_object.metadata.labels = function_object.metadata.labels or {}
             function_object.metadata.labels["parent-function"] = self._function_uri()
             if function_object.spec.graph.is_empty():
                 # copy the current graph only if the child doesnt have a graph of his own

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -140,7 +140,14 @@ class RemoteState(storey.SendToHttp):
     def to_dict(self):
         args = {
             key: getattr(self, key)
-            for key in ["url", "subpath", "method", "headers", "return_json"]
+            for key in [
+                "url",
+                "subpath",
+                "method",
+                "headers",
+                "return_json",
+                "url_expression",
+            ]
         }
         return {
             "class_name": "$remote",

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -1,0 +1,112 @@
+import json
+
+import requests
+import storey
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+http_adapter = HTTPAdapter(
+    max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+)
+
+
+class RemoteState(storey.SendToHttp):
+    """class for calling remote endpoints
+    """
+
+    def __init__(
+        self, url, subpath=None, method=None, headers=None, return_json=True, **kwargs
+    ):
+        """class for calling remote endpoints
+
+        :param url:     http(s) url or function [project/]name to call
+        :param subpath: path (which follows the url), use `$path` to use the event.path
+        :param method:  HTTP method (GET, POST, ..)
+        :param headers: dictionary with http header values
+        :param return_json: indicate the returned value is json, and convert it to a py object
+        """
+        self.url = url
+        self.headers = headers
+        self.method = method
+        self.return_json = return_json
+        self.subpath = subpath or ""
+        super().__init__(None, None, **kwargs)
+
+        self._append_event_path = False
+        self._endpoint = ""
+        self._session = None
+
+    def post_init(self, mode="sync"):
+        self._append_event_path = self.subpath == "$path"
+        self._endpoint = self.context.get_remote_endpoint(self.url).strip("/")
+        if self.subpath and not self._append_event_path:
+            self._endpoint = self._endpoint + "/" + self.subpath.lstrip("/")
+
+    async def _process_event(self, event):
+        method, url, headers, body = self._gen_request(event)
+        return await self._client_session.request(
+            method, url, headers=headers, data=body, ssl=False
+        )
+
+    async def _handle_completed(self, event, response):
+        response_body = await response.read()
+        body = self._get_data(response_body, response.headers)
+
+        if body is not None:
+            new_event = self._user_fn_output_to_event(event, body)
+            await self._do_downstream(new_event)
+
+    def do_event(self, event):
+        if not self._session:
+            self._session = requests.Session()
+            self._session.mount("http://", http_adapter)
+            self._session.mount("https://", http_adapter)
+
+        method, url, headers, body = self._gen_request(event)
+        try:
+            resp = self._session.request(
+                method, url, verify=False, headers=headers, data=body
+            )
+        except OSError as err:
+            raise OSError(f"error: cannot run function at url {url}, {err}")
+        if not resp.ok:
+            raise RuntimeError(f"bad function response {resp.text}")
+
+        event.body = self._get_data(resp.content, resp.headers)
+        return event
+
+    def _gen_request(self, event):
+        method = self.method or event.method or "POST"
+        headers = self.headers or event.headers or {}
+
+        body = None
+        if method != "GET" and event.body is not None:
+            if isinstance(event.body, (str, bytes)):
+                body = event.body
+            else:
+                body = json.dumps(event.body)
+                headers["Content-Type"] = "application/json"
+
+        url = self._endpoint
+        if self._append_event_path:
+            url = url + "/" + event.path.lstrip("/")
+        return method, url, headers, body
+
+    def _get_data(self, data, headers):
+        if (
+            self.return_json
+            or headers.get("content-type", "").lower() == "application/json"
+        ) and isinstance(data, (str, bytes)):
+            data = json.loads(data)
+        return data
+
+    def to_dict(self):
+        args = {
+            key: getattr(self, key)
+            for key in ["url", "subpath", "method", "headers", "return_json"]
+        }
+        return {
+            "class_name": "$remote",
+            "name": self.name or "RemoteStep",
+            "class_args": args,
+        }

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -36,7 +36,7 @@ class RemoteState(storey.SendToHttp):
 
             flow = function.set_topology("flow", engine="async")
             flow.to(name="step1", handler="func1").\
-                 to("$remote", "remote_echo", url="https://myservice/path", method="POST").\
+                 to(RemoteState(name="remote_echo", url="https://myservice/path", method="POST")).\
                  to(name="laststep", handler="func2").respond()
 
 

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -35,9 +35,9 @@ class RemoteStep(storey.SendToHttp):
         example pipeline::
 
             flow = function.set_topology("flow", engine="async")
-            flow.to(name="step1", handler="func1").\
-                 to(RemoteState(name="remote_echo", url="https://myservice/path", method="POST")).\
-                 to(name="laststep", handler="func2").respond()
+            flow.to(name="step1", handler="func1")\
+                .to(RemoteStep(name="remote_echo", url="https://myservice/path", method="POST"))\
+                .to(name="laststep", handler="func2").respond()
 
 
         :param url:     http(s) url or function [project/]name to call

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -411,6 +411,39 @@ class GraphContext:
             return self._server._secrets.get(key)
         return None
 
+    def get_remote_endpoint(self, name, external=False):
+        """return the remote nuclio/serving function http(s) endpoint given its name
+
+        """
+        if "://" in name:
+            return name
+        project, uri, tag, _ = mlrun.utils.parse_versioned_object_uri(
+            self._server.function_uri
+        )
+        if name.startswith("."):
+            name = f"{uri}-{name[1:]}"
+        else:
+            project, name, tag, _ = mlrun.utils.parse_versioned_object_uri(uri, project)
+        (
+            state,
+            fullname,
+            _,
+            _,
+            _,
+            function_status,
+        ) = mlrun.runtimes.function.get_nuclio_deploy_status(name, project, tag)
+
+        if state in ["error", "unhealthy"]:
+            raise ValueError(
+                f"Nuclio function {fullname} is in error state, cannot be accessed"
+            )
+
+        key = "externalInvocationUrls" if external else "internalInvocationUrls"
+        urls = function_status.get(key)
+        if not urls:
+            raise ValueError(f"cannot read {key} for nuclio function {fullname}")
+        return urls[0]
+
 
 def format_error(server, context, source, event, message, args):
     return {

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -331,9 +331,9 @@ class TaskStep(BaseStep):
         if not self._class_object:
             if self.class_name == "$remote":
 
-                from mlrun.serving.remote import RemoteState
+                from mlrun.serving.remote import RemoteStep
 
-                self._class_object = RemoteState
+                self._class_object = RemoteStep
             else:
                 self._class_object = get_class(
                     self.class_name or self._default_class, namespace

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -14,7 +14,6 @@
 
 __all__ = ["TaskStep", "RouterStep", "RootFlowStep"]
 
-import json
 import os
 import pathlib
 import traceback
@@ -22,10 +21,6 @@ import warnings
 from copy import copy, deepcopy
 from inspect import getfullargspec, signature
 from typing import Union
-
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 
 from ..config import config
 from ..datastore import get_stream_pusher
@@ -335,7 +330,10 @@ class TaskStep(BaseStep):
 
         if not self._class_object:
             if self.class_name == "$remote":
-                self._class_object = RemoteHttpHandler
+
+                from mlrun.serving.remote import RemoteState
+
+                self._class_object = RemoteState
             else:
                 self._class_object = get_class(
                     self.class_name or self._default_class, namespace
@@ -373,11 +371,11 @@ class TaskStep(BaseStep):
                         f"handler ({handler}) specified but doesnt exist in class {self.class_name}"
                     )
             else:
-                if hasattr(self._object, "do"):
-                    handler = "do"
-                elif hasattr(self._object, "do_event"):
+                if hasattr(self._object, "do_event"):
                     handler = "do_event"
                     self.full_event = True
+                elif hasattr(self._object, "do"):
+                    handler = "do"
             if handler:
                 self._handler = getattr(self._object, handler, None)
 
@@ -1022,12 +1020,16 @@ class FlowStep(BaseStep):
             if step.kind == StepKinds.queue:
                 for item in step.next or []:
                     next_step = self[item]
-                    if next_step.function:
-                        if next_step.function in links:
-                            raise GraphError(
-                                f"function ({next_step.function}) cannot read from multiple queues"
-                            )
-                        links[next_step.function] = step
+                    if not next_step.function:
+                        raise GraphError(
+                            f"child function name must be specified in steps ({next_step.name}) which follow a queue"
+                        )
+
+                    if next_step.function in links:
+                        raise GraphError(
+                            f"function ({next_step.function}) cannot read from multiple queues"
+                        )
+                    links[next_step.function] = step
         return links
 
     def init_queues(self):
@@ -1125,50 +1127,6 @@ class RootFlowStep(FlowStep):
         return super().from_dict(
             struct, fields=fields, deprecated_fields={"final_state": "final_step"}
         )
-
-
-http_adapter = HTTPAdapter(
-    max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
-)
-
-
-class RemoteHttpHandler:
-    """class for calling remote endpoints"""
-
-    def __init__(self, url):
-        self.url = url
-        self.format = "json"
-        self._session = requests.Session()
-        self._session.mount("http://", http_adapter)
-        self._session.mount("https://", http_adapter)
-
-    def do_event(self, event):
-        kwargs = {}
-        kwargs["headers"] = event.headers or {}
-        method = event.method or "POST"
-        if method != "GET":
-            if isinstance(event.body, (str, bytes)):
-                kwargs["data"] = event.body
-            else:
-                kwargs["json"] = event.body
-
-        url = self.url.strip("/") + event.path
-        try:
-            resp = self._session.request(method, url, verify=False, **kwargs)
-        except OSError as err:
-            raise OSError(f"error: cannot run function at url {url}, {err}")
-        if not resp.ok:
-            raise RuntimeError(f"bad function response {resp.text}")
-
-        data = resp.content
-        if (
-            self.format == "json"
-            or resp.headers["content-type"] == "application/json"
-            and isinstance(data, (str, bytes))
-        ):
-            data = json.loads(data)
-        event.body = data
-        return event
 
 
 classes_map = {

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -107,12 +107,13 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_labels = {}
         deploy_mock = nuclio.deploy.deploy_config
         assert deploy_mock.call_count == call_count
+        print(f"\n>>>expected_params:\n{expected_params}")
 
         call_args_list = deploy_mock.call_args_list
         for single_call_args in call_args_list:
             args, kwargs = single_call_args
             print(f"\n>>>args:\n{args}\n{kwargs}")
-            parent_function = ""
+            parent_function = None
             if expected_params:
                 current_parameters = expected_params.pop(0)
                 expected_function_name = current_parameters["function_name"]
@@ -129,9 +130,10 @@ class TestNuclioRuntime(TestRuntimeBase):
             function_metadata = deploy_config["metadata"]
             assert function_metadata["name"] == expected_function_name
             expected_labels.update({"mlrun/class": expected_class})
-            # if parent_function:
-            #     expected_labels.update({"mlrun/parent-function": parent_function})
+            if parent_function:
+                expected_labels.update({"mlrun/parent-function": parent_function})
             print(f"\n>>>function_metadata:\n{function_metadata}")
+            print(f"\n>>>expected_labels:\n{expected_labels}")
             assert deepdiff.DeepDiff(function_metadata["labels"], expected_labels) == {}
 
             build_info = deploy_config["spec"]["build"]

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -111,6 +111,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         call_args_list = deploy_mock.call_args_list
         for single_call_args in call_args_list:
             args, kwargs = single_call_args
+            print(f"\n>>>args:\n{args}\n{kwargs}")
             parent_function = ""
             if expected_params:
                 current_parameters = expected_params.pop(0)
@@ -128,8 +129,9 @@ class TestNuclioRuntime(TestRuntimeBase):
             function_metadata = deploy_config["metadata"]
             assert function_metadata["name"] == expected_function_name
             expected_labels.update({"mlrun/class": expected_class})
-            if parent_function:
-                expected_labels.update({"mlrun/parent-function": parent_function})
+            # if parent_function:
+            #     expected_labels.update({"mlrun/parent-function": parent_function})
+            print(f"\n>>>function_metadata:\n{function_metadata}")
             assert deepdiff.DeepDiff(function_metadata["labels"], expected_labels) == {}
 
             build_info = deploy_config["spec"]["build"]

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -111,10 +111,12 @@ class TestNuclioRuntime(TestRuntimeBase):
         call_args_list = deploy_mock.call_args_list
         for single_call_args in call_args_list:
             args, kwargs = single_call_args
+            parent_function = ""
             if expected_params:
                 current_parameters = expected_params.pop(0)
                 expected_function_name = current_parameters["function_name"]
                 source_filename = current_parameters["file_name"]
+                parent_function = current_parameters.get("parent_function")
             else:
                 expected_function_name = f"{self.project}-{self.name}"
                 source_filename = self.code_filename
@@ -126,6 +128,8 @@ class TestNuclioRuntime(TestRuntimeBase):
             function_metadata = deploy_config["metadata"]
             assert function_metadata["name"] == expected_function_name
             expected_labels.update({"mlrun/class": expected_class})
+            if parent_function:
+                expected_labels.update({"mlrun/parent-function": parent_function})
             assert deepdiff.DeepDiff(function_metadata["labels"], expected_labels) == {}
 
             build_info = deploy_config["spec"]["build"]

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -107,12 +107,10 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_labels = {}
         deploy_mock = nuclio.deploy.deploy_config
         assert deploy_mock.call_count == call_count
-        print(f"\n>>>expected_params:\n{expected_params}")
 
         call_args_list = deploy_mock.call_args_list
         for single_call_args in call_args_list:
             args, kwargs = single_call_args
-            print(f"\n>>>args:\n{args}\n{kwargs}")
             parent_function = None
             if expected_params:
                 current_parameters = expected_params.pop(0)
@@ -129,12 +127,11 @@ class TestNuclioRuntime(TestRuntimeBase):
             deploy_config = args[0]
             function_metadata = deploy_config["metadata"]
             assert function_metadata["name"] == expected_function_name
-            expected_labels.update({"mlrun/class": expected_class})
+            labels_for_diff = expected_labels.copy()
+            labels_for_diff.update({"mlrun/class": expected_class})
             if parent_function:
-                expected_labels.update({"mlrun/parent-function": parent_function})
-            print(f"\n>>>function_metadata:\n{function_metadata}")
-            print(f"\n>>>expected_labels:\n{expected_labels}")
-            assert deepdiff.DeepDiff(function_metadata["labels"], expected_labels) == {}
+                labels_for_diff.update({"mlrun/parent-function": parent_function})
+            assert deepdiff.DeepDiff(function_metadata["labels"], labels_for_diff) == {}
 
             build_info = deploy_config["spec"]["build"]
 

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -241,7 +241,7 @@ class TestServingRuntime(TestNuclioRuntime):
             {
                 "function_name": f"{self.project}-{self.name}-child_function",
                 "file_name": child_function_path,
-                "parent_function": function._function_uri()
+                "parent_function": function._function_uri(),
             },
             {
                 "function_name": f"{self.project}-{self.name}",

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -241,6 +241,7 @@ class TestServingRuntime(TestNuclioRuntime):
             {
                 "function_name": f"{self.project}-{self.name}-child_function",
                 "file_name": child_function_path,
+                "parent_function": function._function_uri()
             },
             {
                 "function_name": f"{self.project}-{self.name}",

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -61,14 +61,14 @@ def test_remote_step(httpserver, engine):
 
 
 def test_remote_class(httpserver):
-    from mlrun.serving.remote import RemoteState
+    from mlrun.serving.remote import RemoteStep
 
     httpserver.expect_request("/cat", method="GET").respond_with_json({"cat": "ok"})
 
     function = mlrun.new_function("test2", kind="serving")
     flow = function.set_topology("flow", engine="sync")
     flow.to(name="s1", handler="echo").to(
-        RemoteState(name="remote_echo", url=httpserver.url_for("/cat"), method="GET")
+        RemoteStep(name="remote_echo", url=httpserver.url_for("/cat"), method="GET")
     ).to(name="s3", handler="echo").respond()
 
     server = function.to_mock_server()

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -1,0 +1,149 @@
+import json
+
+import requests
+import storey
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+import mlrun
+
+
+def echo(event):
+    print(event)
+    return event
+
+
+http_adapter = HTTPAdapter(
+    max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+)
+
+
+class AsyncRemote(storey.SendToHttp):
+    def __init__(
+        self, context, url, subpath=None, method=None, headers=None, return_json=True
+    ):
+        self.url = url
+        self.headers = headers
+        self.method = method
+        self.return_json = return_json
+        self.subpath = subpath or ""
+        super().__init__(None, None, context=context)
+
+        self._append_event_path = False
+        self._endpoint = ""
+        self._session = None
+
+    def post_init(self, mode="sync"):
+        self._append_event_path = self.subpath == "$path"
+        self._endpoint = self.context.get_remote_endpoint(self.url).strip("/")
+        if self.subpath and not self._append_event_path:
+            self._endpoint = self._endpoint + "/" + self.subpath.lstrip("/")
+
+    async def _process_event(self, event):
+        method, url, headers, body = self._gen_request(event)
+        return await self._client_session.request(
+            method, url, headers=headers, data=body, ssl=False
+        )
+
+    async def _handle_completed(self, event, response):
+        response_body = await response.read()
+        body = self._get_data(response_body, response.headers)
+
+        if body is not None:
+            new_event = self._user_fn_output_to_event(event, body)
+            await self._do_downstream(new_event)
+
+    def do_event(self, event):
+        if not self._session:
+            self._session = requests.Session()
+            self._session.mount("http://", http_adapter)
+            self._session.mount("https://", http_adapter)
+
+        method, url, headers, body = self._gen_request(event)
+        try:
+            resp = self._session.request(
+                method, url, verify=False, headers=headers, data=body
+            )
+        except OSError as err:
+            raise OSError(f"error: cannot run function at url {url}, {err}")
+        if not resp.ok:
+            raise RuntimeError(f"bad function response {resp.text}")
+
+        event.body = self._get_data(resp.content, resp.headers)
+        return event
+
+    def _gen_request(self, event):
+        method = self.method or event.method or "POST"
+        headers = self.headers or event.headers or {}
+
+        body = None
+        if method != "GET" and event.body is not None:
+            if isinstance(event.body, (str, bytes)):
+                body = event.body
+            else:
+                body = json.dumps(event.body)
+                headers["Content-Type"] = "application/json"
+
+        url = self._endpoint
+        if self._append_event_path:
+            url = url + "/" + event.path.lstrip("/")
+        return method, url, headers, body
+
+    def _get_data(self, data, headers):
+        if (
+            self.return_json
+            or headers.get("content-type", "").lower() == "application/json"
+        ) and isinstance(data, (str, bytes)):
+            data = json.loads(data)
+        return data
+
+
+# tests map, list of (params, request args, expected result)
+tests_map = [
+    ({"method": "GET"}, {"body": {"x": 5}}, {"get": "ok"}),
+    (
+        {"method": "POST", "subpath": "data", "return_json": False},
+        {"body": b"req text"},
+        b"my str",
+    ),
+    ({"method": "POST", "subpath": "json"}, {"body": {"x": 5}}, {"post": "ok"}),
+    (
+        {"method": "POST", "subpath": "$path"},
+        {"body": {"x": 5}, "path": "/json"},
+        {"post": "ok"},
+    ),
+]
+
+
+def _new_server(url, method="POST", subpath=None, headers=None, return_json=True):
+    function = mlrun.new_function("test", kind="serving")
+    flow = function.set_topology("flow", engine="async")
+    flow.to(name="s1", handler="echo").to(
+        "mlrun.serving.remote.RemoteState",
+        # "$remote",
+        "remote_echo",
+        url=url,
+        method=method,
+        subpath=subpath,
+        headers=headers,
+        return_json=return_json,
+    ).to(name="s3", handler="echo").respond()
+    return function.to_mock_server()
+
+
+def test_remote_step(httpserver):
+    httpserver.expect_request("/", method="GET").respond_with_json({"get": "ok"})
+    httpserver.expect_request(
+        "/data", method="POST", data="req text"
+    ).respond_with_data("my str")
+    httpserver.expect_request("/json", method="POST", json={"x": 5}).respond_with_json(
+        {"post": "ok"}
+    )
+    url = httpserver.url_for("/")
+
+    for params, request, expected in tests_map:
+        print(f"test params: {params}")
+        server = _new_server(url, **params)
+        resp = server.test(**request)
+        server.wait_for_completion()
+        assert resp == expected

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -1,9 +1,4 @@
-import json
-
-import requests
-import storey
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+import pytest
 
 import mlrun
 
@@ -11,91 +6,6 @@ import mlrun
 def echo(event):
     print(event)
     return event
-
-
-http_adapter = HTTPAdapter(
-    max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
-)
-
-
-class AsyncRemote(storey.SendToHttp):
-    def __init__(
-        self, context, url, subpath=None, method=None, headers=None, return_json=True
-    ):
-        self.url = url
-        self.headers = headers
-        self.method = method
-        self.return_json = return_json
-        self.subpath = subpath or ""
-        super().__init__(None, None, context=context)
-
-        self._append_event_path = False
-        self._endpoint = ""
-        self._session = None
-
-    def post_init(self, mode="sync"):
-        self._append_event_path = self.subpath == "$path"
-        self._endpoint = self.context.get_remote_endpoint(self.url).strip("/")
-        if self.subpath and not self._append_event_path:
-            self._endpoint = self._endpoint + "/" + self.subpath.lstrip("/")
-
-    async def _process_event(self, event):
-        method, url, headers, body = self._gen_request(event)
-        return await self._client_session.request(
-            method, url, headers=headers, data=body, ssl=False
-        )
-
-    async def _handle_completed(self, event, response):
-        response_body = await response.read()
-        body = self._get_data(response_body, response.headers)
-
-        if body is not None:
-            new_event = self._user_fn_output_to_event(event, body)
-            await self._do_downstream(new_event)
-
-    def do_event(self, event):
-        if not self._session:
-            self._session = requests.Session()
-            self._session.mount("http://", http_adapter)
-            self._session.mount("https://", http_adapter)
-
-        method, url, headers, body = self._gen_request(event)
-        try:
-            resp = self._session.request(
-                method, url, verify=False, headers=headers, data=body
-            )
-        except OSError as err:
-            raise OSError(f"error: cannot run function at url {url}, {err}")
-        if not resp.ok:
-            raise RuntimeError(f"bad function response {resp.text}")
-
-        event.body = self._get_data(resp.content, resp.headers)
-        return event
-
-    def _gen_request(self, event):
-        method = self.method or event.method or "POST"
-        headers = self.headers or event.headers or {}
-
-        body = None
-        if method != "GET" and event.body is not None:
-            if isinstance(event.body, (str, bytes)):
-                body = event.body
-            else:
-                body = json.dumps(event.body)
-                headers["Content-Type"] = "application/json"
-
-        url = self._endpoint
-        if self._append_event_path:
-            url = url + "/" + event.path.lstrip("/")
-        return method, url, headers, body
-
-    def _get_data(self, data, headers):
-        if (
-            self.return_json
-            or headers.get("content-type", "").lower() == "application/json"
-        ) and isinstance(data, (str, bytes)):
-            data = json.loads(data)
-        return data
 
 
 # tests map, list of (params, request args, expected result)
@@ -115,24 +25,19 @@ tests_map = [
 ]
 
 
-def _new_server(url, method="POST", subpath=None, headers=None, return_json=True):
+def _new_server(url, engine, method="POST", **kwargs):
     function = mlrun.new_function("test", kind="serving")
-    flow = function.set_topology("flow", engine="async")
+    flow = function.set_topology("flow", engine=engine)
     flow.to(name="s1", handler="echo").to(
-        "mlrun.serving.remote.RemoteState",
-        # "$remote",
-        "remote_echo",
-        url=url,
-        method=method,
-        subpath=subpath,
-        headers=headers,
-        return_json=return_json,
+        "$remote", "remote_echo", url=url, method=method, **kwargs
     ).to(name="s3", handler="echo").respond()
     return function.to_mock_server()
 
 
-def test_remote_step(httpserver):
+@pytest.mark.parametrize("engine", ["sync", "async"])
+def test_remote_step(httpserver, engine):
     httpserver.expect_request("/", method="GET").respond_with_json({"get": "ok"})
+    httpserver.expect_request("/foo", method="GET").respond_with_json({"foo": "ok"})
     httpserver.expect_request(
         "/data", method="POST", data="req text"
     ).respond_with_data("my str")
@@ -143,7 +48,13 @@ def test_remote_step(httpserver):
 
     for params, request, expected in tests_map:
         print(f"test params: {params}")
-        server = _new_server(url, **params)
+        server = _new_server(url, engine, **params)
         resp = server.test(**request)
         server.wait_for_completion()
         assert resp == expected
+
+    # test with url generated with expression (from the event)
+    server = _new_server(None, engine, method="GET", url_expression="event['myurl']")
+    resp = server.test(body={"myurl": httpserver.url_for("/foo")})
+    server.wait_for_completion()
+    assert resp == {"foo": "ok"}


### PR DESCRIPTION
* add parameters (path/method/headers/..) to remote steps, run async in async/story graphs
* support specify function uri ([project/]name) vs full http URL 
* support getting uri from the event using `url_expression`
* add checks for user errors, docs, and tests 
* fix child function init and add validation that the steps which follow after a queue must be in a child function
* disable model tracking in mock server by default (can still be set via a param)

example usage:

```python
flow = function.set_topology("flow")
flow.to(name="step1", handler="func1")\
    .to(RemoteStep(name="remote_echo", url="https://myservice/path", method="POST"))\
    .to(name="laststep", handler="func2").respond()
```