### PR TITLE
[API] Fix dask list runtime resources with cluster without Kubernetes service

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -698,7 +698,8 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
             return response
         service_resources = []
         for runtime_resources in runtime_resources_list:
-            service_resources += runtime_resources.service_resources
+            if runtime_resources.service_resources:
+                service_resources += runtime_resources.service_resources
         return self._enrich_service_resources_in_response(
             response, service_resources, group_by
         )

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -254,9 +254,10 @@ class TestRuntimeHandlerBase:
                 "pod", pod_dict, resources, "pod_resources", group_by_field_extractor
             )
         for index, service in enumerate(expected_services):
+            service_dict = service.to_dict()
             self._assert_resource_in_response_resources(
                 "service",
-                service,
+                service_dict,
                 resources,
                 "service_resources",
                 group_by_field_extractor,

--- a/tests/api/runtime_handlers/test_daskjob.py
+++ b/tests/api/runtime_handlers/test_daskjob.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from kubernetes import client
 from sqlalchemy.orm import Session
 
+import mlrun.api.schemas
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.runtimes import RuntimeKinds, get_runtime_handler
 from mlrun.runtimes.constants import PodPhases
@@ -20,7 +21,7 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
             "dask.org/component": "scheduler",
             "mlrun/class": "dask",
             "mlrun/function": "mydask",
-            "mlrun/project": "default",
+            "mlrun/project": self.project,
             "mlrun/scrape_metrics": "False",
             "mlrun/tag": "latest",
             "user": "root",
@@ -44,7 +45,7 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
             "dask.org/component": "worker",
             "mlrun/class": "dask",
             "mlrun/function": "mydask",
-            "mlrun/project": "default",
+            "mlrun/project": self.project,
             "mlrun/scrape_metrics": "False",
             "mlrun/tag": "latest",
             "user": "root",
@@ -69,7 +70,7 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
             "dask.org/component": "scheduler",
             "mlrun/class": "dask",
             "mlrun/function": "mydask",
-            "mlrun/project": "default",
+            "mlrun/project": self.project,
             "mlrun/scrape_metrics": "False",
             "mlrun/tag": "latest",
             "user": "root",
@@ -84,6 +85,37 @@ class TestDaskjobRuntimeHandler(TestRuntimeHandlerBase):
             RuntimeKinds.dask,
             expected_pods=pods,
             expected_services=services,
+        )
+
+    def test_list_resources_grouped_by(self, db: Session, client: TestClient):
+        for group_by in [
+            mlrun.api.schemas.ListRuntimeResourcesGroupByField.project,
+        ]:
+            pods = self._mock_list_resources_pods()
+            services = self._mock_list_services([self.cluster_service])
+            self._assert_runtime_handler_list_resources(
+                RuntimeKinds.dask,
+                expected_pods=pods,
+                expected_services=services,
+                group_by=group_by,
+            )
+
+    def test_build_output_from_runtime_resources(self, db: Session, client: TestClient):
+        """
+        Some scenario happened in field (not sure what was the background) in which there were no services
+        And it caused build_output_from_runtime_resources when given the group by project list (happening in the crud
+        logic), this test reproduce it
+        """
+
+        self._mock_list_resources_pods()
+        self._mock_list_services([])
+        runtime_handler = get_runtime_handler(RuntimeKinds.dask)
+        resources = runtime_handler.list_resources(
+            self.project,
+            group_by=mlrun.api.schemas.ListRuntimeResourcesGroupByField.project,
+        )
+        runtime_handler.build_output_from_runtime_resources(
+            [resources[self.project][RuntimeKinds.dask]]
         )
 
     def test_delete_resources_completed_cluster(self, db: Session, client: TestClient):


### PR DESCRIPTION
We had some scenario happened in field (not sure what was the background) in which there were no services and it caused `build_output_from_runtime_resources` to explode when given the group by project list (happening in the crud logic), added a test and fixed, in addition added a `test_list_resources_grouped_by` that was missing for Dask

This was the stack trace:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/usr/local/lib/python3.7/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/fastapi/applications.py", line 199, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 25, in __call__
    response = await self.dispatch_func(request, self.call_next)
  File "/mlrun/mlrun/api/main.py", line 121, in log_request_response
    response = await call_next(request)
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 45, in call_next
    task.result()
  File "/usr/local/lib/python3.7/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/usr/local/lib/python3.7/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 580, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 241, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.7/site-packages/starlette/routing.py", line 52, in app
    response = await func(request)
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 220, in app
    dependant=dependant, values=values, is_coroutine=is_coroutine
  File "/usr/local/lib/python3.7/site-packages/fastapi/routing.py", line 154, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/usr/local/lib/python3.7/site-packages/starlette/concurrency.py", line 40, in run_in_threadpool
    return await loop.run_in_executor(None, func, *args)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/mlrun/mlrun/api/api/endpoints/runtime_resources.py", line 63, in list_runtime_resources_by_kind_legacy
    "*", auth_info, label_selector, kind_filter=kind
  File "/mlrun/mlrun/api/api/endpoints/runtime_resources.py", line 276, in _list_runtime_resources
    group_by,
  File "/mlrun/mlrun/api/crud/runtime_resources.py", line 79, in filter_and_format_grouped_by_project_runtime_resources_output
    runtime_resources_list, group_by
  File "/mlrun/mlrun/runtimes/base.py", line 1157, in build_output_from_runtime_resources
    response, runtime_resources_list, group_by
  File "/mlrun/mlrun/runtimes/daskjob.py", line 699, in _build_output_from_runtime_resources
    service_resources += runtime_resources.service_resources
TypeError: 'NoneType' object is not iterable
```

Fixes: https://jira.iguazeng.com/browse/ML-1971