### PR TITLE
[DB] Fix labels setting in `update_run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ endif
 	docker run \
 		--name=migration-db \
 		--rm \
-		-v $(pwd):/mlrun \
+		-v $(PWD):/mlrun \
 		-p 3306:3306 \
 		-e MYSQL_ROOT_PASSWORD="pass" \
 		-e MYSQL_ROOT_HOST=% \
@@ -563,7 +563,7 @@ run-api: api ## Run mlrun api (dockerized)
 run-test-db:
 	docker run \
 		--name=test-db \
-		-v $(pwd):/mlrun \
+		-v $(PWD):/mlrun \
 		-p 3306:3306 \
 		-e MYSQL_ROOT_PASSWORD="" \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD="true" \

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -133,10 +133,7 @@ class SQLDB(DBInterface):
         start_time = run_start_time(struct)
         if start_time:
             run.start_time = start_time
-        run.labels.clear()
-        for name, value in run_labels(struct).items():
-            lbl = Run.Label(name=name, value=value, parent=run.id)
-            run.labels.append(lbl)
+        update_labels(run, run_labels(struct))
         session.merge(run)
         session.commit()
         self._delete_empty_labels(session, Run.Label)

--- a/tests/integration/sdk_api/run/test_run.py
+++ b/tests/integration/sdk_api/run/test_run.py
@@ -11,3 +11,18 @@ class TestRun(tests.integration.sdk_api.base.TestMLRunIntegration):
         )
         assert len(runs) == 1
         assert runs[0]["metadata"]["project"] == mlrun.mlconf.default_project
+
+    def test_ctx_state_change(self):
+        ctx_name = "some-context"
+        ctx = mlrun.get_or_create_ctx(ctx_name)
+        runs = mlrun.get_run_db().list_runs(
+            name=ctx_name, project=mlrun.mlconf.default_project
+        )
+        assert len(runs) == 1
+        assert runs[0]["status"]["state"] == mlrun.runtimes.constants.RunStates.running
+        ctx.set_state(mlrun.runtimes.constants.RunStates.completed)
+        runs = mlrun.get_run_db().list_runs(
+            name=ctx_name, project=mlrun.mlconf.default_project
+        )
+        assert len(runs) == 1
+        assert runs[0]["status"]["state"] == mlrun.runtimes.constants.RunStates.completed

--- a/tests/integration/sdk_api/run/test_run.py
+++ b/tests/integration/sdk_api/run/test_run.py
@@ -2,7 +2,7 @@ import mlrun
 import tests.integration.sdk_api.base
 
 
-class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
+class TestRun(tests.integration.sdk_api.base.TestMLRunIntegration):
     def test_ctx_creation_creates_run_with_project(self):
         ctx_name = "some-context"
         mlrun.get_or_create_ctx(ctx_name)

--- a/tests/integration/sdk_api/run/test_run.py
+++ b/tests/integration/sdk_api/run/test_run.py
@@ -25,4 +25,6 @@ class TestRun(tests.integration.sdk_api.base.TestMLRunIntegration):
             name=ctx_name, project=mlrun.mlconf.default_project
         )
         assert len(runs) == 1
-        assert runs[0]["status"]["state"] == mlrun.runtimes.constants.RunStates.completed
+        assert (
+            runs[0]["status"]["state"] == mlrun.runtimes.constants.RunStates.completed
+        )


### PR DESCRIPTION
We started getting this when calling the function:
```
sqlalchemy.exc.IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(pymysql.err.IntegrityError) (1062, "Duplicate entry 'v3io_user-115' for key '_runs_labels_uc'")
[SQL: INSERT INTO runs_labels (name, value, parent) VALUES (%(name)s, %(value)s, %(parent)s)]
```
It's happening because we were creating new label objects instead of using the existing ones
Fixes: https://jira.iguazeng.com/browse/ML-1492