### PR TITLE
[Bugfix] Fixing issues when running MLRun service not inside k8s

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -21,6 +21,7 @@ from mlrun.api.utils.singletons.logs_dir import get_logs_dir
 from mlrun.api.utils.singletons.scheduler import get_scheduler
 from mlrun.config import config
 from mlrun.db.sqldb import SQLDB as SQLRunDB
+from mlrun.k8s_utils import get_k8s_helper
 from mlrun.run import import_function, new_function
 from mlrun.runtimes.utils import enrich_function_from_dict
 from mlrun.utils import get_in, logger, parse_versioned_object_uri
@@ -192,6 +193,10 @@ def try_perform_auto_mount(function, auth_info: mlrun.api.schemas.AuthInfo):
 
 
 def process_function_service_account(function):
+    # If we're not running inside k8s, skip this check as it's not relevant.
+    if not get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+        return
+
     allowed_service_accounts = mlrun.api.crud.secrets.Secrets().get_secret(
         function.metadata.project,
         SecretProviderName.kubernetes,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1192,9 +1192,11 @@ def compile_function_config(function: RemoteRuntime, client_version: str = None)
     for key, value in labels.items():
         function.set_config(f"metadata.labels.{key}", value)
 
-    # Add vault configurations to function's pod spec, if vault secret source was added.
+    # Add secret configurations to function's pod spec, if secret sources were added.
     # Needs to be here, since it adds env params, which are handled in the next lines.
-    function.add_secrets_config_to_spec()
+    # This only needs to run if we're not running within k8s context. If running in Docker, for example, skip.
+    if get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+        function.add_secrets_config_to_spec()
 
     env_dict, external_source_env_dict = function.get_nuclio_config_spec_env()
     spec = nuclio.ConfigSpec(


### PR DESCRIPTION
When running the service in Docker, for example, without k8s available, function deployment and running would explode because it's looking for k8s secrets and service-accounts.
Fixed this so it's conditional - if inside k8s continue to perform these actions, else continue.