### PR TITLE
[DB] Only backup database if data/schema migration is needed

### DIFF
--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -49,11 +49,11 @@ def _perform_schema_migrations():
     dir_path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
     alembic_config_path = dir_path / alembic_config_file_name
 
-    alembic_util = AlembicUtil(alembic_config_path, _check_latest_data_version())
+    alembic_util = AlembicUtil(alembic_config_path, _is_latest_data_version())
     alembic_util.init_alembic(config.httpdb.db.database_backup_mode == "enabled")
 
 
-def _check_latest_data_version():
+def _is_latest_data_version():
     db_session = create_session()
     db = mlrun.api.db.sqldb.db.SQLDB("")
 

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -50,9 +50,7 @@ def _perform_schema_migrations(from_scratch: bool = False):
     alembic_config_path = dir_path / alembic_config_file_name
 
     alembic_util = AlembicUtil(alembic_config_path, _check_latest_data_version())
-    alembic_util.init_alembic(
-        from_scratch, config.httpdb.db.database_backup_mode == "enabled"
-    )
+    alembic_util.init_alembic(config.httpdb.db.database_backup_mode == "enabled")
 
 
 def _check_latest_data_version():

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -23,7 +23,7 @@ from .utils.db.sqlite_migration import SQLiteMigrationUtil
 def init_data(from_scratch: bool = False) -> None:
     logger.info("Creating initial data")
 
-    _perform_schema_migrations(from_scratch)
+    _perform_schema_migrations()
 
     _perform_database_migration(from_scratch)
 
@@ -40,7 +40,7 @@ def init_data(from_scratch: bool = False) -> None:
 latest_data_version = 1
 
 
-def _perform_schema_migrations(from_scratch: bool = False):
+def _perform_schema_migrations():
     alembic_config_file_name = "alembic.ini"
     if MySQLUtil.get_mysql_dsn_data():
         alembic_config_file_name = "alembic_mysql.ini"

--- a/mlrun/api/utils/db/alembic.py
+++ b/mlrun/api/utils/db/alembic.py
@@ -21,22 +21,15 @@ class AlembicUtil(object):
         self._alembic_output = ""
         self._data_version_is_latest = data_version_is_latest
 
-    def init_alembic(self, from_scratch: bool = False, use_backups: bool = False):
+    def init_alembic(self, use_backups: bool = False):
         revision_history = self._get_revision_history_list()
         latest_revision = revision_history[0]
-        initial_alembic_revision = revision_history[-1]
         db_file_path = self._get_db_file_path()
         db_path_exists = os.path.isfile(db_file_path)
         # this command for some reason creates a dummy db file so it has to be after db_path_exists
         current_revision = self._get_current_revision()
 
-        if not from_scratch and db_path_exists and not current_revision:
-
-            # if database file exists but no alembic version exists, stamp the existing
-            # database with the initial alembic version, so we can upgrade it later
-            alembic.command.stamp(self._alembic_config, initial_alembic_revision)
-
-        elif (
+        if (
             use_backups
             and db_path_exists
             and current_revision

--- a/tests/api/utils/test_alembic_util.py
+++ b/tests/api/utils/test_alembic_util.py
@@ -25,7 +25,7 @@ def test_no_database_exists(
 ):
     mock_database(db_file_exists=False)
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
-    alembic_util.init_alembic(from_scratch=from_scratch, use_backups=True)
+    alembic_util.init_alembic(use_backups=True)
     assert mock_alembic.stamp_calls == []
     assert mock_alembic.upgrade_calls == ["head"]
     mock_shutil_copy.assert_not_called()
@@ -37,7 +37,7 @@ def test_database_exists_no_revision(
 ):
     mock_database()
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
-    alembic_util.init_alembic(from_scratch=from_scratch, use_backups=True)
+    alembic_util.init_alembic(use_backups=True)
 
     # from scratch should skip stamp even if no revision exists
     expected_stamp_calls = ["revision1"] if not from_scratch else []
@@ -52,7 +52,7 @@ def test_database_exists_known_revision(
 ):
     mock_database(current_revision=Constants.initial_revision)
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
-    alembic_util.init_alembic(from_scratch=from_scratch, use_backups=True)
+    alembic_util.init_alembic(use_backups=True)
     assert mock_alembic.stamp_calls == []
     assert mock_alembic.upgrade_calls == ["head"]
     mock_shutil_copy.assert_called_once_with(
@@ -66,7 +66,7 @@ def test_database_exists_unknown_revision_successful_downgrade(
 ):
     mock_database(current_revision=Constants.unknown_revision)
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
-    alembic_util.init_alembic(from_scratch=from_scratch, use_backups=True)
+    alembic_util.init_alembic(use_backups=True)
     assert mock_alembic.stamp_calls == []
     assert mock_alembic.upgrade_calls == ["head"]
     copy_calls = [
@@ -101,7 +101,7 @@ def test_database_exists_unknown_revision_failed_downgrade(
         match=f"Cannot fall back to revision {Constants.latest_revision}, "
         f"no back up exists. Current revision: {Constants.unknown_revision}",
     ):
-        alembic_util.init_alembic(from_scratch=from_scratch, use_backups=True)
+        alembic_util.init_alembic(use_backups=True)
 
     assert mock_alembic.stamp_calls == []
     assert mock_alembic.upgrade_calls == []

--- a/tests/api/utils/test_alembic_util.py
+++ b/tests/api/utils/test_alembic_util.py
@@ -19,10 +19,7 @@ class Constants(object):
     unknown_revision = "revision3"
 
 
-@pytest.mark.parametrize("from_scratch", [True, False])
-def test_no_database_exists(
-    mock_alembic, mock_database, mock_shutil_copy, from_scratch
-):
+def test_no_database_exists(mock_alembic, mock_database, mock_shutil_copy):
     mock_database(db_file_exists=False)
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
     alembic_util.init_alembic(use_backups=True)
@@ -31,24 +28,17 @@ def test_no_database_exists(
     mock_shutil_copy.assert_not_called()
 
 
-@pytest.mark.parametrize("from_scratch", [True, False])
-def test_database_exists_no_revision(
-    mock_alembic, mock_database, mock_shutil_copy, from_scratch
-):
+def test_database_exists_no_revision(mock_alembic, mock_database, mock_shutil_copy):
     mock_database()
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
     alembic_util.init_alembic(use_backups=True)
 
-    # from scratch should skip stamp even if no revision exists
-    expected_stamp_calls = ["revision1"] if not from_scratch else []
-    assert mock_alembic.stamp_calls == expected_stamp_calls
     assert mock_alembic.upgrade_calls == ["head"]
     mock_shutil_copy.assert_not_called()
 
 
-@pytest.mark.parametrize("from_scratch", [True, False])
 def test_database_exists_known_revision(
-    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name, from_scratch
+    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name
 ):
     mock_database(current_revision=Constants.initial_revision)
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
@@ -60,9 +50,8 @@ def test_database_exists_known_revision(
     )
 
 
-@pytest.mark.parametrize("from_scratch", [True, False])
 def test_database_exists_unknown_revision_successful_downgrade(
-    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name, from_scratch
+    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name
 ):
     mock_database(current_revision=Constants.unknown_revision)
     alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(pathlib.Path(""))
@@ -88,9 +77,8 @@ def test_database_exists_unknown_revision_successful_downgrade(
     mock_shutil_copy.assert_has_calls(copy_calls)
 
 
-@pytest.mark.parametrize("from_scratch", [True, False])
 def test_database_exists_unknown_revision_failed_downgrade(
-    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name, from_scratch
+    mock_alembic, mock_database, mock_shutil_copy, mock_db_file_name
 ):
     mock_database(
         current_revision=Constants.unknown_revision, db_backup_exists=False,


### PR DESCRIPTION
Only backup database if data/schema migration is needed.
*Database migration doesn't require backup as it is non-destructive to the old sqlite db