### PR TITLE
[Frameworks] Fix to logging the target columns in favor of model monitoring

### DIFF
--- a/mlrun/frameworks/_ml_common/mlrun_interface.py
+++ b/mlrun/frameworks/_ml_common/mlrun_interface.py
@@ -231,12 +231,10 @@ class MLMLRunInterface(MLRunInterface, ABC):
             # Set the sample set to the training set if None:
             if self._model_handler.sample_set is None:
                 sample_set, y_columns = concatenate_x_y(
-                        x=x, y=y, y_columns=self._model_handler.y_columns
-                    )
-                self._model_handler.set_y_columns(y_columns=y_columns)
-                self._model_handler.set_sample_set(
-                    sample_set=sample_set
+                    x=x, y=y, y_columns=self._model_handler.y_columns
                 )
+                self._model_handler.set_y_columns(y_columns=y_columns)
+                self._model_handler.set_sample_set(sample_set=sample_set)
             # Log the model:
             self._logger.log_run(model_handler=self._model_handler)
 

--- a/mlrun/frameworks/_ml_common/mlrun_interface.py
+++ b/mlrun/frameworks/_ml_common/mlrun_interface.py
@@ -230,10 +230,12 @@ class MLMLRunInterface(MLRunInterface, ABC):
         if self._model_handler is not None:
             # Set the sample set to the training set if None:
             if self._model_handler.sample_set is None:
-                self._model_handler.set_sample_set(
-                    sample_set=concatenate_x_y(
+                sample_set, y_columns = concatenate_x_y(
                         x=x, y=y, y_columns=self._model_handler.y_columns
-                    )[0]
+                    )
+                self._model_handler.set_y_columns(y_columns=y_columns)
+                self._model_handler.set_sample_set(
+                    sample_set=sample_set
                 )
             # Log the model:
             self._logger.log_run(model_handler=self._model_handler)

--- a/mlrun/frameworks/sklearn/__init__.py
+++ b/mlrun/frameworks/sklearn/__init__.py
@@ -103,11 +103,10 @@ def apply_mlrun(
     :param y_test:                   The test data ground truth for producing and calculating artifacts and metrics post
                                      training or post predict / predict_proba.
     :param sample_set:               A sample set of inputs for the model for logging its stats along the model in
-                                     favour of model monitoring.
+                                     favour of model monitoring. If not given the 'x_train' will be used by default.
     :param y_columns:                List of names of all the columns in the ground truth labels in case its a
                                      pd.DataFrame or a list of integers in case the dataset is a np.ndarray. If not
-                                     given but 'y_train' / 'y_test' is given then the labels / indices in it will be
-                                     used by default.
+                                     given 'y_train' is given then the labels / indices in it will be used by default.
     :param feature_vector:           Feature store feature vector uri (store://feature-vectors/<project>/<name>[:tag])
     :param feature_weights:          List of feature weights, one per input column.
     :param labels:                   Labels to log with the model.


### PR DESCRIPTION
When the attribute `y_columns` was not provided the columns in `y_train` should have been used, now they are.