### PR TITLE
[Serving] Set proper event metadata defaults, add step for setting metadata from body

### DIFF
--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, Dict, List, Union
 
 import pandas as pd
@@ -273,6 +274,7 @@ class SetEventMetadata(MapClass):
         id_path: str = None,
         key_path: str = None,
         time_path: str = None,
+        random_id: bool = None,
         **kwargs,
     ):
         """Set the event metadata (id, key, timestamp) from the event body
@@ -297,12 +299,14 @@ class SetEventMetadata(MapClass):
         :param id_path:   path to the id value
         :param key_path:  path to the key value
         :param time_path: path to the time value (value should be of type str or datetime)
+        :param random_id: if True will set the event.id to a random value
         """
         kwargs["full_event"] = True
         super().__init__(**kwargs)
         self.id_path = id_path
         self.key_path = key_path
         self.time_path = time_path
+        self.random_id = random_id
 
         self._tagging_funcs = []
 
@@ -314,6 +318,9 @@ class SetEventMetadata(MapClass):
 
             return _add_meta
 
+        def set_random_id(event):
+            event.id = uuid.uuid4().hex
+
         self._tagging_funcs = []
         if self.id_path:
             self._tagging_funcs.append(add_metadata("id", self.id_path))
@@ -323,6 +330,8 @@ class SetEventMetadata(MapClass):
             self._tagging_funcs.append(
                 add_metadata("time", self.time_path, get_event_time)
             )
+        if self.random_id:
+            self._tagging_funcs.append(set_random_id)
 
     def do(self, event):
         for func in self._tagging_funcs:

--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -3,7 +3,9 @@ from typing import Any, Dict, List, Union
 import pandas as pd
 from storey import MapClass
 
+from mlrun.serving.server import get_event_time
 from mlrun.serving.utils import StepToDict
+from mlrun.utils import get_in
 
 
 class FeaturesetValidator(StepToDict, MapClass):
@@ -260,4 +262,69 @@ class DateExtractor(StepToDict, MapClass):
             extracted_part = getattr(timestamp, part)
             # Add to event
             event[self._get_key_name(part, self.timestamp_col)] = extracted_part
+        return event
+
+
+class SetEventMetadata(MapClass):
+    """Set the event metadata (id, key, timestamp) from the event body"""
+
+    def __init__(
+        self,
+        id_path: str = None,
+        key_path: str = None,
+        time_path: str = None,
+        **kwargs,
+    ):
+        """Set the event metadata (id, key, timestamp) from the event body
+
+        set the event metadata fields (id, key, and time) from the event body data structure
+        the xx_path attribute defines the key or path to the value in the body dict, "." in the path string
+        indicate the value is in a nested dict e.g. `"x.y"` means `{"x": {"y": value}}`
+
+        example::
+
+            flow = function.set_topology("flow")
+            # build a graph and use the SetEventMetadata step to extract the id, key and path from the event body
+            # ("myid", "mykey" and "mytime" fields), the metadata will be used for following data processing steps
+            # (e.g. feature store ops, time/key aggregations, write to databases/streams, etc.)
+            flow.to(SetEventMetadata(id_path="myid", key_path="mykey", time_path="mytime"))
+                .to(...)  # additional steps
+
+            server = function.to_mock_server()
+            event = {"myid": "34", "mykey": "123", "mytime": "2022-01-18 15:01"}
+            resp = server.test(body=event)
+
+        :param id_path:   path to the id value
+        :param key_path:  path to the key value
+        :param time_path: path to the time value (value should be of type str or datetime)
+        """
+        kwargs["full_event"] = True
+        super().__init__(**kwargs)
+        self.id_path = id_path
+        self.key_path = key_path
+        self.time_path = time_path
+
+        self._tagging_funcs = []
+
+    def post_init(self, mode="sync"):
+        def add_metadata(name, path, operator=str):
+            def _add_meta(event):
+                value = get_in(event.body, path)
+                setattr(event, name, operator(value))
+
+            return _add_meta
+
+        self._tagging_funcs = []
+        if self.id_path:
+            self._tagging_funcs.append(add_metadata("id", self.id_path))
+        if self.key_path:
+            self._tagging_funcs.append(add_metadata("key", self.key_path))
+        if self.time_path:
+            self._tagging_funcs.append(
+                add_metadata("time", self.time_path, get_event_time)
+            )
+
+    def do(self, event):
+        for func in self._tagging_funcs:
+            func(event)
         return event

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -216,7 +216,9 @@ class RemoteStep(storey.SendToHttp):
                 url = url + "/" + striped_path
             if striped_path:
                 headers[event_path_key] = event.path
-        headers[event_id_key] = event.id
+
+        if event.id:
+            headers[event_id_key] = event.id
 
         if method == "GET":
             body = None

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -21,6 +21,7 @@ import socket
 import sys
 import traceback
 import uuid
+from datetime import datetime, timezone
 from typing import Optional, Union
 
 import mlrun
@@ -189,6 +190,7 @@ class GraphServer(ModelObj):
         event_id: Optional[str] = None,
         trigger: "MockTrigger" = None,
         offset=None,
+        time=None,
     ):
         """invoke a test event into the server to simulate/test server behavior
 
@@ -208,6 +210,7 @@ class GraphServer(ModelObj):
         :param event_id:   specify the unique event ID (by default a random value will be generated)
         :param trigger:    nuclio trigger info or mlrun.serving.server.MockTrigger class (holds kind and name)
         :param offset:     trigger offset (for streams)
+        :param time:       event time Datetime or str, default to now()
         """
         if not self.graph:
             raise MLRunInvalidArgumentError(
@@ -222,6 +225,7 @@ class GraphServer(ModelObj):
             event_id=event_id,
             trigger=trigger,
             offset=offset,
+            time=time,
         )
         resp = self.run(event, get_body=get_body)
         if hasattr(resp, "status_code") and resp.status_code >= 300 and not silent:
@@ -371,11 +375,12 @@ class MockEvent(object):
         event_id=None,
         trigger: MockTrigger = None,
         offset=None,
+        time=None,
     ):
         self.id = event_id or uuid.uuid4().hex
         self.key = ""
         self.body = body
-        self.time = None
+        self.time = get_event_time(time) or datetime.now(timezone.utc)
 
         # optional
         self.headers = headers or {}
@@ -502,3 +507,17 @@ def format_error(server, context, source, event, message, args):
         "message": message,
         "args": args,
     }
+
+
+def get_event_time(time):
+    # init the event time from time, date, or str (similar to storey)
+    if time is not None and not isinstance(time, datetime):
+        if isinstance(time, str):
+            time = datetime.fromisoformat(time)
+        elif isinstance(time, int):
+            time = datetime.utcfromtimestamp(time)
+        else:
+            raise TypeError(
+                f"Event time parameter must be a datetime, string, or int. Got {type(time)} instead."
+            )
+    return time

--- a/tests/feature-store/test_steps.py
+++ b/tests/feature-store/test_steps.py
@@ -1,3 +1,5 @@
+import datetime
+
 import mlrun
 from mlrun.feature_store.steps import SetEventMetadata
 
@@ -12,7 +14,7 @@ def extract_meta(event):
 
 
 def test_set_event_meta():
-    function = mlrun.new_function("test2", kind="serving")
+    function = mlrun.new_function("test1", kind="serving")
     flow = function.set_topology("flow")
     flow.to(SetEventMetadata(id_path="myid", key_path="mykey", time_path="mytime")).to(
         name="e", handler="extract_meta", full_event=True
@@ -21,4 +23,22 @@ def test_set_event_meta():
     server = function.to_mock_server()
     event = {"myid": "34", "mykey": "123", "mytime": "2022-01-18 15:01"}
     resp = server.test(body=event)
-    print(resp)
+    server.wait_for_completion()
+    assert resp == {
+        "id": "34",
+        "key": "123",
+        "time": datetime.datetime(2022, 1, 18, 15, 1),
+    }
+
+
+def test_set_event_random_id():
+    function = mlrun.new_function("test2", kind="serving")
+    flow = function.set_topology("flow")
+    flow.to(SetEventMetadata(random_id=True)).to(
+        name="e", handler="extract_meta", full_event=True
+    ).respond()
+
+    server = function.to_mock_server()
+    resp = server.test(body={"data": "123"}, event_id="XYZ")
+    server.wait_for_completion()
+    assert resp["id"] != "XYZ", "id was not overwritten"

--- a/tests/feature-store/test_steps.py
+++ b/tests/feature-store/test_steps.py
@@ -1,0 +1,24 @@
+import mlrun
+from mlrun.feature_store.steps import SetEventMetadata
+
+
+def extract_meta(event):
+    event.body = {
+        "id": event.id,
+        "key": event.key,
+        "time": event.time,
+    }
+    return event
+
+
+def test_set_event_meta():
+    function = mlrun.new_function("test2", kind="serving")
+    flow = function.set_topology("flow")
+    flow.to(SetEventMetadata(id_path="myid", key_path="mykey", time_path="mytime")).to(
+        name="e", handler="extract_meta", full_event=True
+    ).respond()
+
+    server = function.to_mock_server()
+    event = {"myid": "34", "mykey": "123", "mytime": "2022-01-18 15:01"}
+    resp = server.test(body=event)
+    print(resp)


### PR DESCRIPTION
* set event time (default to now) in MockEvents 
* fix failue in RemoteStep when event.id is missing
* add `SetEventMetadata` step class to set event metadata from event body fields