### PR TITLE
[Spark] Allow setting executor and driver cores parameter in Spark runtime

### DIFF
--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -679,11 +679,20 @@ class Spark3Runtime(AbstractSparkRuntime):
 
     def with_cores(self, executor_cores: int = None, driver_cores: int = None):
         """
-        Allows to configure spark.executor.cores and spark.driver.cores parameters. The values must be integers, and
-        default to 1 if not specified.
+        Allows to configure spark.executor.cores and spark.driver.cores parameters. The values must be integers
+        greater than or equal to 1. If a parameter is not specified, it defaults to 1.
 
-        :param executor_cores: Number of cores to use for executor
-        :param driver_cores:   Number of cores to use for driver
+        Spark operator has multiple options to control the number of cores available to the executor and driver.
+        The .coreLimit and .coreRequest parameters can be set for both executor and driver,
+        but they only controls the k8s properties of the pods created to run driver/executor.
+        Spark itself uses the spec.[executor|driver].cores parameter to set the parallelism of tasks and cores
+        assigned to each task within the pod. This function sets the .cores parameters for the job executed.
+
+        See https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/581 for a discussion about those
+        parameters and their meaning in Spark operator.
+
+        :param executor_cores: Number of cores to use for executor (spark.executor.cores)
+        :param driver_cores:   Number of cores to use for driver (spark.driver.cores)
         """
         if executor_cores:
             if not isinstance(executor_cores, int) or executor_cores < 1:

--- a/tests/api/runtimes/test_spark.py
+++ b/tests/api/runtimes/test_spark.py
@@ -316,7 +316,8 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
         else:
             runtime.with_cores(executor_cores=executor_cores, driver_cores=driver_cores)
 
-        expected_cores = {"executor": executor_cores or 1, "driver": driver_cores}
+        # By default, if not specified otherwise, the cores are set to 1
+        expected_cores = {"executor": executor_cores or 1, "driver": driver_cores or 1}
 
         self.execute_function(runtime)
         self._assert_custom_object_creation_config(expected_cores=expected_cores)

--- a/tests/api/runtimes/test_spark.py
+++ b/tests/api/runtimes/test_spark.py
@@ -48,6 +48,12 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
         else:
             assert "javaOptions" not in body["spec"]["executor"]
 
+    @staticmethod
+    def _assert_cores(body: dict, expected_cores: dict):
+        for resource in ["executor", "driver"]:
+            if expected_cores.get(resource):
+                assert body[resource]["cores"] == expected_cores[resource]
+
     def _assert_custom_object_creation_config(
         self,
         expected_runtime_class_name="spark",
@@ -59,6 +65,7 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
         expected_executor_java_options=None,
         expected_driver_resources: dict = None,
         expected_executor_resources: dict = None,
+        expected_cores: dict = None,
     ):
         if assert_create_custom_object_called:
             mlrun.api.utils.singletons.k8s.get_k8s().crdapi.create_namespaced_custom_object.assert_called_once()
@@ -84,6 +91,9 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
             self._assert_resources(
                 body["spec"]["executor"], expected_executor_resources
             )
+
+        if expected_cores:
+            self._assert_cores(body["spec"], expected_cores)
 
     def _assert_volume_and_mounts(
         self,
@@ -183,10 +193,17 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
         runtime.with_driver_requests(cpu="2", mem="512m")
         runtime.with_driver_limits(cpu="3", gpus=1)
 
+        expected_cores = {
+            "executor": 8,
+            "driver": 2,
+        }
+        runtime.with_cores(expected_cores["executor"], expected_cores["driver"])
+
         self.execute_function(runtime)
         self._assert_custom_object_creation_config(
             expected_driver_resources=expected_driver,
             expected_executor_resources=expected_executor,
+            expected_cores=expected_cores,
         )
 
     def test_run_with_host_path_volume(
@@ -269,3 +286,37 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
             expected_driver_java_options=driver_java_options,
             expected_executor_java_options=executor_java_options,
         )
+
+    @pytest.mark.parametrize(
+        "executor_cores, driver_cores, expect_failure",
+        [
+            (4, None, False),
+            (3, 3, False),
+            (None, 2, False),
+            (None, None, False),
+            (0.5, None, True),
+            (None, -1, True),
+        ],
+    )
+    def test_cores(
+        self,
+        executor_cores,
+        driver_cores,
+        expect_failure,
+        db: sqlalchemy.orm.Session,
+        client: fastapi.testclient.TestClient,
+    ):
+        runtime = self._generate_runtime()
+        if expect_failure:
+            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+                runtime.with_cores(
+                    executor_cores=executor_cores, driver_cores=driver_cores
+                )
+            return
+        else:
+            runtime.with_cores(executor_cores=executor_cores, driver_cores=driver_cores)
+
+        expected_cores = {"executor": executor_cores or 1, "driver": driver_cores}
+
+        self.execute_function(runtime)
+        self._assert_custom_object_creation_config(expected_cores=expected_cores)


### PR DESCRIPTION
Spark operator has multiple options to control the number of cores available to the executor and driver. Up until now MLRun would set the `.coreLimit` and `.coreRequest` for both executor and driver, but this only controls the k8s properties of the pods created to run them. Spark itself uses the `spec.[executor|driver].cores` parameter to set the parallelism of tasks and cores assigned to each task within the pod - this parameter was always set to 1 until now.
See https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/581 for a discussion about those parameters and their meaning in Spark operator.

This PR adds a `.with_cores()` function to the `Spark3Runtime` class, enabling the user to control this property for both executor and driver.

This fixes [ML-2195](https://jira.iguazeng.com/browse/ML-2195)