### PR TITLE
[DB] Improve backup logic

### DIFF
--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   procps \
   sqlite3 \
   vim \
+  mariadb-client \
  && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install --upgrade pip~=21.2.0

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -40,6 +40,13 @@ def init_data(
         is_backup_needed,
     ) = _is_migration_needed(alembic_util, sqlite_migration_util)
     from_scratch = from_scratch or is_migration_from_scratch
+
+    if is_backup_needed:
+        logger.info("DB Backup is needed, backing up...")
+        backup_file_name = datetime.datetime.now().strftime("%Y%m%d%H%M.db")
+        db_backup = DBBackup()
+        db_backup.backup_database(backup_file_name)
+
     if not from_scratch and not perform_migrations_if_needed and is_migration_needed:
         state = mlrun.api.schemas.APIStates.waiting_for_migrations
         logger.info("Migration is needed, changing API state", state=state)
@@ -48,10 +55,6 @@ def init_data(
 
     logger.info("Creating initial data")
     config.httpdb.state = mlrun.api.schemas.APIStates.migrations_in_progress
-    if is_backup_needed:
-        backup_file_name = datetime.datetime.now().strftime("%Y%m%d%H%M.db")
-        db_backup = DBBackup()
-        db_backup.backup_database(backup_file_name)
 
     if from_scratch or is_migration_needed:
         try:

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -43,7 +43,7 @@ def init_data(
 
     if is_backup_needed:
         logger.info("DB Backup is needed, backing up...")
-        backup_file_name = datetime.datetime.now().strftime("%Y%m%d%H%M.db")
+        backup_file_name = datetime.datetime.now().strftime("db_backup_%Y%m%d%H%M.db")
         db_backup = DBBackup()
         db_backup.backup_database(backup_file_name)
 
@@ -143,7 +143,7 @@ def _create_alembic_util() -> AlembicUtil:
 
 def _perform_schema_migrations(alembic_util: AlembicUtil):
     logger.info("Performing schema migration")
-    alembic_util.init_alembic(config.httpdb.db.database_backup_mode == "enabled")
+    alembic_util.init_alembic()
 
 
 def _is_latest_data_version():

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -42,11 +42,8 @@ def init_data(
 
     if is_backup_needed:
         logger.info("DB Backup is needed, backing up...")
-        backup_file_name = datetime.datetime.now(tz=datetime.timezone.utc).strftime(
-            "db_backup_%Y%m%d%H%M.db"
-        )
         db_backup = DBBackupUtil()
-        db_backup.backup_database(backup_file_name)
+        db_backup.backup_database()
 
     if (
         not is_migration_from_scratch
@@ -119,7 +116,8 @@ def _resolve_needed_operations(
         and (is_schema_migration_needed or is_data_migration_needed)
     )
     is_backup_needed = (
-        is_migration_needed
+        config.httpdb.db.backup.mode == "enabled"
+        and is_migration_needed
         and not is_migration_from_scratch
         and not is_database_migration_needed
     )

--- a/mlrun/api/utils/db/alembic.py
+++ b/mlrun/api/utils/db/alembic.py
@@ -1,15 +1,10 @@
-import os
 import pathlib
-import shutil
 import typing
 
 import alembic.command
 import alembic.config
 
-from mlrun import mlconf
 from mlrun.utils import logger
-
-from .mysql import MySQLUtil
 
 
 class AlembicUtil(object):
@@ -20,33 +15,12 @@ class AlembicUtil(object):
         self._alembic_config = alembic.config.Config(self._alembic_config_path)
         self._alembic_output = ""
         self._data_version_is_latest = data_version_is_latest
-        self._db_file_path = self._get_db_file_path()
-        # call to _get_current_revision might create dummy db file so we first of all check whether the db file exist
-        self._db_path_exists = os.path.isfile(self._db_file_path)
         self._revision_history = self._get_revision_history_list()
         self._latest_revision = self._revision_history[0]
         self._initial_revision = self._revision_history[-1]
 
-    def init_alembic(self, use_backups: bool = False):
-        current_revision = self._get_current_revision()
-
-        if (
-            use_backups
-            and self._db_path_exists
-            and current_revision
-            and current_revision not in self._revision_history
-        ):
-            self._downgrade_to_revision(
-                self._db_file_path, current_revision, self._latest_revision
-            )
-
-        # get current revision again if it changed during the last commands
-        current_revision = self._get_current_revision()
-        if use_backups and current_revision:
-            self._backup_revision(
-                self._db_file_path, current_revision, self._latest_revision
-            )
-        logger.debug("Performing schema migrations")
+    def init_alembic(self):
+        logger.debug("Performing alembic schema migrations")
         alembic.command.upgrade(self._alembic_config, "head")
 
     def is_schema_migration_needed(self):
@@ -58,18 +32,6 @@ class AlembicUtil(object):
         if not current_revision:
             return True
         return current_revision == self._initial_revision
-
-    @staticmethod
-    def _get_db_file_path() -> str:
-        """
-        Get the db file path from the dsn.
-        Converts the dsn to the file path. e.g.:
-        sqlite:////mlrun/db/mlrun.db?check_same_thread=false -> /mlrun/db/mlrun.db
-        if mysql is used returns empty string
-        """
-        if "mysql" in mlconf.httpdb.dsn:
-            return ""
-        return mlconf.httpdb.dsn.split("?")[0].split("sqlite:///")[-1]
 
     def _get_current_revision(self) -> typing.Optional[str]:
 
@@ -105,60 +67,6 @@ class AlembicUtil(object):
     @staticmethod
     def _parse_revision_history(output: str) -> typing.List[str]:
         return [line.split(" ")[2].replace(",", "") for line in output.splitlines()]
-
-    def _backup_revision(
-        self, db_file_path: str, current_version: str, latest_revision: str
-    ):
-        if db_file_path == ":memory:":
-            return
-
-        if self._data_version_is_latest and not self.is_schema_migration_needed():
-            logger.debug(
-                "Schema version and Data version are latest, skipping backup..."
-            )
-            return
-
-        if "mysql" in mlconf.httpdb.dsn:
-            self._backup_revision_mysql(db_file_path, current_version)
-        else:
-            self._backup_revision_sqlite(db_file_path, current_version)
-
-    @staticmethod
-    def _backup_revision_sqlite(db_file_path: str, current_version: str):
-        db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
-        backup_path = db_dir_path / f"{current_version}.db"
-
-        logger.debug(
-            "Backing up DB file", db_file_path=db_file_path, backup_path=backup_path
-        )
-        shutil.copy2(db_file_path, backup_path)
-
-    @staticmethod
-    def _backup_revision_mysql(db_file_path: str, current_version: str):
-        db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
-        backup_path = db_dir_path / f"{current_version}.db"
-
-        mysql_util = MySQLUtil()
-        mysql_util.dump_database_to_file(backup_path)
-
-    @staticmethod
-    def _downgrade_to_revision(
-        db_file_path: str, current_revision: str, fallback_version: str
-    ):
-        db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
-        backup_path = db_dir_path / f"{fallback_version}.db"
-
-        if not os.path.isfile(backup_path):
-            raise RuntimeError(
-                f"Cannot fall back to revision {fallback_version}, "
-                f"no back up exists. Current revision: {current_revision}"
-            )
-
-        # backup the current DB
-        current_backup_path = db_dir_path / f"{current_revision}.db"
-        shutil.copy2(db_file_path, current_backup_path)
-
-        shutil.copy2(backup_path, db_file_path)
 
     def _save_output(self, text: str, *_):
         self._alembic_output += f"{text}\n"

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -9,7 +9,7 @@ from mlrun import mlconf
 from mlrun.utils import logger
 
 
-class DBBackup(object):
+class DBBackupUtil(object):
     def backup_database(self, backup_file_name: str) -> None:
         if ":memory:" in mlconf.httpdb.dsn:
             return
@@ -52,14 +52,19 @@ class DBBackup(object):
     def _load_database_backup_sqlite(self, backup_file_name: str) -> None:
         db_file_path = self._get_sqlite_db_file_path()
         backup_path = self._get_backup_file_path(backup_file_name)
+
+        logger.debug(
+            "Loading sqlite DB backup file",
+            db_file_path=db_file_path,
+            backup_path=backup_path,
+        )
         shutil.copy2(backup_path, db_file_path)
 
     def _backup_database_mysql(self, backup_file_name: str) -> None:
         backup_path = self._get_backup_file_path(backup_file_name)
 
-        logger.debug("Backing up mysql DB file", backup_path=backup_path)
+        logger.debug("Backing up mysql DB data", backup_path=backup_path)
         dsn_data = mlrun.api.utils.db.mysql.MySQLUtil.get_mysql_dsn_data()
-
         self._run_shell_command(
             "mysqldump "
             f"-h f{dsn_data['host']} "
@@ -76,6 +81,9 @@ class DBBackup(object):
         """
         backup_path = self._get_backup_file_path(backup_file_name)
 
+        logger.debug(
+            "Loading mysql DB backup data", backup_path=backup_path,
+        )
         dsn_data = mlrun.api.utils.db.mysql.MySQLUtil.get_mysql_dsn_data()
         self._run_shell_command(
             "mysql "

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -73,11 +73,10 @@ class DBBackup(object):
             return
         elif "mysql" in mlconf.httpdb.dsn:
             db_dir_path = pathlib.Path(mlconf.httpdb.dirpath)
-            return db_dir_path / backup_file_name
         else:
             db_file_path = self._get_sqlite_db_file_path()
             db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
-            return db_dir_path / backup_file_name
+        return db_dir_path / backup_file_name
 
     @staticmethod
     def _get_sqlite_db_file_path() -> str:

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -72,7 +72,7 @@ class DBBackup(object):
         if ":memory:" in mlconf.httpdb.dsn:
             return
         elif "mysql" in mlconf.httpdb.dsn:
-            db_dir_path = pathlib.Path(mlconf.httpdb.dirpath)
+            db_dir_path = pathlib.Path(mlconf.httpdb.dirpath) / "mysql"
         else:
             db_file_path = self._get_sqlite_db_file_path()
             db_dir_path = pathlib.Path(os.path.dirname(db_file_path))

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -173,7 +173,7 @@ class DBBackupUtil(object):
         return mlconf.httpdb.dsn.split("?")[0].split("sqlite:///")[-1]
 
     @staticmethod
-    def _run_shell_command(command):
+    def _run_shell_command(command: str) -> int:
         logger.debug(
             "Running shell command", command=command,
         )

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -1,0 +1,90 @@
+import os
+import pathlib
+import shutil
+import typing
+
+import mlrun.api.utils.db.mysql
+from mlrun import mlconf
+from mlrun.utils import logger
+
+
+class DBBackup(object):
+    def backup_database(self, backup_file_name: str) -> None:
+        if ":memory:" in mlconf.httpdb.dsn:
+            return
+        elif "mysql" in mlconf.httpdb.dsn:
+            self._backup_database_mysql(backup_file_name)
+        else:
+            self._backup_database_sqlite(backup_file_name)
+
+    def load_database_from_backup(
+        self, backup_file_name: str, new_backup_file_name: str
+    ) -> None:
+
+        backup_path = self._get_backup_file_path(backup_file_name)
+        if not backup_path or not os.path.isfile(backup_path):
+            raise RuntimeError(
+                f"Cannot load backup from {backup_file_name}, file doesn't exist"
+            )
+
+        # backup the current DB
+        self.backup_database(new_backup_file_name)
+
+        if ":memory:" in mlconf.httpdb.dsn:
+            return
+        elif "mysql" in mlconf.httpdb.dsn:
+            self._load_database_backup_mysql(backup_file_name)
+        else:
+            self._load_database_backup_sqlite(backup_file_name)
+
+    def _backup_database_sqlite(self, backup_file_name: str) -> None:
+        db_file_path = self._get_sqlite_db_file_path()
+        backup_path = self._get_backup_file_path(backup_file_name)
+
+        logger.debug(
+            "Backing up sqlite DB file",
+            db_file_path=db_file_path,
+            backup_path=backup_path,
+        )
+        shutil.copy2(db_file_path, backup_path)
+
+    def _load_database_backup_sqlite(self, backup_file_name: str) -> None:
+        db_file_path = self._get_sqlite_db_file_path()
+        backup_path = self._get_backup_file_path(backup_file_name)
+        shutil.copy2(backup_path, db_file_path)
+
+    def _backup_database_mysql(self, backup_file_name: str) -> None:
+        backup_path = self._get_backup_file_path(backup_file_name)
+
+        logger.debug("Backing up mysql DB file", backup_path=backup_path)
+
+        mysql_util = mlrun.api.utils.db.mysql.MySQLUtil()
+        mysql_util.dump_database_to_file(backup_path)
+
+    def _load_database_backup_mysql(self, backup_file_name: str) -> None:
+        backup_path = self._get_backup_file_path(backup_file_name)
+        mysql_util = mlrun.api.utils.db.mysql.MySQLUtil()
+        mysql_util.load_database_from_file(backup_path)
+
+    def _get_backup_file_path(
+        self, backup_file_name: str
+    ) -> typing.Optional[pathlib.Path]:
+        if ":memory:" in mlconf.httpdb.dsn:
+            return
+        elif "mysql" in mlconf.httpdb.dsn:
+            db_dir_path = pathlib.Path(mlconf.httpdb.dirpath)
+            return db_dir_path / backup_file_name
+        else:
+            db_file_path = self._get_sqlite_db_file_path()
+            db_dir_path = pathlib.Path(os.path.dirname(db_file_path))
+            return db_dir_path / backup_file_name
+
+    @staticmethod
+    def _get_sqlite_db_file_path() -> str:
+        """
+        Get the db file path from the dsn.
+        Converts the dsn to the file path. e.g.:
+        sqlite:////mlrun/db/mlrun.db?check_same_thread=false -> /mlrun/db/mlrun.db
+        if mysql is used returns empty string
+        """
+        return mlconf.httpdb.dsn.split("?")[0].split("sqlite:///")[-1]

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -67,7 +67,7 @@ class DBBackupUtil(object):
         dsn_data = mlrun.api.utils.db.mysql.MySQLUtil.get_mysql_dsn_data()
         self._run_shell_command(
             "mysqldump "
-            f"-h f{dsn_data['host']} "
+            f"-h {dsn_data['host']} "
             f"-P {dsn_data['port']} "
             f"-u {dsn_data['username']} "
             f"{dsn_data['database']} > {backup_path}"
@@ -87,7 +87,7 @@ class DBBackupUtil(object):
         dsn_data = mlrun.api.utils.db.mysql.MySQLUtil.get_mysql_dsn_data()
         self._run_shell_command(
             "mysql "
-            f"-h f{dsn_data['host']} "
+            f"-h {dsn_data['host']} "
             f"-P {dsn_data['port']} "
             f"-u {dsn_data['username']} "
             f"{dsn_data['database']} < {backup_path}"

--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -117,6 +117,9 @@ class DBBackupUtil(object):
 
     @staticmethod
     def _run_shell_command(command):
+        logger.debug(
+            "Running shell command", command=command,
+        )
         process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -92,28 +92,6 @@ class MySQLUtil(object):
             **extra_flags,
         )
 
-    def dump_database_to_file(self, filepath: pathlib.Path):
-        connection = self._create_connection()
-        try:
-            with connection.cursor() as cursor:
-                database_dump = self._get_database_dump(cursor)
-        finally:
-            connection.close()
-        with open(str(filepath), "w") as f:
-            f.writelines(database_dump)
-
-    def load_database_from_file(self, filepath: pathlib.Path):
-        """
-        To run this operation manually, you can enter the mysql pod and run:
-        mysql -S /var/run/mysqld/mysql.sock -p mlrun < FILE_PATH
-        """
-        with open(str(filepath), "r") as f:
-            database_dump = f.read()
-
-        connection = self._create_connection(multi_statements=True)
-        with connection.cursor() as cursor:
-            cursor.execute(database_dump)
-
     @staticmethod
     def get_dsn() -> str:
         return os.environ.get(MySQLUtil.dsn_env_var, "")

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -76,7 +76,6 @@ class MySQLUtil(object):
         mysql_dsn_data = self.get_mysql_dsn_data()
         if not mysql_dsn_data:
             raise RuntimeError(f"Invalid mysql dsn: {self.get_dsn()}")
-
         return pymysql.connect(
             host=mysql_dsn_data["host"],
             user=mysql_dsn_data["username"],
@@ -95,26 +94,3 @@ class MySQLUtil(object):
             return None
 
         return match.groupdict()
-
-    @staticmethod
-    def _get_database_dump(cursor) -> str:
-        cursor.execute("SHOW TABLES")
-        data = ""
-        table_names = []
-        for table_name in cursor.fetchall():
-            table_names.append(table_name[0])
-
-        for table_name in table_names:
-            data += f"DROP TABLE IF EXISTS `{table_name}`;"
-
-            cursor.execute(f"SHOW CREATE TABLE `{table_name}`;")
-            table_definition = cursor.fetchone()[1]
-            data += f"\n{table_definition};\n\n"
-
-            cursor.execute(f"SELECT * FROM `{table_name}`;")
-            for row in cursor.fetchall():
-                values = ", ".join([f'"{field}"' for field in row])
-                data += f"INSERT INTO `{table_name}` VALUES({values});\n"
-            data += "\n\n"
-
-        return data

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -1,10 +1,8 @@
 import os
-import pathlib
 import re
 import typing
 
 import pymysql
-from pymysql.constants import CLIENT
 
 import mlrun.utils
 
@@ -74,22 +72,16 @@ class MySQLUtil(object):
         finally:
             connection.close()
 
-    def _create_connection(self, multi_statements=False):
+    def _create_connection(self):
         mysql_dsn_data = self.get_mysql_dsn_data()
         if not mysql_dsn_data:
             raise RuntimeError(f"Invalid mysql dsn: {self.get_dsn()}")
-
-        extra_flags = {}
-
-        if multi_statements:
-            extra_flags["client_flag"] = CLIENT.MULTI_STATEMENTS
 
         return pymysql.connect(
             host=mysql_dsn_data["host"],
             user=mysql_dsn_data["username"],
             port=int(mysql_dsn_data["port"]),
             database=mysql_dsn_data["database"],
-            **extra_flags,
         )
 
     @staticmethod

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -144,8 +144,13 @@ default_config = {
             "data_migrations_mode": "enabled",
             # Whether or not to perform database migration from sqlite to mysql on initialization
             "database_migration_mode": "enabled",
-            # Whether or not to use db backups on initialization
-            "database_backup_mode": "enabled",
+            "backup": {
+                # Whether or not to use db backups on initialization
+                "mode": "enabled",
+                "file_format": "db_backup_%Y%m%d%H%M.db",
+                "use_rotation": True,
+                "rotation_limit": 3,
+            },
             "connections_pool_size": 20,
             "connections_pool_max_overflow": 50,
         },

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -46,7 +46,7 @@ def test_init_data_migration_required_recognition() -> None:
     # mock that migration is needed
     original_is_migration_needed = mlrun.api.initial_data._is_migration_needed
     mlrun.api.initial_data._is_migration_needed = unittest.mock.Mock(
-        return_value=(True, False)
+        return_value=(True, False, False)
     )
     mlrun.api.initial_data.init_data()
     assert (

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -44,12 +44,12 @@ def test_migrations_states(
 
 def test_init_data_migration_required_recognition() -> None:
     # mock that migration is needed
-    original_is_migration_needed = mlrun.api.initial_data._is_migration_needed
-    mlrun.api.initial_data._is_migration_needed = unittest.mock.Mock(
+    original_is_migration_needed = mlrun.api.initial_data._resolve_needed_operations
+    mlrun.api.initial_data._resolve_needed_operations = unittest.mock.Mock(
         return_value=(True, False, False)
     )
     mlrun.api.initial_data.init_data()
     assert (
         mlrun.mlconf.httpdb.state == mlrun.api.schemas.APIStates.waiting_for_migrations
     )
-    mlrun.api.initial_data._is_migration_needed = original_is_migration_needed
+    mlrun.api.initial_data._resolve_needed_operations = original_is_migration_needed

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -1,0 +1,153 @@
+import os.path
+import pathlib
+import shutil
+import typing
+import unittest.mock
+
+import pytest
+
+import mlrun.api.utils.db.backup
+import mlrun.api.utils.db.mysql
+from mlrun import mlconf
+
+
+class Constants:
+    sqlite_db_file_path = "test.db"
+    backup_file = "backup.db"
+    new_backup_file = "new_backup.db"
+
+
+def test_backup_and_load_sqlite(mock_db_dsn, mock_shutil_copy, mock_is_file_result):
+    dsn = f"sqlite:///{Constants.sqlite_db_file_path}"
+    mock_db_dsn(dsn)
+
+    db_backup = mlrun.api.utils.db.backup.DBBackup()
+    db_backup.backup_database(Constants.backup_file)
+
+    mock_is_file_result(True)
+    db_backup.load_database_from_backup(
+        Constants.backup_file, Constants.new_backup_file
+    )
+
+    copy_calls = [
+        # first copy - backup via the `backup_database` call
+        unittest.mock.call(
+            Constants.sqlite_db_file_path, pathlib.PosixPath(Constants.backup_file)
+        ),
+        # second copy - via `load_database_from_backup`, backup the current database before loading backup
+        unittest.mock.call(
+            Constants.sqlite_db_file_path, pathlib.PosixPath(Constants.new_backup_file)
+        ),
+        # third copy - via `load_database_from_backup`, load the db backup file
+        unittest.mock.call(
+            pathlib.PosixPath(Constants.backup_file), Constants.sqlite_db_file_path
+        ),
+    ]
+    mock_shutil_copy.assert_has_calls(copy_calls)
+
+
+def test_backup_and_load_mysql(mock_db_dsn, mock_mysql_util, mock_is_file_result):
+    dsn = "mysql://mysql-dsn"
+    mock_db_dsn(dsn)
+
+    db_backup = mlrun.api.utils.db.backup.DBBackup()
+    db_backup.backup_database(Constants.backup_file)
+
+    mock_is_file_result(True)
+    db_backup.load_database_from_backup(
+        Constants.backup_file, Constants.new_backup_file
+    )
+
+    backup_file_path = f"{mlrun.api.utils.db.backup.DBBackup.mysql_database_dir}/{Constants.backup_file}"
+    new_backup_file_path = f"{mlrun.api.utils.db.backup.DBBackup.mysql_database_dir}/{Constants.new_backup_file}"
+
+    mysql_util_calls = [
+        # first backup - backup via the `backup_database` call
+        unittest.mock.call(pathlib.PosixPath(backup_file_path)),
+        # second backup - via `load_database_from_backup`, backup the current database before loading backup
+        unittest.mock.call(pathlib.PosixPath(new_backup_file_path)),
+    ]
+    mock_mysql_util.dump_database_to_file.assert_has_calls(mysql_util_calls)
+    mock_mysql_util.load_database_from_file.assert_called_once_with(
+        pathlib.PosixPath(backup_file_path),
+    )
+
+
+def test_load_backup_file_does_not_exist_sqlite(
+    mock_db_dsn, mock_shutil_copy, mock_is_file_result
+):
+    dsn = f"sqlite:///{Constants.sqlite_db_file_path}"
+    mock_db_dsn(dsn)
+
+    db_backup = mlrun.api.utils.db.backup.DBBackup()
+
+    mock_is_file_result(False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"Cannot load backup from {Constants.backup_file}, file doesn't exist",
+    ):
+        db_backup.load_database_from_backup(
+            Constants.backup_file, Constants.new_backup_file
+        )
+
+    mock_shutil_copy.assert_not_called()
+
+
+def test_load_backup_file_does_not_exist_mysql(
+    mock_db_dsn, mock_mysql_util, mock_is_file_result
+):
+    dsn = "mysql://mysql-dsn"
+    mock_db_dsn(dsn)
+
+    db_backup = mlrun.api.utils.db.backup.DBBackup()
+
+    mock_is_file_result(False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=f"Cannot load backup from {Constants.backup_file}, file doesn't exist",
+    ):
+        db_backup.load_database_from_backup(
+            Constants.backup_file, Constants.new_backup_file
+        )
+
+    mock_mysql_util.dump_database_to_file.assert_not_called()
+    mock_mysql_util.load_database_from_file.assert_not_called()
+
+
+@pytest.fixture()
+def mock_db_dsn(monkeypatch) -> typing.Callable:
+    def _mock_db_dsn(dsn):
+        monkeypatch.setattr(mlconf.httpdb, "dsn", dsn)
+
+    return _mock_db_dsn
+
+
+@pytest.fixture()
+def mock_is_file_result(monkeypatch) -> typing.Callable:
+    def _mock_is_file_result(result=True):
+        def _file_exists(_):
+            return result
+
+        monkeypatch.setattr(os.path, "isfile", _file_exists)
+
+    return _mock_is_file_result
+
+
+@pytest.fixture()
+def mock_shutil_copy(monkeypatch) -> unittest.mock.Mock:
+    copy = unittest.mock.Mock()
+    monkeypatch.setattr(shutil, "copy2", copy)
+    return copy
+
+
+@pytest.fixture()
+def mock_mysql_util(monkeypatch) -> unittest.mock.Mock:
+    mysql_util = unittest.mock.Mock()
+
+    def _mysql_util():
+        return mysql_util
+
+    monkeypatch.setattr(mlrun.api.utils.db.mysql, "MySQLUtil", _mysql_util)
+    return mysql_util

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -21,7 +21,7 @@ def test_backup_and_load_sqlite(mock_db_dsn, mock_shutil_copy, mock_is_file_resu
     dsn = f"sqlite:///{Constants.sqlite_db_file_path}"
     mock_db_dsn(dsn)
 
-    db_backup = mlrun.api.utils.db.backup.DBBackup()
+    db_backup = mlrun.api.utils.db.backup.DBBackupUtil()
     db_backup.backup_database(Constants.backup_file)
 
     mock_is_file_result(True)
@@ -50,7 +50,7 @@ def test_backup_and_load_mysql(mock_db_dsn, mock_mysql_util, mock_is_file_result
     dsn = "mysql://mysql-dsn"
     mock_db_dsn(dsn)
 
-    db_backup = mlrun.api.utils.db.backup.DBBackup()
+    db_backup = mlrun.api.utils.db.backup.DBBackupUtil()
     db_backup.backup_database(Constants.backup_file)
 
     mock_is_file_result(True)
@@ -58,8 +58,8 @@ def test_backup_and_load_mysql(mock_db_dsn, mock_mysql_util, mock_is_file_result
         Constants.backup_file, Constants.new_backup_file
     )
 
-    backup_file_path = f"{mlrun.api.utils.db.backup.DBBackup.mysql_database_dir}/{Constants.backup_file}"
-    new_backup_file_path = f"{mlrun.api.utils.db.backup.DBBackup.mysql_database_dir}/{Constants.new_backup_file}"
+    backup_file_path = f"{mlrun.api.utils.db.backup.DBBackupUtil.mysql_database_dir}/{Constants.backup_file}"
+    new_backup_file_path = f"{mlrun.api.utils.db.backup.DBBackupUtil.mysql_database_dir}/{Constants.new_backup_file}"
 
     mysql_util_calls = [
         # first backup - backup via the `backup_database` call
@@ -79,7 +79,7 @@ def test_load_backup_file_does_not_exist_sqlite(
     dsn = f"sqlite:///{Constants.sqlite_db_file_path}"
     mock_db_dsn(dsn)
 
-    db_backup = mlrun.api.utils.db.backup.DBBackup()
+    db_backup = mlrun.api.utils.db.backup.DBBackupUtil()
 
     mock_is_file_result(False)
 
@@ -100,7 +100,7 @@ def test_load_backup_file_does_not_exist_mysql(
     dsn = "mysql://mysql-dsn"
     mock_db_dsn(dsn)
 
-    db_backup = mlrun.api.utils.db.backup.DBBackup()
+    db_backup = mlrun.api.utils.db.backup.DBBackupUtil()
 
     mock_is_file_result(False)
 

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -138,15 +138,19 @@ def test_backup_file_rotation(mock_db_dsn, mock_listdir_result, mock_os_remove):
 
 @pytest.fixture()
 def mock_db_dsn(monkeypatch) -> typing.Callable:
-    old_dsn_value = os.environ.get("MLRUN_HTTPDB__DSN", None)
+    dsn_env_var = "MLRUN_HTTPDB__DSN"
+    old_dsn_value = os.environ.get(dsn_env_var, None)
 
     def _mock_db_dsn(dsn):
         monkeypatch.setattr(mlconf.httpdb, "dsn", dsn)
-        os.environ["MLRUN_HTTPDB__DSN"] = dsn
+        os.environ[dsn_env_var] = dsn
 
     yield _mock_db_dsn
 
-    os.environ["MLRUN_HTTPDB__DSN"] = old_dsn_value
+    if old_dsn_value is None:
+        os.environ.pop(dsn_env_var)
+    else:
+        os.environ[dsn_env_var] = old_dsn_value
 
 
 @pytest.fixture()

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -138,11 +138,15 @@ def test_backup_file_rotation(mock_db_dsn, mock_listdir_result, mock_os_remove):
 
 @pytest.fixture()
 def mock_db_dsn(monkeypatch) -> typing.Callable:
+    old_dsn_value = os.environ.get("MLRUN_HTTPDB__DSN", None)
+
     def _mock_db_dsn(dsn):
         monkeypatch.setattr(mlconf.httpdb, "dsn", dsn)
         os.environ["MLRUN_HTTPDB__DSN"] = dsn
 
-    return _mock_db_dsn
+    yield _mock_db_dsn
+
+    os.environ["MLRUN_HTTPDB__DSN"] = old_dsn_value
 
 
 @pytest.fixture()


### PR DESCRIPTION
- Move backup logic out of alembic util
- Fix mysql backup
- No automatic load from backup
- Backup condition is now: data/schema migration is needed, not from scratch and database migration is not needed.

For loading MySQL from backup:
Either exec into the mlrun pod and run:
```
mysql -h mlrun-db -P 3306 -u root mlrun < DB_BACKUP_FILE_PATH
```
Or exec into the db pod and run
```
mysql -S /var/run/mysqld/mysql.sock mlrun < DB_BACKUP_FILE_PATH
```

Fixes: https://jira.iguazeng.com/browse/ML-1652