### PR TITLE
[Feature Store] Remake run id feature store's only

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -295,8 +295,8 @@ default_config = {
     },
     "feature_store": {
         "data_prefixes": {
-            "default": "v3io:///projects/{project}/FeatureStore/{name}/{run_id}/{kind}",
-            "nosql": "v3io:///projects/{project}/FeatureStore/{name}/{run_id}/{kind}",
+            "default": "v3io:///projects/{project}/FeatureStore/{name}/{kind}",
+            "nosql": "v3io:///projects/{project}/FeatureStore/{name}/{kind}",
         },
         "default_targets": "parquet,nosql",
         "default_job_image": "mlrun/mlrun",

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -95,7 +95,7 @@ def get_default_prefix_for_target(kind):
 
 
 def get_default_prefix_for_source(kind):
-    return get_default_prefix_for_target(kind).replace(f"/{RUN_ID_PLACE_HOLDER}/", "/")
+    return get_default_prefix_for_target(kind)
 
 
 def validate_target_list(targets):
@@ -507,7 +507,7 @@ class BaseStoreTarget(DataTargetBase):
         is_single_file = hasattr(self, "is_single_file") and self.is_single_file()
         return self.get_path() or (
             TargetPathObject(
-                _get_target_path(self, self._resource), self.run_id, is_single_file
+                _get_target_path(self, self._resource, self.run_id is None), self.run_id, is_single_file
             )
             if self._resource
             else None
@@ -1295,7 +1295,7 @@ kind_to_driver = {
 }
 
 
-def _get_target_path(driver, resource):
+def _get_target_path(driver, resource, run_id_mode=False):
     """return the default target path given the resource and target kind"""
     kind = driver.kind
     suffix = driver.suffix
@@ -1316,9 +1316,11 @@ def _get_target_path(driver, resource):
         project=project,
         kind=kind,
         name=name,
-        run_id=RUN_ID_PLACE_HOLDER,
     )
     # todo: handle ver tag changes, may need to copy files?
+    if not run_id_mode:
+        version = resource.metadata.tag
+        name = f"{name}-{version or 'latest'}"
     return f"{data_prefix}/{kind_prefix}/{name}{suffix}"
 
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -907,7 +907,9 @@ class CSVTarget(BaseStoreTarget):
         return df
 
     def is_single_file(self):
-        return True
+        if self.path:
+            return self.path.endswith(".csv")
+        return False
 
 
 class NoSqlTarget(BaseStoreTarget):

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -909,7 +909,7 @@ class CSVTarget(BaseStoreTarget):
     def is_single_file(self):
         if self.path:
             return self.path.endswith(".csv")
-        return False
+        return True
 
 
 class NoSqlTarget(BaseStoreTarget):

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -24,12 +24,7 @@ import pandas as pd
 import mlrun
 import mlrun.utils.helpers
 from mlrun.config import config
-from mlrun.model import (
-    RUN_ID_PLACE_HOLDER,
-    DataTarget,
-    DataTargetBase,
-    TargetPathObject,
-)
+from mlrun.model import DataTarget, DataTargetBase, TargetPathObject
 from mlrun.utils import now_date
 from mlrun.utils.v3io_clients import get_frames_client
 
@@ -507,7 +502,9 @@ class BaseStoreTarget(DataTargetBase):
         is_single_file = hasattr(self, "is_single_file") and self.is_single_file()
         return self.get_path() or (
             TargetPathObject(
-                _get_target_path(self, self._resource, self.run_id is None), self.run_id, is_single_file
+                _get_target_path(self, self._resource, self.run_id is None),
+                self.run_id,
+                is_single_file,
             )
             if self._resource
             else None

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -155,10 +155,6 @@ def get_offline_features(
         entity_timestamp_column or feature_vector.spec.timestamp_field
     )
 
-    if target:
-        if not target.run_id:
-            target.run_id = "offline-features"
-
     if run_config:
         return run_merge_job(
             feature_vector,

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1066,7 +1066,9 @@ class TargetPathObject:
                         + self.full_path_template[dir_name_end:]
                     )
                     self.full_path_template = updated_path
-
+            else:
+                if self.full_path_template[-1] != "/" and self.full_path_template.endswith(RUN_ID_PLACE_HOLDER):
+                    self.full_path_template = self.full_path_template + "/"
         else:
             if RUN_ID_PLACE_HOLDER in self.full_path_template:
                 raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1028,7 +1028,7 @@ def new_task(
 
 
 class TargetPathObject:
-    """Class configuring the target path
+    """ Class configuring the target path
     This class will take consideration of a few parameters to create the correct end result path:
     * run_id - if run_id is provided target will be considered as run_id mode
                which require to contain a {run_id} place holder in the path.

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1067,8 +1067,9 @@ class TargetPathObject:
                     )
                     self.full_path_template = updated_path
             else:
-                if self.full_path_template[-1] != "/" and self.full_path_template.endswith(RUN_ID_PLACE_HOLDER):
-                    self.full_path_template = self.full_path_template + "/"
+                if self.full_path_template[-1] != "/":
+                    if self.full_path_template.endswith(RUN_ID_PLACE_HOLDER):
+                        self.full_path_template = self.full_path_template + "/"
         else:
             if RUN_ID_PLACE_HOLDER in self.full_path_template:
                 raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1028,7 +1028,7 @@ def new_task(
 
 
 class TargetPathObject:
-    """ Class configuring the target path
+    """Class configuring the target path
     This class will take consideration of a few parameters to create the correct end result path:
     * run_id - if run_id is provided target will be considered as run_id mode
                which require to contain a {run_id} place holder in the path.

--- a/tests/feature-store/test_model.py
+++ b/tests/feature-store/test_model.py
@@ -51,7 +51,7 @@ def test_features_parser():
 @pytest.mark.parametrize(
     "pass_run_id, is_single_file, target_path, expected_path",
     [
-        (True, False, "v3io:///bigdata/{run_id}", "v3io:///bigdata/run_id_val"),
+        (True, False, "v3io:///bigdata/{run_id}", "v3io:///bigdata/run_id_val/"),
         (
             True,
             True,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -381,7 +381,7 @@ class TestFeatureStore(TestMLRunSystem):
             ),
             (
                 "v3io:///bigdata/csvtest/csvname",
-                "v3io:///bigdata/csvtest/{run_id}/csvname",
+                "v3io:///bigdata/csvtest/csvname/{run_id}/",
             ),
             (
                 "v3io:///bigdata/csvtest/csvname/",

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -32,7 +32,6 @@ from mlrun.datastore.targets import (
     NoSqlTarget,
     ParquetTarget,
     TargetTypes,
-    get_default_prefix_for_target,
     get_target_driver,
 )
 from mlrun.feature_store import Entity, FeatureSet
@@ -342,10 +341,15 @@ class TestFeatureStore(TestMLRunSystem):
             (None, False),  # default
             (f"v3io:///bigdata/{project_name}/gof_wt.parquet", False),  # single file
             (f"v3io:///bigdata/{project_name}/gof_wt/", False),  # directory
-            (f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet", True),  # single file with run_id
+            (
+                f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
+                True,
+            ),  # with run_id
         ],
     )
-    def test_different_target_paths_for_get_offline_features(self, target_path, should_raise_error):
+    def test_different_target_paths_for_get_offline_features(
+        self, target_path, should_raise_error
+    ):
         stocks = pd.DataFrame(
             {
                 "ticker": ["MSFT", "GOOG", "AAPL"],
@@ -371,10 +375,19 @@ class TestFeatureStore(TestMLRunSystem):
     @pytest.mark.parametrize(
         "target_path, final_path",
         [
-            ("v3io:///bigdata/csvtest/csvname.csv", "v3io:///bigdata/csvtest/{run_id}/csvname.csv"),
-            ("v3io:///bigdata/csvtest/csvname", "v3io:///bigdata/csvtest/{run_id}/csvname"),
-            ("v3io:///bigdata/csvtest/csvname/", "v3io:///bigdata/csvtest/csvname/{run_id}/")
-        ]
+            (
+                "v3io:///bigdata/csvtest/csvname.csv",
+                "v3io:///bigdata/csvtest/{run_id}/csvname.csv",
+            ),
+            (
+                "v3io:///bigdata/csvtest/csvname",
+                "v3io:///bigdata/csvtest/{run_id}/csvname",
+            ),
+            (
+                "v3io:///bigdata/csvtest/csvname/",
+                "v3io:///bigdata/csvtest/csvname/{run_id}/",
+            ),
+        ],
     )
     def test_csv_path(self, target_path, final_path):
         df = pd.DataFrame(
@@ -695,7 +708,6 @@ class TestFeatureStore(TestMLRunSystem):
         assert resp1 == resp2
 
         file_system = fsspec.filesystem("v3io")
-        kind = TargetTypes.parquet
         path = measurements.get_target_path("parquet")
         dataset = pq.ParquetDataset(
             path,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -387,6 +387,10 @@ class TestFeatureStore(TestMLRunSystem):
                 "v3io:///bigdata/csvtest/csvname/",
                 "v3io:///bigdata/csvtest/csvname/{run_id}/",
             ),
+            (
+                "v3io:///bigdata/csvtest/csvname/{run_id}",
+                "v3io:///bigdata/csvtest/csvname/{run_id}/",
+            ),
         ],
     )
     def test_csv_path(self, target_path, final_path):


### PR DESCRIPTION
Target is now working with or without run_id. In feature store flows run_id is generated and in case it isn't provided in path it is added.
Removed run_id place holder from the default path.
*** Few important notes:
in order to use csv target as a single file - enter path with '[filename].csv' at the end of the path
in case csv path is ending with anything other then .csv it will handle it as a path and the output filename will be the 'run_id' generated for that run