### PR TITLE
[CLI] Run/deploy/build project function (from project.yaml)

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1009,9 +1009,12 @@ def func_url_to_runtime(func_url):
             project_instance, name, tag, hash_key = parse_versioned_object_uri(func_url)
             run_db = get_run_db(mlconf.dbpath)
             runtime = run_db.get_function(name, project_instance, tag, hash_key)
-        else:
+        elif func_url == "." or func_url.endswith(".yaml"):
             func_url = "function.yaml" if func_url == "." else func_url
             runtime = import_function_to_dict(func_url, {})
+        else:
+            mlrun_project = load_project(".")
+            runtime = mlrun_project.get_function(func_url, enrich=True).to_dict()
     except Exception as exc:
         logger.error(f"function {func_url} not found, {exc}")
         return None

--- a/tests/projects/assets/handler.py
+++ b/tests/projects/assets/handler.py
@@ -1,0 +1,6 @@
+import mlrun
+
+
+def myhandler(context: mlrun.MLClientCtx, x=4):
+    print(f"Run: {context.name} (uid={context.uid})")
+    context.log_result("y", x * 2)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -199,3 +199,19 @@ def test_set_func_requirements():
         "python -m pip install y",
         "python -m pip install pandas",
     ]
+
+
+def test_function_run_cli():
+    # run function stored in the project spec
+    project_dir_path = pathlib.Path(tests.conftest.results) / "project-run-func"
+    function_path = pathlib.Path(__file__).parent / "assets" / "handler.py"
+    project = mlrun.new_project("run-cli", str(project_dir_path))
+    project.set_function(
+        str(function_path), "my-func", image="mlrun/mlrun", handler="myhandler",
+    )
+    project.export()
+
+    args = "-f my-func --local --dump -p x=3".split()
+    out = tests.conftest.exec_mlrun(args, str(project_dir_path))
+    assert out.find("state: completed") != -1, out
+    assert out.find("y: 6") != -1, out  # = x * 2


### PR DESCRIPTION
mlrun cli run/build/deploy now support specify function name (-f name) and if it is not a db or .yaml path it will be looked up in the current path project.yaml spec, this can be combined with `mlrun project` command:

```python
# load a project from git to ./
mlrun project -n myproj -u "git://github.com/mlrun/project-demo.git" ./proj
# cd to the project dir and run the project function named data-prep with param (-w = watch logs)
cd proj
mlrun run -f data-prep -p x=5 -w
```