### PR TITLE
[Featurestore] fix bug that would cause `d` time units to be invalid for Spark engine aggregations.

### DIFF
--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -717,7 +717,7 @@ class SparkAggregateByKey(StepToDict):
         unit = duration[-1:]
         if unit == "d":
             unit = "day"
-        if unit == "h":
+        elif unit == "h":
             unit = "hour"
         elif unit == "m":
             unit = "minute"


### PR DESCRIPTION
When using `Spark` engine and adding aggregations, time units with the `d` type would cause execptions:
`ValueError: Invalid duration '1d'`
This was due to bad `if` statement processing.