### PR TITLE
[Spark] Support setting different volume mounts for driver and executor and add helper for host path

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -225,14 +225,16 @@ class KubeResourceSpec(FunctionSpec):
         struct["tolerations"] = api.sanitize_for_serialization(self.tolerations)
         return struct
 
-    def update_vols_and_mounts(self, volumes, volume_mounts):
+    def update_vols_and_mounts(
+        self, volumes, volume_mounts, volume_mounts_field_name="_volume_mounts"
+    ):
         if volumes:
             for vol in volumes:
                 set_named_item(self._volumes, vol)
 
         if volume_mounts:
             for volume_mount in volume_mounts:
-                self._set_volume_mount(volume_mount)
+                self._set_volume_mount(volume_mount, volume_mounts_field_name)
 
     def _get_affinity_as_k8s_class_instance(self):
         pass
@@ -319,11 +321,13 @@ class KubeResourceSpec(FunctionSpec):
         api = k8s_client.ApiClient()
         return api.sanitize_for_serialization(attribute)
 
-    def _set_volume_mount(self, volume_mount):
+    def _set_volume_mount(
+        self, volume_mount, volume_mounts_field_name="_volume_mounts"
+    ):
         # using the mountPath as the key cause it must be unique (k8s limitation)
         # volume_mount may be an V1VolumeMount instance (object access, snake case) or sanitized dict (dict
         # access, camel case)
-        self._volume_mounts[
+        getattr(self, volume_mounts_field_name)[
             get_item_name(volume_mount, "mountPath")
             or get_item_name(volume_mount, "mount_path")
         ] = volume_mount
@@ -895,7 +899,12 @@ class KubeResource(BaseRuntime):
         struct = api.sanitize_for_serialization(struct)
         if strip:
             spec = struct["spec"]
-            for attr in ["volumes", "volume_mounts"]:
+            for attr in [
+                "volumes",
+                "volume_mounts",
+                "driver_volume_mounts",
+                "executor_volume_mounts",
+            ]:
                 if attr in spec:
                     del spec[attr]
             if "env" in spec and spec["env"]:

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -14,7 +14,7 @@
 
 import typing
 
-from kubernetes import client
+import kubernetes.client
 
 import mlrun.api.schemas.function
 import mlrun.errors
@@ -37,6 +37,8 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         "executor_affinity",
         "driver_preemption_mode",
         "executor_preemption_mode",
+        "driver_volume_mounts",
+        "executor_volume_mounts",
     ]
 
     def __init__(
@@ -87,6 +89,8 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         preemption_mode=None,
         executor_preemption_mode=None,
         driver_preemption_mode=None,
+        driver_volume_mounts=None,
+        executor_volume_mounts=None,
     ):
 
         super().__init__(
@@ -138,6 +142,10 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         self.driver_affinity = driver_affinity
         self.executor_preemption_mode = executor_preemption_mode
         self.driver_preemption_mode = driver_preemption_mode
+        self._driver_volume_mounts = {}
+        self.driver_volume_mounts = driver_volume_mounts or {}
+        self._executor_volume_mounts = {}
+        self.executor_volume_mounts = executor_volume_mounts or {}
 
     def to_dict(self, fields=None, exclude=None):
         struct = super().to_dict(
@@ -149,7 +157,7 @@ class Spark3JobSpec(AbstractSparkJobSpec):
                 "driver_tolerations",
             ],
         )
-        api = client.ApiClient()
+        api = kubernetes.client.ApiClient()
         struct["executor_affinity"] = api.sanitize_for_serialization(
             self.executor_affinity
         )
@@ -163,7 +171,7 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         return struct
 
     @property
-    def executor_tolerations(self) -> typing.List[client.V1Toleration]:
+    def executor_tolerations(self) -> typing.List[kubernetes.client.V1Toleration]:
         return self._executor_tolerations
 
     @executor_tolerations.setter
@@ -175,7 +183,7 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         )
 
     @property
-    def driver_tolerations(self) -> typing.List[client.V1Toleration]:
+    def driver_tolerations(self) -> typing.List[kubernetes.client.V1Toleration]:
         return self._driver_tolerations
 
     @driver_tolerations.setter
@@ -187,7 +195,7 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         )
 
     @property
-    def executor_affinity(self) -> client.V1Affinity:
+    def executor_affinity(self) -> kubernetes.client.V1Affinity:
         return self._executor_affinity
 
     @executor_affinity.setter
@@ -199,7 +207,7 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         )
 
     @property
-    def driver_affinity(self) -> client.V1Affinity:
+    def driver_affinity(self) -> kubernetes.client.V1Affinity:
         return self._driver_affinity
 
     @driver_affinity.setter
@@ -241,6 +249,32 @@ class Spark3JobSpec(AbstractSparkJobSpec):
             affinity_field_name="executor_affinity",
             node_selector_field_name="executor_node_selector",
         )
+
+    @property
+    def driver_volume_mounts(self) -> list:
+        return list(self._driver_volume_mounts.values())
+
+    @driver_volume_mounts.setter
+    def driver_volume_mounts(self, volume_mounts):
+        self._driver_volume_mounts = {}
+        if volume_mounts:
+            for volume_mount in volume_mounts:
+                self._set_volume_mount(
+                    volume_mount, volume_mounts_field_name="_driver_volume_mounts"
+                )
+
+    @property
+    def executor_volume_mounts(self) -> list:
+        return list(self._executor_volume_mounts.values())
+
+    @executor_volume_mounts.setter
+    def executor_volume_mounts(self, volume_mounts):
+        self._executor_volume_mounts = {}
+        if volume_mounts:
+            for volume_mount in volume_mounts:
+                self._set_volume_mount(
+                    volume_mount, volume_mounts_field_name="_executor_volume_mounts"
+                )
 
 
 class Spark3Runtime(AbstractSparkRuntime):
@@ -325,6 +359,21 @@ class Spark3Runtime(AbstractSparkRuntime):
                         "spec.monitoring.prometheus.jmxExporterJar",
                         self.spec.monitoring["exporter_jar"],
                     )
+
+        if self.spec.driver_volume_mounts:
+            update_in(
+                job,
+                "spec.driver.volumeMounts",
+                self.spec.driver_volume_mounts,
+                append=True,
+            )
+        if self.spec.executor_volume_mounts:
+            update_in(
+                job,
+                "spec.executor.volumeMounts",
+                self.spec.executor_volume_mounts,
+                append=True,
+            )
         return
 
     def _get_spark_version(self):
@@ -354,8 +403,10 @@ class Spark3Runtime(AbstractSparkRuntime):
         self,
         node_name: typing.Optional[str] = None,
         node_selector: typing.Optional[typing.Dict[str, str]] = None,
-        affinity: typing.Optional[client.V1Affinity] = None,
-        tolerations: typing.Optional[typing.List[client.V1Toleration]] = None,
+        affinity: typing.Optional[kubernetes.client.V1Affinity] = None,
+        tolerations: typing.Optional[
+            typing.List[kubernetes.client.V1Toleration]
+        ] = None,
     ):
         if node_name:
             raise NotImplementedError(
@@ -376,8 +427,10 @@ class Spark3Runtime(AbstractSparkRuntime):
         self,
         node_name: typing.Optional[str] = None,
         node_selector: typing.Optional[typing.Dict[str, str]] = None,
-        affinity: typing.Optional[client.V1Affinity] = None,
-        tolerations: typing.Optional[typing.List[client.V1Toleration]] = None,
+        affinity: typing.Optional[kubernetes.client.V1Affinity] = None,
+        tolerations: typing.Optional[
+            typing.List[kubernetes.client.V1Toleration]
+        ] = None,
     ):
         """
         Enables to control on which k8s node the spark executor will run
@@ -407,8 +460,10 @@ class Spark3Runtime(AbstractSparkRuntime):
         self,
         node_name: typing.Optional[str] = None,
         node_selector: typing.Optional[typing.Dict[str, str]] = None,
-        affinity: typing.Optional[client.V1Affinity] = None,
-        tolerations: typing.Optional[typing.List[client.V1Toleration]] = None,
+        affinity: typing.Optional[kubernetes.client.V1Affinity] = None,
+        tolerations: typing.Optional[
+            typing.List[kubernetes.client.V1Toleration]
+        ] = None,
     ):
         """
         Enables to control on which k8s node the spark executor will run

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -57,7 +57,7 @@ class TestDaskRuntime(TestRuntimeBase):
         _, kwargs = self.kube_cluster_mock.call_args
         return kwargs["scheduler_pod_template"]
 
-    def _get_namespace_arg(self):
+    def _get_create_pod_namespace_arg(self):
         _, kwargs = self.kube_cluster_mock.call_args
         return kwargs["namespace"]
 

--- a/tests/api/runtimes/test_spark.py
+++ b/tests/api/runtimes/test_spark.py
@@ -1,0 +1,170 @@
+import typing
+
+import deepdiff
+import fastapi.testclient
+import kubernetes
+import sqlalchemy.orm
+
+import mlrun.api.schemas
+import mlrun.api.utils.singletons.k8s
+import mlrun.errors
+import mlrun.runtimes.pod
+import tests.api.runtimes.base
+
+
+class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
+    def custom_setup_after_fixtures(self):
+        self._mock_create_namespaced_custom_object()
+
+    def custom_setup(self):
+        self.image_name = "mlrun/mlrun:latest"
+
+    def _generate_runtime(
+        self, set_resources: bool = True
+    ) -> mlrun.runtimes.Spark3Runtime:
+        runtime = mlrun.runtimes.Spark3Runtime()
+        runtime.spec.image = self.image_name
+        if set_resources:
+            runtime.with_executor_requests(cpu=1, mem="512m")
+            runtime.with_driver_requests(cpu=1, mem="512m")
+        return runtime
+
+    def _assert_custom_object_creation_config(
+        self,
+        expected_runtime_class_name="spark",
+        assert_create_custom_object_called=True,
+        expected_volumes: typing.Optional[list] = None,
+        expected_driver_volume_mounts: typing.Optional[list] = None,
+        expected_executor_volume_mounts: typing.Optional[list] = None,
+    ):
+        if assert_create_custom_object_called:
+            mlrun.api.utils.singletons.k8s.get_k8s().crdapi.create_namespaced_custom_object.assert_called_once()
+
+        assert self._get_create_custom_object_namespace_arg() == self.namespace
+
+        body = self._get_custom_object_creation_body()
+        self._assert_labels(body["metadata"]["labels"], expected_runtime_class_name)
+        self._assert_volume_and_mounts(
+            body,
+            expected_volumes,
+            expected_driver_volume_mounts,
+            expected_executor_volume_mounts,
+        )
+
+    def _assert_volume_and_mounts(
+        self,
+        body: dict,
+        expected_volumes: typing.Optional[list] = None,
+        expected_driver_volume_mounts: typing.Optional[list] = None,
+        expected_executor_volume_mounts: typing.Optional[list] = None,
+    ):
+        if expected_volumes:
+            sanitized_volumes = self._sanitize_list_for_serialization(expected_volumes)
+            assert (
+                deepdiff.DeepDiff(
+                    body["spec"]["volumes"], sanitized_volumes, ignore_order=True
+                )
+                == {}
+            )
+        if expected_driver_volume_mounts:
+            sanitized_driver_volume_mounts = self._sanitize_list_for_serialization(
+                expected_driver_volume_mounts
+            )
+            assert (
+                deepdiff.DeepDiff(
+                    body["spec"]["driver"]["volumeMounts"],
+                    sanitized_driver_volume_mounts,
+                    ignore_order=True,
+                )
+                == {}
+            )
+        if expected_executor_volume_mounts:
+            sanitized_executor_volume_mounts = self._sanitize_list_for_serialization(
+                expected_executor_volume_mounts
+            )
+            assert (
+                deepdiff.DeepDiff(
+                    body["spec"]["executor"]["volumeMounts"],
+                    sanitized_executor_volume_mounts,
+                    ignore_order=True,
+                )
+                == {}
+            )
+
+    def _sanitize_list_for_serialization(self, list_: list):
+        kubernetes_api_client = kubernetes.client.ApiClient()
+        return list(map(kubernetes_api_client.sanitize_for_serialization, list_))
+
+    def test_run_without_runspec(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        runtime: mlrun.runtimes.Spark3Runtime = self._generate_runtime()
+        self.execute_function(runtime)
+        self._assert_custom_object_creation_config()
+
+    def test_run_with_host_path_volume(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        runtime: mlrun.runtimes.Spark3Runtime = self._generate_runtime()
+        shared_volume = kubernetes.client.V1Volume(
+            name="shared-volume",
+            host_path=kubernetes.client.V1HostPathVolumeSource(
+                path="/shared-volume-host-path", type=""
+            ),
+        )
+        shared_volume_driver_volume_mount = kubernetes.client.V1VolumeMount(
+            mount_path="/shared-volume-driver-mount-path", name=shared_volume.name
+        )
+        shared_volume_executor_volume_mount = kubernetes.client.V1VolumeMount(
+            mount_path="/shared-volume-executor-mount-path", name=shared_volume.name
+        )
+        driver_volume = kubernetes.client.V1Volume(
+            name="driver-volume",
+            host_path=kubernetes.client.V1HostPathVolumeSource(
+                path="/driver-volume-host-path", type=""
+            ),
+        )
+        driver_volume_volume_mount = kubernetes.client.V1VolumeMount(
+            mount_path="/driver-mount-path", name=driver_volume.name
+        )
+        executor_volume = kubernetes.client.V1Volume(
+            name="executor-volume",
+            host_path=kubernetes.client.V1HostPathVolumeSource(
+                path="/executor-volume-host-path", type=""
+            ),
+        )
+        executor_volume_volume_mount = kubernetes.client.V1VolumeMount(
+            mount_path="/executor-mount-path", name=executor_volume.name
+        )
+        runtime.with_driver_host_path_volume(
+            shared_volume.host_path.path,
+            shared_volume_driver_volume_mount.mount_path,
+            volume_name=shared_volume.name,
+        )
+        runtime.with_executor_host_path_volume(
+            shared_volume.host_path.path,
+            shared_volume_executor_volume_mount.mount_path,
+            volume_name=shared_volume.name,
+        )
+        runtime.with_driver_host_path_volume(
+            driver_volume.host_path.path,
+            driver_volume_volume_mount.mount_path,
+            volume_name=driver_volume.name,
+        )
+        runtime.with_executor_host_path_volume(
+            executor_volume.host_path.path,
+            executor_volume_volume_mount.mount_path,
+            volume_name=executor_volume.name,
+        )
+        self.execute_function(runtime)
+        self._assert_custom_object_creation_config(
+            expected_volumes=[shared_volume, driver_volume, executor_volume],
+            expected_driver_volume_mounts=[
+                shared_volume_driver_volume_mount,
+                driver_volume_volume_mount,
+            ],
+            expected_executor_volume_mounts=[
+                shared_volume_executor_volume_mount,
+                executor_volume_volume_mount,
+            ],
+        )


### PR DESCRIPTION
* Add `driver_volume_mounts` and `executor_volume_mounts` field to the Spark3JobSpec to enable different volume mounts
* Expose new `with_executor_host_path_volume` and `with_driver_host_path_volume`
* Add test infrastructure for spark runtime

Implements: https://jira.iguazeng.com/browse/ML-1344