### PR TITLE
[Runtimes] Add java options spark job parameters

### DIFF
--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -100,6 +100,8 @@ class AbstractSparkJobSpec(KubeResourceSpec):
         "main_class",
         "spark_conf",
         "hadoop_conf",
+        "driver_java_options",
+        "executor_java_options",
         "use_default_image",
     ]
 
@@ -132,6 +134,8 @@ class AbstractSparkJobSpec(KubeResourceSpec):
         build=None,
         spark_conf=None,
         hadoop_conf=None,
+        driver_java_options=None,
+        executor_java_options=None,
         node_selector=None,
         use_default_image=False,
         priority_class_name=None,
@@ -179,6 +183,8 @@ class AbstractSparkJobSpec(KubeResourceSpec):
         )
         self.spark_conf = spark_conf or {}
         self.hadoop_conf = hadoop_conf or {}
+        self.driver_java_options = driver_java_options
+        self.executor_java_options = executor_java_options
         self.job_type = job_type
         self.python_version = python_version
         self.spark_version = spark_version

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -100,8 +100,6 @@ class AbstractSparkJobSpec(KubeResourceSpec):
         "main_class",
         "spark_conf",
         "hadoop_conf",
-        "driver_java_options",
-        "executor_java_options",
         "use_default_image",
     ]
 
@@ -134,8 +132,6 @@ class AbstractSparkJobSpec(KubeResourceSpec):
         build=None,
         spark_conf=None,
         hadoop_conf=None,
-        driver_java_options=None,
-        executor_java_options=None,
         node_selector=None,
         use_default_image=False,
         priority_class_name=None,
@@ -183,8 +179,6 @@ class AbstractSparkJobSpec(KubeResourceSpec):
         )
         self.spark_conf = spark_conf or {}
         self.hadoop_conf = hadoop_conf or {}
-        self.driver_java_options = driver_java_options
-        self.executor_java_options = executor_java_options
         self.job_type = job_type
         self.python_version = python_version
         self.spark_version = spark_version

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -374,6 +374,18 @@ class Spark3Runtime(AbstractSparkRuntime):
                 self.spec.executor_volume_mounts,
                 append=True,
             )
+        if self.spec.driver_java_options:
+            update_in(
+                job,
+                "spec.driver.javaOptions",
+                self.spec.driver_java_options,
+            )
+        if self.spec.executor_java_options:
+            update_in(
+                job,
+                "spec.executor.javaOptions",
+                self.spec.executor_java_options,
+            )
         return
 
     def _get_spark_version(self):

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -39,6 +39,8 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         "executor_preemption_mode",
         "driver_volume_mounts",
         "executor_volume_mounts",
+        "driver_java_options",
+        "executor_java_options",
     ]
 
     def __init__(
@@ -91,6 +93,8 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         driver_preemption_mode=None,
         driver_volume_mounts=None,
         executor_volume_mounts=None,
+        driver_java_options=None,
+        executor_java_options=None,
     ):
 
         super().__init__(
@@ -146,6 +150,8 @@ class Spark3JobSpec(AbstractSparkJobSpec):
         self.driver_volume_mounts = driver_volume_mounts or {}
         self._executor_volume_mounts = {}
         self.executor_volume_mounts = executor_volume_mounts or {}
+        self.driver_java_options = driver_java_options
+        self.executor_java_options = executor_java_options
 
     def to_dict(self, fields=None, exclude=None):
         struct = super().to_dict(

--- a/tests/api/runtimes/test_spark.py
+++ b/tests/api/runtimes/test_spark.py
@@ -29,6 +29,24 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
             runtime.with_driver_requests(cpu=1, mem="512m")
         return runtime
 
+    def _assert_java_options(
+        self,
+        body: dict,
+        expected_driver_java_options: str,
+        expected_executor_java_options: str,
+    ):
+        if expected_driver_java_options:
+            assert body["spec"]["driver"]["javaOptions"] == expected_driver_java_options
+        else:
+            assert "javaOptions" not in body["spec"]["driver"]
+        if expected_executor_java_options:
+            assert (
+                body["spec"]["executor"]["javaOptions"]
+                == expected_executor_java_options
+            )
+        else:
+            assert "javaOptions" not in body["spec"]["executor"]
+
     def _assert_custom_object_creation_config(
         self,
         expected_runtime_class_name="spark",
@@ -36,6 +54,8 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
         expected_volumes: typing.Optional[list] = None,
         expected_driver_volume_mounts: typing.Optional[list] = None,
         expected_executor_volume_mounts: typing.Optional[list] = None,
+        expected_driver_java_options=None,
+        expected_executor_java_options=None,
     ):
         if assert_create_custom_object_called:
             mlrun.api.utils.singletons.k8s.get_k8s().crdapi.create_namespaced_custom_object.assert_called_once()
@@ -49,6 +69,10 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
             expected_volumes,
             expected_driver_volume_mounts,
             expected_executor_volume_mounts,
+        )
+
+        self._assert_java_options(
+            body, expected_driver_java_options, expected_executor_java_options
         )
 
     def _assert_volume_and_mounts(
@@ -167,4 +191,18 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
                 shared_volume_executor_volume_mount,
                 executor_volume_volume_mount,
             ],
+        )
+
+    def test_java_options(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        runtime = self._generate_runtime()
+        driver_java_options = "-Dmyproperty=somevalue"
+        runtime.spec.driver_java_options = driver_java_options
+        executor_java_options = "-Dmyotherproperty=someothervalue"
+        runtime.spec.executor_java_options = executor_java_options
+        self.execute_function(runtime)
+        self._assert_custom_object_creation_config(
+            expected_driver_java_options=driver_java_options,
+            expected_executor_java_options=executor_java_options,
         )


### PR DESCRIPTION
ML-1979

Usage:
```
sj.spec.driver_java_options="-Dlog4j.configuration=file:///v3io/bigdata/log4j.properties"
sj.spec.executor_java_options="-Dlog4j.configuration=file:///v3io/bigdata/log4j.properties"
```