### PR TITLE
[Makefile] Force sed to use extended regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ MLRUN_VERSION ?= unstable
 # character so we're doing best effort - if the provided version doesn't look valid (like unstable), we prefix the
 # version for the python package with 0.0.0+
 # if the provided version includes a "+" we replace it with "-" for the docker tag
-MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed 's/\+/\-/g')
+MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed -E 's/\+/\-/g')
 MLRUN_PYTHON_PACKAGE_VERSION ?= $(MLRUN_VERSION)
 ifeq ($(shell echo "$(MLRUN_VERSION)" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+.*$$"),) # empty result from egrep
 	MLRUN_PYTHON_PACKAGE_VERSION := 0.0.0+$(MLRUN_VERSION)


### PR DESCRIPTION
Our Jenkins uses image similar to the alpine image in which `sed --version` gives:
`This is not GNU sed version 4.0` which fails when executing `echo "0.9.0-rc1" | sed 's/\+/\-/g'` on
`sed: bad regex '\+': Repetition not preceded by valid expression`
adding `-E` forces it to use the extended regex which makes it to work