### PR TITLE
[Serving] Bug fixes and enhancements to Serving/Graph

### DIFF
--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -346,6 +346,7 @@ class OnlineVectorService:
         if not self.impute_policy:
             return
 
+        impute_policy = copy(self.impute_policy)
         vector = self.vector
         feature_stats = vector.get_stats_table()
         self._impute_values = {}
@@ -354,18 +355,18 @@ class OnlineVectorService:
         if vector.status.label_column in feature_keys:
             feature_keys.remove(vector.status.label_column)
 
-        if "*" in self.impute_policy:
-            value = self.impute_policy["*"]
-            del self.impute_policy["*"]
+        if "*" in impute_policy:
+            value = impute_policy["*"]
+            del impute_policy["*"]
 
             for name in feature_keys:
-                if name not in self.impute_policy:
+                if name not in impute_policy:
                     if isinstance(value, str) and value.startswith("$"):
                         self._impute_values[name] = feature_stats.loc[name, value[1:]]
                     else:
                         self._impute_values[name] = value
 
-        for name, value in self.impute_policy.items():
+        for name, value in impute_policy.items():
             if name not in feature_keys:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"feature {name} in impute_policy but not in feature vector"

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -1,11 +1,21 @@
+import asyncio
 import json
 
+import aiohttp
 import requests
 import storey
 from requests.adapters import HTTPAdapter
+from storey.flow import _ConcurrentJobExecution
 from urllib3.util.retry import Retry
 
-from .utils import _extract_input_data, _update_result_body
+import mlrun
+
+from .utils import (
+    _extract_input_data,
+    _update_result_body,
+    event_id_key,
+    event_path_key,
+)
 
 http_adapter = HTTPAdapter(
     max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
@@ -141,8 +151,12 @@ class RemoteStep(storey.SendToHttp):
             url = self._url_function_handler(body)
         else:
             url = self._endpoint
+            striped_path = event.path.lstrip("/")
             if self._append_event_path:
-                url = url + "/" + event.path.lstrip("/")
+                url = url + "/" + striped_path
+            if striped_path:
+                headers[event_path_key] = event.path
+        headers[event_id_key] = event.id
 
         if method == "GET":
             body = None
@@ -153,6 +167,185 @@ class RemoteStep(storey.SendToHttp):
             headers["Content-Type"] = "application/json"
 
         return method, url, headers, body
+
+    def _get_data(self, data, headers):
+        if (
+            self.return_json
+            or headers.get("content-type", "").lower() == "application/json"
+        ) and isinstance(data, (str, bytes)):
+            data = json.loads(data)
+        return data
+
+    def to_dict(self):
+        args = {
+            key: getattr(self, key)
+            for key in [
+                "url",
+                "subpath",
+                "method",
+                "headers",
+                "return_json",
+                "url_expression",
+                "body_expression",
+            ]
+            if getattr(self, key) is not None
+        }
+        return {
+            "class_name": f"{__name__}.{self.__class__.__name__}",
+            "name": self.name or self.__class__.__name__,
+            "class_args": args,
+            "input_path": self._input_path,
+            "result_path": self._result_path,
+        }
+
+
+class BatchHttpRequests(_ConcurrentJobExecution):
+    """class for calling remote endpoints in parallel
+    """
+
+    def __init__(
+        self,
+        url: str = None,
+        subpath: str = None,
+        method: str = None,
+        headers: dict = None,
+        url_expression: str = None,
+        body_expression: str = None,
+        return_json: bool = True,
+        input_path: str = None,
+        result_path: str = None,
+        **kwargs,
+    ):
+        """class for calling remote endpoints in parallel
+
+        sync and async graph step implementation for request/resp to remote service (class shortcut = "$remote")
+        url can be an http(s) url (e.g. "https://myservice/path") or an mlrun function uri ([project/]name).
+        alternatively the url_expression can be specified to build the url from the event (e.g. "event['url']").
+
+        example pipeline::
+
+            flow = function.set_topology("flow", engine="async")
+            flow.to("BatchRemoteStep",
+                    url_expression="event['url']",
+                    body_expression="event['data']",
+                    input_path="req",
+                    result_path="resp",
+                    ).respond()
+
+            server = function.to_mock_server()
+            resp = server.test(body={"req": [{"url": url, "data": data}]})
+
+
+        :param url:     http(s) url or function [project/]name to call
+        :param subpath: path (which follows the url)
+        :param method:  HTTP method (GET, POST, ..), default to POST
+        :param headers: dictionary with http header values
+        :param url_expression: an expression for getting the url from the event, e.g. "event['url']"
+        :param body_expression: an expression for getting the request body from the event, e.g. "event['data']"
+        :param return_json: indicate the returned value is json, and convert it to a py object
+        :param input_path:  when specified selects the key/path in the event to use as body
+                            this require that the event body will behave like a dict, example:
+                            event: {"data": {"a": 5, "b": 7}}, input_path="data.b" means request body will be 7
+        :param result_path: selects the key/path in the event to write the results to
+                            this require that the event body will behave like a dict, example:
+                            event: {"x": 5} , result_path="resp" means the returned response will be written
+                            to event["y"] resulting in {"x": 5, "resp": <result>}
+        """
+        if url and url_expression:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "cannot set both url and url_expression"
+            )
+        self.url = url
+        self.url_expression = url_expression
+        self.body_expression = body_expression
+        self.headers = headers
+        self.method = method
+        self.return_json = return_json
+        self.subpath = subpath or ""
+        super().__init__(input_path=input_path, result_path=result_path, **kwargs)
+
+        self._append_event_path = False
+        self._endpoint = ""
+        self._session = None
+        self._url_function_handler = None
+        self._body_function_handler = None
+
+    def _init(self):
+        super()._init()
+        self._client_session = None
+
+    async def _lazy_init(self):
+        connector = aiohttp.TCPConnector()
+        self._client_session = aiohttp.ClientSession(connector=connector)
+
+    async def _cleanup(self):
+        await self._client_session.close()
+
+    def post_init(self, mode="sync"):
+        self._endpoint = self.url
+        if self.url and self.context:
+            self._endpoint = self.context.get_remote_endpoint(self.url).strip("/")
+        if self.body_expression:
+            # init lambda function for calculating url from event
+            self._body_function_handler = eval(
+                "lambda event: " + self.body_expression, {}, {}
+            )
+        if self.url_expression:
+            # init lambda function for calculating url from event
+            self._url_function_handler = eval(
+                "lambda event: " + self.url_expression, {}, {"endpoint": self._endpoint}
+            )
+        elif self.subpath:
+            self._endpoint = self._endpoint + "/" + self.subpath.lstrip("/")
+
+    async def _process_event(self, event):
+        # async implementation (with storey)
+        method = self.method or event.method or "POST"
+        headers = self.headers or event.headers or {}
+        input_list = self._get_event_or_body(event)
+        is_get = method == "GET"
+        is_json = False
+
+        body_list = []
+        url_list = []
+        for body in input_list:
+            if self._url_function_handler:
+                url_list.append(self._url_function_handler(body))
+            else:
+                url_list.append(self._endpoint)
+
+            if is_get:
+                body = None
+            elif body is not None and not isinstance(body, (str, bytes)):
+                if self._body_function_handler:
+                    body = self._body_function_handler(body)
+                body = json.dumps(body)
+                is_json = True
+            body_list.append(body)
+
+        if is_json:
+            headers["Content-Type"] = "application/json"
+
+        responses = []
+        for url, body in zip(url_list, body_list):
+            responses.append(
+                asyncio.ensure_future(self._submit(method, url, headers, body))
+            )
+        return await asyncio.gather(*responses)
+
+    async def _submit(self, method, url, headers, body):
+        async with self._client_session.request(
+            method, url, headers=headers, data=body, ssl=False
+        ) as future:
+            return await future.read(), future.headers
+
+    async def _handle_completed(self, event, response):
+        data = []
+        for body, headers in response:
+            data.append(self._get_data(body, headers))
+
+        new_event = self._user_fn_output_to_event(event, data)
+        await self._do_downstream(new_event)
 
     def _get_data(self, data, headers):
         if (

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -22,16 +22,6 @@ http_adapter = HTTPAdapter(
     max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
 )
 
-_fields = [
-    "url",
-    "subpath",
-    "method",
-    "headers",
-    "return_json",
-    "url_expression",
-    "body_expression",
-]
-
 
 class RemoteStep(StepToDict, storey.SendToHttp):
     """class for calling remote endpoints

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -11,6 +11,7 @@ from urllib3.util.retry import Retry
 import mlrun
 
 from .utils import (
+    StepToDict,
     _extract_input_data,
     _update_result_body,
     event_id_key,
@@ -21,8 +22,18 @@ http_adapter = HTTPAdapter(
     max_retries=Retry(total=3, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
 )
 
+_fields = [
+    "url",
+    "subpath",
+    "method",
+    "headers",
+    "return_json",
+    "url_expression",
+    "body_expression",
+]
 
-class RemoteStep(storey.SendToHttp):
+
+class RemoteStep(StepToDict, storey.SendToHttp):
     """class for calling remote endpoints
     """
 
@@ -176,30 +187,8 @@ class RemoteStep(storey.SendToHttp):
             data = json.loads(data)
         return data
 
-    def to_dict(self):
-        args = {
-            key: getattr(self, key)
-            for key in [
-                "url",
-                "subpath",
-                "method",
-                "headers",
-                "return_json",
-                "url_expression",
-                "body_expression",
-            ]
-            if getattr(self, key) is not None
-        }
-        return {
-            "class_name": f"{__name__}.{self.__class__.__name__}",
-            "name": self.name or self.__class__.__name__,
-            "class_args": args,
-            "input_path": self._input_path,
-            "result_path": self._result_path,
-        }
 
-
-class BatchHttpRequests(_ConcurrentJobExecution):
+class BatchHttpRequests(StepToDict, _ConcurrentJobExecution):
     """class for calling remote endpoints in parallel
     """
 
@@ -354,25 +343,3 @@ class BatchHttpRequests(_ConcurrentJobExecution):
         ) and isinstance(data, (str, bytes)):
             data = json.loads(data)
         return data
-
-    def to_dict(self):
-        args = {
-            key: getattr(self, key)
-            for key in [
-                "url",
-                "subpath",
-                "method",
-                "headers",
-                "return_json",
-                "url_expression",
-                "body_expression",
-            ]
-            if getattr(self, key) is not None
-        }
-        return {
-            "class_name": f"{__name__}.{self.__class__.__name__}",
-            "name": self.name or self.__class__.__name__,
-            "class_args": args,
-            "input_path": self._input_path,
-            "result_path": self._result_path,
-        }

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -31,17 +31,17 @@ from ..api.schemas import (
     ModelEndpointStatus,
 )
 from ..config import config
-from .utils import _extract_input_data, _update_result_body
+from .utils import RouterToDict, _extract_input_data, _update_result_body
 from .v2_serving import _ModelLogPusher
 
 
-class BaseModelRouter:
+class BaseModelRouter(RouterToDict):
     """base model router class"""
 
     def __init__(
         self,
-        context,
-        name,
+        context=None,
+        name: str = None,
         routes=None,
         protocol=None,
         url_prefix=None,
@@ -80,7 +80,7 @@ class BaseModelRouter:
 
         except Exception as exc:
             #  if images convert to bytes
-            content_type = getattr(event, "content_type") or ""
+            content_type = getattr(event, "content_type", "") or ""
             if content_type.startswith("image/"):
                 sample = BytesIO(event.body)
                 parsed_event[self.inputs_key] = [sample]
@@ -214,8 +214,8 @@ class OperationTypes(str, Enum):
 class VotingEnsemble(BaseModelRouter):
     def __init__(
         self,
-        context,
-        name,
+        context=None,
+        name: str = None,
         routes=None,
         protocol=None,
         url_prefix=None,
@@ -318,7 +318,9 @@ class VotingEnsemble(BaseModelRouter):
         self.vote_flag = True if self.vote_type is not None else False
         self.executor_type = executor_type
         self._model_logger = (
-            _ModelLogPusher(self, context) if context.stream.enabled else None
+            _ModelLogPusher(self, context)
+            if context and context.stream.enabled
+            else None
         )
         self.version = kwargs.get("version", "v1")
         self.log_router = True

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -333,7 +333,8 @@ class VotingEnsemble(BaseModelRouter):
             logger.warn("GraphServer not initialized for VotingEnsemble instance")
             return
 
-        _init_endpoint_record(server, self)
+        if not self.context.is_mock or self.context.server.track_models:
+            _init_endpoint_record(server, self)
 
     def _resolve_route(self, body, urlpath):
         """Resolves the appropriate model to send the event to.

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -43,9 +43,9 @@ class BaseModelRouter(RouterToDict):
         context=None,
         name: str = None,
         routes=None,
-        protocol=None,
-        url_prefix=None,
-        health_prefix=None,
+        protocol: str = None,
+        url_prefix: str = None,
+        health_prefix: str = None,
         input_path: str = None,
         result_path: str = None,
         **kwargs,
@@ -217,9 +217,9 @@ class VotingEnsemble(BaseModelRouter):
         context=None,
         name: str = None,
         routes=None,
-        protocol=None,
-        url_prefix=None,
-        health_prefix=None,
+        protocol: str = None,
+        url_prefix: str = None,
+        health_prefix: str = None,
         vote_type=None,
         executor_type=None,
         prediction_col_name=None,
@@ -724,17 +724,30 @@ def _init_endpoint_record(graph_server, voting_ensemble: VotingEnsemble):
         )
 
 
+extra_doc = """
+        feature_vector_uri : str, optional
+            feature vector uri in the form: [project/]name[:tag]
+        impute_policy : dict, optional
+            value imputing (substitute NaN/Inf values with statistical or constant value), you can set 
+            the impute_policy parameter with the imputing policy, and specify which constant or statistical value 
+            will be used instead of NaN/Inf value, this can be defined per column or for all the columns ("*"). 
+            the replaced value can be fixed number for constants or $mean, $max, $min, $std, $count for statistical 
+            values. “*” is used to specify the default for all features, example: 
+            impute_policy={"*": "$mean", "age": 33}
+"""  # noqa
+
+
 class EnrichmentModelRouter(ModelRouter):
-    """model router with feature enrichment and imputing"""
+    """model router with feature enrichment and imputing""" + extra_doc
 
     def __init__(
         self,
-        context,
-        name,
+        context=None,
+        name: str = None,
         routes=None,
-        protocol=None,
-        url_prefix=None,
-        health_prefix=None,
+        protocol: str = None,
+        url_prefix: str = None,
+        health_prefix: str = None,
         feature_vector_uri: str = "",
         impute_policy: dict = {},
         **kwargs,
@@ -765,17 +778,18 @@ class EnrichmentModelRouter(ModelRouter):
 
 
 class EnrichmentVotingEnsemble(VotingEnsemble):
-    """model ensemble with feature enrichment and imputing"""
+
+    __doc__ = VotingEnsemble.__doc__ + extra_doc
 
     def __init__(
         self,
-        context,
-        name,
+        context=None,
+        name: str = None,
         routes=None,
         protocol=None,
-        url_prefix=None,
-        health_prefix=None,
-        vote_type=None,
+        url_prefix: str = None,
+        health_prefix: str = None,
+        vote_type: str = None,
         executor_type=None,
         prediction_col_name=None,
         feature_vector_uri: str = "",

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -779,7 +779,7 @@ class EnrichmentModelRouter(ModelRouter):
 
 class EnrichmentVotingEnsemble(VotingEnsemble):
 
-    __doc__ = VotingEnsemble.__doc__ + extra_doc
+    __doc__ = extra_doc  # todo: edit doc strings
 
     def __init__(
         self,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -511,7 +511,15 @@ class RouterStep(TaskStep):
     def routes(self, routes: dict):
         self._routes = ObjectDict.from_dict(classes_map, routes, "task")
 
-    def add_route(self, key, route=None, class_name=None, handler=None, **class_args):
+    def add_route(
+        self,
+        key,
+        route=None,
+        class_name=None,
+        handler=None,
+        function=None,
+        **class_args,
+    ):
         """add child route step or class to the router
 
         :param key:        unique name (and route path) for the child step
@@ -525,6 +533,7 @@ class RouterStep(TaskStep):
             raise MLRunInvalidArgumentError("route or class_name must be specified")
         if not route:
             route = TaskStep(class_name, class_args, handler=handler)
+        route.function = function or route.function
         route = self._routes.update(key, route)
         route.set_parent(self)
         return route
@@ -546,6 +555,10 @@ class RouterStep(TaskStep):
         )
 
         for route in self._routes.values():
+            if self.function and not route.function:
+                # if the router runs on a child function and the
+                # model function is not specified use the router function
+                route.function = self.function
             route.set_parent(self)
             route.init_object(context, namespace, mode, reset=reset)
 
@@ -998,10 +1011,6 @@ class FlowStep(BaseStep):
 
     def _build_async_flow(self):
         """initialize and build the async/storey DAG"""
-        try:
-            import storey
-        except ImportError:
-            raise GraphError("storey package is not installed, use pip install storey")
 
         def process_step(state, step, root):
             if not state._is_local_function(self.context):
@@ -1012,41 +1021,11 @@ class FlowStep(BaseStep):
                     next_step = step.to(next_state.async_object)
                     process_step(next_state, next_step, root)
 
-        for step in self._steps.values():
-            if hasattr(step, "async_object") and step._is_local_function(self.context):
-                if step.kind == StepKinds.queue:
-                    skip_stream = self.context.is_mock and step.next
-                    if step.path and not skip_stream:
-                        stream_path = step.path
-                        endpoint = None
-                        if "://" in stream_path:
-                            endpoint, stream_path = parse_v3io_path(step.path)
-                            stream_path = stream_path.strip("/")
-                        step._async_object = storey.StreamTarget(
-                            storey.V3ioDriver(endpoint), stream_path
-                        )
-                    else:
-                        step._async_object = storey.Map(lambda x: x)
+        default_source, self._wait_for_result = _init_async_objects(
+            self.context, self._steps.values()
+        )
 
-                elif not step.async_object or not hasattr(
-                    step.async_object, "_outlets"
-                ):
-                    # if regular class, wrap with storey Map
-                    step._async_object = storey.Map(
-                        step._handler,
-                        full_event=step.full_event or step._call_with_event,
-                        input_path=step.input_path,
-                        result_path=step.result_path,
-                        name=step.name,
-                        context=self.context,
-                    )
-                if not step.next and hasattr(step, "responder") and step.responder:
-                    # if responder step (return result), add Complete()
-                    step.async_object.to(storey.Complete(full_event=True))
-                    self._wait_for_result = True
-
-        # todo: allow source array (e.g. data->json loads..)
-        source = self._source or storey.SyncEmitSource()
+        source = self._source or default_source
         for next_state in self._start_steps:
             next_step = source.to(next_state.async_object)
             process_step(next_state, next_step, self)
@@ -1374,3 +1353,46 @@ def params_to_step(
     if graph_shape:
         step.shape = graph_shape
     return name, step
+
+
+def _init_async_objects(context, steps):
+    try:
+        import storey
+    except ImportError:
+        raise GraphError("storey package is not installed, use pip install storey")
+
+    wait_for_result = False
+
+    for step in steps:
+        if hasattr(step, "async_object") and step._is_local_function(context):
+            if step.kind == StepKinds.queue:
+                skip_stream = context.is_mock and step.next
+                if step.path and not skip_stream:
+                    stream_path = step.path
+                    endpoint = None
+                    if "://" in stream_path:
+                        endpoint, stream_path = parse_v3io_path(step.path)
+                        stream_path = stream_path.strip("/")
+                    step._async_object = storey.StreamTarget(
+                        storey.V3ioDriver(endpoint), stream_path
+                    )
+                else:
+                    step._async_object = storey.Map(lambda x: x)
+
+            elif not step.async_object or not hasattr(step.async_object, "_outlets"):
+                # if regular class, wrap with storey Map
+                step._async_object = storey.Map(
+                    step._handler,
+                    full_event=step.full_event or step._call_with_event,
+                    input_path=step.input_path,
+                    result_path=step.result_path,
+                    name=step.name,
+                    context=context,
+                )
+            if not step.next and hasattr(step, "responder") and step.responder:
+                # if responder step (return result), add Complete()
+                step.async_object.to(storey.Complete(full_event=True))
+                wait_for_result = True
+
+    default_source = storey.SyncEmitSource()
+    return default_source, wait_for_result

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -1,5 +1,8 @@
 from mlrun.utils import get_in, update_in
 
+event_id_key = "MLRUN_EVENT_ID"
+event_path_key = "MLRUN_EVENT_PATH"
+
 
 def _extract_input_data(input_path, body):
     if input_path:

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -1,3 +1,5 @@
+import inspect
+
 from mlrun.utils import get_in, update_in
 
 event_id_key = "MLRUN_EVENT_ID"
@@ -22,3 +24,50 @@ def _update_result_body(result_path, event_body, result):
     else:
         event_body = result
     return event_body
+
+
+class StepToDict:
+    """auto serialization of graph steps to a python dictionary"""
+
+    def to_dict(self, fields=None, exclude=None):
+        """convert the step object to a python dictionary"""
+        fields = fields or getattr(self, "_dict_fields", None)
+        if not fields:
+            fields = list(inspect.signature(self.__init__).parameters.keys())
+        if exclude:
+            fields = [field for field in fields if field not in exclude]
+
+        meta_keys = ["context", "name", "input_path", "result_path", "kwargs"]
+        args = {
+            key: getattr(self, key)
+            for key in fields
+            if getattr(self, key, None) is not None and key not in meta_keys
+        }
+        # add storey kwargs or extra kwargs
+        if "kwargs" in fields and (hasattr(self, "kwargs") or hasattr(self, "_kwargs")):
+            kwargs = getattr(self, "kwargs", {}) or getattr(self, "_kwargs", {})
+            for key, value in kwargs.items():
+                if key not in meta_keys:
+                    args[key] = value
+
+        mod_name = self.__class__.__module__
+        struct = {
+            "class_name": f"{mod_name}.{self.__class__.__qualname__}",
+            "name": self.name or self.__class__.__name__,
+            "class_args": args,
+        }
+        if hasattr(self, "_STEP_KIND"):
+            struct["kind"] = self._STEP_KIND
+        if hasattr(self, "_input_path"):
+            struct["input_path"] = self._input_path
+        if hasattr(self, "_result_path"):
+            struct["result_path"] = self._result_path
+        return struct
+
+
+class RouterToDict(StepToDict):
+
+    _STEP_KIND = "router"
+
+    def to_dict(self, fields=None, exclude=None):
+        return super().to_dict(exclude=["routes"])

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -27,8 +27,10 @@ from mlrun.artifacts import ModelArtifact  # noqa: F401
 from mlrun.config import config
 from mlrun.utils import logger, now_date, parse_versioned_object_uri
 
+from .utils import StepToDict
 
-class V2ModelServer:
+
+class V2ModelServer(StepToDict):
     """base model serving class (v2), using similar API to KFServing v2 and Triton
 
     The class is initialized automatically by the model server and can run locally
@@ -63,12 +65,12 @@ class V2ModelServer:
 
     def __init__(
         self,
-        context,
-        name: str,
+        context=None,
+        name: str = None,
         model_path: str = None,
         model=None,
         protocol=None,
-        **class_args,
+        **kwargs,
     ):
         self.name = name
         self.version = ""
@@ -80,9 +82,12 @@ class V2ModelServer:
         self.protocol = protocol or "v2"
         self.model_path = model_path
         self.model_spec: mlrun.artifacts.ModelArtifact = None
-        self._params = class_args
+        self._kwargs = kwargs  # for to_dict()
+        self._params = kwargs
         self._model_logger = (
-            _ModelLogPusher(self, context) if context.stream.enabled else None
+            _ModelLogPusher(self, context)
+            if context and context.stream.enabled
+            else None
         )
 
         self.metrics = {}

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -118,7 +118,8 @@ class V2ModelServer:
             logger.warn("GraphServer not initialized for VotingEnsemble instance")
             return
 
-        _init_endpoint_record(server, self)
+        if not self.context.is_mock or self.context.server.track_models:
+            _init_endpoint_record(server, self)
 
     def get_param(self, key: str, default=None):
         """get param by key (specified in the model or the function)"""
@@ -196,6 +197,10 @@ class V2ModelServer:
         """main model event handler method"""
         start = now_date()
         op = event.path.strip("/")
+        if not op and event.body and isinstance(event.body, dict):
+            op = event.body.get("operation")
+        if not op and event.method != "GET":
+            op = "infer"
 
         if op == "predict" or op == "infer":
             # predict operation

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -281,3 +281,30 @@ def test_path_control_routers():
     server.wait_for_completion()
     # expect avg of (5*10) and (5*20) = 75
     assert resp["y"]["outputs"] == [75], "wrong output"
+
+
+def test_to_dict():
+    from mlrun.serving.remote import RemoteStep
+
+    rs = RemoteStep(
+        name="remote_echo",
+        url="/url",
+        method="GET",
+        input_path="req",
+        result_path="resp",
+    )
+
+    assert rs.to_dict() == {
+        "name": "remote_echo",
+        "class_args": {"method": "GET", "return_json": True, "url": "/url"},
+        "class_name": "mlrun.serving.remote.RemoteStep",
+        "input_path": "req",
+        "result_path": "resp",
+    }, "unexpected serialization"
+
+    ms = V2ModelServer(name="ms", model_path="./xx", multiplier=7)
+    assert ms.to_dict() == {
+        "class_args": {"model_path": "./xx", "multiplier": 7, "protocol": "v2"},
+        "class_name": "mlrun.serving.v2_serving.V2ModelServer",
+        "name": "ms",
+    }, "unexpected serialization"


### PR DESCRIPTION
* fix impute policy (values where reset after to_mock_server())
* fix model serving in multi-function graph (init the model `function` attribute)
* pass event id/path to the next functions via headers
* do not register model endpoint when running mock (unless set_tracking=True in `to_mock_server`)
* add the parallel remote step class to mlrun (`BatchHttpRequests`)
* `V2ModelServer` classes can now work without a router (the path should be without the router prefix e.g. `/infer`)
* auto serialization of graph steps to dict (models, routers, remote, ..) allow using the class in the `.to` and `.add_step`