### PR TITLE
[Runtimes] Add preemption mode support

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -66,7 +66,7 @@ class ClientSpec(
                 "preemptible_nodes.tolerations"
             ),
             default_preemption_mode=self._get_config_value_if_not_default(
-                "default_preemption_mode"
+                "function_defaults.preemption_mode"
             ),
         )
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -59,6 +59,15 @@ class ClientSpec(
             default_function_pod_resources=self._get_config_value_if_not_default(
                 "default_function_pod_resources"
             ),
+            preemptible_nodes_node_selector=self._get_config_value_if_not_default(
+                "preemptible_nodes.node_selector"
+            ),
+            preemptible_nodes_tolerations=self._get_config_value_if_not_default(
+                "preemptible_nodes.tolerations"
+            ),
+            default_preemption_mode=self._get_config_value_if_not_default(
+                "default_preemption_mode"
+            ),
         )
 
     @staticmethod

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -57,8 +57,8 @@ from .frontend_spec import (
     NuclioStreamsFeatureFlag,
     ProjectMembershipFeatureFlag,
 )
-from .function import FunctionState
-from .k8s import Resources, ResourceSpec
+from .function import FunctionState, PreemptionModes
+from .k8s import NodeSelectorOperator, Resources, ResourceSpec
 from .marketplace import (
     IndexedMarketplaceSource,
     MarketplaceCatalog,

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -32,3 +32,6 @@ class ClientSpec(pydantic.BaseModel):
     valid_function_priority_class_names: typing.Optional[str]
     default_tensorboard_logs_path: typing.Optional[str]
     default_function_pod_resources: typing.Optional[Resources]
+    preemptible_nodes_node_selector: typing.Optional[str]
+    preemptible_nodes_tolerations: typing.Optional[str]
+    default_preemption_mode: typing.Optional[str]

--- a/mlrun/api/schemas/function.py
+++ b/mlrun/api/schemas/function.py
@@ -1,3 +1,6 @@
+from enum import Enum
+
+
 # Ideally we would want this to be class FunctionState(str, enum.Enum) which is the "FastAPI-compatible" way of creating
 # schemas
 # But, when we save a function to the DB, we pickle the body, which saves the state as an instance of this class (and
@@ -23,3 +26,16 @@ class FunctionState:
     pending = "pending"
     # same goes for the build which is not coming from the pod, but is used and we can't just omit it for BC reasons
     build = "build"
+
+
+class PreemptionModes(str, Enum):
+    # makes function pods be able to run on preemptible nodes
+    allow = "allow"
+    # makes the function pods run on preemtible nodes only
+    constrain = "constrain"
+    # prevents the function pods from running on preemptible nodes
+    prevent = "prevent"
+
+    @classmethod
+    def has_preemption_mode(cls, value):
+        return value in cls._value2member_map_

--- a/mlrun/api/schemas/function.py
+++ b/mlrun/api/schemas/function.py
@@ -35,7 +35,3 @@ class PreemptionModes(str, Enum):
     constrain = "constrain"
     # prevents the function pods from running on preemptible nodes
     prevent = "prevent"
-
-    @classmethod
-    def has_preemption_mode(cls, value):
-        return value in cls._value2member_map_

--- a/mlrun/api/schemas/function.py
+++ b/mlrun/api/schemas/function.py
@@ -31,7 +31,7 @@ class FunctionState:
 class PreemptionModes(str, Enum):
     # makes function pods be able to run on preemptible nodes
     allow = "allow"
-    # makes the function pods run on preemtible nodes only
+    # makes the function pods run on preemptible nodes only
     constrain = "constrain"
     # prevents the function pods from running on preemptible nodes
     prevent = "prevent"

--- a/mlrun/api/schemas/k8s.py
+++ b/mlrun/api/schemas/k8s.py
@@ -16,7 +16,10 @@ class Resources(pydantic.BaseModel):
 
 
 class NodeSelectorOperator(str, Enum):
-    """A node selector operator is the set of operators that can be used in a node selector requirement"""
+    """
+    A node selector operator is the set of operators that can be used in a node selector requirement
+    https://github.com/kubernetes/api/blob/b754a94214be15ffc8d648f9fe6481857f1fc2fe/core/v1/types.go#L2765
+    """
 
     node_selector_op_in = "In"
     node_selector_op_not_in = "NotIn"

--- a/mlrun/api/schemas/k8s.py
+++ b/mlrun/api/schemas/k8s.py
@@ -1,5 +1,5 @@
+import enum
 import typing
-from enum import Enum
 
 import pydantic
 
@@ -15,7 +15,7 @@ class Resources(pydantic.BaseModel):
     limits: ResourceSpec = ResourceSpec()
 
 
-class NodeSelectorOperator(str, Enum):
+class NodeSelectorOperator(str, enum.Enum):
     """
     A node selector operator is the set of operators that can be used in a node selector requirement
     https://github.com/kubernetes/api/blob/b754a94214be15ffc8d648f9fe6481857f1fc2fe/core/v1/types.go#L2765

--- a/mlrun/api/schemas/k8s.py
+++ b/mlrun/api/schemas/k8s.py
@@ -1,4 +1,5 @@
 import typing
+from enum import Enum
 
 import pydantic
 
@@ -12,3 +13,14 @@ class ResourceSpec(pydantic.BaseModel):
 class Resources(pydantic.BaseModel):
     requests: ResourceSpec = ResourceSpec()
     limits: ResourceSpec = ResourceSpec()
+
+
+class NodeSelectorOperator(str, Enum):
+    """A node selector operator is the set of operators that can be used in a node selector requirement"""
+
+    node_selector_op_in = "In"
+    node_selector_op_not_in = "NotIn"
+    node_selector_op_exists = "Exists"
+    node_selector_op_does_not_exist = "DoesNotExist"
+    node_selector_op_gt = "Gt"
+    node_selector_op_lt = "Lt"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -123,7 +123,9 @@ default_config = {
             "remote": "mlrun/mlrun",
             "dask": "mlrun/ml-base",
             "mpijob": "mlrun/ml-models",
-        }
+        },
+        # see enrich function preemption spec for more info, and schemas.functionPreemptionModes for available options
+        "preemption_mode": "prevent",
     },
     "httpdb": {
         "port": 8080,
@@ -334,8 +336,6 @@ default_config = {
         # encoded empty list
         "tolerations": "W10=",
     },
-    # see enrich function preemption spec for more info, and api.schemas.functionPreemptionModes for available options
-    "default_preemption_mode": "prevent",
 }
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -330,7 +330,7 @@ default_config = {
     # preemptible node selector and tolerations to be added when running on spot nodes
     "preemptible_nodes": {
         "node_selector": "e30=",
-        "tolerations": "e30=",
+        "tolerations": "W10=",
     },
 }
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -329,9 +329,13 @@ default_config = {
     },
     # preemptible node selector and tolerations to be added when running on spot nodes
     "preemptible_nodes": {
+        # encoded empty dict
         "node_selector": "e30=",
+        # encoded empty list
         "tolerations": "W10=",
     },
+    # see enrich function preemption spec for more info, and api.schemas.functionPreemptionModes for available options
+    "default_preemption_mode": "prevent",
 }
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -415,6 +415,12 @@ class Config:
     def decode_base64_config_and_load_to_object(
         attribute_path: str, expected_type=dict
     ):
+        """
+        decodes and loads the config attribute to expected type
+        :param attribute_path: the path in the default_config e.g preemptible_nodes.node_selector
+        :param expected_type: the object type valid values are : `dict`, `list` etc...
+        :return: the expected type instance
+        """
         attributes = attribute_path.split(".")
         raw_attribute_value = config
         for part in attributes:

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -412,7 +412,7 @@ class Config:
         return config.hub_url
 
     @staticmethod
-    def decode_base64_config_and_load_to_dict(attribute_path: str) -> dict:
+    def decode_base64_config_and_load_to_object(attribute_path: str, expected_type):
         attributes = attribute_path.split(".")
         raw_attribute_value = config
         for part in attributes:
@@ -432,22 +432,26 @@ class Config:
                     f"Unable to decode {attribute_path}"
                 )
             parsed_attribute_value = json.loads(decoded_attribute_value)
+            if type(parsed_attribute_value) != expected_type:
+                raise mlrun.errors.MLRunInvalidArgumentTypeError(
+                    f"Expected type {expected_type}, got {type(parsed_attribute_value)}"
+                )
             return parsed_attribute_value
-        return {}
+        return expected_type()
 
     def get_default_function_node_selector(self) -> dict:
-        return self.decode_base64_config_and_load_to_dict(
-            "default_function_node_selector"
+        return self.decode_base64_config_and_load_to_object(
+            "default_function_node_selector", dict
         )
 
     def get_preemptible_node_selector(self) -> dict:
-        return self.decode_base64_config_and_load_to_dict(
-            "preemptible_nodes.node_selector"
+        return self.decode_base64_config_and_load_to_object(
+            "preemptible_nodes.node_selector", dict
         )
 
-    def get_preemptible_tolerations(self) -> dict:
-        return self.decode_base64_config_and_load_to_dict(
-            "preemptible_nodes.tolerations"
+    def get_preemptible_tolerations(self) -> list:
+        return self.decode_base64_config_and_load_to_object(
+            "preemptible_nodes.tolerations", list
         )
 
     @staticmethod

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -412,7 +412,9 @@ class Config:
         return config.hub_url
 
     @staticmethod
-    def decode_base64_config_and_load_to_object(attribute_path: str, expected_type):
+    def decode_base64_config_and_load_to_object(
+        attribute_path: str, expected_type=dict
+    ):
         attributes = attribute_path.split(".")
         raw_attribute_value = config
         for part in attributes:

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -124,7 +124,8 @@ default_config = {
             "dask": "mlrun/ml-base",
             "mpijob": "mlrun/ml-models",
         },
-        # see enrich function preemption spec for more info, and schemas.functionPreemptionModes for available options
+        # see enrich_function_preemption_spec for more info,
+        # and mlrun.api.schemas.functionPreemptionModes for available options
         "preemption_mode": "prevent",
     },
     "httpdb": {

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -338,6 +338,18 @@ class HTTPRunDB(RunDBInterface):
                 server_cfg.get("default_tensorboard_logs_path")
                 or config.default_tensorboard_logs_path
             )
+            config.default_preemption_mode = (
+                server_cfg.get("default_preemption_mode")
+                or config.default_preemption_mode
+            )
+            config.preemptible_nodes.node_selector = (
+                server_cfg.get("preemptible_nodes_node_selector")
+                or config.preemptible_nodes.node_selector
+            )
+            config.preemptible_nodes.tolerations = (
+                server_cfg.get("preemptible_nodes_tolerations")
+                or config.preemptible_nodes.tolerations
+            )
 
         except Exception as exc:
             logger.warning(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -338,9 +338,9 @@ class HTTPRunDB(RunDBInterface):
                 server_cfg.get("default_tensorboard_logs_path")
                 or config.default_tensorboard_logs_path
             )
-            config.default_preemption_mode = (
+            config.function_defaults.preemption_mode = (
                 server_cfg.get("default_preemption_mode")
-                or config.default_preemption_mode
+                or config.function_defaults.preemption_mode
             )
             config.preemptible_nodes.node_selector = (
                 server_cfg.get("preemptible_nodes_node_selector")

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -671,10 +671,6 @@ def compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes() -> ty
     )
     for expression in affinity:
         node_selector_terms.append(
-            kubernetes.client.V1NodeSelectorTerm(
-                match_expressions=kubernetes.client.V1NodeSelectorRequirement(
-                    expression
-                )
-            )
+            kubernetes.client.V1NodeSelectorTerm(match_expressions=expression)
         )
     return node_selector_terms

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -644,12 +644,12 @@ def generate_preemptible_nodes_anti_affinity_terms() -> typing.List[
     from mlrun.api.schemas import NodeSelectorOperator
 
     # compile affinities with operator NotIn to make sure pods are not running on preemptible nodes.
-    anti_affinity = generate_preemptible_node_selector_requirements(
+    node_selector_requirements = generate_preemptible_node_selector_requirements(
         NodeSelectorOperator.node_selector_op_not_in
     )
     return [
         kubernetes.client.V1NodeSelectorTerm(
-            match_expressions=anti_affinity,
+            match_expressions=node_selector_requirements,
         )
     ]
 
@@ -660,7 +660,7 @@ def generate_preemptible_nodes_affinity_terms() -> typing.List[
     """
     Use for purpose of scheduling on node having at least one of the node selectors.
     When specifying multiple nodeSelectorTerms associated with nodeAffinity types,
-    then the pod can be scheduled onto a node if only one of the nodeSelectorTerms can be satisfied.
+    then the pod can be scheduled onto a node if at least one of the nodeSelectorTerms can be satisfied.
     :return: List of nodeSelectorTerms associated with the preemptible nodes.
     """
     # import here to avoid circular imports
@@ -669,10 +669,10 @@ def generate_preemptible_nodes_affinity_terms() -> typing.List[
     node_selector_terms = []
 
     # compile affinities with operator In so pods could schedule on at least one of the preemptible nodes.
-    affinity = generate_preemptible_node_selector_requirements(
+    node_selector_requirements = generate_preemptible_node_selector_requirements(
         NodeSelectorOperator.node_selector_op_in
     )
-    for expression in affinity:
+    for expression in node_selector_requirements:
         node_selector_terms.append(
             kubernetes.client.V1NodeSelectorTerm(match_expressions=[expression])
         )
@@ -682,9 +682,9 @@ def generate_preemptible_nodes_affinity_terms() -> typing.List[
 def generate_preemptible_tolerations() -> typing.List[kubernetes.client.V1Toleration]:
     tolerations = mlconfig.get_preemptible_tolerations()
 
-    list_of_toleration_objects = []
+    toleration_objects = []
     for toleration in tolerations:
-        list_of_toleration_objects.append(
+        toleration_objects.append(
             kubernetes.client.V1Toleration(
                 effect=toleration.get("effect", None),
                 key=toleration.get("key", None),
@@ -694,4 +694,4 @@ def generate_preemptible_tolerations() -> typing.List[kubernetes.client.V1Tolera
                 or toleration.get("tolerationSeconds", None),
             )
         )
-    return list_of_toleration_objects
+    return toleration_objects

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -604,7 +604,9 @@ def verify_gpu_requests_and_limits(requests_gpu: str = None, limits_gpu: str = N
         )
 
 
-def generate_preemptible_node_selector_requirements(node_selector_operator: str):
+def generate_preemptible_node_selector_requirements(
+    node_selector_operator: str,
+) -> typing.List[kubernetes.client.V1NodeSelectorRequirement]:
     """
     Generate node selector requirements based on the pre-configured node selector of the preemptible nodes.
     node selector operator represents a key's relationship to a set of values.
@@ -652,7 +654,7 @@ def generate_preemptible_nodes_anti_affinity_terms() -> typing.List[
     ]
 
 
-def compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes() -> typing.List[
+def generate_preemptible_nodes_affinity_terms() -> typing.List[
     kubernetes.client.V1NodeSelectorTerm
 ]:
     """
@@ -675,3 +677,21 @@ def compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes() -> ty
             kubernetes.client.V1NodeSelectorTerm(match_expressions=[expression])
         )
     return node_selector_terms
+
+
+def generate_preemptible_tolerations() -> typing.List[kubernetes.client.V1Toleration]:
+    tolerations = mlconfig.get_preemptible_tolerations()
+
+    list_of_toleration_objects = []
+    for toleration in tolerations:
+        list_of_toleration_objects.append(
+            kubernetes.client.V1Toleration(
+                effect=toleration.get("effect", None),
+                key=toleration.get("key", None),
+                value=toleration.get("value", None),
+                operator=toleration.get("operator", None),
+                toleration_seconds=toleration.get("toleration_seconds", None)
+                or toleration.get("tolerationSeconds", None),
+            )
+        )
+    return list_of_toleration_objects

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -671,6 +671,6 @@ def compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes() -> ty
     )
     for expression in affinity:
         node_selector_terms.append(
-            kubernetes.client.V1NodeSelectorTerm(match_expressions=expression)
+            kubernetes.client.V1NodeSelectorTerm(match_expressions=[expression])
         )
     return node_selector_terms

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -606,9 +606,9 @@ def verify_gpu_requests_and_limits(requests_gpu: str = None, limits_gpu: str = N
 
 def generate_preemptible_node_selector_requirements(node_selector_operator: str):
     """
-    Compiles affinity spec based on pre-configured node selector.
-    operator represents a key's relationship to a set of values.
-    Valid operators are listed in :py:class:`~mlrun.api.schemas.NodeSelectorOperator`.
+    Generate node selector requirements based on the pre-configured node selector of the preemptible nodes
+    operator represents a key's relationship to a set of values
+    Valid operators are listed in :py:class:`~mlrun.api.schemas.NodeSelectorOperator`
     :param node_selector_operator: The operator of V1NodeSelectorRequirement
     :return: List[V1NodeSelectorRequirement]
     """

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -617,7 +617,7 @@ def compile_affinity_by_label_selector(node_selector_operator: str):
     for (
         node_selector_key,
         node_selector_value,
-    ) in mlconfig.get_preemptible_node_selector():
+    ) in mlconfig.get_preemptible_node_selector().items():
         match_expressions.append(
             kubernetes.client.V1NodeSelectorRequirement(
                 key=node_selector_key,

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -606,8 +606,8 @@ def verify_gpu_requests_and_limits(requests_gpu: str = None, limits_gpu: str = N
 
 def generate_preemptible_node_selector_requirements(node_selector_operator: str):
     """
-    Generate node selector requirements based on the pre-configured node selector of the preemptible nodes
-    operator represents a key's relationship to a set of values
+    Generate node selector requirements based on the pre-configured node selector of the preemptible nodes.
+    node selector operator represents a key's relationship to a set of values.
     Valid operators are listed in :py:class:`~mlrun.api.schemas.NodeSelectorOperator`
     :param node_selector_operator: The operator of V1NodeSelectorRequirement
     :return: List[V1NodeSelectorRequirement]
@@ -627,10 +627,12 @@ def generate_preemptible_node_selector_requirements(node_selector_operator: str)
     return match_expressions
 
 
-def compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes() -> typing.List[
+def generate_preemptible_nodes_anti_affinity_terms() -> typing.List[
     kubernetes.client.V1NodeSelectorTerm
 ]:
     """
+    Generate node selector term containing anti-affinity expressions based on the
+    pre-configured node selector of the preemptible nodes.
     Use for purpose of scheduling on node only if all match_expressions are satisfied.
     This function uses a single term with potentially multiple expressions to ensure anti affinity.
     https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -604,12 +604,11 @@ def verify_gpu_requests_and_limits(requests_gpu: str = None, limits_gpu: str = N
         )
 
 
-def compile_affinity_by_label_selector(node_selector_operator: str):
+def generate_preemptible_node_selector_requirements(node_selector_operator: str):
     """
     Compiles affinity spec based on pre-configured node selector.
     operator represents a key's relationship to a set of values.
-    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt
-
+    Valid operators are listed in :py:class:`~mlrun.api.schemas.NodeSelectorOperator`.
     :param node_selector_operator: The operator of V1NodeSelectorRequirement
     :return: List[V1NodeSelectorRequirement]
     """
@@ -641,7 +640,7 @@ def compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes() -> t
     from mlrun.api.schemas import NodeSelectorOperator
 
     # compile affinities with operator NotIn to make sure pods are not running on preemptible nodes.
-    anti_affinity = compile_affinity_by_label_selector(
+    anti_affinity = generate_preemptible_node_selector_requirements(
         NodeSelectorOperator.node_selector_op_not_in
     )
     return [
@@ -666,7 +665,7 @@ def compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes() -> ty
     node_selector_terms = []
 
     # compile affinities with operator In so pods could schedule on at least one of the preemptible nodes.
-    affinity = compile_affinity_by_label_selector(
+    affinity = generate_preemptible_node_selector_requirements(
         NodeSelectorOperator.node_selector_op_in
     )
     for expression in affinity:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -230,7 +230,7 @@ class BaseRuntime(ModelObj):
     def _enrich_on_server_side(self):
         pass
 
-    def _enrich_on_both_sides(self):
+    def _enrich_on_server_and_client_sides(self):
         """
         enrich function also in client side and also on server side
         """
@@ -244,7 +244,7 @@ class BaseRuntime(ModelObj):
             self._enrich_on_client_side()
         else:
             self._enrich_on_server_side()
-        self._enrich_on_both_sides()
+        self._enrich_on_server_and_client_sides()
 
     def _function_uri(self, tag=None, hash_key=None):
         return generate_object_uri(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -233,7 +233,7 @@ class BaseRuntime(ModelObj):
         """
         enrich function also in client side and also on server side
         """
-        self.spec.enrich_function_preemption_spec()
+        pass
 
     def _enrich_function(self):
         """

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -137,6 +137,9 @@ class FunctionSpec(ModelObj):
     def build(self, build):
         self._build = self._verify_dict(build, "build", ImageBuilder)
 
+    def enrich_function_preemption_spec(self):
+        pass
+
 
 class BaseRuntime(ModelObj):
     kind = "base"
@@ -218,6 +221,30 @@ class BaseRuntime(ModelObj):
         ):
             return True
         return False
+
+    def _enrich_on_client_side(self):
+        # Perform auto-mount if necessary - make sure it only runs on client side (when using remote API)
+        self.try_auto_mount_based_on_config()
+        self.fill_credentials()
+
+    def _enrich_on_server_side(self):
+        pass
+
+    def _enrich_on_both_sides(self):
+        """
+        enrich function also in client side and also on server side
+        """
+        self.spec.enrich_function_preemption_spec()
+
+    def _enrich_function(self):
+        """
+        enriches the function based on the flow state we run in (sdk or server)
+        """
+        if self._use_remote_api():
+            self._enrich_on_client_side()
+        else:
+            self._enrich_on_server_side()
+        self._enrich_on_both_sides()
 
     def _function_uri(self, tag=None, hash_key=None):
         return generate_object_uri(
@@ -309,10 +336,7 @@ class BaseRuntime(ModelObj):
         if self.spec.mode and self.spec.mode not in run_modes:
             raise ValueError(f'run mode can only be {",".join(run_modes)}')
 
-        # Perform auto-mount if necessary - make sure it only runs on client side (when using remote API)
-        if self._use_remote_api():
-            self.try_auto_mount_based_on_config()
-            self.fill_credentials()
+        self._enrich_function()
 
         if local:
             return self._run_local(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -223,7 +223,6 @@ class BaseRuntime(ModelObj):
         return False
 
     def _enrich_on_client_side(self):
-        # Perform auto-mount if necessary - make sure it only runs on client side (when using remote API)
         self.try_auto_mount_based_on_config()
         self.fill_credentials()
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -584,14 +584,12 @@ class KubeResourceSpec(FunctionSpec):
                             node_selector_terms=new_node_selector_terms
                         )
                     )
-            # check if there is something to set into required_during_scheduling_ignored_during_execution
+            # if both preferred and new required are empty, clean node_affinity
             if (
                 not node_affinity.preferred_during_scheduling_ignored_during_execution
                 and not new_required_during_scheduling_ignored_during_execution
             ):
-                self.affinity.node_affinity.required_during_scheduling_ignored_during_execution = (
-                    None
-                )
+                self.affinity.node_affinity = None
                 return
 
             self._initialize_affinity()

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -312,7 +312,6 @@ class KubeResourceSpec(FunctionSpec):
 
     @staticmethod
     def _resolve_if_type_sanitized(attribute_name, attribute):
-        print(attribute)
         attribute_config = sanitized_attributes[attribute_name]
         # heuristic - if one of the keys contains _ as part of the dict it means to_dict on the kubernetes
         # object performed, there's nothing we can do at that point to transform it to the sanitized version

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -155,7 +155,7 @@ class KubeResourceSpec(FunctionSpec):
             priority_class_name or mlrun.mlconf.default_function_priority_class_name
         )
         self._tolerations = tolerations
-        self.preemption_mode = preemption_mode or mlconf.default_preemption_mode
+        self.preemption_mode = preemption_mode or mlconf.function_defaults.preemption_mode
 
     @property
     def volumes(self) -> list:
@@ -470,7 +470,7 @@ class KubeResourceSpec(FunctionSpec):
             return
 
         if not self.preemption_mode:
-            self.preemption_mode = mlconf.default_preemption_mode
+            self.preemption_mode = mlconf.function_defaults.preemption_mode
             logger.debug(
                 "No preemption mode was given, using the default preemption mode",
                 new_preemption_mode=self.preemption_mode,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -573,7 +573,7 @@ class KubeResourceSpec(FunctionSpec):
                 node_selector: client.V1NodeSelector = (
                     node_affinity.required_during_scheduling_ignored_during_execution
                 )
-                new_node_selector_terms = self._get_node_selector_terms_without_provided_node_selector_requirements(
+                new_node_selector_terms = self._prune_node_selector_requirements_from_node_selector_terms(
                     node_selector_terms=node_selector.node_selector_terms,
                     node_selector_requirements_to_remove=node_selector_requirements,
                 )
@@ -599,7 +599,7 @@ class KubeResourceSpec(FunctionSpec):
             )
 
     @staticmethod
-    def _get_node_selector_terms_without_provided_node_selector_requirements(
+    def _prune_node_selector_requirements_from_node_selector_terms(
         node_selector_terms: typing.List[client.V1NodeSelectorTerm],
         node_selector_requirements_to_remove: typing.List[
             client.V1NodeSelectorRequirement
@@ -612,7 +612,6 @@ class KubeResourceSpec(FunctionSpec):
         :return: New list of terms without the provided node selector requirements
         """
         new_node_selector_terms: typing.List[client.V1NodeSelectorTerm] = []
-        # for all term expressions on function spec
         for term in node_selector_terms:
             new_node_selector_requirements: typing.List[
                 client.V1NodeSelectorRequirement

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -28,8 +28,8 @@ import mlrun.utils.regex
 from ..api.schemas import NodeSelectorOperator, PreemptionModes
 from ..config import config as mlconf
 from ..k8s_utils import (
-    generate_preemptible_node_selector_requirements,
     compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes,
+    generate_preemptible_node_selector_requirements,
     generate_preemptible_nodes_anti_affinity_terms,
     verify_gpu_requests_and_limits,
 )

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -422,14 +422,14 @@ class KubeResourceSpec(FunctionSpec):
             return {}
         return resources
 
-    def _enrich_with_node_selectors(self, node_selector: typing.Dict[str, str]):
+    def _merge_node_selector(self, node_selector: typing.Dict[str, str]):
         if not node_selector:
             return
 
         # merge node selectors - precedence to existing node selector
         self.node_selector = {**node_selector, **self.node_selector}
 
-    def _enrich_with_tolerations(self, tolerations: typing.List[client.V1Toleration]):
+    def _merge_tolerations(self, tolerations: typing.List[client.V1Toleration]):
         if len(tolerations) == 0:
             return
 
@@ -507,7 +507,7 @@ class KubeResourceSpec(FunctionSpec):
         # enrich tolerations and override all node selector terms with preemptible node selector terms
         elif self.preemption_mode == PreemptionModes.constrain:
             # enrich with tolerations
-            self._enrich_with_tolerations(mlconf.get_preemptible_tolerations())
+            self._merge_tolerations(mlconf.get_preemptible_tolerations())
             # TODO add gpu tolerations enrichment
             self._initialize_affinity()
             self._initialize_node_affinity()
@@ -538,7 +538,7 @@ class KubeResourceSpec(FunctionSpec):
             self._prune_node_selector(mlconf.get_preemptible_node_selector())
 
             # enrich with tolerations
-            self._enrich_with_tolerations(mlconf.get_preemptible_tolerations())
+            self._merge_tolerations(mlconf.get_preemptible_tolerations())
 
             # TODO add gpu tolerations enrichment
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -903,24 +903,21 @@ class KubeResource(BaseRuntime):
             raise mlrun.errors.MLRunInvalidArgumentError(message)
         self.spec.priority_class_name = name
 
-    def with_preemption_mode(self, mode: str):
+    def with_preemption_mode(self, mode: typing.Union[PreemptionModes, str]):
         """
-        Preemption modes enable users to run function pods on preemptible nodes, when filled,
-        tolerations, node labels and affinity would be populated correspondingly to the function spec on server side.
+        Preemption modes enable users to control whether or not function pods will be scheduled on preemptible nodes.
+        Tolerations, node selector and affinity would be populated correspondingly to the function spec.
 
-        currently supports 3 modes:
+        currently 3 modes are supported:
 
-        allow - Allows function to be scheduled on preemptible nodes
-        constrains - Makes function to run only on preemptible nodes
-        prevent - Prevents function to be scheduled on preemptible nodes
+        * **allow** - Allow the function to be scheduled on preemptible nodes
+        * **constrain** - Constrain the function to run only on preemptible nodes
+        * **prevent** - Prevent the function from being scheduled on preemptible nodes
 
-        :param mode: accepts allow | constraint | prevent defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
+        :param mode: accepts allow | constrain | prevent defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
         """
-        if not PreemptionModes.has_preemption_mode(mode):
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"{mode} is not one of the supported preemption modes"
-            )
-        self.spec.preemption_mode = mode
+        preemptible_mode = PreemptionModes(mode)
+        self.spec.preemption_mode = preemptible_mode.value
 
     def list_valid_priority_class_names(self):
         return mlconf.get_valid_function_priority_class_names()

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -647,13 +647,19 @@ class KubeResourceSpec(FunctionSpec):
         :param tolerations: tolerations to prune
         """
         # both needs to exist to prune required tolerations from spec tolerations
-        if len(tolerations) or not self.tolerations:
+        if not tolerations or not self.tolerations:
             return
 
-        # Generate a list of tolerations without tolerations to prune
-        tolerations_without_tolerations_to_prune = list(
-            set(self.tolerations) - set(tolerations)
-        )
+        # generate a list of tolerations without tolerations to prune
+        tolerations_without_tolerations_to_prune = []
+        for toleration in self.tolerations:
+            tolerations_without_tolerations_to_prune.append(toleration)
+            for toleration_to_delete in tolerations:
+                if toleration == toleration_to_delete:
+                    # remove from new tolerations list
+                    tolerations_without_tolerations_to_prune.pop()
+                    # no need to keep going over the list provided for the current toleration
+                    break
 
         # Set tolerations without tolerations to prune
         self.tolerations = tolerations_without_tolerations_to_prune

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -451,18 +451,19 @@ class KubeResourceSpec(FunctionSpec):
 
     def enrich_function_preemption_spec(self):
         """
-        Enriches function pod with the below described spec. if no platformConfiguration related
-        configuration is given, do nothing.
-            `Allow` 	- Adds Tolerations if taints were given.
-                        otherwise, assume pods can be scheduled on preemptible nodes.
+        Enriches function pod with the below described spec.
+        If no preemptible node configuration is provided, do nothing.
+            `Allow` 	- Adds Tolerations if configured.
+                          otherwise, assume pods can be scheduled on preemptible nodes.
                         > Purges any `affinity` / `anti-affinity` preemption related configuration
-            `Constrain` - Uses node-affinity to make sure pods are assigned using OR on the given node label selectors.
+            `Constrain` - Uses node-affinity to make sure pods are assigned using OR on the configured
+                          node label selectors.
                         > Uses `Allow` configuration as well.
                         > Purges any `anti-affinity` preemption related configuration
-            `Prevent`	- Prevention is done either using taints (if Tolerations were given) or anti-affinity.
-                        > Purges any `tolerations` / `gpuTolerations` preemption related configuration
+            `Prevent`	- Prevention is done either using taints (if Tolerations were configured) or anti-affinity.
+                        > Purges any `tolerations` preemption related configuration
                         > Purges any `affinity` preemption related configuration
-                        > Adds anti-affinity IF no tolerations were given
+                        > Adds anti-affinity IF no tolerations were configured
         """
         # nothing to do here, configuration is not populated
         if (

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -155,7 +155,9 @@ class KubeResourceSpec(FunctionSpec):
             priority_class_name or mlrun.mlconf.default_function_priority_class_name
         )
         self._tolerations = tolerations
-        self.preemption_mode = preemption_mode or mlconf.function_defaults.preemption_mode
+        self.preemption_mode = (
+            preemption_mode or mlconf.function_defaults.preemption_mode
+        )
 
     @property
     def volumes(self) -> list:

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -476,7 +476,7 @@ class KubeResourceSpec(FunctionSpec):
             self.preemption_mode = mlconf.function_defaults.preemption_mode
             logger.debug(
                 "No preemption mode was given, using the default preemption mode",
-                new_preemption_mode=self.preemption_mode,
+                default_preemption_mode=self.preemption_mode,
             )
 
         logger.debug(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -541,8 +541,6 @@ class KubeResourceSpec(FunctionSpec):
             # enrich with tolerations
             self._merge_tolerations(mlconf.get_preemptible_tolerations())
 
-            # TODO add gpu tolerations enrichment
-
     def _initialize_affinity(self):
         if not self.affinity:
             self.affinity = client.V1Affinity()

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -509,7 +509,7 @@ class KubeResourceSpec(FunctionSpec):
         elif self.preemption_mode == PreemptionModes.constrain:
             # enrich with tolerations
             self._merge_tolerations(mlconf.get_preemptible_tolerations())
-            # TODO add gpu tolerations enrichment
+
             self._initialize_affinity()
             self._initialize_node_affinity()
             # setting required_during_scheduling_ignored_during_execution

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -509,6 +509,7 @@ class KubeResourceSpec(FunctionSpec):
             self._enrich_with_tolerations(mlconf.get_preemptible_tolerations())
             # TODO add gpu tolerations enrichment
             self._initialize_affinity()
+            self._initialize_node_affinity()
             # setting required_during_scheduling_ignored_during_execution
             # overriding other terms that have been set, and only setting terms for preemptible nodes
             # when having multiple terms, pod scheduling is succeeded if at least one term is satisfied
@@ -546,7 +547,7 @@ class KubeResourceSpec(FunctionSpec):
 
     def _initialize_node_affinity(self):
         if not self.affinity.node_affinity:
-            self.affinity.node_affinity = client.V1NodeAffinity
+            self.affinity.node_affinity = client.V1NodeAffinity()
 
     def _prune_affinity_node_selector_requirement(
         self,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -28,7 +28,7 @@ import mlrun.utils.regex
 from ..api.schemas import NodeSelectorOperator, PreemptionModes
 from ..config import config as mlconf
 from ..k8s_utils import (
-    compile_affinity_by_label_selector,
+    generate_preemptible_node_selector_requirements,
     compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes,
     compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes,
     verify_gpu_requests_and_limits,
@@ -491,7 +491,7 @@ class KubeResourceSpec(FunctionSpec):
             if mlconf.get_preemptible_tolerations():
                 self._prune_affinity_node_selector_requirement(
                     (
-                        compile_affinity_by_label_selector(
+                        generate_preemptible_node_selector_requirements(
                             NodeSelectorOperator.node_selector_op_in
                         )
                     )
@@ -523,13 +523,13 @@ class KubeResourceSpec(FunctionSpec):
 
             # remove anti-affinity
             self._prune_affinity_node_selector_requirement(
-                compile_affinity_by_label_selector(
+                generate_preemptible_node_selector_requirements(
                     NodeSelectorOperator.node_selector_op_not_in
                 ),
             )
             # remove affinity
             self._prune_affinity_node_selector_requirement(
-                compile_affinity_by_label_selector(
+                generate_preemptible_node_selector_requirements(
                     NodeSelectorOperator.node_selector_op_in
                 ),
             )

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -30,7 +30,7 @@ from ..config import config as mlconf
 from ..k8s_utils import (
     generate_preemptible_node_selector_requirements,
     compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes,
-    compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes,
+    generate_preemptible_nodes_anti_affinity_terms,
     verify_gpu_requests_and_limits,
 )
 from ..secrets import SecretsStore
@@ -501,7 +501,7 @@ class KubeResourceSpec(FunctionSpec):
                 self._initialize_node_affinity()
                 # using a single term with potentially multiple expressions to ensure affinity
                 self.affinity.node_affinity.required_during_scheduling_ignored_during_execution = client.V1NodeSelector(
-                    node_selector_terms=compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes()
+                    node_selector_terms=generate_preemptible_nodes_anti_affinity_terms()
                 )
 
         # enrich tolerations and override all node selector terms with preemptible node selector terms

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -556,8 +556,9 @@ class KubeResourceSpec(FunctionSpec):
         ],
     ):
         """
-        Prunes given node selector requirements from affinity
-
+        Prunes given node selector requirements from affinity.
+        We are only editing required_during_scheduling_ignored_during_execution because the scheduler can't schedule
+        the pod unless the rule is met.
         :param node_selector_requirements:
         :return:
         """
@@ -568,8 +569,6 @@ class KubeResourceSpec(FunctionSpec):
             node_affinity: client.V1NodeAffinity = self.affinity.node_affinity
 
             new_required_during_scheduling_ignored_during_execution = None
-            # we are only looping over required_during_scheduling_ignored_during_execution
-            # because the scheduler can't schedule the Pod unless the rule is met
             if node_affinity.required_during_scheduling_ignored_during_execution:
                 node_selector: client.V1NodeSelector = (
                     node_affinity.required_during_scheduling_ignored_during_execution

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -420,7 +420,7 @@ class KubeResourceSpec(FunctionSpec):
             return {}
         return resources
 
-    def enrich_with_node_selectors(self, node_selector: typing.Dict[str, str]):
+    def _enrich_with_node_selectors(self, node_selector: typing.Dict[str, str]):
         if not node_selector:
             return
 

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -1,6 +1,9 @@
+import base64
 import http
+import json
 
 import fastapi.testclient
+import kubernetes
 import sqlalchemy.orm
 
 import mlrun
@@ -14,10 +17,29 @@ import mlrun.runtimes
 def test_client_spec(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
+    k8s_api = kubernetes.client.ApiClient()
     overridden_ui_projects_prefix = "some-prefix"
     mlrun.mlconf.ui.projects_prefix = overridden_ui_projects_prefix
     nuclio_version = "x.x.x"
     mlrun.mlconf.nuclio_version = nuclio_version
+    mlrun.mlconf.default_preemption_mode = "constrain"
+    node_selector = {"label-1": "val1"}
+    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
+        json.dumps(node_selector).encode("utf-8")
+    )
+
+    tolerations = [
+        kubernetes.client.V1Toleration(
+            effect="NoSchedule",
+            key="test1",
+            operator="Exists",
+            toleration_seconds=3600,
+        )
+    ]
+    serialized_tolerations = k8s_api.sanitize_for_serialization(tolerations)
+    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
+        json.dumps(serialized_tolerations).encode("utf-8")
+    )
     response = client.get("client-spec")
     assert response.status_code == http.HTTPStatus.OK.value
     response_body = response.json()
@@ -48,3 +70,13 @@ def test_client_spec(
         response_body["default_function_pod_resources"]
         == mlrun.mlconf.default_function_pod_resources.to_dict()
     )
+
+    assert (
+        response_body["default_preemption_mode"] == mlrun.mlconf.default_preemption_mode
+    )
+    assert response_body[
+        "preemptible_nodes_node_selector"
+    ] == mlrun.mlconf.preemptible_nodes.node_selector.decode("utf-8")
+    assert response_body[
+        "preemptible_nodes_tolerations"
+    ] == mlrun.mlconf.preemptible_nodes.tolerations.decode("utf-8")

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -22,7 +22,7 @@ def test_client_spec(
     mlrun.mlconf.ui.projects_prefix = overridden_ui_projects_prefix
     nuclio_version = "x.x.x"
     mlrun.mlconf.nuclio_version = nuclio_version
-    mlrun.mlconf.default_preemption_mode = "constrain"
+    mlrun.mlconf.function_defaults.preemption_mode = "constrain"
     node_selector = {"label-1": "val1"}
     mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
         json.dumps(node_selector).encode("utf-8")
@@ -72,7 +72,8 @@ def test_client_spec(
     )
 
     assert (
-        response_body["default_preemption_mode"] == mlrun.mlconf.default_preemption_mode
+        response_body["default_preemption_mode"]
+        == mlrun.mlconf.function_defaults.preemption_mode
     )
     assert response_body[
         "preemptible_nodes_node_selector"

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -15,13 +15,9 @@ from kubernetes import client
 from kubernetes import client as k8s_client
 from kubernetes.client import V1EnvVar
 
+import mlrun.k8s_utils
 from mlrun.api.utils.singletons.k8s import get_k8s
 from mlrun.config import config as mlconf
-from mlrun.k8s_utils import (
-    generate_preemptible_nodes_affinity_terms,
-    generate_preemptible_nodes_anti_affinity_terms,
-    generate_preemptible_tolerations,
-)
 from mlrun.model import new_task
 from mlrun.runtimes.constants import PodPhases
 from mlrun.utils import create_logger
@@ -123,7 +119,7 @@ class TestRuntimeBase:
         )
 
     def _generate_preemptible_tolerations(self) -> typing.List[k8s_client.V1Toleration]:
-        return generate_preemptible_tolerations()
+        return mlrun.k8s_utils.generate_preemptible_tolerations()
 
     def _generate_tolerations(self):
         return [self._generate_toleration()]
@@ -149,7 +145,7 @@ class TestRuntimeBase:
         return k8s_client.V1Affinity(
             node_affinity=k8s_client.V1NodeAffinity(
                 required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
-                    node_selector_terms=generate_preemptible_nodes_anti_affinity_terms(),
+                    node_selector_terms=mlrun.k8s_utils.generate_preemptible_nodes_anti_affinity_terms(),
                 ),
             ),
         )
@@ -158,7 +154,7 @@ class TestRuntimeBase:
         return k8s_client.V1Affinity(
             node_affinity=k8s_client.V1NodeAffinity(
                 required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
-                    node_selector_terms=generate_preemptible_nodes_affinity_terms(),
+                    node_selector_terms=mlrun.k8s_utils.generate_preemptible_nodes_affinity_terms(),
                 ),
             ),
         )

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -159,6 +159,28 @@ class TestRuntimeBase:
             ),
         )
 
+    def _generate_not_preemptible_affinity(self):
+        return k8s_client.V1Affinity(
+            node_affinity=k8s_client.V1NodeAffinity(
+                required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
+                    node_selector_terms=[
+                        k8s_client.V1NodeSelectorTerm(
+                            match_expressions=[
+                                k8s_client.V1NodeSelectorRequirement(
+                                    key="not_preemptible_node",
+                                    operator="In",
+                                    values=[
+                                        "not_preemptible_required-label-value-1",
+                                        "not_preemptible_required-label-value-2",
+                                    ],
+                                )
+                            ]
+                        ),
+                    ]
+                )
+            )
+        )
+
     def _generate_affinity(self) -> k8s_client.V1Affinity:
         return k8s_client.V1Affinity(
             node_affinity=k8s_client.V1NodeAffinity(

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -53,6 +53,8 @@ class TestRuntimeBase:
         self.azure_secret_value = "azure-secret-123!@"
         self.azure_vault_secret_name = "k8s-vault-secret"
 
+        self.k8s_api = k8s_client.ApiClient()
+
         self._logger.info(
             f"Setting up test {self.__class__.__name__}::{method.__name__}"
         )

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -125,7 +125,16 @@ class TestRuntimeBase:
             toleration_seconds=3600,
         )
 
-    def _generate_affinity(self):
+    def _generate_node_selector(self):
+        return {
+            "label-1": "val1",
+            "label-2": "val2",
+        }
+
+    def _generate_node_name(self):
+        return "node-name"
+
+    def _generate_affinity(self) -> k8s_client.V1Affinity:
         return k8s_client.V1Affinity(
             node_affinity=k8s_client.V1NodeAffinity(
                 preferred_during_scheduling_ignored_during_execution=[

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -144,9 +144,12 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_affinity=affinity,
         )
 
-    def test_run_with_allow_preemptible_mode(self, db: Session, client: TestClient):
-        api = k8s_client.ApiClient()
+    def test_run_with_constraint_preemptible_mode(
+        self, db: Session, client: TestClient
+    ):
+        pass
 
+    def test_run_with_allow_preemptible_mode(self, db: Session, client: TestClient):
         node_selector = self._generate_node_selector()
         mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
             json.dumps(node_selector).encode("utf-8")
@@ -159,7 +162,7 @@ class TestKubejobRuntime(TestRuntimeBase):
 
         # set default preemptible tolerations
         tolerations = self._generate_tolerations()
-        serialized_tolerations = api.sanitize_for_serialization(tolerations)
+        serialized_tolerations = self.k8s_api.sanitize_for_serialization(tolerations)
         mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
             json.dumps(serialized_tolerations).encode("utf-8")
         )

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -12,7 +12,7 @@ import mlrun.errors
 from mlrun.api.schemas import NodeSelectorOperator, PreemptionModes
 from mlrun.config import config as mlconf
 from mlrun.k8s_utils import (
-    compile_affinity_by_label_selector,
+    generate_preemptible_node_selector_requirements,
     compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes,
     compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes,
 )
@@ -331,7 +331,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         # set preemptible label selector in affinity
         affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms = [
             k8s_client.V1NodeSelectorTerm(
-                match_expressions=compile_affinity_by_label_selector(
+                match_expressions=generate_preemptible_node_selector_requirements(
                     NodeSelectorOperator.node_selector_op_in
                 )
             )
@@ -351,7 +351,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         affinity = self._generate_affinity()
         affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms.append(
             k8s_client.V1NodeSelectorTerm(
-                match_expressions=compile_affinity_by_label_selector(
+                match_expressions=generate_preemptible_node_selector_requirements(
                     NodeSelectorOperator.node_selector_op_in
                 )
             )

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -14,7 +14,7 @@ from mlrun.config import config as mlconf
 from mlrun.k8s_utils import (
     generate_preemptible_node_selector_requirements,
     compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes,
-    compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes,
+    generate_preemptible_nodes_anti_affinity_terms,
 )
 from mlrun.platforms import auto_mount
 from mlrun.runtimes.kubejob import KubejobRuntime
@@ -161,7 +161,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         expected_anti_affinity = k8s_client.V1Affinity(
             node_affinity=k8s_client.V1NodeAffinity(
                 required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
-                    node_selector_terms=compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes(),
+                    node_selector_terms=generate_preemptible_nodes_anti_affinity_terms(),
                 ),
             ),
         )
@@ -223,7 +223,7 @@ class TestKubejobRuntime(TestRuntimeBase):
         expected_affinity = k8s_client.V1Affinity(
             node_affinity=k8s_client.V1NodeAffinity(
                 required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
-                    node_selector_terms=compile_anti_affinity_by_label_selector_no_schedule_on_matching_nodes(),
+                    node_selector_terms=generate_preemptible_nodes_anti_affinity_terms(),
                 ),
             ),
         )

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -12,8 +12,8 @@ import mlrun.errors
 from mlrun.api.schemas import NodeSelectorOperator, PreemptionModes
 from mlrun.config import config as mlconf
 from mlrun.k8s_utils import (
-    generate_preemptible_node_selector_requirements,
     compile_affinity_by_label_selector_schedule_on_one_of_matching_nodes,
+    generate_preemptible_node_selector_requirements,
     generate_preemptible_nodes_anti_affinity_terms,
 )
 from mlrun.platforms import auto_mount

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -3,7 +3,6 @@ import copy
 from deepdiff import DeepDiff
 
 import mlrun
-from mlrun.config import config
 
 
 def _get_runtime():
@@ -48,7 +47,7 @@ def test_new_function_from_runtime():
     expected_runtime = runtime
     expected_runtime["spec"][
         "preemption_mode"
-    ] = config.function_defaults.preemption_mode
+    ] = mlrun.mlconf.function_defaults.preemption_mode
     assert (
         DeepDiff(
             function.to_dict(),
@@ -66,7 +65,7 @@ def test_new_function_args_without_command():
     expected_runtime = runtime
     expected_runtime["spec"][
         "preemption_mode"
-    ] = config.function_defaults.preemption_mode
+    ] = mlrun.mlconf.function_defaults.preemption_mode
     assert (
         DeepDiff(
             function.to_dict(),
@@ -121,7 +120,7 @@ def test_new_function_with_resources():
         expected_runtime["spec"]["resources"] = test_case.get("expected_resources")
         expected_runtime["spec"][
             "preemption_mode"
-        ] = config.function_defaults.preemption_mode
+        ] = mlrun.mlconf.function_defaults.preemption_mode
         runtime["spec"]["resources"] = test_case.get("resources", None)
         mlrun.mlconf.default_function_pod_resources = test_case.get("default_resources")
         function = mlrun.new_function(runtime=runtime)

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -46,7 +46,9 @@ def test_new_function_from_runtime():
     runtime = _get_runtime()
     function = mlrun.new_function(runtime=runtime)
     expected_runtime = runtime
-    expected_runtime["spec"]["preemption_mode"] = config.default_preemption_mode
+    expected_runtime["spec"][
+        "preemption_mode"
+    ] = config.function_defaults.preemption_mode
     assert (
         DeepDiff(
             function.to_dict(),
@@ -62,7 +64,9 @@ def test_new_function_args_without_command():
     runtime["spec"]["command"] = ""
     function = mlrun.new_function(runtime=runtime)
     expected_runtime = runtime
-    expected_runtime["spec"]["preemption_mode"] = config.default_preemption_mode
+    expected_runtime["spec"][
+        "preemption_mode"
+    ] = config.function_defaults.preemption_mode
     assert (
         DeepDiff(
             function.to_dict(),
@@ -115,7 +119,9 @@ def test_new_function_with_resources():
     ]:
         expected_runtime = copy.deepcopy(runtime)
         expected_runtime["spec"]["resources"] = test_case.get("expected_resources")
-        expected_runtime["spec"]["preemption_mode"] = config.default_preemption_mode
+        expected_runtime["spec"][
+            "preemption_mode"
+        ] = config.function_defaults.preemption_mode
         runtime["spec"]["resources"] = test_case.get("resources", None)
         mlrun.mlconf.default_function_pod_resources = test_case.get("default_resources")
         function = mlrun.new_function(runtime=runtime)

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -3,6 +3,7 @@ import copy
 from deepdiff import DeepDiff
 
 import mlrun
+from mlrun.config import config
 
 
 def _get_runtime():
@@ -44,11 +45,12 @@ def _get_runtime():
 def test_new_function_from_runtime():
     runtime = _get_runtime()
     function = mlrun.new_function(runtime=runtime)
-    expected_resources = runtime
+    expected_runtime = runtime
+    expected_runtime["spec"]["preemption_mode"] = config.default_preemption_mode
     assert (
         DeepDiff(
             function.to_dict(),
-            expected_resources,
+            expected_runtime,
             ignore_order=True,
         )
         == {}
@@ -59,10 +61,12 @@ def test_new_function_args_without_command():
     runtime = _get_runtime()
     runtime["spec"]["command"] = ""
     function = mlrun.new_function(runtime=runtime)
+    expected_runtime = runtime
+    expected_runtime["spec"]["preemption_mode"] = config.default_preemption_mode
     assert (
         DeepDiff(
             function.to_dict(),
-            runtime,
+            expected_runtime,
             ignore_order=True,
         )
         == {}
@@ -111,6 +115,7 @@ def test_new_function_with_resources():
     ]:
         expected_runtime = copy.deepcopy(runtime)
         expected_runtime["spec"]["resources"] = test_case.get("expected_resources")
+        expected_runtime["spec"]["preemption_mode"] = config.default_preemption_mode
         runtime["spec"]["resources"] = test_case.get("resources", None)
         mlrun.mlconf.default_function_pod_resources = test_case.get("default_resources")
         function = mlrun.new_function(runtime=runtime)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,63 +104,41 @@ def test_env_override(config):
     assert config.namespace == env_ns, "env did not override"
 
 
-def test_decode_base64_config_and_load_to_dict():
-    encoded_dict_attribute = "eyJlbmNvZGVkIjogImF0dHJpYnV0ZSJ9"
-    expected_decoded_dict_output = {"encoded": "attribute"}
+def test_decode_base64_config_and_load_to_object():
+    encoded_attribute = "eyJlbmNvZGVkIjogImF0dHJpYnV0ZSJ9"
+    expected_decoded_output = {"encoded": "attribute"}
 
-    encoded_list = "W3sidGVzdCI6IHsidGVzdF9kaWN0IjogMX19LCAxLCAyXQ=="
-    expected_decoded_list_output = [{"test": {"test_dict": 1}}, 1, 2]
-
-    # Non-hierarchical attribute loading with passing of expected type
-    mlconf.config.encoded_attribute = encoded_dict_attribute
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
-        "encoded_attribute", dict
+    # Non-hierarchical attribute loading
+    mlconf.config.encoded_attribute = encoded_attribute
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
+        "encoded_attribute"
     )
-    assert type(decoded_output) == dict
-    assert decoded_output == expected_decoded_dict_output
+    assert decoded_output == expected_decoded_output
 
-    # Hierarchical attribute loading without passing of expected type
-    mlconf.config.for_test = {"encoded_attribute": encoded_dict_attribute}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
+    # Hierarchical attribute loading
+    mlconf.config.for_test = {"encoded_attribute": encoded_attribute}
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
         "for_test.encoded_attribute"
     )
-    assert type(decoded_output) == dict
-    assert decoded_output == expected_decoded_dict_output
+    assert decoded_output == expected_decoded_output
 
-    # Not defined attribute without passing of expected type
+    # Not defined attribute
     mlconf.config.for_test = {"encoded_attribute": None}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
         "for_test.encoded_attribute"
     )
-    assert type(decoded_output) == dict
     assert decoded_output == {}
-
-    # Not defined attribute with passing of expected type
-    mlconf.config.for_test = {"encoded_attribute": None}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
-        "for_test.encoded_attribute", list
-    )
-    assert type(decoded_output) == list
-    assert decoded_output == []
 
     # Non existing attribute loading
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        mlconf.config.decode_base64_config_and_load_to_object("non_existing_attribute")
+        mlconf.config.decode_base64_config_and_load_to_dict("non_existing_attribute")
 
     # Attribute defined but not encoded
     mlconf.config.for_test = {"encoded_attribute": "notencoded"}
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentTypeError):
-        mlconf.config.decode_base64_config_and_load_to_object(
+        mlconf.config.decode_base64_config_and_load_to_dict(
             "for_test.encoded_attribute"
         )
-
-    # list attribute loading
-    mlconf.config.for_test = {"encoded_attribute": encoded_list}
-    decoded_list_output = mlconf.config.decode_base64_config_and_load_to_object(
-        "for_test.encoded_attribute", list
-    )
-    assert type(decoded_list_output) == list
-    assert decoded_list_output == expected_decoded_list_output
 
 
 def test_gpu_validation(config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,40 +105,62 @@ def test_env_override(config):
 
 
 def test_decode_base64_config_and_load_to_dict():
-    encoded_attribute = "eyJlbmNvZGVkIjogImF0dHJpYnV0ZSJ9"
-    expected_decoded_output = {"encoded": "attribute"}
+    encoded_dict_attribute = "eyJlbmNvZGVkIjogImF0dHJpYnV0ZSJ9"
+    expected_decoded_dict_output = {"encoded": "attribute"}
 
-    # Non-hierarchical attribute loading
-    mlconf.config.encoded_attribute = encoded_attribute
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
-        "encoded_attribute"
+    encoded_list = "W3sidGVzdCI6IHsidGVzdF9kaWN0IjogMX19LCAxLCAyXQ=="
+    expected_decoded_list_output = [{"test": {"test_dict": 1}}, 1, 2]
+
+    # Non-hierarchical attribute loading with passing of expected type
+    mlconf.config.encoded_attribute = encoded_dict_attribute
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
+        "encoded_attribute", dict
     )
-    assert decoded_output == expected_decoded_output
+    assert type(decoded_output) == dict
+    assert decoded_output == expected_decoded_dict_output
 
-    # Hierarchical attribute loading
-    mlconf.config.for_test = {"encoded_attribute": encoded_attribute}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
+    # Hierarchical attribute loading without passing of expected type
+    mlconf.config.for_test = {"encoded_attribute": encoded_dict_attribute}
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
         "for_test.encoded_attribute"
     )
-    assert decoded_output == expected_decoded_output
+    assert type(decoded_output) == dict
+    assert decoded_output == expected_decoded_dict_output
 
-    # Not defined attribute
+    # Not defined attribute without passing of expected type
     mlconf.config.for_test = {"encoded_attribute": None}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
         "for_test.encoded_attribute"
     )
+    assert type(decoded_output) == dict
     assert decoded_output == {}
+
+    # Not defined attribute with passing of expected type
+    mlconf.config.for_test = {"encoded_attribute": None}
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
+        "for_test.encoded_attribute", list
+    )
+    assert type(decoded_output) == list
+    assert decoded_output == []
 
     # Non existing attribute loading
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        mlconf.config.decode_base64_config_and_load_to_dict("non_existing_attribute")
+        mlconf.config.decode_base64_config_and_load_to_object("non_existing_attribute")
 
     # Attribute defined but not encoded
     mlconf.config.for_test = {"encoded_attribute": "notencoded"}
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentTypeError):
-        mlconf.config.decode_base64_config_and_load_to_dict(
+        mlconf.config.decode_base64_config_and_load_to_object(
             "for_test.encoded_attribute"
         )
+
+    # list attribute loading
+    mlconf.config.for_test = {"encoded_attribute": encoded_list}
+    decoded_list_output = mlconf.config.decode_base64_config_and_load_to_object(
+        "for_test.encoded_attribute", list
+    )
+    assert type(decoded_list_output) == list
+    assert decoded_list_output == expected_decoded_list_output
 
 
 def test_gpu_validation(config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,40 +105,62 @@ def test_env_override(config):
 
 
 def test_decode_base64_config_and_load_to_object():
-    encoded_attribute = "eyJlbmNvZGVkIjogImF0dHJpYnV0ZSJ9"
-    expected_decoded_output = {"encoded": "attribute"}
+    encoded_dict_attribute = "eyJlbmNvZGVkIjogImF0dHJpYnV0ZSJ9"
+    expected_decoded_dict_output = {"encoded": "attribute"}
 
-    # Non-hierarchical attribute loading
-    mlconf.config.encoded_attribute = encoded_attribute
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
-        "encoded_attribute"
+    encoded_list = "W3sidGVzdCI6IHsidGVzdF9kaWN0IjogMX19LCAxLCAyXQ=="
+    expected_decoded_list_output = [{"test": {"test_dict": 1}}, 1, 2]
+
+    # Non-hierarchical attribute loading with passing of expected type
+    mlconf.config.encoded_attribute = encoded_dict_attribute
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
+        "encoded_attribute", dict
     )
-    assert decoded_output == expected_decoded_output
+    assert type(decoded_output) == dict
+    assert decoded_output == expected_decoded_dict_output
 
-    # Hierarchical attribute loading
-    mlconf.config.for_test = {"encoded_attribute": encoded_attribute}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
+    # Hierarchical attribute loading without passing of expected type
+    mlconf.config.for_test = {"encoded_attribute": encoded_dict_attribute}
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
         "for_test.encoded_attribute"
     )
-    assert decoded_output == expected_decoded_output
+    assert type(decoded_output) == dict
+    assert decoded_output == expected_decoded_dict_output
 
-    # Not defined attribute
+    # Not defined attribute without passing of expected type
     mlconf.config.for_test = {"encoded_attribute": None}
-    decoded_output = mlconf.config.decode_base64_config_and_load_to_dict(
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
         "for_test.encoded_attribute"
     )
+    assert type(decoded_output) == dict
     assert decoded_output == {}
+
+    # Not defined attribute with passing of expected type
+    mlconf.config.for_test = {"encoded_attribute": None}
+    decoded_output = mlconf.config.decode_base64_config_and_load_to_object(
+        "for_test.encoded_attribute", list
+    )
+    assert type(decoded_output) == list
+    assert decoded_output == []
 
     # Non existing attribute loading
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        mlconf.config.decode_base64_config_and_load_to_dict("non_existing_attribute")
+        mlconf.config.decode_base64_config_and_load_to_object("non_existing_attribute")
 
     # Attribute defined but not encoded
     mlconf.config.for_test = {"encoded_attribute": "notencoded"}
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentTypeError):
-        mlconf.config.decode_base64_config_and_load_to_dict(
+        mlconf.config.decode_base64_config_and_load_to_object(
             "for_test.encoded_attribute"
         )
+
+    # list attribute loading
+    mlconf.config.for_test = {"encoded_attribute": encoded_list}
+    decoded_list_output = mlconf.config.decode_base64_config_and_load_to_object(
+        "for_test.encoded_attribute", list
+    )
+    assert type(decoded_list_output) == list
+    assert decoded_list_output == expected_decoded_list_output
 
 
 def test_gpu_validation(config):


### PR DESCRIPTION
Introducing new SDK API : `function.with_preemptible_mode(mode=(allow|constrain|prevent))`
With the new feature, users can specify how their function should run if and when preemptible nodes are present in the cluster.

Preemptible/Spot instances doesn't guarantee stability but they are mostly available at up to a 90% discount compared to On-Demand prices. You can use Spot Instances for various stateless, fault-tolerant or flexible applications such as big data, containerized workloads, CI/CD and etc.

We support 3 preemptible modes:

- **allow** : allows function pods to run on preemptible nodes (e.g., could be used for training jobs that uses checkpoints and are fault tolerant in case node fails).
- **constrain** : allow functions to run only on preemptible nodes (e.g., could be used for opportunist jobs that aren't really required, but if spot nodes (which are much cheaper) are available, schedule those jobs on them).
- **prevent** : prevents functions from being scheduled on preemptible nodes (e.g, would be set for mission critical functions that must retain active all time).

When preemptible mode is not set, the default mode is **prevent**.