### PR TITLE
[System Tests] Increase enterprise tests timeout to 180 minutes

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   run-system-tests-enterprise-ci:
-    timeout-minutes: 120
+    timeout-minutes: 180
     name: Run System Tests Enterprise
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
It seems like our tests became longer than 120 minutes which is our current timeout