### PR TITLE
[Automation] Fix the pypi release waiter script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,12 +42,10 @@ jobs:
         run: sudo apt-get install curl jq
       - name: Run script file
         timeout-minutes: 240
-        # sleep 60 at the end to give pypi cache chance to refresh
         run: |
           export tag=$(echo ${GITHUB_REF#refs/tags/})
           chmod +x ./automation/scripts/pypi_release_waiter.sh
           ./automation/scripts/pypi_release_waiter.sh $tag
-          sleep 60
         shell: bash
       - uses: benc-uk/workflow-dispatch@v1
         with:

--- a/automation/scripts/pypi_release_waiter.sh
+++ b/automation/scripts/pypi_release_waiter.sh
@@ -6,7 +6,7 @@ version=${version#"v"}
 echo "Waiting for version to be released on Pypi. version:$version"
 while true ; do
   released_versions="$(curl -sf https://pypi.org/pypi/mlrun/json | jq -r '.releases | keys | join(",")')"
-  if [[ "$released_versions" == *"$version"* ]]; then
+  if [[ "$released_versions" == *,"$version",* ]]; then
     echo "Version released: $version"
     break;
   else


### PR DESCRIPTION
The `released_versions` there looks something like `0.5.0,0.5.1,0.5.1rc1,0.5.1rc2,0.5.2`... 
So conditioning it on equality with `*"$version"*` was making 0.5.1 to match with 0.5.1rc1 as well
Fixed it to `*,"$version",*`