### PR TITLE
[Secrets] Make k8s provider the default secrets provider in httpdb and API calls

### DIFF
--- a/mlrun/api/api/endpoints/secrets.py
+++ b/mlrun/api/api/endpoints/secrets.py
@@ -46,7 +46,7 @@ def store_project_secrets(
 @router.delete("/projects/{project}/secrets", status_code=HTTPStatus.NO_CONTENT.value)
 def delete_project_secrets(
     project: str,
-    provider: schemas.SecretProviderName,
+    provider: schemas.SecretProviderName = schemas.SecretProviderName.kubernetes,
     secrets: List[str] = fastapi.Query(None, alias="secret"),
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
@@ -72,7 +72,7 @@ def delete_project_secrets(
 @router.get("/projects/{project}/secret-keys", response_model=schemas.SecretKeysData)
 def list_secret_keys(
     project: str,
-    provider: schemas.SecretProviderName = schemas.SecretProviderName.vault,
+    provider: schemas.SecretProviderName = schemas.SecretProviderName.kubernetes,
     token: str = fastapi.Header(None, alias=schemas.HeaderNames.secret_store_token),
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
@@ -96,7 +96,7 @@ def list_secret_keys(
 def list_secrets(
     project: str,
     secrets: List[str] = fastapi.Query(None, alias="secret"),
-    provider: schemas.SecretProviderName = schemas.SecretProviderName.vault,
+    provider: schemas.SecretProviderName = schemas.SecretProviderName.kubernetes,
     token: str = fastapi.Header(None, alias=schemas.HeaderNames.secret_store_token),
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -326,7 +326,7 @@ class RunDBInterface(ABC):
         project: str,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         secrets: dict = None,
     ):
         pass
@@ -338,7 +338,7 @@ class RunDBInterface(ABC):
         token: str,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         secrets: List[str] = None,
     ) -> schemas.SecretsData:
         pass
@@ -349,7 +349,7 @@ class RunDBInterface(ABC):
         project: str,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         token: str = None,
     ) -> schemas.SecretKeysData:
         pass
@@ -360,7 +360,7 @@ class RunDBInterface(ABC):
         project: str,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         secrets: List[str] = None,
     ):
         pass

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -652,7 +652,7 @@ class FileRunDB(RunDBInterface):
     def create_project_secrets(
         self,
         project: str,
-        provider: str = mlrun.api.schemas.SecretProviderName.vault.value,
+        provider: str = mlrun.api.schemas.SecretProviderName.kubernetes.value,
         secrets: dict = None,
     ):
         raise NotImplementedError()
@@ -661,7 +661,7 @@ class FileRunDB(RunDBInterface):
         self,
         project: str,
         token: str,
-        provider: str = mlrun.api.schemas.SecretProviderName.vault.value,
+        provider: str = mlrun.api.schemas.SecretProviderName.kubernetes.value,
         secrets: List[str] = None,
     ) -> mlrun.api.schemas.SecretsData:
         raise NotImplementedError()
@@ -669,7 +669,7 @@ class FileRunDB(RunDBInterface):
     def list_project_secret_keys(
         self,
         project: str,
-        provider: str = mlrun.api.schemas.SecretProviderName.vault,
+        provider: str = mlrun.api.schemas.SecretProviderName.kubernetes,
         token: str = None,
     ) -> mlrun.api.schemas.SecretKeysData:
         raise NotImplementedError()
@@ -677,7 +677,7 @@ class FileRunDB(RunDBInterface):
     def delete_project_secrets(
         self,
         project: str,
-        provider: str = mlrun.api.schemas.SecretProviderName.vault.value,
+        provider: str = mlrun.api.schemas.SecretProviderName.kubernetes.value,
         secrets: List[str] = None,
     ):
         raise NotImplementedError()

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2059,7 +2059,7 @@ class HTTPRunDB(RunDBInterface):
         project: str,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         secrets: dict = None,
     ):
         """ Create project-context secrets using either ``vault`` or ``kubernetes`` provider.
@@ -2084,7 +2084,7 @@ class HTTPRunDB(RunDBInterface):
                 secrets = {'password': 'myPassw0rd', 'aws_key': '111222333'}
                 db.create_project_secrets(
                     "project1",
-                    provider=mlrun.api.schemas.SecretProviderName.vault,
+                    provider=mlrun.api.schemas.SecretProviderName.kubernetes,
                     secrets=secrets
                 )
         """
@@ -2104,7 +2104,7 @@ class HTTPRunDB(RunDBInterface):
         token: str = None,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         secrets: List[str] = None,
     ) -> schemas.SecretsData:
         """ Retrieve project-context secrets from Vault.
@@ -2143,7 +2143,7 @@ class HTTPRunDB(RunDBInterface):
         project: str,
         provider: Union[
             str, schemas.SecretProviderName
-        ] = schemas.SecretProviderName.vault,
+        ] = schemas.SecretProviderName.kubernetes,
         token: str = None,
     ) -> schemas.SecretKeysData:
         """ Retrieve project-context secret keys from Vault or Kubernetes.

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -571,7 +571,7 @@ class SQLDB(RunDBInterface):
         project: str,
         provider: Union[
             str, mlrun.api.schemas.SecretProviderName
-        ] = mlrun.api.schemas.SecretProviderName.vault,
+        ] = mlrun.api.schemas.SecretProviderName.kubernetes,
         secrets: dict = None,
     ):
         raise NotImplementedError()
@@ -582,7 +582,7 @@ class SQLDB(RunDBInterface):
         token: str,
         provider: Union[
             str, mlrun.api.schemas.SecretProviderName
-        ] = mlrun.api.schemas.SecretProviderName.vault,
+        ] = mlrun.api.schemas.SecretProviderName.kubernetes,
         secrets: List[str] = None,
     ) -> mlrun.api.schemas.SecretsData:
         raise NotImplementedError()
@@ -592,7 +592,7 @@ class SQLDB(RunDBInterface):
         project: str,
         provider: Union[
             str, mlrun.api.schemas.SecretProviderName
-        ] = mlrun.api.schemas.SecretProviderName.vault,
+        ] = mlrun.api.schemas.SecretProviderName.kubernetes,
         token: str = None,
     ) -> mlrun.api.schemas.SecretKeysData:
         raise NotImplementedError()
@@ -602,7 +602,7 @@ class SQLDB(RunDBInterface):
         project: str,
         provider: Union[
             str, mlrun.api.schemas.SecretProviderName
-        ] = mlrun.api.schemas.SecretProviderName.vault,
+        ] = mlrun.api.schemas.SecretProviderName.kubernetes,
         secrets: List[str] = None,
     ):
         raise NotImplementedError()


### PR DESCRIPTION
Set the k8s provider to be the default parameter in all secret-related calls (other than `create_user_secrets` which is only implemented for Vault).