### PR TITLE
[Feature Store] Fix inconsistency of s3 paths

### DIFF
--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -242,7 +242,7 @@ feature set to S3 in the parquet format:
 from pyspark import SparkConf
 
 target = ParquetTarget(
-    path="s3:///my-s3-bucket/some/path",
+    path="s3://my-s3-bucket/some/path",
     partitioned=False,
 )
 

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -3,4 +3,6 @@ def store_path_to_spark(path):
         path = "v3io:" + path[len("v3io:/") :]
     elif path.startswith("s3:///"):
         path = "s3a:" + path[len("s3:/") :]
+    elif path.startswith("s3://"):
+        path = "s3a:" + path[len("s3:") :]
     return path

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -3,7 +3,7 @@ def store_path_to_spark(path):
         path = "v3io:" + path[len("v3io:/") :]
     elif path.startswith("s3://"):
         if path.startswith("s3:///"):
-            # 's3:///' not supported since mlrun 0.9.0 should use s3://
+            # 's3:///' not supported since mlrun 0.9.0 should use s3:// instead
             from mlrun.errors import MLRunInvalidArgumentError
             valid_path = path.replace('///', '//')
             raise MLRunInvalidArgumentError(

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -5,9 +5,10 @@ def store_path_to_spark(path):
         if path.startswith("s3:///"):
             # 's3:///' not supported since mlrun 0.9.0 should use s3:// instead
             from mlrun.errors import MLRunInvalidArgumentError
-            valid_path = path.replace('///', '//')
+
+            valid_path = "s3:" + path[len("s3:/") :]
             raise MLRunInvalidArgumentError(
-                f"'s3:///' is not supported, try using 's3://' instead.\nUse '{valid_path}'"
+                f"'s3:///' is not supported, try using 's3://' instead.\nE.g: '{valid_path}'"
             )
         else:
             path = "s3a:" + path[len("s3:") :]

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -2,7 +2,7 @@ def store_path_to_spark(path):
     if path.startswith("v3io:///"):
         path = "v3io:" + path[len("v3io:/") :]
     elif path.startswith("s3:///"):
-        path = "s3a:" + path[len("s3:/") :]
+        pass    # 's3:///' not supported since mlrun 0.9.0
     elif path.startswith("s3://"):
         path = "s3a:" + path[len("s3:") :]
     return path

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -1,8 +1,14 @@
 def store_path_to_spark(path):
     if path.startswith("v3io:///"):
         path = "v3io:" + path[len("v3io:/") :]
-    elif path.startswith("s3:///"):
-        pass    # 's3:///' not supported since mlrun 0.9.0
     elif path.startswith("s3://"):
-        path = "s3a:" + path[len("s3:") :]
+        if path.startswith("s3:///"):
+            # 's3:///' not supported since mlrun 0.9.0 should use s3://
+            from mlrun.errors import MLRunInvalidArgumentError
+            valid_path = path.replace('///', '//')
+            raise MLRunInvalidArgumentError(
+                f"'s3:///' is not supported, try using 's3://' instead.\nUse '{valid_path}'"
+            )
+        else:
+            path = "s3a:" + path[len("s3:") :]
     return path


### PR DESCRIPTION
Added support for ingestion with spark for 's3://'.
Fixes the issue of get_offline - [ML-1047](https://jira.iguazeng.com/browse/ML-1047)
*** Also support of s3:/// was removed.