### PR TITLE
[Utils] Fix tag enrichment

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -565,7 +565,7 @@ def enrich_image_url(image_url: str) -> str:
     image_url = image_url.strip()
     tag = config.images_tag or mlrun.utils.version.Version().get()["version"].replace(
         "+", "-"
-    )
+    ).replace("0.0.0-", "")
     registry = config.images_registry
 
     # it's an mlrun image if the repository is mlrun

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -223,9 +223,15 @@ def test_enrich_image():
         },
         {
             "image": "mlrun/mlrun",
-            "expected_output": "ghcr.io/mlrun/mlrun:0.0.0-unstable",
+            "expected_output": "ghcr.io/mlrun/mlrun:unstable",
             "images_tag": None,
             "version": "0.0.0+unstable",
+        },
+        {
+            "image": "mlrun/mlrun",
+            "expected_output": "ghcr.io/mlrun/mlrun:0.1.2-some-special-tag",
+            "images_tag": None,
+            "version": "0.1.2+some-special-tag",
         },
     ]
     default_images_to_enrich_registry = config.images_to_enrich_registry


### PR DESCRIPTION
When the MLRun version is being set to some free text and we're building an image (e.g. `MLRUN_VERSION=abcd make api`) the makefile will generate the `mlrun/mlrun-api:abcd` image, but the version of the code would be `0.0.0+abcd` because pip requires us to comply to it's version regex.
Therefore when we enrich the tag, if we see `0.0.0+` in the version, we should take that off