### PR TITLE
[Runtimes] Fix and enhance work with context and artifacts

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -79,6 +79,7 @@ class Artifact(ModelObj):
         self._inline = is_inline
         self.license = ""
         self.extra_data = {}
+        self.tag = None  # temp store of the tag
 
     def before_log(self):
         pass

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -24,6 +24,7 @@ import mlrun
 from mlrun.artifacts import ModelArtifact
 from mlrun.datastore.store_resources import get_store_resource
 from mlrun.errors import MLRunInvalidArgumentError
+from mlrun.runtimes.utils import global_context
 
 from .artifacts import DatasetArtifact
 from .artifacts.manager import ArtifactManager, extend_artifact_path
@@ -810,6 +811,8 @@ class MLClientCtx(object):
             self.update_child_iterations(commit_children=True, completed=completed)
         self._last_update = now_date()
         self._update_db(commit=True, message=message)
+        if completed and not self.iteration:
+            global_context.set(None)
 
     def set_state(self, state: str = None, error: str = None, commit=True):
         """modify and store the run state or mark an error

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -24,7 +24,6 @@ import mlrun
 from mlrun.artifacts import ModelArtifact
 from mlrun.datastore.store_resources import get_store_resource
 from mlrun.errors import MLRunInvalidArgumentError
-from mlrun.runtimes.utils import global_context
 
 from .artifacts import DatasetArtifact
 from .artifacts.manager import ArtifactManager, extend_artifact_path
@@ -812,7 +811,7 @@ class MLClientCtx(object):
         self._last_update = now_date()
         self._update_db(commit=True, message=message)
         if completed and not self.iteration:
-            global_context.set(None)
+            mlrun.runtimes.utils.global_context.set(None)
 
     def set_state(self, state: str = None, error: str = None, commit=True):
         """modify and store the run state or mark an error

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -25,7 +25,8 @@ from mlrun.artifacts import ModelArtifact
 from mlrun.datastore.store_resources import get_store_resource
 from mlrun.errors import MLRunInvalidArgumentError
 
-from .artifacts import ArtifactManager, DatasetArtifact
+from .artifacts import DatasetArtifact
+from .artifacts.manager import ArtifactManager, extend_artifact_path
 from .datastore import store_manager
 from .db import get_run_db
 from .features import Feature
@@ -108,7 +109,7 @@ class MLClientCtx(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
-        self.commit(completed=exc_value is None)
+        self.commit()
 
     def get_child_context(self, with_parent_params=False, **params):
         """get child context (iteration)
@@ -158,17 +159,20 @@ class MLClientCtx(object):
         self._children.append(ctx)
         return ctx
 
-    def update_child_iterations(self, best_run=0, commit_children=False):
+    def update_child_iterations(
+        self, best_run=0, commit_children=False, completed=True
+    ):
         """update children results in the parent, and optionally mark the best
 
         :param best_run:  marks the child iteration number (starts from 1)
         :param commit_children:  commit all child runs to the db
+        :param completed:  mark children as completed
         """
         if not self._children:
             return
         if commit_children:
             for child in self._children:
-                child.commit()
+                child.commit(completed=completed)
         results = [child.to_dict() for child in self._children]
         summary = mlrun.runtimes.utils.results_to_iter(results, None, self)
         task = results[best_run - 1] if best_run else None
@@ -589,7 +593,7 @@ class MLClientCtx(object):
             item,
             body=body,
             local_path=local_path,
-            artifact_path=artifact_path or self.artifact_path,
+            artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
             target_path=target_path,
             tag=tag,
             viewer=viewer,
@@ -666,7 +670,7 @@ class MLClientCtx(object):
             self,
             ds,
             local_path=local_path,
-            artifact_path=artifact_path or self.artifact_path,
+            artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
             target_path=target_path,
             tag=tag,
             upload=upload,
@@ -768,7 +772,7 @@ class MLClientCtx(object):
             self,
             model,
             local_path=model_dir,
-            artifact_path=artifact_path or self.artifact_path,
+            artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
             tag=tag,
             upload=upload,
             db_key=db_key,
@@ -777,12 +781,21 @@ class MLClientCtx(object):
         self._update_db()
         return item
 
-    def commit(self, message: str = "", completed=False):
+    def get_cached_artifact(self, key):
+        """return an a logged artifact from cache (for potential updates)"""
+        return self._artifacts_manager.artifacts[key]
+
+    def update_artifact(self, artifact_object):
+        """update an artifact object in the cache and the DB"""
+        self._artifacts_manager.update_artifact(self, artifact_object)
+
+    def commit(self, message: str = "", completed=True):
         """save run state and optionally add a commit message
 
         :param message:   commit message to save in the run
         :param completed: mark run as completed
         """
+        completed = completed and self._state == "running"
         if message:
             self._annotations["message"] = message
         if completed:
@@ -794,7 +807,7 @@ class MLClientCtx(object):
             self._parent._update_db(commit=True, message=message)
 
         if self._children:
-            self.update_child_iterations(commit_children=True)
+            self.update_child_iterations(commit_children=True, completed=completed)
         self._last_update = now_date()
         self._update_db(commit=True, message=message)
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -27,13 +27,8 @@ import mlrun.api.schemas
 import mlrun.errors
 import mlrun.utils.regex
 
-from ..artifacts import (
-    ArtifactManager,
-    ArtifactProducer,
-    DatasetArtifact,
-    ModelArtifact,
-    dict_to_artifact,
-)
+from ..artifacts import ArtifactProducer, DatasetArtifact, ModelArtifact
+from ..artifacts.manager import ArtifactManager, dict_to_artifact, extend_artifact_path
 from ..datastore import store_manager
 from ..db import get_run_db
 from ..features import Feature
@@ -1061,8 +1056,8 @@ class MlrunProject(ModelObj):
         target_path=None,
     ):
         am = self._get_artifact_manager()
-        artifact_path = (
-            artifact_path or self.spec.artifact_path or mlrun.mlconf.artifact_path
+        artifact_path = extend_artifact_path(
+            artifact_path, self.spec.artifact_path or mlrun.mlconf.artifact_path
         )
         artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
             artifact_path, self.metadata.name

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -64,6 +64,7 @@ from .utils import (
     new_pipe_meta,
     parse_versioned_object_uri,
     retry_until_successful,
+    run_keys,
     update_in,
 )
 
@@ -305,6 +306,7 @@ def get_or_create_ctx(
     with_env: bool = True,
     rundb: str = "",
     project: str = "",
+    upload_artifacts=False,
 ):
     """called from within the user program to obtain a run context
 
@@ -321,6 +323,8 @@ def get_or_create_ctx(
     :param with_env: look for context in environment vars, default True
     :param rundb:    path/url to the metadata and artifact database
     :param project:  project to initiate the context in (by default mlrun.mlctx.default_project)
+    :param upload_artifacts:  when using local context (not as part of a job/run), upload artifacts to the
+                              system default artifact path location
 
     :return: execution context
 
@@ -375,6 +379,11 @@ def get_or_create_ctx(
 
     if not newspec:
         newspec = {}
+        if upload_artifacts:
+            artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
+                mlconf.artifact_path, project or mlconf.default_project
+            )
+            update_in(newspec, ["spec", run_keys.output_path], artifact_path)
 
     newspec.setdefault("metadata", {})
     update_in(newspec, "metadata.name", name, replace=False)
@@ -386,7 +395,7 @@ def get_or_create_ctx(
         logger.info(f"logging run results to: {out}")
 
     newspec["metadata"]["project"] = (
-        project or newspec["metadata"].get("project") or mlconf.default_project
+        newspec["metadata"].get("project") or project or mlconf.default_project
     )
 
     ctx = MLClientCtx.from_dict(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -401,6 +401,7 @@ def get_or_create_ctx(
     ctx = MLClientCtx.from_dict(
         newspec, rundb=out, autocommit=autocommit, tmp=tmp, host=socket.gethostname()
     )
+    global_context.set(ctx)
     return ctx
 
 

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -1,5 +1,6 @@
 import mlrun
 import mlrun.artifacts
+from mlrun.artifacts.manager import extend_artifact_path
 from mlrun.utils import StorePrefix
 
 
@@ -32,3 +33,13 @@ def test_artifact_uri():
     artifact = mlrun.artifacts.ModelArtifact("data", body="abc")
     prefix, uri = mlrun.datastore.parse_store_uri(artifact.uri)
     assert prefix == StorePrefix.Model, "illegal artifact uri"
+
+
+def test_extend_artifact_path():
+    tests = ["", "./", "abc", "+/", "+/x"]
+    expected = ["", "./", "abc", "", "x"]
+    for i, test in enumerate(tests):
+        assert extend_artifact_path(test, "") == expected[i]
+    expected = ["yz", "./", "abc", "yz/", "yz/x"]
+    for i, test in enumerate(tests):
+        assert extend_artifact_path(test, "yz") == expected[i]

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -24,6 +24,7 @@ from mlrun.api.utils.singletons.db import initialize_db
 from mlrun.config import config
 from mlrun.runtimes import BaseRuntime
 from mlrun.runtimes.function import NuclioStatus
+from mlrun.runtimes.utils import global_context
 from tests.conftest import logs_path, root_path, rundb_path
 
 session_maker: Callable
@@ -38,6 +39,8 @@ def config_test_base():
     environ["MLRUN_httpdb__logs_path"] = logs_path
     environ["MLRUN_httpdb__projects__periodic_sync_interval"] = "0 seconds"
     environ["MLRUN_httpdb__projects__counters_cache_ttl"] = "0 seconds"
+    environ["MLRUN_EXEC_CONFIG"] = ""
+    global_context.set(None)
     log_level = "DEBUG"
     environ["MLRUN_log_level"] = log_level
     # reload config so that values overridden by tests won't pass to other tests

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import pathlib
 from unittest.mock import Mock
 
@@ -21,7 +20,6 @@ import pytest
 import mlrun
 import mlrun.errors
 from mlrun import get_run_db, new_function, new_task
-from mlrun.runtimes.utils import global_context
 from tests.conftest import (
     examples_path,
     has_secrets,
@@ -320,10 +318,6 @@ def test_local_args():
 
 
 def test_local_context():
-    global_context.set(None)
-    os.environ["MLRUN_EXEC_CONFIG"] = ""
-
-    db = mlrun.get_run_db()
     project_name = "xtst"
     mlrun.mlconf.artifact_path = out_path
     context = mlrun.get_or_create_ctx("xx", project=project_name, upload_artifacts=True)
@@ -337,6 +331,7 @@ def test_local_context():
 
     assert context._state == "completed", "task did not complete"
 
+    db = mlrun.get_run_db()
     run = db.read_run(context._uid, project=project_name)
     assert run["status"]["state"] == "completed", "run status not updated in db"
     assert run["status"]["artifacts"][0]["key"] == "xx", "artifact not updated in db"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -316,3 +316,33 @@ def test_local_args():
     print(state)
     print(log)
     assert log.find(", '--xyz', '789']") != -1, "params not detected in argv"
+
+
+def test_local_context():
+    project_name = "xtst"
+    mlrun.mlconf.artifact_path = out_path
+    context = mlrun.get_or_create_ctx("xx", project=project_name, upload_artifacts=True)
+    with context:
+        context.log_artifact("xx", body="123", local_path="a.txt")
+        context.log_model("mdl", body="456", model_file="mdl.pkl", artifact_path="+/mm")
+
+        artifact = context.get_cached_artifact("xx")
+        artifact.format = "z"
+        context.update_artifact(artifact)
+        print(artifact.to_yaml())
+
+    assert context._state == "completed", "task did not complete"
+
+    db = mlrun.get_run_db()
+    run = db.read_run(context._uid, project=project_name)
+    assert run["status"]["state"] == "completed", "run status not updated in db"
+    assert run["status"]["artifacts"][0]["key"] == "xx", "artifact not updated in db"
+    assert (
+        run["status"]["artifacts"][0]["format"] == "z"
+    ), "run/artifact attribute not updated in db"
+    assert (
+        run["status"]["artifacts"][1]["target_path"] == out_path + "/mm/"
+    ), "artifact not uploaded to subpath"
+
+    db_artifact = db.read_artifact(artifact.db_key, project=project_name)
+    assert db_artifact["format"] == "z", "artifact attribute not updated in db"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import pathlib
 from unittest.mock import Mock
 
@@ -21,6 +21,7 @@ import pytest
 import mlrun
 import mlrun.errors
 from mlrun import get_run_db, new_function, new_task
+from mlrun.runtimes.utils import global_context
 from tests.conftest import (
     examples_path,
     has_secrets,
@@ -319,6 +320,10 @@ def test_local_args():
 
 
 def test_local_context():
+    global_context.set(None)
+    os.environ["MLRUN_EXEC_CONFIG"] = ""
+
+    db = mlrun.get_run_db()
     project_name = "xtst"
     mlrun.mlconf.artifact_path = out_path
     context = mlrun.get_or_create_ctx("xx", project=project_name, upload_artifacts=True)
@@ -329,11 +334,9 @@ def test_local_context():
         artifact = context.get_cached_artifact("xx")
         artifact.format = "z"
         context.update_artifact(artifact)
-        print(artifact.to_yaml())
 
     assert context._state == "completed", "task did not complete"
 
-    db = mlrun.get_run_db()
     run = db.read_run(context._uid, project=project_name)
     assert run["status"]["state"] == "completed", "run status not updated in db"
     assert run["status"]["artifacts"][0]["key"] == "xx", "artifact not updated in db"


### PR DESCRIPTION
* fix use of local context (get_or_create_context() outside of a run()) with artifacts
* allow using the default artifact path with local context
* support using artifact_path="+/subpath" when logging artifacts (add subpath to default path)
* support get/update artifacts in the execution context (allow the auto logging framework to update model objects after the log) 