### PR TITLE
[Builder] Pass default resource requests to kaniko pod

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -97,12 +97,16 @@ def make_kaniko_pod(
     if verbose:
         args += ["--verbosity", "debug"]
 
+    resources = {
+        "requests": config.get_default_function_pod_requirement_resources("requests")
+    }
     kpod = BasePod(
         name or "mlrun-build",
         config.httpdb.builder.kaniko_image,
         args=args,
         kind="build",
         project=project,
+        resources=resources,
     )
     kpod.env = builder_env
     kpod.set_node_selector(mlrun.mlconf.get_default_function_node_selector())

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -104,6 +104,9 @@ def make_kaniko_pod(
     if verbose:
         args += ["--verbosity", "debug"]
 
+    # While requests mainly affect scheduling, setting a limit may prevent Kaniko
+    # from finishing successfully (destructive), since we're not allowing to override the default
+    # specifically for the Kaniko pod, we're setting only the requests
     resources = {
         "requests": config.get_default_function_pod_requirement_resources("requests")
     }

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -537,7 +537,8 @@ class Config:
         resources: dict = copy.deepcopy(config.default_function_pod_resources.to_dict())
         gpu_type = "nvidia.com/gpu"
         gpu = "gpu"
-        resource_requirement = resources.get(requirement, {}).setdefault(gpu)
+        resource_requirement = resources.get(requirement, {})
+        resource_requirement.setdefault(gpu)
         resource_requirement[gpu_type] = resource_requirement.pop(gpu)
         return resource_requirement
 
@@ -720,7 +721,7 @@ def _convert_resources_to_str(config: dict = None):
         if not resource_requirement:
             continue
         for resource_type in resources_types:
-            value = resource_requirement.setdefault(resource_type, "")
+            value = resource_requirement.setdefault(resource_type, None)
             if value is None:
                 continue
             resource_requirement[resource_type] = str(value)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -518,16 +518,28 @@ class Config:
 
         return auto_mount_params
 
+    def get_default_function_pod_resources(self):
+        resources = {}
+        resource_requirements = ["requests", "limits"]
+        for requirement in resource_requirements:
+            resources[
+                requirement
+            ] = self.get_default_function_pod_requirement_resources(requirement)
+        return resources
+
     @staticmethod
-    def get_default_function_pod_resources():
+    def get_default_function_pod_requirement_resources(requirement: str):
+        """
+
+        :param requirement: kubernetes requirement resource one of the following : requests, limits
+        :return: a dict containing the defaults resources (cpu, memory, nvidia.com/gpu)
+        """
         resources: dict = copy.deepcopy(config.default_function_pod_resources.to_dict())
         gpu_type = "nvidia.com/gpu"
         gpu = "gpu"
-        resource_requirements = ["requests", "limits"]
-        for requirement in resource_requirements:
-            resources.setdefault(requirement, {}).setdefault(gpu)
-            resources[requirement][gpu_type] = resources.get(requirement).pop(gpu)
-        return resources
+        resource_requirement = resources.get(requirement, {}).setdefault(gpu)
+        resource_requirement[gpu_type] = resource_requirement.pop(gpu)
+        return resource_requirement
 
     def to_dict(self):
         return copy.copy(self._cfg)

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -435,6 +435,7 @@ class BasePod:
         namespace="",
         kind="job",
         project=None,
+        resources=None,
     ):
         self.namespace = namespace
         self.name = ""
@@ -454,6 +455,7 @@ class BasePod:
         }
         self._annotations = {}
         self._init_container = None
+        self.resources = resources
 
     @property
     def pod(self):
@@ -549,6 +551,7 @@ class BasePod:
             command=self.command,
             args=self.args,
             volume_mounts=self._mounts,
+            resources=self.resources,
         )
 
         pod_spec = client.V1PodSpec(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,9 +26,15 @@ from mlrun import config as mlconf
 from mlrun.db.httpdb import HTTPRunDB
 
 ns_env_key = f"{mlconf.env_prefix}NAMESPACE"
-dfpr_env_key = f"{mlconf.env_prefix}DEFAULT_FUNCTION_POD_RESOURCES__"
-request_gpu_env_key = f"{dfpr_env_key}REQUESTS__GPU"
-limits_gpu_env_key = f"{dfpr_env_key}LIMITS__GPU"
+default_function_pod_resources_env_key = (
+    f"{mlconf.env_prefix}DEFAULT_FUNCTION_POD_RESOURCES__"
+)
+default_function_pod_resources_request_gpu_env_key = (
+    f"{default_function_pod_resources_env_key}REQUESTS__GPU"
+)
+default_function_pod_resources_limits_gpu_env_key = (
+    f"{default_function_pod_resources_env_key}LIMITS__GPU"
+)
 
 
 @pytest.fixture
@@ -148,7 +154,10 @@ def test_decode_base64_config_and_load_to_dict():
 def test_get_default_function_pod_resources(config):
     requests_gpu = "2"
     limits_gpu = "2"
-    env = {request_gpu_env_key: requests_gpu, limits_gpu_env_key: limits_gpu}
+    env = {
+        default_function_pod_resources_request_gpu_env_key: requests_gpu,
+        default_function_pod_resources_limits_gpu_env_key: limits_gpu,
+    }
     expected_resources = {
         "requests": {"cpu": None, "memory": None, "nvidia.com/gpu": requests_gpu},
         "limits": {"cpu": None, "memory": None, "nvidia.com/gpu": limits_gpu},
@@ -194,14 +203,17 @@ def test_gpu_validation(config):
     # when gpu requests and gpu limits are not equal
     requests_gpu = "3"
     limits_gpu = "2"
-    env = {request_gpu_env_key: requests_gpu, limits_gpu_env_key: limits_gpu}
+    env = {
+        default_function_pod_resources_request_gpu_env_key: requests_gpu,
+        default_function_pod_resources_limits_gpu_env_key: limits_gpu,
+    }
     with patch_env(env):
         with pytest.raises(mlrun.errors.MLRunConflictError):
             mlconf.config.reload()
 
     # when only gpu request is set
     requests_gpu = "3"
-    env = {request_gpu_env_key: requests_gpu}
+    env = {default_function_pod_resources_request_gpu_env_key: requests_gpu}
     with patch_env(env):
         with pytest.raises(mlrun.errors.MLRunConflictError):
             mlconf.config.reload()
@@ -209,7 +221,10 @@ def test_gpu_validation(config):
     # when gpu requests and gpu limits are equal
     requests_gpu = "2"
     limits_gpu = "2"
-    env = {request_gpu_env_key: requests_gpu, limits_gpu_env_key: limits_gpu}
+    env = {
+        default_function_pod_resources_request_gpu_env_key: requests_gpu,
+        default_function_pod_resources_limits_gpu_env_key: limits_gpu,
+    }
     with patch_env(env):
         mlconf.config.reload()
     assert config.default_function_pod_resources.requests.gpu == requests_gpu

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,7 @@ import mlrun.errors
 from mlrun import config as mlconf
 from mlrun.db.httpdb import HTTPRunDB
 
-ns_env_key = f"{mlconf.env_prefix}NAMESPACE"
+namespace_env_key = f"{mlconf.env_prefix}NAMESPACE"
 default_function_pod_resources_env_key = (
     f"{mlconf.env_prefix}DEFAULT_FUNCTION_POD_RESOURCES__"
 )
@@ -92,7 +92,7 @@ def test_file(config):
 
 def test_env(config):
     ns = "orange"
-    with patch_env({ns_env_key: ns}):
+    with patch_env({namespace_env_key: ns}):
         mlconf.config.reload()
 
     assert config.namespace == ns, "not populated from env"
@@ -105,7 +105,7 @@ def test_env_override(config):
     config_path = create_yaml_config(namespace=config_ns)
     env = {
         mlconf.env_file_key: config_path,
-        ns_env_key: env_ns,
+        namespace_env_key: env_ns,
     }
 
     with patch_env(env):


### PR DESCRIPTION
second part for kaniko assignment of attributes and resources
https://jira.iguazeng.com/browse/ML-1880

As part of adding the feature, I fixed a bug where when we read default function pod resources from env and not all of them are defined, we set the ones that aren't defined to be "" rather than None.