### PR TITLE
[Feature Store] Fix issues with CSV targets and run_id

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -262,10 +262,12 @@ def get_offline_target(featureset, name=None):
     return None
 
 
-def get_online_target(resource):
+def get_online_target(resource, name=None):
     """return an optimal online feature set target"""
     # todo: take lookup order into account
     for target in resource.status.targets:
+        if name and target.name != name:
+            continue
         driver = kind_to_driver[target.kind]
         if driver.is_online:
             return get_target_driver(target, resource)
@@ -908,9 +910,7 @@ class CSVTarget(BaseStoreTarget):
         return df
 
     def is_single_file(self):
-        if self.path:
-            return self.path.endswith(".csv")
-        return False
+        return True
 
 
 class NoSqlTarget(BaseStoreTarget):

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -27,6 +27,7 @@ from ..datastore.targets import (
     TargetTypes,
     default_target_names,
     get_offline_target,
+    get_online_target,
     get_target_driver,
     update_targets_run_id_for_ingest,
     validate_target_list,
@@ -348,6 +349,10 @@ class FeatureSet(ModelObj):
     def get_target_path(self, name=None):
         """get the url/path for an offline or specified data target"""
         target = get_offline_target(self, name=name)
+
+        if not target and name:
+            target = get_online_target(self, name)
+
         if target:
             return target.get_path().get_absolute_path()
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1130,10 +1130,6 @@ class DataTargetBase(ModelObj):
         else:
             return None
 
-    def get_target_path(self):
-        path_object = self.get_path()
-        return path_object.get_absolute_path() if path_object else None
-
     def __init__(
         self,
         kind: str = None,


### PR DESCRIPTION
Removed get_target_path from DataTargetBase - caused issues with single file targets.
Fix issue with CSV paths
get_target_path can return online in case name is passed as param
Added tests

Fix for issues:
[ML-1961](https://jira.iguazeng.com/browse/ML-1961)
[ML-1983](https://jira.iguazeng.com/browse/ML-1983)