### PR TITLE
[Builder] Bump kaniko image version to 1.8.0

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -251,7 +251,7 @@ default_config = {
             # pip install <requirement_specifier>, e.g. mlrun==0.5.4, mlrun~=0.5,
             # git+https://github.com/mlrun/mlrun@development. by default uses the version
             "mlrun_version_specifier": "",
-            "kaniko_image": "gcr.io/kaniko-project/executor:v1.6.0",  # kaniko builder image
+            "kaniko_image": "gcr.io/kaniko-project/executor:v1.8.0",  # kaniko builder image
             "kaniko_init_container_image": "alpine:3.13.1",
             # additional docker build args in json encoded base64 format
             "build_args": "",


### PR DESCRIPTION
Although we were using 1.6.0 and it worked, we want to align it to the version.
https://jira.iguazeng.com/browse/IG-20718 