### PR TITLE
[System Tests] Change Spark tests to use a single window

### DIFF
--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -46,11 +46,8 @@ def get_df_preview_spark(df, preview_lines=20):
     """capture preview data from spark df"""
     df = df.limit(preview_lines)
 
-    values = [df.select(funcs.collect_list(val)).first()[0] for val in df.columns]
-    preview = [df.columns]
-    for row in list(zip(*values)):
-        preview.append(list(row))
-    return preview
+    result_dict = df.toPandas().to_dict(orient="split")
+    return [result_dict["columns"], *result_dict["data"]]
 
 
 def _create_hist_data(df, column, minim, maxim, bins=10):

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -104,7 +104,9 @@ def get_dtype(df, colname):
 # how many histograms will be calculated in a single query. By default we're using 20 bins per histogram, so
 # using 500 will calculate histograms over 25 columns in a single query. If there are more, more queries will
 # be executed.
-MAX_HISTOGRAM_COLUMNS_IN_QUERY = int(environ.get("MLRUN_MAX_HISTOGRAM_COLUMNS_IN_QUERY", 500))
+MAX_HISTOGRAM_COLUMNS_IN_QUERY = int(
+    environ.get("MLRUN_MAX_HISTOGRAM_COLUMNS_IN_QUERY", 500)
+)
 
 
 def get_df_stats_spark(df, options, num_bins=20, sample_size=None):

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -56,6 +56,9 @@ def _create_hist_data(df, calculation_cols, results_dict, bins=20):
     bins_values = {}
 
     for orig_col in calculation_cols:
+        print(
+            f"{orig_col}: {results_dict[orig_col]['min']} ==> {results_dict[orig_col]['max']}"
+        )
         bins_start = np.linspace(
             results_dict[orig_col]["min"],
             results_dict[orig_col]["max"],

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -100,9 +100,9 @@ def get_dtype(df, colname):
 # Histogram calculation in Spark relies on adding a column to the DF per histogram bin. Spark supports many
 # columns, but not infinitely (and there's no hard-limit on number of columns). This value will determine
 # how many histograms will be calculated in a single query. By default we're using 20 bins per histogram, so
-# using 1000 will calculate histograms over 50 columns in a single query. If there are more, more queries will
+# using 500 will calculate histograms over 25 columns in a single query. If there are more, more queries will
 # be executed.
-MAX_HISTOGRAM_COLUMNS_IN_QUERY = 1000
+MAX_HISTOGRAM_COLUMNS_IN_QUERY = 500
 
 
 def get_df_stats_spark(df, options, num_bins=20, sample_size=None):

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -1,3 +1,5 @@
+from os import environ
+
 import numpy as np
 
 from .data_types import InferOptions, spark_to_value_type
@@ -102,7 +104,7 @@ def get_dtype(df, colname):
 # how many histograms will be calculated in a single query. By default we're using 20 bins per histogram, so
 # using 500 will calculate histograms over 25 columns in a single query. If there are more, more queries will
 # be executed.
-MAX_HISTOGRAM_COLUMNS_IN_QUERY = 500
+MAX_HISTOGRAM_COLUMNS_IN_QUERY = int(environ.get("MAX_HISTOGRAM_COLUMNS_IN_QUERY", 500))
 
 
 def get_df_stats_spark(df, options, num_bins=20, sample_size=None):
@@ -136,8 +138,8 @@ def get_df_stats_spark(df, options, num_bins=20, sample_size=None):
         ) and get_dtype(df, col) in ["double", "int"]:
             hist_columns.append(col)
 
-    # We may need multiple queries here. See above comment for reasoning.
-    max_columns_per_query = int(MAX_HISTOGRAM_COLUMNS_IN_QUERY // num_bins)
+    # We may need multiple queries here. See comment before this function for reasoning.
+    max_columns_per_query = int(MAX_HISTOGRAM_COLUMNS_IN_QUERY // num_bins) or 1
     while len(hist_columns) > 0:
         calculation_cols = hist_columns[:max_columns_per_query]
         _create_hist_data(df, calculation_cols, results_dict, num_bins)

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -50,74 +50,59 @@ def get_df_preview_spark(df, preview_lines=20):
     return [result_dict["columns"], *result_dict["data"]]
 
 
-def _create_hist_data(df, column, minim, maxim, bins=10):
-    def create_all_conditions(current_col, column, left_edges, count=1):
-        """
-        Recursive function that exploits the
-        ability to call the Spark SQL Column method
-        .when() in a recursive way.
-        """
-        left_edges = left_edges[:]
-        if len(left_edges) == 0:
-            return current_col
-        if len(left_edges) == 1:
-            next_col = current_col.when(
-                funcs.col(column) >= float(left_edges[0]), count
-            )
-            left_edges.pop(0)
-            return create_all_conditions(next_col, column, left_edges[:], count + 1)
-        next_col = current_col.when(
-            (float(left_edges[0]) <= funcs.col(column))
-            & (funcs.col(column) < float(left_edges[1])),
-            count,
-        )
-        left_edges.pop(0)
-        return create_all_conditions(next_col, column, left_edges[:], count + 1)
+def _create_hist_data(df, calculation_cols, results_dict, bins=20):
+    hist_df = df
+    col_names = []
+    bins_values = {}
 
-    num_range = maxim - minim
-    bin_width = num_range / float(bins)
-    left_edges = [minim]
+    for orig_col in calculation_cols:
+        bins_start = np.linspace(
+            results_dict[orig_col]["min"],
+            results_dict[orig_col]["max"],
+            bins,
+            endpoint=False,
+        ).tolist()
+        bins_values[orig_col] = bins_start
 
-    for _bin in range(bins):
-        left_edges = left_edges + [left_edges[-1] + bin_width]
-    left_edges.pop()
-    expression_col = funcs.when(
-        (float(left_edges[0]) <= funcs.col(column))
-        & (funcs.col(column) < float(left_edges[1])),
-        0,
-    )
-    left_edges_copy = left_edges[:]
-    left_edges_copy.pop(0)
-    bin_data = (
-        df.select(funcs.col(column))
-        .na.drop()
-        .select(
-            funcs.col(column),
-            create_all_conditions(expression_col, column, left_edges_copy).alias(
-                "bin_id"
-            ),
-        )
-        .groupBy("bin_id")
-        .count()
-    ).toPandas()
+        for i in range(bins):
+            col_name = f"{orig_col}_hist_bin_{i}"
+            if i < (bins - 1):
+                hist_df = hist_df.withColumn(
+                    col_name,
+                    funcs.when(
+                        (funcs.col(orig_col) >= bins_start[i])
+                        & (funcs.col(orig_col) < bins_start[i + 1]),
+                        1,
+                    ).otherwise(0),
+                )
+            else:
+                hist_df = hist_df.withColumn(
+                    col_name,
+                    funcs.when(funcs.col(orig_col) >= bins_start[i], 1).otherwise(0),
+                )
+            col_names.append(col_name)
 
-    bin_data.index = bin_data["bin_id"]
-    new_index = list(range(bins))
-    bin_data = bin_data.reindex(new_index)
-    bin_data["bin_id"] = bin_data.index
-    bin_data = bin_data.fillna(0)
-    bin_data["left_edge"] = left_edges
-    bin_data["width"] = bin_width
-    bin_data = [
-        bin_data["count"].tolist(),
-        [round(x, 2) for x in bin_data["left_edge"].tolist()],
-    ]
+    agg_funcs = [funcs.sum(hist_df[col]).alias(col) for col in col_names]
+    hist_values = hist_df.groupBy().agg(*agg_funcs).toPandas()
 
-    return bin_data
+    for orig_col in calculation_cols:
+        bin_data = [
+            [hist_values.loc[0][f"{orig_col}_hist_bin_{i}"] for i in range(bins)],
+            [round(x, 2) for x in bins_values[orig_col]],
+        ]
+        results_dict[orig_col]["hist"] = bin_data
 
 
 def get_dtype(df, colname):
     return [dtype for name, dtype in df.dtypes if name == colname][0]
+
+
+# Histogram calculation in Spark relies on adding a column to the DF per histogram bin. Spark supports many
+# columns, but not infinitely (and there's no hard-limit on number of columns). This value will determine
+# how many histograms will be calculated in a single query. By default we're using 20 bins per histogram, so
+# using 1000 will calculate histograms over 50 columns in a single query. If there are more, more queries will
+# be executed.
+MAX_HISTOGRAM_COLUMNS_IN_QUERY = 1000
 
 
 def get_df_stats_spark(df, options, num_bins=20, sample_size=None):
@@ -129,6 +114,7 @@ def get_df_stats_spark(df, options, num_bins=20, sample_size=None):
     summary_df = df.summary().toPandas()
     summary_df.set_index(["summary"], drop=True, inplace=True)
     results_dict = {}
+    hist_columns = []
     for col, values in summary_df.items():
         stats_dict = {}
         for stat, val in values.dropna().items():
@@ -148,16 +134,14 @@ def get_df_stats_spark(df, options, num_bins=20, sample_size=None):
         if InferOptions.get_common_options(
             options, InferOptions.Histogram
         ) and get_dtype(df, col) in ["double", "int"]:
-            try:
-                results_dict[col]["hist"] = _create_hist_data(
-                    df,
-                    col,
-                    float(results_dict[col]["min"]),
-                    float(results_dict[col]["max"]),
-                    bins=num_bins,
-                )
-            except Exception:
-                pass
+            hist_columns.append(col)
+
+    # We may need multiple queries here. See above comment for reasoning.
+    max_columns_per_query = int(MAX_HISTOGRAM_COLUMNS_IN_QUERY // num_bins)
+    while len(hist_columns) > 0:
+        calculation_cols = hist_columns[:max_columns_per_query]
+        _create_hist_data(df, calculation_cols, results_dict, num_bins)
+        hist_columns = hist_columns[max_columns_per_query:]
 
     return results_dict
 

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -56,12 +56,9 @@ def _create_hist_data(df, calculation_cols, results_dict, bins=20):
     bins_values = {}
 
     for orig_col in calculation_cols:
-        print(
-            f"{orig_col}: {results_dict[orig_col]['min']} ==> {results_dict[orig_col]['max']}"
-        )
         bins_start = np.linspace(
-            results_dict[orig_col]["min"],
-            results_dict[orig_col]["max"],
+            float(results_dict[orig_col]["min"]),
+            float(results_dict[orig_col]["max"]),
             bins,
             endpoint=False,
         ).tolist()

--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -104,7 +104,7 @@ def get_dtype(df, colname):
 # how many histograms will be calculated in a single query. By default we're using 20 bins per histogram, so
 # using 500 will calculate histograms over 25 columns in a single query. If there are more, more queries will
 # be executed.
-MAX_HISTOGRAM_COLUMNS_IN_QUERY = int(environ.get("MAX_HISTOGRAM_COLUMNS_IN_QUERY", 500))
+MAX_HISTOGRAM_COLUMNS_IN_QUERY = int(environ.get("MLRUN_MAX_HISTOGRAM_COLUMNS_IN_QUERY", 500))
 
 
 def get_df_stats_spark(df, options, num_bins=20, sample_size=None):

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -350,7 +350,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         data_set.add_aggregation(
             column="bid",
             operations=["sum", "max", "count"],
-            windows=["1h", "2h"],
+            windows=["2h"],
             period="10m",
             emit_policy=EmitEveryEvent(),
         )
@@ -368,9 +368,6 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         expected_results = df.to_dict(orient="list")
         expected_results.update(
             {
-                "bid_sum_1h": [2000, 10, 12, 26, 24],
-                "bid_max_1h": [2000, 10, 12, 16, 16],
-                "bid_count_1h": [1, 1, 1, 2, 2],
                 "bid_sum_2h": [2000, 10, 2012, 26, 34],
                 "bid_max_2h": [2000, 10, 2000, 16, 16],
                 "bid_count_2h": [1, 1, 2, 2, 3],
@@ -389,7 +386,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         storey_data_set.add_aggregation(
             column="bid",
             operations=["sum", "max", "count"],
-            windows=["1h", "2h"],
+            windows=["2h"],
             period="10m",
         )
         fs.ingest(storey_data_set, source)


### PR DESCRIPTION
When running Spark aggregations with multiple windows on Spark version < 3.1, the code fails. This is since the code uses `unionByName` with the `allowMissingColumns=True` parameter which was added in Spark 3.1. This PR changes the test to use a single window, which doesn't call `unionByName`, since some system-tests were running on old systems with old Spark version, and the tests failed.