### PR TITLE
[Serving] Support fn.add_model() in flow topologies

### DIFF
--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -268,6 +268,7 @@ class ServingRuntime(RemoteRuntime):
         class_name=None,
         model_url=None,
         handler=None,
+        router_step=None,
         **class_args,
     ):
         """add ml model and/or route to the function.
@@ -287,6 +288,8 @@ class ServingRuntime(RemoteRuntime):
                             (can also module.submodule.class and it will be imported automatically)
         :param model_url:   url of a remote model serving endpoint (cannot be used with model_path)
         :param handler:     for advanced users!, override default class handler name (do_event)
+        :param router_step: router step name (to determine which router we add the model to in graphs
+                            with multiple router steps)
         :param class_args:  extra kwargs to pass to the model serving class __init__
                             (can be read in the model using .get_param(key) method)
         """
@@ -295,7 +298,29 @@ class ServingRuntime(RemoteRuntime):
             graph = self.set_topology()
 
         if graph.kind != StepKinds.router:
-            raise ValueError("models can only be added under router state")
+            if router_step:
+                if router_step not in graph:
+                    raise ValueError(
+                        f"router step {router_step} not present in the graph"
+                    )
+                graph = graph[router_step]
+            else:
+                routers = [
+                    step
+                    for step in graph.steps.values()
+                    if step.kind == StepKinds.router
+                ]
+                if len(routers) == 0:
+                    raise ValueError(
+                        "graph does not contain any router, add_model can only be "
+                        "used when there is a router step"
+                    )
+                if len(routers) > 1:
+                    raise ValueError(
+                        f"found {len(routers)} routers, please specify the router_step"
+                        " you would like to add this model to"
+                    )
+                graph = routers[0]
 
         if not model_path and not model_url:
             raise ValueError("model_path or model_url must be provided")

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -146,3 +146,33 @@ def test_content_type():
     server = fn.to_mock_server()
     resp = server.test(body="[1,2]")
     assert resp == "list", "did not load json"
+
+
+def test_add_model():
+    fn = mlrun.new_function("tests", kind="serving")
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to("Echo", "e1").to("Echo", "e2")
+    try:
+        # should fail, we dont have a router
+        fn.add_model("m1", class_name="ModelTestingClass", model_path=".")
+        assert True, "add_model did not fail without router"
+    except Exception:
+        pass
+
+    # model should be added to the one (and only) router
+    fn = mlrun.new_function("tests", kind="serving")
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to("Echo", "e1").to("*", "router").to("Echo", "e2")
+    fn.add_model("m1", class_name="ModelTestingClass", model_path=".")
+    print(graph.to_yaml())
+
+    assert "m1" in graph["router"].routes, "model was not added to router"
+
+    # model is added to the specified router (by name)
+    fn = mlrun.new_function("tests", kind="serving")
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to("Echo", "e1").to("*", "r1").to("Echo", "e2").to("*", "r2")
+    fn.add_model("m1", class_name="ModelTestingClass", model_path=".", router_step="r2")
+    print(graph.to_yaml())
+
+    assert "m1" in graph["r2"].routes, "model was not added to proper router"


### PR DESCRIPTION
this PR adds the ability to use add_model when the graph topology is a flow.
this also enable the proper use in KFP pipelines and with the CLI which use the add_model() method 
to update models in serving functions