### PR TITLE
[API] Fix auth secret name template to comply to Nuclio rules

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -289,7 +289,7 @@ default_config = {
             # unless user asks for a specific list of secrets.
             "auto_add_project_secrets": True,
             "project_secret_name": "mlrun-project-secrets-{project}",
-            "auth_secret_name": "mlrun-auth-secrets-{sanitized_username}-{hashed_access_key}",
+            "auth_secret_name": "mlrun-auth-secrets.{sanitized_username}.{hashed_access_key}",
             "env_variable_prefix": "MLRUN_K8S_SECRET__",
         },
     },

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -350,7 +350,7 @@ class K8sHelper:
 
     @staticmethod
     def _hash_access_key(access_key: str):
-        return hashlib.sha256(access_key.encode()).hexdigest()
+        return hashlib.sha224(access_key.encode()).hexdigest()
 
     def store_project_secrets(self, project, secrets, namespace=""):
         secret_name = self.get_project_secret_name(project)


### PR DESCRIPTION
Nuclio (mistakenly) apply a "Max length between two periods: 63" validation rule on secret names, it was fixed already, but in order to be compatible with older Nuclio versions we want to comply to this rule, therefore using dots (`.`) as separators in the template, and switching to sha224 which generated 56 characters hash (instead of 64 for sha256)
Related to: https://jira.iguazeng.com/browse/ML-1585