### PR TITLE
[Docs] Bump docs docker tag to 0.9.3 [Backport 0.9.x]

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -35,16 +35,16 @@ Where:<br>
 * `MLRUN_DOCKER_REGISTRY` is the docker registry (e.g. `quay.io/`, `gcr.io/`, defaults to empty (docker hub))
 
 
-For example, running `MLRUN_VERSION=0.7.0 make docker-images` will generate the following images:
-  * `mlrun/mlrun-api:0.9.2`
-  * `mlrun/mlrun:0.9.2`
-  * `mlrun/jupyter:0.9.2`
-  * `mlrun/ml-base:0.9.2`
-  * `mlrun/ml-base:0.9.2-py36`
-  * `mlrun/ml-models:0.9.2`
-  * `mlrun/ml-models:0.9.2-py36`
-  * `mlrun/ml-models-gpu:0.9.2` 
-  * `mlrun/ml-models-gpu:0.9.2-py36`
+For example, running `MLRUN_VERSION=0.9.3 make docker-images` will generate the following images:
+  * `mlrun/mlrun-api:0.9.3`
+  * `mlrun/mlrun:0.9.3`
+  * `mlrun/jupyter:0.9.3`
+  * `mlrun/ml-base:0.9.3`
+  * `mlrun/ml-base:0.9.3-py36`
+  * `mlrun/ml-models:0.9.3`
+  * `mlrun/ml-models:0.9.3-py36`
+  * `mlrun/ml-models-gpu:0.9.3` 
+  * `mlrun/ml-models-gpu:0.9.3-py36`
 
 It's also possible to build only a specific image - `make api` (will build only the api image)<br>
 Or a set of images - `make mlrun jupyter base`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -242,7 +242,7 @@ spec:
   image: .mlrun/func-default-remote-demo-ps-latest
   image_pull_policy: Always
   build:
-    base_image: mlrun/mlrun:0.9.2
+    base_image: mlrun/mlrun:0.9.3
     source: git://github.com/mlrun/mlrun
 ```
 
@@ -272,7 +272,7 @@ spec:
   image_pull_policy: Always
   build:
     commands: []
-    base_image: mlrun/mlrun:0.9.2
+    base_image: mlrun/mlrun:0.9.3
     source: git://github.com/mlrun/ci-demo.git
 ```
 
@@ -300,7 +300,7 @@ spec:
   image_pull_policy: Always
   build:
     commands: []
-    base_image: mlrun/mlrun:0.9.2
+    base_image: mlrun/mlrun:0.9.3
 ```
 
 Next, run the following MLRun CLI command to build the function; replace the `<...>` placeholders to match your configuration:

--- a/docs/install.md
+++ b/docs/install.md
@@ -248,12 +248,12 @@ To use MLRun with your local Docker registry, run the MLRun API service, dashboa
 ```sh
 SHARED_DIR=~/mlrun-data
 
-docker pull mlrun/jupyter:0.9.2
-docker pull mlrun/mlrun-ui:0.9.2
+docker pull mlrun/jupyter:0.9.3
+docker pull mlrun/mlrun-ui:0.9.3
 
 docker network create mlrun-network
-docker run -it -p 8080:8080 -p 30040:8888 --rm -d --network mlrun-network --name jupyter -v ${SHARED_DIR}:/home/jovyan/data mlrun/jupyter:0.9.2
-docker run -it -p 30050:80 --rm -d --network mlrun-network --name mlrun-ui -e MLRUN_API_PROXY_URL=http://jupyter:8080 mlrun/mlrun-ui:0.9.2
+docker run -it -p 8080:8080 -p 30040:8888 --rm -d --network mlrun-network --name jupyter -v ${SHARED_DIR}:/home/jovyan/data mlrun/jupyter:0.9.3
+docker run -it -p 30050:80 --rm -d --network mlrun-network --name mlrun-ui -e MLRUN_API_PROXY_URL=http://jupyter:8080 mlrun/mlrun-ui:0.9.3
 ```
 
 When the execution completes &mdash;

--- a/hack/local/README.md
+++ b/hack/local/README.md
@@ -28,12 +28,12 @@ To use MLRun with your local Docker registry, run the MLRun API service, dashboa
 ```
 SHARED_DIR=~/mlrun-data
 
-docker pull mlrun/jupyter:0.9.2
-docker pull mlrun/mlrun-ui:0.9.2
+docker pull mlrun/jupyter:0.9.3
+docker pull mlrun/mlrun-ui:0.9.3
 
 docker network create mlrun-network
-docker run -it -p 8080:8080 -p 8888:8888 --rm -d --network mlrun-network --name jupyter -v ${SHARED_DIR}:/home/jovyan/data mlrun/jupyter:0.9.2
-docker run -it -p 4000:80 --rm -d --network mlrun-network --name mlrun-ui -e MLRUN_API_PROXY_URL=http://jupyter:8080 mlrun/mlrun-ui:0.9.2
+docker run -it -p 8080:8080 -p 8888:8888 --rm -d --network mlrun-network --name jupyter -v ${SHARED_DIR}:/home/jovyan/data mlrun/jupyter:0.9.3
+docker run -it -p 4000:80 --rm -d --network mlrun-network --name mlrun-ui -e MLRUN_API_PROXY_URL=http://jupyter:8080 mlrun/mlrun-ui:0.9.3
 ```
 
 When the execution completes &mdash;

--- a/hack/local/mljupy.yaml
+++ b/hack/local/mljupy.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
       - name: jupyter-notebook
-        image: mlrun/jupyter:0.9.2
+        image: mlrun/jupyter:0.9.3
         env:
         - name: MLRUN_NAMESPACE
           valueFrom:

--- a/hack/local/mlrun-local.yaml
+++ b/hack/local/mlrun-local.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: mlrun-api
-        image: mlrun/mlrun-api:0.9.2
+        image: mlrun/mlrun-api:0.9.3
         env:
         - name: MLRUN_NAMESPACE
           valueFrom:
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: mlrun-ui
-        image: mlrun/mlrun-ui:0.9.2
+        image: mlrun/mlrun-ui:0.9.3
         env:
         - name: MLRUN_API_PROXY_URL
           value: http://mlrun-api:8080

--- a/hack/mlrun-all.yaml
+++ b/hack/mlrun-all.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: mlrun-api
-        image: mlrun/mlrun-api:0.9.2
+        image: mlrun/mlrun-api:0.9.3
         env:
         - name: MLRUN_NAMESPACE
           valueFrom:
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: mlrun-ui
-        image: mlrun/mlrun-ui:0.9.2
+        image: mlrun/mlrun-ui:0.9.3
         env:
         - name: MLRUN_API_PROXY_URL
           value: http://mlrun-api:8080

--- a/hack/mlrunapi.yaml
+++ b/hack/mlrunapi.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: mlrun-api
-        image: mlrun/mlrun-api:0.9.2
+        image: mlrun/mlrun-api:0.9.3
         env:
         - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
           value: "default registry url e.g. index.docker.io/<username>, if repository is not set it will default to mlrun"

--- a/hack/mlrunui.yaml
+++ b/hack/mlrunui.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: mlrun-ui
-        image: mlrun/mlrun-ui:0.9.2
+        image: mlrun/mlrun-ui:0.9.3
         env:
         - name: MLRUN_API_PROXY_URL
           value: http://mlrun-api:8080


### PR DESCRIPTION
Backport https://github.com/mlrun/mlrun/pull/1695
