### PR TITLE
[DB] Align run `start_time` column and body field

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2470,7 +2470,10 @@ class SQLDB(DBInterface):
         sqlalchemy losing timezone information with sqlite so we're returning it
         https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite
         """
-        setattr(obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name)))
+        if isinstance(obj, dict):
+            obj[attribute_name] = pytz.utc.localize(obj[attribute_name])
+        else:
+            setattr(obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name)))
 
     @staticmethod
     def _transform_feature_set_model_to_schema(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -114,6 +114,8 @@ class SQLDB(DBInterface):
         if new_state:
             run.state = new_state
         update_labels(run, labels)
+        SQLDB._add_utc_timezone(run, "start_time")
+        run_data.setdefault("status", {})["start_time"] = run.start_time
         run.struct = run_data
         self._upsert(session, run, ignore=True)
 
@@ -2456,7 +2458,6 @@ class SQLDB(DBInterface):
         if commit:
             session.commit()
 
-    @staticmethod
     def _transform_schedule_record_to_scheme(
         self,
         schedule_record: Schedule,

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2471,9 +2471,11 @@ class SQLDB(DBInterface):
         https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite
         """
         if isinstance(obj, dict):
-            obj[attribute_name] = pytz.utc.localize(obj[attribute_name])
+            if obj.get(attribute_name) is not None and obj.get(attribute_name).tzinfo is None:
+                obj[attribute_name] = pytz.utc.localize(obj[attribute_name])
         else:
-            setattr(obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name)))
+            if getattr(obj, attribute_name) is not None and getattr(obj, attribute_name).tzinfo is None:
+                setattr(obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name)))
 
     @staticmethod
     def _transform_feature_set_model_to_schema(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2458,10 +2458,11 @@ class SQLDB(DBInterface):
 
     @staticmethod
     def _transform_schedule_record_to_scheme(
-        db_schedule: Schedule,
+        self,
+        schedule_record: Schedule,
     ) -> schemas.ScheduleRecord:
-        schedule = schemas.ScheduleRecord.from_orm(db_schedule)
-        SQLDB._add_utc_timezone(schedule, "creation_time")
+        schedule = schemas.ScheduleRecord.from_orm(schedule_record)
+        self._add_utc_timezone(schedule, "creation_time")
         return schedule
 
     @staticmethod

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -701,7 +701,7 @@ class SQLDB(DBInterface):
         query = self._add_labels_filter(session, query, Schedule, labels)
 
         schedules = [
-            self._transform_schedule_model_to_scheme(db_schedule)
+            self._transform_schedule_record_to_scheme(db_schedule)
             for db_schedule in query
         ]
         return schedules
@@ -711,7 +711,7 @@ class SQLDB(DBInterface):
     ) -> schemas.ScheduleRecord:
         logger.debug("Getting schedule from db", project=project, name=name)
         schedule_record = self._get_schedule_record(session, project, name)
-        schedule = self._transform_schedule_model_to_scheme(schedule_record)
+        schedule = self._transform_schedule_record_to_scheme(schedule_record)
         return schedule
 
     def _get_schedule_record(
@@ -2457,7 +2457,7 @@ class SQLDB(DBInterface):
             session.commit()
 
     @staticmethod
-    def _transform_schedule_model_to_scheme(
+    def _transform_schedule_record_to_scheme(
         db_schedule: Schedule,
     ) -> schemas.ScheduleRecord:
         schedule = schemas.ScheduleRecord.from_orm(db_schedule)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2459,8 +2459,7 @@ class SQLDB(DBInterface):
             session.commit()
 
     def _transform_schedule_record_to_scheme(
-        self,
-        schedule_record: Schedule,
+        self, schedule_record: Schedule,
     ) -> schemas.ScheduleRecord:
         schedule = schemas.ScheduleRecord.from_orm(schedule_record)
         self._add_utc_timezone(schedule, "creation_time")
@@ -2473,11 +2472,19 @@ class SQLDB(DBInterface):
         https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite
         """
         if isinstance(obj, dict):
-            if obj.get(attribute_name) is not None and obj.get(attribute_name).tzinfo is None:
+            if (
+                obj.get(attribute_name) is not None
+                and obj.get(attribute_name).tzinfo is None
+            ):
                 obj[attribute_name] = pytz.utc.localize(obj[attribute_name])
         else:
-            if getattr(obj, attribute_name) is not None and getattr(obj, attribute_name).tzinfo is None:
-                setattr(obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name)))
+            if (
+                getattr(obj, attribute_name) is not None
+                and getattr(obj, attribute_name).tzinfo is None
+            ):
+                setattr(
+                    obj, attribute_name, pytz.utc.localize(getattr(obj, attribute_name))
+                )
 
     @staticmethod
     def _transform_feature_set_model_to_schema(

--- a/tests/api/db/test_runs.py
+++ b/tests/api/db/test_runs.py
@@ -154,7 +154,7 @@ def test_list_runs_state_filter(db: DBInterface, db_session: Session):
 @pytest.mark.parametrize(
     "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
 )
-def test_store_run_not_overriding_start_time(db: DBInterface, db_session: Session):
+def test_store_run_overriding_start_time(db: DBInterface, db_session: Session):
     project = "project"
     run_name = "run_name_1"
     run = {"metadata": {"name": run_name}}
@@ -163,16 +163,17 @@ def test_store_run_not_overriding_start_time(db: DBInterface, db_session: Sessio
     # First store - fills the start_time
     db.store_run(db_session, run, run_uid, project)
 
-    # get the start time
-    runs = db.list_runs(db_session, project=project)
+    # use to internal function to get the record itself to be able to assert the column itself
+    runs = db._find_runs(db_session, uid=None, project=project, labels=None).all()
     assert len(runs) == 1
-    original_start_time = runs[0]["status"]["start_time"]
+    assert db._add_utc_timezone(runs[0].start_time).isoformat() == runs[0].struct["status"]["start_time"]
 
-    # Second store - shouldn't allow to override the start time
-    run["status"]["start_time"] = datetime.now()
+    # Second store - should allow to override the start time
+    run["status"]["start_time"] = datetime.now(timezone.utc).isoformat()
     db.store_run(db_session, run, run_uid, project)
 
     # get the start time and verify
-    runs = db.list_runs(db_session, project=project)
+    runs = db._find_runs(db_session, uid=None, project=project, labels=None).all()
     assert len(runs) == 1
-    assert original_start_time == runs[0]["status"]["start_time"]
+    assert db._add_utc_timezone(runs[0].start_time).isoformat() == runs[0].struct["status"]["start_time"]
+    assert runs[0].struct["status"]["start_time"] == run["status"]["start_time"]

--- a/tests/api/db/test_runs.py
+++ b/tests/api/db/test_runs.py
@@ -166,7 +166,10 @@ def test_store_run_overriding_start_time(db: DBInterface, db_session: Session):
     # use to internal function to get the record itself to be able to assert the column itself
     runs = db._find_runs(db_session, uid=None, project=project, labels=None).all()
     assert len(runs) == 1
-    assert db._add_utc_timezone(runs[0].start_time).isoformat() == runs[0].struct["status"]["start_time"]
+    assert (
+        db._add_utc_timezone(runs[0].start_time).isoformat()
+        == runs[0].struct["status"]["start_time"]
+    )
 
     # Second store - should allow to override the start time
     run["status"]["start_time"] = datetime.now(timezone.utc).isoformat()
@@ -175,5 +178,8 @@ def test_store_run_overriding_start_time(db: DBInterface, db_session: Session):
     # get the start time and verify
     runs = db._find_runs(db_session, uid=None, project=project, labels=None).all()
     assert len(runs) == 1
-    assert db._add_utc_timezone(runs[0].start_time).isoformat() == runs[0].struct["status"]["start_time"]
+    assert (
+        db._add_utc_timezone(runs[0].start_time).isoformat()
+        == runs[0].struct["status"]["start_time"]
+    )
     assert runs[0].struct["status"]["start_time"] == run["status"]["start_time"]

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -168,7 +168,7 @@ def server_fixture():
 
 servers = [
     "server",
-    "docker",
+    # "docker",
 ]
 
 
@@ -205,7 +205,15 @@ def test_run(create_server):
     db.store_run(run_as_dict, uid, prj)
 
     data = db.read_run(uid, prj)
-    assert data == run_as_dict, "read_run"
+    assert (
+        deepdiff.DeepDiff(
+            data,
+            run_as_dict,
+            ignore_order=True,
+            exclude_paths={"root['status']['start_time']"},
+        )
+        == {}
+    )
 
     new_c = 4
     updates = {"metadata.C": new_c}


### PR DESCRIPTION
Fixes: https://jira.iguazeng.com/browse/ML-145
When storing run the logic was that on creation the start time column is either coming from the body or `datetime.now()` (by that precedence), and on update, nothing happens with it.
When running a job the first the triggering client is storing the run, it's the first store, so it's creation, no start time is in the body, therefore the time is just now. but then, when the job starting, on the `MLClientCtx` initialization, the start time is being set to now, and then when the job is finishing, the context store the run again, this time causing an update, but now the column doesn't change, while the body is being changed to have a different time (it takes some time for the pod to come up and actually start running the code)
So bottomline the `start_time` column and the field inside the body were inconsistent.
After consulting with @yaronha we agreed that it does make more sense to have the time from when the code execution actually started (without considering the time to pull the image and such) as the start time, therefore we needed to make sure that on update, if something is in the body, it applies to the column as well (we do keep defaulting to now on creation as some runtimes won't have any MLRun context used in them)
In a followup PR I'll add a data migration that will go over all runs and align the column to have the body field if it exists