### PR TITLE
[System Tests] Fix broken test due to artifacts refactor

### DIFF
--- a/mlrun/lists.py
+++ b/mlrun/lists.py
@@ -23,7 +23,7 @@ import mlrun.frameworks
 from .artifacts import Artifact, dict_to_artifact
 from .config import config
 from .render import artifacts_to_html, runs_to_html
-from .utils import flatten, get_artifact_target, get_in
+from .utils import flatten, get_artifact_target, get_in, is_legacy_artifact
 
 list_header = [
     "project",
@@ -167,21 +167,22 @@ class ArtifactList(list):
         """return the artifact list as flattened rows"""
         rows = []
         head = {
-            "tree": "",
-            "key": "",
-            "iter": "",
-            "kind": "",
-            "path": "target_path",
-            "hash": "",
-            "viewer": "",
-            "updated": "",
-            "description": "",
-            "producer": "",
-            "sources": "",
-            "labels": "",
+            "tree": ["tree", "metadata.tree"],
+            "key": ["key", "metadata.key"],
+            "iter": ["iter", "metadata.iter"],
+            "kind": ["kind", "kind"],
+            "path": ["target_path", "spec.target_path"],
+            "hash": ["hash", "metadata.hash"],
+            "viewer": ["viewer", "spec.viewer"],
+            "updated": ["updated", "metadata.updated"],
+            "description": ["description", "metadata.description"],
+            "producer": ["producer", "spec.producer"],
+            "sources": ["sources", "spec.sources"],
+            "labels": ["labels", "metadata.labels"],
         }
         for artifact in self:
-            row = [get_in(artifact, v or k, "") for k, v in head.items()]
+            fields_index = 0 if is_legacy_artifact(artifact) else 1
+            row = [get_in(artifact, v[fields_index], "") for k, v in head.items()]
             rows.append(row)
 
         return [head.keys()] + rows

--- a/tests/system/examples/basics/test_db.py
+++ b/tests/system/examples/basics/test_db.py
@@ -61,3 +61,8 @@ class TestDB(TestMLRunSystem):
                     artifact_exists = True
                     break
             assert artifact_exists
+
+        # Verify that ArtifactList methods process result properly
+        result_keys = artifacts.to_df().to_dict(orient="list")["key"]
+        for artifact_key in ["chart", "html_result", "model", "mydf"]:
+            assert artifact_key in result_keys

--- a/tests/system/examples/basics/test_db.py
+++ b/tests/system/examples/basics/test_db.py
@@ -57,7 +57,7 @@ class TestDB(TestMLRunSystem):
         for artifact_key in ["chart", "html_result", "model", "mydf"]:
             artifact_exists = False
             for artifact in artifacts:
-                if artifact["key"] == artifact_key:
+                if artifact["metadata"]["key"] == artifact_key:
                     artifact_exists = True
                     break
             assert artifact_exists


### PR DESCRIPTION
Was looking for `key` in the wrong place.
Also fixed the `ArtifactList` functionality which would generate empty results when using `to_df()` or similar methods on objects of the new format. This was not tested anywhere and not sure if anyone uses it. Still, added a small test to verify the results have contents (at least the `key` field).