### PR TITLE
[Artifacts] Move `stats` and `preview` fields from artifact `spec` to `status`

### DIFF
--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -241,7 +241,7 @@ def _fix_datasets_large_previews(
                     preview = (
                         artifact_dict.get("preview")
                         if is_legacy
-                        else artifact_dict.get("spec", {}).get("preview")
+                        else artifact_dict.get("status", {}).get("preview")
                     )
                     if preview:
                         new_preview = []
@@ -265,14 +265,14 @@ def _fix_datasets_large_previews(
                         if is_legacy:
                             artifact_dict["preview"] = new_preview
                         else:
-                            artifact_dict["spec"]["preview"] = new_preview
+                            artifact_dict["status"]["preview"] = new_preview
 
                     # align stats
                     for column_to_remove in columns_to_remove:
                         artifact_stats = (
                             artifact_dict.get("stats", {})
                             if is_legacy
-                            else artifact_dict.get("spec").get("stats", {})
+                            else artifact_dict.get("status").get("stats", {})
                         )
                         if column_to_remove in artifact_stats:
                             del artifact_stats[column_to_remove]

--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -140,10 +140,12 @@ class ArtifactSpec(ModelObj):
 
 
 class ArtifactStatus(ModelObj):
-    _dict_fields = ["state"]
+    _dict_fields = ["state", "stats", "preview"]
 
     def __init__(self):
         self.state = "created"
+        self.stats = None
+        self.preview = None
 
     def base_dict(self):
         return super().to_dict()

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -102,8 +102,6 @@ class DatasetArtifactSpec(ArtifactSpec):
         "schema",
         "header",
         "length",
-        "preview",
-        "stats",
         "column_metadata",
     ]
 
@@ -112,8 +110,6 @@ class DatasetArtifactSpec(ArtifactSpec):
         self.schema = None
         self.header = None
         self.length = None
-        self.preview = None
-        self.stats = None
         self.column_metadata = None
 
 
@@ -146,7 +142,7 @@ class DatasetArtifact(Artifact):
         if format == "pq":
             format = "parquet"
         self.format = format
-        self.stats = None
+        self.status.stats = None
         self.extra_data = extra_data or {}
         self.column_metadata = column_metadata or {}
 
@@ -227,7 +223,7 @@ class DatasetArtifact(Artifact):
         if len(preview_df.columns) > max_preview_columns and not ignore_preview_limits:
             preview_df = preview_df.iloc[:, :max_preview_columns]
         artifact.spec.header = preview_df.columns.values.tolist()
-        artifact.spec.preview = preview_df.values.tolist()
+        artifact.status.preview = preview_df.values.tolist()
         artifact.spec.schema = build_table_schema(preview_df)
         if (
             stats
@@ -236,7 +232,7 @@ class DatasetArtifact(Artifact):
             )
             or ignore_preview_limits
         ):
-            artifact.spec.stats = get_df_stats(df)
+            artifact.status.stats = get_df_stats(df)
 
     @property
     def column_metadata(self):
@@ -315,48 +311,48 @@ class DatasetArtifact(Artifact):
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used ArtifactLegacy"""
         warnings.warn(
-            "This is a property of the spec, use artifact.spec.preview instead"
+            "This is a property of the status, use artifact.status.preview instead"
             "This will be deprecated in 1.0.0, and will be removed in 1.2.0",
             # TODO: In 1.0.0 do changes in examples & demos In 1.2.0 remove
             PendingDeprecationWarning,
         )
-        return self.spec.preview
+        return self.status.preview
 
     @preview.setter
     def preview(self, preview):
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used ArtifactLegacy"""
         warnings.warn(
-            "This is a property of the spec, use artifact.spec.preview instead"
+            "This is a property of the status, use artifact.status.preview instead"
             "This will be deprecated in 1.0.0, and will be removed in 1.2.0",
             # TODO: In 1.0.0 do changes in examples & demos In 1.2.0 remove
             PendingDeprecationWarning,
         )
-        self.spec.preview = preview
+        self.status.preview = preview
 
     @property
     def stats(self):
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used ArtifactLegacy"""
         warnings.warn(
-            "This is a property of the spec, use artifact.spec.stats instead"
+            "This is a property of the status, use artifact.status.stats instead"
             "This will be deprecated in 1.0.0, and will be removed in 1.2.0",
             # TODO: In 1.0.0 do changes in examples & demos In 1.2.0 remove
             PendingDeprecationWarning,
         )
-        return self.spec.stats
+        return self.status.stats
 
     @stats.setter
     def stats(self, stats):
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used ArtifactLegacy"""
         warnings.warn(
-            "This is a property of the spec, use artifact.spec.stats instead"
+            "This is a property of the status, use artifact.status.stats instead"
             "This will be deprecated in 1.0.0, and will be removed in 1.2.0",
             # TODO: In 1.0.0 do changes in examples & demos In 1.2.0 remove
             PendingDeprecationWarning,
         )
-        self.spec.stats = stats
+        self.status.stats = stats
 
 
 class LegacyTableArtifact(LegacyArtifact):
@@ -607,11 +603,11 @@ def update_dataset_meta(
     if header:
         artifact_spec.spec.header = header
     if stats:
-        artifact_spec.spec.stats = stats
+        artifact_spec.status.stats = stats
     if schema:
         artifact_spec.spec.schema = schema
     if preview:
-        artifact_spec.spec.preview = preview
+        artifact_spec.status.preview = preview
     if column_metadata:
         artifact_spec.spec.column_metadata = column_metadata
     if labels:

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -103,6 +103,10 @@ class DatasetArtifactSpec(ArtifactSpec):
         "header",
         "length",
         "column_metadata",
+        "features",
+        "partition_keys",
+        "timestamp_key",
+        "label_column",
     ]
 
     def __init__(self):
@@ -111,6 +115,10 @@ class DatasetArtifactSpec(ArtifactSpec):
         self.header = None
         self.length = None
         self.column_metadata = None
+        self.features = None
+        self.partition_keys = None
+        self.timestamp_key = None
+        self.label_column = None
 
 
 class DatasetArtifact(Artifact):

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -866,9 +866,9 @@ def test_data_migration_fix_datasets_large_previews(
             exclude_paths=[
                 "root['metadata']['updated']",
                 "root['spec']['header']",
-                "root['spec']['stats']",
+                "root['status']['stats']",
                 "root['spec']['schema']",
-                "root['spec']['preview']",
+                "root['status']['preview']",
                 "root['metadata']['tag']",
                 "root['spec']['db_key']",
             ],
@@ -880,11 +880,11 @@ def test_data_migration_fix_datasets_large_previews(
         == mlrun.artifacts.dataset.max_preview_columns
     )
     assert (
-        len(artifact_with_invalid_preview_after_migration["spec"]["stats"])
+        len(artifact_with_invalid_preview_after_migration["status"]["stats"])
         == mlrun.artifacts.dataset.max_preview_columns - 1
     )
     assert (
-        len(artifact_with_invalid_preview_after_migration["spec"]["preview"][0])
+        len(artifact_with_invalid_preview_after_migration["status"]["preview"][0])
         == mlrun.artifacts.dataset.max_preview_columns
     )
     assert (


### PR DESCRIPTION
These fields were wrongly included in the `spec` part of the object, while they need to be in the `status`.

Also added some fields to the `spec` of `DatasetArtifact` to align it with feature-sets.