### PR TITLE
[Runtimes] Fix mount modifiers to keep mount path unique

### DIFF
--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -18,12 +18,12 @@ from datetime import datetime
 from http import HTTPStatus
 from urllib.parse import urlparse
 
+import kfp.dsl
 import requests
 import urllib3
 import v3io
 
 import mlrun.errors
-import kfp.dsl
 from mlrun.config import config as mlconf
 from mlrun.utils import dict_to_json
 
@@ -311,7 +311,9 @@ def v3io_cred(api="", user="", access_key=""):
         v3io_framesd = mlconf.v3io_framesd or environ.get("V3IO_FRAMESD")
 
         return (
-            container_op.container.add_env_variable(k8s_client.V1EnvVar(name="V3IO_API", value=web_api))
+            container_op.container.add_env_variable(
+                k8s_client.V1EnvVar(name="V3IO_API", value=web_api)
+            )
             .add_env_variable(k8s_client.V1EnvVar(name="V3IO_USERNAME", value=_user))
             .add_env_variable(
                 k8s_client.V1EnvVar(name="V3IO_ACCESS_KEY", value=_access_key)

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -23,6 +23,7 @@ import urllib3
 import v3io
 
 import mlrun.errors
+import kfp.dsl
 from mlrun.config import config as mlconf
 from mlrun.utils import dict_to_json
 
@@ -92,21 +93,21 @@ def mount_v3io_extended(
     ):
         raise TypeError("mounts should be a list of Mount")
 
-    def _mount_v3io_extended(task):
+    def _mount_v3io_extended(container_op: kfp.dsl.ContainerOp):
         from kubernetes import client as k8s_client
 
         vol = v3io_to_vol(name, remote, access_key, user, secret=secret)
-        task.add_volume(vol)
+        container_op.add_volume(vol)
         for mount in mounts:
-            task.add_volume_mount(
+            container_op.container.add_volume_mount(
                 k8s_client.V1VolumeMount(
                     mount_path=mount.path, sub_path=mount.sub_path, name=name
                 )
             )
 
         if not secret:
-            task = v3io_cred(access_key=access_key, user=user)(task)
-        return task
+            container_op = v3io_cred(access_key=access_key, user=user)(container_op)
+        return container_op
 
     return _mount_v3io_extended
 
@@ -213,21 +214,21 @@ def mount_v3io_legacy(
 
 
 def mount_spark_conf():
-    def _mount_spark(task):
+    def _mount_spark(container_op: kfp.dsl.ContainerOp):
         from kubernetes import client as k8s_client
 
-        task.add_volume_mount(
+        container_op.container.add_volume_mount(
             k8s_client.V1VolumeMount(
                 name="spark-master-config", mount_path="/etc/config/spark"
             )
         )
-        return task
+        return container_op
 
     return _mount_spark
 
 
 def mount_v3iod(namespace, v3io_config_configmap):
-    def _mount_v3iod(task):
+    def _mount_v3iod(container_op: kfp.dsl.ContainerOp):
         from kubernetes import client as k8s_client
 
         def add_vol(name, mount_path, host_path):
@@ -235,7 +236,8 @@ def mount_v3iod(namespace, v3io_config_configmap):
                 name=name,
                 host_path=k8s_client.V1HostPathVolumeSource(path=host_path, type=""),
             )
-            task.add_volume(vol).add_volume_mount(
+            container_op.add_volume(vol)
+            container_op.container.add_volume_mount(
                 k8s_client.V1VolumeMount(mount_path=mount_path, name=name)
             )
 
@@ -249,7 +251,8 @@ def mount_v3iod(namespace, v3io_config_configmap):
         vol = k8s_client.V1Volume(
             name="daemon-health", empty_dir=k8s_client.V1EmptyDirVolumeSource()
         )
-        task.add_volume(vol).add_volume_mount(
+        container_op.add_volume(vol)
+        container_op.container.add_volume_mount(
             k8s_client.V1VolumeMount(
                 mount_path="/var/run/iguazio/daemon_health", name="daemon-health"
             )
@@ -261,11 +264,12 @@ def mount_v3iod(namespace, v3io_config_configmap):
                 name=v3io_config_configmap, default_mode=420
             ),
         )
-        task.add_volume(vol).add_volume_mount(
+        container_op.add_volume(vol)
+        container_op.container.add_volume_mount(
             k8s_client.V1VolumeMount(mount_path="/etc/config/v3io", name="v3io-config")
         )
 
-        task.add_env_variable(
+        container_op.container.add_env_variable(
             k8s_client.V1EnvVar(
                 name="CURRENT_NODE_IP",
                 value_from=k8s_client.V1EnvVarSource(
@@ -275,20 +279,20 @@ def mount_v3iod(namespace, v3io_config_configmap):
                 ),
             )
         )
-        task.add_env_variable(
+        container_op.container.add_env_variable(
             k8s_client.V1EnvVar(
                 name="IGZ_DATA_CONFIG_FILE", value="/igz/java/conf/v3io.conf"
             )
         )
 
-        return task
+        return container_op
 
     return _mount_v3iod
 
 
 def v3io_cred(api="", user="", access_key=""):
     """
-    Modifier function to copy local v3io env vars to task
+    Modifier function to copy local v3io env vars to container
 
     Usage::
 
@@ -296,7 +300,7 @@ def v3io_cred(api="", user="", access_key=""):
         train.apply(use_v3io_cred())
     """
 
-    def _use_v3io_cred(task):
+    def _use_v3io_cred(container_op: kfp.dsl.ContainerOp):
         from os import environ
 
         from kubernetes import client as k8s_client
@@ -307,7 +311,7 @@ def v3io_cred(api="", user="", access_key=""):
         v3io_framesd = mlconf.v3io_framesd or environ.get("V3IO_FRAMESD")
 
         return (
-            task.add_env_variable(k8s_client.V1EnvVar(name="V3IO_API", value=web_api))
+            container_op.container.add_env_variable(k8s_client.V1EnvVar(name="V3IO_API", value=web_api))
             .add_env_variable(k8s_client.V1EnvVar(name="V3IO_USERNAME", value=_user))
             .add_env_variable(
                 k8s_client.V1EnvVar(name="V3IO_ACCESS_KEY", value=_access_key)

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -206,12 +206,8 @@ class KubeResourceSpec(FunctionSpec):
         return api.sanitize_for_serialization(self.affinity)
 
     def _set_volume_mount(self, volume_mount):
-        # calculate volume mount hash
-        volume_name = get_item_name(volume_mount, "name")
-        volume_sub_path = get_item_name(volume_mount, "subPath")
-        volume_mount_path = get_item_name(volume_mount, "mountPath")
-        volume_mount_key = hash(f"{volume_name}-{volume_sub_path}-{volume_mount_path}")
-        self._volume_mounts[volume_mount_key] = volume_mount
+        # using the mountPath as the key cause it must be unique (k8s limitation)
+        self._volume_mounts[get_item_name(volume_mount, "mountPath")] = volume_mount
 
     def _verify_and_set_limits(
         self,

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -272,10 +272,17 @@ def test_mount_v3io_multiple_user():
     os.environ["V3IO_ACCESS_KEY"] = access_key_2
     function.apply(mlrun.mount_v3io())
 
-    user_volume_mounts = list(filter(lambda volume_mount: volume_mount["mountPath"] == "/User", function.spec.volume_mounts))
+    user_volume_mounts = list(
+        filter(
+            lambda volume_mount: volume_mount["mountPath"] == "/User",
+            function.spec.volume_mounts,
+        )
+    )
     assert len(user_volume_mounts) == 1
     assert user_volume_mounts[0]["subPath"] == f"users/{username_2}"
-    assert function.spec.volumes[0]["flexVolume"]["options"]["accessKey"] == access_key_2
+    assert (
+        function.spec.volumes[0]["flexVolume"]["options"]["accessKey"] == access_key_2
+    )
 
 
 def test_mount_v3io_extended():


### PR DESCRIPTION
We had a bug where we were doing `function.apply(mlrun.mount_v3io())` twice on the same function with 2 different users and it caused k8s to return:
```
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod \\"some-pod-name\\" is invalid: spec.containers[0].volumeMounts[2].mountPath: Invalid value: \\"/User\\": must be unique","reason":"Invalid","details":{"name":"some-pod-name","kind":"Pod","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \\"/User\\": must be unique","field":"spec.containers[0].volumeMounts[2].mountPath"}]},"code":422}\n\n'}}
```
The problem is that we were identifying a volume mount by hashing all of its values together which allows us to have two different volume mount using the same mount path, I've changed the identifier to be mount path which promises it will be unique
Fixes https://jira.iguazeng.com/browse/ML-1801