### PR TITLE
[Serving] Improve handling of KFP PipelineParams in nuclio/serving functions

### DIFF
--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -457,7 +457,7 @@ def deploy_op(
 
     if models:
         for m in models:
-            for key in ["model_path", "model_url", "class_name"]:
+            for key in ["key", "model_path", "model_url", "class_name", "model_url"]:
                 if key in m:
                     m[key] = str(m[key])  # verify we stringify pipeline params
             if function.kind == mlrun.runtimes.RuntimeKinds.serving:

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -300,13 +300,13 @@ class ServingRuntime(RemoteRuntime):
 
     def add_model(
         self,
-        key,
-        model_path=None,
-        class_name=None,
-        model_url=None,
-        handler=None,
-        router_step=None,
-        child_function=None,
+        key: str,
+        model_path: str = None,
+        class_name: str = None,
+        model_url: str = None,
+        handler: str = None,
+        router_step: str = None,
+        child_function: str = None,
         **class_args,
     ):
         """add ml model and/or route to the function.


### PR DESCRIPTION
allow using/passing KFP PipelineParams (pipeline args or step outputs) to Nuclio/Serving function spec elements, e.g. in graph steps