### PR TITLE
[General] Improve git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,9 @@ mlrun.egg-info/
 model.txt
 result*.html
 tests/test_results/
-venv
+*venv*
 mlrun/utils/version/version.json
 mlrun/api/migrations_sqlite/mlrun.db
 tests/system/env.yml
+# pyenv file for working with several python versions
+.python-version


### PR DESCRIPTION
* `venv` to `*venv*` allowing to have multiple virtual environments (I usually go with `venv-X` (e.g. `venv-py36`) that way it's near the venv in the file list)
* Added `.python-version` which is a file pyenv create when you change the python version locally for the project