### PR TITLE
[Docs] Add limitation on column name for data ingestion with Pandas engine

### DIFF
--- a/docs/feature-store/feature-sets.md
+++ b/docs/feature-store/feature-sets.md
@@ -109,8 +109,8 @@ When targets are not specified, data is stored in the configured default targets
 Batch ingestion can be done locally (i.e. running as a python process in the Jupyter pod) or as an MLRun job.
 
 ```{admonition} Limitation
-Do not name columns starting with either `t_` or `aggr_`. They are reserved for internal use, and the data does not ingest correctly. See 
-also general limitations in [Attribute name restrictions](https://www.iguazio.com/docs/latest-release/data-layer/objects/attributes/#attribute-names).
+- Do not name columns starting with either `t_` or `aggr_`. They are reserved for internal use, and the data does not ingest correctly. See also general limitations in [Attribute name restrictions](https://www.iguazio.com/docs/latest-release/data-layer/objects/attributes/#attribute-names).
+- When using the pandas engine, do not use spaces (` `) or periods (`.`) in the column names. These cause errors in the ingestion.
 ```
 
 ### Ingest data (locally)


### PR DESCRIPTION
When using pandas engine, ingestion errors out when column names includes spaces (" ") and periods (".")