### PR TITLE
[System Tests] Fix import bug

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -9,7 +9,6 @@ logger = mlrun.utils.create_logger(level="debug", name="automation")
 
 
 class PackageTester:
-
     def __init__(self):
         self._logger = logger
 

--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -10,11 +10,6 @@ logger = mlrun.utils.create_logger(level="debug", name="automation")
 
 class PackageTester:
 
-    import_test_result_map_key = "import test"
-    requirements_conflicts_test_result_map_key = "requirements conflicts test"
-    test_passed_result_map_key = "passed"
-    test_exception_result_map_key = "exc"
-
     def __init__(self):
         self._logger = logger
 

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -224,12 +224,6 @@ async def test_schedule_upgrade_from_scheduler_without_credentials_store(
     scheduler: Scheduler,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
-    """
-    Continue here
-    this test doesn't work cause reload schedules takes for granted that there is a session, which made me think whether
-    session is enough - after runtimes refactor and getting auth info out of sqlrundb is will be enough, so also can
-    remove the mlrun.api.utils.auth.AuthVerifier().generate_auth_info_from_session call from scheduler run wrapper
-    """
     name = "schedule-name"
     project = config.default_project
     scheduled_object = _create_mlrun_function_and_matching_scheduled_object(db, project)


### PR DESCRIPTION
We started seeing this bug originating from https://github.com/mlrun/mlrun/pull/1361
```
  File "/home/runner/work/mlrun/mlrun/tests/common_fixtures.py", line 13, in <module>
    import mlrun.api.utils.singletons.project_member
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/singletons/project_member.py", line 1, in <module>
    import mlrun.api.utils.projects.follower
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/projects/follower.py", line 9, in <module>
    import mlrun.api.utils.auth.verifier
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/auth/verifier.py", line 8, in <module>
    import mlrun.api.api.utils
  File "/home/runner/work/mlrun/mlrun/mlrun/api/api/utils.py", line 18, in <module>
    from mlrun.api.utils.singletons.scheduler import get_scheduler
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/singletons/scheduler.py", line 2, in <module>
    from mlrun.api.utils.scheduler import Scheduler
  File "/home/runner/work/mlrun/mlrun/mlrun/api/utils/scheduler.py", line 10, in <module>
    from apscheduler.schedulers.asyncio import AsyncIOScheduler
ImportError: Error importing plugin "tests.common_fixtures": No module named 'apscheduler'
```
The fix here is not ideal, but solves the problem
Also removed some left overs