### PR TITLE
[DB] Set the default pool size and max overflow to be equal to the API max workers

### DIFF
--- a/mlrun/api/db/sqldb/session.py
+++ b/mlrun/api/db/sqldb/session.py
@@ -37,9 +37,15 @@ def _init_engine(dsn=None):
     dsn = dsn or config.httpdb.dsn
     kwargs = {}
     if "mysql" in dsn:
+        pool_size = config.httpdb.db.connections_pool_size
+        if pool_size is None:
+            pool_size = config.httpdb.max_workers
+        max_overflow = config.httpdb.db.connections_pool_max_overflow
+        if max_overflow is None:
+            max_overflow = config.httpdb.max_workers
         kwargs = {
-            "pool_size": config.httpdb.db.connections_pool_size,
-            "max_overflow": config.httpdb.db.connections_pool_max_overflow,
+            "pool_size": pool_size,
+            "max_overflow": max_overflow,
         }
     engine = create_engine(dsn, **kwargs)
     _init_session_maker()

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -160,8 +160,9 @@ default_config = {
                 "use_rotation": True,
                 "rotation_limit": 3,
             },
-            "connections_pool_size": 20,
-            "connections_pool_max_overflow": 50,
+            # None will set this to be equal to the httpdb.max_workers
+            "connections_pool_size": None,
+            "connections_pool_max_overflow": None,
         },
         "jobs": {
             # whether to allow to run local runtimes in the API - configurable to allow the scheduler testing to work


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-1860