### PR TITLE
[Artifacts] Fix processing of link artifacts in `get_store_resource`

### DIFF
--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -160,7 +160,7 @@ def get_store_resource(uri, db=None, secrets=None, project=None):
             link_iteration = (
                 resource.get("link_iteration", 0)
                 if is_legacy_artifact(resource)
-                else resource["metadata"].get("link_iteration", 0)
+                else resource["spec"].get("link_iteration", 0)
             )
 
             resource = db.read_artifact(

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -16,7 +16,11 @@
 
 import mlrun
 from mlrun.config import config
-from mlrun.utils.helpers import parse_artifact_uri, parse_versioned_object_uri
+from mlrun.utils.helpers import (
+    is_legacy_artifact,
+    parse_artifact_uri,
+    parse_versioned_object_uri,
+)
 
 from ..platforms.iguazio import parse_v3io_path
 from ..utils import DB_SCHEMA, StorePrefix
@@ -153,10 +157,16 @@ def get_store_resource(uri, db=None, secrets=None, project=None):
         )
         if resource.get("kind", "") == "link":
             # todo: support other link types (not just iter, move this to the db/api layer
+            link_iteration = (
+                resource.get("link_iteration", 0)
+                if is_legacy_artifact(resource)
+                else resource["metadata"].get("link_iteration", 0)
+            )
+
             resource = db.read_artifact(
                 key,
                 tag=tag,
-                iter=resource.get("link_iteration", 0),
+                iter=link_iteration,
                 project=project,
             )
         if resource:

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -33,6 +33,7 @@ from .utils import (
     get_in,
     get_workflow_url,
     is_ipython,
+    is_legacy_artifact,
     logger,
     run_keys,
 )
@@ -111,10 +112,18 @@ def get_kfp_outputs(artifacts, labels, project):
     outputs = []
     out_dict = {}
     for output in artifacts:
-        key = output.get("metadata")["key"]
-        output_spec = output.get("spec", {})
+        if is_legacy_artifact(output):
+            key = output["key"]
+            # The spec in a legacy artifact is contained in the main object, so using this assignment saves us a lot
+            # of if/else in the rest of this function.
+            output_spec = output
+        else:
+            key = output.get("metadata")["key"]
+            output_spec = output.get("spec", {})
+
         target = output_spec.get("target_path", "")
         target = output_spec.get("inline", target)
+
         out_dict[key] = get_artifact_target(output, project=project)
 
         if target.startswith("v3io:///"):

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -20,6 +20,9 @@ import pytest
 
 import mlrun
 import mlrun.errors
+from mlrun.artifacts import ModelArtifact
+from mlrun.artifacts.base import LegacyLinkArtifact, LinkArtifact
+from mlrun.artifacts.model import LegacyModelArtifact
 from tests.conftest import rundb_path
 
 mlrun.mlconf.dbpath = rundb_path
@@ -186,6 +189,54 @@ def test_get_store_artifact_url_parsing():
 
         db.read_artifact = mock_read_artifact
         mlrun.datastore.store_resources.get_store_resource(url, db)
+
+
+@pytest.mark.parametrize("legacy_format", [False, True])
+def test_get_store_resource_with_linked_artifacts(legacy_format):
+    artifact_key = "key1"
+    project = "test_project"
+    link_iteration = 7
+
+    if legacy_format:
+        link_artifact = LegacyLinkArtifact(
+            key=artifact_key, target_path="/some/path", link_iteration=link_iteration
+        )
+        link_artifact.project = project
+        model_artifact = LegacyModelArtifact(
+            key=f"{artifact_key}#{link_iteration}",
+            project=project,
+            target_path="/some/path/again",
+            body="just a body",
+        )
+    else:
+        link_artifact = LinkArtifact(
+            key=artifact_key,
+            project=project,
+            target_path="/some/path",
+            link_iteration=link_iteration,
+        )
+        model_artifact = ModelArtifact(
+            key=f"{artifact_key}#{link_iteration}",
+            project=project,
+            target_path="/some/path/again",
+            body="just a body",
+        )
+
+    mock_artifacts = [link_artifact, model_artifact]
+
+    def mock_read_artifact(key, tag=None, iter=None, project=""):
+        for artifact in mock_artifacts:
+            key_ = f"{key}#{iter}" if iter else key
+            if artifact.key == key_:
+                return artifact.to_dict()
+        return {}
+
+    db = Mock()
+    db.read_artifact = mock_read_artifact
+
+    url = f"store://{project}/{artifact_key}"
+    result = mlrun.datastore.store_resources.get_store_resource(url, db)
+    assert result.kind == "model" and result.key == f"{artifact_key}#{link_iteration}"
 
 
 @pytest.mark.usefixtures("patch_file_forbidden")


### PR DESCRIPTION
The `get_store_resource` method does parsing of artifacts returned from DB, and if a link artifact is returned it queries again for the actual artifact from the correct iteration. However, the `link_iteration` field was taken from the location it was in the legacy artifact structure, causing the artifact to not be returned properly. Added code to properly handle new and legacy artifacts. 
Fixing [ML-2183](https://jira.iguazeng.com/browse/ML-2183).

While fixing this, found another location where backwards compatibility is needed (in `get_kfp_outputs` which only assumed new-format artifacts exist), fixed it as well.