### PR TITLE
[Scheduler] Fix secrets handling

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -30,6 +30,8 @@ def create_schedule(
         mlrun.api.schemas.AuthorizationAction.create,
         auth_info,
     )
+    if not auth_info.access_key:
+        auth_info.access_key = schedule.credentials.access_key
     get_scheduler().create_schedule(
         db_session,
         auth_info,
@@ -59,6 +61,8 @@ def update_schedule(
         mlrun.api.schemas.AuthorizationAction.update,
         auth_info,
     )
+    if not auth_info.access_key:
+        auth_info.access_key = schedule.credentials.access_key
     get_scheduler().update_schedule(
         db_session,
         auth_info,

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -78,6 +78,7 @@ def list_schedules(
     labels: str = None,
     kind: schemas.ScheduleKinds = None,
     include_last_run: bool = False,
+    include_credentials: bool = fastapi.Query(False, alias="include-credentials"),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -85,7 +86,7 @@ def list_schedules(
         project, mlrun.api.schemas.AuthorizationAction.read, auth_info,
     )
     schedules = get_scheduler().list_schedules(
-        db_session, project, name, kind, labels, include_last_run=include_last_run,
+        db_session, project, name, kind, labels, include_last_run, include_credentials
     )
     filtered_schedules = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
@@ -104,11 +105,12 @@ def get_schedule(
     project: str,
     name: str,
     include_last_run: bool = False,
+    include_credentials: bool = fastapi.Query(False, alias="include-credentials"),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
     schedule = get_scheduler().get_schedule(
-        db_session, project, name, include_last_run=include_last_run,
+        db_session, project, name, include_last_run, include_credentials
     )
     mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -38,8 +38,8 @@ def create_schedule(
         schedule.kind,
         schedule.scheduled_object,
         schedule.cron_trigger,
-        labels=schedule.labels,
-        concurrency_limit=schedule.concurrency_limit,
+        schedule.labels,
+        schedule.concurrency_limit,
     )
     return Response(status_code=HTTPStatus.CREATED.value)
 

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -149,24 +149,23 @@ def ensure_function_has_auth_set(function, auth_info: mlrun.api.schemas.AuthInfo
         and function.kind not in mlrun.runtimes.RuntimeKinds.local_runtimes()
         and mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required()
     ):
-        if auth_info and auth_info.session:
-            if (
-                function.metadata.credentials.access_key
-                == mlrun.model.Credentials.generate_access_key
-            ):
-                # fmt: off
-                function.metadata.credentials.access_key = mlrun.api.utils.auth.verifier\
+        if (
+            function.metadata.credentials.access_key
+            == mlrun.model.Credentials.generate_access_key
+        ):
+            if not auth_info.access_key:
+                auth_info.access_key = mlrun.api.utils.auth.verifier\
                     .AuthVerifier().get_or_create_access_key(auth_info.session)
-                # fmt: on
-            if not function.metadata.credentials.access_key:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Function access key must be set (function.metadata.credentials.access_key)"
-                )
-            auth_env_vars = {
-                "MLRUN_AUTH_SESSION": function.metadata.credentials.access_key,
-            }
-            for key, value in auth_env_vars.items():
-                function.set_env(key, value)
+            function.metadata.credentials.access_key = auth_info.access_key
+        if not function.metadata.credentials.access_key:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Function access key must be set (function.metadata.credentials.access_key)"
+            )
+        auth_env_vars = {
+            "MLRUN_AUTH_SESSION": function.metadata.credentials.access_key,
+        }
+        for key, value in auth_env_vars.items():
+            function.set_env(key, value)
 
 
 def try_perform_auto_mount(function, auth_info: mlrun.api.schemas.AuthInfo):
@@ -177,8 +176,8 @@ def try_perform_auto_mount(function, auth_info: mlrun.api.schemas.AuthInfo):
         return
     # Retrieve v3io auth params from the caller auth info
     override_params = {}
-    if auth_info.data_session:
-        override_params["access_key"] = auth_info.data_session
+    if auth_info.data_session or auth_info.access_key:
+        override_params["access_key"] = auth_info.data_session or auth_info.access_key
     if auth_info.username:
         override_params["user"] = auth_info.username
 

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -154,8 +154,9 @@ def ensure_function_has_auth_set(function, auth_info: mlrun.api.schemas.AuthInfo
             == mlrun.model.Credentials.generate_access_key
         ):
             if not auth_info.access_key:
-                auth_info.access_key = mlrun.api.utils.auth.verifier\
-                    .AuthVerifier().get_or_create_access_key(auth_info.session)
+                auth_info.access_key = mlrun.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key(
+                    auth_info.session
+                )
             function.metadata.credentials.access_key = auth_info.access_key
         if not function.metadata.credentials.access_key:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -16,7 +16,13 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
     # make it a subset of internal since key map are by definition internal
     key_map_secrets_key_prefix = f"{internal_secrets_key_prefix}map."
 
-    def generate_schedule_secret_key(self, schedule_name: str):
+    def generate_schedule_username_secret_key(self, schedule_name: str):
+        return f"{self._generate_schedule_secret_key(schedule_name)}.username"
+
+    def generate_schedule_access_key_secret_key(self, schedule_name: str):
+        return f"{self._generate_schedule_secret_key(schedule_name)}.access_key"
+
+    def _generate_schedule_secret_key(self, schedule_name: str):
         return f"{self.internal_secrets_key_prefix}schedules.{schedule_name}"
 
     def generate_schedule_key_map_secret_key(self):

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -6,6 +6,7 @@ from .auth import (
     AuthorizationAction,
     AuthorizationResourceTypes,
     AuthorizationVerificationInput,
+    Credentials,
     ProjectsRole,
 )
 from .background_task import (

--- a/mlrun/api/schemas/auth.py
+++ b/mlrun/api/schemas/auth.py
@@ -83,6 +83,7 @@ class AuthInfo(pydantic.BaseModel):
     # Iguazio auth
     session: typing.Optional[str] = None
     data_session: typing.Optional[str] = None
+    access_key: typing.Optional[str] = None
     user_id: typing.Optional[str] = None
     user_group_ids: typing.List[str] = []
     projects_role: typing.Optional[ProjectsRole] = None

--- a/mlrun/api/schemas/auth.py
+++ b/mlrun/api/schemas/auth.py
@@ -99,3 +99,7 @@ class AuthInfo(pydantic.BaseModel):
         if self.user_group_ids:
             member_ids.extend(self.user_group_ids)
         return member_ids
+
+
+class Credentials(pydantic.BaseModel):
+    access_key: typing.Optional[str]

--- a/mlrun/api/schemas/feature_store.py
+++ b/mlrun/api/schemas/feature_store.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Extra, Field
 
-from .auth import AuthorizationResourceTypes
+from .auth import AuthorizationResourceTypes, Credentials
 from .object import (
     LabelRecord,
     ObjectKind,
@@ -148,10 +148,6 @@ class DataTarget(BaseModel):
 
     class Config:
         extra = Extra.allow
-
-
-class Credentials(BaseModel):
-    access_key: Optional[str]
 
 
 class FeatureSetIngestInput(BaseModel):

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -65,6 +65,12 @@ class ScheduleKinds(str, Enum):
     # this is mainly for testing purposes
     local_function = "local_function"
 
+    @staticmethod
+    def local_kinds():
+        return [
+            ScheduleKinds.local_function,
+        ]
+
 
 class ScheduleUpdate(BaseModel):
     scheduled_object: Optional[Any]

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
-import mlrun.api.schemas
+from mlrun.api.schemas.auth import Credentials
 from mlrun.api.schemas.object import LabelRecord
 
 
@@ -72,6 +72,7 @@ class ScheduleUpdate(BaseModel):
     desired_state: Optional[str]
     labels: Optional[dict]
     concurrency_limit: Optional[int]
+    credentials: Credentials = Credentials()
 
 
 # Properties to receive via API on creation
@@ -83,6 +84,7 @@ class ScheduleInput(BaseModel):
     desired_state: Optional[str]
     labels: Optional[dict]
     concurrency_limit: Optional[int]
+    credentials: Credentials = Credentials()
 
 
 # the schedule object returned from the db layer
@@ -102,7 +104,7 @@ class ScheduleOutput(ScheduleRecord):
     next_run_time: Optional[datetime]
     last_run: Optional[Dict]
     labels: Optional[dict]
-    credentials: mlrun.api.schemas.Credentials = mlrun.api.schemas.Credentials()
+    credentials: Credentials = Credentials()
 
 
 class SchedulesOutput(BaseModel):

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
+import mlrun.api.schemas
 from mlrun.api.schemas.object import LabelRecord
 
 
@@ -101,6 +102,7 @@ class ScheduleOutput(ScheduleRecord):
     next_run_time: Optional[datetime]
     last_run: Optional[Dict]
     labels: Optional[dict]
+    credentials: mlrun.api.schemas.Credentials = mlrun.api.schemas.Credentials()
 
 
 class SchedulesOutput(BaseModel):

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -278,7 +278,9 @@ class Scheduler:
                 raise mlrun.errors.MLRunAccessDeniedError(
                     "Session is required to create schedules in OPA authorization mode"
                 )
-            access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(name)
+            access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
+                name
+            )
             secret_key_map = (
                 mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
             )
@@ -286,14 +288,13 @@ class Scheduler:
                 access_key_secret_key: auth_info.access_key,
             }
             if auth_info.username:
-                username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(name)
+                username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(
+                    name
+                )
                 secrets[username_secret_key] = auth_info.username
             mlrun.api.crud.Secrets().store_secrets(
                 project,
-                schemas.SecretsData(
-                    provider=self._secrets_provider,
-                    secrets=secrets,
-                ),
+                schemas.SecretsData(provider=self._secrets_provider, secrets=secrets,),
                 allow_internal_secrets=True,
                 key_map_secret_key=secret_key_map,
             )
@@ -305,8 +306,12 @@ class Scheduler:
         import mlrun.api.crud
 
         if self._store_schedule_credentials_in_secrets:
-            access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(name)
-            username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(name)
+            access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
+                name
+            )
+            username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(
+                name
+            )
             secret_key_map = (
                 mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
             )
@@ -328,7 +333,7 @@ class Scheduler:
             )
 
     def _get_schedule_secrets(
-            self, project: str, name: str, include_username: bool = True
+        self, project: str, name: str, include_username: bool = True
     ) -> typing.Tuple[typing.Optional[str], typing.Optional[str]]:
         # import here to avoid circular imports
         import mlrun.api.crud
@@ -336,9 +341,7 @@ class Scheduler:
         schedule_access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
             name
         )
-        secret_key_map = (
-            mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
-        )
+        secret_key_map = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
         # TODO: support listing (and not only get) secrets using key map
         access_key = mlrun.api.crud.Secrets().get_secret(
             project,
@@ -486,7 +489,9 @@ class Scheduler:
                 access_key = None
                 username = None
                 if self._store_schedule_credentials_in_secrets:
-                    username, access_key = self._get_schedule_secrets(db_schedule.project, db_schedule.name)
+                    username, access_key = self._get_schedule_secrets(
+                        db_schedule.project, db_schedule.name
+                    )
                 self._create_schedule_in_scheduler(
                     db_schedule.project,
                     db_schedule.name,
@@ -494,7 +499,9 @@ class Scheduler:
                     db_schedule.scheduled_object,
                     db_schedule.cron_trigger,
                     db_schedule.concurrency_limit,
-                    mlrun.api.schemas.AuthInfo(username=username, access_key=access_key),
+                    mlrun.api.schemas.AuthInfo(
+                        username=username, access_key=access_key
+                    ),
                 )
             except Exception as exc:
                 logger.warn(
@@ -544,7 +551,9 @@ class Scheduler:
     def _enrich_schedule_with_credentials(
         self, schedule_output: schemas.ScheduleOutput
     ):
-        _, schedule_output.credentials.access_key = self._get_schedule_secrets(schedule_output.project, schedule_output.name, include_username=False)
+        _, schedule_output.credentials.access_key = self._get_schedule_secrets(
+            schedule_output.project, schedule_output.name, include_username=False
+        )
 
     def _resolve_job_function(
         self,
@@ -639,7 +648,10 @@ class Scheduler:
         # if credentials are needed but missing (will happen for schedules on upgrade from scheduler that didn't store
         # credentials to one that does store) enrich them
         # Note that here we're using the "knowledge" that submit_run only requires the access key of the auth info
-        if not auth_info.access_key and scheduler._store_schedule_credentials_in_secrets:
+        if (
+            not auth_info.access_key
+            and scheduler._store_schedule_credentials_in_secrets
+        ):
             # import here to avoid circular imports
             import mlrun.api.utils.auth
             import mlrun.api.utils.singletons.project_member
@@ -656,7 +668,9 @@ class Scheduler:
             # Update the schedule with the new auth info so we won't need to do the above again in the next run
             scheduler.update_schedule(
                 db_session,
-                mlrun.api.schemas.AuthInfo(username=project_owner.username, access_key=project_owner.session),
+                mlrun.api.schemas.AuthInfo(
+                    username=project_owner.username, access_key=project_owner.session
+                ),
                 project_name,
                 schedule_name,
             )

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -281,6 +281,8 @@ class Scheduler:
             access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
                 name
             )
+            # schedule name may be an invalid secret key, therefore we're using the key map feature of our secrets
+            # handler
             secret_key_map = (
                 mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
             )
@@ -315,6 +317,7 @@ class Scheduler:
             secret_key_map = (
                 mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
             )
+            # TODO: support delete secrets (plural and not only singular) using key map
             mlrun.api.crud.Secrets().delete_secret(
                 project,
                 self._secrets_provider,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import json
 import traceback
+import typing
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -11,6 +12,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
 from sqlalchemy.orm import Session
 
+import mlrun.api.utils.auth.verifier
 import mlrun.errors
 from mlrun.api import schemas
 from mlrun.api.db.session import close_session, create_session
@@ -171,6 +173,7 @@ class Scheduler:
         kind: str = None,
         labels: str = None,
         include_last_run: bool = False,
+        include_credentials: bool = False,
     ) -> schemas.SchedulesOutput:
         logger.debug(
             "Getting schedules", project=project, name=name, labels=labels, kind=kind
@@ -179,7 +182,7 @@ class Scheduler:
         schedules = []
         for db_schedule in db_schedules:
             schedule = self._transform_and_enrich_db_schedule(
-                db_session, db_schedule, include_last_run
+                db_session, db_schedule, include_last_run, include_credentials
             )
             schedules.append(schedule)
         return schemas.SchedulesOutput(schedules=schedules)
@@ -190,11 +193,12 @@ class Scheduler:
         project: str,
         name: str,
         include_last_run: bool = False,
+        include_credentials: bool = False,
     ) -> schemas.ScheduleOutput:
         logger.debug("Getting schedule", project=project, name=name)
         db_schedule = get_db().get_schedule(db_session, project, name)
         return self._transform_and_enrich_db_schedule(
-            db_session, db_schedule, include_last_run
+            db_session, db_schedule, include_last_run, include_credentials
         )
 
     def delete_schedule(
@@ -253,19 +257,25 @@ class Scheduler:
 
         if self._store_schedule_credentials_in_secrets:
             # sanity
-            if not auth_info.session:
+            if not auth_info.access_key:
                 raise mlrun.errors.MLRunAccessDeniedError(
                     "Session is required to create schedules in OPA authorization mode"
                 )
-            secret_key = mlrun.api.crud.Secrets().generate_schedule_secret_key(name)
+            access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(name)
             secret_key_map = (
                 mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
             )
+            secrets = {
+                access_key_secret_key: auth_info.access_key,
+            }
+            if auth_info.username:
+                username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(name)
+                secrets[username_secret_key] = auth_info.username
             mlrun.api.crud.Secrets().store_secrets(
                 project,
                 schemas.SecretsData(
                     provider=self._secrets_provider,
-                    secrets={secret_key: auth_info.session},
+                    secrets=secrets,
                 ),
                 allow_internal_secrets=True,
                 key_map_secret_key=secret_key_map,
@@ -278,19 +288,64 @@ class Scheduler:
         import mlrun.api.crud
 
         if self._store_schedule_credentials_in_secrets:
-            # sanity
-            secret_key = mlrun.api.crud.Secrets().generate_schedule_secret_key(name)
+            access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(name)
+            username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(name)
             secret_key_map = (
                 mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
             )
             mlrun.api.crud.Secrets().delete_secret(
                 project,
                 self._secrets_provider,
-                secret_key,
+                access_key_secret_key,
                 allow_secrets_from_k8s=True,
                 allow_internal_secrets=True,
                 key_map_secret_key=secret_key_map,
             )
+            mlrun.api.crud.Secrets().delete_secret(
+                project,
+                self._secrets_provider,
+                username_secret_key,
+                allow_secrets_from_k8s=True,
+                allow_internal_secrets=True,
+                key_map_secret_key=secret_key_map,
+            )
+
+    def _get_schedule_secrets(
+            self, project: str, name: str, include_username: bool = True
+    ) -> typing.Tuple[typing.Optional[str], typing.Optional[str]]:
+        # import here to avoid circular imports
+        import mlrun.api.crud
+
+        schedule_access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
+            name
+        )
+        secret_key_map = (
+            mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+        )
+        # TODO: support listing (and not only get) secrets using key map
+        access_key = mlrun.api.crud.Secrets().get_secret(
+            project,
+            self._secrets_provider,
+            schedule_access_key_secret_key,
+            allow_secrets_from_k8s=True,
+            allow_internal_secrets=True,
+            key_map_secret_key=secret_key_map,
+        )
+        username = None
+        if include_username:
+            schedule_username_secret_key = mlrun.api.crud.Secrets().generate_schedule_username_secret_key(
+                name
+            )
+            username = mlrun.api.crud.Secrets().get_secret(
+                project,
+                self._secrets_provider,
+                schedule_username_secret_key,
+                allow_secrets_from_k8s=True,
+                allow_internal_secrets=True,
+                key_map_secret_key=secret_key_map,
+            )
+
+        return username, access_key
 
     def _validate_cron_trigger(
         self,
@@ -411,22 +466,10 @@ class Scheduler:
                 # import here to avoid circular imports
                 import mlrun.api.crud
 
-                session = None
+                access_key = None
+                username = None
                 if self._store_schedule_credentials_in_secrets:
-                    schedule_secret_key = mlrun.api.crud.Secrets().generate_schedule_secret_key(
-                        db_schedule.name
-                    )
-                    secret_key_map = (
-                        mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
-                    )
-                    session = mlrun.api.crud.Secrets().get_secret(
-                        db_schedule.project,
-                        self._secrets_provider,
-                        schedule_secret_key,
-                        allow_secrets_from_k8s=True,
-                        allow_internal_secrets=True,
-                        key_map_secret_key=secret_key_map,
-                    )
+                    username, access_key = self._get_schedule_secrets(db_schedule.project, db_schedule.name)
                 self._create_schedule_in_scheduler(
                     db_schedule.project,
                     db_schedule.name,
@@ -434,7 +477,7 @@ class Scheduler:
                     db_schedule.scheduled_object,
                     db_schedule.cron_trigger,
                     db_schedule.concurrency_limit,
-                    mlrun.api.schemas.AuthInfo(session=session),
+                    mlrun.api.schemas.AuthInfo(username=username, access_key=access_key),
                 )
             except Exception as exc:
                 logger.warn(
@@ -449,6 +492,7 @@ class Scheduler:
         db_session: Session,
         schedule_record: schemas.ScheduleRecord,
         include_last_run: bool = False,
+        include_credentials: bool = False,
     ) -> schemas.ScheduleOutput:
         schedule_dict = schedule_record.dict()
         schedule_dict["labels"] = {
@@ -462,7 +506,10 @@ class Scheduler:
             schedule.next_run_time = job.next_run_time
 
         if include_last_run:
-            schedule = self._enrich_schedule_with_last_run(db_session, schedule)
+            self._enrich_schedule_with_last_run(db_session, schedule)
+
+        if include_credentials:
+            self._enrich_schedule_with_credentials(schedule)
 
         return schedule
 
@@ -476,7 +523,11 @@ class Scheduler:
             )
             run_data = get_db().read_run(db_session, run_uid, run_project, iteration)
             schedule_output.last_run = run_data
-        return schedule_output
+
+    def _enrich_schedule_with_credentials(
+        self, schedule_output: schemas.ScheduleOutput
+    ):
+        _, schedule_output.credentials.access_key = self._get_schedule_secrets(schedule_output.project, schedule_output.name, include_username=False)
 
     def _resolve_job_function(
         self,
@@ -570,8 +621,8 @@ class Scheduler:
 
         # if credentials are needed but missing (will happen for schedules on upgrade from scheduler that didn't store
         # credentials to one that does store) enrich them
-        # Note that here we're using the "knowledge" that submit_run only requires the session of the auth info
-        if not auth_info.session and scheduler._store_schedule_credentials_in_secrets:
+        # Note that here we're using the "knowledge" that submit_run only requires the access key of the auth info
+        if not auth_info.access_key and scheduler._store_schedule_credentials_in_secrets:
             # import here to avoid circular imports
             import mlrun.api.utils.auth
             import mlrun.api.utils.singletons.project_member
@@ -588,7 +639,7 @@ class Scheduler:
             # Update the schedule with the new auth info so we won't need to do the above again in the next run
             scheduler.update_schedule(
                 db_session,
-                mlrun.api.schemas.AuthInfo(session=project_owner.session),
+                mlrun.api.schemas.AuthInfo(username=project_owner.username, access_key=project_owner.session),
                 project_name,
                 schedule_name,
             )

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -276,7 +276,7 @@ class Scheduler:
             # sanity
             if not auth_info.access_key:
                 raise mlrun.errors.MLRunAccessDeniedError(
-                    "Session is required to create schedules in OPA authorization mode"
+                    "Access key is required to create schedules in OPA authorization mode"
                 )
             access_key_secret_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
                 name

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -179,8 +179,6 @@ default_config = {
             # misfire_grace_time is 1 second, we do not want jobs not being scheduled because of the delays so setting
             # it to None. the default for coalesce it True just adding it here to be explicit
             "scheduler_config": '{"job_defaults": {"misfire_grace_time": null, "coalesce": true}}',
-            # one of enabled, disabled, auto (in which it will be determined by whether the authorization mode is opa)
-            "schedule_credentials_secrets_store_mode": "auto",
         },
         "projects": {
             "leader": "mlrun",

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -205,7 +205,7 @@ def test_delete_secret_verifications(
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
     key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
-    internal_key = mlrun.api.crud.Secrets().generate_schedule_secret_key("some-name")
+    internal_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key("some-name")
 
     # verifications check
     # internal key without allow

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -205,7 +205,9 @@ def test_delete_secret_verifications(
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
     key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
-    internal_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key("some-name")
+    internal_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
+        "some-name"
+    )
 
     # verifications check
     # internal key without allow

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -247,7 +247,9 @@ async def test_schedule_upgrade_from_scheduler_without_credentials_store(
     )
     # stop scheduler, reconfigure to store credentials and start again (upgrade)
     await scheduler.stop()
-    scheduler._store_schedule_credentials_in_secrets = True
+    mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required = unittest.mock.Mock(
+        return_value=True
+    )
     await scheduler.start(db)
 
     # at this point the schedule is inside the scheduler without auth_info, so the first trigger should try to generate
@@ -636,7 +638,9 @@ async def test_rescheduling_secrets_storing(
     scheduler: Scheduler,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
-    scheduler._store_schedule_credentials_in_secrets = True
+    mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required = unittest.mock.Mock(
+        return_value=True
+    )
     name = "schedule-name"
     project = config.default_project
     scheduled_object = _create_mlrun_function_and_matching_scheduled_object(db, project)
@@ -685,7 +689,9 @@ async def test_schedule_crud_secrets_handling(
     scheduler: Scheduler,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
-    scheduler._store_schedule_credentials_in_secrets = True
+    mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required = unittest.mock.Mock(
+        return_value=True
+    )
     for schedule_name in ["valid-secret-key", "invalid/secret/key"]:
         project = config.default_project
         scheduled_object = _create_mlrun_function_and_matching_scheduled_object(
@@ -740,7 +746,9 @@ async def test_schedule_access_key_generation(
     scheduler: Scheduler,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
-    scheduler._store_schedule_credentials_in_secrets = True
+    mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required = unittest.mock.Mock(
+        return_value=True
+    )
     project = config.default_project
     schedule_name = "schedule-name"
     scheduled_object = _create_mlrun_function_and_matching_scheduled_object(db, project)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -182,6 +182,7 @@ class TestProject(TestMLRunSystem):
         state = pipeline["run"]["status"]
         assert state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
         self._delete_test_project(name)
+        self._delete_test_project(project2.metadata.name)
 
     def test_inline_pipeline(self):
         name = "pipe5"
@@ -257,3 +258,4 @@ class TestProject(TestMLRunSystem):
         out = exec_project(args, projects_dir)
         print("OUT:\n", out)
         assert out.find("pipeline run finished, state=Succeeded"), "pipeline failed"
+        self._delete_test_project(name)


### PR DESCRIPTION
The previous handling was using the `auth_info.session` which is not good since the session will expire
Now we're using the new `auth_info.access_key`, we're supporting auto-generating it, allowing to get it back in get & list schedules and more