### PR TITLE
[Secrets] Fix project secret injection for `nuclio` and `nuclio:mlrun` runtimes

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -493,11 +493,8 @@ class RemoteRuntime(KubeResource):
         # For nuclio functions, we just add the project secrets as env variables. Since there's no MLRun code
         # to decode the secrets and special env variable names in the function, we just use the same env variable as
         # the key name (encode_key_names=False)
-        # If function_kind is mlrun then this is MLRun code (nuclio:mlrun), so we still encode key names.
-        encode_key_names = self.spec.function_kind == "mlrun"
-
         self._add_project_k8s_secrets_to_spec(
-            None, project=self.metadata.project, encode_key_names=encode_key_names
+            None, project=self.metadata.project, encode_key_names=False
         )
 
     def deploy(

--- a/mlrun/runtimes/nuclio.py
+++ b/mlrun/runtimes/nuclio.py
@@ -80,7 +80,7 @@ def nuclio_jobs_handler(context, event):
     if secret_list:
         secrets_keys = secret_list.split(",")
         secrets = {key: os.environ.get(key) for key in secrets_keys}
-        context._secrets_manager.add_source("inline", secrets)
+        ctx._secrets_manager.add_source("inline", secrets)
 
     args = get_func_arg(fhandler, RunTemplate.from_dict(ctx.to_dict()), ctx)
     try:

--- a/mlrun/runtimes/nuclio.py
+++ b/mlrun/runtimes/nuclio.py
@@ -78,9 +78,7 @@ def nuclio_jobs_handler(context, event):
     # Inject project secrets from env. variables to the context
     secret_list = os.environ.get("MLRUN_PROJECT_SECRETS_LIST")
     if secret_list:
-        secrets_keys = secret_list.split(",")
-        secrets = {key: os.environ.get(key) for key in secrets_keys}
-        ctx._secrets_manager.add_source("inline", secrets)
+        ctx._secrets_manager.add_source("env", secret_list)
 
     args = get_func_arg(fhandler, RunTemplate.from_dict(ctx.to_dict()), ctx)
     try:

--- a/mlrun/runtimes/nuclio.py
+++ b/mlrun/runtimes/nuclio.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import inspect
 import json
+import os
 import socket
 
 from ..db import get_or_set_dburl
@@ -73,6 +74,13 @@ def nuclio_jobs_handler(context, event):
         log_stream=context.logger,
         host=socket.gethostname(),
     )
+
+    # Inject project secrets from env. variables to the context
+    secret_list = os.environ.get("MLRUN_PROJECT_SECRETS_LIST")
+    if secret_list:
+        secrets_keys = secret_list.split(",")
+        secrets = {key: os.environ.get(key) for key in secrets_keys}
+        context._secrets_manager.add_source("inline", secrets)
 
     args = get_func_arg(fhandler, RunTemplate.from_dict(ctx.to_dict()), ctx)
     try:

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -517,6 +517,11 @@ class KubeResource(BaseRuntime):
             if key in existing_secret_keys:
                 self.set_env_from_secret(env_var_name, secret_name, key)
 
+        # Keep a list of the variables that relate to secrets, so that the MLRun context (when using nuclio:mlrun)
+        # can be initialized with those env variables as secrets
+        if not encode_key_names:
+            self.set_env("MLRUN_PROJECT_SECRETS_LIST", ",".join(secrets.keys()))
+
     def _add_vault_params_to_spec(self, runobj=None, project=None):
         project_name = project or runobj.metadata.project
         if project_name is None:

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -389,7 +389,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         # This test runs in serving, nuclio:mlrun as well, with different secret names encoding
         expected_secrets = k8s_secrets_mock.get_expected_env_variables_from_secrets(
-            self.project, encode_key_names=(self.runtime_kind != "nuclio")
+            self.project, encode_key_names=(self.class_name != "remote")
         )
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_env_from_secrets=expected_secrets


### PR DESCRIPTION
The change introduced at PR #1499 was based on using the `spec.function_kind` to distinguish between `nuclio` and `nuclio:mlrun` functions. However, this turned out to be wrong, as the `function_kind` is set to `mlrun` when calling `new_function` on nuclio functions, which is always done when deploying a nuclio function.

This fix uses a different approach:
* Project secrets in nuclio runtimes are always attached to the pod as env variables without any specific prefix (using just the secret key name)
* Another env variable is used to store the list of secrets that were attached (since there's no other way to distinguish between "regular" env variables and those originating from secrets)
* When initializing the MLRun context object for `nuclio:mlrun` functions, the secrets from the list are injected into the context's secret store, where they can then be retrieved using the `context.get_secret()` API

This fixes the issue: https://jira.iguazeng.com/browse/ML-1472