### PR TITLE
[Serving] Handle timeouts and retries in remote step

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -59,7 +59,7 @@ class BaseSourceDriver(DataSource):
     def to_step(self, key_field=None, time_field=None, context=None):
         import storey
 
-        return storey.SyncEmitSource()
+        return storey.SyncEmitSource(context=context)
 
     def get_table_object(self):
         """get storey Table object"""
@@ -138,6 +138,7 @@ class CSVSource(BaseSourceDriver):
         if context:
             attributes["context"] = context
         return storey.CSVSource(
+            context=context,
             paths=self.path,
             header=True,
             build_dict=True,
@@ -228,6 +229,7 @@ class ParquetSource(BaseSourceDriver):
         if context:
             attributes["context"] = context
         return storey.ParquetSource(
+            context=context,
             paths=self.path,
             key_field=self.key_field or key_field,
             time_field=self.time_field or time_field,
@@ -412,7 +414,7 @@ class CustomSource(BaseSourceDriver):
         attributes = copy(self.attributes)
         class_name = attributes.pop("class_name")
         class_object = get_class(class_name)
-        return class_object(**attributes,)
+        return class_object(context=context, **attributes)
 
 
 class DataFrameSource:
@@ -492,6 +494,7 @@ class OnlineSource(BaseSourceDriver):
             else storey.SyncEmitSource
         )
         return source_class(
+            context=context,
             key_field=self.key_field or key_field,
             time_field=self.time_field or time_field,
             full_event=True,

--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -5,8 +5,6 @@ from storey import MapClass
 
 from mlrun.serving.utils import StepToDict
 
-this_path = "mlrun.feature_store.steps"
-
 
 class FeaturesetValidator(StepToDict, MapClass):
     """Validate feature values according to the feature set validation policy"""

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -30,15 +30,7 @@ def get_http_adapter(retries, backoff_factor):
             if backoff_factor is None
             else backoff_factor,
             status_forcelist=[500, 502, 503, 504],
-            method_whitelist=[
-                "HEAD",
-                "GET",
-                "PUT",
-                "POST",
-                "DELETE",
-                "OPTIONS",
-                "TRACE",
-            ],
+            method_whitelist=False,
         )
     else:
         retry = Retry(0, read=False)

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -153,9 +153,8 @@ class RemoteStep(storey.SendToHttp):
                 method, url, headers=headers, data=body, ssl=False, **kwargs
             )
             if resp.status >= 500:
-                raise RuntimeError(
-                    f"bad http response {resp.status}: {await resp.text()}"
-                )
+                text = await resp.text()
+                raise RuntimeError(f"bad http response {resp.status}: {text}")
             return resp
         except asyncio.TimeoutError as exc:
             logger.error(f"http request to {url} timed out in RemoteStep {self.name}")
@@ -402,9 +401,8 @@ class BatchHttpRequests(_ConcurrentJobExecution):
             method, url, headers=headers, data=body, ssl=False, **self._request_args
         ) as future:
             if future.status >= 500:
-                raise RuntimeError(
-                    f"bad http response {future.status}: {await future.text()}"
-                )
+                text = await future.text()
+                raise RuntimeError(f"bad http response {future.status}: {text}")
             return await future.read(), future.headers
 
     async def _submit_with_retries(self, method, url, headers, body):

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -12,7 +12,6 @@ import mlrun
 from mlrun.utils import logger
 
 from .utils import (
-    StepToDict,
     _extract_input_data,
     _update_result_body,
     event_id_key,
@@ -241,7 +240,7 @@ class RemoteStep(storey.SendToHttp):
         return data
 
 
-class BatchHttpRequests(StepToDict, _ConcurrentJobExecution):
+class BatchHttpRequests(_ConcurrentJobExecution):
     """class for calling remote endpoints in parallel
     """
 
@@ -315,7 +314,7 @@ class BatchHttpRequests(StepToDict, _ConcurrentJobExecution):
         self.headers = headers
         self.method = method
         self.return_json = return_json
-        self.subpath = subpath or ""
+        self.subpath = subpath
         super().__init__(input_path=input_path, result_path=result_path, **kwargs)
 
         self.timeout = timeout

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -434,11 +434,11 @@ class GraphContext:
             return self._server._secrets.get(key)
         return None
 
-    def get_remote_endpoint(self, name, external=False):
+    def get_remote_endpoint(self, name, external=True):
         """return the remote nuclio/serving function http(s) endpoint given its name
 
         :param name: the function name/uri in the form [project/]function-name[:tag]
-        :param external: return the external url (returns the in-cluster url by default)
+        :param external: return the external url (returns the external url by default)
         """
         if "://" in name:
             return name

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -248,7 +248,7 @@ class GraphServer(ModelObj):
         try:
             response = self.graph.run(event, **(extra_args or {}))
         except Exception as exc:
-            message = str(exc)
+            message = f"{exc.__class__.__name__}: {exc}"
             if server_context.verbose:
                 message += "\n" + str(traceback.format_exc())
             context.logger.error(f"run error, {traceback.format_exc()}")

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1402,5 +1402,5 @@ def _init_async_objects(context, steps):
                 wait_for_result = True
 
     source_args = context.get_param("source_args", {})
-    default_source = storey.SyncEmitSource(**source_args)
+    default_source = storey.SyncEmitSource(context=context, **source_args)
     return default_source, wait_for_result

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1401,5 +1401,6 @@ def _init_async_objects(context, steps):
                 step.async_object.to(storey.Complete(full_event=True))
                 wait_for_result = True
 
-    default_source = storey.SyncEmitSource()
+    source_args = context.get_param("source_args", {})
+    default_source = storey.SyncEmitSource(**source_args)
     return default_source, wait_for_result

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ fsspec~=2021.8.1
 v3iofs~=0.1.7
 # 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
 cryptography~=3.0, <3.4
-storey~=0.8.7; python_version >= '3.7'
+storey~=0.8.8; python_version >= '3.7'
 deepdiff~=5.0
 pymysql~=1.0
 inflection~=0.5.0

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -292,11 +292,17 @@ def test_to_dict():
         method="GET",
         input_path="req",
         result_path="resp",
+        retries=4,
     )
 
     assert rs.to_dict() == {
         "name": "remote_echo",
-        "class_args": {"method": "GET", "return_json": True, "url": "/url"},
+        "class_args": {
+            "method": "GET",
+            "return_json": True,
+            "url": "/url",
+            "retries": 4,
+        },
         "class_name": "mlrun.serving.remote.RemoteStep",
         "input_path": "req",
         "result_path": "resp",

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -162,12 +162,14 @@ def _timed_out_handler(request: Request):
 
 @pytest.mark.parametrize("engine", ["async", "sync"])
 def test_timeout(httpserver, engine):
-    httpserver.expect_request("/data", method="POST").respond_with_handler(_timed_out_handler)
+    httpserver.expect_request("/data", method="POST").respond_with_handler(
+        _timed_out_handler
+    )
     url = httpserver.url_for("/data")
     server = _new_server(url, engine, timeout=1, retries=0, return_json=False)
 
     try:
-        resp = server.test(body=b"tst", method="POST")
+        server.test(body=b"tst", method="POST")
         assert False, "did not time out"
     except Exception as exc:
         is_timeout = (

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 import pytest
@@ -155,17 +156,16 @@ def test_remote_advance(httpserver, engine):
     assert resp == {"req": {"url": "/dog", "data": {"x": 5}}, "resp": {"post": "ok"}}
 
 
-def sleeping(request: Request):
-    print("\nDATA:\n", request.data)
+def _sleeping(request: Request):
     time.sleep(2)  # this should be greater than the client's timeout parameter
-    return Response("Ok", status=200)
+    return Response(request.data, status=200)
 
 
-@pytest.mark.parametrize("engine", ["sync", "async"])
+@pytest.mark.parametrize("engine", ["async", "sync"])
 def test_timeout(httpserver, engine):
-    httpserver.expect_request("/data", method="POST").respond_with_handler(sleeping)
+    httpserver.expect_request("/data", method="POST").respond_with_handler(_sleeping)
     url = httpserver.url_for("/data")
-    server = _new_server(url, engine, timeout=1, return_json=False)
+    server = _new_server(url, engine, timeout=1, retries=0, return_json=False)
 
     try:
         resp = server.test(body=b"tst", method="POST")
@@ -183,35 +183,138 @@ def test_timeout(httpserver, engine):
     try:
         server.wait_for_completion()
     except Exception:
-        # handle potential exceptions due to canceled events
+        # ignore the delayed errors
         pass
 
 
 class RetryTester:
-    def __init__(self):
-        self.retries = 0
+    def __init__(self, ok_after=0):
+        self.retries_dict = {}
+        self.ok_after = ok_after
 
     def handler(self, request: Request):
-        self.retries += 1
-        print(f"retries={self.retries}")
-        return Response(str(self.retries), status=500)
+        print(request.path)
+        retries = self.retries_dict.get(request.path, 0)
+        self.retries_dict[request.path] = retries + 1
+        print(f"retries={retries}")
+        if self.ok_after and retries >= self.ok_after:
+            print("resp ok!")
+            return Response(request.data, status=200)
+        return Response("Failed", status=500)
 
 
-@pytest.mark.parametrize("engine", ["sync"])
-@pytest.mark.parametrize("retries", [0, 2])
-def test_retry(httpserver, engine, retries):
+@pytest.mark.parametrize("engine", ["sync", "async"])
+def test_failure(httpserver, engine):
     tester = RetryTester()
-    method = "PUT"
+    method = "POST"
+    httpserver.expect_request("/data", method=method).respond_with_handler(
+        tester.handler
+    )
+    url = httpserver.url_for("/data")
+    server = _new_server(url, engine, method=method, return_json=False, retries=0)
+
+    try:
+        server.test(body=b"tst", method=method)
+        assert False, "did not fail the request"
+    except RuntimeError:
+        pass
+
+    assert tester.retries_dict["/data"] == 1, "did not get expected number of retries"
+    try:
+        server.wait_for_completion()
+    except RuntimeError:
+        # ignore the delayed errors
+        pass
+
+
+@pytest.mark.parametrize("engine", ["sync", "async"])
+def test_retry(httpserver, engine):
+    # test with one failure/retry and 2nd try succeed
+    retries = 1
+    tester = RetryTester(retries)
+    method = "POST"
     httpserver.expect_request("/data", method=method).respond_with_handler(
         tester.handler
     )
     url = httpserver.url_for("/data")
     server = _new_server(url, engine, method=method, return_json=False, retries=retries)
-
     try:
         server.test(body=b"tst", method=method)
-        assert False, "did not fail the request"
-    except Exception:
-        pass
+    finally:
+        server.wait_for_completion()
+    assert (
+        tester.retries_dict["/data"] == retries + 1
+    ), "did not get expected number of retries"
 
-    assert tester.retries == retries + 1, "did not get expected number of retries"
+
+def _echo(request: Request):
+    return Response(request.data, status=200)
+
+
+def test_parallel_remote(httpserver):
+    # test calling multiple http clients
+    from mlrun.serving.remote import BatchHttpRequests
+
+    httpserver.expect_request(re.compile("^/.*"), method="POST").respond_with_handler(
+        _echo
+    )
+    url = httpserver.url_for("/")
+
+    function = mlrun.new_function("test2", kind="serving")
+    flow = function.set_topology("flow", engine="async")
+    flow.to(
+        BatchHttpRequests(
+            url_expression="event['url']",
+            body_expression="event['data']",
+            method="POST",
+            input_path="req",
+            result_path="resp",
+        )
+    ).respond()
+
+    server = function.to_mock_server()
+    items = list(range(2))
+    request = [{"url": f"{url}{i}", "data": i} for i in items]
+    try:
+        resp = server.test(body={"req": request})
+    finally:
+        server.wait_for_completion()
+    assert resp["resp"] == items, "unexpected response"
+
+
+def test_parallel_remote_retry(httpserver):
+    # test calling multiple http clients with failure and one retry
+    from mlrun.serving.remote import BatchHttpRequests
+
+    retries = 1
+    tester = RetryTester(retries)
+    httpserver.expect_request(re.compile("^/.*"), method="POST").respond_with_handler(
+        tester.handler
+    )
+    url = httpserver.url_for("/")
+
+    function = mlrun.new_function("test2", kind="serving")
+    flow = function.set_topology("flow", engine="async")
+    flow.to(
+        BatchHttpRequests(
+            url_expression="event['url']",
+            body_expression="event['data']",
+            method="POST",
+            input_path="req",
+            result_path="resp",
+            retries=1,
+        )
+    ).respond()
+
+    server = function.to_mock_server()
+    items = list(range(2))
+    request = [{"url": f"{url}{i}", "data": i} for i in items]
+    try:
+        resp = server.test(body={"req": request})
+    finally:
+        server.wait_for_completion()
+    assert resp["resp"] == items, "unexpected response"
+    assert tester.retries_dict == {
+        "/1": retries + 1,
+        "/0": retries + 1,
+    }, "didnt retry properly"


### PR DESCRIPTION
* add configurable timeout support to `RemoteStep` and `BatchHttpRequests`
* add retries and exponential backoff support to `RemoteStep` and `BatchHttpRequests`
* support setting Storey source arguments via serving spec params["source_args"]
* change function endpoint default to external (ingress) IP