### PR TITLE
[API] Add `default_function_pod_resources` to the frontend spec endpoint response

### DIFF
--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -48,7 +48,7 @@ def get_frontend_spec(
         auto_mount_type=config.storage.auto_mount_type,
         auto_mount_params=config.get_storage_auto_mount_params(),
         default_artifact_path=config.artifact_path,
-        default_pod_resources=mlrun.mlconf.default_pod_resources.to_dict(),
+        default_user_pod_resources=mlrun.mlconf.default_user_pod_resources.to_dict(),
     )
 
 

--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -48,7 +48,7 @@ def get_frontend_spec(
         auto_mount_type=config.storage.auto_mount_type,
         auto_mount_params=config.get_storage_auto_mount_params(),
         default_artifact_path=config.artifact_path,
-        default_user_pod_resources=mlrun.mlconf.default_user_pod_resources.to_dict(),
+        default_function_pod_resources=mlrun.mlconf.default_function_pod_resources.to_dict(),
     )
 
 

--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -48,6 +48,7 @@ def get_frontend_spec(
         auto_mount_type=config.storage.auto_mount_type,
         auto_mount_params=config.get_storage_auto_mount_params(),
         default_artifact_path=config.artifact_path,
+        default_pod_resources=mlrun.mlconf.default_pod_resources.to_dict(),
     )
 
 

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -55,6 +55,8 @@ from .frontend_spec import (
     FeatureFlags,
     FrontendSpec,
     ProjectMembershipFeatureFlag,
+    Resources,
+    ResourceSpec,
 )
 from .function import FunctionState
 from .marketplace import (

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -44,4 +44,4 @@ class FrontendSpec(pydantic.BaseModel):
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Dict[str, str] = {}
     default_artifact_path: str
-    default_pod_resources: typing.Optional[Resources]
+    default_user_pod_resources: typing.Optional[Resources]

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -44,4 +44,4 @@ class FrontendSpec(pydantic.BaseModel):
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Dict[str, str] = {}
     default_artifact_path: str
-    default_user_pod_resources: Resources = Resources()
+    default_function_pod_resources: Resources = Resources()

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -22,9 +22,9 @@ class FeatureFlags(pydantic.BaseModel):
 
 
 class ResourceSpec(pydantic.BaseModel):
-    cpu: typing.Optional[str] = ""
-    memory: typing.Optional[str] = ""
-    gpu: typing.Optional[str] = ""
+    cpu: typing.Optional[str]
+    memory: typing.Optional[str]
+    gpu: typing.Optional[str]
 
 
 class Resources(pydantic.BaseModel):

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -22,9 +22,9 @@ class FeatureFlags(pydantic.BaseModel):
 
 
 class ResourceSpec(pydantic.BaseModel):
-    cpu: str = None
-    memory: str = None
-    gpu: str = None
+    cpu: str = ""
+    memory: str = ""
+    gpu: str = ""
 
 
 class Resources(pydantic.BaseModel):

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -22,14 +22,14 @@ class FeatureFlags(pydantic.BaseModel):
 
 
 class ResourceSpec(pydantic.BaseModel):
-    cpu: typing.Optional[str]
-    memory: typing.Optional[str]
-    gpu: typing.Optional[str]
+    cpu: str = None
+    memory: str = None
+    gpu: str = None
 
 
 class Resources(pydantic.BaseModel):
-    requests: typing.Optional[ResourceSpec]
-    limits: typing.Optional[ResourceSpec]
+    requests: ResourceSpec = ResourceSpec()
+    limits: ResourceSpec = ResourceSpec()
 
 
 class FrontendSpec(pydantic.BaseModel):
@@ -44,4 +44,4 @@ class FrontendSpec(pydantic.BaseModel):
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Dict[str, str] = {}
     default_artifact_path: str
-    default_user_pod_resources: typing.Optional[Resources]
+    default_user_pod_resources: Resources = Resources()

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -22,9 +22,9 @@ class FeatureFlags(pydantic.BaseModel):
 
 
 class ResourceSpec(pydantic.BaseModel):
-    cpu: str = ""
-    memory: str = ""
-    gpu: str = ""
+    cpu: typing.Optional[str] = ""
+    memory: typing.Optional[str] = ""
+    gpu: typing.Optional[str] = ""
 
 
 class Resources(pydantic.BaseModel):

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -21,6 +21,17 @@ class FeatureFlags(pydantic.BaseModel):
     authentication: AuthenticationFeatureFlag
 
 
+class ResourceSpec(pydantic.BaseModel):
+    cpu: typing.Optional[str]
+    memory: typing.Optional[str]
+    gpu: typing.Optional[str]
+
+
+class Resources(pydantic.BaseModel):
+    requests: typing.Optional[ResourceSpec]
+    limits: typing.Optional[ResourceSpec]
+
+
 class FrontendSpec(pydantic.BaseModel):
     jobs_dashboard_url: typing.Optional[str]
     abortable_function_kinds: typing.List[str] = []
@@ -33,3 +44,4 @@ class FrontendSpec(pydantic.BaseModel):
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Dict[str, str] = {}
     default_artifact_path: str
+    default_pod_resources: typing.Optional[Resources]

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -312,7 +312,7 @@ default_config = {
         # 2. A base-64 encoded json dictionary containing the list of parameters
         "auto_mount_params": "",
     },
-    "default_pod_resources": {
+    "default__user_pod_resources": {
         "requests": {"cpu": "", "memory": "", "gpu": ""},
         "limits": {"cpu": "", "memory": "", "gpu": ""},
     },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -312,6 +312,18 @@ default_config = {
         # 2. A base-64 encoded json dictionary containing the list of parameters
         "auto_mount_params": "",
     },
+    "default_pod_resources": {
+        "requests": {
+            "cpu": "",
+            "memory": "",
+            "gpu": "",
+        },
+        "limits": {
+            "cpu": "",
+            "memory": "",
+            "gpu": "",
+        },
+    }
 }
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -312,7 +312,7 @@ default_config = {
         # 2. A base-64 encoded json dictionary containing the list of parameters
         "auto_mount_params": "",
     },
-    "default__user_pod_resources": {
+    "default_user_pod_resources": {
         "requests": {"cpu": "", "memory": "", "gpu": ""},
         "limits": {"cpu": "", "memory": "", "gpu": ""},
     },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -312,7 +312,7 @@ default_config = {
         # 2. A base-64 encoded json dictionary containing the list of parameters
         "auto_mount_params": "",
     },
-    "default_user_pod_resources": {
+    "default_function_pod_resources": {
         "requests": {"cpu": "", "memory": "", "gpu": ""},
         "limits": {"cpu": "", "memory": "", "gpu": ""},
     },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -313,17 +313,9 @@ default_config = {
         "auto_mount_params": "",
     },
     "default_pod_resources": {
-        "requests": {
-            "cpu": "",
-            "memory": "",
-            "gpu": "",
-        },
-        "limits": {
-            "cpu": "",
-            "memory": "",
-            "gpu": "",
-        },
-    }
+        "requests": {"cpu": "", "memory": "", "gpu": ""},
+        "limits": {"cpu": "", "memory": "", "gpu": ""},
+    },
 }
 
 

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -18,7 +18,12 @@ def test_get_frontend_spec(
     mlrun.api.utils.clients.iguazio.Client().try_get_grafana_service_url = (
         unittest.mock.Mock()
     )
+    default_function_pod_resources = {
+        "requests": {"cpu": "25m", "memory": "1Mi", "gpu": ""},
+        "limits": {"cpu": "2", "memory": "20Gi", "gpu": ""},
+    }
     mlrun.mlconf.httpdb.builder.docker_registry = "quay.io/some-repo"
+    mlrun.mlconf.default_function_pod_resources = default_function_pod_resources
     response = client.get("frontend-spec")
     assert response.status_code == http.HTTPStatus.OK.value
     frontend_spec = mlrun.api.schemas.FrontendSpec(**response.json())
@@ -49,9 +54,8 @@ def test_get_frontend_spec(
         bla = f"{{{expected_template_field}}}"
         assert bla in frontend_spec.function_deployment_target_image_template
 
-    assert frontend_spec.default_function_pod_resources is not None
-    assert isinstance(
-        frontend_spec.default_function_pod_resources, mlrun.api.schemas.Resources
+    assert frontend_spec.default_function_pod_resources, mlrun.api.schemas.Resources(
+        **default_function_pod_resources
     )
 
 

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -49,6 +49,11 @@ def test_get_frontend_spec(
         bla = f"{{{expected_template_field}}}"
         assert bla in frontend_spec.function_deployment_target_image_template
 
+    assert frontend_spec.default_user_pod_resources is not None
+    assert isinstance(
+        frontend_spec.default_user_pod_resources, mlrun.api.schemas.Resources
+    )
+
 
 def test_get_frontend_spec_jobs_dashboard_url_resolution(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -49,9 +49,9 @@ def test_get_frontend_spec(
         bla = f"{{{expected_template_field}}}"
         assert bla in frontend_spec.function_deployment_target_image_template
 
-    assert frontend_spec.default_user_pod_resources is not None
+    assert frontend_spec.default_function_pod_resources is not None
     assert isinstance(
-        frontend_spec.default_user_pod_resources, mlrun.api.schemas.Resources
+        frontend_spec.default_function_pod_resources, mlrun.api.schemas.Resources
     )
 
 


### PR DESCRIPTION
Define default_function_pod_resources scheme in frontend_spec for UI purposes.

Requirements :
https://jira.iguazeng.com/browse/ML-375

Part of :
- https://jira.iguazeng.com/browse/ML-374
- https://jira.iguazeng.com/browse/IG-18106

Next PR's will include the logic for the backend.