### PR TITLE
[Runtimes] Properly handle project secrets for `nuclio:mlrun` kind

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -452,8 +452,11 @@ class RemoteRuntime(KubeResource):
         # For nuclio functions, we just add the project secrets as env variables. Since there's no MLRun code
         # to decode the secrets and special env variable names in the function, we just use the same env variable as
         # the key name (encode_key_names=False)
+        # If function_kind is mlrun then this is MLRun code (nuclio:mlrun), so we still encode key names.
+        encode_key_names = self.spec.function_kind == "mlrun"
+
         self._add_project_k8s_secrets_to_spec(
-            None, project=self.metadata.project, encode_key_names=False
+            None, project=self.metadata.project, encode_key_names=encode_key_names
         )
 
     def deploy(

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -379,9 +379,9 @@ class TestNuclioRuntime(TestRuntimeBase):
         function = self._generate_runtime(self.runtime_kind)
         self._serialize_and_deploy_nuclio_function(function)
 
-        # This test runs in KubeJob as well, with different secret names encoding
+        # This test runs in serving, nuclio:mlrun as well, with different secret names encoding
         expected_secrets = k8s_secrets_mock.get_expected_env_variables_from_secrets(
-            self.project, encode_key_names=(self.class_name != "remote")
+            self.project, encode_key_names=(self.runtime_kind != "nuclio")
         )
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_env_from_secrets=expected_secrets
@@ -727,3 +727,11 @@ class TestNuclioRuntime(TestRuntimeBase):
                 },
             },
         }
+
+
+# Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well
+class TestNuclioMLRunRuntime(TestNuclioRuntime):
+    @property
+    def runtime_kind(self):
+        # enables extending classes to run the same tests with different runtime
+        return "nuclio:mlrun"


### PR DESCRIPTION
When the function's kind is `nuclio:mlrun` it runs MLRun code wrapped up by a nuclio function. To enable using `context.get_secret()` in such functions, the project-secrets environment variable names need to be formatted properly (with prefix etc.).