### PR TITLE
[Runtimes] Fix jobs stuck in non-terminal state after node drain/preemption

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -564,7 +564,7 @@ class Config:
             )
         return resources
 
-    def resolve_debouncing_period_for_non_terminal_state_run_without_resource(self):
+    def resolve_runs_monitoring_missing_runtime_resources_debouncing_interval(self):
         return (
             float(self.runs_monitoring_missing_runtime_resources_debouncing_interval)
             if self.runs_monitoring_missing_runtime_resources_debouncing_interval

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -91,7 +91,7 @@ default_config = {
     "runs_monitoring_interval": "30",
     # runs monitoring debouncing interval in seconds for run with non-terminal state without corresponding k8s resource
     # by default the interval will be - (runs_monitoring_interval * 2 ), if set will override the default
-    "runs_monitoring_non_terminal_run_without_resource_debouncing_interval": None,
+    "runs_monitoring_missing_runtime_resources_debouncing_interval": None,
     # the grace period (in seconds) that will be given to runtime resources (after they're in terminal state)
     # before deleting them
     "runtime_resources_deletion_grace_period": "14400",
@@ -567,9 +567,9 @@ class Config:
     def resolve_debouncing_period_for_non_terminal_state_run_without_resource(self):
         return (
             float(
-                self.runs_monitoring_non_terminal_run_without_resource_debouncing_interval
+                self.runs_monitoring_missing_runtime_resources_debouncing_interval
             )
-            if self.runs_monitoring_non_terminal_run_without_resource_debouncing_interval
+            if self.runs_monitoring_missing_runtime_resources_debouncing_interval
             else float(config.runs_monitoring_interval) * 2.0
         )
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -89,6 +89,9 @@ default_config = {
     "runtimes_cleanup_interval": "300",
     # runs monitoring interval in seconds
     "runs_monitoring_interval": "30",
+    # runs monitoring debouncing interval in seconds for run with non-terminal state without corresponding k8s resource
+    # by default the interval will be - (runs_monitoring_interval * 2 ), if set will override the default
+    "runs_monitoring_non_terminal_run_without_resource_debouncing_interval": None,
     # the grace period (in seconds) that will be given to runtime resources (after they're in terminal state)
     # before deleting them
     "runtime_resources_deletion_grace_period": "14400",
@@ -560,6 +563,15 @@ class Config:
                 requirement, with_gpu
             )
         return resources
+
+    def resolve_debouncing_period_for_non_terminal_state_run_without_resource(self):
+        return (
+            float(
+                self.runs_monitoring_non_terminal_run_without_resource_debouncing_interval
+            )
+            if self.runs_monitoring_non_terminal_run_without_resource_debouncing_interval
+            else float(config.runs_monitoring_interval) * 2.0
+        )
 
     @staticmethod
     def get_default_function_pod_requirement_resources(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -566,9 +566,7 @@ class Config:
 
     def resolve_debouncing_period_for_non_terminal_state_run_without_resource(self):
         return (
-            float(
-                self.runs_monitoring_missing_runtime_resources_debouncing_interval
-            )
+            float(self.runs_monitoring_missing_runtime_resources_debouncing_interval)
             if self.runs_monitoring_missing_runtime_resources_debouncing_interval
             else float(config.runs_monitoring_interval) * 2.0
         )

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1292,9 +1292,6 @@ class BaseRuntimeHandler(ABC):
                     exc=str(exc),
                     traceback=traceback.format_exc(),
                 )
-        project_run_uid_map = self._list_runs_for_monitoring(
-            db, db_session, states=RunStates.non_terminal_states()
-        )
         for project, runs in project_run_uid_map.items():
             if runs:
                 for run_uid, run in runs.items():

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1360,6 +1360,8 @@ class BaseRuntimeHandler(ABC):
                     debounce_period=debounce_period,
                 )
             if last_update > now - timedelta(seconds=debounce_period):
+                # we are setting non-terminal states to runs before the run is actually applied to k8s, that is
+                # why we want to give a grace period in case that is the situation and the resource hasn't been applied
                 logger.warning(
                     "Monitoring did not discover a runtime resource that corresponded to a run in a "
                     "non-terminal state. but record has recently updated. Debouncing",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1308,7 +1308,7 @@ class BaseRuntimeHandler(ABC):
                         )
                     except Exception as exc:
                         logger.warning(
-                            "Failed monitoring run. Continuing",
+                            "Failed ensuring run not stuck. Continuing",
                             run_uid=run_uid,
                             run=run,
                             project=project,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1316,7 +1316,7 @@ class BaseRuntimeHandler(ABC):
         if not db_run_state:
             # can't do any verification due to no run_state updated
             return
-        if db_run_state not in RunStates.terminal_states():
+        if db_run_state in RunStates.k8s_non_terminal_states():
             for runtime_resource in runtime_resources:
                 (
                     run_project,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1357,7 +1357,7 @@ class BaseRuntimeHandler(ABC):
                 return
             last_update_str = run.get("status", {}).get("last_update")
             debounce_period = (
-                config.resolve_debouncing_period_for_non_terminal_state_run_without_resource()
+                config.resolve_runs_monitoring_missing_runtime_resources_debouncing_interval()
             )
             if last_update_str is None:
                 logger.info(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1292,7 +1292,9 @@ class BaseRuntimeHandler(ABC):
                     exc=str(exc),
                     traceback=traceback.format_exc(),
                 )
-        project_run_uid_map = self._list_runs_for_monitoring(db, db_session, states=RunStates.non_terminal_states())
+        project_run_uid_map = self._list_runs_for_monitoring(
+            db, db_session, states=RunStates.non_terminal_states()
+        )
         for project, runs in project_run_uid_map.items():
             if runs:
                 for run_uid, run in runs.items():
@@ -1339,12 +1341,13 @@ class BaseRuntimeHandler(ABC):
         if not db_run_state:
             # we are setting the run state to a terminal state to avoid log spamming, this is mainly sanity as we are
             # setting state to runs when storing new runs.
-            logger.info("Runs monitoring found a run without state, updating to a terminal state",
-                        project=project,
-                        uid=run_uid,
-                        db_run_state=db_run_state,
-                        now=now,
-                        )
+            logger.info(
+                "Runs monitoring found a run without state, updating to a terminal state",
+                project=project,
+                uid=run_uid,
+                db_run_state=db_run_state,
+                now=now,
+            )
             run.setdefault("status", {})["state"] = RunStates.absent
             run.setdefault("status", {})["last_update"] = now.isoformat()
             db.store_run(db_session, run, run_uid, project)
@@ -1373,7 +1376,9 @@ class BaseRuntimeHandler(ABC):
                 db.store_run(db_session, run, run_uid, project)
                 return
 
-            if datetime.fromisoformat(last_update_str) > now - timedelta(seconds=debounce_period):
+            if datetime.fromisoformat(last_update_str) > now - timedelta(
+                seconds=debounce_period
+            ):
                 # we are setting non-terminal states to runs before the run is actually applied to k8s, meaning there is
                 # a timeframe where the run exists and no runtime resources exist and it's ok, therefore we're applying
                 # a debounce period before setting the state to absent
@@ -1388,7 +1393,9 @@ class BaseRuntimeHandler(ABC):
                     debounce_period=debounce_period,
                 )
             else:
-                logger.info("Updating run state", run_uid=run_uid, run_state=RunStates.absent)
+                logger.info(
+                    "Updating run state", run_uid=run_uid, run_state=RunStates.absent
+                )
                 run.setdefault("status", {})["state"] = RunStates.absent
                 run.setdefault("status", {})["last_update"] = now.isoformat()
                 db.store_run(db_session, run, run_uid, project)
@@ -1908,10 +1915,7 @@ class BaseRuntimeHandler(ABC):
         return True, last_update
 
     def _list_runs_for_monitoring(
-        self,
-        db: DBInterface,
-        db_session: Session,
-        states: list = None
+        self, db: DBInterface, db_session: Session, states: list = None
     ):
         runs = db.list_runs(db_session, project="*", states=states)
         project_run_uid_map = {}

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -85,6 +85,13 @@ class RunStates(object):
     def non_terminal_states():
         return list(set(RunStates.all()) - set(RunStates.terminal_states()))
 
+    @staticmethod
+    def k8s_non_terminal_states():
+        return [
+            RunStates.pending,
+            RunStates.running,
+        ]
+
 
 class SparkApplicationStates:
     """

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -60,7 +60,7 @@ class RunStates(object):
     pending = "pending"
     unknown = "unknown"
     aborted = "aborted"
-    gone = "gone"
+    absent = "absent"
 
     @staticmethod
     def all():
@@ -72,7 +72,7 @@ class RunStates(object):
             RunStates.pending,
             RunStates.unknown,
             RunStates.aborted,
-            RunStates.gone,
+            RunStates.absent,
         ]
 
     @staticmethod
@@ -81,19 +81,12 @@ class RunStates(object):
             RunStates.completed,
             RunStates.error,
             RunStates.aborted,
-            RunStates.gone,
+            RunStates.absent,
         ]
 
     @staticmethod
     def non_terminal_states():
         return list(set(RunStates.all()) - set(RunStates.terminal_states()))
-
-    @staticmethod
-    def k8s_non_terminal_states():
-        return [
-            RunStates.pending,
-            RunStates.running,
-        ]
 
 
 class SparkApplicationStates:

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -60,6 +60,7 @@ class RunStates(object):
     pending = "pending"
     unknown = "unknown"
     aborted = "aborted"
+    gone = "gone"
 
     @staticmethod
     def all():
@@ -71,6 +72,7 @@ class RunStates(object):
             RunStates.pending,
             RunStates.unknown,
             RunStates.aborted,
+            RunStates.gone,
         ]
 
     @staticmethod
@@ -79,6 +81,7 @@ class RunStates(object):
             RunStates.completed,
             RunStates.error,
             RunStates.aborted,
+            RunStates.gone,
         ]
 
     @staticmethod

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -195,7 +195,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "runs_monitoring_interval": 30,
                 "debouncing_interval": 100,
                 "list_namespaced_pods_calls": [[], [], []],
-                "interval_time_to_add_to_run_update_time": -50,
+                "interval_time_to_add_to_run_update_time": -70,
                 "start_run_states": RunStates.non_terminal_states(),
                 "expected_reached_state": RunStates.non_terminal_states(),
             },
@@ -238,7 +238,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "runs_monitoring_interval", 0
             )
 
-            config.runs_monitoring_non_terminal_run_without_resource_debouncing_interval = test_case.get(
+            config.runs_monitoring_missing_runtime_resources_debouncing_interval = test_case.get(
                 "debouncing_interval", None
             )
 

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -222,8 +222,9 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler, expected_number_of_list_pods_calls
         )
 
-        self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.created)
-
+        self._assert_run_reached_state(
+            db, self.project, self.run_uid, RunStates.created
+        )
 
     def test_monitor_run_debouncing_non_terminal_state_without_resource(
         self, db: Session, client: TestClient

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -186,7 +186,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "list_namespaced_pods_calls": [[]],
                 "interval_time_to_add_to_run_update_time": 0,
                 "start_run_states": RunStates.non_terminal_states(),
-                "expected_reached_state": RunStates.gone,
+                "expected_reached_state": RunStates.absent,
             },
             # monitoring interval and debouncing interval are configured which means debouncing interval will
             # be the debounce period, run is still in the debounce period that's why expecting not to override state
@@ -200,7 +200,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "expected_reached_state": RunStates.non_terminal_states(),
             },
             # monitoring interval and debouncing interval are configured which means debouncing interval will
-            # be the debounce period, run isn't still in the debounce period that's why expecting to override state
+            # be the debounce period, run update time passed the debounce period that's why expecting to override state
             # to terminal state
             {
                 "runs_monitoring_interval": 30,
@@ -208,7 +208,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "list_namespaced_pods_calls": [[], [], []],
                 "interval_time_to_add_to_run_update_time": -200,
                 "start_run_states": RunStates.non_terminal_states(),
-                "expected_reached_state": RunStates.gone,
+                "expected_reached_state": RunStates.absent,
             },
             # monitoring interval configured and debouncing interval isn't configured which means
             # monitoring interval * 2 will be the debounce period.
@@ -219,7 +219,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "list_namespaced_pods_calls": [[], [], []],
                 "interval_time_to_add_to_run_update_time": -65,
                 "start_run_states": RunStates.non_terminal_states(),
-                "expected_reached_state": RunStates.gone,
+                "expected_reached_state": RunStates.absent,
             },
             # monitoring interval configured and debouncing interval isn't configured which means
             # monitoring interval * 2 will be the debounce period.
@@ -255,6 +255,8 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             for idx in range(len(start_run_states)):
                 self.run["status"]["state"] = start_run_states[idx]
 
+                # using freeze enables us to set the now attribute when calling the sub-function
+                # _update_run_updated_time without the need to call the function directly
                 original_update_run_updated_time = (
                     mlrun.api.utils.singletons.db.get_db()._update_run_updated_time
                 )

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -238,8 +238,8 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "runs_monitoring_interval", 0
             )
 
-            config.runs_monitoring_missing_runtime_resources_debouncing_interval = test_case.get(
-                "debouncing_interval", None
+            config.runs_monitoring_missing_runtime_resources_debouncing_interval = (
+                test_case.get("debouncing_interval", None)
             )
 
             list_namespaced_pods_calls = test_case.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,12 @@ def new_run(state, labels, uid=None, **kw):
 
 
 def freeze(f, **kwargs):
+    """
+    Enables to override an attribute passed to a sub-function without the need to access the function directly.
+    :param f: the function we want to pass the attribute to
+    :param kwargs: dictionary containing name(key) and value of the attributes to override.
+    :return: wrapped function with overridden attributes
+    """
     frozen = kwargs
 
     def wrapper(*args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def new_run(state, labels, uid=None, **kw):
 
 def freeze(f, **kwargs):
     """
-    Enables to override an attribute passed to a sub-function without the need to access the function directly.
+    Enables to override an attribute passed to a sub-function without the need to access the function directly
     :param f: the function we want to pass the attribute to
     :param kwargs: dictionary containing name(key) and value of the attributes to override.
     :return: wrapped function with overridden attributes


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-758
https://jira.iguazeng.com/browse/ML-679

Previously, we monitored tasks by looping over the k8s resources and then looking for the corresponding runs recorded in the database.
This caused a bug in which when a job was monitored in non-terminal state and then the node the job was running on was evicted / preempted in the time between monitoring cycles, the next time the monitoring started running it didn't find the corresponding k8s resource and the job was stuck forever as non-terminal. This has a significant impact on scheduled jobs that could not be scheduled until the job was brought to a terminal state.

The addition I've made is that now, in addition to cycling over the listed k8s resources, we also cycle through the runs recorded in the database, looking for runs that are in kubernetes non-terminal state but do not have a corresponding k8s resource.