### PR TITLE
[Runtimes] Limit function's service accounts based on project configuration

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -508,6 +508,7 @@ def _start_function(function, auth_info: mlrun.api.schemas.AuthInfo):
             run_db = get_run_db_instance(db_session)
             function.set_db_connection(run_db)
             mlrun.api.api.utils.ensure_function_has_auth_set(function, auth_info)
+            mlrun.api.api.utils.process_function_service_account(function)
             #  resp = resource["start"](fn)  # TODO: handle resp?
             resource["start"](function)
             function.save(versioned=False)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -425,6 +425,7 @@ def _build_function(
         fn.save(versioned=False)
         if fn.kind in RuntimeKinds.nuclio_runtimes():
             mlrun.api.api.utils.ensure_function_has_auth_set(fn, auth_info)
+            mlrun.api.api.utils.process_function_service_account(fn)
 
             if fn.kind == RuntimeKinds.serving:
                 # Handle model monitoring

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -31,6 +31,9 @@ class Secrets(metaclass=mlrun.utils.singleton.Singleton,):
     def generate_model_monitoring_secret_key(self, key):
         return f"{self.internal_secrets_key_prefix}model-monitoring.{key}"
 
+    def generate_service_account_secret_key(self, key):
+        return f"{self.internal_secrets_key_prefix}service-accounts.{key}"
+
     @staticmethod
     def validate_secret_key_regex(key: str, raise_on_failure: bool = True) -> bool:
         return mlrun.utils.helpers.verify_field_regex(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -227,6 +227,11 @@ class BaseRuntime(ModelObj):
     def try_auto_mount_based_on_config(self):
         pass
 
+    def validate_and_enrich_service_account(
+        self, allowed_service_account, default_service_account
+    ):
+        pass
+
     def fill_credentials(self):
         if "MLRUN_AUTH_SESSION" in os.environ or "V3IO_ACCESS_KEY" in os.environ:
             self.metadata.credentials.access_key = os.environ.get(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1077,6 +1077,9 @@ def compile_function_config(function: RemoteRuntime):
         spec.set_config("spec.minReplicas", function.spec.min_replicas)
         spec.set_config("spec.maxReplicas", function.spec.max_replicas)
 
+    if function.spec.service_account:
+        spec.set_config("spec.serviceAccount", function.spec.service_account)
+
     if function.spec.base_spec or function.spec.build.functionSourceCode:
         config = function.spec.base_spec
         if not config:

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -586,6 +586,26 @@ class KubeResource(BaseRuntime):
 
         self.apply(modifier(**mount_params_dict))
 
+    def validate_and_enrich_service_account(
+        self, allowed_service_accounts, default_service_account
+    ):
+        if not self.spec.service_account:
+            if default_service_account:
+                self.spec.service_account = default_service_account
+                logger.info(
+                    f"Setting default service account to function: {default_service_account}"
+                )
+            return
+
+        if (
+            allowed_service_accounts
+            and self.spec.service_account not in allowed_service_accounts
+        ):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Function service account {self.spec.service_account} is not in allowed "
+                + f"service accounts {allowed_service_accounts}"
+            )
+
 
 def kube_resource_spec_to_pod_spec(
     kube_resource_spec: KubeResourceSpec, container: client.V1Container

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -1,4 +1,3 @@
-import unittest
 from http import HTTPStatus
 
 import pytest
@@ -9,17 +8,10 @@ from sqlalchemy.orm import Session
 import mlrun
 import mlrun.api.schemas
 from mlrun.api.api.utils import _generate_function_and_task_from_submit_run_body
-from mlrun.api.utils.singletons.k8s import get_k8s
 
-
-@pytest.fixture(autouse=True)
-def mock_secrets_call():
-    orig_function = get_k8s()._get_project_secrets_raw_data
-    get_k8s()._get_project_secrets_raw_data = unittest.mock.Mock(return_value={})
-
-    yield
-
-    get_k8s()._get_project_secrets_raw_data = orig_function
+# Want to use k8s_secrets_mock for all tests in this module. It is needed since
+# _generate_function_and_task_from_submit_run_body looks for project secrets for secret-accoutn validation.
+pytestmark = pytest.mark.usefixtures("k8s_secrets_mock")
 
 
 def test_generate_function_and_task_from_submit_run_body_body_override_values(

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -1,5 +1,7 @@
+import unittest
 from http import HTTPStatus
 
+import pytest
 from deepdiff import DeepDiff
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -7,6 +9,17 @@ from sqlalchemy.orm import Session
 import mlrun
 import mlrun.api.schemas
 from mlrun.api.api.utils import _generate_function_and_task_from_submit_run_body
+from mlrun.api.utils.singletons.k8s import get_k8s
+
+
+@pytest.fixture(autouse=True)
+def mock_secrets_call():
+    orig_function = get_k8s()._get_project_secrets_raw_data
+    get_k8s()._get_project_secrets_raw_data = unittest.mock.Mock(return_value={})
+
+    yield
+
+    get_k8s()._get_project_secrets_raw_data = orig_function
 
 
 def test_generate_function_and_task_from_submit_run_body_body_override_values(

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -113,6 +113,24 @@ class K8sSecretsMock:
             == {}
         )
 
+    def set_service_account_keys(
+        self, project, default_service_account, allowed_service_accounts
+    ):
+        secrets = {}
+        if default_service_account:
+            secrets[
+                mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
+                    "default"
+                )
+            ] = default_service_account
+        if allowed_service_accounts:
+            secrets[
+                mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
+                    "allowed"
+                )
+            ] = ",".join(allowed_service_accounts)
+        self.store_project_secrets(project, secrets)
+
 
 @pytest.fixture()
 def k8s_secrets_mock(client: TestClient) -> K8sSecretsMock:

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -398,16 +398,7 @@ class TestNuclioRuntime(TestRuntimeBase):
     def test_deploy_with_service_accounts(
         self, db: Session, k8s_secrets_mock: K8sSecretsMock
     ):
-        secrets = {
-            mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
-                "default"
-            ): "sa1",
-            mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
-                "allowed"
-            ): "sa1, sa2",
-        }
-
-        k8s_secrets_mock.store_project_secrets(self.project, secrets)
+        k8s_secrets_mock.set_service_account_keys(self.project, "sa1", ["sa1", "sa2"])
 
         function = self._generate_runtime(self.runtime_kind)
         # Need to call _build_function, since service-account enrichment is happening only on server side, before the

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -7,11 +7,13 @@ import deepdiff
 import kubernetes
 import nuclio
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 import mlrun.errors
 from mlrun import code_to_function, mlconf
+from mlrun.api.api.endpoints.functions import _build_function
 from mlrun.platforms.iguazio import split_path
 from mlrun.runtimes.constants import NuclioIngressAddTemplatedIngressModes
 from mlrun.runtimes.function import (
@@ -120,6 +122,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         expected_params=[],
         expected_labels=None,
         expected_env_from_secrets=None,
+        expected_service_account=None,
     ):
         if expected_labels is None:
             expected_labels = {}
@@ -166,6 +169,11 @@ class TestNuclioRuntime(TestRuntimeBase):
             if expected_env_from_secrets:
                 env_vars = deploy_config["spec"]["env"]
                 self._assert_pod_env_from_secrets(env_vars, expected_env_from_secrets)
+
+            if expected_service_account:
+                assert (
+                    deploy_config["spec"]["serviceAccount"] == expected_service_account
+                )
 
     def _assert_triggers(self, http_trigger=None, v3io_trigger=None):
         args, _ = nuclio.deploy.deploy_config.call_args
@@ -385,6 +393,39 @@ class TestNuclioRuntime(TestRuntimeBase):
         )
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_env_from_secrets=expected_secrets
+        )
+
+    def test_deploy_with_service_accounts(
+        self, db: Session, k8s_secrets_mock: K8sSecretsMock
+    ):
+        secrets = {
+            mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
+                "default"
+            ): "sa1",
+            mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
+                "allowed"
+            ): "sa1, sa2",
+        }
+
+        k8s_secrets_mock.store_project_secrets(self.project, secrets)
+
+        function = self._generate_runtime(self.runtime_kind)
+        # Need to call _build_function, since service-account enrichment is happening only on server side, before the
+        # call to deploy_nuclio_function
+        _build_function(db, None, function)
+        self._assert_deploy_called_basic_config(
+            expected_class=self.class_name, expected_service_account="sa1"
+        )
+        nuclio.deploy.deploy_config.reset_mock()
+
+        function.spec.service_account = "bad-sa"
+        with pytest.raises(HTTPException):
+            _build_function(db, None, function)
+
+        function.spec.service_account = "sa2"
+        _build_function(db, None, function)
+        self._assert_deploy_called_basic_config(
+            expected_class=self.class_name, expected_service_account="sa2"
         )
 
     def test_deploy_basic_function(self, db: Session, client: TestClient):

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -22,6 +22,7 @@ import tests.api.conftest
 from mlrun.api import schemas
 from mlrun.api.utils.scheduler import Scheduler
 from mlrun.api.utils.singletons.db import get_db
+from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.runtimes.base import RunStates
 from mlrun.utils import logger
@@ -56,6 +57,16 @@ async def bump_counter_and_wait():
 
 async def do_nothing():
     pass
+
+
+@pytest.fixture(autouse=True)
+def mock_secrets_call():
+    orig_function = get_k8s()._get_project_secrets_raw_data
+    get_k8s()._get_project_secrets_raw_data = unittest.mock.Mock(return_value={})
+
+    yield
+
+    get_k8s()._get_project_secrets_raw_data = orig_function
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Up until now there was no mechanism to limit the service account that a user can set on a function (using `function.spec.service_account = '<something>'`. This is a potential security issue, for example if users are utilizing Google workload identity that maps service accounts to Google service accounts.

This PR adds the following mechanism to limit the service accounts:
Use 2 internal project secrets (per project):
* `mlrun.service-accounts.allowed` - a list of allowed service accounts, separated by `,`. For example - `sa1, sa2, sa3`
* `mlrun.service-accounts.default` - a default service account per project. This will be automatically assigned to every function deployed from that function, unless the user manually set a different SA

The logic is as follows:

1. If the allowed SAs list is empty (secret does not exist) - the logic is exactly like today, i.e. there's no restriction on the SAs that the user can assign to a function.
2. If a default SA is provided and a function does not have an SA assigned, then set the default SA to the function. If the function already has a SA, keep it.
3. If the allowed SA list is not empty, then validate that the function's SA exists in the list of allowed SAs. If it is not, fail the submitting/deploying of the function.

It's valid to have a default SA without an allowed list. It's also valid to have an allowed list without a default SA.

Currently this PR only adds the validation side, it does not add MLRun APIs to set the allowed list or the default SA. This will be done in the future once we make a decision on the permissions needed for this API and how this should be managed. This can be utilized by externally creating the relevant secret keys per project (it cannot be done through MLRun's project-secret mechanism, since the secrets are internal secrets and MLRun will block it).

Another fix in this PR - up until now the `func.spec.service_account` property completely ignored for nuclio functions. This PR fixes it.