### PR TITLE
[Projects] Support setting requirements in project & functions and accept hub urls in project ops

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -240,6 +240,8 @@ def enrich_function_object(
             f.spec.build.source = project.spec.source
             f.spec.build.load_source_on_run = project.spec.load_source_on_run
 
+    if project.spec.default_requirements:
+        f.with_requirements(project.spec.default_requirements)
     if decorator:
         decorator(f)
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -448,6 +448,7 @@ class ProjectSpec(ModelObj):
         origin_url=None,
         goals=None,
         load_source_on_run=None,
+        default_requirements: typing.Union[str, typing.List[str]] = None,
         desired_state=mlrun.api.schemas.ProjectState.online.value,
         owner=None,
         disable_auto_mount=False,
@@ -472,6 +473,7 @@ class ProjectSpec(ModelObj):
         self.artifact_path = artifact_path
         self._artifacts = {}
         self.artifacts = artifacts or []
+        self.default_requirements = default_requirements
 
         self._workflows = {}
         self.workflows = workflows or []
@@ -663,6 +665,7 @@ class MlrunProject(ModelObj):
         # all except these 2 are for backwards compatibility with MlrunProjectLegacy
         metadata=None,
         spec=None,
+        default_requirements: typing.Union[str, typing.List[str]] = None,
     ):
         self._metadata = None
         self.metadata = metadata
@@ -680,6 +683,9 @@ class MlrunProject(ModelObj):
         self.spec.artifacts = artifacts or self.spec.artifacts
         self.spec.artifact_path = artifact_path or self.spec.artifact_path
         self.spec.conda = conda or self.spec.conda
+        self.spec.default_requirements = (
+            default_requirements or self.spec.default_requirements
+        )
 
         self._initialized = False
         self._secrets = SecretsStore()
@@ -1308,8 +1314,15 @@ class MlrunProject(ModelObj):
         return project
 
     def set_function(
-        self, func, name="", kind="", image=None, handler=None, with_repo=None
-    ):
+        self,
+        func: typing.Union[str, mlrun.runtimes.BaseRuntime],
+        name: str = "",
+        kind: str = "",
+        image: str = None,
+        handler=None,
+        with_repo: bool = None,
+        requirements: typing.Union[str, typing.List[str]] = None,
+    ) -> mlrun.runtimes.BaseRuntime:
         """update or add a function object to the project
 
         function can be provided as an object (func) or a .py/.ipynb/.yaml url
@@ -1336,6 +1349,7 @@ class MlrunProject(ModelObj):
                           the function object/yaml
         :param handler:   default function handler to invoke (can only be set with .py/.ipynb files)
         :param with_repo: add (clone) the current repo to the build source
+        :param requirements:    list of python packages or pip requirements file path
 
         :returns: project object
         """
@@ -1350,6 +1364,7 @@ class MlrunProject(ModelObj):
                 "image": image,
                 "handler": handler,
                 "with_repo": with_repo,
+                "requirements": requirements,
             }
             func = {k: v for k, v in function_dict.items() if v}
             name, function_object = _init_function_from_dict(func, self)
@@ -1364,6 +1379,8 @@ class MlrunProject(ModelObj):
                 function_object.spec.image = image
             if with_repo:
                 function_object.spec.build.source = "./"
+            if requirements:
+                function_object.with_requirements(requirements)
             if not name:
                 raise ValueError("function name must be specified")
         else:
@@ -2085,7 +2102,14 @@ class MlrunProjectLegacy(ModelObj):
         self._workflows[name] = workflow
 
     # needed for tests
-    def set_function(self, func, name="", kind="", image=None, with_repo=None):
+    def set_function(
+        self,
+        func: typing.Union[str, mlrun.runtimes.BaseRuntime],
+        name: str = "",
+        kind: str = "",
+        image: str = None,
+        with_repo: bool = None,
+    ):
         """update or add a function object to the project
 
         function can be provided as an object (func) or a .py/.ipynb/.yaml url
@@ -2158,6 +2182,7 @@ def _init_function_from_dict(f, project):
     image = f.get("image", None)
     handler = f.get("handler", None)
     with_repo = f.get("with_repo", False)
+    requirements = f.get("requirements", None)
 
     in_context = False
     if not url and "spec" not in f:
@@ -2203,6 +2228,8 @@ def _init_function_from_dict(f, project):
 
     if with_repo:
         func.spec.build.source = "./"
+    if requirements:
+        func.with_requirements(requirements)
 
     return _init_function_from_obj(func, project, name)
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -871,7 +871,10 @@ class BaseRuntime(ModelObj):
             with open(requirements, "r") as fp:
                 requirements = fp.read().splitlines()
         commands = self.spec.build.commands or []
-        commands.append("python -m pip install " + " ".join(requirements))
+        new_command = "python -m pip install " + " ".join(requirements)
+        # make sure we dont append the same line twice
+        if new_command not in commands:
+            commands.append(new_command)
         self.spec.build.commands = commands
         return self
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -183,3 +183,19 @@ def _assert_project_function_objects(project, expected_function_objects):
             )
             == {}
         )
+
+
+def test_set_func_requirements():
+    project = mlrun.projects.MlrunProject("newproj", default_requirements=["pandas"])
+    project.set_function("hub://describe", "desc1", requirements=["x"])
+    assert project.get_function("desc1", enrich=True).spec.build.commands == [
+        "python -m pip install x",
+        "python -m pip install pandas",
+    ]
+
+    fn = mlrun.import_function("hub://describe")
+    project.set_function(fn, "desc2", requirements=["y"])
+    assert project.get_function("desc2", enrich=True).spec.build.commands == [
+        "python -m pip install y",
+        "python -m pip install pandas",
+    ]

--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -4,7 +4,6 @@ from mlrun import (
     build_function,
     deploy_function,
     get_current_project,
-    import_function,
     run_function,
 )
 from mlrun.model import HyperParamOptions
@@ -78,9 +77,8 @@ def newpipe():
     )
 
     # test out new model server (via REST API calls), use imported function
-    tester = import_function("hub://v2_model_tester", new_name="live_tester")
     run_function(
-        tester,
+        "hub://v2_model_tester",
         name="model-tester",
         params={"addr": deploy.outputs["endpoint"], "model": f"{DATASET}:v1"},
         inputs={"table": train.outputs["test_set"]},

--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -1,11 +1,6 @@
 from kfp import dsl
 
-from mlrun import (
-    build_function,
-    deploy_function,
-    get_current_project,
-    run_function,
-)
+from mlrun import build_function, deploy_function, get_current_project, run_function
 from mlrun.model import HyperParamOptions
 
 funcs = {}


### PR DESCRIPTION
* support setting `project.spec.default_requirements` with list/path to python requirements (will be added to all project functions)
* support `requirements` in set_function: `project.set_function("my.py", "f1", requirements=["pandas"])`
* support passing `hub://xx` url to run/build/deploy_function() methods (no need to import first) 
 