### PR TITLE
[Integration Tests] Fix httpdb exception handling regex

### DIFF
--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -121,7 +121,9 @@ class TestMLRunIntegration:
         output = self._run_command("docker", args=["ps", "--last", "1", "-q"],)
         self.api_container_id = output.strip()
         # retrieve container bind port + host
-        output = self._run_command("docker", args=["port", self.api_container_id, "8080"])
+        output = self._run_command(
+            "docker", args=["port", self.api_container_id, "8080"]
+        )
         # usually the output is something like '0.0.0.0:49154\n' but sometimes (in GH actions) it's something like
         # '0.0.0.0:49154\n:::49154\n' for some reason, so just taking the first line
         host = output.splitlines()[0]

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -33,8 +33,8 @@ class TestMLRunIntegration:
         self._logger.info(
             f"Setting up test {self.__class__.__name__}::{method.__name__}"
         )
-        self.db_container_id = self._run_db()
-        self.api_container_id, api_url = self._run_api()
+        self._run_db()
+        api_url = self._run_api()
         self._test_env = {}
         self._old_env = {}
         self._setup_env({"MLRUN_DBPATH": api_url})
@@ -102,13 +102,11 @@ class TestMLRunIntegration:
             "make", args=["run-test-db"], cwd=TestMLRunIntegration.root_path,
         )
         output = self._run_command("docker", args=["ps", "--last", "1", "-q"],)
-        container_id = output.strip()
+        self.db_container_id = output.strip()
 
-        self._logger.debug("Started DataBase", container_id=container_id)
+        self._logger.debug("Started DataBase", container_id=self.db_container_id)
 
         self._ensure_database_liveness(timeout=self.db_liveness_timeout)
-
-        return container_id
 
     def _run_api(self):
         self._logger.debug("Starting API")
@@ -121,18 +119,18 @@ class TestMLRunIntegration:
             cwd=TestMLRunIntegration.root_path,
         )
         output = self._run_command("docker", args=["ps", "--last", "1", "-q"],)
-        container_id = output.strip()
+        self.api_container_id = output.strip()
         # retrieve container bind port + host
-        output = self._run_command("docker", args=["port", container_id, "8080"])
+        output = self._run_command("docker", args=["port", self.api_container_id, "8080"])
         # usually the output is something like '0.0.0.0:49154\n' but sometimes (in GH actions) it's something like
         # '0.0.0.0:49154\n:::49154\n' for some reason, so just taking the first line
         host = output.splitlines()[0]
         url = f"http://{host}"
         self._check_api_is_healthy(url)
         self._logger.info(
-            "Successfully started API", url=url, container_id=container_id
+            "Successfully started API", url=url, container_id=self.api_container_id
         )
-        return container_id, url
+        return url
 
     def _remove_api(self):
         if self.api_container_id:

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -63,7 +63,8 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         with pytest.raises(
             mlrun.errors.MLRunInternalServerError,
             match=r"500 Server Error: Internal Server Error for url: http:\/\/(.*)\/api\/projects\/some-project\/model-"
-            r"endpoints\?start=now-1h&end=now&top-level=False: details: {'reason': \"gaierror\((.*)\)\"}",
+                  r"endpoints\?start=now-1h&end=now&top-level=False: details: {\'reason\': \"ValueError\(\'Access key m"
+                  r"ust be provided in Client\(\) arguments or in the V3IO_ACCESS_KEY environment variable\'\)\"}",
         ):
             mlrun.get_run_db().list_model_endpoints(
                 "some-project", access_key="some-access-key"

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -63,8 +63,8 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         with pytest.raises(
             mlrun.errors.MLRunInternalServerError,
             match=r"500 Server Error: Internal Server Error for url: http:\/\/(.*)\/api\/projects\/some-project\/model-"
-                  r"endpoints\?start=now-1h&end=now&top-level=False: details: {\'reason\': \"ValueError\(\'Access key m"
-                  r"ust be provided in Client\(\) arguments or in the V3IO_ACCESS_KEY environment variable\'\)\"}",
+            r"endpoints\?start=now-1h&end=now&top-level=False: details: {\'reason\': \"ValueError\(\'Access key must be"
+            r" provided in Client\(\) arguments or in the V3IO_ACCESS_KEY environment variable\'\)\"}",
         ):
             mlrun.get_run_db().list_model_endpoints(
                 "some-project", access_key="some-access-key"


### PR DESCRIPTION
Also fix the integration tests base class to remove the containers it creates also when tests fail