### PR TITLE
[Secrets] Verify project secrets do not exist when deleting a project

### DIFF
--- a/mlrun/api/crud/model_endpoints.py
+++ b/mlrun/api/crud/model_endpoints.py
@@ -522,6 +522,16 @@ class ModelEndpoints:
             metrics_mapping[metric] = Metric(name=metric, values=values)
         return metrics_mapping
 
+    def verify_project_has_no_model_endpoints(self, project_name: str):
+        auth_info = mlrun.api.schemas.AuthInfo(
+            data_session=os.getenv("V3IO_ACCESS_KEY")
+        )
+        endpoints = self.list_endpoints(auth_info, project_name)
+        if endpoints.endpoints:
+            raise mlrun.errors.MLRunPreconditionFailedError(
+                f"Project {project_name} can not be deleted since related resources found: model endpoints"
+            )
+
     def delete_model_endpoints_resources(self, project_name: str):
         auth_info = mlrun.api.schemas.AuthInfo(
             data_session=os.getenv("V3IO_ACCESS_KEY")

--- a/mlrun/api/crud/model_endpoints.py
+++ b/mlrun/api/crud/model_endpoints.py
@@ -526,6 +526,10 @@ class ModelEndpoints:
         auth_info = mlrun.api.schemas.AuthInfo(
             data_session=os.getenv("V3IO_ACCESS_KEY")
         )
+
+        if not config.igz_version or not config.v3io_api:
+            return
+
         endpoints = self.list_endpoints(auth_info, project_name)
         if endpoints.endpoints:
             raise mlrun.errors.MLRunPreconditionFailedError(

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -102,6 +102,10 @@ class Projects(
         # secrets and model endpoints.
         mlrun.api.crud.ModelEndpoints().verify_project_has_no_model_endpoints(project)
 
+        # Note: this check lists also internal secrets. The assumption is that any internal secret that relate to
+        # an MLRun resource (such as model-endpoints) was already verified in previous checks. Therefore, any internal
+        # secret existing here is something that the user needs to be notified about, as MLRun didn't generate it.
+        # Therefore, this check should remain at the end of the verification flow.
         if mlrun.api.utils.singletons.k8s.get_k8s().get_project_secret_keys(project):
             raise mlrun.errors.MLRunPreconditionFailedError(
                 f"Project {project} can not be deleted since related resources found: project secrets"

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -360,6 +360,45 @@ def test_delete_project_deletion_strategy_check(
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
 
 
+def test_delete_project_deletion_strategy_check_external_resource(
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+) -> None:
+    project = mlrun.api.schemas.Project(
+        metadata=mlrun.api.schemas.ProjectMetadata(name="project-name"),
+        spec=mlrun.api.schemas.ProjectSpec(),
+    )
+
+    # create
+    response = client.post("/api/projects", json=project.dict())
+    assert response.status_code == HTTPStatus.CREATED.value
+    _assert_project_response(project, response)
+
+    # Set a project secret
+    k8s_secrets_mock.store_project_secrets("project-name", {"secret": "value"})
+
+    # deletion strategy - check - should fail because there's a project secret
+    response = client.delete(
+        f"/api/projects/{project.metadata.name}",
+        headers={
+            mlrun.api.schemas.HeaderNames.deletion_strategy: mlrun.api.schemas.DeletionStrategy.restricted
+        },
+    )
+    assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
+    assert "project secrets" in response.text
+
+    k8s_secrets_mock.delete_project_secrets("project-name", None)
+    response = client.delete(
+        f"/api/projects/{project.metadata.name}",
+        headers={
+            mlrun.api.schemas.HeaderNames.deletion_strategy: mlrun.api.schemas.DeletionStrategy.restricted
+        },
+    )
+    assert response
+
+
 # leader format is only relevant to follower mode
 @pytest.mark.parametrize("project_member_mode", ["follower"], indirect=True)
 def test_list_projects_leader_format(

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -316,7 +316,10 @@ def test_list_and_get_project_summaries(
 
 
 def test_delete_project_deletion_strategy_check(
-    db: Session, client: TestClient, project_member_mode: str
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ) -> None:
     project = mlrun.api.schemas.Project(
         metadata=mlrun.api.schemas.ProjectMetadata(name="project-name"),

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -14,6 +14,7 @@ import mlrun.api.utils.singletons.db
 import mlrun.api.utils.singletons.project_member
 import mlrun.config
 import mlrun.errors
+import tests.api.conftest
 from mlrun.utils import logger
 
 
@@ -137,6 +138,7 @@ def test_delete_project(
     db: sqlalchemy.orm.Session,
     projects_follower: mlrun.api.utils.projects.follower.Member,
     nop_leader: mlrun.api.utils.projects.remotes.leader.Member,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ):
     project = _generate_project()
     projects_follower.create_project(


### PR DESCRIPTION
When deleting a project with `restricted` mode, existence of project secrets did not fail the deletion as expected. Adding this verification.
The same issue existed for model-endpoints, added verification for that as well.

Fixes https://jira.iguazeng.com/browse/ML-1503