### PR TITLE
Revert "[Spark] Allow mounting v3io on driver but not executors [Backport 1.0.x]"

### DIFF
--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import typing
-from copy import copy, deepcopy
+from copy import deepcopy
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 
@@ -603,18 +603,9 @@ with ctx:
                 self.spec.deps["files"] = []
             self.spec.deps["files"] += deps["files"]
 
-    def with_igz_spark(self, mount_v3io_to_executor=True):
+    def with_igz_spark(self):
         self._update_igz_jars(deps=self._get_igz_deps())
-        additional_executor_volume_mounts = copy(self.spec.volume_mounts)
         self.apply(mount_v3io_extended())
-
-        # move volume_mounts to driver and executor specific fields and leave v3io mounts
-        # out of executor mounts if mount_v3io_to_executor=False
-        self.spec.driver_volume_mounts += self.spec.volume_mounts
-        if mount_v3io_to_executor:
-            additional_executor_volume_mounts = self.spec.volume_mounts
-        self.spec.executor_volume_mounts += additional_executor_volume_mounts
-        self.spec.volume_mounts = []
         self.apply(
             mount_v3iod(
                 namespace=config.namespace,

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -670,8 +670,8 @@ class Spark3Runtime(AbstractSparkRuntime):
             if exporter_jar:
                 self.spec.monitoring["exporter_jar"] = exporter_jar
 
-    def with_igz_spark(self, mount_v3io_to_executor=True):
-        super().with_igz_spark(mount_v3io_to_executor)
+    def with_igz_spark(self):
+        super().with_igz_spark()
         if "enabled" not in self.spec.monitoring or self.spec.monitoring["enabled"]:
             self._with_monitoring(
                 exporter_jar="/spark/jars/jmx_prometheus_javaagent-0.16.1.jar",

--- a/tests/api/runtimes/test_spark.py
+++ b/tests/api/runtimes/test_spark.py
@@ -1,4 +1,3 @@
-import os
 import typing
 
 import deepdiff
@@ -94,7 +93,7 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
         expected_driver_volume_mounts: typing.Optional[list] = None,
         expected_executor_volume_mounts: typing.Optional[list] = None,
     ):
-        if expected_volumes is not None:
+        if expected_volumes:
             sanitized_volumes = self._sanitize_list_for_serialization(expected_volumes)
             assert (
                 deepdiff.DeepDiff(
@@ -102,7 +101,7 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
                 )
                 == {}
             )
-        if expected_driver_volume_mounts is not None:
+        if expected_driver_volume_mounts:
             sanitized_driver_volume_mounts = self._sanitize_list_for_serialization(
                 expected_driver_volume_mounts
             )
@@ -114,7 +113,7 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
                 )
                 == {}
             )
-        if expected_executor_volume_mounts is not None:
+        if expected_executor_volume_mounts:
             sanitized_executor_volume_mounts = self._sanitize_list_for_serialization(
                 expected_executor_volume_mounts
             )
@@ -253,55 +252,3 @@ class TestSpark3Runtime(tests.api.runtimes.base.TestRuntimeBase):
 
         self.execute_function(runtime)
         self._assert_custom_object_creation_config(expected_cores=expected_cores)
-
-    @pytest.mark.parametrize(
-        "mount_v3io_to_executor",
-        [True, False],
-    )
-    def test_with_igz_spark_volume_mounts(
-        self,
-        mount_v3io_to_executor,
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-    ):
-        runtime = self._generate_runtime()
-
-        orig = os.getenv("V3IO_USERNAME")
-        os.environ["V3IO_USERNAME"] = "me"
-        try:
-            runtime.with_igz_spark(mount_v3io_to_executor=mount_v3io_to_executor)
-        finally:
-            if orig:
-                os.environ["V3IO_USERNAME"] = orig
-            else:
-                os.unsetenv("V3IO_USERNAME")
-
-        self.execute_function(runtime)
-        expected_common_mounts = [
-            kubernetes.client.V1VolumeMount(mount_path="/dev/shm", name="shm"),
-            kubernetes.client.V1VolumeMount(
-                mount_path="/var/run/iguazio/dayman", name="v3iod-comm"
-            ),
-            kubernetes.client.V1VolumeMount(
-                mount_path="/var/run/iguazio/daemon_health", name="daemon-health"
-            ),
-            kubernetes.client.V1VolumeMount(
-                mount_path="/etc/config/v3io", name="v3io-config"
-            ),
-        ]
-        v3io_mounts = [
-            kubernetes.client.V1VolumeMount(
-                mount_path="/v3io", name="v3io", sub_path=""
-            ),
-            kubernetes.client.V1VolumeMount(
-                mount_path="/User", name="v3io", sub_path="users/me"
-            ),
-        ]
-        expected_driver_mounts = expected_common_mounts + v3io_mounts
-        expected_executor_mounts = expected_common_mounts
-        if mount_v3io_to_executor:
-            expected_executor_mounts += v3io_mounts
-        self._assert_custom_object_creation_config(
-            expected_driver_volume_mounts=expected_driver_mounts,
-            expected_executor_volume_mounts=expected_executor_mounts,
-        )


### PR DESCRIPTION
Reverting as the PR is targeted for 1.0.4 but 1.0.3 was not released yet