### PR TITLE
[Runtimes] Add `none` preemption mode

### DIFF
--- a/mlrun/api/schemas/function.py
+++ b/mlrun/api/schemas/function.py
@@ -35,3 +35,5 @@ class PreemptionModes(str, Enum):
     constrain = "constrain"
     # prevents the function pods from running on preemptible nodes
     prevent = "prevent"
+    # doesn't apply any preemptible node selection on the function
+    none = "none"

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -659,19 +659,23 @@ class RemoteRuntime(KubeResource):
             )
         super().with_node_selection(node_name, node_selector, affinity, tolerations)
 
-    @min_nuclio_versions("1.8.1")
+    @min_nuclio_versions("1.8.6")
     def with_preemption_mode(self, mode):
         """
         Preemption mode controls whether pods can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Three modes are supported:
+        Four modes are supported:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
+        * **none** - No preemptible configuration will apply on the function
 
-        :param mode: accepts allow | constrain | prevent defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
+        The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
+        by default it's set to **prevent**
+
+        :param mode: allow | constrain | prevent | none defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
         """
         super().with_preemption_mode(mode=mode)
 
@@ -1214,7 +1218,7 @@ def compile_function_config(
                 ),
             )
     # don't send preemption_mode if nuclio is not compatible
-    if validate_nuclio_version_compatibility("1.8.1"):
+    if validate_nuclio_version_compatibility("1.8.6"):
         if function.spec.preemption_mode:
             nuclio_spec.set_config(
                 "spec.PreemptionMode",

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -665,12 +665,12 @@ class RemoteRuntime(KubeResource):
         Preemption mode controls whether pods can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Four modes are supported:
+        The supported modes are:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
-        * **none** - No preemptible configuration will apply on the function
+        * **none** - No preemptible configuration will be applied on the function
 
         The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
         by default it's set to **prevent**

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1047,12 +1047,12 @@ class KubeResource(BaseRuntime):
         Preemption mode controls whether pods can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Four modes are supported:
+        The supported modes are:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
-        * **none** - No preemptible configuration will apply on the function
+        * **none** - No preemptible configuration will be applied on the function
 
         The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
         by default it's set to **prevent**

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -491,6 +491,7 @@ class KubeResourceSpec(FunctionSpec):
                         > Purges any `affinity` preemption related configuration
                         > Purges preemptible node selector
                         > Sets anti-affinity and overrides any affinity if no tolerations were configured
+            `none`      - Doesn't apply any preemptible node selection configuration.
         """
         # nothing to do here, configuration is not populated
         if not mlconf.is_preemption_nodes_configured():
@@ -509,6 +510,9 @@ class KubeResourceSpec(FunctionSpec):
                 default_preemption_mode=getattr(self, preemption_mode_field_name),
             )
         self_preemption_mode = getattr(self, preemption_mode_field_name)
+        # don't enrich with preemption configuration.
+        if self_preemption_mode == PreemptionModes.none.value:
+            return
         # remove preemptible tolerations and remove preemption related configuration
         # and enrich with anti-affinity if preemptible tolerations configuration haven't been provided
         if self_preemption_mode == PreemptionModes.prevent.value:
@@ -1043,13 +1047,17 @@ class KubeResource(BaseRuntime):
         Preemption mode controls whether pods can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Three modes are supported:
+        Four modes are supported:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
+        * **none** - No preemptible configuration will apply on the function
 
-        :param mode: accepts allow | constrain | prevent defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
+        The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
+        by default it's set to **prevent**
+
+        :param mode: allow | constrain | prevent | none defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
         """
         preemptible_mode = PreemptionModes(mode)
         self.spec.preemption_mode = preemptible_mode.value

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -452,13 +452,17 @@ class Spark3Runtime(AbstractSparkRuntime):
         Preemption mode controls whether the spark driver can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Three modes are supported:
+        Four modes are supported:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
+        * **none** - No preemptible configuration will apply on the function
 
-        :param mode: accepts allow | constrain | prevent defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
+        The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
+        by default it's set to **prevent**
+
+        :param mode: allow | constrain | prevent | none defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
         """
         preemption_mode = mlrun.api.schemas.function.PreemptionModes(mode)
         self.spec.driver_preemption_mode = preemption_mode.value
@@ -470,13 +474,17 @@ class Spark3Runtime(AbstractSparkRuntime):
         Preemption mode controls whether the spark executor can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Three modes are supported:
+        Four modes are supported:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
+        * **none** - No preemptible configuration will apply on the function
 
-        :param mode: accepts allow | constrain | prevent defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
+        The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
+        by default it's set to **prevent**
+
+        :param mode: allow | constrain | prevent | none defined in :py:class:`~mlrun.api.schemas.PreemptionModes`
         """
         preemption_mode = mlrun.api.schemas.function.PreemptionModes(mode)
         self.spec.executor_preemption_mode = preemption_mode.value

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -452,12 +452,12 @@ class Spark3Runtime(AbstractSparkRuntime):
         Preemption mode controls whether the spark driver can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Four modes are supported:
+        The supported modes are:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
-        * **none** - No preemptible configuration will apply on the function
+        * **none** - No preemptible configuration will be applied on the function
 
         The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
         by default it's set to **prevent**
@@ -474,12 +474,12 @@ class Spark3Runtime(AbstractSparkRuntime):
         Preemption mode controls whether the spark executor can be scheduled on preemptible nodes.
         Tolerations, node selector, and affinity are populated on preemptible nodes corresponding to the function spec.
 
-        Four modes are supported:
+        The supported modes are:
 
         * **allow** - The function can be scheduled on preemptible nodes
         * **constrain** - The function can only run on preemptible nodes
         * **prevent** - The function cannot be scheduled on preemptible nodes
-        * **none** - No preemptible configuration will apply on the function
+        * **none** - No preemptible configuration will be applied on the function
 
         The default preemption mode is configurable in mlrun.mlconf.function_defaults.preemption_mode,
         by default it's set to **prevent**

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -169,6 +169,11 @@ class TestKubejobRuntime(TestRuntimeBase):
     ):
         self.assert_run_preemption_mode_with_preemptible_node_selector_without_preemptible_tolerations_with_extra_settings()  # noqa: E501
 
+    def test_with_preemption_mode_none_transitions(
+        self, db: Session, client: TestClient
+    ):
+        self.assert_run_with_preemption_mode_none_transitions()
+
     def assert_node_selection(
         self, node_name=None, node_selector=None, affinity=None, tolerations=None
     ):

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -941,7 +941,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
             fn.with_preemption_mode(mlrun.api.schemas.PreemptionModes.allow.value)
 
-        mlconf.nuclio_version = "1.8.1"
+        mlconf.nuclio_version = "1.8.6"
         fn.with_preemption_mode(mlrun.api.schemas.PreemptionModes.allow.value)
         assert fn.spec.preemption_mode == "allow"
 

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -965,6 +965,11 @@ class TestNuclioRuntime(TestRuntimeBase):
     ):
         self.assert_run_preemption_mode_with_preemptible_node_selector_and_tolerations_with_extra_settings()
 
+    def test_with_preemption_mode_none_transitions(
+        self, db: Session, client: TestClient
+    ):
+        self.assert_run_with_preemption_mode_none_transitions()
+
     def test_preemption_mode_with_preemptible_node_selector_without_preemptible_tolerations_with_extra_settings(
         self, db: Session, client: TestClient
     ):


### PR DESCRIPTION
none preemption mode allow users to define that no preemption enrichment will apply on functions.

Changed nuclio minimum required version for preemption mode support after this fix - https://github.com/nuclio/nuclio/pull/2541 which released in https://github.com/nuclio/nuclio/releases/tag/1.8.6 