### PR TITLE
[Requirements] Bump fastapi to 0.68.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ kubernetes~=11.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from
 #  separating the SDK and API code) (referring to humanfriendly and fastapi)
 humanfriendly~=8.2
-fastapi~=0.62.0
+fastapi~=0.68.0
 fsspec~=0.9.0
 v3iofs~=0.1.7
 # 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771


### PR DESCRIPTION
We got dependabot alert for using version lower than 0.65.2 (see https://github.com/tiangolo/fastapi/security/advisories/GHSA-8h2j-cgx8-6xv7)