### PR TITLE
[Requirements] Make fsspec and its sub-requirements more strict

### DIFF
--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -11,9 +11,9 @@
 boto3~=1.9, <1.17.107
 botocore>=1.20.106,<1.20.107
 aiobotocore~=1.4.0
-s3fs>=0.5.0, <=2021.8.1
+s3fs~=2021.8.1
 azure-storage-blob~=12.0
-adlfs>=0.7.1, <=2021.8.1
+adlfs~=2021.8.1
 azure-identity~=1.5
 azure-keyvault-secrets~=4.2
 typing-extensions>=3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,8 +65,7 @@ humanfriendly~=8.2
 # the breaking PR is: https://github.com/tiangolo/fastapi/commit/97fa743ecb5a716fa0223a7463cb83f3f0df494c
 # the bug report on: https://github.com/tiangolo/fastapi/issues/3782
 fastapi~= 0.67.0
-# fsspec versioning changed to year.month.patch after 0.9.0
-fsspec>=0.9.0, <=2021.8.1
+fsspec~=2021.8.1
 v3iofs~=0.1.7
 # 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
 cryptography~=3.0, <3.4

--- a/setup.py
+++ b/setup.py
@@ -77,15 +77,13 @@ extras_require = {
     # conflicts with s3fs 2021.8.1 that has aiobotocore~=1.4.0
     # which so far (1.4.1) has botocore>=1.20.106,<1.20.107
     # boto3 1.17.106 has botocore>=1.20.106,<1.21.0, so we must add botocore explicitly
-    # s3fs versioning changed to year.month.patch after 0.6.0
     "s3": [
         "boto3~=1.9, <1.17.107",
         "botocore>=1.20.106,<1.20.107",
         "aiobotocore~=1.4.0",
-        "s3fs>=0.5.0, <=2021.8.1",
+        "s3fs~=2021.8.1",
     ],
-    # adlfs versioning changed to year.month.patch after 0.7.7
-    "azure-blob-storage": ["azure-storage-blob~=12.0", "adlfs>=0.7.1, <=2021.8.1"],
+    "azure-blob-storage": ["azure-storage-blob~=12.0", "adlfs~=2021.8.1"],
     "azure-key-vault": ["azure-identity~=1.5", "azure-keyvault-secrets~=4.2"],
     # bokeh 2.4.0 requires typing-extensions>=3.10.0 but previous packages installs 3.7.4.3 which is incompatible so
     # adding it explictly

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -81,21 +81,22 @@ def test_requirement_specifiers_convention():
         "kfp": {"~=1.0.1"},
         "botocore": {">=1.20.106,<1.20.107"},
         "aiobotocore": {"~=1.4.0"},
-        "fsspec": {">=0.9.0, <=2021.8.1"},
-        "adlfs": {">=0.7.1, <=2021.8.1"},
-        "s3fs": {">=0.5.0, <=2021.8.1"},
         "typing-extensions": {">=3.10.0"},
         # Black is not stable yet and does not have a release that is not beta, so can't be used with ~=
         "black": {"<=19.10b0"},
         # These 2 are used in a tests that is purposed to test requirement without specifiers
         "faker": {""},
         "python-dotenv": {""},
-        # These 3 are not semver so can't be used with ~=
+        # These are not semver
         "opencv-contrib-python": {">=4.2.0.34"},
         "pyhive": {" @ git+https://github.com/v3io/PyHive.git@v0.6.999"},
         "v3io-generator": {
             " @ git+https://github.com/v3io/data-science.git#subdirectory=generator"
         },
+        "fsspec": {"~=2021.8.1"},
+        "adlfs": {"~=2021.8.1"},
+        "s3fs": {"~=2021.8.1"},
+        "gcsfs": {"~=2021.8.1"},
         # All of these are actually valid, they just don't use ~= so the test doesn't "understand" that
         # TODO: make test smart enough to understand that
         "urllib3": {">=1.25.4, <1.27"},
@@ -111,7 +112,6 @@ def test_requirement_specifiers_convention():
         "boto3": {"~=1.9, <1.17.107"},
         "azure-storage-blob": {"~=12.0, <12.7.0"},
         "dask-ml": {"~=1.4,<1.9.0"},
-        "gcsfs": {"~=2021.8.1"},
     }
 
     for (ignored_requirement_name, ignored_specifiers,) in ignored_invalid_map.items():


### PR DESCRIPTION
The problem we have is that let's say someone had 0.7.1, it means he got fsspec 0.9.0, now when they'll install 0.8.0, the fsspec version specifier is >=0.9.0, <=2021.8.1 meaning the current version is compatible so it won't change anything, but when it will install gcsfs (a new requirement) which is ~=2021.8.1 it will yell that:
ERROR: gcsfs 2021.8.1 has requirement fsspec==2021.08.1, but you'll have fsspec 0.9.0 which is incompatible.

So aligning fsspec and its sub-requirements to ~=2021.8.1