### PR TITLE
[CI] Refactor use of pwd in Makefile + fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,4 +173,6 @@ jobs:
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
           echo "::set-output name=tag::$(echo $unstable_tag)"
       - name: Run Backward Compatibility Tests
-        run: MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} cd head/mlrun && make test-backward-compatibility-dockerized
+        run: |
+          cd head/mlrun
+          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-backward-compatibility-dockerized

--- a/Makefile
+++ b/Makefile
@@ -661,9 +661,9 @@ ifndef MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH
 	$(error MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH is undefined)
 endif
 	export MLRUN_OPENAPI_JSON_NAME=mlrun_bc_base_oai.json && \
-	python -m pytest -v $(MLRUN_BC_TESTS_BASE_CODE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
+	python -m pytest -v --capture=no --disable-warnings --durations=100 $(MLRUN_BC_TESTS_BASE_CODE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	export MLRUN_OPENAPI_JSON_NAME=mlrun_bc_head_oai.json && \
-	python -m pytest -v tests/api/api/test_docs.py::test_save_openapi_json && \
+	python -m pytest -v --capture=no --disable-warnings --durations=100 tests/api/api/test_docs.py::test_save_openapi_json && \
 	docker run --rm -t -v $(MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH):/specs:ro openapitools/openapi-diff:2.0.1 /specs/mlrun_bc_base_oai.json /specs/mlrun_bc_head_oai.json --fail-on-incompatible
 
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ MLRUN_DOCKER_NO_CACHE_FLAG := $(if $(MLRUN_NO_CACHE),--no-cache,)
 MLRUN_PIP_NO_CACHE_FLAG := $(if $(MLRUN_NO_CACHE),--no-cache-dir,)
 
 MLRUN_OLD_VERSION_ESCAPED = $(shell echo "$(MLRUN_OLD_VERSION)" | sed 's/\./\\\./g')
+MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH ?= $(shell pwd)
 
 .PHONY: help
 help: ## Display available commands
@@ -78,7 +79,7 @@ install-requirements: ## Install all requirements needed for development
 		-r docs/requirements.txt
 
 .PHONY: create-migration-sqlite
-create-migration-sqlite: export MLRUN_HTTPDB__DSN="sqlite:///$(PWD)/mlrun/api/migrations_sqlite/mlrun.db?check_same_thread=false"
+create-migration-sqlite: export MLRUN_HTTPDB__DSN="sqlite:///$(shell pwd)/mlrun/api/migrations_sqlite/mlrun.db?check_same_thread=false"
 create-migration-sqlite: ## Create a DB migration (MLRUN_MIGRATION_MESSAGE must be set)
 ifndef MLRUN_MIGRATION_MESSAGE
 	$(error MLRUN_MIGRATION_MESSAGE is undefined)
@@ -95,7 +96,7 @@ endif
 	docker run \
 		--name=migration-db \
 		--rm \
-		-v $(PWD):/mlrun \
+		-v $(shell pwd):/mlrun \
 		-p 3306:3306 \
 		-e MYSQL_ROOT_PASSWORD="pass" \
 		-e MYSQL_ROOT_HOST=% \
@@ -563,7 +564,7 @@ run-api: api ## Run mlrun api (dockerized)
 run-test-db:
 	docker run \
 		--name=test-db \
-		-v $(PWD):/mlrun \
+		-v $(shell pwd):/mlrun \
 		-p 3306:3306 \
 		-e MYSQL_ROOT_PASSWORD="" \
 		-e MYSQL_ALLOW_EMPTY_PASSWORD="true" \
@@ -584,7 +585,7 @@ html-docs: ## Build html docs
 html-docs-dockerized: build-test ## Build html docs dockerized
 	docker run \
 		--rm \
-		-v $(PWD)/docs/_build:/mlrun/docs/_build \
+		-v $(shell pwd)/docs/_build:/mlrun/docs/_build \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) \
 		make html-docs
 
@@ -643,12 +644,12 @@ endif
 	    --rm \
 	    --network='host' \
 	    -v /tmp:/tmp \
-	    -v $(PWD):$(PWD) \
+	    -v $(shell pwd):$(shell pwd) \
 	    -v $(MLRUN_BC_TESTS_BASE_CODE_PATH):$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
 	    -v /var/run/docker.sock:/var/run/docker.sock \
 	    --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
-	    --env MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH=$(PWD) \
-	    --workdir=$(PWD) \
+	    --env MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH=$(shell pwd) \
+	    --workdir=$(shell pwd) \
 	    $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
 
 .PHONY: test-backward-compatibility

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -5,6 +5,8 @@ import fastapi.testclient
 import pytest
 import sqlalchemy.orm
 
+from mlrun.utils import logger
+
 
 def test_docs(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
@@ -25,7 +27,7 @@ def test_save_openapi_json(
     path = os.path.abspath(os.getcwd())
     if os.getenv("MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH"):
         path = os.getenv("MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH")
-    with open(
-        os.path.join(os.path.join(path, os.getenv("MLRUN_OPENAPI_JSON_NAME"))), "w"
-    ) as file:
+    file_path = os.path.join(path, os.getenv("MLRUN_OPENAPI_JSON_NAME"))
+    with open(file_path, "w") as file:
         file.write(response.text)
+    logger.info(f"Saved openapi file in {file_path}")

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -30,4 +30,4 @@ def test_save_openapi_json(
     file_path = os.path.join(path, os.getenv("MLRUN_OPENAPI_JSON_NAME"))
     with open(file_path, "w") as file:
         file.write(response.text)
-    logger.info(f"Saved openapi file in {file_path}")
+    logger.info("Saved openapi JSON file", file_path=file_path)


### PR DESCRIPTION
When executing docker run using the makeFile, the $(PWD) variable is not being defined at the container runtime, to use the current working directory anyway the alternative is to use $(shell pwd).

This topic is being discussed in the following links :

- https://jerome-wang.github.io/2015/08/13/pwd-in-sudo-make/
- https://stackoverflow.com/questions/15050748/what-value-does-shell-pwd-give

Also:
* Caching was not working for the migrations CI job because of configuration in the wrong place - fixed that
* Added log to the openapi test