### PR TITLE
[Builder] Allow to configure whether push/pull registries are insecure

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -84,9 +84,12 @@ def make_kaniko_pod(
         dockerfile = "/empty/Dockerfile"
 
     args = ["--dockerfile", dockerfile, "--context", context, "--destination", dest]
-    if not secret_name:
-        args.append("--insecure")
-        args.append("--insecure-pull")
+    for value, flag in [(config.httpdb.builder.insecure_pull_registry_mode, "--insecure-pull"),
+                        (config.httpdb.builder.insecure_push_registry_mode, "--insecure")]:
+        if value == "disabled":
+            continue
+        if value == "enabled" or (value == "auto" and not secret_name):
+            args.append(flag)
     if verbose:
         args += ["--verbosity", "debug"]
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -84,8 +84,10 @@ def make_kaniko_pod(
         dockerfile = "/empty/Dockerfile"
 
     args = ["--dockerfile", dockerfile, "--context", context, "--destination", dest]
-    for value, flag in [(config.httpdb.builder.insecure_pull_registry_mode, "--insecure-pull"),
-                        (config.httpdb.builder.insecure_push_registry_mode, "--insecure")]:
+    for value, flag in [
+        (config.httpdb.builder.insecure_pull_registry_mode, "--insecure-pull"),
+        (config.httpdb.builder.insecure_push_registry_mode, "--insecure"),
+    ]:
         if value == "disabled":
             continue
         if value == "enabled" or (value == "auto" and not secret_name):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -226,6 +226,12 @@ default_config = {
             # index.docker.io/<username>, if not included repository will default to mlrun
             "docker_registry": "",
             "docker_registry_secret": "",
+            # whether to allow the docker registry we're pulling from to be insecure. "enabled", "disabled" or "auto"
+            # which will resolve by the existence of secret
+            "insecure_pull_registry_mode": "auto",
+            # whether to allow the docker registry we're pushing to, to be insecure. "enabled", "disabled" or "auto"
+            # which will resolve by the existence of secret
+            "insecure_push_registry_mode": "auto",
             # the requirement specifier used by the builder when installing mlrun in images when it runs
             # pip install <requirement_specifier>, e.g. mlrun==0.5.4, mlrun~=0.5,
             # git+https://github.com/mlrun/mlrun@development. by default uses the version

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -3,6 +3,7 @@ import unittest.mock
 import mlrun
 import mlrun.api.schemas
 import mlrun.builder
+import mlrun.k8s_utils
 import mlrun.utils.version
 from mlrun.config import config
 
@@ -40,6 +41,52 @@ def test_build_runtime_use_image_when_no_build():
     )
     assert ready is True
     assert fn.spec.image == image
+
+
+def test_build_runtime_insecure_registries():
+    mlrun.k8s_utils.get_k8s_helper().create_pod = unittest.mock.Mock(
+        side_effect=lambda pod: (pod, "some-namespace")
+    )
+    mlrun.mlconf.httpdb.builder.docker_registry = "registry.hub.docker.com/username"
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind="job",
+        requirements=["some-package"],
+    )
+
+    insecure_flags = {"--insecure", "--insecure-pull"}
+    for pull_mode, push_mode, secret, flags_expected in (
+        ("auto", "auto", "", True),
+        ("auto", "auto", "some-secret-name", False),
+        ("enabled", "enabled", "some-secret-name", True),
+        ("enabled", "enabled", "", True),
+        ("disabled", "disabled", "some-secret-name", False),
+        ("disabled", "disabled", "", False),
+    ):
+        mlrun.mlconf.httpdb.builder.insecure_pull_registry_mode = pull_mode
+        mlrun.mlconf.httpdb.builder.insecure_push_registry_mode = push_mode
+        mlrun.mlconf.httpdb.builder.docker_registry_secret = secret
+        mlrun.builder.build_runtime(
+            mlrun.api.schemas.AuthInfo(),
+            function,
+            with_mlrun=False,
+            mlrun_version_specifier=None,
+            skip_deployed=False,
+        )
+        assert (
+            insecure_flags.issubset(
+                set(
+                    mlrun.k8s_utils.get_k8s_helper()
+                    .create_pod.call_args[0][0]
+                    .pod.spec.containers[0]
+                    .args
+                )
+            )
+            == flags_expected
+        )
 
 
 def test_resolve_mlrun_install_command():

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -43,8 +43,12 @@ def test_build_runtime_use_image_when_no_build():
     assert fn.spec.image == image
 
 
-def test_build_runtime_insecure_registries():
-    mlrun.k8s_utils.get_k8s_helper().create_pod = unittest.mock.Mock(
+def test_build_runtime_insecure_registries(monkeypatch):
+    get_k8s_helper_mock = unittest.mock.Mock()
+    monkeypatch.setattr(
+        mlrun.builder, "get_k8s_helper", lambda *args, **kwargs: get_k8s_helper_mock
+    )
+    mlrun.builder.get_k8s_helper().create_pod = unittest.mock.Mock(
         side_effect=lambda pod: (pod, "some-namespace")
     )
     mlrun.mlconf.httpdb.builder.docker_registry = "registry.hub.docker.com/username"
@@ -79,7 +83,7 @@ def test_build_runtime_insecure_registries():
         assert (
             insecure_flags.issubset(
                 set(
-                    mlrun.k8s_utils.get_k8s_helper()
+                    mlrun.builder.get_k8s_helper()
                     .create_pod.call_args[0][0]
                     .pod.spec.containers[0]
                     .args

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -62,17 +62,47 @@ def test_build_runtime_insecure_registries(monkeypatch):
     )
 
     insecure_flags = {"--insecure", "--insecure-pull"}
-    for pull_mode, push_mode, secret, flags_expected in (
-        ("auto", "auto", "", True),
-        ("auto", "auto", "some-secret-name", False),
-        ("enabled", "enabled", "some-secret-name", True),
-        ("enabled", "enabled", "", True),
-        ("disabled", "disabled", "some-secret-name", False),
-        ("disabled", "disabled", "", False),
-    ):
-        mlrun.mlconf.httpdb.builder.insecure_pull_registry_mode = pull_mode
-        mlrun.mlconf.httpdb.builder.insecure_push_registry_mode = push_mode
-        mlrun.mlconf.httpdb.builder.docker_registry_secret = secret
+    for case in [
+        {
+            "pull_mode": "auto",
+            "push_mode": "auto",
+            "secret": "",
+            "flags_expected": True,
+        },
+        {
+            "pull_mode": "auto",
+            "push_mode": "auto",
+            "secret": "some-secret-name",
+            "flags_expected": False,
+        },
+        {
+            "pull_mode": "enabled",
+            "push_mode": "enabled",
+            "secret": "some-secret-name",
+            "flags_expected": True,
+        },
+        {
+            "pull_mode": "enabled",
+            "push_mode": "enabled",
+            "secret": "",
+            "flags_expected": True,
+        },
+        {
+            "pull_mode": "disabled",
+            "push_mode": "disabled",
+            "secret": "some-secret-name",
+            "flags_expected": False,
+        },
+        {
+            "pull_mode": "disabled",
+            "push_mode": "disabled",
+            "secret": "",
+            "flags_expected": False,
+        },
+    ]:
+        mlrun.mlconf.httpdb.builder.insecure_pull_registry_mode = case["pull_mode"]
+        mlrun.mlconf.httpdb.builder.insecure_push_registry_mode = case["push_mode"]
+        mlrun.mlconf.httpdb.builder.docker_registry_secret = case["secret"]
         mlrun.builder.build_runtime(
             mlrun.api.schemas.AuthInfo(),
             function,
@@ -89,7 +119,7 @@ def test_build_runtime_insecure_registries(monkeypatch):
                     .args
                 )
             )
-            == flags_expected
+            == case["flags_expected"]
         )
 
 


### PR DESCRIPTION
When building an image (using Kaniko) if we're using an insecure docker registry (for pulling from or pushing to) we need to add the appropriate flags (`--insecure-pull`/`--insecure` accordingly)
So far we were resolving whether to have those flags by whether a secret was provided or not (by setting `function.spec.build.secret` or `mlrun.mlconf.httpdb.builder.docker_registry_secret`)
There is no real connection between whether our registry is secured (http vs https) to whether it requires auth, in addition we might have different registries for pull and push and all/one/none of them might be insecure.
To enable controlling that I added two new values under the `mlrun.mlconf.httpdb.builder` config section:
* `insecure_pull_registry_mode`
* `insecure_push_registry_mode`

Both supports the following modes: 
* `enabled` for setting the flag 
* `disabled` for not setting it 
* `auto` to retain the current behavior of resolving by the secret existence

The default is `auto` to keep backwards compatibility