### PR TITLE
[Runtimes] Fixes in nuclio build status API

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -301,7 +301,8 @@ def build_status(
             name,
             project,
             tag,
-            last_log_timestamp=last_log_timestamp,
+            # Workaround since when passing 0.0 to nuclio current timestamp is used and no logs are returned
+            last_log_timestamp=last_log_timestamp or 1.0,
             verbose=verbose,
             auth_info=auth_info,
         )

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1115,7 +1115,7 @@ def _fullname(project, name):
 def get_fullname(name, project, tag):
     if project:
         name = f"{project}-{name}"
-    if tag:
+    if tag and tag != "latest":
         name = f"{name}-{tag}"
     return name
 


### PR DESCRIPTION
Two fixes to the build status API:
1. When a tag is passed to the API and it is `latest`, the nuclio function was not found. This is due to the fact that the UI explicitly passes the tag as `latest`, while most of the flows for building functions do not pass a tag at all, and the `latest` tag is implicitly added to the function when stored to the DB. To overcome this, the nuclio function name was modified to not take the tag into account if it is `latest`. If the user specifically asked for a tag (i.e. `v1` or something) the tag would still be accounted for.
2. If the API didn't get the `last_log_timestamp` parameter, it would use default of `0`, with the intention of providing all logs - for example, the MLRun UI does that. However, the nuclio `get_deploy_status` function uses this to calculate the time to start logs from: `last_time = last_time or (time() * 1000.0)`. When `last_time = 0` it is the same as not passing it at all, and uses the current time, which doesn't show any logs. The workaround would be to pass a very small value instead (used `1`), which shows all the logs - eventually we may want to fix this in `nuclio-jupyter` to separate between `None` and an actual `0` being passed.