### PR TITLE
[Feature Store] Support fixed/relative time string ranges in `get_offline_features()`

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -102,9 +102,11 @@ def get_offline_features(
     and statistics. returns :py:class:`~mlrun.feature_store.OfflineVectorResponse`,
     results can be returned as a dataframe or written to a target
 
-    The start_time and end_time attributed allow filtering the data to a given time range, they accept
+    The start_time and end_time attributes allow filtering the data to a given time range, they accept
     string values or pandas `Timestamp` objects, string values can also be relative, for example:
-    "now", "now - 1d2h", "now+5m", where a valid pandas Timedelta string follows the verb "now"
+    "now", "now - 1d2h", "now+5m", where a valid pandas Timedelta string follows the verb "now",
+    for time alignment you can use the verb "floor" e.g. "now -1d floor 1H" will align the time to the last hour
+    (the floor string is passed to pandas.Timestamp.floor(), can use D, H, T, S for day, hour, min, sec alignment).
 
     example::
 

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Union
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -34,7 +34,7 @@ from ..db import RunDBError
 from ..model import DataSource, DataTargetBase
 from ..runtimes import RuntimeKinds
 from ..runtimes.function_reference import FunctionReference
-from ..utils import get_caller_globals, logger
+from ..utils import get_caller_globals, logger, str_to_timestamp
 from .common import (
     RunConfig,
     get_feature_set_by_uri,
@@ -89,8 +89,8 @@ def get_offline_features(
     target: DataTargetBase = None,
     run_config: RunConfig = None,
     drop_columns: List[str] = None,
-    start_time: Optional[pd.Timestamp] = None,
-    end_time: Optional[pd.Timestamp] = None,
+    start_time: Union[str, pd.Timestamp] = None,
+    end_time: Union[str, pd.Timestamp] = None,
     with_indexes: bool = False,
     update_stats: bool = False,
     engine: str = None,
@@ -101,6 +101,10 @@ def get_offline_features(
     specify a feature vector object/uri and retrieve the desired features, their metadata
     and statistics. returns :py:class:`~mlrun.feature_store.OfflineVectorResponse`,
     results can be returned as a dataframe or written to a target
+
+    The start_time and end_time attributed allow filtering the data to a given time range, they accept
+    string values or pandas `Timestamp` objects, string values can also be relative, for example:
+    "now", "now - 1d2h", "now+5m", where a valid pandas Timedelta string follows the verb "now"
 
     example::
 
@@ -156,6 +160,8 @@ def get_offline_features(
             with_indexes=with_indexes,
         )
 
+    start_time = str_to_timestamp(start_time)
+    end_time = str_to_timestamp(end_time)
     if (start_time or end_time) and not entity_timestamp_column:
         raise TypeError(
             "entity_timestamp_column or feature_vector.spec.timestamp_field is required when passing start/end time"

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1160,9 +1160,7 @@ def str_to_timestamp(time_str: str, now_time: Timestamp = None):
         split = time_str.split("floor")
         time_str = split[0].strip()
 
-        if not time_str:
-            return timestamp
-        if time_str[0] in ["+", "-"]:
+        if time_str and time_str[0] in ["+", "-"]:
             timestamp = timestamp + Timedelta(time_str)
         elif time_str:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -29,7 +29,7 @@ import numpy as np
 import requests
 import yaml
 from dateutil import parser
-from pandas._libs.tslibs.timestamps import Timestamp
+from pandas._libs.tslibs.timestamps import Timedelta, Timestamp
 from tabulate import tabulate
 from yaml.representer import RepresenterError
 
@@ -1135,3 +1135,33 @@ def fill_artifact_path_template(artifact_path, project):
         artifact_path = artifact_path.replace("{{run.project}}", project)
         artifact_path = artifact_path.replace("{{project}}", project)
     return artifact_path
+
+
+def str_to_timestamp(time_str: str, now_time=None):
+    """convert fixed/relative time string to Pandas Timestamp
+
+    time string examples::
+
+        1/1/2021
+        now
+        now + 1d2h
+    """
+    if not isinstance(time_str, str):
+        return time_str
+
+    time_str = time_str.strip()
+    if time_str.lower().startswith("now"):
+        # handle now +/- timedelta
+        timestamp = now_time or Timestamp.now()
+        time_str = time_str[len("now") :].lstrip()
+        if not time_str:
+            return timestamp
+        if time_str[0] in ["+", "-"]:
+            return timestamp + Timedelta(time_str)
+        else:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"illegal time string expression now{time_str}, "
+                'use "now +/- <timestring>" for relative times'
+            )
+
+    return Timestamp(time_str)

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -614,7 +614,7 @@ class TestFeatureStore(TestMLRunSystem):
         resp = fs.get_offline_features(
             vector,
             start_time=datetime(2020, 12, 1, 17, 33, 15),
-            end_time=datetime(2020, 12, 1, 17, 33, 16),
+            end_time="2020-12-01 17:33:16",
             entity_timestamp_column="timestamp",
         )
         resp2 = resp.to_dataframe()
@@ -857,7 +857,7 @@ class TestFeatureStore(TestMLRunSystem):
         resp = fs.get_offline_features(
             vector,
             entity_timestamp_column="time_stamp",
-            start_time=datetime(2021, 6, 9, 9, 30),
+            start_time="2021-06-09 09:30",
             end_time=datetime(2021, 6, 9, 10, 30),
         )
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -425,7 +425,6 @@ def test_str_to_timestamp():
             None,
         ),
     ]
-    print(now_time)
     for time_str, expected, exception in cases:
         if exception is not None:
             with pytest.raises(exception):

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -411,8 +411,10 @@ def test_str_to_timestamp():
         (Timestamp("1/1/2022"), Timestamp("1/1/2022"), None),
         ("not now", None, ValueError),
         (" now ", now_time, None),
+        (" now floor 1H", now_time, None),
         ("now - 1d1h", now_time - Timedelta("1d1h"), None),
         ("now +1d1m", now_time + Timedelta("1d1m"), None),
+        ("now +1d1m floor 1D", now_time + Timedelta("1d"), None),
         ("now * 1d1m", None, mlrun.errors.MLRunInvalidArgumentError),
         (
             "2022-01-11T18:28:00+00:00",

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -404,17 +404,17 @@ def test_get_pretty_types_names():
 
 
 def test_str_to_timestamp():
-    now_time = Timestamp("2021-01-01 00:00:00")
+    now_time = Timestamp("2021-01-01 00:01:00")
     cases = [
         (None, None, None),
         ("1/1/2022", Timestamp("2022-01-01 00:00:00"), None),
         (Timestamp("1/1/2022"), Timestamp("1/1/2022"), None),
         ("not now", None, ValueError),
         (" now ", now_time, None),
-        (" now floor 1H", now_time, None),
+        (" now floor 1H", now_time - Timedelta("1m"), None),
         ("now - 1d1h", now_time - Timedelta("1d1h"), None),
         ("now +1d1m", now_time + Timedelta("1d1m"), None),
-        ("now +1d1m floor 1D", now_time + Timedelta("1d"), None),
+        ("now +1d1m floor 1D", now_time + Timedelta("1d") - Timedelta("1m"), None),
         ("now * 1d1m", None, mlrun.errors.MLRunInvalidArgumentError),
         (
             "2022-01-11T18:28:00+00:00",
@@ -433,4 +433,5 @@ def test_str_to_timestamp():
                 str_to_timestamp(time_str, now_time=now_time)
         else:
             timestamp = str_to_timestamp(time_str, now_time=now_time)
+            print(time_str, timestamp, expected)
             assert timestamp == expected


### PR DESCRIPTION
start_time and end_time attrs in get_offline_features() accept time strings (e.g. "2021/1/1 9:34") or relative time strings ("now", "now - 1d1h", "now + 2m") in addition to pd.Timestamp objects