### PR TITLE
[Feature Store] Fix issue of histogram calculation for spark failing on empty DFs

### DIFF
--- a/mlrun/data_types/spark.py
+++ b/mlrun/data_types/spark.py
@@ -135,9 +135,14 @@ def get_df_stats_spark(df, options, num_bins=20, sample_size=None):
                     stats_dict[stat] = str(val)
         results_dict[col] = stats_dict
 
-        if InferOptions.get_common_options(
-            options, InferOptions.Histogram
-        ) and get_dtype(df, col) in ["double", "int"]:
+        if (
+            InferOptions.get_common_options(options, InferOptions.Histogram)
+            and get_dtype(df, col) in ["double", "int"]
+            # in some situations (empty DF may cause this) we won't have stats for columns with suitable types, in this
+            # case we won't calculate histogram for the column.
+            and "min" in results_dict[col]
+            and "max" in results_dict[col]
+        ):
             hist_columns.append(col)
 
     # We may need multiple queries here. See comment before this function for reasoning.


### PR DESCRIPTION
In some cases (empty DF may cause this) when running with the Spark engine, the `summary()` calculation on the DF would not return `min` and `max` values for numeric fields. This caused the histogram calculation to explode. Fix this by verifying that the stats exist per column prior to running histogram calculation on it - if they don't exist then histogram will not be calculated for this field.