### PR TITLE
[Images] Fix GPU image to have new signing keys

### DIFF
--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -26,6 +26,10 @@ ENV PATH /opt/conda/bin:$PATH
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
+RUN apt-key del 7fa2af80 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+
 RUN apt-get update && \
     apt-mark hold libcublas-dev libcublas10 && \
     apt-get upgrade -y && \


### PR DESCRIPTION
During the `models-gpu` image build, in the `Step 9/36 : RUN apt-get update...` step we started getting:
```
Reading package lists...
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
```
Reading https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771 it seems like some keys have been rotated
Ideally they are suggesting to fix this by installing some cuda keyring package that should fix this issue permanently (won't break on future keys rotation) but it requires `wget` to download that package, and we don't have it in our base image, and we can't install it cause we need to run `apt-get update` for that, and it fails for the missing keys...
There's [this solution](https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771/10) to allow installing `wget` but I don't like, I assume soon enough nvidia will release a new base image with the updated keys
So for now used the manual way of specifically installing the missing keys by specifying their hashes 