### PR TITLE
[Feature Store] Fix run id for get offline features with target

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -154,6 +154,11 @@ def get_offline_features(
     entity_timestamp_column = (
         entity_timestamp_column or feature_vector.spec.timestamp_field
     )
+
+    if target:
+        if not target.run_id:
+            target.run_id = "offline-features"
+
     if run_config:
         return run_merge_job(
             feature_vector,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -336,6 +336,36 @@ class TestFeatureStore(TestMLRunSystem):
         assert df_with_index.index.name == "ticker"
         assert "time" in df_with_index.columns, "'time' column should be present"
 
+    @pytest.mark.parametrize("target_path", [
+        None,   # default
+        f"v3io:///bigdata/{project_name}/gof_wt.parquet",   # single file
+        f"v3io:///bigdata/{project_name}/" + "{run_id}/gof_wt.parquet",  # single file with run_id
+        f"v3io:///bigdata/{project_name}/gof_wt/",  # directory
+        f"v3io:///bigdata/{project_name}/gof_wt/" + "{run_id}",  # directory with run_id
+        f"v3io:///bigdata/{project_name}/gof_wt/" + "{run_id}/gof_wt",  # directory with run_id in middle of path
+    ])
+    def test_different_target_paths_for_get_offline_features(self, target_path):
+        stocks = pd.DataFrame(
+            {
+                "ticker": ["MSFT", "GOOG", "AAPL"],
+                "name": ["Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
+                "booly": [True, False, True],
+            }
+        )
+        stocks_set = fs.FeatureSet(
+            "stocks_test", entities=[Entity("ticker", ValueType.STRING)]
+        )
+        fs.ingest(stocks_set, stocks)
+
+        vector = fs.FeatureVector("SjqevLXR", ["stocks_test.*"])
+        target = ParquetTarget(name="parquet", path=target_path)
+        fs.get_offline_features(vector, target=target)
+        df = pd.read_parquet(target.get_target_path())
+        print("BBBBBBBB " + target.get_target_path())
+        print("BFBFBFBF " + df.to_string())
+        assert df is not None
+        assert target.run_id == "offline-features"
+
     def test_feature_set_db(self):
         name = "stocks_test"
         stocks_set = fs.FeatureSet(name, entities=["ticker"])

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -336,14 +336,17 @@ class TestFeatureStore(TestMLRunSystem):
         assert df_with_index.index.name == "ticker"
         assert "time" in df_with_index.columns, "'time' column should be present"
 
-    @pytest.mark.parametrize("target_path", [
-        None,   # default
-        f"v3io:///bigdata/{project_name}/gof_wt.parquet",   # single file
-        f"v3io:///bigdata/{project_name}/" + "{run_id}/gof_wt.parquet",  # single file with run_id
-        f"v3io:///bigdata/{project_name}/gof_wt/",  # directory
-        f"v3io:///bigdata/{project_name}/gof_wt/" + "{run_id}",  # directory with run_id
-        f"v3io:///bigdata/{project_name}/gof_wt/" + "{run_id}/gof_wt",  # directory with run_id in middle of path
-    ])
+    @pytest.mark.parametrize(
+        "target_path",
+        [
+            None,  # default
+            f"v3io:///bigdata/{project_name}/gof_wt.parquet",  # single file
+            f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",  # single file with run_id
+            f"v3io:///bigdata/{project_name}/gof_wt/",  # directory
+            f"v3io:///bigdata/{project_name}/gof_wt/{{run_id}}",  # directory with run_id
+            f"v3io:///bigdata/{project_name}/gof_wt/{{run_id}}/gof_wt",  # directory with run_id in middle of path
+        ],
+    )
     def test_different_target_paths_for_get_offline_features(self, target_path):
         stocks = pd.DataFrame(
             {
@@ -359,7 +362,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         vector = fs.FeatureVector("SjqevLXR", ["stocks_test.*"])
         target = ParquetTarget(name="parquet", path=target_path)
-        fs.get_offline_features(vector, target=target)
+        fs.get_offline_features(vector, with_indexes=True, target=target)
         df = pd.read_parquet(target.get_target_path())
         assert df is not None
         assert target.run_id == "offline-features"

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -361,8 +361,6 @@ class TestFeatureStore(TestMLRunSystem):
         target = ParquetTarget(name="parquet", path=target_path)
         fs.get_offline_features(vector, target=target)
         df = pd.read_parquet(target.get_target_path())
-        print("BBBBBBBB " + target.get_target_path())
-        print("BFBFBFBF " + df.to_string())
         assert df is not None
         assert target.run_id == "offline-features"
 


### PR DESCRIPTION
Fixed issue when calling get_offline_features with target to save results. 
Created a default run_id for that case - "offline-features"
[ML-1980](https://jira.iguazeng.com/browse/ML-1980)