### PR TITLE
[Runtimes] Support auto-add of k8s project secrets to spark runtime

### DIFF
--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -294,18 +294,7 @@ class KubejobRuntime(KubeResource):
         k8s = self._get_k8s()
         new_meta = self._get_meta(runobj)
 
-        if self._secrets:
-            if self._secrets.has_vault_source():
-                self._add_vault_params_to_spec(runobj)
-            if self._secrets.has_azure_vault_source():
-                self._add_azure_vault_params_to_spec(
-                    self._secrets.get_azure_vault_k8s_secret()
-                )
-            self._add_project_k8s_secrets_to_spec(
-                self._secrets.get_k8s_secrets(), runobj
-            )
-        else:
-            self._add_project_k8s_secrets_to_spec(None, runobj)
+        self._add_secrets_to_spec_before_running(runobj)
 
         pod_spec = func_to_pod(
             self.full_image_path(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -538,6 +538,20 @@ class KubeResource(BaseRuntime):
             new_meta.generate_name = norm_name
         return new_meta
 
+    def _add_secrets_to_spec_before_running(self, runobj):
+        if self._secrets:
+            if self._secrets.has_vault_source():
+                self._add_vault_params_to_spec(runobj)
+            if self._secrets.has_azure_vault_source():
+                self._add_azure_vault_params_to_spec(
+                    self._secrets.get_azure_vault_k8s_secret()
+                )
+            self._add_project_k8s_secrets_to_spec(
+                self._secrets.get_k8s_secrets(), runobj
+            )
+        else:
+            self._add_project_k8s_secrets_to_spec(None, runobj)
+
     def _add_azure_vault_params_to_spec(self, k8s_secret_name=None):
         secret_name = (
             k8s_secret_name or mlconf.secret_stores.azure_vault.default_secret_name

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -382,6 +382,8 @@ class AbstractSparkRuntime(KubejobRuntime):
 
         update_in(job, "spec.volumes", self.spec.volumes)
 
+        self._add_secrets_to_spec_before_running(runobj)
+
         command, args, extra_env = self._get_cmd_args(runobj)
         code = None
         if "MLRUN_EXEC_CODE" in [e.get("name") for e in extra_env]:


### PR DESCRIPTION
Code to add project secrets was executed in the runtime's `_run()` method, which works for all runtimes except `spark` which overrides this method. This means that project secrets were not added to spark runtimes at all.
Added call to add secrets to spec to the `spark` runtime as well.