### PR TITLE
[API] Support artifact list filtering by kind & category in httpdb

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -96,6 +96,8 @@ class RunDBInterface(ABC):
         until=None,
         iter: int = None,
         best_iteration: bool = False,
+        kind: str = None,
+        category: Union[str, schemas.ArtifactCategories] = None,
     ):
         pass
 

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -236,10 +236,12 @@ class FileRunDB(RunDBInterface):
         until=None,
         iter: int = None,
         best_iteration: bool = False,
+        kind: str = None,
+        category: Union[str, schemas.ArtifactCategories] = None,
     ):
-        if iter:
+        if iter or kind or category:
             raise NotImplementedError(
-                "iter parameter not supported for filedb implementation"
+                "iter/kind/category parameters are not supported for filedb implementation"
             )
 
         labels = [] if labels is None else labels

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -583,6 +583,8 @@ class HTTPRunDB(RunDBInterface):
         until=None,
         iter: int = None,
         best_iteration: bool = False,
+        kind: str = None,
+        category: Union[str, schemas.ArtifactCategories] = None,
     ) -> ArtifactList:
         """ List artifacts filtered by various parameters.
 
@@ -605,9 +607,14 @@ class HTTPRunDB(RunDBInterface):
         :param best_iteration: Returns the artifact which belongs to the best iteration of a given run, in the case of
             artifacts generated from a hyper-param run. If only a single iteration exists, will return the artifact
             from that iteration. If using ``best_iter``, the ``iter`` parameter must not be used.
+        :param kind: Return artifacts of the requested kind.
+        :param category: Return artifacts of the requested category.
         """
 
         project = project or config.default_project
+        if category and isinstance(category, schemas.ArtifactCategories):
+            category = category.value
+
         params = {
             "name": name,
             "project": project,
@@ -615,6 +622,8 @@ class HTTPRunDB(RunDBInterface):
             "label": labels or [],
             "iter": iter,
             "best-iteration": best_iteration,
+            "kind": kind,
+            "category": category,
         }
         error = "list artifacts"
         resp = self.api_call("GET", "artifacts", error, params=params)

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -166,8 +166,13 @@ class SQLDB(RunDBInterface):
         until=None,
         iter: int = None,
         best_iteration: bool = False,
+        kind: str = None,
+        category: Union[str, schemas.ArtifactCategories] = None,
     ):
         import mlrun.api.crud
+
+        if category and isinstance(category, str):
+            category = schemas.ArtifactCategories(category)
 
         return self._transform_db_error(
             mlrun.api.crud.Artifacts().list_artifacts,
@@ -180,6 +185,8 @@ class SQLDB(RunDBInterface):
             until,
             iter=iter,
             best_iteration=best_iteration,
+            kind=kind,
+            category=category,
         )
 
     def del_artifact(self, key, tag="", project=""):

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -1,0 +1,57 @@
+import pandas
+
+import mlrun
+import mlrun.artifacts
+import tests.integration.sdk_api.base
+
+
+class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
+    def test_artifacts(self):
+        db = mlrun.get_run_db()
+        prj, uid, key, body = "p9", "u19", "k802", "tomato"
+        artifact = mlrun.artifacts.Artifact(key, body, target_path="a.txt")
+
+        db.store_artifact(key, artifact, uid, project=prj)
+        db.store_artifact(key, artifact, uid, project=prj, iter=42)
+        artifacts = db.list_artifacts(project=prj, tag="*")
+        assert len(artifacts) == 2, "bad number of artifacts"
+        assert artifacts.objects()[0].key == key, "not a valid artifact object"
+        assert artifacts.dataitems()[0].url, "not a valid artifact dataitem"
+
+        artifacts = db.list_artifacts(project=prj, tag="*", iter=0)
+        assert len(artifacts) == 1, "bad number of artifacts"
+
+        # Only 1 will be returned since it's only looking for iter 0
+        artifacts = db.list_artifacts(project=prj, tag="*", best_iteration=True)
+        assert len(artifacts) == 1, "bad number of artifacts"
+
+        db.del_artifacts(project=prj, tag="*")
+        artifacts = db.list_artifacts(project=prj, tag="*")
+        assert len(artifacts) == 0, "bad number of artifacts after del"
+
+    def test_list_artifacts_filter_by_kind(self):
+        prj, uid, key, body = "p9", "u19", "k802", "tomato"
+        model_artifact = mlrun.artifacts.model.ModelArtifact(
+            key, body, target_path="a.txt"
+        )
+
+        data = {"col1": [1, 2], "col2": [3, 4]}
+        data_frame = pandas.DataFrame(data=data)
+        dataset_artifact = mlrun.artifacts.dataset.DatasetArtifact(
+            key, df=data_frame, format="parquet", target_path="b.pq"
+        )
+
+        db = mlrun.get_run_db()
+        db.store_artifact(key, model_artifact, f"model_{uid}", project=prj)
+        db.store_artifact(key, dataset_artifact, f"ds_{uid}", project=prj, iter=42)
+
+        artifacts = db.list_artifacts(project=prj)
+        assert len(artifacts) == 2, "bad number of artifacts"
+
+        artifacts = db.list_artifacts(project=prj, kind="model")
+        assert len(artifacts) == 1, "bad number of model artifacts"
+
+        artifacts = db.list_artifacts(
+            project=prj, category=mlrun.api.schemas.ArtifactCategories.dataset
+        )
+        assert len(artifacts) == 1, "bad number of dataset artifacts"

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -24,13 +24,14 @@ from tempfile import mkdtemp
 from uuid import uuid4
 
 import deepdiff
+import pandas
 import pytest
 
 import mlrun.errors
 import mlrun.projects.project
 from mlrun import RunObject
 from mlrun.api import schemas
-from mlrun.artifacts import Artifact
+from mlrun.artifacts import Artifact, DatasetArtifact, ModelArtifact
 from mlrun.db.httpdb import HTTPRunDB
 from tests.conftest import tests_root_directory, wait_for_server
 
@@ -274,6 +275,34 @@ def test_artifacts(create_server):
     db.del_artifacts(project=prj, tag="*")
     artifacts = db.list_artifacts(project=prj, tag="*")
     assert len(artifacts) == 0, "bad number of artifacts after del"
+
+
+def test_list_artifacts_filter_by_kind(create_server):
+    server: Server = create_server()
+    db = server.conn
+
+    prj, uid, key, body = "p9", "u19", "k802", "tomato"
+    model_artifact = ModelArtifact(key, body, target_path="a.txt")
+
+    data = {"col1": [1, 2], "col2": [3, 4]}
+    data_frame = pandas.DataFrame(data=data)
+    dataset_artifact = DatasetArtifact(
+        key, df=data_frame, format="parquet", target_path="b.pq"
+    )
+
+    db.store_artifact(key, model_artifact, f"model_{uid}", project=prj)
+    db.store_artifact(key, dataset_artifact, f"ds_{uid}", project=prj, iter=42)
+
+    artifacts = db.list_artifacts(project=prj)
+    assert len(artifacts) == 2, "bad number of artifacts"
+
+    artifacts = db.list_artifacts(project=prj, kind="model")
+    assert len(artifacts) == 1, "bad number of model artifacts"
+
+    artifacts = db.list_artifacts(
+        project=prj, category=schemas.ArtifactCategories.dataset
+    )
+    assert len(artifacts) == 1, "bad number of dataset artifacts"
 
 
 def test_basic_auth(create_server):


### PR DESCRIPTION
Add the option to pass `kind` and `category` filters to the `list_artifacts` API in httpdb. This was already supported in the REST API.