### PR TITLE
[CI] Fix periodic system tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
       id: git_info
       run: |
         echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-        echo "::set-output name=mlrun_commit_hash::$(git rev-parse --short $GITHUB_SHA)"
+        echo "::set-output name=mlrun_commit_hash::$(git rev-parse --short=8 $GITHUB_SHA)"
         echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"
     - name: Resolve docker cache tag
       id: docker_cache

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -64,7 +64,7 @@ jobs:
       if: ${{ github.event.inputs.test_code_from_action == 'true' }}
       id: git_action_info
       run: |
-        echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+        echo "::set-output name=mlrun_hash::$(git rev-parse --short=8 $GITHUB_SHA)"
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
@@ -73,7 +73,7 @@ jobs:
           cd /tmp && \
           git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
-          git rev-parse --short HEAD && \
+          git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)"
     - name: Extract git hashes from upstream and latest version
@@ -83,14 +83,14 @@ jobs:
           cd /tmp && \
           git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
           cd mlrun-upstream && \
-          git rev-parse --short HEAD && \
+          git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-upstream)"
         echo "::set-output name=ui_hash::$( \
           cd /tmp && \
           git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
-          git rev-parse --short HEAD && \
+          git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)"
         echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -163,7 +163,6 @@ jobs:
             install mlrun-kit \
             --debug \
             --wait \
-            --timeout 10m \
             --set global.registry.url=localhost:5000 \
             --set global.externalHostAddress=$(minikube ip) \
             --set mlrun.api.image.repository=${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api \
@@ -171,6 +170,18 @@ jobs:
             --set mlrun.ui.image.repository=ghcr.io/mlrun/mlrun-ui \
             --set mlrun.ui.image.tag=${{ steps.computed_params.outputs.mlrun_ui_version }} \
             v3io-stable/mlrun-kit
+
+    - name: Output some logs in case of failure
+      if: ${{ failure() }}
+      run: |
+        minikube logs
+        kubectl --namespace ${NAMESPACE} get pvc
+        kubectl --namespace ${NAMESPACE} get pv
+        kubectl --namespace ${NAMESPACE} get pods
+        kubectl --namespace ${NAMESPACE} get pods -o yaml
+        kubectl --namespace ${NAMESPACE} describe pods
+        kubectl --namespace ${NAMESPACE} get all
+        kubectl --namespace ${NAMESPACE} get all -o yaml
 
     - name: Prepare system tests env
       run: |

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -165,6 +165,7 @@ jobs:
             install mlrun-kit \
             --debug \
             --wait \
+            --timeout 10m \
             --set global.registry.url=localhost:5000 \
             --set global.externalHostAddress=$(minikube ip) \
             --set mlrun.api.image.repository=${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'hedingber/mlrun' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -173,7 +173,9 @@ jobs:
 
     - name: Output some logs in case of failure
       if: ${{ failure() }}
+      # add set -x to print commands before executing to make logs reading easier
       run: |
+        set -x
         minikube logs
         kubectl --namespace ${NAMESPACE} get pvc
         kubectl --namespace ${NAMESPACE} get pv
@@ -182,6 +184,7 @@ jobs:
         kubectl --namespace ${NAMESPACE} describe pods
         kubectl --namespace ${NAMESPACE} get all
         kubectl --namespace ${NAMESPACE} get all -o yaml
+        set +x
 
     - name: Prepare system tests env
       run: |

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -42,10 +42,10 @@ jobs:
   run-system-tests-opensource-ci:
     timeout-minutes: 60
     name: Run System Tests Open Source
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'hedingber/mlrun' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v2
@@ -130,16 +130,10 @@ jobs:
       with:
         version: "v3.3.4"
 
-    - name: Hotfix for minikube < 1.21
-      run: |
-        # Hotfix for minikube < 1.21.0
-        # https://serverfault.com/questions/1063166/kube-proxy-wont-start-in-minikube-because-of-permission-denied-issue-with-proc#comment1385632_1063305
-        sudo sysctl net/netfilter/nf_conntrack_max=131072
-
     - uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: "v1.15.1"
-        kubernetes version: "v1.17.9"
+        minikube version: "v1.22.0"
+        kubernetes version: "v1.19.13"
         driver: docker
         github token: ${{ github.token }}
         start args: '--addons registry'

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -67,7 +67,7 @@ jobs:
       if: ${{ github.event.inputs.test_code_from_action == 'true' }}
       id: git_action_info
       run: |
-        echo "::set-output name=mlrun_hash::$(git rev-parse --short $GITHUB_SHA)"
+        echo "::set-output name=mlrun_hash::$(git rev-parse --short=8 $GITHUB_SHA)"
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
@@ -76,7 +76,7 @@ jobs:
           cd /tmp && \
           git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
-          git rev-parse --short HEAD && \
+          git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)"
     - name: Extract git hashes from upstream and latest version
@@ -86,14 +86,14 @@ jobs:
           cd /tmp && \
           git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
           cd mlrun-upstream && \
-          git rev-parse --short HEAD && \
+          git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-upstream)"
         echo "::set-output name=ui_hash::$( \
           cd /tmp && \
           git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
-          git rev-parse --short HEAD && \
+          git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)"
         echo "::set-output name=latest_version::$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.info.version')"

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -145,7 +145,6 @@ jobs:
         minikube kubectl -- create namespace ${NAMESPACE}
 
     - name: Override MLRun Registry ConfigMap
-      # TODO: remove auto mount when it's enabled by default
       run: |
         cat <<EOF | minikube kubectl -- apply -f -
         apiVersion: v1
@@ -156,7 +155,6 @@ jobs:
         data:
           MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER: mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}
           MLRUN_IMAGES_REGISTRY: ${{ steps.computed_params.outputs.mlrun_docker_registry }}
-          MLRUN_STORAGE__AUTO_MOUNT_TYPE: v3io_credentials
         EOF
 
     - name: Install MLRun Kit helm chart

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -310,8 +310,6 @@ class SystemTestPreparer:
             # will make our tests really long)
             "MLRUN_HTTPDB__SCHEDULING__MIN_ALLOWED_INTERVAL": "0 Seconds",
             # Enabling it in system tests until we enable it by default in config
-            # TODO: remove when it's enabled by default
-            "MLRUN_STORAGE__AUTO_MOUNT_TYPE": "v3io_credentials",
         }
         if self._override_image_registry:
             data["MLRUN_IMAGES_REGISTRY"] = f"{self._override_image_registry}"


### PR DESCRIPTION
1. (OS system tests) Minikube stopped working on the ubuntu we're using in GH actions, at first this helped - https://github.com/mlrun/mlrun/pull/1168 but then it stopped working, changing minikube, k8s and ubuntu versions following https://github.com/nuclio/nuclio/pull/2294
2. For some reason `git rev-parse --short` started generating hash of 8 characters while it used to generate length of 7 causing the tests to fail (cause images not found) - changed it to ask for 8 characters explicitly
3. Added some logging in case OS system tests helm install fails (as it used to) for easier debugging
4. Removed redundant re-configuration of auto mount type