### PR TITLE
[Secrets] Fixing nuclio remote deploy flow - remove dependency on Secrets crud

### DIFF
--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -395,12 +395,17 @@ class K8sHelper:
 
         return k8s_secret.data
 
-    def get_project_secret_keys(self, project, namespace=""):
+    def get_project_secret_keys(self, project, namespace="", filter_internal=False):
         secrets_data = self._get_project_secrets_raw_data(project, namespace)
         if not secrets_data:
             return None
 
-        return list(secrets_data.keys())
+        secret_keys = list(secrets_data.keys())
+        if filter_internal:
+            secret_keys = list(
+                filter(lambda key: not key.startswith("mlrun."), secret_keys)
+            )
+        return secret_keys
 
     def get_project_secret_data(self, project, secret_keys=None, namespace=""):
         results = {}

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -564,9 +564,6 @@ class KubeResource(BaseRuntime):
     def _add_project_k8s_secrets_to_spec(
         self, secrets, runobj=None, project=None, encode_key_names=True
     ):
-        # Needs to happen here to avoid circular dependencies
-        from mlrun.api.crud.secrets import Secrets
-
         # the secrets param may be an empty dictionary (asking for all secrets of that project) -
         # it's a different case than None (not asking for project secrets at all).
         if (
@@ -581,12 +578,10 @@ class KubeResource(BaseRuntime):
             return
 
         secret_name = self._get_k8s().get_project_secret_name(project_name)
-        existing_secret_keys = (
-            Secrets()
-            .list_secret_keys(
-                project_name, mlrun.api.schemas.SecretProviderName.kubernetes
-            )
-            .secret_keys
+        # Not utilizing the same functionality from the Secrets crud object because this code also runs client-side
+        # in the nuclio remote-dashboard flow, which causes dependency problems.
+        existing_secret_keys = self._get_k8s().get_project_secret_keys(
+            project_name, filter_internal=True
         )
 
         # If no secrets were passed or auto-adding all secrets, we need all existing keys

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -92,8 +92,13 @@ class K8sSecretsMock:
             for key in secrets:
                 self.project_secrets_map.get(project, {}).pop(key, None)
 
-    def get_project_secret_keys(self, project, namespace=""):
-        return list(self.project_secrets_map.get(project, {}).keys())
+    def get_project_secret_keys(self, project, namespace="", filter_internal=False):
+        secret_keys = list(self.project_secrets_map.get(project, {}).keys())
+        if filter_internal:
+            secret_keys = list(
+                filter(lambda key: not key.startswith("mlrun."), secret_keys)
+            )
+        return secret_keys
 
     def get_project_secret_data(self, project, secret_keys=None, namespace=""):
         secrets_data = self.project_secrets_map.get(project, {})


### PR DESCRIPTION
When doing a nuclio deploy using a dashboard (i.e. not through the MLRun service), the k8s project secret addition code would explode due to dependency on libraries that do not exist in client side.
To fix, removed the use of the `Secrets` crud object, instead going directly to the k8s utils.