### PR TITLE
[Requirements] Limit click versions to 8.0.x

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,4 +1,4 @@
-click~=8.0
+click<=8.0.2
 paramiko~=2.7
 semver~=2.13
 requests~=2.22

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,4 +1,4 @@
-click<=8.0.2
+click~=8.0.0
 paramiko~=2.7
 semver~=2.13
 requests~=2.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ urllib3>=1.25.4, <1.27
 chardet>=3.0.2, <4.0
 GitPython~=3.0
 aiohttp~=3.8
-click<=8.0.2
+click~=8.0.0
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
 kfp~=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ urllib3>=1.25.4, <1.27
 chardet>=3.0.2, <4.0
 GitPython~=3.0
 aiohttp~=3.8
-click~=8.0
+click<=8.0.2
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
 kfp~=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ urllib3>=1.25.4, <1.27
 chardet>=3.0.2, <4.0
 GitPython~=3.0
 aiohttp~=3.8
+# 8.1.0+ breaks dask/distributed versions older than 2022.04.0, see here - https://github.com/dask/distributed/pull/6018
 click~=8.0.0
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -99,6 +99,7 @@ def test_requirement_specifiers_convention():
         "gcsfs": {"~=2021.8.1"},
         "distributed": {"~=2021.11.2"},
         "dask": {"~=2021.11.2"},
+        "click": {"~=8.0.0"},
         # All of these are actually valid, they just don't use ~= so the test doesn't "understand" that
         # TODO: make test smart enough to understand that
         "urllib3": {">=1.25.4, <1.27"},


### PR DESCRIPTION
Version 8.1.0 of click removed a function that dask used.
For now we will pin the click version.
You can find more information here : https://github.com/dask/distributed/pull/6018