### PR TITLE
[DB] Align all upserts to happen from helper method

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2712,9 +2712,11 @@ class SQLDB(DBInterface):
 
         for source_record in query:
             source_record.index = source_record.index + modifier
+            # using merge since primary key is changing
             session.merge(source_record)
 
         if move_to:
+            # using merge since primary key is changing
             session.merge(moved_object)
         else:
             session.delete(moved_object)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2334,7 +2334,7 @@ class SQLDB(DBInterface):
                         if any([message in str(err) for message in conflict_messages]):
                             raise mlrun.errors.MLRunConflictError(
                                 f"Conflict - {cls} already exists: {identifiers}"
-                            )
+                            ) from err
                         raise mlrun.errors.MLRunRuntimeError(
                             f"Failed committing changes to DB. class={cls} objects={identifiers}"
                         ) from err
@@ -2698,7 +2698,9 @@ class SQLDB(DBInterface):
 
         if move_from == move_to:
             # It's just modifying the same object - update and exit.
-            self._upsert(session, [moved_object])
+            # using merge since primary key is changing
+            session.merge(moved_object)
+            session.commit()
             return
 
         modifier = 1

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2303,6 +2303,7 @@ class SQLDB(DBInterface):
     def _upsert(self, session, objects, ignore=False):
         if not objects:
             return
+
         def _try_commit_obj():
             try:
                 for object_ in objects:
@@ -2320,7 +2321,9 @@ class SQLDB(DBInterface):
                     ) from err
                 logger.warning("Conflict adding resource to DB", cls=cls, err=str(err))
                 if not ignore:
-                    identifiers = ",".join(object_.get_identifier_string() for object_ in objects)
+                    identifiers = ",".join(
+                        object_.get_identifier_string() for object_ in objects
+                    )
                     # We want to retry only when database is locked so for any other scenario escalate to fatal failure
                     try:
                         raise mlrun.errors.MLRunConflictError(

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -407,7 +407,7 @@ def _align_runs_table(
             )
         db._update_run_updated_time(run, run_dict, updated)
         run.struct = run_dict
-        db._upsert(db_session, run, ignore=True)
+        db._upsert(db_session, [run], ignore=True)
 
 
 def _perform_version_1_data_migrations(

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -112,7 +112,7 @@ def test_list_runs_times_filters(db: Session, client: TestClient) -> None:
         updated=run_1_update_time,
     )
     run.struct = run_1
-    get_db()._upsert(db, run, ignore=True)
+    get_db()._upsert(db, [run], ignore=True)
 
     between_run_1_and_2 = datetime.now(timezone.utc)
 
@@ -138,7 +138,7 @@ def test_list_runs_times_filters(db: Session, client: TestClient) -> None:
         updated=run_2_update_time,
     )
     run.struct = run_2
-    get_db()._upsert(db, run, ignore=True)
+    get_db()._upsert(db, [run], ignore=True)
 
     # all start time range
     assert_time_range_request(client, [run_1_uid, run_2_uid])

--- a/tests/api/db/test_runs.py
+++ b/tests/api/db/test_runs.py
@@ -138,7 +138,7 @@ def test_data_migration_align_runs_table(db: DBInterface, db_session: Session):
     runs = db._find_runs(db_session, None, "*", None).all()
     for run in runs:
         _change_run_record_to_before_align_runs_migration(run, time_before_creation)
-        db._upsert(db_session, run, ignore=True)
+        db._upsert(db_session, [run], ignore=True)
 
     # run the migration
     mlrun.api.initial_data._align_runs_table(db, db_session)
@@ -168,7 +168,7 @@ def test_data_migration_align_runs_table_with_empty_run_body(
     # change to be as it will be in field (before the migration) and then empty the body
     _change_run_record_to_before_align_runs_migration(run, time_before_creation)
     run.struct = {}
-    db._upsert(db_session, run, ignore=True)
+    db._upsert(db_session, [run], ignore=True)
 
     # run the migration
     mlrun.api.initial_data._align_runs_table(db, db_session)


### PR DESCRIPTION
In a scale test we saw this error:
```
> 2022-03-09 12:38:06,465 [warning] Got conflict error from DB. Retrying: {'err': 'This Session\'s transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (pymysql.err.IntegrityError) (1062, "Duplicate entry \'aaaa-latest-fnc43\' for key \'functions_tags._functions_tags_uc\'")\n[SQL: INSERT INTO functions_tags (project, name, obj_id, obj_name) VALUES (%(project)s, %(name)s, %(obj_id)s, %(obj_name)s)]\n[parameters: {\'project\': \'aaaa\', \'name\': \'latest\', \'obj_id\': 72, \'obj_name\': \'fnc43\'}]\n(Background on this error at: https://sqlalche.me/e/14/gkpj) (Background on this error at: https://sqlalche.me/e/14/7s2a)'}
```
Which made me notice that not all of the times where we add something to the DB (by `session.add()` or `session.merge()`) we're using the `_upsert` method, which has some retries mechanism, plus handling of doing `session.rollback()` on failure as suggested by SQLAlchemy
Aligned everywhere to use it

Fixes https://jira.iguazeng.com/browse/ML-1867