### PR TITLE
[API] Increase http connection pools maxsize to be equal to number of workers

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -157,7 +157,9 @@ async def startup_event():
     )
     loop = asyncio.get_running_loop()
     loop.set_default_executor(
-        concurrent.futures.ThreadPoolExecutor(max_workers=int(config.httpdb.max_workers))
+        concurrent.futures.ThreadPoolExecutor(
+            max_workers=int(config.httpdb.max_workers)
+        )
     )
 
     initialize_logs_dir()

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -156,9 +156,8 @@ async def startup_event():
         version=mlrun.utils.version.Version().get(),
     )
     loop = asyncio.get_running_loop()
-    max_workers = config.httpdb.max_workers or 64
     loop.set_default_executor(
-        concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        concurrent.futures.ThreadPoolExecutor(max_workers=int(config.httpdb.max_workers))
     )
 
     initialize_logs_dir()

--- a/mlrun/api/utils/auth/providers/opa.py
+++ b/mlrun/api/utils/auth/providers/opa.py
@@ -22,7 +22,8 @@ class Provider(
     def __init__(self) -> None:
         super().__init__()
         http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1)
+            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
+            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers)
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)

--- a/mlrun/api/utils/auth/providers/opa.py
+++ b/mlrun/api/utils/auth/providers/opa.py
@@ -23,7 +23,7 @@ class Provider(
         super().__init__()
         http_adapter = requests.adapters.HTTPAdapter(
             max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
-            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers)
+            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers),
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -61,7 +61,7 @@ class Client(
         super().__init__()
         http_adapter = requests.adapters.HTTPAdapter(
             max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
-            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers)
+            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers),
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -60,7 +60,8 @@ class Client(
     def __init__(self) -> None:
         super().__init__()
         http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1)
+            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
+            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers)
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -20,7 +20,8 @@ class Client(
     def __init__(self) -> None:
         super().__init__()
         http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1)
+            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
+            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers)
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -21,7 +21,7 @@ class Client(
         super().__init__()
         http_adapter = requests.adapters.HTTPAdapter(
             max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
-            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers)
+            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers),
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -138,7 +138,7 @@ default_config = {
         "data_volume": "",
         "real_path": "",
         "db_type": "sqldb",
-        "max_workers": "",
+        "max_workers": 64,
         # See mlrun.api.schemas.APIStates for options
         "state": "online",
         "db": {


### PR DESCRIPTION
During some scale bug investigation I noticed a lot of logs like:
```
WARNI [urllib3.connectionpool] Connection pool is full, discarding connection: 127.0.0.1. Connection pool size: 10
```
This is not horrific, there's [no data loss](https://stackoverflow.com/questions/53765366/urllib3-connectionpool-connection-pool-is-full-discarding-connection) or something, but sounds like we better increase the pool size to be equal to our workers number