### PR TITLE
[Requirements] Limit storey to <0.8.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,8 @@ fsspec~=2021.8.1
 v3iofs~=0.1.7
 # 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
 cryptography~=3.0, <3.4
-storey~=0.8.11; python_version >= '3.7'
+# In 0.8.12 the requirements loosen too much so pip resolver never finds a resolution
+storey~=0.8.11, <0.8.12; python_version >= '3.7'
 deepdiff~=5.0
 pymysql~=1.0
 inflection~=0.5.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -83,6 +83,7 @@ def test_requirement_specifiers_convention():
         "aiobotocore": {"~=1.4.0"},
         "aiohttp": {">=3.6,<3.8"},
         "bokeh": {"~=2.3.0"},
+        "storey": {"~=0.8.11, <0.8.12; python_version >= '3.7'"},
         # Black is not stable yet and does not have a release that is not beta, so can't be used with ~=
         "black": {"<=19.10b0"},
         # These 2 are used in a tests that is purposed to test requirement without specifiers


### PR DESCRIPTION
From the moment storey 0.8.12 published our `CI / Run package tests` step started failing
The failure can be reproduced very easily by `pip install .` of mlrun (note to have the right pip installed - `python -m pip install --upgrade pip~=21.2.0`)
What happens is that pip resolver just tries finding a resolution forever, therefore I assume this is the root cause https://github.com/mlrun/storey/pull/314 - probably requirements are now too loose
