### PR TITLE
[API] Support clusterization roles

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -186,7 +186,8 @@ async def move_api_to_online():
     # periodic functions should only run on the chief instance
     if (
         get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster()
-        and config.httpdb.clusterization.role == "chief"
+        and config.httpdb.clusterization.role
+        == mlrun.api.schemas.ClusterizationRole.chief
     ):
         _start_periodic_cleanup()
         _start_periodic_runs_monitoring()

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -182,8 +182,12 @@ async def move_api_to_online():
     logger.info("Moving api to online")
     initialize_project_member()
     await initialize_scheduler()
-    # periodic cleanup is not needed if we're not inside kubernetes cluster
-    if get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+    # runs cleanup/monitoring is not needed if we're not inside kubernetes cluster
+    # periodic functions should only run on the chief instance
+    if (
+        get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster()
+        and config.httpdb.clusterization.role == "chief"
+    ):
         _start_periodic_cleanup()
         _start_periodic_runs_monitoring()
 

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -19,6 +19,7 @@ from .background_task import (
 from .client_spec import ClientSpec
 from .constants import (
     APIStates,
+    ClusterizationRole,
     DeletionStrategy,
     FeatureStorePartitionByField,
     HeaderNames,

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -147,3 +147,8 @@ class APIStates:
     migrations_failed = "migrations_failed"
     migrations_completed = "migrations_completed"
     offline = "offline"
+
+
+class ClusterizationRole:
+    chief = "chief"
+    worker = "worker"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -132,6 +132,10 @@ default_config = {
         "preemption_mode": "prevent",
     },
     "httpdb": {
+        "clusterization": {
+            # one of chief/worker
+            "role": "chief",
+        },
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),
         "dsn": "sqlite:///db/mlrun.db?check_same_thread=false",


### PR DESCRIPTION
We're starting a process of making the API stateless in order to be able to run multiple instances of it
Some things, like the periodic functions (runs monitoring/cleanup) don't need to run on all instances, therefore we're introducing a new clusterization role config value which define whether the instance is a chief or a worker