### PR TITLE
[Runtimes] Add project secrets to Nuclio functions

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -441,8 +441,12 @@ class RemoteRuntime(KubeResource):
         self.spec.max_replicas = shards
 
     def add_secrets_config_to_spec(self):
-        # Currently secrets are only handled in Serving runtime.
-        pass
+        # For nuclio functions, we just add the project secrets as env variables. Since there's no MLRun code
+        # to decode the secrets and special env variable names in the function, we just use the same env variable as
+        # the key name (encode_key_names=False)
+        self._add_project_k8s_secrets_to_spec(
+            None, project=self.metadata.project, encode_key_names=False
+        )
 
     def deploy(
         self,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -474,7 +474,9 @@ class KubeResource(BaseRuntime):
         volume_mounts = [{"name": "azure-vault-secret", "mountPath": secret_path}]
         self.spec.update_vols_and_mounts(volumes, volume_mounts)
 
-    def _add_project_k8s_secrets_to_spec(self, secrets, runobj=None, project=None):
+    def _add_project_k8s_secrets_to_spec(
+        self, secrets, runobj=None, project=None, encode_key_names=True
+    ):
         # the secrets param may be an empty dictionary (asking for all secrets of that project) -
         # it's a different case than None (not asking for project secrets at all).
         if (
@@ -490,13 +492,15 @@ class KubeResource(BaseRuntime):
 
         secret_name = self._get_k8s().get_project_secret_name(project_name)
         existing_secret_keys = (
-            self._get_k8s().get_project_secret_keys(project_name) or {}
+            self._get_k8s().get_project_secret_keys(project_name) or []
         )
 
         # If no secrets were passed or auto-adding all secrets, we need all existing keys
         if not secrets:
             secrets = {
                 key: SecretsStore.k8s_env_variable_name_for_secret(key)
+                if encode_key_names
+                else key
                 for key in existing_secret_keys
             }
 

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -18,7 +18,6 @@ from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config as mlconf
 from mlrun.model import new_task
 from mlrun.runtimes.constants import PodPhases
-from mlrun.secrets import SecretsStore
 from mlrun.utils import create_logger
 from mlrun.utils.azure_vault import AzureVaultStore
 from mlrun.utils.vault import VaultStore
@@ -244,24 +243,6 @@ class TestRuntimeBase:
         get_k8s().v1api.read_namespaced_service_account = unittest.mock.Mock(
             return_value=service_account
         )
-
-    @staticmethod
-    def _mock_project_secrets(secret_name, secret_keys, encode_key_names=True):
-        get_k8s().get_project_secret_name = unittest.mock.Mock(return_value=secret_name)
-        get_k8s().get_project_secret_keys = unittest.mock.Mock(return_value=secret_keys)
-
-        # What we expect in this case is that environment variables will be added to the pod which get their
-        # value from the k8s secret, using the correct keys.
-        expected_env_from_secrets = {}
-        for key in secret_keys:
-            env_variable_name = (
-                SecretsStore.k8s_env_variable_name_for_secret(key)
-                if encode_key_names
-                else key
-            )
-            expected_env_from_secrets[env_variable_name] = {secret_name: key}
-
-        return expected_env_from_secrets
 
     def _execute_run(self, runtime, **kwargs):
         # Reset the mock, so that when checking is create_pod was called, no leftovers are there (in case running

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import os
-import unittest.mock
 
 import deepdiff
 import pytest
@@ -9,12 +8,10 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 import mlrun.errors
-from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config as mlconf
 from mlrun.platforms import auto_mount
 from mlrun.runtimes.kubejob import KubejobRuntime
 from mlrun.runtimes.utils import generate_resources
-from mlrun.secrets import SecretsStore
 from tests.api.runtimes.base import TestRuntimeBase
 
 
@@ -200,10 +197,9 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         # Need to do some mocking, so code thinks that the secret contains these keys. Otherwise it will not add
         # the env. variables to the pod spec.
-        get_k8s().get_project_secret_name = unittest.mock.Mock(
-            return_value=project_secret_name
+        expected_env_from_secrets = self._mock_project_secrets(
+            project_secret_name, secret_keys
         )
-        get_k8s().get_project_secret_keys = unittest.mock.Mock(return_value=secret_keys)
 
         runtime = self._generate_runtime()
 
@@ -214,13 +210,6 @@ class TestKubejobRuntime(TestRuntimeBase):
             "source": secret_keys,
         }
         task.with_secrets(secret_source["kind"], secret_keys)
-
-        # What we expect in this case is that environment variables will be added to the pod which get their
-        # value from the k8s secret, using the correct keys.
-        expected_env_from_secrets = {}
-        for key in secret_keys:
-            env_variable_name = SecretsStore.k8s_env_variable_name_for_secret(key)
-            expected_env_from_secrets[env_variable_name] = {project_secret_name: key}
 
         self._execute_run(runtime, runspec=task)
 


### PR DESCRIPTION
Closing an existing gap - when a nuclio (`remote` runtime) function is deployed, add project-secrets automatically as env variables.
Unlike other runtimes, since the nuclio function does not execute MLRun code, the env variables are added with the same name as the secret key, not adding special prefix/uppercasing. This way, if a project secret called `AWS_SECRET_ACCESS_KEY` is configured, then in the nuclio function itself it will be an env variable called `AWS_SECRET_ACCESS_KEY` - this way it's usable through `fsspec`, for example.

Implements https://jira.iguazeng.com/browse/ML-1109