### PR TITLE
[Serving] Fix regression introduced in #1319.

### DIFF
--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -392,7 +392,7 @@ class ServingRuntime(RemoteRuntime):
             function_object.metadata.labels = function_object.metadata.labels or {}
             function_object.metadata.labels[
                 "mlrun/parent-function"
-            ] = self._function_uri()
+            ] = self._function_uri().replace("/", "-")
             if not function_object.spec.graph:
                 # copy the current graph only if the child doesnt have a graph of his own
                 function_object.set_env("SERVING_CURRENT_FUNCTION", function_ref.name)

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -392,7 +392,7 @@ class ServingRuntime(RemoteRuntime):
             function_object.metadata.labels = function_object.metadata.labels or {}
             function_object.metadata.labels[
                 "mlrun/parent-function"
-            ] = self._function_uri().replace("/", "-")
+            ] = self.metadata.name
             if not function_object.spec.graph:
                 # copy the current graph only if the child doesnt have a graph of his own
                 function_object.set_env("SERVING_CURRENT_FUNCTION", function_ref.name)

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -251,7 +251,7 @@ class TestServingRuntime(TestNuclioRuntime):
             {
                 "function_name": f"{self.project}-{self.name}-child_function",
                 "file_name": child_function_path,
-                "parent_function": function._function_uri().replace("/", "-"),
+                "parent_function": function.metadata.name,
             },
             {
                 "function_name": f"{self.project}-{self.name}",

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -251,7 +251,7 @@ class TestServingRuntime(TestNuclioRuntime):
             {
                 "function_name": f"{self.project}-{self.name}-child_function",
                 "file_name": child_function_path,
-                "parent_function": function._function_uri(),
+                "parent_function": function._function_uri().replace("/", "-"),
             },
             {
                 "function_name": f"{self.project}-{self.name}",


### PR DESCRIPTION
[ML-1195](https://jira.iguazeng.com/browse/ML-1195)

Regression introduced in 0.8.0-rc2, by [this bit of code](https://github.com/mlrun/mlrun/commit/b0fff2ccacc5333b24decc363df2c35757bd18e9#diff-12fc9377f79a1177302bc72542967cabd14a5234c3a315f5a46f3a4c5b64d271R359-R361).

Slash character is not allowed inside a kubernetes label value.