### PR TITLE
[Utils] Fix precedence issue with enrich_image_url

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -612,11 +612,14 @@ def _convert_python_package_version_to_image_tag(version: typing.Optional[str]):
 
 
 def enrich_image_url(image_url: str, client_version: str = None) -> str:
+    unstable_versions = ["unstable", "0.0.0+unstable"]
     client_version = _convert_python_package_version_to_image_tag(client_version)
     server_version = _convert_python_package_version_to_image_tag(
         mlrun.utils.version.Version().get()["version"]
     )
     image_url = image_url.strip()
+
+    client_version = client_version if client_version not in unstable_versions else None
     tag = config.images_tag or client_version or server_version
     registry = config.images_registry
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -283,6 +283,14 @@ def test_enrich_image():
             "expected_output": "some/image",
             "images_to_enrich_registry": "",
         },
+        {
+            "image": "mlrun/mlrun",
+            "client_version": "unstable",
+            "images_tag": None,
+            "version": "0.10.5-server-version",
+            "expected_output": "mlrun/mlrun:0.10.5-server-version",
+            "images_to_enrich_registry": "",
+        },
     ]
     default_images_to_enrich_registry = config.images_to_enrich_registry
     for case in cases:


### PR DESCRIPTION
We have three parameters to use when enriching a mlrun image url:
1. Override the version specified by config.images_tag
2. The client version = client_version  
3. The server version = server_version
 
When deciding on an image tag, keep the following in mind:

If an override version is defined, use it;
If not, and the client version is stable, use it;
Otherwise, use the server version.
