### PR TITLE
[API] Add nuclio streams feature flag to the frontend spec

### DIFF
--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -1,6 +1,7 @@
 import typing
 
 import fastapi
+import semver
 
 import mlrun.api.api.deps
 import mlrun.api.schemas
@@ -86,6 +87,14 @@ def _resolve_feature_flags() -> mlrun.api.schemas.FeatureFlags:
     authentication = mlrun.api.schemas.AuthenticationFeatureFlag(
         mlrun.mlconf.httpdb.authentication.mode
     )
+    nuclio_streams = mlrun.api.schemas.NuclioStreamsFeatureFlag.disabled
+
+    if mlrun.mlconf.get_parsed_igz_version() and semver.VersionInfo.parse(
+        mlrun.mlconf.resolve_nuclio_version()
+    ) >= semver.VersionInfo.parse("1.7.8"):
+        nuclio_streams = mlrun.api.schemas.NuclioStreamsFeatureFlag.enabled
     return mlrun.api.schemas.FeatureFlags(
-        project_membership=project_membership, authentication=authentication
+        project_membership=project_membership,
+        authentication=authentication,
+        nuclio_streams=nuclio_streams,
     )

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -54,6 +54,7 @@ from .frontend_spec import (
     AuthenticationFeatureFlag,
     FeatureFlags,
     FrontendSpec,
+    NuclioStreamsFeatureFlag,
     ProjectMembershipFeatureFlag,
 )
 from .function import FunctionState

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -18,9 +18,15 @@ class AuthenticationFeatureFlag(str, enum.Enum):
     iguazio = "iguazio"
 
 
+class NuclioStreamsFeatureFlag(str, enum.Enum):
+    enabled = "enabled"
+    disabled = "disabled"
+
+
 class FeatureFlags(pydantic.BaseModel):
     project_membership: ProjectMembershipFeatureFlag
     authentication: AuthenticationFeatureFlag
+    nuclio_streams: NuclioStreamsFeatureFlag
 
 
 class FrontendSpec(pydantic.BaseModel):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -491,6 +491,33 @@ class Config:
             return f"http://ml-pipeline.{namespace}.svc.cluster.local:8888"
         return None
 
+    # if nuclio version specified on mlrun config set it likewise,
+    # if not specified, get it from nuclio api client
+    # since this is a heavy operation (sending requests to API), and it's unlikely that the version
+    # will change - cache it (this means if we upgrade nuclio, we need to restart mlrun to re-fetch the new version)
+    def resolve_nuclio_version(self):
+        from mlrun.api.utils.clients import nuclio
+        from mlrun.utils import logger
+
+        try:
+            if not config._cached_nuclio_version:
+                raise AttributeError
+
+        except AttributeError:
+
+            # config override everything
+            nuclio_version = config.nuclio_version
+            if not nuclio_version and config.nuclio_dashboard_url:
+                try:
+                    nuclio_client = nuclio.Client()
+                    nuclio_version = nuclio_client.get_dashboard_version()
+                except Exception as exc:
+                    logger.warning("Failed to resolve nuclio version", exc=str(exc))
+
+            config._cached_nuclio_version = nuclio_version
+
+        return config._cached_nuclio_version
+
     @staticmethod
     def get_storage_auto_mount_params():
         auto_mount_params = {}

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -42,6 +42,10 @@ def test_get_frontend_spec(
         frontend_spec.feature_flags.authentication
         == mlrun.api.schemas.AuthenticationFeatureFlag.none
     )
+    assert (
+        frontend_spec.feature_flags.nuclio_streams
+        == mlrun.api.schemas.NuclioStreamsFeatureFlag.disabled
+    )
     assert frontend_spec.default_function_image_by_kind is not None
     assert frontend_spec.function_deployment_mlrun_command is not None
     assert frontend_spec.default_artifact_path is not None
@@ -131,3 +135,41 @@ def test_get_frontend_spec_jobs_dashboard_url_resolution(
         f"&var-groupBy={{filter_name}}&var-filter={{filter_value}}"
     )
     mlrun.api.utils.clients.iguazio.Client().try_get_grafana_service_url.assert_called_once()
+
+
+def test_get_frontend_spec_nuclio_streams(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    for testcase in [
+        {
+            "iguazio_version": "3.2.0",
+            "nuclio_version": "1.6.23",
+            "expected_feature_flag": mlrun.api.schemas.NuclioStreamsFeatureFlag.disabled,
+        },
+        {
+            "iguazio_version": None,
+            "nuclio_version": "1.6.23",
+            "expected_feature_flag": mlrun.api.schemas.NuclioStreamsFeatureFlag.disabled,
+        },
+        {
+            "iguazio_version": None,
+            "nuclio_version": "1.7.8",
+            "expected_feature_flag": mlrun.api.schemas.NuclioStreamsFeatureFlag.disabled,
+        },
+        {
+            "iguazio_version": "3.4.0",
+            "nuclio_version": "1.7.8",
+            "expected_feature_flag": mlrun.api.schemas.NuclioStreamsFeatureFlag.enabled,
+        },
+    ]:
+        # init cached value to empty string in the beginning of the test case
+        mlrun.mlconf._cached_nuclio_version = ""
+        mlrun.mlconf.igz_version = testcase["iguazio_version"]
+        mlrun.mlconf.nuclio_version = testcase["nuclio_version"]
+
+        response = client.get("frontend-spec")
+        frontend_spec = mlrun.api.schemas.FrontendSpec(**response.json())
+        assert response.status_code == http.HTTPStatus.OK.value
+        assert frontend_spec.feature_flags.nuclio_streams == testcase.get(
+            "expected_feature_flag"
+        )


### PR DESCRIPTION
Define nuclio streams feature flag in frontend_spec for UI purposes.

Enable the nuclio streams endpoint in the UI if we are in an Iguazio system, and Nuclio's version >= 1.7.8 (endpoint was introduced in https://github.com/nuclio/nuclio/pull/2456).