### PR TITLE
[API] Fix projects leader to sync enrichment to followers

### DIFF
--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -1,5 +1,6 @@
 import collections
 import typing
+import traceback
 
 import humanfriendly
 import sqlalchemy.orm
@@ -258,6 +259,7 @@ class Member(
                     project=project,
                     project_name=project_name,
                     exc=str(exc),
+                    traceback=traceback.format_exc(),
                 )
             else:
                 project_in_leader = True
@@ -270,38 +272,66 @@ class Member(
             missing_followers = set(follower_names).symmetric_difference(
                 self._followers.keys()
             )
-            if missing_followers:
-                # projects name validation is enforced on creation, the only way for a project name to be invalid is
-                # if it was created prior to 0.6.0, and the version was upgraded
-                # we do not want to sync these projects since it will anyways fail (Nuclio doesn't allow these names
-                # as well)
-                if not mlrun.projects.ProjectMetadata.validate_project_name(
-                    project_name, raise_on_failure=False
-                ):
-                    return
-                for missing_follower in missing_followers:
+            if self._should_sync_project_to_followers(project_name):
+                if missing_followers:
+                    for missing_follower in missing_followers:
+                        logger.debug(
+                            "Project is missing from follower. Creating",
+                            missing_follower_name=missing_follower,
+                            project_follower_name=project_follower_name,
+                            project_name=project_name,
+                            project=project,
+                        )
+                        try:
+                            self._enrich_and_validate_before_creation(project)
+                            self._followers[missing_follower].create_project(
+                                db_session,
+                                project,
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "Failed creating missing project in follower",
+                                missing_follower_name=missing_follower,
+                                project_follower_name=project_follower_name,
+                                project_name=project_name,
+                                project=project,
+                                exc=str(exc),
+                                traceback=traceback.format_exc(),
+                            )
+                # we possibly enriched the project we found in the follower, so let's update the followers that had it
+                for follower_name in follower_names:
                     logger.debug(
-                        "Project is missing from follower. Creating",
-                        missing_follower_name=missing_follower,
-                        project_follower_name=project_follower_name,
+                        "Updating project in follower",
+                        follower_name=follower_name,
                         project_name=project_name,
                         project=project,
                     )
                     try:
                         self._enrich_and_validate_before_creation(project)
-                        self._followers[missing_follower].create_project(
+                        self._followers[follower_name].store_project(
                             db_session,
+                            project_name,
                             project,
                         )
                     except Exception as exc:
                         logger.warning(
-                            "Failed creating missing project in follower",
-                            missing_follower_name=missing_follower,
-                            project_follower_name=project_follower_name,
+                            "Failed updating project in follower",
+                            follower_name=follower_name,
                             project_name=project_name,
                             project=project,
                             exc=str(exc),
+                            traceback=traceback.format_exc(),
                         )
+
+    def _should_sync_project_to_followers(self, project_name: str) -> bool:
+        """
+        projects name validation is enforced on creation, the only way for a project name to be invalid is if it was
+        created prior to 0.6.0, and the version was upgraded we do not want to sync these projects since it will
+        anyways fail (Nuclio doesn't allow these names as well)
+        """
+        return mlrun.projects.ProjectMetadata.validate_project_name(
+                project_name, raise_on_failure=False
+        )
 
     def _run_on_all_followers(
         self, leader_first: bool, method: str, *args, **kwargs

--- a/mlrun/api/utils/projects/leader.py
+++ b/mlrun/api/utils/projects/leader.py
@@ -1,6 +1,6 @@
 import collections
-import typing
 import traceback
+import typing
 
 import humanfriendly
 import sqlalchemy.orm
@@ -330,7 +330,7 @@ class Member(
         anyways fail (Nuclio doesn't allow these names as well)
         """
         return mlrun.projects.ProjectMetadata.validate_project_name(
-                project_name, raise_on_failure=False
+            project_name, raise_on_failure=False
         )
 
     def _run_on_all_followers(

--- a/mlrun/api/utils/projects/remotes/nop_follower.py
+++ b/mlrun/api/utils/projects/remotes/nop_follower.py
@@ -18,7 +18,8 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
     ):
         if project.metadata.name in self._projects:
             raise mlrun.errors.MLRunConflictError("Project already exists")
-        self._projects[project.metadata.name] = project
+        # deep copy so we won't accidentally get changes from tests
+        self._projects[project.metadata.name] = project.copy(deep=True)
 
     def store_project(
         self,
@@ -26,7 +27,8 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
         name: str,
         project: mlrun.api.schemas.Project,
     ):
-        self._projects[name] = project
+        # deep copy so we won't accidentally get changes from tests
+        self._projects[name] = project.copy(deep=True)
 
     def patch_project(
         self,
@@ -52,7 +54,8 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str
     ) -> mlrun.api.schemas.Project:
-        return self._projects[name]
+        # deep copy so we won't accidentally get changes from tests
+        return self._projects[name].copy(deep=True)
 
     def list_projects(
         self,
@@ -68,6 +71,8 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
                 "Filtering by owner, labels or state is not supported"
             )
         projects = list(self._projects.values())
+        # deep copy so we won't accidentally get changes from tests
+        projects = [project.copy(deep=True) for project in projects]
         if names:
             projects = [
                 project

--- a/tests/api/utils/projects/test_leader_member.py
+++ b/tests/api/utils/projects/test_leader_member.py
@@ -131,7 +131,10 @@ def test_projects_sync_leader_project_syncing(
         metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
         spec=mlrun.api.schemas.ProjectSpec(description=project_description),
     )
-    leader_follower.create_project(None, project)
+    enriched_project = project.copy(deep=True)
+    # simulate project enrichment
+    enriched_project.status.state = enriched_project.spec.desired_state
+    leader_follower.create_project(None, enriched_project)
     invalid_project_name = "invalid_name"
     invalid_project = mlrun.api.schemas.Project(
         metadata=mlrun.api.schemas.ProjectMetadata(name=invalid_project_name),


### PR DESCRIPTION
Recently we started seeing these tests almost constantly fail in CI:
```
>               assert (
                    follower._projects[project.metadata.name].status.state
                    == project.spec.desired_state
                )
E               AssertionError: assert None == <ProjectDesiredState.online: 'online'>
E                 +None
E                 -<ProjectDesiredState.online: 'online'>

tests/api/utils/projects/test_leader_member.py:595: AssertionError
FAILED tests/api/utils/projects/test_leader_member.py::test_projects_sync_follower_project_adoption
FAILED tests/api/utils/projects/test_leader_member.py::test_projects_sync_leader_project_syncing
FAILED tests/api/utils/projects/test_leader_member.py::test_projects_sync_multiple_follower_project_adoption
```
In the investigation we saw that it only reproduces with the dockerized tests and it also reproduces with very old code leading to the conclusions that the cause for this bug is not in our code but some package that was updated (when testing in docker it rebuild the image and pull latest packages vs local which you usually have slightly older versions)
After some searching I found that Pydantic 1.9.0 -> 1.9.1 caused it, and after going over the changes this PR was the suspect - https://github.com/samuelcolvin/pydantic/pull/3642
I've changed the nop follower we're using in those tests to always use `.copy(deep=True)` of what it is getting and saw that indeed the test now fails even with 1.9.0
This revealed and actual bug in our code, when the leader finds a project in the follower, it enriches it (as of now enrichment is just assigning the desired state to the status state) but then it doesn't update the project in that follower which is why the tests fail, so beside of changing the nop-follower to use deep copy, I fixed the leader to do this update