### PR TITLE
[System Tests] Fix `test_ingest_and_query`

### DIFF
--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -39,7 +39,7 @@ from mlrun.feature_store import Entity, FeatureSet
 from mlrun.feature_store.feature_set import aggregates_step
 from mlrun.feature_store.feature_vector import FixedWindowType
 from mlrun.feature_store.steps import FeaturesetValidator
-from mlrun.features import MinMaxLenValidator, MinMaxValidator
+from mlrun.features import MinMaxValidator
 from tests.system.base import TestMLRunSystem
 
 from .data_sample import quotes, stocks, trades
@@ -152,9 +152,6 @@ class TestFeatureStore(TestMLRunSystem):
         self._logger.info(f"quotes spec: {quotes_set.spec.to_yaml()}")
         assert df["zz"].mean() == 9, "map didnt set the zz column properly"
         quotes_set["bid"].validator = MinMaxValidator(min=52, severity="info")
-        quotes_set["ticker"].validator = MinMaxLenValidator(
-            min=1, max=10, severity="info"
-        )
 
         quotes_set.plot(
             str(self.results_path / "pipe.png"), rankdir="LR", with_targets=True


### PR DESCRIPTION
The test currently fails with
```
KeyError: 'ticker'
```
because an entity is not a feature.