### PR TITLE
[Datastore] Enable no credentials for working with GCP workload identity

### DIFF
--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -20,6 +20,7 @@ import fsspec
 import mlrun.errors
 
 from .base import DataStore, FileStats
+from mlrun.utils import logger
 
 # Google storage objects will be represented with the following URL: gcs://<bucket name>/<path> or gs://...
 
@@ -34,15 +35,14 @@ class GoogleCloudStorageStore(DataStore):
         # we just read a specific env. variable, write it to a temp file and point the env variable to it.
         if "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
             gcp_credentials = self._get_secret_or_env("GCP_CREDENTIALS")
-            if not gcp_credentials:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "No google cloud storage credentials available"
-                )
-            with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".json", delete=False
-            ) as cred_file:
-                cred_file.write(gcp_credentials)
-                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_file.name
+            if gcp_credentials:
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".json", delete=False
+                ) as cred_file:
+                    cred_file.write(gcp_credentials)
+                    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_file.name
+            else:
+                logger.info("No GCS credentials available - auth will rely on auto-discovery of credentials")
 
         self.get_filesystem(silent=False)
 

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -18,9 +18,9 @@ from pathlib import Path
 import fsspec
 
 import mlrun.errors
+from mlrun.utils import logger
 
 from .base import DataStore, FileStats
-from mlrun.utils import logger
 
 # Google storage objects will be represented with the following URL: gcs://<bucket name>/<path> or gs://...
 
@@ -42,7 +42,9 @@ class GoogleCloudStorageStore(DataStore):
                     cred_file.write(gcp_credentials)
                     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_file.name
             else:
-                logger.info("No GCS credentials available - auth will rely on auto-discovery of credentials")
+                logger.info(
+                    "No GCS credentials available - auth will rely on auto-discovery of credentials"
+                )
 
         self.get_filesystem(silent=False)
 


### PR DESCRIPTION
When working with GCP, users may use workload-identity (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for authentication. In that case the `GOOGLE_APPLICATION_CREDENTIALS` environment variable will not be set, as auto-discovery will work with the GCP metadata server to inject the identity to the GCP API calls.

To enable working this way, removed the exception raised if this env variable is not set. If the user is not in a context that supports auto-discovery, the calls to access storage will fail due to no authentication, which is fine.