### PR TITLE
[CI] Add step that runs backward compatibility tests on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,14 +158,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: head/mlrun
-      - name: Git merge operation
-        uses: alexrogalskiy/github-action-git-operation@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          mode: 'merge-fast-forward'
-          sourceBranch: 'development'
-          targetBranch: 'test'
+      - run : |
+          git status
+          cd head/mlrun
+          git remote add Base ../../base/mlrun
+          git pull Base ${{ steps.base_branch.outputs.branch }}
       - name : Setup python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,9 @@ jobs:
 #    if: github.event_name == 'pull'
     runs-on: ubuntu-latest
     steps:
+      - id: base_branch
+        run: |
+            echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
       - name: Checkout Base Branch
         uses: actions/checkout@v2
         with:
@@ -174,9 +177,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - id: base_branch
-        run: |
-            echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .
       - name: Run Backward Compatibility Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
           pwd
           ls -l base
           ls -l head
-          cat diff.output
           set +x
       - name: Setup tmate session
+        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
 
   api-backward-compatibilty:
     name: Run Backward Compatibility Checks
-#    if: github.event_name == 'pull'
+    if: github.event_name == 'pull'
     runs-on: ubuntu-latest
     steps:
       - id: base_branch
@@ -157,10 +157,7 @@ jobs:
         with:
           ref: ${{ steps.base_branch.outputs.branch }}
           path: base/mlrun
-      - name: Checkout Head Branch
-#        uses: actions/checkout@v2
-#        with:
-#          path: head/mlrun
+      - name: Checkout Head Branch and Stable with the target Branch
         run : |
           mkdir head && cd head
           git init

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,14 +178,3 @@ jobs:
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .
       - name: Run Backward Compatibility Check
         run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make api-backward-compatibility BASE_PATH='/home/runner/work/mlrun/mlrun/base/mlrun'
-      - name: Output some logs in case of failure
-        if: ${{ failure() }}
-        # add set -x to print commands before executing to make logs reading easier
-        run: |
-          set -x
-          ls -l
-          pwd
-          ls -l base
-          ls -l head
-          cat /home/runner/work/mlrun/mlrun/head/mlrun/d.diff 2>/dev/null
-          set +x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,10 +157,13 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - id: base_branch
+        run: |
+            echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
       - name: Checkout Head Branch
         uses: actions/checkout@v2
         with:
-          ref: ${GITHUB_BASE_REF}
+          ref: base_branch
           path: base/mlrun
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MLRUN_BC_TESTS_BASE_CODE_PATH: /home/runner/work/mlrun/mlrun/base/mlrun
-      MLRUN_DOCKER_REGISTRY: ghcr.io
+      MLRUN_DOCKER_REGISTRY: ghcr.io/
     steps:
       - id: resolve_base_branch
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,6 +163,5 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: head/mlrun
-      - name : Setup python
       - name: Run Backward Compatibility Tests
         run: cd head/mlrun && make test-backward-compatibility-dockerized

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,9 +159,8 @@ jobs:
         with:
           path: head/mlrun
       - run : |
-          git init
-          git config user.name github-actions
-          git config user.email github-actions@mlrun
+          git config user.name github-actions --global
+          git config user.email github-actions@mlrun --global
           git init base
           cd head
           git remote add Base ../../base

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
           git config  --global user.email github-actions@mlrun
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           git config github.token ${{ secrets.GITHUB_TOKEN }}
-          git add remote origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           git pull origin development
       - name : Setup python
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,8 @@ jobs:
     name: Run Backward Compatibility Tests
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      MLRUN_BC_TESTS_BASE_CODE_PATH: /home/runner/work/mlrun/mlrun/base/mlrun
     steps:
       - id: resolve_base_branch
         run: |
@@ -162,10 +164,5 @@ jobs:
         with:
           path: head/mlrun
       - name : Setup python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-      - name: Install automation scripts dependencies and add mlrun to dev packages
-        run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .
       - name: Run Backward Compatibility Tests
-        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make test-backward-compatibility MLRUN_BC_TESTS_BASE_CODE_PATH='/home/runner/work/mlrun/mlrun/base/mlrun'
+        run: cd head/mlrun && make test-backward-compatibility-dockerized

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          mode: merge-fast-forward
+          mode: 'merge-fast-forward'
           sourceBranch: 'development'
           targetBranch: 'test'
       - name : Setup python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,7 +152,17 @@ jobs:
       - name: Checkout Base Branch
         uses: actions/checkout@v2
         with:
+          ref: ${{ steps.base_branch.outputs.branch }}
+          path: base/mlrun
+      - name: Checkout Head Branch
+        uses: actions/checkout@v2
+        with:
           path: head/mlrun
+      - name : Merge Base Branch into Head Branch
+        run : |
+          cd head/mlrun
+          git remote add Base ../../base/mlrun
+          git pull Base ${{ steps.base_branch.outputs.branch }}
       - name : Setup python
         uses: actions/setup-python@v1
         with:
@@ -160,15 +170,10 @@ jobs:
       - id: base_branch
         run: |
             echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
-      - name: Checkout Head Branch
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.base_branch.outputs.branch }}
-          path: base/mlrun
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .
       - name: Run Backward Compatibility Check
-        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make api-backward-compatibility BASE_PATH='/home/runner/work/mlrun/mlrun/base' HEAD_PATH='/home/runner/work/mlrun/mlrun/head'
+        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make api-backward-compatibility BASE_PATH='/home/runner/work/mlrun/mlrun/base/mlrun'
       - name: Output some logs in case of failure
         if: ${{ failure() }}
         # add set -x to print commands before executing to make logs reading easier
@@ -178,6 +183,7 @@ jobs:
           pwd
           ls -l base
           ls -l head
+          cat /home/runner/work/mlrun/mlrun/head/mlrun/d.diff 2>/dev/null
           set +x
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,10 +161,11 @@ jobs:
       - run : |
           cd head
           git init
-          git config user.name github-actions --global
-          git config user.email github-actions@mlrun --global
+          git config  --global user.name github-actions
+          git config  --global user.email github-actions@mlrun
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           git config github.token ${{ secrets.GITHUB_TOKEN }}
+          git add remote origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           git pull origin development
       - name : Setup python
         uses: actions/setup-python@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Checkout Head Branch
         uses: actions/checkout@v2
         with:
-          ref: base_branch
+          ref: ${{ steps.base_branch.outputs.branch }}
           path: base/mlrun
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,13 +161,9 @@ jobs:
       - run : |
           git config user.name github-actions --global
           git config user.email github-actions@mlrun --global
-          git init base
-          cd head
-          git remote add Base ../../base
-          git commit --allow-empty -m ''
-          git pull Base ${{ steps.base_branch.outputs.branch }} master --allow-unrelated-histories
+          git config github.token ${{ secrets.GITHUB_TOKEN }}
+          git pull origin development
       - name : Setup python
-
         uses: actions/setup-python@v1
         with:
           python-version: 3.8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MLRUN_BC_TESTS_BASE_CODE_PATH: /home/runner/work/mlrun/mlrun/base/mlrun
+      MLRUN_DOCKER_REGISTRY: ghcr.io
     steps:
       - id: resolve_base_branch
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,7 +164,7 @@ jobs:
           git config  --global user.name github-actions
           git config  --global user.email github-actions@mlrun
           git config github.token ${{ secrets.GITHUB_TOKEN }}
-          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
           git checkout $GITHUB_HEAD_REF
           git pull origin $GITHUB_BASE_REF
       - name : Setup python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,7 @@ jobs:
         with:
           path: head/mlrun
       - run : |
+          git init
           git config user.name github-actions
           git config user.email github-actions@mlrun
           git init base

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,7 @@ jobs:
 #          path: head/mlrun
         run : |
           mkdir head && cd head
+          git init
           git config  --global user.name github-actions
           git config  --global user.email github-actions@mlrun
           git config github.token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,11 +158,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: head/mlrun
-      - name : Merge Base Branch into Head Branch
-        run : |
-          cd head/mlrun
-          git remote add Base ../../base/mlrun
-          git pull Base ${{ steps.base_branch.outputs.branch }}
+      - name: Git merge operation
+        uses: alexrogalskiy/github-action-git-operation@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: merge-fast-forward
+          sourceBranch: 'development'
+          targetBranch: 'test'
       - name : Setup python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,7 @@ jobs:
           git config  --global user.email github-actions@mlrun
           git config github.token ${{ secrets.GITHUB_TOKEN }}
           git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
+          git remote add upstream $GITHUB_SERVER_URL/GITHUB_REPOSITORY
           cd mlrun
           git checkout $GITHUB_HEAD_REF
           git pull upstream $GITHUB_BASE_REF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,4 +173,4 @@ jobs:
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
           echo "::set-output name=tag::$(echo $unstable_tag)"
       - name: Run Backward Compatibility Tests
-        run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} cd head/mlrun && make test-backward-compatibility-dockerized
+        run: MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} cd head/mlrun && make test-backward-compatibility-dockerized

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,5 +193,4 @@ jobs:
           cat /home/runner/work/mlrun/mlrun/head/mlrun/d.diff 2>/dev/null
           set +x
       - name: Setup tmate session
-        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,18 +155,17 @@ jobs:
           ref: ${{ steps.base_branch.outputs.branch }}
           path: base/mlrun
       - name: Checkout Head Branch
-        uses: actions/checkout@v2
-        with:
-          path: head/mlrun
-      - run : |
-          cd head
-          git init
+#        uses: actions/checkout@v2
+#        with:
+#          path: head/mlrun
+        run : |
+          mkdir head && cd head
           git config  --global user.name github-actions
           git config  --global user.email github-actions@mlrun
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           git config github.token ${{ secrets.GITHUB_TOKEN }}
-          git remote add origin $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
-          git pull origin development
+          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+          git checkout $GITHUB_HEAD_REF
+          git pull origin $GITHUB_BASE_REF
       - name : Setup python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,14 +161,15 @@ jobs:
         run : |
           mkdir head && cd head
           git init
-          git config  --global user.name github-actions
-          git config  --global user.email github-actions@mlrun
-          git config github.token ${{ secrets.GITHUB_TOKEN }}
+          git config --global user.name github-actions
+          git config --global user.email github-actions@mlrun
+          git config --global github.token ${{ secrets.GITHUB_TOKEN }}
+          git config --global pull.rebase false
           git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
           cd mlrun
           git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           git checkout $GITHUB_HEAD_REF
-          git pull upstream $GITHUB_BASE_REF
+          git pull upstream $GITHUB_BASE_REF --commit
       - name : Setup python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,5 +189,3 @@ jobs:
           ls -l head
           cat /home/runner/work/mlrun/mlrun/head/mlrun/d.diff 2>/dev/null
           set +x
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,13 +159,15 @@ jobs:
         with:
           path: head/mlrun
       - run : |
-          git init head
+          git config user.name github-actions
+          git config user.email github-actions@mlrun
           git init base
           cd head
           git remote add Base ../../base
           git commit --allow-empty -m ''
           git pull Base ${{ steps.base_branch.outputs.branch }} master --allow-unrelated-histories
       - name : Setup python
+
         uses: actions/setup-python@v1
         with:
           python-version: 3.8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
           git config  --global user.email github-actions@mlrun
           git config github.token ${{ secrets.GITHUB_TOKEN }}
           git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
-          git remote add upstream $GITHUB_SERVER_URL/GITHUB_REPOSITORY
+          git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           cd mlrun
           git checkout $GITHUB_HEAD_REF
           git pull upstream $GITHUB_BASE_REF

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,7 +165,7 @@ jobs:
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .
       - name: Run Backward Compatibility Check
-        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make api-backward-compatibility BASE_PATH='/home/runner/work/mlrun/mlrun/base/mlrun' HEAD_PATH='/home/runner/work/mlrun/mlrun/head/mlrun'
+        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make api-backward-compatibility BASE_PATH='/home/runner/work/mlrun/mlrun/base' HEAD_PATH='/home/runner/work/mlrun/mlrun/head'
       - name: Output some logs in case of failure
         if: ${{ failure() }}
         # add set -x to print commands before executing to make logs reading easier

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,8 +165,8 @@ jobs:
           git config  --global user.email github-actions@mlrun
           git config github.token ${{ secrets.GITHUB_TOKEN }}
           git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
-          git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           cd mlrun
+          git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
           git checkout $GITHUB_HEAD_REF
           git pull upstream $GITHUB_BASE_REF
       - name : Setup python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,11 +164,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: head/mlrun
-    - name: Resolve docker cache tag
-      id: docker_cache
-      run: |
-        export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
-        export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-        echo "::set-output name=tag::$(echo $unstable_tag)"
-    - name: Run Backward Compatibility Tests
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} cd head/mlrun && make test-backward-compatibility-dockerized
+      - name: Resolve docker cache tag
+        id: docker_cache
+        run: |
+          export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
+          export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
+          echo "::set-output name=tag::$(echo $unstable_tag)"
+      - name: Run Backward Compatibility Tests
+        run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} cd head/mlrun && make test-backward-compatibility-dockerized

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,8 +159,11 @@ jobs:
         with:
           path: head/mlrun
       - run : |
+          cd head
+          git init
           git config user.name github-actions --global
           git config user.email github-actions@mlrun --global
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           git config github.token ${{ secrets.GITHUB_TOKEN }}
           git pull origin development
       - name : Setup python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
+      MLRUN_BC_TESTS_HOME_PATH: /home/runner/work/mlrun/mlrun
       MLRUN_BC_TESTS_BASE_CODE_PATH: /home/runner/work/mlrun/mlrun/base/mlrun
+      MLRUN_BC_TESTS_HEAD_CODE_PATH: /home/runner/work/mlrun/mlrun/head/mlrun
       MLRUN_DOCKER_REGISTRY: ghcr.io/
     steps:
       - id: resolve_base_branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,8 +165,9 @@ jobs:
           git config  --global user.email github-actions@mlrun
           git config github.token ${{ secrets.GITHUB_TOKEN }}
           git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
+          cd mlrun
           git checkout $GITHUB_HEAD_REF
-          git pull origin $GITHUB_BASE_REF
+          git pull upstream $GITHUB_BASE_REF
       - name : Setup python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Checkout Head Branch
         uses: actions/checkout@v2
         with:
-          ref: development
+          ref: ${GITHUB_BASE_REF}
           path: base/mlrun
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,37 +144,27 @@ jobs:
           path: docs/_build/html
 
 
-  api-backward-compatibilty:
-    name: Run Backward Compatibility Checks
+  backward-compatibilty-tests:
+    name: Run Backward Compatibility Tests
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - id: base_branch
+      - id: resolve_base_branch
         run: |
             echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
-      - name: Checkout Base Branch
+      - name: Checkout PR Base (target) Branch
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.base_branch.outputs.branch }}
+          ref: ${{ steps.resolve_base_branch.outputs.branch }}
           path: base/mlrun
-      - name: Checkout Head Branch and Stable with the target Branch
-        run : |
-          mkdir head && cd head
-          git init
-          git config --global user.name github-actions
-          git config --global user.email github-actions@mlrun
-          git config --global github.token ${{ secrets.GITHUB_TOKEN }}
-          git config --global pull.rebase false
-          git clone $GITHUB_SERVER_URL/$GITHUB_ACTOR/mlrun.git
-          cd mlrun
-          git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
-          git checkout $GITHUB_HEAD_REF
-          git pull upstream $GITHUB_BASE_REF --commit
+      - name: Checkout Merge Commit (requested branch merged with the target branch)
+        with:
+          path: head/mlrun
       - name : Setup python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.7
       - name: Install automation scripts dependencies and add mlrun to dev packages
         run: cd head/mlrun && pip install -r requirements.txt -r dev-requirements.txt -r dockerfiles/mlrun-api/requirements.txt && pip install -e .
-      - name: Run Backward Compatibility Check
-        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make api-backward-compatibility BASE_PATH='/home/runner/work/mlrun/mlrun/base/mlrun'
+      - name: Run Backward Compatibility Tests
+        run: MLRUN_PYTHON_VERSION=3.8 cd head/mlrun && make test-backward-compatibility MLRUN_BC_TESTS_BASE_CODE_PATH='/home/runner/work/mlrun/mlrun/base/mlrun'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,10 +159,12 @@ jobs:
         with:
           path: head/mlrun
       - run : |
-          git status
-          cd head/mlrun
-          git remote add Base ../../base/mlrun
-          git pull Base ${{ steps.base_branch.outputs.branch }}
+          git init head
+          git init base
+          cd head
+          git remote add Base ../../base
+          git commit --allow-empty -m ''
+          git pull Base ${{ steps.base_branch.outputs.branch }} master --allow-unrelated-histories
       - name : Setup python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,7 @@ jobs:
           ref: ${{ steps.resolve_base_branch.outputs.branch }}
           path: base/mlrun
       - name: Checkout Merge Commit (requested branch merged with the target branch)
+        uses: actions/checkout@v2
         with:
           path: head/mlrun
       - name : Setup python

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,5 +164,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: head/mlrun
-      - name: Run Backward Compatibility Tests
-        run: cd head/mlrun && make test-backward-compatibility-dockerized
+    - name: Resolve docker cache tag
+      id: docker_cache
+      run: |
+        export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
+        export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
+        echo "::set-output name=tag::$(echo $unstable_tag)"
+    - name: Run Backward Compatibility Tests
+      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} cd head/mlrun && make test-backward-compatibility-dockerized

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
 
   api-backward-compatibilty:
     name: Run Backward Compatibility Checks
-    if: github.event_name == 'pull'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - id: base_branch

--- a/Makefile
+++ b/Makefile
@@ -640,10 +640,10 @@ test-backward-compatibility-dockerized: build-test ## Run backward compatibility
 	    --rm \
 	    --network='host' \
 	    -v /tmp:/tmp \
-	    -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \
+	    -v $(MLRUN_BC_TESTS_HOME_PATH):$(MLRUN_BC_TESTS_HOME_PATH) \
 	    -v /var/run/docker.sock:/var/run/docker.sock \
 	    --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
-	    --workdir="/home/runner/work/mlrun/mlrun/head/mlrun" \
+	    --workdir=$(MLRUN_BC_TESTS_HEAD_CODE_PATH) \
 	    $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
 
 .PHONY: test-backward-compatibility

--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,7 @@ test-backward-compatibility-dockerized: build-test ## Run backward compatibility
         -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \
         -v /var/run/docker.sock:/var/run/docker.sock \
         --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
-        --workdir="/home/runner/work/mlrun/mlrun" \
+        --workdir="/home/runner/work/mlrun/mlrun/head/mlrun" \
          $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
 
 .PHONY: test-backward-compatibility

--- a/Makefile
+++ b/Makefile
@@ -647,7 +647,7 @@ endif
 	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head; \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output ; \
-	rmdir base && rmdir head;
+	rm -rf base && rm -rf head;
 
 .PHONY: release-notes
 release-notes: ## Create release notes

--- a/Makefile
+++ b/Makefile
@@ -633,7 +633,7 @@ endif
 	git commit -m "Adding $(MLRUN_VERSION) tag contents" --allow-empty; \
 	git push origin $$BRANCH_NAME
 
-.PHONY test-backward-compatibility-dockerized
+.PHONY: test-backward-compatibility-dockerized
 test-backward-compatibility-dockerized: ## Run backward compatibility tests in docker container
     docker run \
         -t \

--- a/Makefile
+++ b/Makefile
@@ -638,16 +638,12 @@ api-backward-compatibility: ## Check for api backward compatibility breakage
 ifndef BASE_PATH
 	$(error BASE_PATH is undefined)
 endif
-ifndef HEAD_PATH
-	$(error HEAD_PATH is undefined)
-endif
 	mkdir base && mkdir head ;\
 	export OPENAPI_JSON_TARGET_PATH=$(PWD)/base; \
-	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
+	python -m pytest -v $(BASE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json; \
 	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head; \
-	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible > diff.output ; \
-	rm -rf base && rm -rf head;
+	python -m pytest -v $(PWD)/tests/api/api/test_docs.py::test_save_openapi_json; \
+	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible > d.diff
 
 .PHONY: release-notes
 release-notes: ## Create release notes

--- a/Makefile
+++ b/Makefile
@@ -639,10 +639,10 @@ ifndef BASE_PATH
 	$(error BASE_PATH is undefined)
 endif
 	mkdir base && mkdir head ;\
-	export OPENAPI_JSON_TARGET_PATH=$(PWD)/base; \
-	python -m pytest -v $(BASE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json; \
-	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head; \
-	python -m pytest -v $(PWD)/tests/api/api/test_docs.py::test_save_openapi_json; \
+	export OPENAPI_JSON_TARGET_PATH=$(PWD)/base &&\
+	python -m pytest -v $(BASE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
+	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head && \
+	python -m pytest -v $(PWD)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible > d.diff
 
 .PHONY: release-notes

--- a/Makefile
+++ b/Makefile
@@ -636,15 +636,15 @@ endif
 .PHONY: test-backward-compatibility-dockerized
 test-backward-compatibility-dockerized: build-test ## Run backward compatibility tests in docker container
 	docker run \
-		-t \
-		--rm \
-        --network='host' \
-        -v /tmp:/tmp \
-        -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \
-        -v /var/run/docker.sock:/var/run/docker.sock \
-        --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
-        --workdir="/home/runner/work/mlrun/mlrun/head/mlrun" \
-         $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
+	    -t \
+	    --rm \
+	    --network='host' \
+	    -v /tmp:/tmp \
+	    -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \
+	    -v /var/run/docker.sock:/var/run/docker.sock \
+	    --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
+	    --workdir="/home/runner/work/mlrun/mlrun/head/mlrun" \
+	    $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
 
 .PHONY: test-backward-compatibility
 test-backward-compatibility: ## Run backward compatibility tests

--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ endif
 	git push origin $$BRANCH_NAME
 
 .PHONY test-backward-compatibility-dockerized
-test-backward-compatibility-dockerized ## Run backward compatibility tests in docker container
+test-backward-compatibility-dockerized: ## Run backward compatibility tests in docker container
     docker run \
         -t \
         -rm \

--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ endif
 	git push origin $$BRANCH_NAME
 
 .PHONY: test-backward-compatibility-dockerized
-test-backward-compatibility-dockerized: ## Run backward compatibility tests in docker container
+test-backward-compatibility-dockerized: build-test ## Run backward compatibility tests in docker container
 	docker run \
 		-t \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -633,15 +633,15 @@ endif
 	git commit -m "Adding $(MLRUN_VERSION) tag contents" --allow-empty; \
 	git push origin $$BRANCH_NAME
 
-.PHONY: api-backward-compatibility
-api-backward-compatibility: ## Check for api backward compatibility breakage
-ifndef BASE_PATH
-	$(error BASE_PATH is undefined)
+.PHONY: test-backward-compatibility
+test-backward-compatibility: ## Run backward compatibility tests
+ifndef MLRUN_BC_TESTS_BASE_CODE_PATH
+	$(error MLRUN_BC_TESTS_BASE_CODE_PATH is undefined)
 endif
 	mkdir base && mkdir head ;\
-	export OPENAPI_JSON_TARGET_PATH=$(PWD)/base &&\
+	export MLRUN_OPENAPI_JSON_TARGET_PATH=$(PWD)/base &&\
 	python -m pytest -v $(BASE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
-	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head && \
+	export MLRUN_OPENAPI_JSON_TARGET_PATH=$(PWD)/head && \
 	python -m pytest -v $(PWD)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible > d.diff
 

--- a/Makefile
+++ b/Makefile
@@ -641,11 +641,13 @@ endif
 ifndef HEAD_PATH
 	$(error HEAD_PATH is undefined)
 endif
-	export OPENAPI_JSON_TARGET_PATH=$(BASE_PATH); \
+	mkdir base && mkdir head ;\
+	export OPENAPI_JSON_TARGET_PATH=$(PWD)/base; \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	export OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH); \
+	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head; \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output
+	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output ; \
+	rmdir base && rmdir head;
 
 .PHONY: release-notes
 release-notes: ## Create release notes

--- a/Makefile
+++ b/Makefile
@@ -642,7 +642,7 @@ ifndef HEAD_PATH
 	$(error HEAD_PATH is undefined)
 endif
 	export OPENAPI_JSON_TARGET_PATH=$(BASE_PATH) \
-	python -m pytest -v $(BASE_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
+	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	export OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH) \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	docker run --rm -t -v $(pwd):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output

--- a/Makefile
+++ b/Makefile
@@ -645,7 +645,7 @@ endif
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	export OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH); \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	docker run --rm -t -v $(pwd):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output
+	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output
 
 .PHONY: release-notes
 release-notes: ## Create release notes

--- a/Makefile
+++ b/Makefile
@@ -642,9 +642,9 @@ ifndef HEAD_PATH
 	$(error HEAD_PATH is undefined)
 endif
 	OPENAPI_JSON_TARGET_PATH=$(BASE_PATH) \
-	python -m pytest -v $(BASE_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json \
+	python -m pytest -v $(BASE_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH) \
-	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json \
+	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	docker run --rm -t -v $(pwd):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output
 
 .PHONY: release-notes

--- a/Makefile
+++ b/Makefile
@@ -652,8 +652,8 @@ ifndef MLRUN_BC_TESTS_BASE_CODE_PATH
 	$(error MLRUN_BC_TESTS_BASE_CODE_PATH is undefined)
 endif
 	mkdir base && mkdir head ;\
-	export MLRUN_OPENAPI_JSON_TARGET_PATH=$(PWD)/base &&\
-	python -m pytest -v $(BASE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
+	export MLRUN_OPENAPI_JSON_TARGET_PATH=$(PWD)/base && \
+	python -m pytest -v $(MLRUN_BC_TESTS_BASE_CODE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	export MLRUN_OPENAPI_JSON_TARGET_PATH=$(PWD)/head && \
 	python -m pytest -v $(PWD)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible

--- a/Makefile
+++ b/Makefile
@@ -641,9 +641,9 @@ endif
 ifndef HEAD_PATH
 	$(error HEAD_PATH is undefined)
 endif
-	export OPENAPI_JSON_TARGET_PATH=$(BASE_PATH) \
+	export OPENAPI_JSON_TARGET_PATH=$(BASE_PATH); \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	export OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH) \
+	export OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH); \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	docker run --rm -t -v $(pwd):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output
 

--- a/Makefile
+++ b/Makefile
@@ -637,7 +637,7 @@ endif
 test-backward-compatibility-dockerized: ## Run backward compatibility tests in docker container
     docker run \
         -t \
-        -rm \
+        --rm \
         --network='host' \
         -v /tmp:/tmp \
         -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \

--- a/Makefile
+++ b/Makefile
@@ -641,6 +641,7 @@ test-backward-compatibility-dockerized: ## Run backward compatibility tests in d
         --network='host' \
         -v /tmp:/tmp \
         -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \
+        -v /var/run/docker.sock:/var/run/docker.sock \
         --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
         --workdir="/home/runner/work/mlrun/mlrun" \
          $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility

--- a/Makefile
+++ b/Makefile
@@ -635,9 +635,9 @@ endif
 
 .PHONY: test-backward-compatibility-dockerized
 test-backward-compatibility-dockerized: ## Run backward compatibility tests in docker container
-    docker run \
-        -t \
-        --rm \
+	docker run \
+		-t \
+		--rm \
         --network='host' \
         -v /tmp:/tmp \
         -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \

--- a/Makefile
+++ b/Makefile
@@ -633,6 +633,18 @@ endif
 	git commit -m "Adding $(MLRUN_VERSION) tag contents" --allow-empty; \
 	git push origin $$BRANCH_NAME
 
+.PHONY test-backward-compatibility-dockerized
+test-backward-compatibility-dockerized ## Run backward compatibility tests in docker container
+    docker run \
+        -t \
+        -rm \
+        --network='host' \
+        -v /tmp:/tmp \
+        -v /home/runner/work/mlrun/mlrun:/home/runner/work/mlrun/mlrun \
+        --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
+        --workdir="/home/runner/work/mlrun/mlrun" \
+         $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
+
 .PHONY: test-backward-compatibility
 test-backward-compatibility: ## Run backward compatibility tests
 ifndef MLRUN_BC_TESTS_BASE_CODE_PATH

--- a/Makefile
+++ b/Makefile
@@ -641,9 +641,9 @@ endif
 ifndef HEAD_PATH
 	$(error HEAD_PATH is undefined)
 endif
-	OPENAPI_JSON_TARGET_PATH=$(BASE_PATH) \
+	export OPENAPI_JSON_TARGET_PATH=$(BASE_PATH) \
 	python -m pytest -v $(BASE_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH) \
+	export OPENAPI_JSON_TARGET_PATH=$(HEAD_PATH) \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	docker run --rm -t -v $(pwd):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output
 

--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ endif
 	python -m pytest -v $(BASE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	export MLRUN_OPENAPI_JSON_TARGET_PATH=$(PWD)/head && \
 	python -m pytest -v $(PWD)/tests/api/api/test_docs.py::test_save_openapi_json && \
-	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible > d.diff
+	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible
 
 .PHONY: release-notes
 release-notes: ## Create release notes

--- a/Makefile
+++ b/Makefile
@@ -646,7 +646,7 @@ endif
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
 	export OPENAPI_JSON_TARGET_PATH=$(PWD)/head; \
 	python -m pytest -v $(HEAD_PATH)/mlrun/tests/api/api/test_docs.py::test_save_openapi_json; \
-	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json > diff.output ; \
+	docker run --rm -t -v $(PWD):/specs:ro openapitools/openapi-diff:2.0.1 /specs/base/openapi.json /specs/head/openapi.json --fail-on-incompatible > diff.output ; \
 	rm -rf base && rm -rf head;
 
 .PHONY: release-notes

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -15,8 +15,8 @@ def test_docs(
 
 def does_env_exists(env):
     if os.getenv(env):
-        return True
-    return False
+        return False
+    return True
 
 
 @pytest.mark.skipif(does_env_exists('OPENAPI_JSON_TARGET_PATH'),

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -13,15 +13,9 @@ def test_docs(
     assert response.status_code == http.HTTPStatus.OK.value
 
 
-def does_env_exists(env):
-    if os.getenv(env):
-        return True
-    return False
-
-
 @pytest.mark.skipif(
-    os.getenv("OPENAPI_JSON_TARGET_PATH") is None,
-    reason="Supposed to run only for CI backward compatibility checks",
+    os.getenv("MLRUN_OPENAPI_JSON_TARGET_PATH") is None,
+    reason="Supposed to run only for CI backward compatibility tests",
 )
 def test_save_openapi_json(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
@@ -29,5 +23,5 @@ def test_save_openapi_json(
     response = client.get("/api/openapi.json")
     with open(
         os.path.join(os.getenv("OPENAPI_JSON_TARGET_PATH"), "openapi.json"), "w"
-    ) as openapi:
-        openapi.write(response.text)
+    ) as file:
+        file.write(response.text)

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -19,7 +19,7 @@ def does_env_exists(env):
     return False
 
 
-@pytest.mark.skipif(os.getenv('OPENAPI_JSON_TARGET_PATH') is not None,
+@pytest.mark.skipif(os.getenv('OPENAPI_JSON_TARGET_PATH') is None,
                     reason="Supposed to run only for CI backward compatibility checks")
 def test_save_openapi_json(db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
                            ) -> None:

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -15,7 +15,7 @@ def test_docs(
 
 @pytest.mark.skipif(
     os.getenv("MLRUN_OPENAPI_JSON_TARGET_PATH") is None,
-    reason="Supposed to run only for CI backward compatibility test",
+    reason="Supposed to run only for CI backward compatibility tests",
 )
 def test_save_openapi_json(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -15,12 +15,12 @@ def test_docs(
 
 def does_env_exists(env):
     if os.getenv(env):
-        return False
-    return True
+        return True
+    return False
 
 
-@pytest.mark.skipif(does_env_exists('OPENAPI_JSON_TARGET_PATH'),
-                    "Supposed to run only for CI backward compatibility checks")
+@pytest.mark.skipif(os.getenv('OPENAPI_JSON_TARGET_PATH') is not None,
+                    reason="Supposed to run only for CI backward compatibility checks")
 def test_save_openapi_json(db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
                            ) -> None:
     response = client.get("/api/openapi.json")

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -14,7 +14,7 @@ def test_docs(
 
 
 @pytest.mark.skipif(
-    os.getenv("MLRUN_OPENAPI_JSON_TARGET_PATH") is None,
+    os.getenv("MLRUN_OPENAPI_JSON_NAME") is None,
     reason="Supposed to run only for CI backward compatibility tests",
 )
 def test_save_openapi_json(
@@ -22,7 +22,10 @@ def test_save_openapi_json(
 ) -> None:
     """"The purpose of the test is to create an openapi.json file that is used to run backward compatibility tests"""
     response = client.get("/api/openapi.json")
+    path = os.path.abspath(os.getcwd())
+    if os.getenv("MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH"):
+        path = os.getenv("MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH")
     with open(
-        os.path.join(os.getenv("MLRUN_OPENAPI_JSON_TARGET_PATH"), "openapi.json"), "w"
+        os.path.join(os.path.join(path, os.getenv("MLRUN_OPENAPI_JSON_NAME"))), "w"
     ) as file:
         file.write(response.text)

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -20,6 +20,7 @@ def test_docs(
 def test_save_openapi_json(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
+    """"The purpose of the test is to create an openapi.json file that is used to run backward compatibility tests"""
     response = client.get("/api/openapi.json")
     with open(
         os.path.join(os.getenv("OPENAPI_JSON_TARGET_PATH"), "openapi.json"), "w"

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -1,13 +1,13 @@
 import http
+import os
 
 import fastapi.testclient
-import sqlalchemy.orm
-import os
 import pytest
+import sqlalchemy.orm
 
 
 def test_docs(
-        db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
     response = client.get("/api/openapi.json")
     assert response.status_code == http.HTTPStatus.OK.value
@@ -19,10 +19,15 @@ def does_env_exists(env):
     return False
 
 
-@pytest.mark.skipif(os.getenv('OPENAPI_JSON_TARGET_PATH') is None,
-                    reason="Supposed to run only for CI backward compatibility checks")
-def test_save_openapi_json(db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-                           ) -> None:
+@pytest.mark.skipif(
+    os.getenv("OPENAPI_JSON_TARGET_PATH") is None,
+    reason="Supposed to run only for CI backward compatibility checks",
+)
+def test_save_openapi_json(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
     response = client.get("/api/openapi.json")
-    with open(os.path.join(os.getenv('OPENAPI_JSON_TARGET_PATH'), 'openapi.json'), "w") as openapi:
+    with open(
+        os.path.join(os.getenv("OPENAPI_JSON_TARGET_PATH"), "openapi.json"), "w"
+    ) as openapi:
         openapi.write(response.text)

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -15,7 +15,7 @@ def test_docs(
 
 @pytest.mark.skipif(
     os.getenv("MLRUN_OPENAPI_JSON_TARGET_PATH") is None,
-    reason="Supposed to run only for CI backward compatibility tests",
+    reason="Supposed to run only for CI backward compatibility test",
 )
 def test_save_openapi_json(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -23,6 +23,6 @@ def test_save_openapi_json(
     """"The purpose of the test is to create an openapi.json file that is used to run backward compatibility tests"""
     response = client.get("/api/openapi.json")
     with open(
-        os.path.join(os.getenv("OPENAPI_JSON_TARGET_PATH"), "openapi.json"), "w"
+        os.path.join(os.getenv("MLRUN_OPENAPI_JSON_TARGET_PATH"), "openapi.json"), "w"
     ) as file:
         file.write(response.text)


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-1274

A few tools have been examined:

1. https://github.com/OpenAPITools/openapi-diff
2. https://github.com/Tufin/oasdiff
3. https://www.npmjs.com/package/openapi-diff

Since we are currently using 3.0.1 of OpenApi with FastApi, there are a few differences in the capabilities that JSON schema provides that are only available in the 3.1.0 version of OpenApi.

That is further explained at https://github.com/tiangolo/fastapi/issues/240#issuecomment-638992109.

These distinctions have an impact on the usability of `oasdiff` and `npm/openapi-diff`.
Currently, `openapi-diff` is the only one capable of handling the aforementioned differences.

Important Notes
- I was impressed by the tool’s explainability capabilities after resolving the OpenApi and JsonSchema differences in order to run `oasdiff`.
- Although `openapi-diff` is useful, it does not provide much useful information about the exact cause of the API breakage, necessitating additional investigation to determine the exact cause. I propose that we switch to `oasdiff` once fastapi supports OpenApi 3.1.0.