### PR TITLE
[API] Fix pipelines creation breakage

### DIFF
--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -46,7 +46,9 @@ class Pipelines(metaclass=mlrun.utils.singleton.Singleton,):
         # When instead of host we provided namespace we tackled this issue
         # https://github.com/canonical/bundle-kubeflow/issues/412
         # TODO: When we'll move to kfp 1.4.0 (server side) it should be resolved
-        kfp_client = kfp.Client(host=f"http://ml-pipeline.{namespace}.svc.cluster.local:8888")
+        kfp_client = kfp.Client(
+            host=f"http://ml-pipeline.{namespace}.svc.cluster.local:8888"
+        )
         if project != "*":
             run_dicts = []
             while page_token is not None:
@@ -92,7 +94,9 @@ class Pipelines(metaclass=mlrun.utils.singleton.Singleton,):
         # When instead of host we provided namespace we tackled this issue
         # https://github.com/canonical/bundle-kubeflow/issues/412
         # TODO: When we'll move to kfp 1.4.0 (server side) it should be resolved
-        kfp_client = kfp.Client(host=f"http://ml-pipeline.{namespace}.svc.cluster.local:8888")
+        kfp_client = kfp.Client(
+            host=f"http://ml-pipeline.{namespace}.svc.cluster.local:8888"
+        )
         run = None
         try:
             api_run_detail = kfp_client.get_run(run_id)
@@ -156,7 +160,9 @@ class Pipelines(metaclass=mlrun.utils.singleton.Singleton,):
             # When instead of host we provided namespace we tackled this issue
             # https://github.com/canonical/bundle-kubeflow/issues/412
             # TODO: When we'll move to kfp 1.4.0 (server side) it should be resolved
-            kfp_client = kfp.Client(host=f"http://ml-pipeline.{namespace}.svc.cluster.local:8888")
+            kfp_client = kfp.Client(
+                host=f"http://ml-pipeline.{namespace}.svc.cluster.local:8888"
+            )
             experiment = kfp_client.create_experiment(name=experiment_name)
             run = kfp_client.run_pipeline(
                 experiment.id, run_name, pipeline_file.name, params=arguments


### PR DESCRIPTION
After we bumped kfp in https://github.com/mlrun/mlrun/pull/1439 we started getting this error when trying to create a pipeline:
```
2022-01-26 01:07:05,618 [warning] Failed creating pipeline: {'traceback': 'Traceback (most recent call last):
  File "/mlrun/mlrun/api/crud/pipelines.py", line 145, in create_pipeline
    experiment = kfp_client.create_experiment(name=experiment_name, namespace=namespace)
  File "/usr/local/lib/python3.7/site-packages/kfp/_client.py", line 450, in create_experiment
    experiment_name=name, namespace=namespace)
  File "/usr/local/lib/python3.7/site-packages/kfp/_client.py", line 582, in get_experiment
    resource_reference_key_id=namespace)
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/api/experiment_service_api.py", line 567, in list_experiment
    return self.list_experiment_with_http_info(**kwargs)  # noqa: E501
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/api/experiment_service_api.py", line 682, in list_experiment_with_http_info
    collection_formats=collection_formats)
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 369, in call_api
    _preload_content, _request_timeout, _host)
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 188, in __call_api
    raise e
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 185, in __call_api
    _request_timeout=_request_timeout)
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/api_client.py", line 393, in request
    headers=headers)
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/rest.py", line 234, in GET
    query_params=query_params)
  File "/usr/local/lib/python3.7/site-packages/kfp_server_api/rest.py", line 224, in request
    raise ApiException(http_resp=r)
kfp_server_api.exceptions.ApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({\'Content-Type\': \'application/json\', \'Trailer\': \'Grpc-Trailer-Content-Type\', \'Date\': \'Wed, 26 Jan 2022 01:07:05 GMT\', \'Transfer-Encoding\': \'chunked\'})
HTTP response body: {"error":"Invalid input error:  , ListExperiment cannot filter by namespace.","message":"Invalid input error: In single-user mode, ListExperiment cannot filter by namespace.","code":3,"details":[{"@type":"type.googleapis.com/api.Error","error_message":"In single-user mode, ListExperiment cannot filter by namespace.","error_details":"Invalid input error: In single-user mode, ListExperiment cannot filter by namespace."}]}
```
It looks like we're hitting this one https://github.com/canonical/bundle-kubeflow/issues/412
According to what they wrote there, it should be solved to us when we'll upgrade our kfp server to 1.4.0, but we're currently running with 1.0.1, so for now, to workaround the bug, I stopped setting the namespace and instead setting the host directly (otherwise the client can't find the server). Left a TODO to change that back when we're bumping kfp server