### PR TITLE
[Feature Store] Spark aggregations with support for emit-per-event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,7 @@ test: clean ## Run mlrun tests
 		--ignore=tests/system \
 		--ignore=tests/test_notebooks.py \
 		--ignore=tests/rundb/test_httpdb.py \
+		--ignore=tests/run/test_hyper.py \
 		-rf \
 		tests
 

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,6 @@ test: clean ## Run mlrun tests
 		--ignore=tests/system \
 		--ignore=tests/test_notebooks.py \
 		--ignore=tests/rundb/test_httpdb.py \
-		--ignore=tests/run/test_hyper.py \
 		-rf \
 		tests
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -16,7 +16,7 @@ import warnings
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
-from storey import EmitPolicy, EmitEveryEvent
+from storey import EmitEveryEvent, EmitPolicy
 
 import mlrun
 import mlrun.api.schemas
@@ -776,10 +776,7 @@ class SparkAggregateByKey(StepToDict):
         time_column = self.time_column or "time"
         input_df = event
 
-        if (
-            not self.emit_policy_mode
-            or self.emit_policy_mode != EmitEveryEvent.name()
-        ):
+        if not self.emit_policy_mode or self.emit_policy_mode != EmitEveryEvent.name():
             last_value_aggs = [
                 funcs.last(column).alias(column)
                 for column in input_df.columns

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -547,7 +547,11 @@ class FeatureSet(ModelObj):
         :param state_name: *Deprecated* - use step_name instead
         :param after:      optional, after which graph step it runs
         :param before:     optional, comes before graph step
-        :param emit_policy: optional, which emit policy to use when performing the aggregations
+        :param emit_policy: optional, which emit policy to use when performing the aggregations. Use the derived
+                            classes of ``storey.EmitPolicy``. The default is to emit every period for Spark engine
+                            and emit every event for storey. Currently the only other supported option is to use
+                            ``emit_policy=storey.EmitEveryEvent()`` when using the Spark engine to emit every event
+
         """
         if isinstance(operations, str):
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -715,9 +715,6 @@ class SparkAggregateByKey(StepToDict):
         aggregates: List[Dict],
         emit_by_row=False,
     ):
-        print(f"SparkAggregateByKey init!!!!!\nkey_columns={key_columns}\ntime_column={time_column}\n")
-        print(f"aggregates={aggregates}\nemit_by_row={emit_by_row}\n")
-
         self.key_columns = key_columns
         self.time_column = time_column
         self.aggregates = aggregates
@@ -755,7 +752,6 @@ class SparkAggregateByKey(StepToDict):
         import pyspark.sql.functions as funcs
         from pyspark.sql import Window
 
-        print(f"SparkAggregateByKey called!!!!! emit_by_row={self._emit_by_row} \nevent=\n{event.collect()}\n")
         time_column = self.time_column or "time"
 
         if not self._emit_by_row:
@@ -798,8 +794,6 @@ class SparkAggregateByKey(StepToDict):
             union_df = dfs[0]
             for df in dfs[1:]:
                 union_df = union_df.unionByName(df, allowMissingColumns=True)
-
-            print(f"SparkAggregateByKey end!!!!! emit_by_row={self._emit_by_row} \nresult=\n{union_df.collect()}\n")
 
             return union_df
 
@@ -863,7 +857,4 @@ class SparkAggregateByKey(StepToDict):
                 if column not in drop_columns
             ]
             union_df = union_df.groupBy(rowid_col).agg(*last_value_aggs).drop(rowid_col)
-
-            print(f"SparkAggregateByKey end!!!!! emit_by_row={self._emit_by_row} \nresult=\n{union_df.collect()}\n")
-
             return union_df

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -715,6 +715,9 @@ class SparkAggregateByKey(StepToDict):
         aggregates: List[Dict],
         emit_by_row=False,
     ):
+        print(f"SparkAggregateByKey init!!!!!\nkey_columns={key_columns}\ntime_column={time_column}\n")
+        print(f"aggregates={aggregates}\nemit_by_row={emit_by_row}\n")
+
         self.key_columns = key_columns
         self.time_column = time_column
         self.aggregates = aggregates
@@ -752,6 +755,7 @@ class SparkAggregateByKey(StepToDict):
         import pyspark.sql.functions as funcs
         from pyspark.sql import Window
 
+        print(f"SparkAggregateByKey called!!!!! emit_by_row={self._emit_by_row} \nevent=\n{event.collect()}\n")
         time_column = self.time_column or "time"
 
         if not self._emit_by_row:
@@ -794,6 +798,9 @@ class SparkAggregateByKey(StepToDict):
             union_df = dfs[0]
             for df in dfs[1:]:
                 union_df = union_df.unionByName(df, allowMissingColumns=True)
+
+            print(f"SparkAggregateByKey end!!!!! emit_by_row={self._emit_by_row} \nresult=\n{union_df.collect()}\n")
+
             return union_df
 
         else:
@@ -856,4 +863,7 @@ class SparkAggregateByKey(StepToDict):
                 if column not in drop_columns
             ]
             union_df = union_df.groupBy(rowid_col).agg(*last_value_aggs).drop(rowid_col)
+
+            print(f"SparkAggregateByKey end!!!!! emit_by_row={self._emit_by_row} \nresult=\n{union_df.collect()}\n")
+
             return union_df

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -775,7 +775,7 @@ class SparkAggregateByKey(StepToDict):
 
                 for window in windows:
                     spark_window = self._duration_to_spark_format(window)
-                    aggs = [last_value_aggs]
+                    aggs = last_value_aggs
                     for operation in operations:
                         func = getattr(funcs, operation)
                         agg_name = f"{name if name else column}_{operation}_{window}"

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -15,7 +15,7 @@ from mlrun.datastore.sources import ParquetSource
 from mlrun.datastore.targets import NoSqlTarget, ParquetTarget
 from mlrun.features import Entity
 from tests.system.base import TestMLRunSystem
-from mlrun.feature_store.feature_set import EmitPolicy, EmitPolicyType
+from storey import EmitEveryEvent
 
 @TestMLRunSystem.skip_test_if_env_not_configured
 # Marked as enterprise because of v3io mount and remote spark
@@ -314,7 +314,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             "time_window": {("moshe", "cohen"): "1h", ("yosi", "levi"): "1h"},
         }
 
-    def test_aggregations_emit_per_row(self):
+    def test_aggregations_emit_every_event(self):
         name = f"measurements_{uuid.uuid4()}"
         test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
 
@@ -351,7 +351,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             operations=["sum", "max", "count"],
             windows=["1h", "2h"],
             period="10m",
-            emit_policy=EmitPolicy(EmitPolicyType.every_event),
+            emit_policy=EmitEveryEvent(),
         )
 
         fs.ingest(

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -25,9 +25,9 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
     spark_service = ""
     pq_source = "testdata.parquet"
     spark_image_deployed = (
-        False  # Set to True if you want to avoid the image building phase
+        True  # Set to True if you want to avoid the image building phase
     )
-    test_branch = ""  # For testing specific branche. e.g.: "https://github.com/mlrun/mlrun.git@development"
+    test_branch = "https://github.com/theSaarco/mlrun.git@spark-emit-per-row"  # For testing specific branche. e.g.: "https://github.com/mlrun/mlrun.git@development"
 
     @classmethod
     def _init_env_from_file(cls):
@@ -360,6 +360,8 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             spark_context=self.spark_service,
             run_config=fs.RunConfig(local=False),
         )
+
+        print(f"Feature-set: \n{data_set.to_dict()}\n\n")
 
         features = [
             f"{name_spark}.*",

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -25,9 +25,9 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
     spark_service = ""
     pq_source = "testdata.parquet"
     spark_image_deployed = (
-        True  # Set to True if you want to avoid the image building phase
+        False  # Set to True if you want to avoid the image building phase
     )
-    test_branch = "https://github.com/theSaarco/mlrun.git@spark-emit-per-row"  # For testing specific branche. e.g.: "https://github.com/mlrun/mlrun.git@development"
+    test_branch = ""  # For testing specific branche. e.g.: "https://github.com/mlrun/mlrun.git@development"
 
     @classmethod
     def _init_env_from_file(cls):
@@ -351,7 +351,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             operations=["sum", "max"],
             windows=["1h", "2h"],
             period="10m",
-            spark_emit_by_row=True,
+            spark_emit_by_row=False,
         )
 
         fs.ingest(


### PR DESCRIPTION
When using Spark as engine, can now ask for aggregations to happen in an emit-per-event mode (rather than emit-per-period as was done until now). This uses a different Spark query to perform the aggregations.
To use this, added back the `emit_policy` parameter to `add_aggregations` - if using `emit_policy=storey.EmitEveryEvent()` this will trigger the new mode when working with Spark. By default (as until now) no emit policy is passed, and `Spark` processing will work in the usual emit-per-period mode.
If working with storey, emit policy is currently not passed to the engine, until various emit policies are officially supported by storey.

Also fixed a small issue in Spark aggregates processing where not providing a `period` for the aggregations would cause the code to explode when trying to parse its time units and convert to Spark units.

**Note:** while it looks like I've modified the existing Spark query logic, I didn't - it just moved because it's now in an `if` statement.