### PR TITLE
[Model Monitoring] Support tracking of complex types + custom inputs/outputs

### DIFF
--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import os
 import warnings
 from collections import namedtuple
@@ -25,6 +24,7 @@ import v3io
 
 import mlrun.errors
 from mlrun.config import config as mlconf
+from mlrun.utils import dict_to_json
 
 _cached_control_session = None
 
@@ -375,6 +375,7 @@ class OutputStream:
         create=True,
         endpoint=None,
         access_key=None,
+        simulated=False,
     ):
         v3io_client_kwargs = {}
         if endpoint:
@@ -384,8 +385,10 @@ class OutputStream:
 
         self._v3io_client = v3io.dataplane.Client(**v3io_client_kwargs)
         self._container, self._stream_path = split_path(stream_path)
+        self._simulated = simulated
+        self._simulation_queue = []
 
-        if create:
+        if create and not simulated:
 
             # this import creates an import loop via the utils module, so putting it in execution path
             from mlrun.utils.helpers import logger
@@ -412,12 +415,21 @@ class OutputStream:
                 response.raise_for_status([409, 204])
 
     def push(self, data):
+        def dump_record(rec):
+            if not isinstance(rec, (str, bytes)):
+                return dict_to_json(rec)
+            return str(rec)
+
         if not isinstance(data, list):
             data = [data]
-        records = [{"data": json.dumps(rec)} for rec in data]
-        self._v3io_client.put_records(
-            container=self._container, path=self._stream_path, records=records
-        )
+        records = [{"data": dump_record(rec)} for rec in data]
+        if self._simulated:
+            # for mock testing
+            self._simulation_queue.extend(records)
+        else:
+            self._v3io_client.put_records(
+                container=self._container, path=self._stream_path, records=records
+            )
 
 
 class V3ioStreamClient:

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -375,7 +375,7 @@ class OutputStream:
         create=True,
         endpoint=None,
         access_key=None,
-        simulated=False,
+        mock=False,
     ):
         v3io_client_kwargs = {}
         if endpoint:
@@ -385,10 +385,10 @@ class OutputStream:
 
         self._v3io_client = v3io.dataplane.Client(**v3io_client_kwargs)
         self._container, self._stream_path = split_path(stream_path)
-        self._simulated = simulated
-        self._simulation_queue = []
+        self._mock = mock
+        self._mock_queue = []
 
-        if create and not simulated:
+        if create and not mock:
 
             # this import creates an import loop via the utils module, so putting it in execution path
             from mlrun.utils.helpers import logger
@@ -423,9 +423,9 @@ class OutputStream:
         if not isinstance(data, list):
             data = [data]
         records = [{"data": dump_record(rec)} for rec in data]
-        if self._simulated:
+        if self._mock:
             # for mock testing
-            self._simulation_queue.extend(records)
+            self._mock_queue.extend(records)
         else:
             self._v3io_client.put_records(
                 container=self._container, path=self._stream_path, records=records

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -19,6 +19,7 @@ import traceback
 from enum import Enum
 from io import BytesIO
 
+import numpy
 from numpy.core.fromnumeric import mean
 
 import mlrun
@@ -616,7 +617,7 @@ class VotingEnsemble(BaseModelRouter):
         List
             The model's predictions
         """
-        if type(response) == list:
+        if isinstance(response, (list, numpy.ndarray)):
             return response
         try:
             self.format_response_with_col_name_flag = True

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -314,9 +314,33 @@ class V2ModelServer(StepToDict):
 
         response = self.postprocess(response)
         if self._model_logger:
-            self._model_logger.push(start, request, response, op)
+            inputs, outputs = self.logged_results(request, response, op)
+            if inputs is None and outputs is None:
+                self._model_logger.push(start, request, response, op)
+            else:
+                track_request = {"id": event_id, "inputs": inputs or []}
+                track_response = {"outputs": outputs or []}
+                self._model_logger.push(start, track_request, track_response, op)
         event.body = _update_result_body(self._result_path, original_body, response)
         return event
+
+    def logged_results(self, request: dict, response: dict, op: str):
+        """hook for controlling which results are tracked by the model monitoring
+
+        this hook allow controlling which input/output data is logged by the model monitoring
+        allow filtering out columns or adding custom values, can also be used to monitor derived metrics
+        for example in image classification calculate and track the RGB values vs the image bitmap
+
+        the request["inputs"] holds a list of input values/arrays, the response["outputs"] holds a list of
+        corresponding output values/arrays (the schema of the input/output fields is stored in the model object),
+        this method should return lists of alternative inputs and outputs which will be monitored
+
+        :param request:   predict/explain request, see model serving docs for details
+        :param response:  result from the model predict/explain (after postprocess())
+        :param op:        operation (predict/infer or explain)
+        :returns: the input and output lists to track
+        """
+        return None, None
 
     def validate(self, request, operation):
         """validate the event body (after preprocess)"""

--- a/tests/serving/test_tracking.py
+++ b/tests/serving/test_tracking.py
@@ -1,0 +1,86 @@
+import json
+from pprint import pprint
+
+import numpy as np
+
+import mlrun
+
+testdata = '{"inputs": [[5, 6]]}'
+
+
+class ModelTestingClass(mlrun.serving.V2ModelServer):
+    def load(self):
+        print("loading")
+
+    def predict(self, request):
+        print("predict:", request)
+        multiplier = self.get_param("multiplier", 1)
+        outputs = [value[0] * multiplier for value in request["inputs"]]
+        return np.array(outputs)  # complex result type to check serialization
+
+
+class ModelTestingCustomTrack(ModelTestingClass):
+    def logged_results(self, request: dict, response: dict, op: str):
+        return [[1]], [self.get_param("multiplier", 1)]
+
+
+def test_tracking():
+    # test that predict() was tracked properly in the stream
+    fn = mlrun.new_function("tests", kind="serving")
+    fn.add_model("my", ".", class_name=ModelTestingClass(multiplier=2))
+    fn.set_tracking("v3io://fake", stream_args={"simulated": True, "access_key": "x"})
+
+    server = fn.to_mock_server()
+    server.test("/v2/models/my/infer", testdata)
+
+    fake_stream = server.context.stream.output_stream._simulation_queue
+    assert len(fake_stream) == 1
+    assert rec_to_data(fake_stream[0]) == ("my", "ModelTestingClass", [[5, 6]], [10])
+
+
+def test_custom_tracking():
+    # test custom values tracking (using the logged_results() hook)
+    fn = mlrun.new_function("tests", kind="serving")
+    fn.add_model("my", ".", class_name=ModelTestingCustomTrack(multiplier=2))
+    fn.set_tracking("v3io://fake", stream_args={"simulated": True, "access_key": "x"})
+
+    server = fn.to_mock_server()
+    server.test("/v2/models/my/infer", testdata)
+
+    fake_stream = server.context.stream.output_stream._simulation_queue
+    assert len(fake_stream) == 1
+    assert rec_to_data(fake_stream[0]) == ("my", "ModelTestingCustomTrack", [[1]], [2])
+
+
+def test_ensemble_tracking():
+    # test proper tracking of an ensemble (router + models are logged)
+    fn = mlrun.new_function("tests", kind="serving")
+    fn.set_topology("router", mlrun.serving.VotingEnsemble(vote_type="regression"))
+    fn.add_model("1", ".", class_name=ModelTestingClass(multiplier=2))
+    fn.add_model("2", ".", class_name=ModelTestingClass(multiplier=3))
+    fn.set_tracking("v3io://fake", stream_args={"simulated": True, "access_key": "x"})
+
+    server = fn.to_mock_server()
+    resp = server.test("/v2/models/infer", testdata)
+
+    fake_stream = server.context.stream.output_stream._simulation_queue
+    assert len(fake_stream) == 3
+    print(resp)
+    results = {}
+    for rec in fake_stream:
+        model, cls, inputs, outputs = rec_to_data(rec)
+        results[model] = [cls, inputs, outputs]
+    pprint(results)
+
+    assert results == {
+        "1": ["ModelTestingClass", [[5, 6]], [10]],
+        "2": ["ModelTestingClass", [[5, 6]], [15]],
+        "VotingEnsemble": ["VotingEnsemble", [[5, 6]], [12.5]],
+    }
+
+
+def rec_to_data(rec):
+    data = json.loads(rec["data"])
+    inputs = data["request"]["inputs"]
+    outputs = data["resp"]["outputs"]
+    return data["model"], data["class"], inputs, outputs


### PR DESCRIPTION
* allow tracking of complex data types like `numpy.ndarray`  (previously failed on the json.dumps)
* allow control of which inputs/outputs values are tracked (using the model server `logged_results()` hook, see the doc string), this is useful for e.g. in deep learning models where you may want to log metrics of the in/out vector (e.g. RGB values) vs the full vector
* add tests for model tracking and v3io simulation