### PR TITLE
[System Tests] Set the client version to fix image enrichment

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -175,4 +175,5 @@ jobs:
     - name: Run System Tests
       run: |
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}" \
+        MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
           make test-system-dockerized

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -172,6 +172,7 @@ jobs:
       timeout-minutes: 15
       run: |
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}" \
+        MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
           make test-system-open-source
 
     - name: Output some logs in case of failure

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ test-system: ## Run mlrun system tests
 		tests/system
 
 .PHONY: test-system-open-source
-test-system-open-source: ## Run mlrun system tests with opensource configuration
+test-system-open-source: update-version-file ## Run mlrun system tests with opensource configuration
 	MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=$(MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES) python -m pytest -v \
 		--capture=no \
 		--disable-warnings \


### PR DESCRIPTION
As part of our CI workflows, for each merge to development, a Build workflow is set up to create images for that specific merge so that when the System tests run, they can pull the image versions that correspond to the current development.

Please keep in mind that our ghcr.io image repo is only for Open Source and Enterprise system tests, and it only contains versioned development images in the following format: "\<image-name>:\<latest-version>-\<merge-commit>", like : mlrun/mlrun:0.9.3-f65cf13e.

The MLRun kit started with the current development images(created in the Build workflow from ghcr.io) when we ran our Open source system tests, but the client running the tests was unversioned because the code it pulled was from the development branch.
As a result, the client version sent an unstable version to the server, and the server, which is configured to the ghcr.io repo in system tests, did not find that `unstable` image tag.

This PR will include the `update-version-file`as part of the `test-system-open-source`, which configures the version for the MLRun running (in this case for the client), so the client will now have the version configured and will pass the correct version to the server. 