### PR TITLE
[Runtimes] Fix to enrich KFP and Kaniko pods with the default function node selector

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -105,6 +105,7 @@ def make_kaniko_pod(
         project=project,
     )
     kpod.env = builder_env
+    kpod.set_node_selector(mlrun.mlconf.get_default_function_node_selector())
 
     if secret_name:
         items = [{"key": ".dockerconfigjson", "path": "config.json"}]

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -552,7 +552,10 @@ class BasePod:
         )
 
         pod_spec = client.V1PodSpec(
-            containers=[container], restart_policy="Never", volumes=self._volumes, node_selector=self.node_selector,
+            containers=[container],
+            restart_policy="Never",
+            volumes=self._volumes,
+            node_selector=self.node_selector,
         )
 
         if self._init_container:

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import base64
 import time
+import typing
 from datetime import datetime
 from sys import stdout
 
@@ -444,6 +445,7 @@ class BasePod:
         self._volumes = []
         self._mounts = []
         self.env = None
+        self.node_selector = None
         self.project = project or mlrun.mlconf.default_project
         self._labels = {
             "mlrun/task-name": task_name,
@@ -529,6 +531,9 @@ class BasePod:
             sub_path=sub_path,
         )
 
+    def set_node_selector(self, node_selector: typing.Optional[typing.Dict[str, str]]):
+        self.node_selector = node_selector
+
     def _get_spec(self, template=False):
 
         pod_obj = client.V1PodTemplate if template else client.V1Pod
@@ -547,7 +552,7 @@ class BasePod:
         )
 
         pod_spec = client.V1PodSpec(
-            containers=[container], restart_policy="Never", volumes=self._volumes
+            containers=[container], restart_policy="Never", volumes=self._volumes, node_selector=self.node_selector,
         )
 
         if self._init_container:

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -777,6 +777,6 @@ def show_kfp_run(run, clear_output=False):
 def add_default_function_node_selector(
     container_op: dsl.ContainerOp,
 ) -> dsl.ContainerOp:
-    for label_name, label_value in config.get_default_function_node_selector():
+    for label_name, label_value in config.get_default_function_node_selector().items():
         container_op.add_node_selector_constraint(label_name, label_value)
     return container_op

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -17,6 +17,7 @@ import json
 import os
 import os.path
 from copy import deepcopy
+
 from kfp import dsl
 from kubernetes import client as k8s_client
 
@@ -439,7 +440,6 @@ def deploy_op(
     verbose=False,
 ):
 
-
     cmd = ["python", "-m", "mlrun", "deploy"]
     if source:
         cmd += ["-s", source]
@@ -774,7 +774,9 @@ def show_kfp_run(run, clear_output=False):
             logger.warning(f"failed to plot graph, {exc}")
 
 
-def add_default_function_node_selector(container_op: dsl.ContainerOp) -> dsl.ContainerOp:
+def add_default_function_node_selector(
+    container_op: dsl.ContainerOp,
+) -> dsl.ContainerOp:
     for label_name, label_value in config.get_default_function_node_selector():
         container_op.add_node_selector_constraint(label_name, label_value)
     return container_op

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -17,6 +17,8 @@ import json
 import os
 import os.path
 from copy import deepcopy
+from kfp import dsl
+from kubernetes import client as k8s_client
 
 import mlrun
 
@@ -253,11 +255,6 @@ def mlrun_op(
             train.outputs['model-txt']).apply(mount_v3io())
 
     """
-    from os import environ
-
-    from kfp import dsl
-    from kubernetes import client as k8s_client
-
     secrets = [] if secrets is None else secrets
     params = {} if params is None else params
     hyperparams = {} if hyperparams is None else hyperparams
@@ -342,7 +339,7 @@ def mlrun_op(
     inputs = inputs or {}
     secrets = secrets or []
 
-    if "V3IO_USERNAME" in environ and "v3io_user" not in labels:
+    if "V3IO_USERNAME" in os.environ and "v3io_user" not in labels:
         labels["v3io_user"] = os.environ.get("V3IO_USERNAME")
     if "owner" not in labels:
         labels["owner"] = os.environ.get("V3IO_USERNAME") or getpass.getuser()
@@ -410,6 +407,7 @@ def mlrun_op(
             "mlpipeline-metrics": "/mlpipeline-metrics.json",
         },
     )
+    cop = add_default_function_node_selector(cop)
 
     add_annotations(cop, PipelineRunType.run, function, func_url, project)
     if code_env:
@@ -440,8 +438,7 @@ def deploy_op(
     tag="",
     verbose=False,
 ):
-    from kfp import dsl
-    from kubernetes import client as k8s_client
+
 
     cmd = ["python", "-m", "mlrun", "deploy"]
     if source:
@@ -481,6 +478,7 @@ def deploy_op(
         command=cmd,
         file_outputs={"endpoint": "/tmp/output", "name": "/tmp/name"},
     )
+    cop = add_default_function_node_selector(cop)
 
     add_annotations(cop, PipelineRunType.deploy, function, func_url)
     add_default_env(k8s_client, cop)
@@ -498,8 +496,6 @@ def add_env(env=None):
     env = {} if env is None else env
 
     def _add_env(task):
-        from kubernetes import client as k8s_client
-
         for k, v in env.items():
             task.add_env_variable(k8s_client.V1EnvVar(name=k, value=v))
         return task
@@ -519,11 +515,6 @@ def build_op(
     skip_deployed=False,
 ):
     """build Docker image."""
-
-    from os import environ
-
-    from kfp import dsl
-    from kubernetes import client as k8s_client
 
     cmd = ["python", "-m", "mlrun", "build", "--kfp"]
     if function:
@@ -555,6 +546,7 @@ def build_op(
         command=cmd,
         file_outputs={"state": "/tmp/state", "image": "/tmp/image"},
     )
+    cop = add_default_function_node_selector(cop)
 
     add_annotations(cop, PipelineRunType.build, function, func_url)
     if config.httpdb.builder.docker_registry:
@@ -564,7 +556,7 @@ def build_op(
                 value=config.httpdb.builder.docker_registry,
             )
         )
-    if "IGZ_NAMESPACE_DOMAIN" in environ:
+    if "IGZ_NAMESPACE_DOMAIN" in os.environ:
         cop.container.add_env_variable(
             k8s_client.V1EnvVar(
                 name="IGZ_NAMESPACE_DOMAIN",
@@ -575,7 +567,7 @@ def build_op(
     is_v3io = function.spec.build.source and function.spec.build.source.startswith(
         "v3io"
     )
-    if "V3IO_ACCESS_KEY" in environ and is_v3io:
+    if "V3IO_ACCESS_KEY" in os.environ and is_v3io:
         cop.container.add_env_variable(
             k8s_client.V1EnvVar(
                 name="V3IO_ACCESS_KEY", value=os.environ.get("V3IO_ACCESS_KEY")
@@ -780,3 +772,9 @@ def show_kfp_run(run, clear_output=False):
             IPython.display.display(html, dag)
         except Exception as exc:
             logger.warning(f"failed to plot graph, {exc}")
+
+
+def add_default_function_node_selector(container_op: dsl.ContainerOp) -> dsl.ContainerOp:
+    for label_name, label_value in config.get_default_function_node_selector():
+        container_op.add_node_selector_constraint(label_name, label_value)
+    return container_op

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -23,7 +23,6 @@ import urllib3
 import v3io
 
 import mlrun.errors
-import mlrun.kfpops
 from mlrun.config import config as mlconf
 from mlrun.utils import dict_to_json
 
@@ -54,6 +53,9 @@ def xcp_op(
         command=["xcp"],
         arguments=args,
     )
+    # import here to avoid circular imports
+    import mlrun.kfpops
+
     container_op = mlrun.kfpops.add_default_function_node_selector(container_op)
     return container_op
 

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -23,6 +23,7 @@ import urllib3
 import v3io
 
 import mlrun.errors
+import mlrun.kfpops
 from mlrun.config import config as mlconf
 from mlrun.utils import dict_to_json
 
@@ -47,12 +48,14 @@ def xcp_op(
     if recursive:
         args = ["-r"] + args
 
-    return dsl.ContainerOp(
+    container_op = dsl.ContainerOp(
         name="xcp",
         image="yhaviv/invoke",
         command=["xcp"],
         arguments=args,
     )
+    container_op = mlrun.kfpops.add_default_function_node_selector(container_op)
+    return container_op
 
 
 VolumeMount = namedtuple("Mount", ["path", "sub_path"])

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -234,7 +234,7 @@ def test_build_runtime_use_default_node_selector(monkeypatch):
         mlrun.api.schemas.AuthInfo(),
         function,
     )
-    assert deepdiff.DeepDiff(mlrun.builder.get_k8s_helper().create_pod.call_args[0][0].pod.spec.node_selector, node_selector, ignore_order=True) == {}
+    assert deepdiff.DeepDiff(_create_pod_mock_pod_spec().node_selector, node_selector, ignore_order=True) == {}
 
 
 def test_resolve_mlrun_install_command():
@@ -319,9 +319,11 @@ def test_resolve_mlrun_install_command():
 
 
 def _get_target_image_from_create_pod_mock():
+    return _create_pod_mock_pod_spec().containers[0].args[5]
+
+def _create_pod_mock_pod_spec():
     return (
         mlrun.builder.get_k8s_helper()
         .create_pod.call_args[0][0]
-        .pod.spec.containers[0]
-        .args[5]
+        .pod.spec
     )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,5 +1,8 @@
 import unittest.mock
+import base64
+import json
 
+import deepdiff
 import pytest
 
 import mlrun
@@ -201,6 +204,37 @@ def test_build_runtime_target_image(monkeypatch):
     )
     target_image = _get_target_image_from_create_pod_mock()
     assert target_image == function.spec.build.image
+
+
+def test_build_runtime_use_default_node_selector(monkeypatch):
+    get_k8s_helper_mock = unittest.mock.Mock()
+    monkeypatch.setattr(
+        mlrun.builder, "get_k8s_helper", lambda *args, **kwargs: get_k8s_helper_mock
+    )
+    mlrun.builder.get_k8s_helper().create_pod = unittest.mock.Mock(
+        side_effect=lambda pod: (pod, "some-namespace")
+    )
+    mlrun.mlconf.httpdb.builder.docker_registry = "registry.hub.docker.com/username"
+    node_selector = {
+        "label-1": "val1",
+        "label-2": "val2",
+    }
+    mlrun.mlconf.default_function_node_selector = base64.b64encode(
+        json.dumps(node_selector).encode("utf-8")
+    )
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind="job",
+        requirements=["some-package"],
+    )
+    mlrun.builder.build_runtime(
+        mlrun.api.schemas.AuthInfo(),
+        function,
+    )
+    assert deepdiff.DeepDiff(mlrun.builder.get_k8s_helper().create_pod.call_args[0][0].pod.spec.node_selector, node_selector, ignore_order=True) == {}
 
 
 def test_resolve_mlrun_install_command():

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,6 +1,6 @@
-import unittest.mock
 import base64
 import json
+import unittest.mock
 
 import deepdiff
 import pytest
@@ -234,7 +234,12 @@ def test_build_runtime_use_default_node_selector(monkeypatch):
         mlrun.api.schemas.AuthInfo(),
         function,
     )
-    assert deepdiff.DeepDiff(_create_pod_mock_pod_spec().node_selector, node_selector, ignore_order=True) == {}
+    assert (
+        deepdiff.DeepDiff(
+            _create_pod_mock_pod_spec().node_selector, node_selector, ignore_order=True
+        )
+        == {}
+    )
 
 
 def test_resolve_mlrun_install_command():
@@ -321,9 +326,6 @@ def test_resolve_mlrun_install_command():
 def _get_target_image_from_create_pod_mock():
     return _create_pod_mock_pod_spec().containers[0].args[5]
 
+
 def _create_pod_mock_pod_spec():
-    return (
-        mlrun.builder.get_k8s_helper()
-        .create_pod.call_args[0][0]
-        .pod.spec
-    )
+    return mlrun.builder.get_k8s_helper().create_pod.call_args[0][0].pod.spec


### PR DESCRIPTION
We noticed our Builder (Kaniko) and KFP pods are not getting the default function node selector when it's set, this PR fixes it
There's no workaround for the builder pod for previous versions
For KFP you can add this to your pipeline handler ([origin](https://github.com/kubeflow/pipelines/issues/2863)):
```
dsl.get_pipeline_conf().set_default_pod_node_selector(label_name="some-label", value="some-value")
```


Fixes https://jira.iguazeng.com/browse/ML-1800