### PR TITLE
[Artifacts] Fix infinite recursive call to `TableArtifact.get_body()`

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -93,7 +93,7 @@ class TableArtifact(Artifact):
         if not self._is_df:
             return self.spec.get_body()
         csv_buffer = StringIO()
-        self.get_body().to_csv(csv_buffer, line_terminator="\n", encoding="utf-8")
+        self.spec.get_body().to_csv(csv_buffer, line_terminator="\n", encoding="utf-8")
         return csv_buffer.getvalue()
 
 

--- a/tests/artifacts/test_table.py
+++ b/tests/artifacts/test_table.py
@@ -1,0 +1,27 @@
+import pandas
+import pytest
+
+import mlrun.artifacts.dataset
+
+
+# Verify TableArtifact.get_body() doesn't hang (ML-2184)
+@pytest.mark.parametrize("use_dataframe", [True, False])
+def test_table_artifact_get_body(use_dataframe):
+    artifact = _generate_table_artifact(use_dataframe=use_dataframe)
+
+    artifact_body = artifact.get_body()
+    print("Artifact body:\n" + artifact_body)
+    assert artifact_body is not None
+
+
+def _generate_table_artifact(use_dataframe=True):
+    if use_dataframe:
+        data_frame = pandas.DataFrame({"x": [1, 2]})
+    else:
+        body = "just an artifact body"
+
+    artifact = mlrun.artifacts.dataset.TableArtifact(
+        df=data_frame if use_dataframe else None,
+        body=body if not use_dataframe else None,
+    )
+    return artifact


### PR DESCRIPTION
The `TableArtifact.get_body()` function called itself recursively instead of calling `spec.get_body()`.
Fixes [ML-2184](https://jira.iguazeng.com/browse/ML-2184)