### PR TITLE
[DB] Safer MySQL Backup

### DIFF
--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -82,7 +82,7 @@ class DBBackupUtil(object):
         logger.debug("Backing up mysql DB data", backup_path=backup_path)
         dsn_data = mlrun.api.utils.db.mysql.MySQLUtil.get_mysql_dsn_data()
         self._run_shell_command(
-            "mysqldump "
+            "mysqldump --single-transaction --routines --triggers "
             f"-h {dsn_data['host']} "
             f"-P {dsn_data['port']} "
             f"-u {dsn_data['username']} "

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -17,7 +17,10 @@ class Constants:
     new_backup_file = "new_backup.db"
 
     mysql_dsn = "mysql+pymysql://root@mlrun-db:3306/mlrun"
-    mysql_backup_command = "mysqldump -h mlrun-db -P 3306 -u root mlrun > {0}"
+    mysql_backup_command = (
+        "mysqldump --single-transaction --routines --triggers "
+        "-h mlrun-db -P 3306 -u root mlrun > {0}"
+    )
     mysql_load_backup_command = "mysql -h mlrun-db -P 3306 -u root mlrun < {0}"
 
 


### PR DESCRIPTION
Added some flags to the `mysqldump` command:
- `--single-transaction` produces a checkpoint that allows the dump to capture all data prior to the checkpoint while receiving incoming changes. Those incoming changes do not become part of the dump. That ensures the same point-in-time for all tables.
- `--routines` dumps all stored procedures and stored functions.
- `--triggers` dumps all triggers for each table that has them.