### PR TITLE
[KFP] Add tests for pipelines monkey patching and set pipeline context in `save_workflow`

### DIFF
--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -799,13 +799,15 @@ def add_default_function_resources(
 def add_function_node_selection_attributes(
     function, container_op: dsl.ContainerOp
 ) -> dsl.ContainerOp:
-    if function.spec.node_selector:
-        container_op.node_selector = function.spec.node_selector
 
-    if function.spec.tolerations:
-        container_op.tolerations = function.spec.tolerations
+    if not mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind):
+        if getattr(function.spec, "node_selector"):
+            container_op.node_selector = function.spec.node_selector
 
-    if function.spec.affinity:
-        container_op.affinity = function.spec.affinity
+        if getattr(function.spec, "tolerations"):
+            container_op.tolerations = function.spec.tolerations
+
+        if getattr(function.spec, "affinity"):
+            container_op.affinity = function.spec.affinity
 
     return container_op

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -216,9 +216,9 @@ def _set_priority_class_name_on_kfp_pod(kfp_pod_template, function):
     if kfp_pod_template.get("container") and kfp_pod_template.get("name").startswith(
         function.metadata.name
     ):
-        kfp_pod_template["PriorityClassName"] = getattr(
-            function.spec, "priority_class_name", ""
-        )
+        priority_class_name = getattr(function.spec, "priority_class_name", None)
+        if priority_class_name:
+            kfp_pod_template["PriorityClassName"] = priority_class_name
 
 
 # When we run pipelines, the kfp.compile.Compile.compile() method takes the decorated function with @dsl.pipeline and
@@ -418,6 +418,7 @@ class _KFPRunner(_PipelineRunner):
 
     @classmethod
     def save(cls, project, workflow_spec: WorkflowSpec, target, artifact_path=None):
+        pipeline_context.set(project, workflow_spec)
         workflow_file = workflow_spec.get_source_file(project.spec.context)
         functions = FunctionsDict(project)
         pipeline = create_pipeline(

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -432,6 +432,8 @@ class _KFPRunner(_PipelineRunner):
         conf = new_pipe_meta(artifact_path, ttl=workflow_spec.ttl)
         compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
         workflow_spec.clear_tmp()
+        pipeline_context.clear()
+
 
     @classmethod
     def run(

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -434,7 +434,6 @@ class _KFPRunner(_PipelineRunner):
         workflow_spec.clear_tmp()
         pipeline_context.clear()
 
-
     @classmethod
     def run(
         cls,

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -162,6 +162,15 @@ class RunDBMock:
         self._function = function
         return "1234-1234-1234-1234"
 
+    def get_function(self, function, project, tag):
+        return {
+            "name": function,
+            "metadata": "bla",
+            "uid": "1234-1234-1234-1234",
+            "project": project,
+            "tag": tag,
+        }
+
     def submit_job(self, runspec, schedule=None):
         return {"status": {"status_text": "just a status"}}
 

--- a/tests/projects/assets/remote_pipeline.py
+++ b/tests/projects/assets/remote_pipeline.py
@@ -1,0 +1,18 @@
+import kfp.dsl
+
+import mlrun
+
+
+def func1(context, p1=1):
+    context.log_result("accuracy", p1 * 2)
+
+
+def func2(context, x=0):
+    context.log_result("y", x + 1)
+
+
+@kfp.dsl.pipeline(name="remote_pipeline", description="tests remote pipeline")
+def pipeline():
+    run1 = mlrun.run_function("func1", handler="func1", params={"p1": 9})
+
+    run2 = mlrun.run_function("func2", handler="func2", params={"x": 2})

--- a/tests/projects/assets/remote_pipeline.py
+++ b/tests/projects/assets/remote_pipeline.py
@@ -7,13 +7,9 @@ def func1(context, p1=1):
     context.log_result("accuracy", p1 * 2)
 
 
-def func2(context, x=0):
-    context.log_result("y", x + 1)
-
-
 @kfp.dsl.pipeline(name="remote_pipeline", description="tests remote pipeline")
 def pipeline():
     run1 = mlrun.run_function("func1", handler="func1", params={"p1": 9})
     print(run1)
-    run2 = mlrun.run_function("func2", handler="func2", params={"x": 2})
+    run2 = mlrun.run_function("func2", handler="func1", params={"p1": 29})
     print(run2)

--- a/tests/projects/assets/remote_pipeline.py
+++ b/tests/projects/assets/remote_pipeline.py
@@ -13,3 +13,7 @@ def pipeline():
     print(run1)
     run2 = mlrun.run_function("func2", handler="func1", params={"p1": 29})
     print(run2)
+    build3 = mlrun.build_function("func3")
+    print(build3)
+    dep4 = mlrun.deploy_function("func4")
+    print(dep4)

--- a/tests/projects/assets/remote_pipeline.py
+++ b/tests/projects/assets/remote_pipeline.py
@@ -14,5 +14,6 @@ def func2(context, x=0):
 @kfp.dsl.pipeline(name="remote_pipeline", description="tests remote pipeline")
 def pipeline():
     run1 = mlrun.run_function("func1", handler="func1", params={"p1": 9})
-
+    print(run1)
     run2 = mlrun.run_function("func2", handler="func2", params={"x": 2})
+    print(run2)

--- a/tests/projects/base_pipeline.py
+++ b/tests/projects/base_pipeline.py
@@ -4,11 +4,11 @@ import sys
 import mlrun
 from tests.conftest import out_path
 
-project_dir = f"{out_path}/project_dir"
-data_url = "https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv"
-
 
 class TestPipeline:
+    project_dir = f"{out_path}/project_dir"
+    data_url = "https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv"
+
     def setup_method(self, method):
         self.assets_path = (
             pathlib.Path(sys.modules[self.__module__].__file__).absolute().parent
@@ -19,7 +19,9 @@ class TestPipeline:
         self,
         project_name,
     ):
-        proj = mlrun.new_project(project_name, f"{project_dir}/{project_name}")
-        proj.set_artifact("data", target_path=data_url)
-        proj.spec.params = {"label_column": "label"}
-        return proj
+        self.project = mlrun.new_project(
+            project_name, f"{self.project_dir}/{project_name}"
+        )
+        self.project.set_artifact("data", target_path=self.data_url)
+        self.project.spec.params = {"label_column": "label"}
+        return self.project

--- a/tests/projects/base_pipeline.py
+++ b/tests/projects/base_pipeline.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+import mlrun
+from tests.conftest import out_path
+
+project_dir = f"{out_path}/project_dir"
+data_url = "https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv"
+
+
+class TestPipeline:
+    def setup_method(self, method):
+        self.assets_path = (
+            pathlib.Path(sys.modules[self.__module__].__file__).absolute().parent
+            / "assets"
+        )
+
+    def _create_project(
+        self,
+        project_name,
+    ):
+        proj = mlrun.new_project(project_name, f"{project_dir}/{project_name}")
+        proj.set_artifact("data", target_path=data_url)
+        proj.spec.params = {"label_column": "label"}
+        return proj

--- a/tests/projects/test_local_pipeline.py
+++ b/tests/projects/test_local_pipeline.py
@@ -1,54 +1,43 @@
-import pathlib
-import sys
-
 import pytest
 
 import mlrun
-from tests.conftest import out_path
-
-project_dir = f"{out_path}/project_dir"
-data_url = "https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv"
+import mlrun.artifacts
+import tests.projects.base_pipeline
 
 
-class TestNewProject:
-    def setup_method(self, method):
-        self.assets_path = (
-            pathlib.Path(sys.modules[self.__module__].__file__).absolute().parent
-            / "assets"
-        )
+class TestLocalPipeline(tests.projects.base_pipeline.TestPipeline):
+    pipeline_path = "localpipe.py"
 
-    def _create_project(self, project_name):
-        proj = mlrun.new_project(project_name, f"{project_dir}/{project_name}")
-        proj.set_function(
-            str(f'{self.assets_path / "localpipe.py"}'),
+    def _set_functions(self):
+        self.project.set_function(
+            str(f"{self.assets_path / self.pipeline_path}"),
             "tstfunc",
             image="mlrun/mlrun",
             # kind="job"
         )
-        proj.set_artifact("data", target_path=data_url)
-        proj.spec.params = {"label_column": "label"}
-        return proj
 
     def test_set_artifact(self):
-        project = mlrun.new_project("test-sa")
-        project.set_artifact("data1", mlrun.artifacts.Artifact(target_path=data_url))
-        project.set_artifact(
-            "data2", target_path=data_url, tag="x"
+        self.project = mlrun.new_project("test-sa")
+        self.project.set_artifact(
+            "data1", mlrun.artifacts.Artifact(target_path=self.data_url)
+        )
+        self.project.set_artifact(
+            "data2", target_path=self.data_url, tag="x"
         )  # test the short form
-        project.register_artifacts()
+        self.project.register_artifacts()
 
-        for artifact in project.spec.artifacts:
+        for artifact in self.project.spec.artifacts:
             assert artifact["key"] in ["data1", "data2"]
-            assert artifact["target_path"] == data_url
+            assert artifact["target_path"] == self.data_url
 
-        artifacts = project.list_artifacts(tag="x")
+        artifacts = self.project.list_artifacts(tag="x")
         assert len(artifacts) == 1
 
     def test_run_alone(self):
         mlrun.projects.pipeline_context.clear(with_project=True)
         function = mlrun.code_to_function(
             "test1",
-            filename=str(f'{self.assets_path / "localpipe.py"}'),
+            filename=str(f"{self.assets_path / self.pipeline_path}"),
             handler="func1",
             kind="job",
         )
@@ -61,6 +50,7 @@ class TestNewProject:
     def test_run_project(self):
         mlrun.projects.pipeline_context.clear(with_project=True)
         self._create_project("localpipe1")
+        self._set_functions()
         run1 = mlrun.run_function(
             "tstfunc", handler="func1", params={"p1": 3}, local=True
         )
@@ -76,10 +66,11 @@ class TestNewProject:
 
     def test_run_pipeline(self):
         mlrun.projects.pipeline_context.clear(with_project=True)
-        project = self._create_project("localpipe2")
-        project.run(
+        self._create_project("localpipe2")
+        self._set_functions()
+        self.project.run(
             "p1",
-            workflow_path=str(f'{self.assets_path / "localpipe.py"}'),
+            workflow_path=str(f"{self.assets_path / self.pipeline_path}"),
             workflow_handler="my_pipe",
             arguments={"param1": 7},
             local=True,
@@ -92,22 +83,23 @@ class TestNewProject:
 
     def test_pipeline_args(self):
         mlrun.projects.pipeline_context.clear(with_project=True)
-        project = self._create_project("localpipe3")
+        self._create_project("localpipe3")
+        self._set_functions()
         args = [
             mlrun.model.EntrypointParam("param1", type="int", doc="p1", required=True),
             mlrun.model.EntrypointParam("param2", type="str", default="abc", doc="p2"),
         ]
-        project.set_workflow(
+        self.project.set_workflow(
             "main",
-            str(f'{self.assets_path / "localpipe.py"}'),
+            str(f"{self.assets_path / self.pipeline_path}"),
             handler="args_pipe",
             args_schema=args,
         )
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             # expect an exception when param1 (required) arg is not specified
-            project.run("main", local=True)
+            self.project.run("main", local=True)
 
-        project.run("main", local=True, arguments={"param1": 6})
+        self.project.run("main", local=True, arguments={"param1": 6})
         run_result: mlrun.RunObject = mlrun.projects.pipeline_context._test_result
         print(run_result.to_yaml())
         # expect p1 = param1, p2 = default for param2 (abc)
@@ -115,7 +107,7 @@ class TestNewProject:
             run_result.output("p1") == 6 and run_result.output("p2") == "abc"
         ), "wrong arg values"
 
-        project.run("main", local=True, arguments={"param1": 6, "param2": "xy"})
+        self.project.run("main", local=True, arguments={"param1": 6, "param2": "xy"})
         run_result: mlrun.RunObject = mlrun.projects.pipeline_context._test_result
         print(run_result.to_yaml())
         # expect p1=param1, p2=xy
@@ -125,13 +117,14 @@ class TestNewProject:
 
     def test_run_pipeline_artifact_path(self):
         mlrun.projects.pipeline_context.clear(with_project=True)
-        project = self._create_project("localpipe2")
+        self._create_project("localpipe2")
+        self._set_functions()
         generic_path = "/path/without/workflow/id"
-        project.spec.artifact_path = generic_path
+        self.project.spec.artifact_path = generic_path
 
-        project.run(
+        self.project.run(
             "p4",
-            workflow_path=str(f'{self.assets_path / "localpipe.py"}'),
+            workflow_path=str(f"{self.assets_path / self.pipeline_path}"),
             workflow_handler="my_pipe",
             arguments={"param1": 7},
             local=True,
@@ -142,9 +135,9 @@ class TestNewProject:
         assert mlrun.projects.pipeline_context._artifact_path == generic_path
 
         mlrun.projects.pipeline_context.clear(with_project=True)
-        run_status = project.run(
+        run_status = self.project.run(
             "p4",
-            workflow_path=str(f'{self.assets_path / "localpipe.py"}'),
+            workflow_path=str(f"{self.assets_path / self.pipeline_path}"),
             workflow_handler="my_pipe",
             arguments={"param1": 7},
             local=True,

--- a/tests/projects/test_remote_pipeline.py
+++ b/tests/projects/test_remote_pipeline.py
@@ -1,0 +1,134 @@
+import base64
+import json
+import unittest.mock
+
+import kfp.compiler
+import kubernetes
+import kubernetes.client
+
+import mlrun
+import tests.projects.base_pipeline
+
+
+class TestRemotePipeline(tests.projects.base_pipeline.TestPipeline):
+    def _set_functions(self):
+        self.project.set_function(
+            func=f"{self.assets_path}/remote_pipeline.py",
+            name="func1",
+            image="mlrun/mlrun",
+            handler="func1",
+        )
+        self.project.set_function(
+            func=f"{self.assets_path}/remote_pipeline.py",
+            name="func2",
+            image="mlrun/mlrun",
+            handler="func2",
+        )
+
+    def test_kfp_pipeline_enriched_with_priority_class_name(self, rundb_mock):
+        mlrun.config.config.default_function_priority_class_name = "default-high"
+
+        mlrun.projects.pipeline_context.clear(with_project=True)
+        self.project = self._create_project("remotepipe")
+        self._set_functions()
+        self.project.set_workflow(
+            "p1",
+            workflow_path=str(f'{self.assets_path / "remote_pipeline.py"}'),
+            handler="kfp_pipeline",
+            engine="kfp",
+            local=False,
+        )
+        self.project.save()
+
+        # we are monkey patching kfp.compiler.Compiler._create_workflow,
+        # in the monkey patching we are enriching the pipeline step with the functions priority_class_name
+        # after enriching the compile function passes the enriched workflow to
+        # kfp.compiler.Compiler._write_workflow and that's why we mock _write_workflow to get the
+        # passed args which one of them is workflow
+        kfp.compiler.Compiler._write_workflow = unittest.mock.Mock(return_value=True)
+        self.project.save_workflow(
+            "p1",
+            target=self.project.artifact_path,
+        )
+
+        workflow = kfp.compiler.Compiler._write_workflow.call_args_list[0][0][0]
+        for step in workflow["spec"]["templates"]:
+            if step.get("container"):
+                assert (
+                    step["PriorityClassName"]
+                    == mlrun.config.config.default_function_priority_class_name
+                )
+
+    def test_kfp_pipeline_enriched_with_affinity_and_tolerations_enriched_by_preemption_mode(
+        self, rundb_mock
+    ):
+        k8s_api = kubernetes.client.ApiClient()
+        mlrun.mlconf.default_function_priority_class_name = "default-high"
+
+        node_selector = {"label-1": "val1"}
+        mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
+            json.dumps(node_selector).encode("utf-8")
+        )
+
+        preemptible_tolerations = [
+            kubernetes.client.V1Toleration(
+                effect="NoSchedule",
+                key="test1",
+                operator="Exists",
+            )
+        ]
+        serialized_tolerations = k8s_api.sanitize_for_serialization(
+            preemptible_tolerations
+        )
+        mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
+            json.dumps(serialized_tolerations).encode("utf-8")
+        )
+        mlrun.mlconf.function_defaults.preemption_mode = "constrain"
+        mlrun.projects.pipeline_context.clear(with_project=True)
+        self.project = self._create_project("remotepipe")
+        self._set_functions()
+        self.project.set_workflow(
+            "p1",
+            workflow_path=str(f'{self.assets_path / "remote_pipeline.py"}'),
+            handler="kfp_pipeline",
+            engine="kfp",
+            local=False,
+        )
+        self.project.save()
+
+        kfp.compiler.Compiler._write_workflow = unittest.mock.Mock(return_value=True)
+        self.project.save_workflow(
+            "p1",
+            target=self.project.artifact_path,
+        )
+
+        workflow = kfp.compiler.Compiler._write_workflow.call_args_list[0][0][0]
+        expected_tolerations = [
+            {"effect": "NoSchedule", "key": "test1", "operator": "Exists"}
+        ]
+        expected_preemptible_affinity = {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "label-1",
+                                    "operator": "In",
+                                    "values": ["val1"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+        for step in workflow["spec"]["templates"]:
+            if step.get("container"):
+                print(step)
+                assert (
+                    step["PriorityClassName"]
+                    == mlrun.config.config.default_function_priority_class_name
+                )
+                assert step["affinity"] == expected_preemptible_affinity
+                assert step["tolerations"] == expected_tolerations

--- a/tests/projects/test_remote_pipeline.py
+++ b/tests/projects/test_remote_pipeline.py
@@ -68,7 +68,7 @@ class TestRemotePipeline(tests.projects.base_pipeline.TestPipeline):
         )
         self.project.save_workflow(
             "p1",
-            target=workflow_path.as_posix(),
+            target=str(workflow_path),
         )
         with workflow_path.open() as workflow_file:
             workflow = yaml.safe_load(workflow_file)
@@ -130,7 +130,7 @@ class TestRemotePipeline(tests.projects.base_pipeline.TestPipeline):
         )
         self.project.save_workflow(
             "p1",
-            target=workflow_path.as_posix(),
+            target=str(workflow_path),
         )
 
         preemptible_tolerations = [


### PR DESCRIPTION
As part of adding the tests I came across a bug in which when running `project.save_workflow` for workflow of kind KFP it thought I was in local context because the pipeline context hasn't been set. I have added `pipeline_context.set()` into the `save` method of `_KFPRunner` which solved the issue.