### PR TITLE
[Projects] Change follower projects store to be the DB instead of cache

### DIFF
--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -235,9 +235,7 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    # adding **kwargs to leave room for other projects store implementations see mlrun.api.crud.projects.delete_project
-    # for explanations
-    def is_project_exists(self, session, name: str, **kwargs):
+    def is_project_exists(self, session, name: str):
         pass
 
     @abstractmethod

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -183,7 +183,7 @@ class FileDB(DBInterface):
     def verify_project_has_no_related_resources(self, session, name: str):
         raise NotImplementedError()
 
-    def is_project_exists(self, session, name: str, **kwargs):
+    def is_project_exists(self, session, name: str):
         raise NotImplementedError()
 
     def list_projects(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1015,6 +1015,7 @@ class SQLDB(DBInterface):
             source=project.spec.source,
             state=project.status.state,
             created=created,
+            owner=project.spec.owner,
             full_object=project.dict(),
         )
         labels = project.metadata.labels or {}
@@ -1287,6 +1288,7 @@ class SQLDB(DBInterface):
         project_record.full_object = project_dict
         project_record.description = project.spec.description
         project_record.source = project.spec.source
+        project_record.owner = project.spec.owner
         project_record.state = project.status.state
         labels = project.metadata.labels or {}
         update_labels(project_record, labels)
@@ -1316,7 +1318,7 @@ class SQLDB(DBInterface):
         project_record.full_object = project_record_full_object
         self._upsert(session, [project_record])
 
-    def is_project_exists(self, session: Session, name: str, **kwargs):
+    def is_project_exists(self, session: Session, name: str):
         project_record = self._get_project_record(
             session, name, raise_on_not_found=False
         )

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -4,6 +4,7 @@ import humanfriendly
 import mergedeep
 import sqlalchemy.orm
 
+import mlrun.api.crud
 import mlrun.api.db.session
 import mlrun.api.schemas
 import mlrun.api.utils.auth.verifier
@@ -26,43 +27,9 @@ class Member(
     mlrun.api.utils.projects.member.Member,
     metaclass=mlrun.utils.singleton.AbstractSingleton,
 ):
-    class ProjectsStoreMode:
-        none = "none"
-        cache = "cache"
-
-        @staticmethod
-        def all():
-            return [
-                Member.ProjectsStoreMode.none,
-                Member.ProjectsStoreMode.cache,
-            ]
-
-    class ProjectsStore:
-        """
-        See mlrun.api.crud.projects.delete_project for explanation for this ugly thing
-        """
-
-        def __init__(self, project_member):
-            self.project_member = project_member
-
-        def is_project_exists(
-            self, session, name: str, leader_session: typing.Optional[str] = None
-        ):
-            return name in self.project_member._projects
-
-        def delete_project(
-            self,
-            session,
-            name: str,
-            deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
-        ):
-            if name in self.project_member._projects:
-                del self.project_member._projects[name]
-
     def initialize(self):
         logger.info("Initializing projects follower")
         self._projects: typing.Dict[str, mlrun.api.schemas.Project] = {}
-        self._projects_store_for_deletion = self.ProjectsStore(self)
         self._leader_name = mlrun.mlconf.httpdb.projects.leader
         self._sync_session = None
         self._leader_client: mlrun.api.utils.projects.remotes.leader.Member
@@ -83,7 +50,11 @@ class Member(
         self._synced_until_datetime = None
         # run one sync to start off on the right foot and fill out the cache but don't fail initialization on it
         try:
-            self._sync_projects()
+            full_sync = (
+                mlrun.mlconf.httpdb.clusterization.role
+                == mlrun.api.schemas.ClusterizationRole.chief
+            )
+            self._sync_projects(full_sync=full_sync)
         except Exception as exc:
             logger.warning("Initial projects sync failed", exc=str(exc))
         self._start_periodic_sync()
@@ -101,9 +72,7 @@ class Member(
         wait_for_completion: bool = True,
     ) -> typing.Tuple[typing.Optional[mlrun.api.schemas.Project], bool]:
         if self._is_request_from_leader(projects_role):
-            if project.metadata.name in self._projects:
-                raise mlrun.errors.MLRunConflictError("Project already exists")
-            self._projects[project.metadata.name] = project
+            mlrun.api.crud.Projects().create_project(db_session, project)
             return project, False
         else:
             is_running_in_background = self._leader_client.create_project(
@@ -126,7 +95,7 @@ class Member(
         wait_for_completion: bool = True,
     ) -> typing.Tuple[typing.Optional[mlrun.api.schemas.Project], bool]:
         if self._is_request_from_leader(projects_role):
-            self._projects[project.metadata.name] = project
+            mlrun.api.crud.Projects().store_project(db_session, name, project)
             return project, False
         else:
             try:
@@ -181,15 +150,8 @@ class Member(
         wait_for_completion: bool = True,
     ) -> bool:
         if self._is_request_from_leader(projects_role):
-            # importing here to avoid circular import (db using project member using mlrun follower using db)
-            import mlrun.api.crud
-
             mlrun.api.crud.Projects().delete_project(
-                db_session,
-                name,
-                deletion_strategy,
-                auth_info,
-                self._projects_store_for_deletion,
+                db_session, name, deletion_strategy
             )
         else:
             return self._leader_client.delete_project(
@@ -206,9 +168,7 @@ class Member(
         name: str,
         leader_session: typing.Optional[str] = None,
     ) -> mlrun.api.schemas.Project:
-        if name not in self._projects:
-            raise mlrun.errors.MLRunNotFoundError(f"Project not found {name}")
-        return self._projects[name]
+        return mlrun.api.crud.Projects().get_project(db_session, name)
 
     def get_project_owner(
         self,
@@ -229,42 +189,24 @@ class Member(
         leader_session: typing.Optional[str] = None,
         names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.api.schemas.ProjectsOutput:
-        projects = []
-        if format_ == mlrun.api.schemas.ProjectsFormat.leader:
-            if not self._is_request_from_leader(projects_role):
-                raise mlrun.errors.MLRunAccessDeniedError(
-                    "Leader format is allowed only to the leader"
-                )
-            # importing here to avoid circular import (db using project member using mlrun follower using db)
-            from mlrun.api.utils.singletons.db import get_db
-
-            # Basically in follower mode our projects source of truth is the leader and the data in the DB is not
-            # relevant or maintained. The leader format purpose is a specific upgrade scenario where we're moving from
-            # leader mode (in which the projects are maintained in the DB) to follower mode in which the leader needs
-            # to be aware of the already existing projects so we're allowing only to the leader, to read from the DB,
-            # and return it in the leader's format
-            projects = get_db().list_projects(
-                db_session, owner, format_, labels, state, names
+        if (
+            format_ == mlrun.api.schemas.ProjectsFormat.leader
+            and not self._is_request_from_leader(projects_role)
+        ):
+            raise mlrun.errors.MLRunAccessDeniedError(
+                "Leader format is allowed only to the leader"
             )
+
+        projects_output = mlrun.api.crud.Projects().list_projects(
+            db_session, owner, format_, labels, state, names
+        )
+        if format_ == mlrun.api.schemas.ProjectsFormat.leader:
             leader_projects = [
                 self._leader_client.format_as_leader_project(project)
-                for project in projects.projects
+                for project in projects_output.projects
             ]
-            return mlrun.api.schemas.ProjectsOutput(projects=leader_projects)
-
-        projects = self._list_projects(leader_session, owner, labels, state, names)
-
-        project_names = list(map(lambda project: project.metadata.name, projects))
-        # format output
-        if format_ == mlrun.api.schemas.ProjectsFormat.name_only:
-            projects = project_names
-        elif format_ == mlrun.api.schemas.ProjectsFormat.full:
-            pass
-        else:
-            raise NotImplementedError(
-                f"Provided format is not supported. format={format_}"
-            )
-        return mlrun.api.schemas.ProjectsOutput(projects=projects)
+            projects_output.projects = leader_projects
+        return projects_output
 
     async def list_project_summaries(
         self,
@@ -276,18 +218,8 @@ class Member(
         leader_session: typing.Optional[str] = None,
         names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.api.schemas.ProjectSummariesOutput:
-        projects = self._list_projects(leader_session, owner, labels, state, names)
-        project_names = list(map(lambda project: project.metadata.name, projects))
-
-        # importing here to avoid circular import (db using project member using mlrun follower using db)
-        import mlrun.api.crud
-
-        project_summaries = await mlrun.api.crud.Projects().generate_projects_summaries(
-            project_names
-        )
-
-        return mlrun.api.schemas.ProjectSummariesOutput(
-            project_summaries=project_summaries
+        return await mlrun.api.crud.Projects().list_project_summaries(
+            db_session, owner, labels, state, names
         )
 
     async def get_project_summary(
@@ -296,58 +228,7 @@ class Member(
         name: str,
         leader_session: typing.Optional[str] = None,
     ) -> mlrun.api.schemas.ProjectSummary:
-        # Call get project so we'll explode if project doesn't exists
-        self.get_project(db_session, name, leader_session)
-
-        # importing here to avoid circular import (db using project member using mlrun follower using db)
-        import mlrun.api.crud
-
-        project_summaries = await mlrun.api.crud.Projects().generate_projects_summaries(
-            [name]
-        )
-
-        return project_summaries[0]
-
-    def _list_projects(
-        self,
-        leader_session: typing.Optional[str] = None,
-        owner: str = None,
-        labels: typing.List[str] = None,
-        state: mlrun.api.schemas.ProjectState = None,
-        names: typing.Optional[typing.List[str]] = None,
-    ) -> typing.List[mlrun.api.schemas.Project]:
-        projects = list(self._projects.values())
-        projects = self._filter_projects(projects, owner, labels, state, names)
-        return projects
-
-    def _filter_projects(
-        self,
-        projects: typing.List[mlrun.api.schemas.Project],
-        owner: str = None,
-        labels: typing.List[str] = None,
-        state: mlrun.api.schemas.ProjectState = None,
-        names: typing.Optional[typing.List[str]] = None,
-    ) -> typing.List[mlrun.api.schemas.Project]:
-        if names is not None:
-            projects = [
-                project for project in projects if project.metadata.name in names
-            ]
-        if owner:
-            projects = list(
-                filter(lambda project: project.spec.owner == owner, projects)
-            )
-        if state:
-            projects = list(
-                filter(lambda project: project.status.state == state, projects)
-            )
-        if labels:
-            projects = list(
-                filter(
-                    lambda project: self._is_project_matching_labels(labels, project),
-                    projects,
-                )
-            )
-        return projects
+        return await mlrun.api.crud.Projects().get_project_summary(db_session, name)
 
     def _start_periodic_sync(self):
         # the > 0 condition is to allow ourselves to disable the sync from configuration
@@ -366,7 +247,7 @@ class Member(
     def _stop_periodic_sync(self):
         mlrun.api.utils.periodic.cancel_periodic_function(self._sync_projects.__name__)
 
-    def _sync_projects(self):
+    def _sync_projects(self, full_sync=False):
         projects, latest_updated_at = self._leader_client.list_projects(
             self._sync_session, self._synced_until_datetime
         )
@@ -380,8 +261,31 @@ class Member(
             ):
                 continue
             filtered_projects.append(project)
+
+        db_session = mlrun.api.db.session.create_session()
         for project in filtered_projects:
-            self._projects[project.metadata.name] = project
+            mlrun.api.crud.Projects().store_project(
+                db_session, project.metadata.name, project
+            )
+        if full_sync:
+            logger.info("Performing full sync")
+            db_projects = mlrun.api.crud.Projects().list_projects(
+                db_session, format_=mlrun.api.schemas.ProjectsFormat.name_only
+            )
+            leader_project_names = [project.metadata.name for project in projects]
+            projects_to_remove = list(
+                set(db_projects.projects).difference(leader_project_names)
+            )
+            for project_to_remove in projects_to_remove:
+                logger.info(
+                    "Found project in the DB that is not in leader. Removing",
+                    name=project_to_remove,
+                )
+                mlrun.api.crud.Projects().delete_project(
+                    db_session,
+                    project_to_remove,
+                    mlrun.api.schemas.DeletionStrategy.cascading,
+                )
         self._synced_until_datetime = latest_updated_at
 
     def _is_request_from_leader(

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -42,9 +42,13 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
 
     @staticmethod
     def _update_state(project: mlrun.api.schemas.Project):
-        project.status.state = mlrun.api.schemas.ProjectState(
-            project.spec.desired_state
-        )
+        if (
+            not project.status.state
+            or project.status.state in mlrun.api.schemas.ProjectState.terminal_states()
+        ):
+            project.status.state = mlrun.api.schemas.ProjectState(
+                project.spec.desired_state
+            )
 
     def delete_project(
         self,

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -206,38 +206,12 @@ def test_create_project(
     db: DBInterface,
     db_session: sqlalchemy.orm.Session,
 ):
-    project_name = "project-name"
-    project_description = "some description"
-    project_labels = {
-        "some-label": "some-label-value",
-    }
-    project_created = datetime.datetime.utcnow()
-
+    project = _generate_project()
     db.create_project(
         db_session,
-        mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(
-                name=project_name,
-                created=project_created,
-                labels=project_labels,
-            ),
-            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
-        ),
+        project.copy(deep=True),
     )
-
-    project_output = db.get_project(db_session, project_name)
-    assert project_output.metadata.name == project_name
-    assert project_output.spec.description == project_description
-    # Created in request body should be ignored and set by the DB layer
-    assert project_output.metadata.created != project_created
-    assert (
-        deepdiff.DeepDiff(
-            project_labels,
-            project_output.metadata.labels,
-            ignore_order=True,
-        )
-        == {}
-    )
+    _assert_project(db, db_session, project)
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon
@@ -248,37 +222,13 @@ def test_store_project_creation(
     db: DBInterface,
     db_session: sqlalchemy.orm.Session,
 ):
-    project_name = "project-name"
-    project_description = "some description"
-    project_created = datetime.datetime.utcnow()
-    project_labels = {
-        "some-label": "some-label-value",
-    }
+    project = _generate_project()
     db.store_project(
         db_session,
-        project_name,
-        mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(
-                name=project_name,
-                created=project_created,
-                labels=project_labels,
-            ),
-            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
-        ),
+        project.metadata.name,
+        project.copy(deep=True),
     )
-    project_output = db.get_project(db_session, project_name)
-    assert project_output.metadata.name == project_name
-    assert project_output.spec.description == project_description
-    # Created in request body should be ignored and set by the DB layer
-    assert project_output.metadata.created != project_created
-    assert (
-        deepdiff.DeepDiff(
-            project_labels,
-            project_output.metadata.labels,
-            ignore_order=True,
-        )
-        == {}
-    )
+    _assert_project(db, db_session, project)
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon
@@ -289,37 +239,25 @@ def test_store_project_update(
     db: DBInterface,
     db_session: sqlalchemy.orm.Session,
 ):
-    project_name = "project-name"
-    project_description = "some description"
-    project_labels = {
-        "some-label": "some-label-value",
-    }
-    project_created = datetime.datetime.utcnow()
+    project = _generate_project()
     db.create_project(
         db_session,
-        mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(
-                name=project_name,
-                created=project_created,
-                labels=project_labels,
-            ),
-            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
-        ),
+        project.copy(deep=True),
     )
 
     db.store_project(
         db_session,
-        project_name,
+        project.metadata.name,
         mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
+            metadata=mlrun.api.schemas.ProjectMetadata(name=project.metadata.name),
         ),
     )
-    project_output = db.get_project(db_session, project_name)
-    assert project_output.metadata.name == project_name
+    project_output = db.get_project(db_session, project.metadata.name)
+    assert project_output.metadata.name == project.metadata.name
     assert project_output.spec.description is None
     assert project_output.metadata.labels is None
     # Created in request body should be ignored and set by the DB layer
-    assert project_output.metadata.created != project_created
+    assert project_output.metadata.created != project.metadata.created
 
 
 # running only on sqldb cause filedb is not really a thing anymore, will be removed soon
@@ -330,15 +268,10 @@ def test_patch_project(
     db: DBInterface,
     db_session: sqlalchemy.orm.Session,
 ):
-    project_name = "project-name"
-    project_description = "some description"
-    project_created = datetime.datetime.utcnow()
+    project = _generate_project()
     db.create_project(
         db_session,
-        mlrun.api.schemas.Project(
-            metadata=mlrun.api.schemas.ProjectMetadata(name=project_name),
-            spec=mlrun.api.schemas.ProjectSpec(description=project_description),
-        ),
+        project.copy(deep=True),
     )
 
     patched_project_description = "some description 2"
@@ -347,17 +280,20 @@ def test_patch_project(
     }
     db.patch_project(
         db_session,
-        project_name,
+        project.metadata.name,
         {
-            "metadata": {"created": project_created, "labels": patched_project_labels},
+            "metadata": {
+                "created": project.metadata.created,
+                "labels": patched_project_labels,
+            },
             "spec": {"description": patched_project_description},
         },
     )
-    project_output = db.get_project(db_session, project_name)
-    assert project_output.metadata.name == project_name
+    project_output = db.get_project(db_session, project.metadata.name)
+    assert project_output.metadata.name == project.metadata.name
     assert project_output.spec.description == patched_project_description
     # Created in request body should be ignored and set by the DB layer
-    assert project_output.metadata.created != project_created
+    assert project_output.metadata.created != project.metadata.created
     assert (
         deepdiff.DeepDiff(
             patched_project_labels,
@@ -389,3 +325,39 @@ def test_delete_project(
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
         db.get_project(db_session, project_name)
+
+
+def _generate_project():
+    return mlrun.api.schemas.Project(
+        metadata=mlrun.api.schemas.ProjectMetadata(
+            name="project-name",
+            created=datetime.datetime.utcnow() - datetime.timedelta(seconds=1),
+            labels={
+                "some-label": "some-label-value",
+            },
+        ),
+        spec=mlrun.api.schemas.ProjectSpec(
+            description="some description", owner="owner-name"
+        ),
+    )
+
+
+def _assert_project(
+    db: DBInterface,
+    db_session: sqlalchemy.orm.Session,
+    expected_project: mlrun.api.schemas.Project,
+):
+    project_output = db.get_project(db_session, expected_project.metadata.name)
+    assert project_output.metadata.name == expected_project.metadata.name
+    assert project_output.spec.description == expected_project.spec.description
+    assert project_output.spec.owner == expected_project.spec.owner
+    # Created in request body should be ignored and set by the DB layer
+    assert project_output.metadata.created != expected_project.metadata.created
+    assert (
+        deepdiff.DeepDiff(
+            expected_project.metadata.labels,
+            project_output.metadata.labels,
+            ignore_order=True,
+        )
+        == {}
+    )


### PR DESCRIPTION
As part of the effort of making the API stateless, we needed to change the projects follower member behavior to keep its projects in the DB instead of in cache. TBH it mainly simplified the follower logic so now it simply using the CRUD layer as is instead of implementing filters and such itself.
The only not trivial thing here was to understand that since we've been with the follower for some time, and its using cache for persistency meaning the projects table is not maintained, it means that when we're switching (persistency from cache to DB) there must be some code that will sync the projects in the DB
We basically are doing this sync periodically as part of the already existing follower logic, but this logic didn't include handling of deleting projects from persistency that are no longer in the leader, added a full_sync knob for that that is done on initialization, see comments in code for more detailed explanation