### PR TITLE
[API] Add schedules and pipelines counters to project summary & create project summary endpoints

### DIFF
--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -137,6 +137,17 @@ class Projects(
         )
         return project_summaries
 
+    def get_project_summary(
+        self, session: sqlalchemy.orm.Session, name: str
+    ) -> mlrun.api.schemas.ProjectSummary:
+        project_summary = mlrun.api.utils.singletons.db.get_db().get_project_summary(
+            session, name
+        )
+        self._add_pipeline_running_count_to_project_summaries(
+            session, [project_summary]
+        )
+        return project_summary
+
     def generate_projects_summaries(
         self, session: sqlalchemy.orm.Session, projects: typing.List[str]
     ) -> typing.List[mlrun.api.schemas.ProjectSummary]:

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -1,3 +1,4 @@
+import collections
 import typing
 
 import sqlalchemy.orm
@@ -119,3 +120,48 @@ class Projects(
         return mlrun.api.utils.singletons.db.get_db().list_projects(
             session, owner, format_, labels, state, names
         )
+
+    def list_project_summaries(
+        self,
+        session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        project_summaries = mlrun.api.utils.singletons.db.get_db().list_project_summaries(
+            session, owner, labels, state, names
+        )
+        self._add_pipeline_running_count_to_project_summaries(
+            session, project_summaries.project_summaries
+        )
+        return project_summaries
+
+    def generate_projects_summaries(
+        self, session: sqlalchemy.orm.Session, projects: typing.List[str]
+    ) -> typing.List[mlrun.api.schemas.ProjectSummary]:
+        project_summaries = mlrun.api.utils.singletons.db.get_db().generate_projects_summaries(
+            session, projects
+        )
+        self._add_pipeline_running_count_to_project_summaries(
+            session, project_summaries
+        )
+        return project_summaries
+
+    def _add_pipeline_running_count_to_project_summaries(
+        self,
+        session: sqlalchemy.orm.Session,
+        project_summaries: typing.List[mlrun.api.schemas.ProjectSummary],
+    ):
+        _, _, pipelines = mlrun.api.crud.Pipelines().list_pipelines(
+            session, "*", format_=mlrun.api.schemas.PipelinesFormat.metadata_only
+        )
+        project_to_running_pipelines_count = collections.defaultdict(int)
+        for pipeline in pipelines:
+            if pipeline["status"] not in mlrun.run.RunStatuses.stable_statuses():
+                project_to_running_pipelines_count[pipeline["project"]] += 1
+        for project_summary in project_summaries:
+            project_summary.pipelines_running_count = project_to_running_pipelines_count.get(
+                project_summary.name, 0
+            )
+        return project_summaries

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -231,6 +231,17 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
+    def list_project_summaries(
+        self,
+        session,
+        owner: str = None,
+        labels: List[str] = None,
+        state: schemas.ProjectState = None,
+        names: Optional[List[str]] = None,
+    ) -> schemas.ProjectSummariesOutput:
+        pass
+
+    @abstractmethod
     def create_project(self, session, project: schemas.Project):
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -242,6 +242,10 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
+    def get_project_summary(self, session, name: str) -> schemas.ProjectSummary:
+        pass
+
+    @abstractmethod
     def create_project(self, session, project: schemas.Project):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -176,6 +176,9 @@ class FileDB(DBInterface):
     ) -> schemas.ProjectSummariesOutput:
         raise NotImplementedError()
 
+    def get_project_summary(self, session, name: str) -> schemas.ProjectSummary:
+        raise NotImplementedError("Get project summary is not supported")
+
     def store_project(self, session, name: str, project: schemas.Project):
         raise NotImplementedError()
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -166,6 +166,16 @@ class FileDB(DBInterface):
             self.db.list_projects, owner, format_, labels, state
         )
 
+    def list_project_summaries(
+        self,
+        session,
+        owner: str = None,
+        labels: List[str] = None,
+        state: schemas.ProjectState = None,
+        names: Optional[List[str]] = None,
+    ) -> schemas.ProjectSummariesOutput:
+        raise NotImplementedError()
+
     def store_project(self, session, name: str, project: schemas.Project):
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -871,7 +871,7 @@ class SQLDB(DBInterface):
             query = self._add_labels_filter(session, query, Project, labels)
         if names:
             query = query.filter(Project.name.in_(names))
-        project_names = query.all()
+        project_names = [name for name, in query]
         project_summaries = self.generate_projects_summaries(session, project_names)
         return schemas.ProjectSummariesOutput(project_summaries=project_summaries)
 
@@ -1013,6 +1013,9 @@ class SQLDB(DBInterface):
                         project, 0
                     ),
                     runs_running_count=project_to_running_runs_count.get(project, 0),
+                    # This is a mandatory field - filling here with 0, it will be filled with the real number in the
+                    # crud layer
+                    pipelines_running_count=0,
                 )
             )
         return project_summaries

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -60,7 +60,7 @@ run_time_fmt = "%Y-%m-%dT%H:%M:%S.%fZ"
 unversioned_tagged_object_uid_prefix = "unversioned-"
 
 
-class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
+class SQLDB(DBInterface):
     def __init__(self, dsn):
         self.dsn = dsn
         self._cache = {

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -878,6 +878,14 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
             project_to_function_count = {
                 result[0]: result[1] for result in functions_count_per_project
             }
+            schedules_count_per_project = (
+                session.query(Schedule.project, func.count(distinct(Schedule.name)))
+                .group_by(Schedule.project)
+                .all()
+            )
+            project_to_schedule_count = {
+                result[0]: result[1] for result in schedules_count_per_project
+            }
             feature_sets_count_per_project = (
                 session.query(FeatureSet.project, func.count(distinct(FeatureSet.name)))
                 .group_by(FeatureSet.project)
@@ -942,6 +950,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
 
             self._cache["project_resources_counters"]["result"] = (
                 project_to_function_count,
+                project_to_schedule_count,
                 project_to_feature_set_count,
                 project_to_models_count,
                 project_to_recent_failed_runs_count,
@@ -961,6 +970,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
     ) -> List[mlrun.api.schemas.ProjectSummary]:
         (
             project_to_function_count,
+            project_to_schedule_count,
             project_to_feature_set_count,
             project_to_models_count,
             project_to_recent_failed_runs_count,
@@ -972,6 +982,7 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
                 mlrun.api.schemas.ProjectSummary(
                     name=project,
                     functions_count=project_to_function_count.get(project, 0),
+                    schedules_count=project_to_schedule_count.get(project, 0),
                     feature_sets_count=project_to_feature_set_count.get(project, 0),
                     models_count=project_to_models_count.get(project, 0),
                     runs_failed_recent_count=project_to_recent_failed_runs_count.get(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -858,6 +858,23 @@ class SQLDB(mlrun.api.utils.projects.remotes.follower.Member, DBInterface):
                     )
         return schemas.ProjectsOutput(projects=projects)
 
+    def list_project_summaries(
+        self,
+        session: Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        query = self._query(session, Project.name, owner=owner, state=state)
+        if labels:
+            query = self._add_labels_filter(session, query, Project, labels)
+        if names:
+            query = query.filter(Project.name.in_(names))
+        project_names = query.all()
+        project_summaries = self.generate_projects_summaries(session, project_names)
+        return schemas.ProjectSummariesOutput(project_summaries=project_summaries)
+
     def _get_project_resources_counters(self, session: Session):
         now = datetime.now()
         if (

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -875,6 +875,13 @@ class SQLDB(DBInterface):
         project_summaries = self.generate_projects_summaries(session, project_names)
         return schemas.ProjectSummariesOutput(project_summaries=project_summaries)
 
+    def get_project_summary(
+        self, session: Session, name: str
+    ) -> mlrun.api.schemas.ProjectSummary:
+        # Call get project so we'll explode if project doesn't exists
+        self.get_project(session, name)
+        return self.generate_projects_summaries(session, [name])[0]
+
     def _get_project_resources_counters(self, session: Session):
         now = datetime.now()
         if (

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -88,6 +88,7 @@ from .project import (
     ProjectSpec,
     ProjectState,
     ProjectStatus,
+    ProjectSummariesOutput,
     ProjectSummary,
 )
 from .runtime_resource import (

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -108,3 +108,7 @@ class ProjectsOutput(pydantic.BaseModel):
     # to add a specific classes for them. it's frustrating but couldn't find other workaround, see:
     # https://github.com/samuelcolvin/pydantic/issues/1423, https://github.com/samuelcolvin/pydantic/issues/619
     projects: typing.List[typing.Union[Project, str, ProjectSummary, IguazioProject]]
+
+
+class ProjectSummariesOutput(pydantic.BaseModel):
+    project_summaries: typing.List[ProjectSummary]

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -86,11 +86,12 @@ class ProjectOwner(pydantic.BaseModel):
 class ProjectSummary(pydantic.BaseModel):
     name: str
     functions_count: int
-    schedules_count: int
     feature_sets_count: int
     models_count: int
     runs_failed_recent_count: int
     runs_running_count: int
+    schedules_count: int
+    pipelines_running_count: int
 
 
 class IguazioProject(pydantic.BaseModel):

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -86,6 +86,7 @@ class ProjectOwner(pydantic.BaseModel):
 class ProjectSummary(pydantic.BaseModel):
     name: str
     functions_count: int
+    schedules_count: int
     feature_sets_count: int
     models_count: int
     runs_failed_recent_count: int

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -121,6 +121,7 @@ class Client(
         format_: mlrun.api.schemas.ProjectsFormat = mlrun.api.schemas.ProjectsFormat.full,
         labels: typing.List[str] = None,
         state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
         if owner:
             raise NotImplementedError(
@@ -133,6 +134,10 @@ class Client(
         if state:
             raise NotImplementedError(
                 "Filtering nuclio projects by state is currently not supported"
+            )
+        if names:
+            raise NotImplementedError(
+                "Filtering nuclio projects by names is currently not supported"
             )
         response = self._send_request_to_api("GET", "projects")
         response_body = response.json()
@@ -149,6 +154,16 @@ class Client(
             raise NotImplementedError(
                 f"Provided format is not supported. format={format_}"
             )
+
+    def list_project_summaries(
+        self,
+        session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        raise NotImplementedError("Listing project summaries is not supported")
 
     def get_dashboard_version(self) -> str:
         response = self._send_request_to_api("GET", "versions")

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -165,6 +165,11 @@ class Client(
     ) -> mlrun.api.schemas.ProjectSummariesOutput:
         raise NotImplementedError("Listing project summaries is not supported")
 
+    def get_project_summary(
+        self, session: sqlalchemy.orm.Session, name: str
+    ) -> mlrun.api.schemas.ProjectSummary:
+        raise NotImplementedError("Get project summary is not supported")
+
     def get_dashboard_version(self) -> str:
         response = self._send_request_to_api("GET", "versions")
         response_body = response.json()

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -267,12 +267,74 @@ class Member(
             ]
             return mlrun.api.schemas.ProjectsOutput(projects=leader_projects)
 
+        projects = self._list_projects(leader_session, owner, labels, state, names)
+
+        project_names = list(map(lambda project: project.metadata.name, projects))
+        # format output
+        if format_ == mlrun.api.schemas.ProjectsFormat.name_only:
+            projects = project_names
+        elif format_ == mlrun.api.schemas.ProjectsFormat.full:
+            pass
+        elif format_ == mlrun.api.schemas.ProjectsFormat.summary:
+            # importing here to avoid circular import (db using project member using mlrun follower using db)
+            from mlrun.api.utils.singletons.db import get_db
+
+            projects = get_db().generate_projects_summaries(db_session, project_names)
+        else:
+            raise NotImplementedError(
+                f"Provided format is not supported. format={format_}"
+            )
+        return mlrun.api.schemas.ProjectsOutput(projects=projects)
+
+    def list_project_summaries(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        projects_role: typing.Optional[mlrun.api.schemas.ProjectsRole] = None,
+        leader_session: typing.Optional[str] = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        projects = self._list_projects(leader_session, owner, labels, state, names)
+        project_names = list(map(lambda project: project.metadata.name, projects))
+
+        # importing here to avoid circular import (db using project member using mlrun follower using db)
+        from mlrun.api.utils.singletons.db import get_db
+
+        project_summaries = get_db().generate_projects_summaries(
+            db_session, project_names
+        )
+
+        return mlrun.api.schemas.ProjectSummariesOutput(
+            project_summaries=project_summaries
+        )
+
+    def _list_projects(
+        self,
+        leader_session: typing.Optional[str] = None,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> typing.List[mlrun.api.schemas.Project]:
+        projects = []
         if self.projects_store_mode == self.ProjectsStoreMode.cache:
             projects = list(self._projects.values())
         elif self.projects_store_mode == self.ProjectsStoreMode.none:
             projects, _ = self._leader_client.list_projects(leader_session)
 
-        # filter projects
+        projects = self._filter_projects(projects, owner, labels, state, names)
+        return projects
+
+    def _filter_projects(
+        self,
+        projects: typing.List[mlrun.api.schemas.Project],
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> typing.List[mlrun.api.schemas.Project]:
         if names:
             projects = [
                 project for project in projects if project.metadata.name in names
@@ -292,22 +354,7 @@ class Member(
                     projects,
                 )
             )
-        project_names = list(map(lambda project: project.metadata.name, projects))
-        # format output
-        if format_ == mlrun.api.schemas.ProjectsFormat.name_only:
-            projects = project_names
-        elif format_ == mlrun.api.schemas.ProjectsFormat.full:
-            pass
-        elif format_ == mlrun.api.schemas.ProjectsFormat.summary:
-            # importing here to avoid circular import (db using project member using mlrun follower using db)
-            from mlrun.api.utils.singletons.db import get_db
-
-            projects = get_db().generate_projects_summaries(db_session, project_names)
-        else:
-            raise NotImplementedError(
-                f"Provided format is not supported. format={format_}"
-            )
-        return mlrun.api.schemas.ProjectsOutput(projects=projects)
+        return projects
 
     def _start_periodic_sync(self):
         # the > 0 condition is to allow ourselves to disable the sync from configuration

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -310,6 +310,22 @@ class Member(
             project_summaries=project_summaries
         )
 
+    def get_project_summary(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        name: str,
+        leader_session: typing.Optional[str] = None,
+    ) -> mlrun.api.schemas.ProjectSummary:
+        # Call get project so we'll explode if project doesn't exists
+        self.get_project(db_session, name, leader_session)
+
+        # importing here to avoid circular import (db using project member using mlrun follower using db)
+        import mlrun.api.crud
+
+        return mlrun.api.crud.Projects().generate_projects_summaries(
+            db_session, [name]
+        )[0]
+
     def _list_projects(
         self,
         leader_session: typing.Optional[str] = None,

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -300,9 +300,9 @@ class Member(
         project_names = list(map(lambda project: project.metadata.name, projects))
 
         # importing here to avoid circular import (db using project member using mlrun follower using db)
-        from mlrun.api.utils.singletons.db import get_db
+        import mlrun.api.crud
 
-        project_summaries = get_db().generate_projects_summaries(
+        project_summaries = mlrun.api.crud.Projects().generate_projects_summaries(
             db_session, project_names
         )
 

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -138,6 +138,14 @@ class Member(
             db_session, owner, labels, state, names
         )
 
+    def get_project_summary(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        name: str,
+        leader_session: typing.Optional[str] = None,
+    ) -> mlrun.api.schemas.ProjectSummary:
+        return self._leader_follower.get_project_summary(db_session, name)
+
     def get_project_owner(
         self, db_session: sqlalchemy.orm.Session, name: str,
     ) -> mlrun.api.schemas.ProjectOwner:

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -124,6 +124,20 @@ class Member(
             db_session, owner, format_, labels, state, names
         )
 
+    def list_project_summaries(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        projects_role: typing.Optional[mlrun.api.schemas.ProjectsRole] = None,
+        leader_session: typing.Optional[str] = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        return self._leader_follower.list_project_summaries(
+            db_session, owner, labels, state, names
+        )
+
     def get_project_owner(
         self, db_session: sqlalchemy.orm.Session, name: str,
     ) -> mlrun.api.schemas.ProjectOwner:

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -118,6 +118,15 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def get_project_summary(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        name: str,
+        leader_session: typing.Optional[str] = None,
+    ) -> mlrun.api.schemas.ProjectSummary:
+        pass
+
+    @abc.abstractmethod
     def list_project_summaries(
         self,
         db_session: sqlalchemy.orm.Session,

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -118,6 +118,19 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def list_project_summaries(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        projects_role: typing.Optional[mlrun.api.schemas.ProjectsRole] = None,
+        leader_session: typing.Optional[str] = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        pass
+
+    @abc.abstractmethod
     def get_project_owner(
         self, db_session: sqlalchemy.orm.Session, name: str,
     ) -> mlrun.api.schemas.ProjectOwner:

--- a/mlrun/api/utils/projects/remotes/follower.py
+++ b/mlrun/api/utils/projects/remotes/follower.py
@@ -69,3 +69,9 @@ class Member(abc.ABC):
         names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.api.schemas.ProjectSummariesOutput:
         pass
+
+    @abc.abstractmethod
+    def get_project_summary(
+        self, session: sqlalchemy.orm.Session, name: str
+    ) -> mlrun.api.schemas.ProjectSummary:
+        pass

--- a/mlrun/api/utils/projects/remotes/follower.py
+++ b/mlrun/api/utils/projects/remotes/follower.py
@@ -58,3 +58,14 @@ class Member(abc.ABC):
         names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
         pass
+
+    @abc.abstractmethod
+    def list_project_summaries(
+        self,
+        session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        pass

--- a/mlrun/api/utils/projects/remotes/nop_follower.py
+++ b/mlrun/api/utils/projects/remotes/nop_follower.py
@@ -83,3 +83,13 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
             raise NotImplementedError(
                 f"Provided format is not supported. format={format_}"
             )
+
+    def list_project_summaries(
+        self,
+        session: sqlalchemy.orm.Session,
+        owner: str = None,
+        labels: typing.List[str] = None,
+        state: mlrun.api.schemas.ProjectState = None,
+        names: typing.Optional[typing.List[str]] = None,
+    ) -> mlrun.api.schemas.ProjectSummariesOutput:
+        raise NotImplementedError("Listing project summaries is not supported")

--- a/mlrun/api/utils/projects/remotes/nop_follower.py
+++ b/mlrun/api/utils/projects/remotes/nop_follower.py
@@ -93,3 +93,8 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
         names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.api.schemas.ProjectSummariesOutput:
         raise NotImplementedError("Listing project summaries is not supported")
+
+    def get_project_summary(
+        self, session: sqlalchemy.orm.Session, name: str
+    ) -> mlrun.api.schemas.ProjectSummary:
+        raise NotImplementedError("Get project summary is not supported")

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -72,8 +72,10 @@ class Scheduler:
         scheduled_object: Union[Dict, Callable],
         cron_trigger: Union[str, schemas.ScheduleCronTrigger],
         labels: Dict = None,
-        concurrency_limit: int = config.httpdb.scheduling.default_concurrency_limit,
+        concurrency_limit: int = None,
     ):
+        if concurrency_limit is None:
+            concurrency_limit = config.httpdb.scheduling.default_concurrency_limit
         if isinstance(cron_trigger, str):
             cron_trigger = schemas.ScheduleCronTrigger.from_crontab(cron_trigger)
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -186,7 +186,7 @@ default_config = {
             "followers": "",
             # This is used as the interval for the sync loop both when mlrun is leader and follower
             "periodic_sync_interval": "1 minute",
-            "counters_cache_ttl": "10 seconds",
+            "counters_cache_ttl": "2 minutes",
             # access key to be used when the leader is iguazio and polling is done from it
             "iguazio_access_key": "",
             # the initial implementation was cache and was working great, now it's not needed because we get (read/list)

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -173,7 +173,7 @@ def test_delete_project_with_resources(
     assert response.status_code == HTTPStatus.NO_CONTENT.value
 
 
-def test_list_projects_summary_format(
+def test_list_project_summaries(
     db: Session, client: TestClient, project_member_mode: str
 ) -> None:
     # create empty project
@@ -251,14 +251,23 @@ def test_list_projects_summary_format(
         client, project_name, 3, mlrun.runtimes.constants.RunStates.error, two_days_ago
     )
 
-    # list projects with summary format
-    response = client.get(
-        "/api/projects", params={"format": mlrun.api.schemas.ProjectsFormat.summary}
+    # create schedules for the project
+    schedules_count = 3
+    _create_schedules(
+        client, project_name, schedules_count,
     )
-    projects_output = mlrun.api.schemas.ProjectsOutput(**response.json())
-    for index, project_summary in enumerate(projects_output.projects):
+
+    # mock pipelines for the project
+    running_pipelines_count = _mock_pipelines(project_name,)
+
+    # list project summaries with summary format
+    response = client.get("/api/project-summaries")
+    project_summaries_output = mlrun.api.schemas.ProjectSummariesOutput(
+        **response.json()
+    )
+    for index, project_summary in enumerate(project_summaries_output.project_summaries):
         if project_summary.name == empty_project_name:
-            _assert_project_summary(project_summary, 0, 0, 0, 0, 0)
+            _assert_project_summary(project_summary, 0, 0, 0, 0, 0, 0, 0)
         elif project_summary.name == project_name:
             _assert_project_summary(
                 project_summary,
@@ -267,6 +276,8 @@ def test_list_projects_summary_format(
                 models_count,
                 recent_failed_runs_count + recent_aborted_runs_count,
                 running_runs_count,
+                schedules_count,
+                running_pipelines_count,
             )
         else:
             pytest.fail(f"Unexpected project summary returned: {project_summary}")
@@ -796,12 +807,16 @@ def _assert_project_summary(
     models_count: int,
     runs_failed_recent_count: int,
     runs_running_count: int,
+    schedules_count: int,
+    pipelines_running_count: int,
 ):
     assert project_summary.functions_count == functions_count
     assert project_summary.feature_sets_count == feature_sets_count
     assert project_summary.models_count == models_count
     assert project_summary.runs_failed_recent_count == runs_failed_recent_count
     assert project_summary.runs_running_count == runs_running_count
+    assert project_summary.schedules_count == schedules_count
+    assert project_summary.pipelines_running_count == pipelines_running_count
 
 
 def _assert_project(
@@ -898,3 +913,34 @@ def _create_runs(
                 run.setdefault("status", {})["start_time"] = start_time.isoformat()
             response = client.post(f"/api/run/{project_name}/{run_uid}", json=run)
             assert response.status_code == HTTPStatus.OK.value, response.json()
+
+
+def _create_schedules(client: TestClient, project_name, schedules_count):
+    for index in range(schedules_count):
+        schedule_name = f"schedule-name-{str(uuid4())}"
+        schedule = mlrun.api.schemas.ScheduleInput(
+            name=schedule_name,
+            kind=mlrun.api.schemas.ScheduleKinds.job,
+            scheduled_object={"metadata": {"name": "something"}},
+            cron_trigger=mlrun.api.schemas.ScheduleCronTrigger(year=1999),
+        )
+        response = client.post(
+            f"/api/projects/{project_name}/schedules", json=schedule.dict()
+        )
+        assert response.status_code == HTTPStatus.CREATED.value, response.json()
+
+
+def _mock_pipelines(project_name):
+    status_count_map = {
+        mlrun.run.RunStatuses.running: 4,
+        mlrun.run.RunStatuses.succeeded: 3,
+        mlrun.run.RunStatuses.failed: 2,
+    }
+    pipelines = []
+    for status, count in status_count_map.items():
+        for index in range(count):
+            pipelines.append({"status": status, "project": project_name})
+    mlrun.api.crud.Pipelines().list_pipelines = unittest.mock.Mock(
+        return_value=(None, None, pipelines)
+    )
+    return status_count_map[mlrun.run.RunStatuses.running]

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -173,7 +173,7 @@ def test_delete_project_with_resources(
     assert response.status_code == HTTPStatus.NO_CONTENT.value
 
 
-def test_list_project_summaries(
+def test_list_and_get_project_summaries(
     db: Session, client: TestClient, project_member_mode: str
 ) -> None:
     # create empty project
@@ -260,7 +260,7 @@ def test_list_project_summaries(
     # mock pipelines for the project
     running_pipelines_count = _mock_pipelines(project_name,)
 
-    # list project summaries with summary format
+    # list project summaries
     response = client.get("/api/project-summaries")
     project_summaries_output = mlrun.api.schemas.ProjectSummariesOutput(
         **response.json()
@@ -281,6 +281,20 @@ def test_list_project_summaries(
             )
         else:
             pytest.fail(f"Unexpected project summary returned: {project_summary}")
+
+    # get project summary
+    response = client.get(f"/api/project-summaries/{project_name}")
+    project_summary = mlrun.api.schemas.ProjectSummary(**response.json())
+    _assert_project_summary(
+        project_summary,
+        functions_count,
+        feature_sets_count,
+        models_count,
+        recent_failed_runs_count + recent_aborted_runs_count,
+        running_runs_count,
+        schedules_count,
+        running_pipelines_count,
+    )
 
 
 def test_delete_project_deletion_strategy_check(

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -287,6 +287,8 @@ def test_list_project_format_summary(
         models_count=6,
         runs_failed_recent_count=7,
         runs_running_count=8,
+        schedules_count=1,
+        pipelines_running_count=2,
     )
     mlrun.api.utils.singletons.db.get_db().generate_projects_summaries = unittest.mock.Mock(
         return_value=[project_summary]


### PR DESCRIPTION
* Added schedules and running pipelines counters to the project summary
* Created dedicated endpoints (a follow up PR will remove the summary format):
1.  `list_project_summaries - GET /project-summaries`
2. `get_project_summary - GET /project-summaries/{name}`
* Changed default counters cache from 10 seconds to 2 minutes