### PR TITLE
[Projects] Fix/support archives with project run/build/deploy methods

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -129,6 +129,7 @@ def run_function(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels
         )
     else:
+        project = project_object or pipeline_context.project
         if pipeline_context.workflow:
             local = local or pipeline_context.workflow.run_local
         task.metadata.labels = task.metadata.labels or labels or {}
@@ -137,6 +138,8 @@ def run_function(
         if function.kind == "local":
             command, function = mlrun.run.load_func_code(function)
             function.spec.command = command
+        if local and project and function.spec.build.source:
+            workdir = workdir or project.spec.get_code_path()
         run_result = function.run(
             name=name,
             runspec=task,
@@ -159,9 +162,10 @@ def run_function(
 class BuildStatus:
     """returned status from build operation"""
 
-    def __init__(self, ready, outputs={}):
+    def __init__(self, ready, outputs={}, function=None):
         self.ready = ready
         self.outputs = outputs
+        self.function = function
 
     def after(self, step):
         """nil function, for KFP compatibility"""
@@ -235,15 +239,16 @@ def build_function(
             builder_env=builder_env,
         )
         # return object with the same outputs as the KFP op (allow using the same pipeline)
-        return BuildStatus(ready, {"image": function.spec.image})
+        return BuildStatus(ready, {"image": function.spec.image}, function=function)
 
 
 class DeployStatus:
     """returned status from deploy operation"""
 
-    def __init__(self, state, outputs={}):
+    def __init__(self, state, outputs={}, function=None):
         self.state = state
         self.outputs = outputs
+        self.function = function
 
     def after(self, step):
         """nil function, for KFP compatibility"""
@@ -296,4 +301,5 @@ def deploy_function(
         return DeployStatus(
             state=function.status.state,
             outputs={"endpoint": address, "name": function.status.nuclio_name},
+            function=function,
         )

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -311,6 +311,7 @@ def enrich_function_object(
         else:
             f.spec.build.source = project.spec.source
             f.spec.build.load_source_on_run = project.spec.load_source_on_run
+            f.spec.workdir = project.spec.workdir or project.spec.subpath
             f.verify_base_image()
 
     if project.spec.default_requirements:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -291,7 +291,7 @@ def get_or_create_project(
         return project
 
     except mlrun.errors.MLRunNotFoundError:
-        spec_path = path.join(context, subpath, "project.yaml")
+        spec_path = path.join(context, subpath or "", "project.yaml")
         if url or path.isfile(spec_path):
             # load project from archive or local project.yaml
             project = load_project(
@@ -2620,4 +2620,6 @@ def _init_function_from_obj_legacy(func, project, name=None):
 
 
 def _has_module(handler, kind):
+    if not handler:
+        return False
     return (kind in RuntimeKinds.nuclio_runtimes() and ":" in handler) or "." in handler

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -14,6 +14,7 @@
 
 import importlib.util as imputil
 import json
+import os
 import pathlib
 import socket
 import tempfile
@@ -172,6 +173,7 @@ def run_local(
     kind = "local" if isinstance(handler, str) and "." in handler else ""
     fn = new_function(meta.name, command=command, args=args, mode=mode, kind=kind)
     fn.metadata = meta
+    setattr(fn, "_is_run_local", True)
     if workdir:
         fn.spec.workdir = str(workdir)
     fn.spec.allow_empty_resources = allow_empty_resources
@@ -226,6 +228,7 @@ def function_to_module(code="", workdir=None, secrets=None, silent=False):
             return None
         raise ValueError("nothing to run, specify command or function")
 
+    command = os.path.join(workdir or "", command)
     path = Path(command)
     mod_name = path.name
     if path.suffix:
@@ -278,9 +281,9 @@ def load_func_code(command="", workdir=None, secrets=None, name="name"):
                     temp_file.write(code)
 
         elif command and not is_remote:
-            command = path.join(workdir or "", command)
-            if not path.isfile(command):
-                raise OSError(f"command file {command} not found")
+            file_path = path.join(workdir or "", command)
+            if not path.isfile(file_path):
+                raise OSError(f"command file {file_path} not found")
 
         else:
             logger.warn("run command, file or code were not specified")

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -252,7 +252,7 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
         execution._current_workdir = workdir
         execution._old_workdir = None
 
-        if self.spec.build.source:
+        if self.spec.build.source and not hasattr(self, "_is_run_local"):
             target_dir = extract_source(
                 self.spec.build.source,
                 self.spec.clone_target_dir,

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -247,7 +247,6 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         run = project.run_function("myjob", local=True)
         assert run.state() == "completed"
         assert run.output("tag")
-        return
 
         # build and run job on the cluster
         project.build_function("myjob")


### PR DESCRIPTION
- Various fixes in set/run_function method to support working with handlers (without files), subpath, and archives 
- Support local run/debug when working with archives 
- Work with project level archive settings and project run/build/deploy methods
- Add various tests

example, working with archives and project:

```python
# load project into a local dir, and look for the project.yaml/sources in the subpath
project = mlrun.load_project(
    "./",
    "git://github.com/mlrun/test-git-load.git",
    "my-project",
    user_project=True,
    subpath="subdir",
)

# run job locally (from cloned source)
run = project.run_function("myjob", local=True)
print(run.outputs)

# build and run job on the cluster
project.build_function("myjob")
run = project.run_function("myjob")
print(run.outputs)

# deploy Nuclio function and invoke
deployment = project.deploy_function("mynuclio")
resp = deployment.function.invoke("")
print(resp)
```