### PR TITLE
[Execution] Add utility function to get project parameter from context

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -433,20 +433,23 @@ class MLClientCtx(object):
             return default
         return self._parameters[key]
 
-    def get_project_param(self, key: str, default=None):
-        """get a parameter from the run's project's parameters"""
-        if not self._project:
-            self.logger.warning("get_project_param called without a project name")
-            return default
-
+    def _load_project_object(self):
         if not self._project_object:
-            if self._rundb:
-                self._project_object = self._rundb.get_project(self._project)
-            else:
+            if not self._project:
+                self.logger.warning("get_project_param called without a project name")
+                return None
+            if not self._rundb:
                 self.logger.warning(
                     "cannot retrieve project parameters - MLRun DB is not accessible"
                 )
-                return default
+                return None
+            self._project_object = self._rundb.get_project(self._project)
+        return self._project_object
+
+    def get_project_param(self, key: str, default=None):
+        """get a parameter from the run's project's parameters"""
+        if not self._load_project_object():
+            return default
 
         return self._project_object.get_param(key, default)
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -103,6 +103,8 @@ class MLClientCtx(object):
         self._parent = None
         self._handler = None
 
+        self._project_object = None
+
     def __enter__(self):
         return self
 
@@ -430,6 +432,23 @@ class MLClientCtx(object):
                 self._update_db()
             return default
         return self._parameters[key]
+
+    def get_project_param(self, key: str, default=None):
+        """get a parameter from the run's project's parameters"""
+        if not self._project:
+            self.logger.warning("get_project_param called without a project name")
+            return default
+
+        if not self._project_object:
+            if self._rundb:
+                self._project_object = self._rundb.get_project(self._project)
+            else:
+                self.logger.warning(
+                    "cannot retrieve project parameters - MLRun DB is not accessible"
+                )
+                return default
+
+        return self._project_object.get_param(key, default)
 
     def get_secret(self, key: str):
         """get a key based secret e.g. DB password from the context

--- a/tests/system/runtimes/assets/function_with_params.py
+++ b/tests/system/runtimes/assets/function_with_params.py
@@ -1,0 +1,5 @@
+def handler(context):
+    param1 = context.get_param("param1")
+    project_param = context.get_project_param("project_param")
+    context.log_result("param1", param1)
+    context.log_result("project_param", project_param)


### PR DESCRIPTION
Added a convenience function `context.get_project_param()` which gets a parameter from the parent project parameters. This was possible before by loading the project from the MLRun DB, this function simplifies the process. It loads the project object on first activation, so further calls will utilize the same object.