### PR TITLE
[Runtimes] Fix `build_config()` to preserve commands order

### DIFF
--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -121,7 +121,8 @@ class KubejobRuntime(KubeResource):
                 raise ValueError("commands must be a string list")
             self.spec.build.commands = self.spec.build.commands or []
             self.spec.build.commands += commands
-            self.spec.build.commands = list(set(self.spec.build.commands))
+            # using list(set(x)) won't retain order, solution inspired from https://stackoverflow.com/a/17016257/8116661
+            self.spec.build.commands = list(dict.fromkeys(self.spec.build.commands))
         if extra:
             self.spec.build.extra = extra
         if secret:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -53,6 +53,22 @@ def test_build_config_with_multiple_commands():
     assert len(fn.spec.build.commands) == 2
 
 
+def test_build_config_preserve_order():
+    function = mlrun.new_function(
+        "some-function", kind="job"
+    )
+    # run a lot of times as order change
+    commands = []
+    for index in range(10):
+        commands.append(str(index))
+    # when using un-stable (doesn't preserve order) methods to make a list unique (like list(set(x))) it's random
+    # whether the order will be preserved, therefore run in a loop
+    for _ in range(100):
+        function.spec.build.commands = []
+        function.build_config(commands=commands)
+        assert function.spec.build.commands == commands
+
+
 def test_build_runtime_insecure_registries(monkeypatch):
     _patch_k8s_helper(monkeypatch)
     mlrun.mlconf.httpdb.builder.docker_registry = "registry.hub.docker.com/username"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -54,9 +54,7 @@ def test_build_config_with_multiple_commands():
 
 
 def test_build_config_preserve_order():
-    function = mlrun.new_function(
-        "some-function", kind="job"
-    )
+    function = mlrun.new_function("some-function", kind="job")
     # run a lot of times as order change
     commands = []
     for index in range(10):


### PR DESCRIPTION
https://github.com/mlrun/mlrun/pull/1783 used `list(set(x))` (to ensure uniqueness) but it caused to lose the order
Fixes https://jira.iguazeng.com/browse/ML-2140