### PR TITLE
[Runtimes] Fix deletion of build image path after runs

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -382,8 +382,9 @@ def build_status(
         )
 
     # read from log file
+    final_states = ["failed", "error", "ready"]
     log_file = log_path(project, f"build_{name}__{tag or 'latest'}")
-    if state in ["failed", "error", "ready"] and log_file.exists():
+    if state in final_states and log_file.exists():
         with log_file.open("rb") as fp:
             fp.seek(offset)
             out = fp.read()
@@ -409,14 +410,14 @@ def build_status(
         logger.error(f"build {state}, watch the build pod logs: {pod}")
         state = mlrun.api.schemas.FunctionState.error
 
-    if logs and state != "pending":
+    if (logs and state != "pending") or state in final_states:
         resp = get_k8s().logs(pod)
-        if state in ["failed", "error", "ready"]:
+        if state in final_states:
             log_file.parent.mkdir(parents=True, exist_ok=True)
             with log_file.open("wb") as fp:
                 fp.write(resp.encode())
 
-        if resp:
+        if resp and logs:
             out = resp.encode()[offset:]
 
     update_in(fn, "status.state", state)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -504,7 +504,7 @@ def _build_function(
                 fn.metadata.project,
                 f"build_{fn.metadata.name}__{fn.metadata.tag or 'latest'}",
             )
-            if log_file.exists() and not (skip_deployed and fn.is_deployed):
+            if log_file.exists() and not (skip_deployed and fn.is_deployed()):
                 # delete old build log file if exist and build is not skipped
                 os.remove(str(log_file))
 

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -382,9 +382,9 @@ def build_status(
         )
 
     # read from log file
-    final_states = ["failed", "error", "ready"]
+    terminal_states = ["failed", "error", "ready"]
     log_file = log_path(project, f"build_{name}__{tag or 'latest'}")
-    if state in final_states and log_file.exists():
+    if state in terminal_states and log_file.exists():
         with log_file.open("rb") as fp:
             fp.seek(offset)
             out = fp.read()
@@ -410,9 +410,9 @@ def build_status(
         logger.error(f"build {state}, watch the build pod logs: {pod}")
         state = mlrun.api.schemas.FunctionState.error
 
-    if (logs and state != "pending") or state in final_states:
+    if (logs and state != "pending") or state in terminal_states:
         resp = get_k8s().logs(pod)
-        if state in final_states:
+        if state in terminal_states:
             log_file.parent.mkdir(parents=True, exist_ok=True)
             with log_file.open("wb") as fp:
                 fp.write(resp.encode())

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -333,7 +333,7 @@ def build_runtime(
     build = runtime.spec.build
     namespace = runtime.metadata.namespace
     project = runtime.metadata.project
-    if skip_deployed and runtime.is_deployed:
+    if skip_deployed and runtime.is_deployed():
         runtime.status.state = mlrun.api.schemas.FunctionState.ready
         return True
     if build.base_image:

--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -318,7 +318,7 @@ class RunConfig:
                 spec=self.extra_spec,
             ).to_function(default_kind, default_image)
 
-        if not function.is_deployed:
+        if not function.is_deployed():
             # todo: handle build for job functions
             logger.warn("cannot run function, it must be built/deployed first")
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1411,18 +1411,21 @@ class MlrunProject(ModelObj):
         )
         return self.get_function(key, sync)
 
-    def get_function(self, key, sync=False, enrich=False) -> mlrun.runtimes.BaseRuntime:
+    def get_function(
+        self, key, sync=False, enrich=False, from_db=False
+    ) -> mlrun.runtimes.BaseRuntime:
         """get function object by name
 
         :param key:   name of key for search
         :param sync:  will reload/reinit the function
         :param enrich: add project info/config/source info to the function object
+        :param from_db: read the function object from the DB (ignore the local cache)
 
         :returns: function object
         """
-        if key in self.spec._function_objects and not sync:
+        if key in self.spec._function_objects and not sync and not from_db:
             function = self.spec._function_objects[key]
-        elif key in self.spec._function_definitions:
+        elif key in self.spec._function_definitions and not from_db:
             self.sync_functions()
             function = self.spec._function_objects[key]
         else:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1412,20 +1412,20 @@ class MlrunProject(ModelObj):
         return self.get_function(key, sync)
 
     def get_function(
-        self, key, sync=False, enrich=False, from_db=False
+        self, key, sync=False, enrich=False, ignore_cache=False
     ) -> mlrun.runtimes.BaseRuntime:
         """get function object by name
 
         :param key:   name of key for search
         :param sync:  will reload/reinit the function
         :param enrich: add project info/config/source info to the function object
-        :param from_db: read the function object from the DB (ignore the local cache)
+        :param ignore_cache: read the function object from the DB (ignore the local cache)
 
         :returns: function object
         """
-        if key in self.spec._function_objects and not sync and not from_db:
+        if key in self.spec._function_objects and not sync and not ignore_cache:
             function = self.spec._function_objects[key]
-        elif key in self.spec._function_definitions and not from_db:
+        elif key in self.spec._function_definitions and not ignore_cache:
             self.sync_functions()
             function = self.spec._function_objects[key]
         else:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -200,7 +200,6 @@ class BaseRuntime(ModelObj):
     def uri(self):
         return self._function_uri()
 
-    @property
     def is_deployed(self):
         return True
 
@@ -424,7 +423,7 @@ class BaseRuntime(ModelObj):
                 )
         db = self._get_db()
 
-        if not self.is_deployed:
+        if not self.is_deployed():
             if self.spec.build.auto_build or auto_build:
                 logger.info(
                     "Function is not deployed and auto_build flag is set, starting deploy..."
@@ -822,7 +821,7 @@ class BaseRuntime(ModelObj):
         if use_db:
             # if the same function is built as part of the pipeline we do not use the versioned function
             # rather the latest function w the same tag so we can pick up the updated image/status
-            versioned = False if hasattr(self, "_build_in_pipeline") else False
+            versioned = False if hasattr(self, "_build_in_pipeline") else True
             url = self.save(versioned=versioned, refresh=True)
         else:
             url = None
@@ -966,10 +965,10 @@ class BaseRuntime(ModelObj):
                     if (
                         self.status.state
                         and self.status.state == "ready"
-                        and "nuclio_name" not in self.status
+                        and not hasattr(self.status, "nuclio_name")
                     ):
                         self.spec.image = get_in(db_func, "spec.image", self.spec.image)
-            except Exception:
+            except mlrun.errors.MLRunNotFoundError:
                 pass
 
         tag = tag or self.metadata.tag

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -190,11 +190,10 @@ class DaskCluster(KubejobRuntime):
     def status(self, status):
         self._status = self._verify_dict(status, "status", DaskStatus)
 
-    @property
     def is_deployed(self):
         if not self.spec.remote:
             return True
-        return super().is_deployed
+        return super().is_deployed()
 
     @property
     def initialized(self):
@@ -223,7 +222,7 @@ class DaskCluster(KubejobRuntime):
             self.try_auto_mount_based_on_config()
             self.fill_credentials()
             db = self._get_db()
-            if not self.is_deployed:
+            if not self.is_deployed():
                 raise RunError(
                     "function image is not built/ready, use .deploy()"
                     " method first, or set base dask image (daskdev/dask:latest)"

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -38,7 +38,6 @@ class KubejobRuntime(KubeResource):
 
     _is_remote = True
 
-    @property
     def is_deployed(self):
         """check if the function is deployed (have a valid container)"""
         if self.spec.image:

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -176,7 +176,6 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
         if pythonpath:
             self.spec.pythonpath = pythonpath
 
-    @property
     def is_deployed(self):
         return True
 

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -102,7 +102,6 @@ class RemoteSparkRuntime(KubejobRuntime):
         sj.deploy()
         get_run_db().delete_function(name=sj.metadata.name)
 
-    @property
     def is_deployed(self):
         if (
             not self.spec.build.source
@@ -110,7 +109,7 @@ class RemoteSparkRuntime(KubejobRuntime):
             and not self.spec.build.extra
         ):
             return True
-        return super().is_deployed
+        return super().is_deployed()
 
     def _run(self, runobj: RunObject, execution):
         self.spec.image = self.spec.image or self.default_image

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -666,7 +666,6 @@ with ctx:
         _ = self._get_k8s()
         return list(pods.items())[0]
 
-    @property
     def is_deployed(self):
         if (
             not self.spec.build.source
@@ -674,7 +673,7 @@ with ctx:
             and not self.spec.build.extra
         ):
             return True
-        return super().is_deployed
+        return super().is_deployed()
 
     @property
     def spec(self) -> AbstractSparkJobSpec:

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -252,7 +252,7 @@ class TestProject(TestMLRunSystem):
             watch=True,
         )
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
-        fn = project.get_function("gen-iris", from_db=True)
+        fn = project.get_function("gen-iris", ignore_cache=True)
         assert fn.status.state == "ready"
         assert fn.spec.image, "image path got cleared"
         self._delete_test_project(name)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -252,6 +252,9 @@ class TestProject(TestMLRunSystem):
             watch=True,
         )
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
+        fn = project.get_function("gen-iris", from_db=True)
+        assert fn.status.state == "ready"
+        assert fn.spec.image, "image path got cleared"
         self._delete_test_project(name)
 
     def test_local_pipeline(self):
@@ -329,6 +332,7 @@ class TestProject(TestMLRunSystem):
         fn.spec.build.auto_build = True
         run_result = project.run_function(fn, params={"text": "good morning"})
         assert fn.status.state == "ready"
+        assert fn.spec.image, "image path got cleared"
         assert run_result.output("score")
 
         self._delete_test_project(name)


### PR DESCRIPTION
generated function.spec.image (from build) got cleared when using function.save() due to mishandled exception, 
also turned is_deployed from property to a method in order to avoid accidental DB reads