### PR TITLE
[Builder] Fix resources assignment to Kaniko pods

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -113,7 +113,6 @@ def make_kaniko_pod(
             "requests", with_gpu=False
         )
     }
-    logger.info("resources", resources=resources)
     kpod = BasePod(
         name or "mlrun-build",
         config.httpdb.builder.kaniko_image,

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -107,9 +107,13 @@ def make_kaniko_pod(
     # While requests mainly affect scheduling, setting a limit may prevent Kaniko
     # from finishing successfully (destructive), since we're not allowing to override the default
     # specifically for the Kaniko pod, we're setting only the requests
+    # we cannot specify gpu requests without specifying gpu limits, so we set requests without gpu field
     resources = {
-        "requests": config.get_default_function_pod_requirement_resources("requests")
+        "requests": config.get_default_function_pod_requirement_resources(
+            "requests", with_gpu=False
+        )
     }
+    logger.info("resources", resources=resources)
     kpod = BasePod(
         name or "mlrun-build",
         config.httpdb.builder.kaniko_image,

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -108,9 +108,12 @@ def make_kaniko_pod(
     # from finishing successfully (destructive), since we're not allowing to override the default
     # specifically for the Kaniko pod, we're setting only the requests
     # we cannot specify gpu requests without specifying gpu limits, so we set requests without gpu field
+    default_requests = config.get_default_function_pod_requirement_resources(
+        "requests", with_gpu=False
+    )
     resources = {
-        "requests": config.get_default_function_pod_requirement_resources(
-            "requests", with_gpu=False
+        "requests": mlrun.runtimes.utils.generate_resources(
+            mem=default_requests.get("memory"), cpu=default_requests.get("cpu")
         )
     }
     kpod = BasePod(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -327,7 +327,7 @@ default_config = {
         "auto_mount_params": "",
     },
     "default_function_pod_resources": {
-        "requests": {"cpu": "25m", "memory": "1Mi", "gpu": None},
+        "requests": {"cpu": None, "memory": None, "gpu": None},
         "limits": {"cpu": None, "memory": None, "gpu": None},
     },
     # preemptible node selector and tolerations to be added when running on spot nodes

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -558,8 +558,8 @@ class Config:
         gpu_type = "nvidia.com/gpu"
         gpu = "gpu"
         resource_requirement = resources.get(requirement, {})
+        resource_requirement.setdefault(gpu)
         if with_gpu:
-            resource_requirement.setdefault(gpu)
             resource_requirement[gpu_type] = resource_requirement.pop(gpu)
         else:
             resource_requirement.pop(gpu)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -328,8 +328,54 @@ def test_function_build_with_default_requests(monkeypatch):
         mlrun.api.schemas.AuthInfo(),
         function,
     )
-    expected_resources = {"requests": {"cpu": None, "memory": None}}
+    expected_resources = {"requests": {}}
     # assert that both limits requirements and gpu requests are not defined
+    assert (
+        deepdiff.DeepDiff(
+            _create_pod_mock_pod_spec().containers[0].resources,
+            expected_resources,
+            ignore_order=True,
+        )
+        == {}
+    )
+    mlrun.mlconf.default_function_pod_resources.requests = {
+        "cpu": "25m",
+        "memory": "1m",
+        "gpu": None,
+    }
+    expected_resources = {"requests": {"cpu": "25m", "memory": "1m"}}
+
+    mlrun.builder.build_runtime(
+        mlrun.api.schemas.AuthInfo(),
+        function,
+    )
+    assert (
+        deepdiff.DeepDiff(
+            _create_pod_mock_pod_spec().containers[0].resources,
+            expected_resources,
+            ignore_order=True,
+        )
+        == {}
+    )
+
+    mlrun.mlconf.default_function_pod_resources = {
+        "requests": {
+            "cpu": "25m",
+            "memory": "1m",
+            "gpu": 2,
+        },
+        "limits": {
+            "cpu": "1",
+            "memory": "1G",
+            "gpu": 2,
+        },
+    }
+    expected_resources = {"requests": {"cpu": "25m", "memory": "1m"}}
+
+    mlrun.builder.build_runtime(
+        mlrun.api.schemas.AuthInfo(),
+        function,
+    )
     assert (
         deepdiff.DeepDiff(
             _create_pod_mock_pod_spec().containers[0].resources,

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -307,6 +307,39 @@ def test_function_build_with_attributes_from_spec(monkeypatch):
     )
 
 
+def test_function_build_with_default_requests(monkeypatch):
+    get_k8s_helper_mock = unittest.mock.Mock()
+    monkeypatch.setattr(
+        mlrun.builder, "get_k8s_helper", lambda *args, **kwargs: get_k8s_helper_mock
+    )
+    mlrun.builder.get_k8s_helper().create_pod = unittest.mock.Mock(
+        side_effect=lambda pod: (pod, "some-namespace")
+    )
+    mlrun.mlconf.httpdb.builder.docker_registry = "registry.hub.docker.com/username"
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind="job",
+        requirements=["some-package"],
+    )
+    mlrun.builder.build_runtime(
+        mlrun.api.schemas.AuthInfo(),
+        function,
+    )
+    expected_resources = {"requests": {"cpu": None, "memory": None}}
+    # assert that both limits requirements and gpu requests are not defined
+    assert (
+        deepdiff.DeepDiff(
+            _create_pod_mock_pod_spec().containers[0].resources,
+            expected_resources,
+            ignore_order=True,
+        )
+        == {}
+    )
+
+
 def test_resolve_mlrun_install_command():
     pip_command = "python -m pip install"
     cases = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -173,6 +173,61 @@ def test_decode_base64_config_and_load_to_object():
     assert decoded_list_output == expected_decoded_list_output
 
 
+def test_get_default_function_pod_requirement_resources(config):
+    requests_gpu = "2"
+    limits_gpu = "2"
+    env = {
+        default_function_pod_resources_request_gpu_env_key: requests_gpu,
+        default_function_pod_resources_limits_gpu_env_key: limits_gpu,
+    }
+    expected_resources_without_gpu = {
+        "requests": {"cpu": None, "memory": None},
+        "limits": {"cpu": None, "memory": None},
+    }
+    expected_resources_with_gpu = {
+        "requests": {"cpu": None, "memory": None, "nvidia.com/gpu": requests_gpu},
+        "limits": {"cpu": None, "memory": None, "nvidia.com/gpu": limits_gpu},
+    }
+    with patch_env(env):
+        mlconf.config.reload()
+        requests = config.get_default_function_pod_requirement_resources("requests", with_gpu=True)
+        assert (
+            deepdiff.DeepDiff(
+                requests,
+                expected_resources_with_gpu["requests"],
+                ignore_order=True,
+            )
+            == {}
+        )
+        limits = config.get_default_function_pod_requirement_resources("limits", with_gpu=True)
+        assert (
+            deepdiff.DeepDiff(
+                limits,
+                expected_resources_with_gpu["limits"],
+                ignore_order=True,
+            )
+            == {}
+        )
+        requests = config.get_default_function_pod_requirement_resources("requests", with_gpu=False)
+        assert (
+            deepdiff.DeepDiff(
+                requests,
+                expected_resources_without_gpu["requests"],
+                ignore_order=True,
+            )
+            == {}
+        )
+        limits = config.get_default_function_pod_requirement_resources("limits", with_gpu=False)
+        assert (
+            deepdiff.DeepDiff(
+                limits,
+                expected_resources_without_gpu["limits"],
+                ignore_order=True,
+            )
+            == {}
+        )
+
+
 def test_get_default_function_pod_resources(config):
     requests_gpu = "2"
     limits_gpu = "2"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,7 +190,9 @@ def test_get_default_function_pod_requirement_resources(config):
     }
     with patch_env(env):
         mlconf.config.reload()
-        requests = config.get_default_function_pod_requirement_resources("requests", with_gpu=True)
+        requests = config.get_default_function_pod_requirement_resources(
+            "requests", with_gpu=True
+        )
         assert (
             deepdiff.DeepDiff(
                 requests,
@@ -199,7 +201,9 @@ def test_get_default_function_pod_requirement_resources(config):
             )
             == {}
         )
-        limits = config.get_default_function_pod_requirement_resources("limits", with_gpu=True)
+        limits = config.get_default_function_pod_requirement_resources(
+            "limits", with_gpu=True
+        )
         assert (
             deepdiff.DeepDiff(
                 limits,
@@ -208,7 +212,9 @@ def test_get_default_function_pod_requirement_resources(config):
             )
             == {}
         )
-        requests = config.get_default_function_pod_requirement_resources("requests", with_gpu=False)
+        requests = config.get_default_function_pod_requirement_resources(
+            "requests", with_gpu=False
+        )
         assert (
             deepdiff.DeepDiff(
                 requests,
@@ -217,7 +223,9 @@ def test_get_default_function_pod_requirement_resources(config):
             )
             == {}
         )
-        limits = config.get_default_function_pod_requirement_resources("limits", with_gpu=False)
+        limits = config.get_default_function_pod_requirement_resources(
+            "limits", with_gpu=False
+        )
         assert (
             deepdiff.DeepDiff(
                 limits,


### PR DESCRIPTION
When assigning default resource requests to Kaniko pods, pods could not be scheduled as a result of mentioning `nvidia.com/gpu` in the requests body despite the fact that it contained no value. This was due to the k8s scheduler's requirement that no GPU requests be specified unless GPU limits were defined. More details can be found at https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/.