### PR TITLE
[Artifacts] Fix broken artifact URIs when using `run_function()` 

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -317,7 +317,7 @@ class MLClientCtx(object):
     @property
     def tag(self):
         """run tag (uid or workflow id if exists)"""
-        return self._labels.get("workflow", self._uid)
+        return self._labels.get("workflow") or self._uid
 
     @property
     def iteration(self):

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -129,7 +129,8 @@ def run_function(
         if pipeline_context.workflow:
             local = local or pipeline_context.workflow.run_local
         task.metadata.labels = task.metadata.labels or labels or {}
-        task.metadata.labels["workflow"] = pipeline_context.workflow_id
+        if pipeline_context.workflow_id:
+            task.metadata.labels["workflow"] = pipeline_context.workflow_id
         run_result = function.run(
             runspec=task,
             workdir=workdir,


### PR DESCRIPTION
Fix broken artifact URIs when using `run_function()` (due to None in workflow label)