### PR TITLE
[DataStore] Support Google cloud storage

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -17,6 +17,7 @@ class PackageTester:
         s3_import = "import mlrun.datastore.s3"
         azure_blob_storage_import = "import mlrun.datastore.azure_blob"
         azure_key_vault_import = "import mlrun.utils.azure_vault"
+        google_cloud_storage_import = "import mlrun.datastore.google_cloud_storage"
 
         self._extras_tests_data = {
             "": {"import_test_command": f"{basic_import}"},
@@ -36,9 +37,12 @@ class PackageTester:
             "[azure-key-vault]": {
                 "import_test_command": f"{basic_import}; {azure_key_vault_import}"
             },
+            "[google-cloud-storage]": {
+                "import_test_command": f"{basic_import}; {google_cloud_storage_import}"
+            },
             "[complete]": {
                 "import_test_command": f"{basic_import}; {s3_import}; {azure_blob_storage_import}; "
-                + f"{azure_key_vault_import}",
+                + f"{azure_key_vault_import}; {google_cloud_storage_import}",
             },
         }
 

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -17,3 +17,4 @@ adlfs>=0.7.1, <=2021.8.1
 azure-identity~=1.5
 azure-keyvault-secrets~=4.2
 bokeh~=2.3
+gcsfs~=2021.10

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -73,6 +73,14 @@ def schema_to_store(schema):
         return V3ioStore
     elif schema in ["http", "https"]:
         return HttpStore
+    elif schema in ["gcs", "gs"]:
+        try:
+            from .google_cloud_storage import GoogleCloudStorageStore
+        except ImportError:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "Google cloud storage packages are missing, use pip install mlrun[google-cloud-storage]"
+            )
+        return GoogleCloudStorageStore
     else:
         raise ValueError(f"unsupported store scheme ({schema})")
 

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -1,0 +1,129 @@
+# Copyright 2021 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import tempfile
+from pathlib import Path
+
+import fsspec
+
+import mlrun.errors
+
+from .base import DataStore, FileStats
+
+# Google storage objects will be represented with the following URL: gcs://<bucket name>/<path> or gs://...
+
+
+class GoogleCloudStorageStore(DataStore):
+    def __init__(self, parent, schema, name, endpoint=""):
+        super().__init__(parent, name, schema, endpoint)
+
+        # Workaround to bypass the
+        if "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+            gcs_credentials = self._get_secret_or_env("GCS_CREDENTIALS")
+            if not gcs_credentials:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "No google cloud storage credentials available"
+                )
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            ) as cred_file:
+                cred_file.write(gcs_credentials)
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_file.name
+
+        self.get_filesystem(silent=False)
+
+    def get_filesystem(self, silent=True):
+        """return fsspec file system object, if supported"""
+        if self._filesystem:
+            return self._filesystem
+
+        try:
+            import gcsfs  # noqa
+        except ImportError as exc:
+            if not silent:
+                raise ImportError(
+                    f"Google gcsfs not installed, run pip install gcsfs, {exc}"
+                )
+            return None
+
+        self._filesystem = fsspec.filesystem("gcs", **self.get_storage_options())
+        return self._filesystem
+
+    def get_storage_options(self):
+        return dict(token=self._get_secret_or_env("GCS_TOKEN"))
+
+    def _prepare_path_and_verify_filesystem(self, key):
+        if not self._filesystem:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Performing actions on data-item without a valid filesystem"
+            )
+
+        key = key.strip("/")
+        path = Path(self.endpoint, key).as_posix()
+        return path
+
+    def get(self, key, size=None, offset=0):
+        path = self._prepare_path_and_verify_filesystem(key)
+
+        end = offset + size if size else None
+        blob = self._filesystem.cat_file(path, start=offset, end=end)
+        return blob
+
+    def put(self, key, data, append=False):
+        path = self._prepare_path_and_verify_filesystem(key)
+
+        if append:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Append mode not supported for Google cloud storage datastore"
+            )
+
+        if isinstance(data, bytes):
+            mode = "wb"
+        elif isinstance(data, str):
+            mode = "w"
+        else:
+            raise TypeError(
+                "Data type unknown.  Unable to put in Google cloud storage!"
+            )
+        with self._filesystem.open(path, mode) as f:
+            f.write(data)
+
+    def upload(self, key, src_path):
+        path = self._prepare_path_and_verify_filesystem(key)
+        self._filesystem.put_file(src_path, path, overwrite=True)
+
+    def stat(self, key):
+        path = self._prepare_path_and_verify_filesystem(key)
+
+        files = self._filesystem.ls(path, detail=True)
+        if len(files) == 1 and files[0]["type"] == "file":
+            size = files[0]["size"]
+            modified = files[0]["updated"]
+        elif len(files) == 1 and files[0]["type"] == "directory":
+            raise FileNotFoundError("Operation expects a file not a directory!")
+        else:
+            raise ValueError("Operation expects to receive a single file!")
+        return FileStats(size, modified)
+
+    def listdir(self, key):
+        path = self._prepare_path_and_verify_filesystem(key)
+        if self._filesystem.isfile(path):
+            return key
+        remote_path = f"{path}/**"
+        files = self._filesystem.glob(remote_path)
+        key_length = len(key)
+        files = [
+            f.split("/", 1)[1][key_length:] for f in files if len(f.split("/")) > 1
+        ]
+        return files

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -59,7 +59,15 @@ class S3Store(DataStore):
     def get_storage_options(self):
         key = self._get_secret_or_env("AWS_ACCESS_KEY_ID")
         secret = self._get_secret_or_env("AWS_SECRET_ACCESS_KEY")
-        return dict(anon=not (key and secret), key=key, secret=secret,)
+
+        storage_options = dict(anon=not (key and secret), key=key, secret=secret)
+
+        endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
+        if endpoint_url:
+            client_kwargs = {"endpoint_url": endpoint_url}
+            storage_options["client_kwargs"] = client_kwargs
+
+        return storage_options
 
     def upload(self, key, src_path):
         self.s3.Object(self.endpoint, self._join(key)[1:]).put(

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ extras_require = {
     "azure-blob-storage": ["azure-storage-blob~=12.0", "adlfs>=0.7.1, <=2021.8.1"],
     "azure-key-vault": ["azure-identity~=1.5", "azure-keyvault-secrets~=4.2"],
     "bokeh": ["bokeh~=2.3"],
+    "google-cloud-storage": ["gcsfs~=2021.10"],
 }
 extras_require["complete"] = sorted(
     {

--- a/tests/integration/google_cloud_storage/test-google-cloud-storage.yml
+++ b/tests/integration/google_cloud_storage/test-google-cloud-storage.yml
@@ -1,0 +1,5 @@
+env:
+  # Path to Google credentials file (in JSON format)
+  credentials_json_file:
+  # Bucket name
+  bucket_name:

--- a/tests/integration/google_cloud_storage/test.txt
+++ b/tests/integration/google_cloud_storage/test.txt
@@ -1,0 +1,2 @@
+This is just a test file, meant to test the upload functionality.
+Nothing really interesting here.

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -1,0 +1,83 @@
+import os
+import random
+from pathlib import Path
+
+import pytest
+import yaml
+
+import mlrun
+import mlrun.errors
+from mlrun.utils import logger
+
+here = Path(__file__).absolute().parent
+config_file_path = here / "test-google-cloud-storage.yml"
+with config_file_path.open() as fp:
+    config = yaml.safe_load(fp)
+
+test_filename = here / "test.txt"
+with open(test_filename, "r") as f:
+    test_string = f.read()
+
+credential_params = ["credentials_json_file"]
+
+
+def google_cloud_storage_configured():
+    env_params = config["env"]
+    needed_params = ["bucket_name", *credential_params]
+    for param in needed_params:
+        if not env_params.get(param):
+            return False
+    return True
+
+
+@pytest.mark.skipif(
+    not google_cloud_storage_configured(),
+    reason="Google cloud storage parameters not configured",
+)
+class TestGoogleCloudStorage:
+    def setup_method(self, method):
+        self._bucket_name = config["env"].get("bucket_name")
+
+        object_dir = "test_mlrun_gcs_objects"
+        object_file = f"file_{random.randint(0, 1000)}.txt"
+
+        self._bucket_path = "gcs://" + self._bucket_name
+        self._object_path = object_dir + "/" + object_file
+        self._object_url = self._bucket_path + "/" + self._object_path
+        self._blob_url = self._object_url + ".blob"
+
+        logger.info(f"Object URL: {self._object_url}")
+
+    def _perform_google_cloud_storage_tests(self):
+        data_item = mlrun.run.get_dataitem(self._object_url)
+        data_item.put(test_string)
+
+        response = data_item.get()
+        assert response.decode() == test_string, "Result differs from original test"
+
+        response = data_item.get(offset=20)
+        assert response.decode() == test_string[20:], "Partial result not as expected"
+
+        stat = data_item.stat()
+        assert stat.size == len(test_string), "Stat size different than expected"
+
+        dir_list = mlrun.run.get_dataitem(self._bucket_path).listdir()
+        assert self._object_path in dir_list, "File not in container dir-list"
+
+        upload_data_item = mlrun.run.get_dataitem(self._blob_url)
+        upload_data_item.upload(test_filename)
+        response = upload_data_item.get()
+        assert response.decode() == test_string, "Result differs from original test"
+
+    def test_using_google_env_variable(self):
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = config["env"].get(
+            "credentials_json_file"
+        )
+        self._perform_google_cloud_storage_tests()
+
+    def test_using_serialized_json_content(self):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with open(config["env"].get("credentials_json_file"), "r") as f:
+            credentials = f.read()
+        os.environ["GCS_CREDENTIALS"] = credentials
+        self._perform_google_cloud_storage_tests()


### PR DESCRIPTION
Support data-items located in Google cloud storage (GCS). These data-items will have a URI beginning with `gs://` or `gcs://`.
Credentials should be provided in one of two ways (in their order of precedence):
1. Save the access-key (which is a JSON file) in a file, and point the `GOOGLE_APPLICATION_CREDENTIALS` environment variable at it. This approach works well for client-side auth
2. For jobs and pods executed by MLRun, the content of the JSON file should be placed in an env. variable on the runtime called `GCS_CREDENTIALS`, or (preferred) in a k8s project-secret with the same name (`GCS_CREDENTIALS`), that will be automatically mounted to the runtime

Additional details on credentials and how to generate them (using a service account) can be found here: https://cloud.google.com/docs/authentication/production

**Note:** this code uses purely `fsspec` for working with the storage. A lot of it is shared with the Azure store and some others. For now, this duplicity exists for saving time, but we should in a future PR refactor this area and make the shared, `fsspec`-using code in some abstract base-class, shared across all similar providers.