### PR TITLE
[DB] Make connection pool size and max overflow configurable and raise numbers

### DIFF
--- a/mlrun/api/db/sqldb/session.py
+++ b/mlrun/api/db/sqldb/session.py
@@ -35,11 +35,13 @@ def _get_session_maker() -> SessionMaker:
 def _init_engine(dsn=None):
     global engine
     dsn = dsn or config.httpdb.dsn
-    engine = create_engine(
-        dsn,
-        pool_size=config.httpdb.db.connections_pool_size,
-        max_overflow=config.httpdb.db.connections_pool_max_overflow,
-    )
+    kwargs = {}
+    if "mysql" in dsn:
+        kwargs = {
+            "pool_size": config.httpdb.db.connections_pool_size,
+            "max_overflow": config.httpdb.db.connections_pool_max_overflow,
+        }
+    engine = create_engine(dsn, **kwargs)
     _init_session_maker()
 
 

--- a/mlrun/api/db/sqldb/session.py
+++ b/mlrun/api/db/sqldb/session.py
@@ -35,7 +35,11 @@ def _get_session_maker() -> SessionMaker:
 def _init_engine(dsn=None):
     global engine
     dsn = dsn or config.httpdb.dsn
-    engine = create_engine(dsn)
+    engine = create_engine(
+        dsn,
+        pool_size=config.httpdb.db.connections_pool_size,
+        max_overflow=config.httpdb.db.connections_pool_max_overflow,
+    )
     _init_session_maker()
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -143,6 +143,8 @@ default_config = {
             "database_migration_mode": "enabled",
             # Whether or not to use db backups on initialization
             "database_backup_mode": "enabled",
+            "connections_pool_size": 20,
+            "connections_pool_max_overflow": 50,
         },
         "jobs": {
             # whether to allow to run local runtimes in the API - configurable to allow the scheduler testing to work


### PR DESCRIPTION
We've hit 
```
> 2021-12-07 22:15:43,608 [error] Traceback (most recent call last):
  File "/mlrun/mlrun/api/api/endpoints/functions.py", line 425, in _build_function
    fn.save(versioned=False)
  File "/mlrun/mlrun/runtimes/base.py", line 932, in save
    obj, self.metadata.name, self.metadata.project, tag, versioned
  File "/mlrun/mlrun/db/sqldb.py", line 221, in store_function
    versioned,
  File "/mlrun/mlrun/db/sqldb.py", line 308, in _transform_db_error
    return func(*args, **kwargs)
  File "/mlrun/mlrun/api/crud/functions.py", line 26, in store_function
    db_session, function, name, project, tag, versioned,
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 461, in store_function
    fn = self._get_class_instance_by_uid(session, Function, name, project, uid)
  File "/mlrun/mlrun/api/db/sqldb/db.py", line 2025, in _get_class_instance_by_uid
    return query.one_or_none()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 2836, in one_or_none
    return self._iter().one_or_none()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 2897, in _iter
    execution_options={"_sa_orm_load_options": self.load_options},
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 1688, in execute
    conn = self._connection_for_bind(bind)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 1530, in _connection_for_bind
    engine, execution_options
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 747, in _connection_for_bind
    conn = bind.connect()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 3197, in connect
    return self._connection_cls(self, close_with_result=close_with_result)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 96, in __init__
    else engine.raw_connection()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 3276, in raw_connection
    return self._wrap_pool_connect(self.pool.connect, _connection)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 3243, in _wrap_pool_connect
    return fn()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 310, in connect
    return _ConnectionFairy._checkout(self)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 868, in _checkout
    fairy = _ConnectionRecord.checkout(pool)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 476, in checkout
    rec = pool._do_get()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/impl.py", line 138, in _do_get
    code="3o7r",
sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/14/3o7r)
```
15 max connections is definitely not enough for us, raised it to 20 (size) and 50 (overflow) and more importantly made it configurable
Fixes: https://jira.iguazeng.com/browse/ML-1517