### PR TITLE
[Workflows] Automatically add `{{workflow.uid}}` to artifact path when running workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,6 +471,7 @@ test: clean ## Run mlrun tests
 		--disable-warnings \
 		--durations=100 \
 		--ignore=tests/integration \
+		--ignore=tests/system \
 		--ignore=tests/test_notebooks.py \
 		--ignore=tests/rundb/test_httpdb.py \
 		-rf \

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -91,6 +91,8 @@ default_config = {
     # sets the background color that is used in printed tables in jupyter
     "background_color": "#4EC64B",
     "artifact_path": "",  # default artifacts path/url
+    # Add {{workflow.uid}} to artifact_path unless user specified a path manually
+    "enrich_artifact_path_with_workflow_id": True,
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to
     #  configure this values on field systems, for newer system this will be configured correctly
     "v3io_api": "http://v3io-webapi:8081",

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -434,6 +434,9 @@ class _LocalRunner(_PipelineRunner):
 
         workflow_id = uuid.uuid4().hex
         pipeline_context.workflow_id = workflow_id
+        # When using KFP, it would do this replacement. When running locally, we need to take care of it.
+        if artifact_path:
+            artifact_path = artifact_path.replace("{{workflow.uid}}", workflow_id)
         pipeline_context.workflow_artifact_path = artifact_path
         project.notifiers.push_start_message(project.metadata.name, id=workflow_id)
         try:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1597,6 +1597,16 @@ class MlrunProject(ModelObj):
             return self.spec.params.get(key, default)
         return default
 
+    def _enrich_artifact_path_with_workflow_uid(self):
+        artifact_path = self.spec.artifact_path or mlrun.mlconf.artifact_path
+        if not mlrun.mlconf.enrich_artifact_path_with_workflow_id:
+            return artifact_path
+        workflow_uid_string = "{{workflow.uid}}"
+        if workflow_uid_string in artifact_path:
+            return artifact_path
+
+        return path.join(artifact_path, workflow_uid_string)
+
     def run(
         self,
         name=None,
@@ -1667,7 +1677,7 @@ class MlrunProject(ModelObj):
         workflow_spec.run_local = local
 
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name
-        artifact_path = artifact_path or self.spec.artifact_path
+        artifact_path = artifact_path or self._enrich_artifact_path_with_workflow_uid()
         workflow_engine = get_workflow_engine(engine or workflow_spec.engine, local)
         workflow_spec.engine = workflow_engine.engine
 

--- a/tests/projects/assets/localpipe.py
+++ b/tests/projects/assets/localpipe.py
@@ -25,6 +25,9 @@ def my_pipe(param1=0):
 
     # hack to return run result to the test for assertions
     mlrun.projects.pipeline_context._test_result = run2
+    mlrun.projects.pipeline_context._artifact_path = (
+        mlrun.projects.pipeline_context.workflow_artifact_path
+    )
 
 
 def args_pipe(param1=0, param2=None):

--- a/tests/projects/test_local_pipeline.py
+++ b/tests/projects/test_local_pipeline.py
@@ -116,3 +116,36 @@ class TestNewProject:
         assert (
             run_result.output("p1") == 6 and run_result.output("p2") == "xy"
         ), "wrong arg values"
+
+    def test_run_pipeline_artifact_path(self):
+        mlrun.projects.pipeline_context.clear(with_project=True)
+        project = self._create_project("localpipe2")
+        generic_path = "/path/without/workflow/id"
+        project.spec.artifact_path = generic_path
+
+        project.run(
+            "p4",
+            workflow_path=str(f'{self.assets_path / "localpipe.py"}'),
+            workflow_handler="my_pipe",
+            arguments={"param1": 7},
+            local=True,
+            artifact_path=generic_path,
+        )
+
+        # When user provided a path, it will be used as-is
+        assert mlrun.projects.pipeline_context._artifact_path == generic_path
+
+        mlrun.projects.pipeline_context.clear(with_project=True)
+        run_status = project.run(
+            "p4",
+            workflow_path=str(f'{self.assets_path / "localpipe.py"}'),
+            workflow_handler="my_pipe",
+            arguments={"param1": 7},
+            local=True,
+        )
+
+        # Otherwise, the artifact_path should automatically have the run id injected in it.
+        assert (
+            mlrun.projects.pipeline_context._artifact_path
+            == f"{generic_path}/{run_status.run_id}"
+        )

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -140,7 +140,7 @@ class TestProject(TestMLRunSystem):
         self._delete_test_project(name)
 
     def test_run_git_build(self):
-        name = "pip e3"
+        name = "pipe3"
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
 


### PR DESCRIPTION
When running a workflow through `project.run()`, impose the following on the artifact path:
* If the user provided the `artifact_path` in the `project.run()` call, do nothing (use the artifact path the user provided)
* if the artifact path already contains `{{workflow.uid}}` in it, do nothing
* else, add `/{{workflow.uid}}` to the artifact path

Added a config parameter (`enrich_artifact_path_with_workflow_id`) to control this - if set to `False` don't do anything. Default is `True`.

Also fixed the implementation of `_LocalRunner` to replace `{{workflow.uid}}` with the workflow id - up until now running local pipelines would not do this replacement (probably assumed this is done elsewhere, but in remote workflows the `KFP` implementation would take care of that, not MLRun, so it was not done at all for local pipelines).

Somewhat unrelated - changed the `makefile` so that when running dockerized tests, it would ignore system tests.