### PR TITLE
[Platforms] Fix `mount_v3iod` for iguazio >=3.2.3

### DIFF
--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -247,19 +247,15 @@ def mount_v3iod(namespace, v3io_config_configmap):
                 k8s_client.V1VolumeMount(mount_path=mount_path, name=name)
             )
 
+        # this is a legacy path for the daemon shared memory
+        host_path = "/dev/shm/"
+
+        # path to shared memory for daemon was changed in Igauzio 3.2.3-b1
         igz_version = mlrun.mlconf.get_parsed_igz_version()
-        # path of shared memory for daemon was changed on Igauzio 3.2.3
         if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3-b1"):
-            add_vol(
-                name="shm",
-                mount_path="/dev/shm",
-                host_path="/var/run/iguazio/dayman-shm/" + namespace,
-            )
-        else:
-            # this is a legacy path for the daemon shared memory
-            add_vol(
-                name="shm", mount_path="/dev/shm", host_path="/dev/shm/" + namespace
-            )
+            host_path = "/var/run/iguazio/dayman-shm/"
+        add_vol(name="shm", mount_path="/dev/shm", host_path=host_path + namespace)
+
         add_vol(
             name="v3iod-comm",
             mount_path="/var/run/iguazio/dayman",

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -250,7 +250,7 @@ def mount_v3iod(namespace, v3io_config_configmap):
         # this is a legacy path for the daemon shared memory
         host_path = "/dev/shm/"
 
-        # path to shared memory for daemon was changed in Igauzio 3.2.3-b1
+        # path to shared memory for daemon was changed in Iguazio 3.2.3-b1
         igz_version = mlrun.mlconf.get_parsed_igz_version()
         if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3-b1"):
             host_path = "/var/run/iguazio/dayman-shm/"

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -252,7 +252,7 @@ def mount_v3iod(namespace, v3io_config_configmap):
         if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3-b1"):
             add_vol(
                 name="shm",
-                mount_path="/var/run/iguazio/dayman-shm",
+                mount_path="/dev/shm",
                 host_path="/var/run/iguazio/dayman-shm/" + namespace,
             )
         else:

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 
 import kfp.dsl
 import requests
+import semver
 import urllib3
 import v3io
 
@@ -246,7 +247,17 @@ def mount_v3iod(namespace, v3io_config_configmap):
                 k8s_client.V1VolumeMount(mount_path=mount_path, name=name)
             )
 
-        add_vol(name="shm", mount_path="/dev/shm", host_path="/dev/shm/" + namespace)
+        igz_version = mlrun.mlconf.get_parsed_igz_version()
+        if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3"):
+            add_vol(
+                name="shm", mount_path="/dev/shm", host_path="/dev/shm/" + namespace
+            )
+        else:
+            add_vol(
+                name="shm",
+                mount_path="/var/run/iguazio/dayman-shm",
+                host_path="/var/run/iguazio/dayman-shm/" + namespace,
+            )
         add_vol(
             name="v3iod-comm",
             mount_path="/var/run/iguazio/dayman",

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -248,7 +248,7 @@ def mount_v3iod(namespace, v3io_config_configmap):
             )
 
         igz_version = mlrun.mlconf.get_parsed_igz_version()
-        if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3"):
+        if True: #igz_version and igz_version >= semver.VersionInfo.parse("3.2.3"):
             add_vol(
                 name="shm",
                 mount_path="/var/run/iguazio/dayman-shm",

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -250,13 +250,13 @@ def mount_v3iod(namespace, v3io_config_configmap):
         igz_version = mlrun.mlconf.get_parsed_igz_version()
         if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3"):
             add_vol(
-                name="shm", mount_path="/dev/shm", host_path="/dev/shm/" + namespace
-            )
-        else:
-            add_vol(
                 name="shm",
                 mount_path="/var/run/iguazio/dayman-shm",
                 host_path="/var/run/iguazio/dayman-shm/" + namespace,
+            )
+        else:
+            add_vol(
+                name="shm", mount_path="/dev/shm", host_path="/dev/shm/" + namespace
             )
         add_vol(
             name="v3iod-comm",

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -248,13 +248,15 @@ def mount_v3iod(namespace, v3io_config_configmap):
             )
 
         igz_version = mlrun.mlconf.get_parsed_igz_version()
-        if True: #igz_version and igz_version >= semver.VersionInfo.parse("3.2.3"):
+        # path of shared memory for daemon was changed on Igauzio 3.2.3
+        if igz_version and igz_version >= semver.VersionInfo.parse("3.2.3-b1"):
             add_vol(
                 name="shm",
                 mount_path="/var/run/iguazio/dayman-shm",
                 host_path="/var/run/iguazio/dayman-shm/" + namespace,
             )
         else:
+            # this is a legacy path for the daemon shared memory
             add_vol(
                 name="shm", mount_path="/dev/shm", host_path="/dev/shm/" + namespace
             )


### PR DESCRIPTION
Fixing issue with Iguazio version 3.2.3 - files' path was changed.
added a conditioned location based on the version.
fix for ticket - [ML-1878](https://jira.iguazeng.com/browse/ML-1878)