### PR TITLE
[Builder] Support configuring image name prefix template to enforce

### DIFF
--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -36,6 +36,12 @@ def get_frontend_spec(
     function_deployment_target_image_template = mlrun.runtimes.utils.fill_function_image_name_template(
         f"{registry}/", repository, "{project}", "{name}", "{tag}",
     )
+    registries_to_enforce_prefix = (
+        mlrun.runtimes.utils.resolve_function_target_image_registries_to_enforce_prefix()
+    )
+    function_target_image_name_prefix_template = (
+        config.httpdb.builder.function_target_image_name_prefix_template
+    )
     return mlrun.api.schemas.FrontendSpec(
         jobs_dashboard_url=jobs_dashboard_url,
         abortable_function_kinds=mlrun.runtimes.RuntimeKinds.abortable_runtimes(),
@@ -44,6 +50,8 @@ def get_frontend_spec(
         valid_function_priority_class_names=config.get_valid_function_priority_class_names(),
         default_function_image_by_kind=mlrun.mlconf.function_defaults.image_by_kind.to_dict(),
         function_deployment_target_image_template=function_deployment_target_image_template,
+        function_deployment_target_image_name_prefix_template=function_target_image_name_prefix_template,
+        function_deployment_target_image_registries_to_enforce_prefix=registries_to_enforce_prefix,
         function_deployment_mlrun_command=mlrun.builder.resolve_mlrun_install_command(),
         auto_mount_type=config.storage.auto_mount_type,
         auto_mount_params=config.get_storage_auto_mount_params(),

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -40,6 +40,8 @@ class FrontendSpec(pydantic.BaseModel):
     valid_function_priority_class_names: typing.List[str] = []
     default_function_image_by_kind: typing.Dict[str, str] = {}
     function_deployment_target_image_template: typing.Optional[str]
+    function_deployment_target_image_name_prefix_template: str
+    function_deployment_target_image_registries_to_enforce_prefix: typing.List[str] = []
     function_deployment_mlrun_command: typing.Optional[str]
     auto_mount_type: typing.Optional[str]
     auto_mount_params: typing.Dict[str, str] = {}

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -28,6 +28,8 @@ from .datastore import store_manager
 from .k8s_utils import BasePod, get_k8s_helper
 from .utils import enrich_image_url, get_parsed_docker_registry, logger, normalize_name
 
+IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."
+
 
 def make_dockerfile(
     base_image,
@@ -164,9 +166,6 @@ def upload_tarball(source_dir, target, secrets=None):
         stores = store_manager.set(secrets)
         datastore, subpath = stores.get_or_create_store(target)
         datastore.upload(subpath, temp_fh.name)
-
-
-IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."
 
 
 def build_image(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -243,6 +243,9 @@ default_config = {
             "pip_ca_secret_name": "",
             "pip_ca_secret_key": "",
             "pip_ca_path": "/etc/ssl/certs/mlrun/pip-ca-certificates.crt",
+            # template for the prefix that the function target image will be enforced to have (as long as it's targeted
+            # to be in the configured registry). Supported template values are: {project} {name}
+            "function_target_image_name_prefix_template": "func-{project}-{name}",
         },
         "v3io_api": "",
         "v3io_framesd": "",

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -24,6 +24,7 @@ import pandas as pd
 from kubernetes import client
 
 import mlrun
+import mlrun.builder
 from mlrun.db import get_run_db
 from mlrun.frameworks.parallel_coordinates import gen_pcp_plot
 from mlrun.k8s_utils import get_k8s_helper
@@ -290,20 +291,54 @@ def log_iter_artifacts(execution, df, header):
         pass
 
 
-def generate_function_image_name(function) -> str:
+def resolve_function_image_name(function, image: typing.Optional[str] = None) -> str:
     project = function.metadata.project or config.default_project
+    name = function.metadata.name
     tag = function.metadata.tag or "latest"
+    if image:
+        image_name_prefix = resolve_function_target_image_name_prefix(project, name)
+        registries_to_enforce_prefix = (
+            resolve_function_target_image_registries_to_enforce_prefix()
+        )
+        for registry in registries_to_enforce_prefix:
+            if image.startswith(registry):
+                prefix_with_registry = f"{registry}{image_name_prefix}"
+                if not image.startswith(prefix_with_registry):
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Configured registry enforces image name to start with this prefix: {image_name_prefix}"
+                    )
+        return image
+    return generate_function_image_name(project, name, tag)
+
+
+def generate_function_image_name(project: str, name: str, tag: str) -> str:
     _, repository = helpers.get_parsed_docker_registry()
     repository = helpers.get_docker_repository_or_default(repository)
     return fill_function_image_name_template(
-        ".", repository, project, function.metadata.name, tag
+        mlrun.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX, repository, project, name, tag
     )
 
 
 def fill_function_image_name_template(
     registry: str, repository: str, project: str, name: str, tag: str,
 ) -> str:
-    return f"{registry}{repository}/func-{project}-{name}:{tag}"
+    image_name_prefix = resolve_function_target_image_name_prefix(project, name)
+    return f"{registry}{repository}/{image_name_prefix}:{tag}"
+
+
+def resolve_function_target_image_name_prefix(project: str, name: str):
+    return config.httpdb.builder.function_target_image_name_prefix_template.format(
+        project=project, name=name
+    )
+
+
+def resolve_function_target_image_registries_to_enforce_prefix():
+    registry, repository = helpers.get_parsed_docker_registry()
+    repository = helpers.get_docker_repository_or_default(repository)
+    return [
+        f"{mlrun.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}{repository}/",
+        f"{registry}/{repository}/",
+    ]
 
 
 def set_named_item(obj, item):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,13 +11,9 @@ click~=7.0
 google-auth>=1.25.0, <2.0dev
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
-kfp~=1.8.0
+kfp~=1.8.11
 nest-asyncio~=1.0
-ipython~=7.0
-# nuclio-jupyter has notebook>=5.2.0 which resolves to 6.4.0 which has ipykernel without specifier, which from 0.6.0
-# has ipython>=7.23.1 which is incompatible with our ipython specifiers, therefore instsalling ipykernel 5.x before
-# nuclio-jupyter
-ipykernel~=5.0
+ipython~=7.31
 nuclio-jupyter~=0.8.22
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,13 @@ click~=7.0
 google-auth>=1.25.0, <2.0dev
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
-kfp~=1.8.11
+kfp~=1.8.0
 nest-asyncio~=1.0
-ipython~=7.31
+ipython~=7.0
+# nuclio-jupyter has notebook>=5.2.0 which resolves to 6.4.0 which has ipykernel without specifier, which from 0.6.0
+# has ipython>=7.23.1 which is incompatible with our ipython specifiers, therefore instsalling ipykernel 5.x before
+# nuclio-jupyter
+ipykernel~=5.0
 nuclio-jupyter~=0.8.22
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -57,6 +57,14 @@ def test_get_frontend_spec(
     assert frontend_spec.default_function_pod_resources, mlrun.api.schemas.Resources(
         **default_function_pod_resources
     )
+    assert (
+        frontend_spec.function_deployment_target_image_name_prefix_template
+        == mlrun.mlconf.httpdb.builder.function_target_image_name_prefix_template
+    )
+    assert (
+        frontend_spec.function_deployment_target_image_registries_to_enforce_prefix
+        == mlrun.runtimes.utils.resolve_function_target_image_registries_to_enforce_prefix()
+    )
 
 
 def test_get_frontend_spec_jobs_dashboard_url_resolution(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -139,12 +139,7 @@ def test_build_runtime_target_image(monkeypatch):
     )
 
     # assert the default target image
-    target_image = (
-        mlrun.builder.get_k8s_helper()
-        .create_pod.call_args[0][0]
-        .pod.spec.containers[0]
-        .args[5]
-    )
+    target_image = _get_target_image_from_create_pod_mock()
     assert target_image == f"{registry}/{image_name_prefix}:{function.metadata.tag}"
 
     # assert we can override the target image as long as we stick to the prefix
@@ -154,12 +149,7 @@ def test_build_runtime_target_image(monkeypatch):
     mlrun.builder.build_runtime(
         mlrun.api.schemas.AuthInfo(), function,
     )
-    target_image = (
-        mlrun.builder.get_k8s_helper()
-        .create_pod.call_args[0][0]
-        .pod.spec.containers[0]
-        .args[5]
-    )
+    target_image = _get_target_image_from_create_pod_mock()
     assert target_image == function.spec.build.image
 
     # assert the same with the registry enrich prefix
@@ -171,12 +161,7 @@ def test_build_runtime_target_image(monkeypatch):
     mlrun.builder.build_runtime(
         mlrun.api.schemas.AuthInfo(), function,
     )
-    target_image = (
-        mlrun.builder.get_k8s_helper()
-        .create_pod.call_args[0][0]
-        .pod.spec.containers[0]
-        .args[5]
-    )
+    target_image = _get_target_image_from_create_pod_mock()
     assert (
         target_image
         == f"{registry}/{image_name_prefix}-some-addition:{function.metadata.tag}"
@@ -201,12 +186,7 @@ def test_build_runtime_target_image(monkeypatch):
     mlrun.builder.build_runtime(
         mlrun.api.schemas.AuthInfo(), function,
     )
-    target_image = (
-        mlrun.builder.get_k8s_helper()
-        .create_pod.call_args[0][0]
-        .pod.spec.containers[0]
-        .args[5]
-    )
+    target_image = _get_target_image_from_create_pod_mock()
     assert target_image == function.spec.build.image
 
 
@@ -289,3 +269,12 @@ def test_resolve_mlrun_install_command():
         assert (
             result == expected_result
         ), f"Test supposed to pass {case.get('test_description')}"
+
+
+def _get_target_image_from_create_pod_mock():
+    return (
+        mlrun.builder.get_k8s_helper()
+        .create_pod.call_args[0][0]
+        .pod.spec.containers[0]
+        .args[5]
+    )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -15,14 +15,7 @@ def test_build_runtime_use_base_image_when_no_build():
     base_image = "mlrun/ml-models"
     fn.build_config(base_image=base_image)
     assert fn.spec.image == ""
-    ready = mlrun.builder.build_runtime(
-        mlrun.api.schemas.AuthInfo(),
-        fn,
-        with_mlrun=False,
-        mlrun_version_specifier=None,
-        skip_deployed=False,
-        builder_env=None,
-    )
+    ready = mlrun.builder.build_runtime(mlrun.api.schemas.AuthInfo(), fn,)
     assert ready is True
     assert fn.spec.image == base_image
 
@@ -34,12 +27,7 @@ def test_build_runtime_use_image_when_no_build():
     )
     assert fn.spec.image == image
     ready = mlrun.builder.build_runtime(
-        mlrun.api.schemas.AuthInfo(),
-        fn,
-        with_mlrun=False,
-        mlrun_version_specifier=None,
-        skip_deployed=False,
-        builder_env=None,
+        mlrun.api.schemas.AuthInfo(), fn, with_mlrun=False,
     )
     assert ready is True
     assert fn.spec.image == image
@@ -106,11 +94,7 @@ def test_build_runtime_insecure_registries(monkeypatch):
         mlrun.mlconf.httpdb.builder.insecure_push_registry_mode = case["push_mode"]
         mlrun.mlconf.httpdb.builder.docker_registry_secret = case["secret"]
         mlrun.builder.build_runtime(
-            mlrun.api.schemas.AuthInfo(),
-            function,
-            with_mlrun=False,
-            mlrun_version_specifier=None,
-            skip_deployed=False,
+            mlrun.api.schemas.AuthInfo(), function,
         )
         assert (
             insecure_flags.issubset(


### PR DESCRIPTION
Adding a new config value under the `mlconf.httpdb.builder` block - `function_target_image_name_prefix_template` which defaults to `func-{project}-{name}`
So far this default template was used when no target image was provided to generate the target image, from now on, in addition to that, if the target image is provided, and as long as it's targeted to the configured registry, we'll enforce the image name to have the configured prefix
To allow the UI to do the same verification added 2 new fields in the frontend spec response:
* `function_deployment_target_image_name_prefix_template` - which just sends the template (e.g. `some-prefix-{project}-{name}-suffix`)
* `function_deployment_target_image_registries_to_enforce_prefix` - which send the possible values for the registry prefix which if exists in the target image, the name should be verified to have the prefix
For example, let's say the configured registry is `registry.hub.docker.com/some-user`, the registries to enforce will be
`registry.hub.docker.com/some-user/` and `./some-user/` (`.` marks us to enrich the registry), so for any target image that starts with this prefix (meaning this is its registry), the part after it (image name) must have the prefix according to the template