### PR TITLE
[Projects] Fix and simplify function enrichment and build flow

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -315,6 +315,8 @@ class ImageBuilder(ModelObj):
         registry=None,
         load_source_on_run=None,
         origin_filename=None,
+        with_mlrun=None,
+        auto_build=None,
     ):
         self.functionSourceCode = functionSourceCode  #: functionSourceCode
         self.codeEntryType = ""  #: codeEntryType
@@ -329,6 +331,8 @@ class ImageBuilder(ModelObj):
         self.secret = secret  #: secret
         self.registry = registry  #: registry
         self.load_source_on_run = load_source_on_run  #: load_source_on_run
+        self.with_mlrun = with_mlrun  #: with_mlrun
+        self.auto_build = auto_build  #: auto_build
         self.build_pod = None
 
 

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -161,7 +161,7 @@ class BuildStatus:
 
 def build_function(
     function: Union[str, mlrun.runtimes.BaseRuntime],
-    with_mlrun: bool = True,
+    with_mlrun: bool = None,
     skip_deployed: bool = False,
     image=None,
     base_image=None,

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -24,7 +24,9 @@ def _get_engine_and_function(function, project=None):
                 )
             function = pipeline_context.functions[function]
     elif project:
-        function = enrich_function_object(project, function)
+        # if a user provide the function object we enrich in-place so build, deploy, etc.
+        # will update the original function object status/image, and not the copy (may fail fn.run())
+        function = enrich_function_object(project, function, copy_function=False)
 
     if not pipeline_context.workflow:
         return "local", function

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -50,6 +50,7 @@ def run_function(
     local: bool = False,
     verbose: bool = None,
     project_object=None,
+    auto_build=None,
 ) -> Union[mlrun.model.RunObject, kfp.dsl.ContainerOp]:
     """Run a local or remote task as part of a local/kubeflow pipeline
 
@@ -103,6 +104,8 @@ def run_function(
     :param watch:           watch/follow run log, True by default
     :param local:           run the function locally vs on the runtime/cluster
     :param verbose:         add verbose prints/logs
+    :param auto_build:      when set to True and the function require build it will be built on the first
+                            function run, use only if you dont plan on changing the build config between runs
 
     :return: MLRun RunObject or KubeFlow containerOp
     """
@@ -134,6 +137,7 @@ def run_function(
             watch=watch,
             local=local,
             artifact_path=pipeline_context.workflow_artifact_path,
+            auto_build=auto_build,
         )
         if run_result:
             run_result._notified = False

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -218,11 +218,11 @@ def get_db_function(project, key) -> mlrun.runtimes.BaseRuntime:
 
 
 def enrich_function_object(
-    project, function, decorator=None
+    project, function, decorator=None, copy_function=True
 ) -> mlrun.runtimes.BaseRuntime:
     if hasattr(function, "_enriched"):
         return function
-    f = function.copy()
+    f = function.copy() if copy_function else function
     f.metadata.project = project.metadata.name
     setattr(f, "_enriched", True)
     src = f.spec.build.source
@@ -239,6 +239,7 @@ def enrich_function_object(
         else:
             f.spec.build.source = project.spec.source
             f.spec.build.load_source_on_run = project.spec.load_source_on_run
+            f.verify_base_image()
 
     if project.spec.default_requirements:
         f.with_requirements(project.spec.default_requirements)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1863,7 +1863,7 @@ class MlrunProject(ModelObj):
     def build_function(
         self,
         function: typing.Union[str, mlrun.runtimes.BaseRuntime],
-        with_mlrun: bool = True,
+        with_mlrun: bool = None,
         skip_deployed: bool = False,
         image=None,
         base_image=None,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1886,7 +1886,6 @@ class MlrunProject(ModelObj):
                                 e.g. builder_env={"GIT_TOKEN": token}, does not work yet in KFP
         """
         return build_function(
-            self,
             function,
             with_mlrun=with_mlrun,
             skip_deployed=skip_deployed,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1810,6 +1810,7 @@ class MlrunProject(ModelObj):
         watch: bool = True,
         local: bool = False,
         verbose: bool = None,
+        auto_build=None,
     ) -> typing.Union[mlrun.model.RunObject, kfp.dsl.ContainerOp]:
         """Run a local or remote task as part of a local/kubeflow pipeline
 
@@ -1839,6 +1840,8 @@ class MlrunProject(ModelObj):
         :param watch:           watch/follow run log, True by default
         :param local:           run the function locally vs on the runtime/cluster
         :param verbose:         add verbose prints/logs
+        :param auto_build:      when set to True and the function require build it will be built on the first
+                                function run, use only if you dont plan on changing the build config between runs
 
         :return: MLRun RunObject or KubeFlow containerOp
         """
@@ -1858,6 +1861,7 @@ class MlrunProject(ModelObj):
             local=local,
             verbose=verbose,
             project_object=self,
+            auto_build=auto_build,
         )
 
     def build_function(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -604,6 +604,7 @@ def new_function(
         runner.with_source_archive(source)
     if requirements:
         runner.with_requirements(requirements)
+    runner.verify_base_image()
     if handler:
         runner.spec.default_handler = handler
         if kind.startswith("nuclio"):
@@ -863,6 +864,7 @@ def code_to_function(
     build.secret = get_in(spec, "spec.build.secret")
     if requirements:
         r.with_requirements(requirements)
+    r.verify_base_image()
 
     if r.kind != "local":
         r.spec.env = get_in(spec, "spec.env")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -401,9 +401,15 @@ class BaseRuntime(ModelObj):
         db = self._get_db()
 
         if not self.is_deployed:
-            raise RunError(
-                "function image is not built/ready, use .deploy() method first"
-            )
+            if self.spec.build.auto_build:
+                logger.info(
+                    "Function is not deployed and auto_build flag is set, starting deploy..."
+                )
+                self.deploy(skip_deployed=True)
+            else:
+                raise RunError(
+                    "function image is not built/ready, use .deploy() method first"
+                )
 
         if self.verbose:
             logger.info(f"runspec:\n{runspec.to_yaml()}")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -876,7 +876,23 @@ class BaseRuntime(ModelObj):
         if new_command not in commands:
             commands.append(new_command)
         self.spec.build.commands = commands
+        self.verify_base_image()
         return self
+
+    def verify_base_image(self):
+        build = self.spec.build
+        require_build = build.commands or (
+            build.source and not build.load_source_on_run
+        )
+        if (
+            self.kind not in mlrun.runtimes.RuntimeKinds.nuclio_runtimes()
+            and require_build
+            and self.spec.image
+            and not self.spec.build.base_image
+        ):
+            # when the function require build use the image as the base_image for the build
+            self.spec.build.base_image = self.spec.image
+            self.spec.image = ""
 
     def export(self, target="", format=".yaml", secrets=None, strip=True):
         """save function spec to a local/remote path (default to./function.yaml)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -257,6 +257,7 @@ class BaseRuntime(ModelObj):
         scrape_metrics: bool = None,
         local=False,
         local_code_path=None,
+        auto_build=None,
     ) -> RunObject:
         """Run a local or remote task.
 
@@ -283,6 +284,8 @@ class BaseRuntime(ModelObj):
         :param scrape_metrics: whether to add the `mlrun/scrape-metrics` label to this run's resources
         :param local:      run the function locally vs on the runtime/cluster
         :param local_code_path: path of the code for local runs & debug
+        :param auto_build: when set to True and the function require build it will be built on the first
+                           function run, use only if you dont plan on changing the build config between runs
 
         :return: run context object (RunObject) with run metadata, results and status
         """
@@ -401,7 +404,7 @@ class BaseRuntime(ModelObj):
         db = self._get_db()
 
         if not self.is_deployed:
-            if self.spec.build.auto_build:
+            if self.spec.build.auto_build or auto_build:
                 logger.info(
                     "Function is not deployed and auto_build flag is set, starting deploy..."
                 )

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -337,7 +337,7 @@ class DaskCluster(KubejobRuntime):
     def deploy(
         self,
         watch=True,
-        with_mlrun=True,
+        with_mlrun=None,
         skip_deployed=False,
         is_kfp=False,
         mlrun_version_specifier=None,

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -152,7 +152,7 @@ class RemoteSparkRuntime(KubejobRuntime):
     def deploy(
         self,
         watch=True,
-        with_mlrun=True,
+        with_mlrun=None,
         skip_deployed=False,
         is_kfp=False,
         mlrun_version_specifier=None,

--- a/tests/system/projects/assets/sentiment.py
+++ b/tests/system/projects/assets/sentiment.py
@@ -1,0 +1,9 @@
+# use a package which is not in mlrun image (to test build)
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+
+def handler(context, text):
+    analyzer = SentimentIntensityAnalyzer()
+    score = analyzer.polarity_scores(text)
+    print("score:", str(score))
+    context.log_result("score", str(score))

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -286,7 +286,8 @@ class TestProject(TestMLRunSystem):
 
     def test_build_and_run(self):
         # test that build creates a proper image and run will use the updated function (with the built image)
-        project = mlrun.new_project("buildandrun", context=str(self.assets_path))
+        name = "buildandrun"
+        project = mlrun.new_project(name, context=str(self.assets_path))
 
         # test with user provided function object
         fn = mlrun.code_to_function(
@@ -315,3 +316,4 @@ class TestProject(TestMLRunSystem):
         project.build_function("scores2", with_mlrun=False)
         run_result = project.run_function("scores2", params={"text": "good morning"})
         assert run_result.output("score")
+        self._delete_test_project(name)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -321,6 +321,7 @@ class TestProject(TestMLRunSystem):
 
         # test auto build option (the function will be built on the first time, then run)
         fn = base_fn.copy()
+        fn.metadata.name = "scores3"
         fn.spec.build.auto_build = True
         run_result = project.run_function(fn, params={"text": "good morning"})
         assert fn.status.state == "ready"


### PR DESCRIPTION
* fix project.build_function(), was broken
* do not copy function object in enrichment when its user provided objects (fixes scenario when you use fn.run() after build_function(), it does not use the updated object with the build status/image and will fail)
* when the function require a build we treat the user provided `image` name as the build `base_image`
* add `with_mlrun` to the build spec and try to auto determine if to add `mlrun` package, eliminate the need to specify it on build/deploy
* add `auto_build` option to the build spec, if set and a build is required the function will build the image on the first `.run()`