### PR TITLE
[Docs] Fix feature store transformation doc

### DIFF
--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -231,7 +231,7 @@ spark_service_name = "iguazio-spark-service" # As configured & shown in the Igua
 feature_set.graph.to(name="s1", handler="my_spark_func")
 my_func = code_to_function("func", kind="remote-spark")
 config = fstore.RunConfig(local=False, function=my_func, handler="ingest_handler")
-fstore.ingest(feature_set, source, run_config=fstore.RunConfig(), spark_context=spark_service_name)
+fstore.ingest(feature_set, source, run_config=config, spark_context=spark_service_name)
 ```
 
 ### Spark execution engine and S3


### PR DESCRIPTION
From slack chat on #feature_store

rotem naimark:headphones:  1:24 PM
feature store documentation code has an issue in https://docs.mlrun.org/en/latest/feature-store/transformations.html#using-spark-execution-engine
fstore run config is set and right afterwards is created new empty one
config = fstore.RunConfig(local=False, function=my_func, handler="ingest_handler")
fstore.ingest(feature_set, source, run_config=fstore.RunConfig(), spark_context=spark_service_name)
docs.mlrun.orgdocs.mlrun.org
Feature set transformations
Feature set transformations A feature set contains an execution graph of operations that are performed when data is ingested, or when simulating data flow for

adih  2:23 PM
@Jason Novich can you fix it?
it should be run_config=config