### PR TITLE
[Config] Ignore null base64 string

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -410,7 +410,7 @@ class Config:
         return config.hub_url
 
     @staticmethod
-    def decode_base64_config_and_load_to_dict(attribute_path: str):
+    def decode_base64_config_and_load_to_dict(attribute_path: str) -> dict:
         attributes = attribute_path.split(".")
         raw_attribute_value = config
         for part in attributes:
@@ -433,17 +433,17 @@ class Config:
             return parsed_attribute_value
         return {}
 
-    def get_default_function_node_selector(self):
+    def get_default_function_node_selector(self) -> dict:
         return self.decode_base64_config_and_load_to_dict(
             "default_function_node_selector"
         )
 
-    def get_preemptible_node_selector(self):
+    def get_preemptible_node_selector(self) -> dict:
         return self.decode_base64_config_and_load_to_dict(
             "preemptible_nodes.node_selector"
         )
 
-    def get_preemptible_tolerations(self):
+    def get_preemptible_tolerations(self) -> dict:
         return self.decode_base64_config_and_load_to_dict(
             "preemptible_nodes.tolerations"
         )

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -420,7 +420,9 @@ class Config:
                 raise mlrun.errors.MLRunNotFoundError(
                     "Attribute does not exist in config"
                 )
-        if raw_attribute_value:
+        # There is a bug in the installer component in iguazio system that causes the configrued value to be base64 of
+        # null (without conditioning it we will end up returning None instead of empty dict)
+        if raw_attribute_value and raw_attribute_value != "bnVsbA==":
             try:
                 decoded_attribute_value = base64.b64decode(raw_attribute_value).decode()
             except Exception:

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -777,6 +777,8 @@ def show_kfp_run(run, clear_output=False):
 def add_default_function_node_selector(
     container_op: dsl.ContainerOp,
 ) -> dsl.ContainerOp:
-    for label_name, label_value in config.get_default_function_node_selector().items():
-        container_op.add_node_selector_constraint(label_name, label_value)
+    node_selector = config.get_default_function_node_selector()
+    if node_selector:
+        for label_name, label_value in node_selector.items():
+            container_op.add_node_selector_constraint(label_name, label_value)
     return container_op

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -777,8 +777,6 @@ def show_kfp_run(run, clear_output=False):
 def add_default_function_node_selector(
     container_op: dsl.ContainerOp,
 ) -> dsl.ContainerOp:
-    node_selector = config.get_default_function_node_selector()
-    if node_selector:
-        for label_name, label_value in node_selector.items():
-            container_op.add_node_selector_constraint(label_name, label_value)
+    for label_name, label_value in config.get_default_function_node_selector().items():
+        container_op.add_node_selector_constraint(label_name, label_value)
     return container_op

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,6 +282,20 @@ def test_get_parsed_igz_version():
     assert igz_version.patch == 0
 
 
+def test_get_default_function_node_selector():
+    mlconf.config.default_function_node_selector = None
+    assert mlconf.config.get_default_function_node_selector() == {}
+
+    mlconf.config.default_function_node_selector = ""
+    assert mlconf.config.get_default_function_node_selector() == {}
+
+    mlconf.config.default_function_node_selector = "e30="
+    assert mlconf.config.get_default_function_node_selector() == {}
+
+    mlconf.config.default_function_node_selector = "bnVsbA=="
+    assert mlconf.config.get_default_function_node_selector() == {}
+
+
 def test_setting_dbpath_trigger_connect(requests_mock: requests_mock_package.Mocker):
     api_url = "http://mlrun-api-url:8080"
     remote_host = "some-namespace"


### PR DESCRIPTION
There was a bug in the installer component in the Iguazio system that ends up in configuring the values with `bnVsbA==` which is base64 of `null` which caused problems in places counting on the configuration to return a dict 
Add a condition to treat this value as empty