### PR TITLE
[Images] Remove Jupyter wrong pvc config

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -43,7 +43,6 @@ ENV MLRUN_ARTIFACT_PATH=$HOME/data \
     MLRUN_HTTPDB__DATA_VOLUME=$HOME/data \
     MLRUN_HTTPDB__DSN='sqlite:////home/jovyan/data/mlrun.db?check_same_thread=false' \
     MLRUN_HTTPDB__LOGS_PATH=$HOME/data/logs \
-    MLRUN_PVC_MOUNT=nfsvol:/home/jovyan/data \
     MLRUN_ENV_FILE=$HOME/mlrun.env
 
 # run the mlrun db (api) and the notebook in parallel

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -129,7 +129,9 @@ class HTTPRunDB(RunDBInterface):
         if version is not None:
             return f"api/{version}" if version else "api"
 
-        api_version_path = "api"
+        api_version_path = (
+            f"api/{config.api_base_version}" if config.api_base_version else "api"
+        )
         return api_version_path
 
     def get_base_api_url(self, path: str, version: str = None) -> str:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -129,9 +129,7 @@ class HTTPRunDB(RunDBInterface):
         if version is not None:
             return f"api/{version}" if version else "api"
 
-        api_version_path = (
-            f"api/{config.api_base_version}" if config.api_base_version else "api"
-        )
+        api_version_path = "api"
         return api_version_path
 
     def get_base_api_url(self, path: str, version: str = None) -> str:

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -73,12 +73,12 @@ def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
             volume_mount_path=volume_mount_path,
             volume_name=volume_name or "pvc",
         )
-    if "MLRUN_PVC_MOUNT" in os.environ:
-        return mount_pvc(volume_name=volume_name or "pvc",)
     # In the case of MLRun-kit when working remotely, no env variables will be defined but auto-mount
     # parameters may still be declared - use them in that case.
     if config.storage.auto_mount_type == "pvc":
         return mount_pvc(**config.get_storage_auto_mount_params())
+    if "MLRUN_PVC_MOUNT" in os.environ:
+        return mount_pvc(volume_name=volume_name or "pvc",)
     if "V3IO_ACCESS_KEY" in os.environ:
         return mount_v3io(name=volume_name or "v3io")
 

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -75,13 +75,12 @@ def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
         )
     if "MLRUN_PVC_MOUNT" in os.environ:
         return mount_pvc(volume_name=volume_name or "pvc",)
-    if "V3IO_ACCESS_KEY" in os.environ:
-        return mount_v3io(name=volume_name or "v3io")
-
     # In the case of MLRun-kit when working remotely, no env variables will be defined but auto-mount
     # parameters may still be declared - use them in that case.
     if config.storage.auto_mount_type == "pvc":
         return mount_pvc(**config.get_storage_auto_mount_params())
+    if "V3IO_ACCESS_KEY" in os.environ:
+        return mount_v3io(name=volume_name or "v3io")
 
     raise ValueError("failed to auto mount, need to set env vars")
 

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -131,9 +131,6 @@ class TestAutoMount:
             mlconf.get_storage_auto_mount_params()
 
     def test_auto_mount_function_with_pvc_config(self, rundb_mock):
-        os.environ.pop("V3IO_ACCESS_KEY", None)
-        os.environ.pop("V3IO_USERNAME", None)
-
         pvc_params = self._setup_pvc_mount()
         pvc_params_str = base64.b64encode(json.dumps(pvc_params).encode())
         mlconf.storage.auto_mount_params = pvc_params_str
@@ -145,7 +142,8 @@ class TestAutoMount:
         self._execute_run(runtime)
         rundb_mock.assert_pvc_mount_configured(pvc_params)
 
+        os.environ.pop("V3IO_ACCESS_KEY", None)
         # This won't work if mount type is not pvc
         mlconf.storage.auto_mount_type = "auto"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="failed to auto mount, need to set env vars"):
             runtime.apply(mlrun.auto_mount())

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -145,5 +145,7 @@ class TestAutoMount:
         os.environ.pop("V3IO_ACCESS_KEY", None)
         # This won't work if mount type is not pvc
         mlconf.storage.auto_mount_type = "auto"
-        with pytest.raises(ValueError, match="failed to auto mount, need to set env vars"):
+        with pytest.raises(
+            ValueError, match="failed to auto mount, need to set env vars"
+        ):
             runtime.apply(mlrun.auto_mount())


### PR DESCRIPTION
In the mlrun-kit, in the getting started demo, we are running some function locally, meaning it was passing through `self.try_auto_mount_based_on_config()` from the runtimes base class, then, when we're running `function.apply(auto_mount())` it receives the same volume mount again, this time for a volume with a different name (`pvc` the default from the code) therefore ending up with two volume mounts on the same path which caused a failure creating the pod:
```
                 'volume_mounts': [{'mountPath': '/home/jovyan/data',
                                    'name': 'shared-persistency'},
                                   {'mountPath': '/home/jovyan/data',
                                    'name': 'pvc'}],
...
 'volumes': [{'name': 'shared-persistency',
              'persistentVolumeClaim': {'claimName': 'mlrun-kit-shared-pvc'}},
             {'name': 'pvc',
              'persistentVolumeClaim': {'claimName': 'mlrun-kit-shared-pvc'}}]}
> 2022-02-07 00:01:26,516 [error] failed to create pod: (422)
Reason: Unprocessable Entity
HTTP response headers: HTTPHeaderDict({'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Date': 'Mon, 07 Feb 2022 00:01:26 GMT', 'Content-Length': '458'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod \"prep-data-7sjbw\" is invalid: spec.containers[0].volumeMounts[1].mountPath: Invalid value: \"/home/jovyan/data\": must be unique","reason":"Invalid","details":{"name":"prep-data-7sjbw","kind":"Pod","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"/home/jovyan/data\": must be unique","field":"spec.containers[0].volumeMounts[1].mountPath"}]},"code":422}
```
To solve this I simply removed the hard coded `MLRUN_PVC_MOUNT` env var from the Jupyter's dockerfile, it does not make sense there.
In addition changed the precedence in `auto_mount` a bit