### PR TITLE
[API] Add `max-partitions` parameter to list runs endpoint

### DIFF
--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -162,6 +162,7 @@ def list_runs(
     partition_order: mlrun.api.schemas.OrderType = Query(
         mlrun.api.schemas.OrderType.desc, alias="partition-order"
     ),
+    max_partitions: int = Query(0, alias="max-partitions", ge=0),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -189,6 +190,7 @@ def list_runs(
         rows_per_partition,
         partition_sort_by,
         partition_order,
+        max_partitions,
     )
     filtered_runs = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -110,6 +110,7 @@ class Runs(
         rows_per_partition: int = 1,
         partition_sort_by: mlrun.api.schemas.SortField = None,
         partition_order: mlrun.api.schemas.OrderType = mlrun.api.schemas.OrderType.desc,
+        max_partitions: int = 0,
     ):
         project = project or mlrun.mlconf.default_project
         return mlrun.api.utils.singletons.db.get_db().list_runs(
@@ -130,6 +131,7 @@ class Runs(
             rows_per_partition,
             partition_sort_by,
             partition_order,
+            max_partitions,
         )
 
     def delete_run(

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -82,6 +82,7 @@ class DBInterface(ABC):
         rows_per_partition: int = 1,
         partition_sort_by: schemas.SortField = None,
         partition_order: schemas.OrderType = schemas.OrderType.desc,
+        max_partitions: int = 0,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -67,6 +67,7 @@ class FileDB(DBInterface):
         rows_per_partition: int = 1,
         partition_sort_by: schemas.SortField = None,
         partition_order: schemas.OrderType = schemas.OrderType.desc,
+        max_partitions: int = 0,
     ):
         return self._transform_run_db_error(
             self.db.list_runs,
@@ -86,6 +87,7 @@ class FileDB(DBInterface):
             rows_per_partition,
             partition_sort_by,
             partition_order,
+            max_partitions,
         )
 
     def del_run(self, session, uid, project="", iter=0):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -75,6 +75,7 @@ class RunDBInterface(ABC):
         rows_per_partition: int = 1,
         partition_sort_by: Union[schemas.SortField, str] = None,
         partition_order: Union[schemas.OrderType, str] = schemas.OrderType.desc,
+        max_partitions: int = 0,
     ):
         pass
 

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -136,6 +136,7 @@ class FileRunDB(RunDBInterface):
         rows_per_partition: int = 1,
         partition_sort_by: Union[schemas.SortField, str] = None,
         partition_order: Union[schemas.OrderType, str] = schemas.OrderType.desc,
+        max_partitions: int = 0,
     ):
         if partition_by is not None:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -128,6 +128,7 @@ class SQLDB(RunDBInterface):
         rows_per_partition: int = 1,
         partition_sort_by: Union[schemas.SortField, str] = None,
         partition_order: Union[schemas.OrderType, str] = schemas.OrderType.desc,
+        max_partitions: int = 0,
     ):
         import mlrun.api.crud
 
@@ -150,6 +151,7 @@ class SQLDB(RunDBInterface):
             rows_per_partition,
             partition_sort_by,
             partition_order,
+            max_partitions,
         )
 
     def del_run(self, uid, project=None, iter=None):

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -281,6 +281,43 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
         15,
     )
 
+    # partitioned list, specific project, 5 rows per partition, max of 2 partitions, so 2 names * 5 rows = 10
+    runs = _list_and_assert_objects(
+        client,
+        {
+            "project": projects[0],
+            "partition-by": mlrun.api.schemas.RunPartitionByField.name,
+            "partition-sort-by": mlrun.api.schemas.SortField.updated,
+            "partition-order": mlrun.api.schemas.OrderType.desc,
+            "rows-per-partition": 5,
+            "max-partitions": 2,
+        },
+        10,
+    )
+    for run in runs:
+        assert run["metadata"]["name"] in ["run-name-1", "run-name-2"]
+
+    # Complex query, with partitioning and filtering over iter==0
+    runs = _list_and_assert_objects(
+        client,
+        {
+            "project": projects[0],
+            "iter": False,
+            "partition-by": mlrun.api.schemas.RunPartitionByField.name,
+            "partition-sort-by": mlrun.api.schemas.SortField.updated,
+            "partition-order": mlrun.api.schemas.OrderType.desc,
+            "rows-per-partition": 2,
+            "max-partitions": 2,
+        },
+        4,
+    )
+
+    for run in runs:
+        assert (
+            run["metadata"]["name"] in ["run-name-1", "run-name-2"]
+            and run["metadata"]["iter"] == 0
+        )
+
     # Some negative testing - no sort by field
     response = client.get("/api/runs?partition-by=name")
     assert response.status_code == HTTPStatus.BAD_REQUEST.value

--- a/tests/integration/sdk_api/httpdb/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/test_runs.py
@@ -89,15 +89,29 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             iter=True,
         )
 
-        # partitioned list, specific project, 4 rows per partition, max of 2 partitions, so 2 names * 4 rows = 8
+        # partitioned list, specific project, 5 rows per partition, max of 2 partitions, so 2 names * 5 rows = 10
         runs = _list_and_assert_objects(
-            8,
+            10,
+            project=projects[0],
+            partition_by=mlrun.api.schemas.RunPartitionByField.name,
+            partition_sort_by=mlrun.api.schemas.SortField.updated,
+            partition_order=mlrun.api.schemas.OrderType.desc,
+            rows_per_partition=5,
+            max_partitions=2,
+            iter=True,
+        )
+
+        # partitioned list, specific project, 4 rows per partition, max of 2 partitions, but only iter=0 so each
+        # partition has 3 rows, so 2 * 3 = 6
+        runs = _list_and_assert_objects(
+            6,
             project=projects[0],
             partition_by=mlrun.api.schemas.RunPartitionByField.name,
             partition_sort_by=mlrun.api.schemas.SortField.updated,
             partition_order=mlrun.api.schemas.OrderType.desc,
             rows_per_partition=4,
             max_partitions=2,
+            iter=False,
         )
 
         # Some negative testing - no sort by field

--- a/tests/integration/sdk_api/httpdb/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/test_runs.py
@@ -89,6 +89,17 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             iter=True,
         )
 
+        # partitioned list, specific project, 4 rows per partition, max of 2 partitions, so 2 names * 4 rows = 8
+        runs = _list_and_assert_objects(
+            8,
+            project=projects[0],
+            partition_by=mlrun.api.schemas.RunPartitionByField.name,
+            partition_sort_by=mlrun.api.schemas.SortField.updated,
+            partition_order=mlrun.api.schemas.OrderType.desc,
+            rows_per_partition=4,
+            max_partitions=2,
+        )
+
         # Some negative testing - no sort by field
         with pytest.raises(mlrun.errors.MLRunBadRequestError):
             _list_and_assert_objects(


### PR DESCRIPTION
The list runs API supports partitioning over run name, but there was no good way to limit the number of runs returned while maintaining the internal number of rows per partition. Specifically, if we want to list the first 5 runs (per name) and for each show the 5 last executions, there was no way to do so. 
This PR adds the `max-partitions` parameter to the API which allows to determine how many partitions (== run names) to return. These will be ordered by the name of the run in ascending order. The new parameter is of course optional, and by default equals 0 which means no filtering.

This is the backend part of the fix needed for https://jira.iguazeng.com/browse/ML-2114.
