### PR TITLE
[Nuclio] Revert default nuclio runtime to python 3.6

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -51,7 +51,7 @@ default_config = {
     # url to nuclio dashboard api (can be with user & token, e.g. https://username:password@dashboard-url.com)
     "nuclio_dashboard_url": "",
     "nuclio_version": "",
-    "default_nuclio_runtime": "python:3.7",
+    "default_nuclio_runtime": "python:3.6",
     "nest_asyncio_enabled": "",  # enable import of nest_asyncio for corner cases with old jupyter, set "1"
     "ui_url": "",  # remote/external mlrun UI url (for hyperlinks) (This is deprecated in favor of the ui block)
     "remote_host": "",


### PR DESCRIPTION
Until https://github.com/mlrun/mlrun/pull/1831 the default from config wasn't really used
We want to use 3.7 as our default but that require changes, reverting to 3.6 for now