### PR TITLE
[DB] Add retry on conflict in store_x methods to prevent race condition

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,7 @@ pytest-asyncio~=0.15.0
 pytest-alembic~=0.4.0
 pytest-httpserver~=1.0
 requests-mock~=1.8
+httpx~=0.22.0
 # needed for system tests
 matplotlib~=3.0
 graphviz~=0.16.0

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1,7 +1,6 @@
 import asyncio
 import collections
 import re
-import time
 import typing
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -119,7 +118,6 @@ class SQLDB(DBInterface):
             "project_resources_counters": {"value": None, "ttl": datetime.min}
         }
         self._name_with_iter_regex = re.compile("^[0-9]+-.+$")
-        self._been_here = 0
 
     def initialize(self, session):
         pass
@@ -619,10 +617,6 @@ class SQLDB(DBInterface):
                 project=project,
                 uid=uid,
             )
-
-        if self._been_here == 0:
-            time.sleep(5)
-        self._been_here += 1
         fn.updated = updated
         labels = get_in(function, "metadata.labels", {})
         update_labels(fn, labels)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2270,7 +2270,7 @@ class SQLDB(DBInterface):
                             f"Conflict - {cls} already exists: {obj.get_identifier_string()}"
                         ) from err
                     except mlrun.errors.MLRunConflictError as exc:
-                        raise mlrun.errors.MLRunFatalFailureException(
+                        raise mlrun.errors.MLRunFatalFailureError(
                             original_exception=exc
                         )
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -79,7 +79,8 @@ def retry_on_conflict(function):
                 return function(*args, **kwargs)
             except Exception as exc:
                 conflict_messages = [
-                    "(sqlite3.IntegrityError) UNIQUE constraint failed"
+                    "(sqlite3.IntegrityError) UNIQUE constraint failed",
+                    "(pymysql.err.IntegrityError) (1062, \"Duplicate entry"
                 ]
                 if mlrun.utils.helpers.are_strings_in_exception_chain_messages(exc, conflict_messages):
                     logger.warning(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2270,7 +2270,7 @@ class SQLDB(DBInterface):
                             f"Conflict - {cls} already exists: {obj.get_identifier_string()}"
                         ) from err
                     except mlrun.errors.MLRunConflictError as exc:
-                        raise mlrun.utils.helpers.FatalFailureException(
+                        raise mlrun.errors.MLRunFatalFailureException(
                             original_exception=exc
                         )
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import re
+import time
 import typing
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -118,6 +119,7 @@ class SQLDB(DBInterface):
             "project_resources_counters": {"value": None, "ttl": datetime.min}
         }
         self._name_with_iter_regex = re.compile("^[0-9]+-.+$")
+        self._been_here = 0
 
     def initialize(self, session):
         pass
@@ -617,6 +619,10 @@ class SQLDB(DBInterface):
                 project=project,
                 uid=uid,
             )
+
+        if self._been_here == 0:
+            time.sleep(5)
+        self._been_here += 1
         fn.updated = updated
         labels = get_in(function, "metadata.labels", {})
         update_labels(fn, labels)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -63,6 +63,16 @@ unversioned_tagged_object_uid_prefix = "unversioned-"
 
 
 def retry_on_conflict(function):
+    """
+    Most of our store_x functions starting from doing get, then if nothing is found creating the object otherwise
+    updating attributes on the existing object. On the SQL level this translates to either INSERT or UPDATE queries.
+    Sometimes we have a race condition in which two requests do the get, find nothing, create a new object, but only the
+    SQL query of the first one will succeed, the second will get a conflict error, in that case, a retry like we're
+    doing on the bottom most layer (like the one for the database is locked error) won't help, cause the object does not
+    hold a reference to the existing DB object, and therefore will always translate to an INSERT query, therefore, in
+    order to make it work, we need to do the get again, and in other words, call the whole store_x function again
+    This why we implemented this retry as a decorator that comes "around" the existing functions
+    """
     def wrapper(*args, **kwargs):
         def _try_function():
             try:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -145,6 +145,7 @@ class SQLDB(DBInterface):
     def _list_logs(self, session: Session, project: str):
         return self._query(session, Log, project=project).all()
 
+    @retry_on_conflict
     def store_run(
         self,
         session,
@@ -327,6 +328,7 @@ class SQLDB(DBInterface):
         run_record.state = state
         run_dict.setdefault("status", {})["state"] = state
 
+    @retry_on_conflict
     def store_artifact(
         self,
         session,
@@ -968,6 +970,7 @@ class SQLDB(DBInterface):
         update_labels(project_record, labels)
         self._upsert(session, project_record)
 
+    @retry_on_conflict
     def store_project(self, session: Session, name: str, project: schemas.Project):
         logger.debug("Storing project in DB", name=name, project=project)
         project_record = self._get_project_record(
@@ -1807,6 +1810,7 @@ class SQLDB(DBInterface):
         labels = common_object_dict["metadata"].pop("labels", {}) or {}
         update_labels(db_object, labels)
 
+    @retry_on_conflict
     def store_feature_set(
         self,
         session,
@@ -2114,6 +2118,7 @@ class SQLDB(DBInterface):
         )
         return [(project, row[0], row[1]) for row in query]
 
+    @retry_on_conflict
     def store_feature_vector(
         self,
         session,
@@ -2795,6 +2800,7 @@ class SQLDB(DBInterface):
             session, source_record, move_to=order, move_from=None
         )
 
+    @retry_on_conflict
     def store_marketplace_source(
         self,
         session,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -144,6 +144,8 @@ default_config = {
         "db": {
             "commit_retry_timeout": 30,
             "commit_retry_interval": 3,
+            "conflict_retry_timeout": 15,
+            "conflict_retry_interval": None,
             # Whether to perform data migrations on initialization. enabled or disabled
             "data_migrations_mode": "enabled",
             # Whether or not to perform database migration from sqlite to mysql on initialization

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -131,6 +131,16 @@ class MLRunTimeoutError(MLRunHTTPStatusError, TimeoutError):
     error_status_code = HTTPStatus.GATEWAY_TIMEOUT.value
 
 
+class MLRunFatalFailureException(Exception):
+    """
+    Internal exception meant to be used inside mlrun.utils.helpers.retry_until_successful to signal the loop not to
+    retry
+    """
+    def __init__(self, original_exception: Exception, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.original_exception = original_exception
+
+
 STATUS_ERRORS = {
     HTTPStatus.BAD_REQUEST.value: MLRunBadRequestError,
     HTTPStatus.UNAUTHORIZED.value: MLRunUnauthorizedError,

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -1,3 +1,4 @@
+import typing
 from http import HTTPStatus
 
 import requests
@@ -135,8 +136,9 @@ class MLRunFatalFailureError(Exception):
     """
     Internal exception meant to be used inside mlrun.utils.helpers.retry_until_successful to signal the loop not to
     retry
+    Allowing to pass to original exception that will be raised from the loop (instead of this exception)
     """
-    def __init__(self, original_exception: Exception, *args, **kwargs) -> None:
+    def __init__(self, *args, original_exception: typing.Optional[Exception] = None, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.original_exception = original_exception
 

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -21,7 +21,7 @@ class MLRunTaskNotReady(MLRunBaseError):
 
 class MLRunHTTPError(MLRunBaseError, requests.HTTPError):
     def __init__(
-        self, message: str, response: requests.Response = None, status_code: int = None
+        self, *args, response: requests.Response = None, status_code: int = None, **kwargs
     ):
 
         # because response object is probably with an error, it returns False, so we
@@ -31,7 +31,7 @@ class MLRunHTTPError(MLRunBaseError, requests.HTTPError):
         if status_code:
             response.status_code = status_code
 
-        requests.HTTPError.__init__(self, message, response=response)
+        requests.HTTPError.__init__(self, *args, response=response, **kwargs)
 
 
 class MLRunHTTPStatusError(MLRunHTTPError):
@@ -43,9 +43,9 @@ class MLRunHTTPStatusError(MLRunHTTPError):
 
     error_status_code = None
 
-    def __init__(self, message: str, response: requests.Response = None):
+    def __init__(self, *args, response: requests.Response = None, **kwargs):
         super(MLRunHTTPStatusError, self).__init__(
-            message, response=response, status_code=self.error_status_code
+            *args, response=response, status_code=self.error_status_code, **kwargs
         )
 
 

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -21,7 +21,11 @@ class MLRunTaskNotReady(MLRunBaseError):
 
 class MLRunHTTPError(MLRunBaseError, requests.HTTPError):
     def __init__(
-        self, *args, response: requests.Response = None, status_code: int = None, **kwargs
+        self,
+        *args,
+        response: requests.Response = None,
+        status_code: int = None,
+        **kwargs,
     ):
 
         # because response object is probably with an error, it returns False, so we
@@ -138,7 +142,10 @@ class MLRunFatalFailureError(Exception):
     retry
     Allowing to pass to original exception that will be raised from the loop (instead of this exception)
     """
-    def __init__(self, *args, original_exception: typing.Optional[Exception] = None, **kwargs) -> None:
+
+    def __init__(
+        self, *args, original_exception: typing.Optional[Exception] = None, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.original_exception = original_exception
 

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -131,7 +131,7 @@ class MLRunTimeoutError(MLRunHTTPStatusError, TimeoutError):
     error_status_code = HTTPStatus.GATEWAY_TIMEOUT.value
 
 
-class MLRunFatalFailureException(Exception):
+class MLRunFatalFailureError(Exception):
     """
     Internal exception meant to be used inside mlrun.utils.helpers.retry_until_successful to signal the loop not to
     retry

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -892,6 +892,14 @@ def get_workflow_url(project, id=None):
     return url
 
 
+def are_strings_in_exception_chain_messages(exception: Exception, strings_list = typing.List[str]) -> bool:
+    while exception is not None:
+        if any([string in str(exception) for string in strings_list]):
+            return True
+        exception = exception.__cause__
+    return False
+
+
 class RunNotifications:
     def __init__(self, with_ipython=True, with_slack=False, secrets=None):
         self._hooks = []

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -892,7 +892,9 @@ def get_workflow_url(project, id=None):
     return url
 
 
-def are_strings_in_exception_chain_messages(exception: Exception, strings_list = typing.List[str]) -> bool:
+def are_strings_in_exception_chain_messages(
+    exception: Exception, strings_list=typing.List[str]
+) -> bool:
     while exception is not None:
         if any([string in str(exception) for string in strings_list]):
             return True

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -843,7 +843,7 @@ def retry_until_successful(
             result = _function(*args, **kwargs)
             return result
 
-        except mlrun.errors.MLRunFatalFailureException as exc:
+        except mlrun.errors.MLRunFatalFailureError as exc:
             logger.debug("Fatal failure exception raised. Not retrying")
             raise exc.original_exception
         except Exception as exc:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -750,12 +750,6 @@ def fill_function_hash(function_dict, tag=""):
     return fill_object_hash(function_dict, "hash", tag)
 
 
-class FatalFailureException(Exception):
-    def __init__(self, original_exception: Exception, *args: object) -> None:
-        super().__init__(*args)
-        self.original_exception = original_exception
-
-
 def create_linear_backoff(base=2, coefficient=2, stop_value=120):
     """
     Create a generator of linear backoff. Check out usage example in test_helpers.py
@@ -849,7 +843,7 @@ def retry_until_successful(
             result = _function(*args, **kwargs)
             return result
 
-        except FatalFailureException as exc:
+        except mlrun.errors.MLRunFatalFailureException as exc:
             logger.debug("Fatal failure exception raised. Not retrying")
             raise exc.original_exception
         except Exception as exc:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -844,7 +844,6 @@ def retry_until_successful(
             return result
 
         except mlrun.errors.MLRunFatalFailureError as exc:
-            logger.debug("Fatal failure exception raised. Not retrying")
             raise exc.original_exception
         except Exception as exc:
             last_exception = exc

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -1,4 +1,9 @@
+import asyncio
+import tests.conftest
 import unittest.mock
+
+import httpx
+import pytest
 from http import HTTPStatus
 
 import kubernetes.client.rest
@@ -48,6 +53,52 @@ def test_build_status_pod_not_found(db: Session, client: TestClient):
         },
     )
     assert response.status_code == HTTPStatus.NOT_FOUND.value
+
+
+@pytest.mark.asyncio
+async def test_multiple_store_function_race_condition(db: Session, async_client: httpx.AsyncClient):
+    """
+    This is testing the case that the retry_on_conflict decorator is coming to solve, see its docstring for more details
+    """
+    project = {
+        "metadata": {
+            "name": "project-name",
+        }
+    }
+    response = await async_client.post(
+        f"projects",
+        json=project,
+    )
+    assert response.status_code == HTTPStatus.CREATED.value
+    # Make the get function method to return None on the first two calls, and then use the original function
+    get_function_mock = tests.conftest.MockSpecificCalls(mlrun.api.utils.singletons.db.get_db()._get_class_instance_by_uid,
+                                          [1, 2],
+                                          None).mock_function
+    mlrun.api.utils.singletons.db.get_db()._get_class_instance_by_uid = unittest.mock.Mock(side_effect=get_function_mock)
+    function = {
+        "kind": "job",
+        "metadata": {
+            "name": "function-name",
+            "project": "project-name",
+            "tag": "latest",
+        },
+    }
+
+    request1_task = asyncio.create_task(async_client.post(
+        f"func/{function['metadata']['project']}/{function['metadata']['name']}",
+        json=function,
+    ))
+    request2_task = asyncio.create_task(async_client.post(
+        f"func/{function['metadata']['project']}/{function['metadata']['name']}",
+        json=function,
+    ))
+    response1, response2 = await asyncio.gather(
+        request1_task,
+        request2_task,
+    )
+
+    assert response1.status_code == HTTPStatus.OK.value
+    assert response2.status_code == HTTPStatus.OK.value
 
 
 def test_build_function_with_mlrun_bool(db: Session, client: TestClient):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,10 +1,10 @@
-import unittest.mock
 import typing
-import httpx
+import unittest.mock
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Generator
 
 import deepdiff
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -50,7 +50,8 @@ def db() -> Generator:
 
 
 def set_base_url_for_test_client(
-    client: typing.Union[httpx.AsyncClient, TestClient], prefix: str = BASE_VERSIONED_API_PREFIX
+    client: typing.Union[httpx.AsyncClient, TestClient],
+    prefix: str = BASE_VERSIONED_API_PREFIX,
 ):
     if isinstance(client, httpx.AsyncClient):
         client.base_url = client.base_url.join(prefix)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,4 +1,6 @@
 import unittest.mock
+import typing
+import httpx
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Generator
 
@@ -48,12 +50,17 @@ def db() -> Generator:
 
 
 def set_base_url_for_test_client(
-    client: TestClient, prefix: str = BASE_VERSIONED_API_PREFIX
+    client: typing.Union[httpx.AsyncClient, TestClient], prefix: str = BASE_VERSIONED_API_PREFIX
 ):
-    client.base_url = client.base_url + prefix
+    if isinstance(client, httpx.AsyncClient):
+        client.base_url = client.base_url.join(prefix)
+    elif isinstance(client, TestClient):
+        client.base_url = client.base_url + prefix
 
-    # https://stackoverflow.com/questions/10893374/python-confusions-with-urljoin/10893427#10893427
-    client.base_url = client.base_url.rstrip("/") + "/"
+        # https://stackoverflow.com/questions/10893374/python-confusions-with-urljoin/10893427#10893427
+        client.base_url = client.base_url.rstrip("/") + "/"
+    else:
+        raise NotImplementedError(f"Unknown test client type: {type(client)}")
 
 
 @pytest.fixture()
@@ -64,9 +71,23 @@ def client(db) -> Generator:
         mlconf.runtimes_cleanup_interval = 0
         mlconf.httpdb.projects.periodic_sync_interval = "0 seconds"
 
-        with TestClient(app) as c:
-            set_base_url_for_test_client(c)
-            yield c
+        with TestClient(app) as test_client:
+            set_base_url_for_test_client(test_client)
+            yield test_client
+
+
+@pytest.fixture()
+@pytest.mark.asyncio
+async def async_client(db) -> Generator:
+    with TemporaryDirectory(suffix="mlrun-logs") as log_dir:
+        mlconf.httpdb.logs_path = log_dir
+        mlconf.runs_monitoring_interval = 0
+        mlconf.runtimes_cleanup_interval = 0
+        mlconf.httpdb.projects.periodic_sync_interval = "0 seconds"
+
+        async with httpx.AsyncClient(app=app, base_url="http://test") as async_client:
+            set_base_url_for_test_client(async_client)
+            yield async_client
 
 
 class K8sSecretsMock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import shutil
+import typing
 import traceback
 from datetime import datetime
 from http import HTTPStatus
@@ -134,3 +135,20 @@ def exec_mlrun(args, cwd=None, op="run"):
         print(traceback.format_exc())
         raise Exception(out.stderr.decode("utf-8"))
     return out.stdout.decode("utf-8")
+
+
+class MockSpecificCalls:
+
+    def __init__(self, original_function: typing.Callable, call_indexes_to_mock: typing.List[int], return_value: typing.Any):
+        self.original_function = original_function
+        self.call_indexes_to_mock = call_indexes_to_mock
+        self.return_value = return_value
+
+    calls = 0
+
+    def mock_function(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls not in self.call_indexes_to_mock:
+            return self.original_function(*args, **kwargs)
+        else:
+            return self.return_value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import shutil
-import typing
 import traceback
+import typing
 from datetime import datetime
 from http import HTTPStatus
 from os import environ
@@ -138,8 +138,12 @@ def exec_mlrun(args, cwd=None, op="run"):
 
 
 class MockSpecificCalls:
-
-    def __init__(self, original_function: typing.Callable, call_indexes_to_mock: typing.List[int], return_value: typing.Any):
+    def __init__(
+        self,
+        original_function: typing.Callable,
+        call_indexes_to_mock: typing.List[int],
+        return_value: typing.Any,
+    ):
         self.original_function = original_function
         self.call_indexes_to_mock = call_indexes_to_mock
         self.return_value = return_value

--- a/tests/integration/sdk_api/httpdb/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/test_runs.py
@@ -6,7 +6,6 @@ import pytest
 import mlrun
 import mlrun.api.schemas
 import tests.integration.sdk_api.base
-import multiprocessing.pool
 
 
 class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
@@ -26,39 +25,6 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             run_body = json.load(run_body_file)
         mlrun.get_run_db().store_run(run_body, uid, project_name)
         mlrun.get_run_db().read_run(uid, project_name)
-
-    def test_conflict_functions(self):
-        """
-        Sometimes when the run has artifacts (inputs or outputs) their preview is pretty big (but it is limited to some
-        size), when we moved to MySQL a run similar to the one this test is storing was failing to be read from the DB
-        after insert on _pickle.UnpicklingError: pickle data was truncated
-        So we fixed this by changing the BLOB fields to sqlalchemy.dialects.mysql.MEDIUMBLOB
-        This test verifies it's working
-        """
-
-        project_name = "project-name"
-        mlrun.get_or_create_project(project_name, "./")
-        function = {
-            "kind": "job",
-            "metadata": {
-                "name": "function-name",
-                "project": "project-name",
-                "tag": "latest",
-            },
-        }
-        with multiprocessing.pool.ThreadPool(2) as pool:
-            result = pool.apply_async(mlrun.get_run_db().store_function,
-                                      args=[function,
-                             function["metadata"]["name"],
-                             function["metadata"]["project"],
-                             function["metadata"]["tag"]])
-            result2 = pool.apply_async(mlrun.get_run_db().store_function,
-                                       args=[function,
-                                             function["metadata"]["name"],
-                                             function["metadata"]["project"],
-                                             function["metadata"]["tag"]])
-            print(result.get(timeout=10))
-            print(result2.get(timeout=10))
 
     def test_list_runs(self):
         # Create runs

--- a/tests/integration/sdk_api/httpdb/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/test_runs.py
@@ -6,6 +6,7 @@ import pytest
 import mlrun
 import mlrun.api.schemas
 import tests.integration.sdk_api.base
+import multiprocessing.pool
 
 
 class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
@@ -25,6 +26,39 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             run_body = json.load(run_body_file)
         mlrun.get_run_db().store_run(run_body, uid, project_name)
         mlrun.get_run_db().read_run(uid, project_name)
+
+    def test_conflict_functions(self):
+        """
+        Sometimes when the run has artifacts (inputs or outputs) their preview is pretty big (but it is limited to some
+        size), when we moved to MySQL a run similar to the one this test is storing was failing to be read from the DB
+        after insert on _pickle.UnpicklingError: pickle data was truncated
+        So we fixed this by changing the BLOB fields to sqlalchemy.dialects.mysql.MEDIUMBLOB
+        This test verifies it's working
+        """
+
+        project_name = "project-name"
+        mlrun.get_or_create_project(project_name, "./")
+        function = {
+            "kind": "job",
+            "metadata": {
+                "name": "function-name",
+                "project": "project-name",
+                "tag": "latest",
+            },
+        }
+        with multiprocessing.pool.ThreadPool(2) as pool:
+            result = pool.apply_async(mlrun.get_run_db().store_function,
+                                      args=[function,
+                             function["metadata"]["name"],
+                             function["metadata"]["project"],
+                             function["metadata"]["tag"]])
+            result2 = pool.apply_async(mlrun.get_run_db().store_function,
+                                       args=[function,
+                                             function["metadata"]["name"],
+                                             function["metadata"]["project"],
+                                             function["metadata"]["tag"]])
+            print(result.get(timeout=10))
+            print(result2.get(timeout=10))
 
     def test_list_runs(self):
         # Create runs

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -26,7 +26,7 @@ def test_retry_until_successful_fatal_failure():
     original_exception = Exception("original")
 
     def _raise_fatal_failure():
-        raise mlrun.errors.MLRunFatalFailureError(original_exception)
+        raise mlrun.errors.MLRunFatalFailureError(original_exception=original_exception)
 
     with pytest.raises(Exception, match=str(original_exception)):
         mlrun.utils.helpers.retry_until_successful(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -26,7 +26,7 @@ def test_retry_until_successful_fatal_failure():
     original_exception = Exception("original")
 
     def _raise_fatal_failure():
-        raise mlrun.utils.helpers.FatalFailureException(original_exception)
+        raise mlrun.errors.MLRunFatalFailureException(original_exception)
 
     with pytest.raises(Exception, match=str(original_exception)):
         mlrun.utils.helpers.retry_until_successful(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -26,7 +26,7 @@ def test_retry_until_successful_fatal_failure():
     original_exception = Exception("original")
 
     def _raise_fatal_failure():
-        raise mlrun.errors.MLRunFatalFailureException(original_exception)
+        raise mlrun.errors.MLRunFatalFailureError(original_exception)
 
     with pytest.raises(Exception, match=str(original_exception)):
         mlrun.utils.helpers.retry_until_successful(


### PR DESCRIPTION
Most of our store_x functions starting from doing get, then if nothing is found creating the object otherwise updating attributes on the existing object. On the SQL level this translates to either INSERT or UPDATE queries.
Sometimes we have a race condition in which two requests do the get, find nothing, create a new object, but only the SQL query of the first one will succeed, the second will get a conflict error. 
Added a decorator that will retry on such scenario and applied it for all store_x methods in the DB class

In addition:
* Added support for async unit tests of the API (was needed to reproduce the race condition)
* Added 2 config values `.httpdb.db.conflict_retry_timeout` by default 15 (seconds), `.httpdb.db.conflict_retry_interval` by default None which will default to the `[[0.0001, 1], [3, None]]` step backoff
* Moved `FatalFailureException` from `utils.helpers` to `mlrun.errors` (and renamed to `MLRunFatalFailureError`)
* Changed Exception class definitions in `mlrun.errors` to add variables to the init as kwargs to allow easier inheritance later (planned to use it, but didn't need eventually)

Fixes https://jira.iguazeng.com/browse/ML-1802