### PR TITLE
[DB] Fix backup and migrations not to happen before unwanted-ly

### DIFF
--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -40,6 +40,7 @@ def verify_api_state(request: Request):
         enabled_endpoints = [
             "healthz",
             "background-tasks",
+            "client-spec",
             "migrations",
         ]
         if not any(enabled_endpoint in path for enabled_endpoint in enabled_endpoints):

--- a/mlrun/api/api/endpoints/operations.py
+++ b/mlrun/api/api/endpoints/operations.py
@@ -22,7 +22,7 @@ current_migration_background_task_name = None
         http.HTTPStatus.ACCEPTED.value: {"model": mlrun.api.schemas.BackgroundTask},
     },
 )
-def start_migration(
+def trigger_migrations(
     background_tasks: fastapi.BackgroundTasks,
     response: fastapi.Response,
 ):

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -13,16 +13,15 @@ import mlrun.api.db.sqldb.db
 import mlrun.api.db.sqldb.helpers
 import mlrun.api.db.sqldb.models
 import mlrun.api.schemas
+import mlrun.api.utils.db.alembic
+import mlrun.api.utils.db.backup
+import mlrun.api.utils.db.mysql
+import mlrun.api.utils.db.sqlite_migration
 import mlrun.artifacts
 from mlrun.api.db.init_db import init_db
 from mlrun.api.db.session import close_session, create_session
 from mlrun.config import config
 from mlrun.utils import logger
-
-import mlrun.api.utils.db.alembic
-import mlrun.api.utils.db.backup
-import mlrun.api.utils.db.mysql
-import mlrun.api.utils.db.sqlite_migration
 
 
 def init_data(
@@ -33,7 +32,9 @@ def init_data(
 
     sqlite_migration_util = None
     if not from_scratch and config.httpdb.db.database_migration_mode == "enabled":
-        sqlite_migration_util = mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil()
+        sqlite_migration_util = (
+            mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil()
+        )
     alembic_util = _create_alembic_util()
     (
         is_migration_needed,
@@ -96,7 +97,9 @@ latest_data_version = 2
 
 def _resolve_needed_operations(
     alembic_util: mlrun.api.utils.db.alembic.AlembicUtil,
-    sqlite_migration_util: typing.Optional[mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil],
+    sqlite_migration_util: typing.Optional[
+        mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil
+    ],
     force_from_scratch: bool = False,
 ) -> typing.Tuple[bool, bool, bool]:
     is_database_migration_needed = False
@@ -146,7 +149,9 @@ def _create_alembic_util() -> mlrun.api.utils.db.alembic.AlembicUtil:
     dir_path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
     alembic_config_path = dir_path / alembic_config_file_name
 
-    alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(alembic_config_path, _is_latest_data_version())
+    alembic_util = mlrun.api.utils.db.alembic.AlembicUtil(
+        alembic_config_path, _is_latest_data_version()
+    )
     return alembic_util
 
 
@@ -168,7 +173,9 @@ def _is_latest_data_version():
 
 
 def _perform_database_migration(
-    sqlite_migration_util: typing.Optional[mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil],
+    sqlite_migration_util: typing.Optional[
+        mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil
+    ],
 ):
     if sqlite_migration_util:
         logger.info("Performing database migration")

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -28,6 +28,7 @@ from .utils.db.sqlite_migration import SQLiteMigrationUtil
 def init_data(
     from_scratch: bool = False, perform_migrations_if_needed: bool = False
 ) -> None:
+    logger.info("Initializing DB data")
     MySQLUtil.wait_for_db_liveness(logger)
 
     sqlite_migration_util = None

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -41,11 +41,6 @@ def init_data(
         is_backup_needed,
     ) = _resolve_needed_operations(alembic_util, sqlite_migration_util, from_scratch)
 
-    if is_backup_needed:
-        logger.info("DB Backup is needed, backing up...")
-        db_backup = mlrun.api.utils.db.backup.DBBackupUtil()
-        db_backup.backup_database()
-
     if (
         not is_migration_from_scratch
         and not perform_migrations_if_needed
@@ -55,6 +50,11 @@ def init_data(
         logger.info("Migration is needed, changing API state", state=state)
         config.httpdb.state = state
         return
+
+    if is_backup_needed:
+        logger.info("DB Backup is needed, backing up...")
+        db_backup = mlrun.api.utils.db.backup.DBBackupUtil()
+        db_backup.backup_database()
 
     logger.info("Creating initial data")
     config.httpdb.state = mlrun.api.schemas.APIStates.migrations_in_progress

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -104,9 +104,11 @@ def _resolve_needed_operations(
         is_database_migration_needed = (
             sqlite_migration_util.is_database_migration_needed()
         )
+    # the util checks whether the target DB has data, when database migration needed, it obviously does not have data
+    # but in that case it's not really a migration from scratch
     is_migration_from_scratch = (
         force_from_scratch or alembic_util.is_migration_from_scratch()
-    )
+    ) and not is_database_migration_needed
     is_schema_migration_needed = alembic_util.is_schema_migration_needed()
     is_data_migration_needed = (
         not _is_latest_data_version()

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -239,7 +239,9 @@ def _cleanup_runtimes():
 def main():
     init_data()
     logger.info(
-        "Starting API server", port=config.httpdb.port, debug=config.httpdb.debug,
+        "Starting API server",
+        port=config.httpdb.port,
+        debug=config.httpdb.debug,
     )
     uvicorn.run(
         "mlrun.api.main:app",

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -238,6 +238,9 @@ def _cleanup_runtimes():
 
 def main():
     init_data()
+    logger.info(
+        "Starting API server", port=config.httpdb.port, debug=config.httpdb.debug,
+    )
     uvicorn.run(
         "mlrun.api.main:app",
         host="0.0.0.0",

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -28,9 +28,13 @@ class MySQLUtil(object):
         logger.debug("Waiting for database liveness")
         mysql_dsn_data = MySQLUtil.get_mysql_dsn_data()
         if not mysql_dsn_data:
-            logger.warn(
-                f"Invalid mysql dsn: {MySQLUtil.get_dsn()}, assuming sqlite and skipping liveness verification"
-            )
+            dsn = MySQLUtil.get_dsn()
+            if "sqlite" in dsn:
+                logger.debug("SQLite DB is used, liveness check not needed")
+            else:
+                logger.warn(
+                    f"Invalid mysql dsn: {MySQLUtil.get_dsn()}, assuming live and skipping liveness verification"
+                )
             return
 
         tmp_connection = mlrun.utils.retry_until_successful(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -113,6 +113,7 @@ class HTTPRunDB(RunDBInterface):
         self.server_version = ""
         self.session = None
         self._wait_for_project_terminal_state_retry_interval = 3
+        self._wait_for_background_task_terminal_state_retry_interval = 3
         self._wait_for_project_deletion_interval = 3
         self.client_version = version.Version().get()["version"]
 
@@ -1230,12 +1231,25 @@ class HTTPRunDB(RunDBInterface):
         project: str,
         name: str,
     ) -> schemas.BackgroundTask:
-        """Retrieve updated information on a background task being executed."""
+        """Retrieve updated information on a project background task being executed."""
 
         project = project or config.default_project
         path = f"projects/{project}/background-tasks/{name}"
         error_message = (
-            f"Failed getting background task. project={project}, name={name}"
+            f"Failed getting project background task. project={project}, name={name}"
+        )
+        response = self.api_call("GET", path, error_message)
+        return schemas.BackgroundTask(**response.json())
+
+    def get_background_task(
+        self,
+        name: str
+    ) -> schemas.BackgroundTask:
+        """Retrieve updated information on a background task being executed."""
+
+        path = f"background-tasks/{name}"
+        error_message = (
+            f"Failed getting background task. name={name}"
         )
         response = self.api_call("GET", path, error_message)
         return schemas.BackgroundTask(**response.json())
@@ -2130,6 +2144,29 @@ class HTTPRunDB(RunDBInterface):
             _verify_project_in_terminal_state,
         )
 
+    def _wait_for_background_task_to_reach_terminal_state(
+            self, name: str
+    ) -> schemas.BackgroundTask:
+        def _verify_background_task_in_terminal_state():
+            background_task = self.get_background_task(name)
+            state = background_task.status.state
+            if (
+                    state
+                    not in mlrun.api.schemas.BackgroundTaskState.terminal_states()
+            ):
+                raise Exception(
+                    f"Background task not in terminal state. name={name}, state={state}"
+                )
+            return background_task
+
+        return mlrun.utils.helpers.retry_until_successful(
+            self._wait_for_background_task_terminal_state_retry_interval,
+            60*60,
+            logger,
+            False,
+            _verify_background_task_in_terminal_state,
+        )
+
     def _wait_for_project_to_be_deleted(self, project_name: str):
         def _verify_project_deleted():
             projects = self.list_projects(
@@ -2734,6 +2771,23 @@ class HTTPRunDB(RunDBInterface):
             error_message,
             body=dict_to_json(authorization_verification_input.dict()),
         )
+
+    def trigger_migrations(
+            self
+    ) -> Optional[schemas.BackgroundTask]:
+        """Trigger migrations (will do nothing if no migrations are needed) and wait for them to finish if actually
+        triggered
+        :returns: :py:class:`~mlrun.api.schemas.BackgroundTask`.
+        """
+        response = self.api_call(
+            "POST",
+            "operations/migrations",
+            "Failed triggering migrations",
+        )
+        if response.status_code == http.HTTPStatus.ACCEPTED:
+            background_task = schemas.BackgroundTask(**response.json())
+            return self._wait_for_background_task_to_reach_terminal_state(background_task.metadata.name)
+        return None
 
 
 def _as_json(obj):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1241,16 +1241,11 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", path, error_message)
         return schemas.BackgroundTask(**response.json())
 
-    def get_background_task(
-        self,
-        name: str
-    ) -> schemas.BackgroundTask:
+    def get_background_task(self, name: str) -> schemas.BackgroundTask:
         """Retrieve updated information on a background task being executed."""
 
         path = f"background-tasks/{name}"
-        error_message = (
-            f"Failed getting background task. name={name}"
-        )
+        error_message = f"Failed getting background task. name={name}"
         response = self.api_call("GET", path, error_message)
         return schemas.BackgroundTask(**response.json())
 
@@ -2145,15 +2140,12 @@ class HTTPRunDB(RunDBInterface):
         )
 
     def _wait_for_background_task_to_reach_terminal_state(
-            self, name: str
+        self, name: str
     ) -> schemas.BackgroundTask:
         def _verify_background_task_in_terminal_state():
             background_task = self.get_background_task(name)
             state = background_task.status.state
-            if (
-                    state
-                    not in mlrun.api.schemas.BackgroundTaskState.terminal_states()
-            ):
+            if state not in mlrun.api.schemas.BackgroundTaskState.terminal_states():
                 raise Exception(
                     f"Background task not in terminal state. name={name}, state={state}"
                 )
@@ -2161,7 +2153,7 @@ class HTTPRunDB(RunDBInterface):
 
         return mlrun.utils.helpers.retry_until_successful(
             self._wait_for_background_task_terminal_state_retry_interval,
-            60*60,
+            60 * 60,
             logger,
             False,
             _verify_background_task_in_terminal_state,
@@ -2772,9 +2764,7 @@ class HTTPRunDB(RunDBInterface):
             body=dict_to_json(authorization_verification_input.dict()),
         )
 
-    def trigger_migrations(
-            self
-    ) -> Optional[schemas.BackgroundTask]:
+    def trigger_migrations(self) -> Optional[schemas.BackgroundTask]:
         """Trigger migrations (will do nothing if no migrations are needed) and wait for them to finish if actually
         triggered
         :returns: :py:class:`~mlrun.api.schemas.BackgroundTask`.
@@ -2786,7 +2776,9 @@ class HTTPRunDB(RunDBInterface):
         )
         if response.status_code == http.HTTPStatus.ACCEPTED:
             background_task = schemas.BackgroundTask(**response.json())
-            return self._wait_for_background_task_to_reach_terminal_state(background_task.metadata.name)
+            return self._wait_for_background_task_to_reach_terminal_state(
+                background_task.metadata.name
+            )
         return None
 
 

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -40,6 +40,9 @@ def test_migrations_states(
         response = client.get("projects/some-project/background-tasks/some-task")
         assert response.status_code == http.HTTPStatus.OK.value
 
+        response = client.get("client-spec")
+        assert response.status_code == http.HTTPStatus.OK.value
+
         response = client.get("projects")
         assert response.status_code == http.HTTPStatus.PRECONDITION_FAILED.value
         assert expected_message in response.text

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -7,6 +7,9 @@ import sqlalchemy.orm
 import mlrun.api.initial_data
 import mlrun.api.schemas
 import mlrun.api.utils.auth.verifier
+import mlrun.api.utils.db.backup
+import mlrun.api.utils.db.sqlite_migration
+import mlrun.api.utils.db.alembic
 
 
 def test_offline_state(
@@ -43,13 +46,64 @@ def test_migrations_states(
 
 
 def test_init_data_migration_required_recognition() -> None:
-    # mock that migration is needed
-    original_is_migration_needed = mlrun.api.initial_data._resolve_needed_operations
-    mlrun.api.initial_data._resolve_needed_operations = unittest.mock.Mock(
-        return_value=(True, False, False)
-    )
-    mlrun.api.initial_data.init_data()
-    assert (
-        mlrun.mlconf.httpdb.state == mlrun.api.schemas.APIStates.waiting_for_migrations
-    )
-    mlrun.api.initial_data._resolve_needed_operations = original_is_migration_needed
+    original_sqlite_migration_util = mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil
+    sqlite_migration_util_mock = unittest.mock.Mock()
+    mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil = sqlite_migration_util_mock
+
+    original_alembic_util = mlrun.api.utils.db.alembic.AlembicUtil
+    alembic_util_mock = unittest.mock.Mock()
+    mlrun.api.utils.db.alembic.AlembicUtil = alembic_util_mock
+
+    original_is_latest_data_version = mlrun.api.initial_data._is_latest_data_version
+    is_latest_data_version_mock = unittest.mock.Mock()
+    mlrun.api.initial_data._is_latest_data_version = is_latest_data_version_mock
+
+    original_db_backup_util = mlrun.api.utils.db.backup.DBBackupUtil
+    db_backup_util_mock = unittest.mock.Mock()
+    mlrun.api.utils.db.backup.DBBackupUtil = db_backup_util_mock
+
+    original_perform_schema_migrations = mlrun.api.initial_data._perform_schema_migrations
+    perform_schema_migrations_mock = unittest.mock.Mock()
+    mlrun.api.initial_data._perform_schema_migrations = perform_schema_migrations_mock
+
+    original_perform_database_migration = mlrun.api.initial_data._perform_database_migration
+    perform_database_migration_mock = unittest.mock.Mock()
+    mlrun.api.initial_data._perform_database_migration = perform_database_migration_mock
+
+    original_perform_data_migrations = mlrun.api.initial_data._perform_data_migrations
+    perform_data_migrations_mock = unittest.mock.Mock()
+    mlrun.api.initial_data._perform_data_migrations = perform_data_migrations_mock
+
+    for case in [
+        {
+            "database_migration": True,
+            "schema_migration": False,
+            "data_migration": False,
+            "from_scratch": False,
+        },
+
+    ]:
+        sqlite_migration_util_mock.return_value.is_database_migration_needed.return_value = case.get("database_migration", False)
+        alembic_util_mock.return_value.is_migration_from_scratch.return_value = case.get("from_scratch", False)
+        alembic_util_mock.return_value.is_schema_migration_needed.return_value = case.get("schema_migration", False)
+        is_latest_data_version_mock.return_value = not case.get("data_migration", False)
+
+        mlrun.api.initial_data.init_data()
+        failure_message = f"Failed in case: {case}"
+        assert (
+            mlrun.mlconf.httpdb.state == mlrun.api.schemas.APIStates.waiting_for_migrations, failure_message
+        )
+        # assert the api just changed state and no operation was done
+        assert db_backup_util_mock.call_count == 0, failure_message
+        assert perform_schema_migrations_mock.call_count == 0, failure_message
+        assert perform_database_migration_mock.call_count == 0, failure_message
+        assert perform_data_migrations_mock.call_count == 0, failure_message
+
+
+    mlrun.api.utils.db.alembic.AlembicUtil = original_alembic_util
+    mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil = original_sqlite_migration_util
+    mlrun.api.initial_data._is_latest_data_version = original_is_latest_data_version
+    mlrun.api.utils.db.backup.DBBackupUtil = original_db_backup_util
+    mlrun.api.initial_data._perform_schema_migrations = original_perform_schema_migrations
+    mlrun.api.initial_data._perform_database_migrations = original_perform_database_migration
+    mlrun.api.initial_data._perform_data_migrations = original_perform_data_migrations

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -75,12 +75,57 @@ def test_init_data_migration_required_recognition() -> None:
     mlrun.api.initial_data._perform_data_migrations = perform_data_migrations_mock
 
     for case in [
+        # All 4 schema and data combinations with database and not from scratch
         {
             "database_migration": True,
             "schema_migration": False,
             "data_migration": False,
             "from_scratch": False,
         },
+        {
+            "database_migration": True,
+            "schema_migration": True,
+            "data_migration": False,
+            "from_scratch": False,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": True,
+            "data_migration": True,
+            "from_scratch": False,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": False,
+            "data_migration": True,
+            "from_scratch": False,
+        },
+        # All 4 schema and data combinations with database and from scratch
+        {
+            "database_migration": True,
+            "schema_migration": False,
+            "data_migration": False,
+            "from_scratch": True,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": True,
+            "data_migration": False,
+            "from_scratch": True,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": True,
+            "data_migration": True,
+            "from_scratch": True,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": False,
+            "data_migration": True,
+            "from_scratch": True,
+        },
+        # No database, not from scratch, at least of schema and data 3 combinations
         {
             "database_migration": False,
             "schema_migration": True,
@@ -99,30 +144,7 @@ def test_init_data_migration_required_recognition() -> None:
             "data_migration": True,
             "from_scratch": False,
         },
-        {
-            "database_migration": True,
-            "schema_migration": False,
-            "data_migration": False,
-            "from_scratch": True,
-        },
-        {
-            "database_migration": True,
-            "schema_migration": True,
-            "data_migration": False,
-            "from_scratch": True,
-        },
-        {
-            "database_migration": True,
-            "schema_migration": True,
-            "data_migration": True,
-            "from_scratch": True,
-        },
-        {
-            "database_migration": True,
-            "schema_migration": False,
-            "data_migration": True,
-            "from_scratch": True,
-        },
+
     ]:
         sqlite_migration_util_mock.return_value.is_database_migration_needed.return_value = case.get("database_migration", False)
         alembic_util_mock.return_value.is_migration_from_scratch.return_value = case.get("from_scratch", False)

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -93,12 +93,43 @@ def test_init_data_migration_required_recognition() -> None:
             "data_migration": True,
             "from_scratch": False,
         },
+        {
+            "database_migration": False,
+            "schema_migration": True,
+            "data_migration": True,
+            "from_scratch": False,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": False,
+            "data_migration": False,
+            "from_scratch": True,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": True,
+            "data_migration": False,
+            "from_scratch": True,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": True,
+            "data_migration": True,
+            "from_scratch": True,
+        },
+        {
+            "database_migration": True,
+            "schema_migration": False,
+            "data_migration": True,
+            "from_scratch": True,
+        },
     ]:
         sqlite_migration_util_mock.return_value.is_database_migration_needed.return_value = case.get("database_migration", False)
         alembic_util_mock.return_value.is_migration_from_scratch.return_value = case.get("from_scratch", False)
         alembic_util_mock.return_value.is_schema_migration_needed.return_value = case.get("schema_migration", False)
         is_latest_data_version_mock.return_value = not case.get("data_migration", False)
 
+        mlrun.mlconf.httpdb.state = mlrun.api.schemas.APIStates.online
         mlrun.api.initial_data.init_data()
         failure_message = f"Failed in case: {case}"
         assert (

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -81,7 +81,18 @@ def test_init_data_migration_required_recognition() -> None:
             "data_migration": False,
             "from_scratch": False,
         },
-
+        {
+            "database_migration": False,
+            "schema_migration": True,
+            "data_migration": False,
+            "from_scratch": False,
+        },
+        {
+            "database_migration": False,
+            "schema_migration": False,
+            "data_migration": True,
+            "from_scratch": False,
+        },
     ]:
         sqlite_migration_util_mock.return_value.is_database_migration_needed.return_value = case.get("database_migration", False)
         alembic_util_mock.return_value.is_migration_from_scratch.return_value = case.get("from_scratch", False)

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -45,34 +45,21 @@ def test_migrations_states(
         assert expected_message in response.text
 
 
-def test_init_data_migration_required_recognition() -> None:
-    original_sqlite_migration_util = mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil
+def test_init_data_migration_required_recognition(monkeypatch) -> None:
     sqlite_migration_util_mock = unittest.mock.Mock()
-    mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil = sqlite_migration_util_mock
-
-    original_alembic_util = mlrun.api.utils.db.alembic.AlembicUtil
+    monkeypatch.setattr(mlrun.api.utils.db.sqlite_migration, "SQLiteMigrationUtil", sqlite_migration_util_mock)
     alembic_util_mock = unittest.mock.Mock()
-    mlrun.api.utils.db.alembic.AlembicUtil = alembic_util_mock
-
-    original_is_latest_data_version = mlrun.api.initial_data._is_latest_data_version
+    monkeypatch.setattr(mlrun.api.utils.db.alembic, "AlembicUtil", alembic_util_mock)
     is_latest_data_version_mock = unittest.mock.Mock()
-    mlrun.api.initial_data._is_latest_data_version = is_latest_data_version_mock
-
-    original_db_backup_util = mlrun.api.utils.db.backup.DBBackupUtil
+    monkeypatch.setattr(mlrun.api.initial_data, "_is_latest_data_version", is_latest_data_version_mock)
     db_backup_util_mock = unittest.mock.Mock()
-    mlrun.api.utils.db.backup.DBBackupUtil = db_backup_util_mock
-
-    original_perform_schema_migrations = mlrun.api.initial_data._perform_schema_migrations
+    monkeypatch.setattr(mlrun.api.utils.db.backup, "DBBackupUtil", db_backup_util_mock)
     perform_schema_migrations_mock = unittest.mock.Mock()
-    mlrun.api.initial_data._perform_schema_migrations = perform_schema_migrations_mock
-
-    original_perform_database_migration = mlrun.api.initial_data._perform_database_migration
+    monkeypatch.setattr(mlrun.api.initial_data, "_perform_schema_migrations", perform_schema_migrations_mock)
     perform_database_migration_mock = unittest.mock.Mock()
-    mlrun.api.initial_data._perform_database_migration = perform_database_migration_mock
-
-    original_perform_data_migrations = mlrun.api.initial_data._perform_data_migrations
+    monkeypatch.setattr(mlrun.api.initial_data, "_perform_database_migration", perform_database_migration_mock)
     perform_data_migrations_mock = unittest.mock.Mock()
-    mlrun.api.initial_data._perform_data_migrations = perform_data_migrations_mock
+    monkeypatch.setattr(mlrun.api.initial_data, "_perform_data_migrations", perform_data_migrations_mock)
 
     for case in [
         # All 4 schema and data combinations with database and not from scratch
@@ -162,12 +149,3 @@ def test_init_data_migration_required_recognition() -> None:
         assert perform_schema_migrations_mock.call_count == 0, failure_message
         assert perform_database_migration_mock.call_count == 0, failure_message
         assert perform_data_migrations_mock.call_count == 0, failure_message
-
-
-    mlrun.api.utils.db.alembic.AlembicUtil = original_alembic_util
-    mlrun.api.utils.db.sqlite_migration.SQLiteMigrationUtil = original_sqlite_migration_util
-    mlrun.api.initial_data._is_latest_data_version = original_is_latest_data_version
-    mlrun.api.utils.db.backup.DBBackupUtil = original_db_backup_util
-    mlrun.api.initial_data._perform_schema_migrations = original_perform_schema_migrations
-    mlrun.api.initial_data._perform_database_migrations = original_perform_database_migration
-    mlrun.api.initial_data._perform_data_migrations = original_perform_data_migrations

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -7,9 +7,9 @@ import sqlalchemy.orm
 import mlrun.api.initial_data
 import mlrun.api.schemas
 import mlrun.api.utils.auth.verifier
+import mlrun.api.utils.db.alembic
 import mlrun.api.utils.db.backup
 import mlrun.api.utils.db.sqlite_migration
-import mlrun.api.utils.db.alembic
 
 
 def test_offline_state(
@@ -47,19 +47,35 @@ def test_migrations_states(
 
 def test_init_data_migration_required_recognition(monkeypatch) -> None:
     sqlite_migration_util_mock = unittest.mock.Mock()
-    monkeypatch.setattr(mlrun.api.utils.db.sqlite_migration, "SQLiteMigrationUtil", sqlite_migration_util_mock)
+    monkeypatch.setattr(
+        mlrun.api.utils.db.sqlite_migration,
+        "SQLiteMigrationUtil",
+        sqlite_migration_util_mock,
+    )
     alembic_util_mock = unittest.mock.Mock()
     monkeypatch.setattr(mlrun.api.utils.db.alembic, "AlembicUtil", alembic_util_mock)
     is_latest_data_version_mock = unittest.mock.Mock()
-    monkeypatch.setattr(mlrun.api.initial_data, "_is_latest_data_version", is_latest_data_version_mock)
+    monkeypatch.setattr(
+        mlrun.api.initial_data, "_is_latest_data_version", is_latest_data_version_mock
+    )
     db_backup_util_mock = unittest.mock.Mock()
     monkeypatch.setattr(mlrun.api.utils.db.backup, "DBBackupUtil", db_backup_util_mock)
     perform_schema_migrations_mock = unittest.mock.Mock()
-    monkeypatch.setattr(mlrun.api.initial_data, "_perform_schema_migrations", perform_schema_migrations_mock)
+    monkeypatch.setattr(
+        mlrun.api.initial_data,
+        "_perform_schema_migrations",
+        perform_schema_migrations_mock,
+    )
     perform_database_migration_mock = unittest.mock.Mock()
-    monkeypatch.setattr(mlrun.api.initial_data, "_perform_database_migration", perform_database_migration_mock)
+    monkeypatch.setattr(
+        mlrun.api.initial_data,
+        "_perform_database_migration",
+        perform_database_migration_mock,
+    )
     perform_data_migrations_mock = unittest.mock.Mock()
-    monkeypatch.setattr(mlrun.api.initial_data, "_perform_data_migrations", perform_data_migrations_mock)
+    monkeypatch.setattr(
+        mlrun.api.initial_data, "_perform_data_migrations", perform_data_migrations_mock
+    )
 
     for case in [
         # All 4 schema and data combinations with database and not from scratch
@@ -131,19 +147,25 @@ def test_init_data_migration_required_recognition(monkeypatch) -> None:
             "data_migration": True,
             "from_scratch": False,
         },
-
     ]:
-        sqlite_migration_util_mock.return_value.is_database_migration_needed.return_value = case.get("database_migration", False)
-        alembic_util_mock.return_value.is_migration_from_scratch.return_value = case.get("from_scratch", False)
-        alembic_util_mock.return_value.is_schema_migration_needed.return_value = case.get("schema_migration", False)
+        sqlite_migration_util_mock.return_value.is_database_migration_needed.return_value = case.get(
+            "database_migration", False
+        )
+        alembic_util_mock.return_value.is_migration_from_scratch.return_value = (
+            case.get("from_scratch", False)
+        )
+        alembic_util_mock.return_value.is_schema_migration_needed.return_value = (
+            case.get("schema_migration", False)
+        )
         is_latest_data_version_mock.return_value = not case.get("data_migration", False)
 
         mlrun.mlconf.httpdb.state = mlrun.api.schemas.APIStates.online
         mlrun.api.initial_data.init_data()
         failure_message = f"Failed in case: {case}"
         assert (
-            mlrun.mlconf.httpdb.state == mlrun.api.schemas.APIStates.waiting_for_migrations, failure_message
-        )
+            mlrun.mlconf.httpdb.state
+            == mlrun.api.schemas.APIStates.waiting_for_migrations
+        ), failure_message
         # assert the api just changed state and no operation was done
         assert db_backup_util_mock.call_count == 0, failure_message
         assert perform_schema_migrations_mock.call_count == 0, failure_message

--- a/tests/integration/sdk_api/httpdb/test_operations.py
+++ b/tests/integration/sdk_api/httpdb/test_operations.py
@@ -1,0 +1,8 @@
+import mlrun
+import tests.integration.sdk_api.base
+
+
+class TestOperations(tests.integration.sdk_api.base.TestMLRunIntegration):
+    def test_trigger_migrations(self):
+        background_task = mlrun.get_run_db().trigger_migrations()
+        assert background_task is None


### PR DESCRIPTION
* Backup was happening before migrations were triggered - fixed that and added test
* Database migration was triggered before migrations were triggered - fixed that and added test
* Improved the logs in those flows

In addition (somewhat related):
* added an option to trigger migrations from the SDK by calling `get_run_db().trigger_migrations()`
* Enabled the `client-spec` endpoint to be called for the migration api states (so the above can happen)

Fixes https://jira.iguazeng.com/browse/ML-1933