### PR TITLE
[Requirements] Bump numpy to fix vulnerabilities

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -180,14 +180,6 @@ class PackageTester:
                         "0.0.0+unstable",
                     },
                 ],
-                "numpy": [
-                    {
-                        "pattern": r"(.*)",
-                        "reason": "Storey require numpy <1.22 and the vulnerabilities fixed after this version, so "
-                        "we're waiting for Storey to release a version that supports the newer numpy and then"
-                        " we'll fix it as well",
-                    },
-                ],
             }
             filtered_vulnerabilities = []
             for vulnerability in vulnerabilities:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,8 @@ kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
 nuclio-jupyter~=0.9.1
-# >=1.16.5 from pandas 1.2.1 and <1.20.0 because we're hitting the same issue as this one
-# https://github.com/Azure/MachineLearningNotebooks/issues/1314
-numpy>=1.16.5, <1.22.0
+# >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
+numpy>=1.16.5, <1.23.0
 pandas~=1.2
 # used as a the engine for parquet files by pandas
 pyarrow>=1,<6

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ fsspec~=2021.8.1
 v3iofs~=0.1.7
 # 3.4 and above failed builidng in some images - see https://github.com/pyca/cryptography/issues/5771
 cryptography~=3.0, <3.4
-storey~=1.0.4
+storey~=1.1.1
 deepdiff~=5.0
 pymysql~=1.0
 inflection~=0.5.0

--- a/tests/automation/package_test/assets/ignored_vulnerabilities.json
+++ b/tests/automation/package_test/assets/ignored_vulnerabilities.json
@@ -1,32 +1,5 @@
 [
   [
-    "numpy",
-    "<1.22.0",
-    "1.21.6",
-    "Numpy 1.22.0 includes a fix for CVE-2021-41496: Buffer overflow in the array_from_pyobj function of fortranobject.c, which allows attackers to conduct a Denial of Service attacks by carefully constructing an array with negative values. \r\nNOTE: The vendor does not agree this is a vulnerability; the negative dimensions can only be created by an already privileged user (or internally).\r\nhttps://github.com/numpy/numpy/issues/19000",
-    "44716",
-    null,
-    null
-  ],
-  [
-    "numpy",
-    "<1.22.0",
-    "1.21.6",
-    "Numpy 1.22.0 includes a fix for CVE-2021-34141: An incomplete string comparison in the numpy.core component in NumPy before 1.22.0 allows attackers to trigger slightly incorrect copying by constructing specific string objects. NOTE: the vendor states that this reported code behavior is \"completely harmless.\"\r\nhttps://github.com/numpy/numpy/issues/18993",
-    "44717",
-    null,
-    null
-  ],
-  [
-    "numpy",
-    "<1.22.2",
-    "1.21.6",
-    "Numpy 1.22.2  includes a fix for CVE-2021-41495: Null Pointer Dereference vulnerability exists in numpy.sort in NumPy in the PyArray_DescrNew function due to missing return-value validation, which allows attackers to conduct DoS attacks by repetitively creating sort arrays. \r\nNOTE: While correct that validation is missing, an error can only occur due to an exhaustion of memory. If the user can exhaust memory, they are already privileged. Further, it should be practically impossible to construct an attack which can target the memory exhaustion to occur at exactly this place.\r\nhttps://github.com/numpy/numpy/issues/19038",
-    "44715",
-    null,
-    null
-  ],
-  [
     "mlrun",
     "<=1.1.0rc1",
     "1.0.3rc2",

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -82,7 +82,7 @@ def test_requirement_specifiers_convention():
         "botocore": {">=1.20.106,<1.20.107"},
         "aiobotocore": {"~=1.4.0"},
         "aioitertools": {"<0.9"},
-        "storey": {"~=1.0.4"},
+        "storey": {"~=1.1.1"},
         "bokeh": {"~=2.4, >=2.4.2"},
         # These 2 are used in a tests that is purposed to test requirement without specifiers
         "faker": {""},
@@ -105,7 +105,7 @@ def test_requirement_specifiers_convention():
         "urllib3": {">=1.25.4, <1.27"},
         "cryptography": {"~=3.0, <3.4"},
         "chardet": {">=3.0.2, <4.0"},
-        "numpy": {">=1.16.5, <1.22.0"},
+        "numpy": {">=1.16.5, <1.23.0"},
         "alembic": {"~=1.4,<1.6.0"},
         "boto3": {"~=1.9, <1.17.107"},
         "azure-core": {"<1.23"},


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/2016
Storey bumped Numpy on their side, so bumping in MLRun as well to fix the vulnerabilities