### PR TITLE
[Requirements] Bump nuclio-jupyter to 0.8.23 

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,4 +6,4 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.16.0
 python-dotenv~=0.17.0
-nuclio-jupyter[jupyter-server]~=0.8.22
+nuclio-jupyter[jupyter-server]~=0.8.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ click~=8.0
 kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
-nuclio-jupyter~=0.8.22
+nuclio-jupyter~=0.8.23
 # >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
 # https://github.com/Azure/MachineLearningNotebooks/issues/1314
 numpy>=1.16.5, <1.22.0


### PR DESCRIPTION
We had a breakage in our integration tests root caused by a backwards incompatible change in jinja2
see - https://github.com/nuclio/nuclio-jupyter/pull/139 for more details. 