### PR TITLE
[API] Fix MySQL initialization from scratch

### DIFF
--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -337,7 +337,11 @@ def _resolve_current_data_version(
 ):
     try:
         return int(db.get_current_data_version(db_session))
-    except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.OperationalError, mlrun.errors.MLRunNotFoundError) as exc:
+    except (
+        sqlalchemy.exc.ProgrammingError,
+        sqlalchemy.exc.OperationalError,
+        mlrun.errors.MLRunNotFoundError,
+    ) as exc:
         try:
             projects = db.list_projects(db_session)
         except (sqlalchemy.exc.ProgrammingError, sqlalchemy.exc.OperationalError):
@@ -351,7 +355,9 @@ def _resolve_current_data_version(
                 latest_data_version=latest_data_version,
             )
             return latest_data_version
-        elif "no such table" in str(exc) or ("Table" in str(exc) and "doesn't exist" in str(exc)):
+        elif "no such table" in str(exc) or (
+            "Table" in str(exc) and "doesn't exist" in str(exc)
+        ):
             logger.info(
                 "Data version table does not exist, assuming prior version",
                 exc=exc,


### PR DESCRIPTION
When initializing from scratch - the DB is empty - meaning `db.get_current_data_version` will fail on Table doesn't exist - with sqlite `sqlalchemy.exc.OperationalError` was raised, but with MySQL `sqlalchemy.exc.ProgrammingError` is raised - catching it as well