### PR TITLE
[Requirements] Bump scikit-learn to 1.x

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,5 +12,5 @@ matplotlib~=3.0
 graphviz~=0.16.0
 nuclio-sdk~=0.3.0
 isort~=5.7
-# needed for mlutils tests
-scikit-learn~=0.23.0
+# both needed for mlutils tests
+scikit-learn~=1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,6 @@ matplotlib~=3.0
 graphviz~=0.16.0
 nuclio-sdk~=0.3.0
 isort~=5.7
-# both needed for mlutils tests
+# needed for mlutils tests
 scikit-learn~=1.0; python_version >= '3.7'
 scikit-learn~=0.23.0; python_version < '3.7'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,5 @@ graphviz~=0.16.0
 nuclio-sdk~=0.3.0
 isort~=5.7
 # both needed for mlutils tests
-scikit-learn~=1.0
+scikit-learn~=1.0; python_version >= '3.7'
+scikit-learn~=0.23.0; python_version < '3.7'

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,6 +1,7 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=1.0
+scikit-learn~=1.0; python_version >= '3.7'
+scikit-learn~=0.23.0; python_version < '3.7'
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=0.23.0
+scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=0.23.0
+scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,5 +1,6 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=1.0
+scikit-learn~=1.0; python_version >= '3.7'
+scikit-learn~=0.23.0; python_version < '3.7'
 seaborn~=0.11.0
 scikit-plot~=0.3.7

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=5.4
 matplotlib~=3.0
 graphviz~=0.16.0
-scikit-learn~=0.23.0
+scikit-learn~=1.0

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,4 +1,5 @@
 pytest~=5.4
 matplotlib~=3.0
 graphviz~=0.16.0
-scikit-learn~=1.0
+scikit-learn~=1.0; python_version >= '3.7'
+scikit-learn~=0.23.0; python_version < '3.7'

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -139,6 +139,10 @@ def test_requirement_specifiers_inconsistencies():
     ignored_inconsistencies_map = {
         # It's ok we have 2 different versions cause they are for different python versions
         "pandas": {"~=1.2; python_version >= '3.7'", "~=1.0; python_version < '3.7'"},
+        "scikit-learn": {
+            "~=1.0; python_version >= '3.7'",
+            "~=0.23.0; python_version < '3.7'",
+        },
         # The empty specifier is from tests/runtimes/assets/requirements.txt which is there specifically to test the
         # scenario of requirements without version specifiers
         "python-dotenv": {"", "~=0.17.0"},


### PR DESCRIPTION
We've seen CI fail in `test_run_mlbase_sklearn_classification` with this bug - https://github.com/scikit-optimize/scikit-optimize/issues/981
Bumping scikit learn should solve it