### PR TITLE
[Images] Bump CUDA to 11.2.1 in `ml-models-gpu` image 

### DIFF
--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG CUDA_VER=11.0
+ARG CUDA_VER=11.2
 
 FROM nvidia/cuda:${CUDA_VER}-cudnn8-devel-ubuntu18.04
 


### PR DESCRIPTION
Continuing https://github.com/mlrun/mlrun/pull/1603 we need to bump CUDA as well according to https://www.tensorflow.org/install/source#gpu

Implements https://jira.iguazeng.com/browse/ML-1535