### PR TITLE
[CI] Enable running Kaniko in open source system tests

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -136,7 +136,9 @@ jobs:
         kubernetes version: "v1.20.11"
         driver: docker
         github token: ${{ github.token }}
-        start args: '--addons=registry --insecure-registry="$(minikube ip):5000"'
+        # I couldn't find a way to configure the IP (https://github.com/kubernetes/minikube/issues/951)
+        # but this seems to work
+        start args: '--addons=registry --insecure-registry="192.168.49.2:5000"'
 
     - name: Get mlrun kit charts and create namespace
       run: |
@@ -176,6 +178,7 @@ jobs:
       # add set -x to print commands before executing to make logs reading easier
       run: |
         set -x
+        minikube ip
         minikube logs
         minikube kubectl -- --namespace ${NAMESPACE} logs -l app.kubernetes.io/component=api,app.kubernetes.io/name=mlrun --tail=-1
         minikube kubectl -- --namespace ${NAMESPACE} get all


### PR DESCRIPTION
There were 2 problems:
1. The mlrun-kit chart forces to put a secret for the registry, otherwise it defaults the secret name to `mustprovide` which doesn't exist, so it fails () - will be fixed, for now setting the secret name to empty string which work around that
2. We were setting the registry url to be `localhost:5000`, while that works for Nuclio (which volume the docker daemon) it doesn't for kaniko (which is in the k8s network), setting it to `$(minikube ip):5000` fixes it for kaniko but then it Nuclio doesn't work since docker is crying for getting http responses, added the registry as an insecure (localhost is insecure by default that's why it worked before) to fix that

In addition:
* Added (configurable) step to allow ssh (to debug) when failures happen
* Improved output logs
* Bumped k8s version to `v1.20.11`