### PR TITLE
[Secrets] Change marketplace to use Secrets crud object + generalize it

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -26,7 +26,7 @@ import mlrun.api.utils.background_tasks
 import mlrun.api.utils.singletons.project_member
 from mlrun.api.api import deps
 from mlrun.api.api.utils import get_run_db_instance, log_and_raise, log_path
-from mlrun.api.crud.secrets import Secrets
+from mlrun.api.crud.secrets import Secrets, SecretsClientType
 from mlrun.api.schemas import SecretProviderName, SecretsData
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.builder import build_runtime
@@ -699,7 +699,9 @@ def _process_model_monitoring_secret(db_session, project_name: str, secret_key: 
         allow_secrets_from_k8s=True,
     )
     user_provided_key = secret_value is not None
-    internal_key_name = Secrets().generate_model_monitoring_secret_key(secret_key)
+    internal_key_name = Secrets().generate_client_secret_key(
+        SecretsClientType.model_monitoring, secret_key
+    )
 
     if not user_provided_key:
         secret_value = Secrets().get_secret(

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -200,7 +200,9 @@ def process_function_service_account(function):
     allowed_service_accounts = mlrun.api.crud.secrets.Secrets().get_secret(
         function.metadata.project,
         SecretProviderName.kubernetes,
-        mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key("allowed"),
+        mlrun.api.crud.secrets.Secrets().generate_client_secret_key(
+            mlrun.api.crud.secrets.SecretsClientType.service_accounts, "allowed"
+        ),
         allow_secrets_from_k8s=True,
         allow_internal_secrets=True,
     )
@@ -213,7 +215,9 @@ def process_function_service_account(function):
     default_service_account = mlrun.api.crud.secrets.Secrets().get_secret(
         function.metadata.project,
         SecretProviderName.kubernetes,
-        mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key("default"),
+        mlrun.api.crud.secrets.Secrets().generate_client_secret_key(
+            mlrun.api.crud.secrets.SecretsClientType.service_accounts, "default"
+        ),
         allow_secrets_from_k8s=True,
         allow_internal_secrets=True,
     )

--- a/mlrun/api/crud/__init__.py
+++ b/mlrun/api/crud/__init__.py
@@ -9,4 +9,4 @@ from .pipelines import Pipelines  # noqa: F401
 from .projects import Projects  # noqa: F401
 from .runs import Runs  # noqa: F401
 from .runtime_resources import RuntimeResources  # noqa: F401
-from .secrets import Secrets  # noqa: F401
+from .secrets import Secrets, SecretsClientType  # noqa: F401

--- a/mlrun/api/crud/marketplace.py
+++ b/mlrun/api/crud/marketplace.py
@@ -29,9 +29,9 @@ class Marketplace(metaclass=mlrun.utils.singleton.Singleton):
     @staticmethod
     def _in_k8s():
         k8s_helper = get_k8s()
-        if not k8s_helper or not k8s_helper.is_running_inside_kubernetes_cluster():
-            return False
-        return True
+        return (
+            k8s_helper is not None and k8s_helper.is_running_inside_kubernetes_cluster()
+        )
 
     @staticmethod
     def _generate_credentials_secret_key(source, key=""):

--- a/mlrun/api/crud/marketplace.py
+++ b/mlrun/api/crud/marketplace.py
@@ -14,6 +14,9 @@ from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config
 from mlrun.datastore import store_manager
 
+from ..schemas import SecretProviderName
+from .secrets import Secrets, SecretsClientType
+
 # Using a complex separator, as it's less likely someone will use it in a real secret name
 secret_name_separator = "-__-"
 
@@ -24,15 +27,18 @@ class Marketplace(metaclass=mlrun.utils.singleton.Singleton):
         self._catalogs = {}
 
     @staticmethod
-    def _get_k8s():
+    def _in_k8s():
         k8s_helper = get_k8s()
-        if not k8s_helper.is_running_inside_kubernetes_cluster():
-            return None
-        return k8s_helper
+        if not k8s_helper or not k8s_helper.is_running_inside_kubernetes_cluster():
+            return False
+        return True
 
     @staticmethod
     def _generate_credentials_secret_key(source, key=""):
-        return source + secret_name_separator + key
+        full_key = source + secret_name_separator + key
+        return Secrets().generate_client_secret_key(
+            SecretsClientType.marketplace, full_key
+        )
 
     def add_source(self, source: MarketplaceSource):
         source_name = source.metadata.name
@@ -42,7 +48,7 @@ class Marketplace(metaclass=mlrun.utils.singleton.Singleton):
 
     def remove_source(self, source_name):
         self._catalogs.pop(source_name, None)
-        if not self._get_k8s():
+        if not self._in_k8s():
             return
 
         source_credentials = self._get_source_credentials(source_name)
@@ -52,12 +58,15 @@ class Marketplace(metaclass=mlrun.utils.singleton.Singleton):
             self._generate_credentials_secret_key(source_name, key)
             for key in source_credentials
         ]
-        self._get_k8s().delete_project_secrets(
-            self._internal_project_name, secrets_to_delete
+        Secrets().delete_secrets(
+            self._internal_project_name,
+            SecretProviderName.kubernetes,
+            secrets_to_delete,
+            allow_internal_secrets=True,
         )
 
     def _store_source_credentials(self, source_name, credentials: dict):
-        if not self._get_k8s():
+        if not self._in_k8s():
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "MLRun is not configured with k8s, marketplace source credentials cannot be stored securely"
             )
@@ -66,16 +75,30 @@ class Marketplace(metaclass=mlrun.utils.singleton.Singleton):
             self._generate_credentials_secret_key(source_name, key): value
             for key, value in credentials.items()
         }
-        self._get_k8s().store_project_secrets(
-            self._internal_project_name, adjusted_credentials
+        Secrets().store_secrets(
+            self._internal_project_name,
+            mlrun.api.schemas.SecretsData(
+                provider=SecretProviderName.kubernetes, secrets=adjusted_credentials
+            ),
+            allow_internal_secrets=True,
         )
 
     def _get_source_credentials(self, source_name):
-        if not self._get_k8s():
+        if not self._in_k8s():
             return {}
 
         secret_prefix = self._generate_credentials_secret_key(source_name)
-        secrets = self._get_k8s().get_project_secret_data(self._internal_project_name)
+        secrets = (
+            Secrets()
+            .list_secrets(
+                self._internal_project_name,
+                SecretProviderName.kubernetes,
+                allow_secrets_from_k8s=True,
+                allow_internal_secrets=True,
+            )
+            .secrets
+        )
+
         source_secrets = {}
         for key, value in secrets.items():
             if key.startswith(secret_prefix):

--- a/mlrun/api/crud/model_endpoints.py
+++ b/mlrun/api/crud/model_endpoints.py
@@ -15,7 +15,7 @@ import mlrun.api.utils.singletons.k8s
 import mlrun.datastore.store_resources
 from mlrun.api.api.endpoints.functions import _build_function
 from mlrun.api.api.utils import _submit_run, get_run_db_instance
-from mlrun.api.crud.secrets import Secrets
+from mlrun.api.crud.secrets import Secrets, SecretsClientType
 from mlrun.api.schemas import (
     Features,
     Metric,
@@ -694,8 +694,8 @@ class ModelEndpoints:
         fn.set_env_from_secret(
             "MODEL_MONITORING_ACCESS_KEY",
             mlrun.api.utils.singletons.k8s.get_k8s().get_project_secret_name(project),
-            Secrets().generate_model_monitoring_secret_key(
-                "MODEL_MONITORING_ACCESS_KEY"
+            Secrets().generate_client_secret_key(
+                SecretsClientType.model_monitoring, "MODEL_MONITORING_ACCESS_KEY"
             ),
         )
 

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import mlrun
 import mlrun.feature_store as fs
 from mlrun import code_to_function, v3io_cred
-from mlrun.api.crud.secrets import Secrets
+from mlrun.api.crud.secrets import Secrets, SecretsClientType
 from mlrun.config import config
 from mlrun.model_monitoring.stream_processing_fs import EventStreamProcessor
 
@@ -46,7 +46,9 @@ def get_model_monitoring_stream_processing_function(
     function.set_env_from_secret(
         "MODEL_MONITORING_ACCESS_KEY",
         mlrun.api.utils.singletons.k8s.get_k8s().get_project_secret_name(project),
-        Secrets().generate_model_monitoring_secret_key("MODEL_MONITORING_ACCESS_KEY"),
+        Secrets().generate_client_secret_key(
+            SecretsClientType.model_monitoring, "MODEL_MONITORING_ACCESS_KEY"
+        ),
     )
 
     run_config = fs.RunConfig(function=function, local=False)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -166,14 +166,14 @@ class K8sSecretsMock:
         secrets = {}
         if default_service_account:
             secrets[
-                mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
-                    "default"
+                mlrun.api.crud.secrets.Secrets().generate_client_secret_key(
+                    mlrun.api.crud.secrets.SecretsClientType.service_accounts, "default"
                 )
             ] = default_service_account
         if allowed_service_accounts:
             secrets[
-                mlrun.api.crud.secrets.Secrets().generate_service_account_secret_key(
-                    "allowed"
+                mlrun.api.crud.secrets.Secrets().generate_client_secret_key(
+                    mlrun.api.crud.secrets.SecretsClientType.service_accounts, "allowed"
                 )
             ] = ",".join(allowed_service_accounts)
         self.store_project_secrets(project, secrets)

--- a/tests/api/crud/test_secrets.py
+++ b/tests/api/crud/test_secrets.py
@@ -42,7 +42,9 @@ def test_store_secrets_with_key_map_verifications(
 ):
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
     # not allowed to edit key map
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         mlrun.api.crud.Secrets().store_secrets(
@@ -101,7 +103,9 @@ def test_get_secret_verifications(
 ):
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
 
     # verifications check
     # not allowed from k8s
@@ -126,7 +130,9 @@ def test_get_secret(
     _mock_secrets_crud_uuid_generation()
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
     invalid_secret_key = "invalid/key"
     invalid_secret_value = "some-value"
     invalid_secret_2_key = "invalid/key/2"
@@ -204,9 +210,11 @@ def test_delete_secret_verifications(
 ):
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
-    internal_key = mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
-        "some-name"
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
+    internal_key = mlrun.api.crud.Secrets().generate_client_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules, "some-name", "access_key"
     )
 
     # verifications check
@@ -244,7 +252,9 @@ def test_delete_secret(
     _mock_secrets_crud_uuid_generation()
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
     invalid_secret_key = "invalid/key"
     invalid_secret_value = "some-value"
     invalid_secret_2_key = "invalid/key/2"
@@ -335,7 +345,9 @@ def test_store_secrets_with_key_map_success(
     _mock_secrets_crud_uuid_generation()
     project = "project-name"
     provider = mlrun.api.schemas.SecretProviderName.kubernetes
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
     invalid_secret_key = "invalid/key"
     invalid_secret_value = "some-value"
     invalid_secret_value_2 = "some-value-2"

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -710,11 +710,15 @@ async def test_rescheduling_secrets_storing(
     k8s_secrets_mock.assert_project_secrets(
         project,
         {
-            mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(
-                name
+            mlrun.api.crud.Secrets().generate_client_secret_key(
+                mlrun.api.crud.SecretsClientType.schedules,
+                name,
+                scheduler._secret_access_key_subtype,
             ): access_key,
-            mlrun.api.crud.Secrets().generate_schedule_username_secret_key(
-                name
+            mlrun.api.crud.Secrets().generate_client_secret_key(
+                mlrun.api.crud.SecretsClientType.schedules,
+                name,
+                scheduler._secret_username_subtype,
             ): username,
         },
     )
@@ -1086,13 +1090,19 @@ def _assert_schedule_secrets(
     expected_username: str,
     expected_access_key: str,
 ):
-    access_key_secret_key = (
-        mlrun.api.crud.Secrets().generate_schedule_access_key_secret_key(schedule_name)
+    access_key_secret_key = mlrun.api.crud.Secrets().generate_client_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules,
+        schedule_name,
+        scheduler._secret_access_key_subtype,
     )
-    username_secret_key = (
-        mlrun.api.crud.Secrets().generate_schedule_username_secret_key(schedule_name)
+    username_secret_key = mlrun.api.crud.Secrets().generate_client_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules,
+        schedule_name,
+        scheduler._secret_username_subtype,
     )
-    key_map_secret_key = mlrun.api.crud.Secrets().generate_schedule_key_map_secret_key()
+    key_map_secret_key = mlrun.api.crud.Secrets().generate_client_key_map_secret_key(
+        mlrun.api.crud.SecretsClientType.schedules
+    )
     secret_value = mlrun.api.crud.Secrets().get_secret(
         project,
         scheduler._secrets_provider,


### PR DESCRIPTION
Make all the objects in the MLRun backend that utilize secrets go through the `Secrets` crud object. This PR changes the `marketplace` implementation (that keeps credentials in k8s secrets) to go through the `Secrets` object.
Also, to make this scalable across the board, change the implementation of the crud object such that it provides generic functionality and APIs, and also has a list of clients (in a new `enum`). Functions that were specific to a given client are removed, and the clients need to call the standard APIs while providing their client name.

**Note** It's important to note that this change is backwards compatible in terms of the secret names generated and the secret keys within. The caveat here is that for marketplace objects there is a difference in the key names generated, but since this functionality is not used yet this has no effect.