### PR TITLE
[Feature Store] Setting function db connection to enable saving in ingest API flow

### DIFF
--- a/mlrun/feature_store/ingestion.py
+++ b/mlrun/feature_store/ingestion.py
@@ -209,6 +209,8 @@ def run_ingestion_job(name, featureset, run_config, schedule=None, spark_service
     featureset.status.run_uri = task.metadata.uid
     featureset.save()
 
+    function.set_db_connection(featureset._get_run_db())
+
     run = function.run(
         task, schedule=schedule, local=run_config.local, watch=run_config.watch
     )


### PR DESCRIPTION
Partial fix for issue: https://jira.iguazeng.com/browse/ML-1095.
When performing feature-set ingest through the API, the function created was not saved to DB, since there was no DB connection in the function. Solving by copying the DB connection from the feature-set (whose DB connection is initialized in the API endpoint). This works for client-side flows as well, since it basically just copies the service API url from the feature-set.