### PR TITLE
[System Tests] Fix failing system tests as a result of none PEP 440 compatiblity 

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -181,5 +181,5 @@ jobs:
     - name: Run System Tests
       run: |
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}" \
-        MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
+        MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_version }}" \
           make test-system-dockerized

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -173,7 +173,7 @@ jobs:
       timeout-minutes: 15
       run: |
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}" \
-        MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
+        MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_version }}" \
           make test-system-open-source
 
     - name: Output some logs in case of failure

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,11 @@ MLRUN_VERSION ?= unstable
 # version for the python package with 0.0.0+
 # if the provided version includes a "+" we replace it with "-" for the docker tag
 MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed -E 's/\+/\-/g')
+MLRUN_PYTHON_PACKAGE_VERSION ?= $(MLRUN_VERSION)
 # if the provided version includes a "-" we replace its first occurrence with "+" to align with PEP 404
-MLRUN_PYTHON_PACKAgE_VERSION ?= $(shell if echo $TEST | grep -Eq "^[0-9]+\.[0-9]+\.[0-9]-.*$"; then echo $TEST | sed 's/\-/\+/'; else echo $TEST; fi)
+ifneq ($(shell echo "$(MLRUN_VERSION)" | grep -E "^[0-9]+\.[0-9]+\.[0-9]-.*$$"),)
+	MLRUN_PYTHON_PACKAGE_VERSION := $(shell echo "$(MLRUN_VERSION)" | sed "s/\-/\+/")
+endif
 ifeq ($(shell echo "$(MLRUN_VERSION)" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+.*$$"),) # empty result from egrep
 	MLRUN_PYTHON_PACKAGE_VERSION := 0.0.0+$(MLRUN_VERSION)
 endif
@@ -59,6 +62,10 @@ MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH ?= $(shell pwd)
 .PHONY: help
 help: ## Display available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: try
+try:
+	@echo $(MLRUN_PYTHON_PACKAGE_VERSION)
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MLRUN_VERSION ?= unstable
 # if the provided version includes a "+" we replace it with "-" for the docker tag
 MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed -E 's/\+/\-/g')
 # if the provided version includes a "-" we replace its first occurrence with "+" to align with PEP 404
-MLRUN_PYTHON_PACKAGE_VERSION ?= $(shell echo "$(MLRUN_VERSION)" | sed 's/\-/\+/')
+MLRUN_PYTHON_PACKAgE_VERSION ?= $(shell if echo $TEST | grep -Eq "^[0-9]+\.[0-9]+\.[0-9]-.*$"; then echo $TEST | sed 's/\-/\+/'; else echo $TEST; fi)
 ifeq ($(shell echo "$(MLRUN_VERSION)" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+.*$$"),) # empty result from egrep
 	MLRUN_PYTHON_PACKAGE_VERSION := 0.0.0+$(MLRUN_VERSION)
 endif

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,6 @@ MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH ?= $(shell pwd)
 help: ## Display available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: try
-try:
-	@echo $(MLRUN_PYTHON_PACKAGE_VERSION)
 
 .PHONY: all
 all:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ MLRUN_VERSION ?= unstable
 # version for the python package with 0.0.0+
 # if the provided version includes a "+" we replace it with "-" for the docker tag
 MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed -E 's/\+/\-/g')
-MLRUN_PYTHON_PACKAGE_VERSION ?= $(MLRUN_VERSION)
+# if the provided version includes a "-" we replace its first occurrence with "+" to align with PEP 404
+MLRUN_PYTHON_PACKAGE_VERSION ?= $(shell echo "$(MLRUN_VERSION)" | sed 's/\-/\+/')
 ifeq ($(shell echo "$(MLRUN_VERSION)" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+.*$$"),) # empty result from egrep
 	MLRUN_PYTHON_PACKAGE_VERSION := 0.0.0+$(MLRUN_VERSION)
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MLRUN_VERSION ?= unstable
 # if the provided version includes a "+" we replace it with "-" for the docker tag
 MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed -E 's/\+/\-/g')
 MLRUN_PYTHON_PACKAGE_VERSION ?= $(MLRUN_VERSION)
-# if the provided version includes a "-" we replace its first occurrence with "+" to align with PEP 404
+# if the provided version is a semver and followed by a "-" we replace its first occurrence with "+" to align with PEP 404
 ifneq ($(shell echo "$(MLRUN_VERSION)" | grep -E "^[0-9]+\.[0-9]+\.[0-9]-.*$$"),)
 	MLRUN_PYTHON_PACKAGE_VERSION := $(shell echo "$(MLRUN_VERSION)" | sed "s/\-/\+/")
 endif

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH ?= $(shell pwd)
 help: ## Display available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-
 .PHONY: all
 all:
 	$(error please pick a target)


### PR DESCRIPTION
- In Enterprise and Open source system tests changes the MLRUN_VERSION that is passed to test-system-dockerized from image_tag to mlrun_version.
- Added logic in Makefile that if MLRUN_VERSION is set to image tag version then when setting MLRUN_PYTHON_PACKAGE_VERSION we modify the version to be PEP 440 compatible which in other words replace the first occurrence of "-" to "+" 