### PR TITLE
[Scheduler] Add re-routing to chief 

### DIFF
--- a/mlrun/api/api/endpoints/background_tasks.py
+++ b/mlrun/api/api/endpoints/background_tasks.py
@@ -65,12 +65,15 @@ def get_internal_background_task(
         )
     if (
         mlrun.mlconf.httpdb.clusterization.role
-        == mlrun.api.schemas.ClusterizationRole.chief
+        != mlrun.api.schemas.ClusterizationRole.chief
     ):
-        return mlrun.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
-            name=name
+        logger.info(
+            "Requesting internal background task, re-routing to chief",
+            internal_background_task=name,
         )
-    else:
-        logger.info("Requesting internal background task, redirecting to chief")
         chief_client = mlrun.api.utils.clients.chief.Client()
         return chief_client.get_background_task(name=name, request=request)
+
+    return mlrun.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+        name=name
+    )

--- a/mlrun/api/api/endpoints/background_tasks.py
+++ b/mlrun/api/api/endpoints/background_tasks.py
@@ -72,7 +72,7 @@ def get_internal_background_task(
             internal_background_task=name,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.get_background_task(name=name, request=request)
+        return chief_client.get_internal_background_task(name=name, request=request)
 
     return mlrun.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
         name=name

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -217,7 +217,7 @@ async def build_function(
                 function=function,
             )
             chief_client = mlrun.api.utils.clients.chief.Client()
-            return await chief_client.build_function(request=request, body=data)
+            return chief_client.build_function(request=request, body=data)
 
     if isinstance(data.get("with_mlrun"), bool):
         with_mlrun = data.get("with_mlrun")

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -199,7 +199,7 @@ async def build_function(
     )
 
     # schedules are meant to be run solely by the chief then if track_models is enabled, it means that schedules
-    # will be created as part of building the function, and if not chief then redirect to chief
+    # will be created as part of building the function, and if not chief then redirect to chief.
     # to reduce redundant load on the chief, we forward the request only if the user has permissions
     if function.get("spec", {}).get("track_models", False):
         if (

--- a/mlrun/api/api/endpoints/operations.py
+++ b/mlrun/api/api/endpoints/operations.py
@@ -34,6 +34,7 @@ def trigger_migrations(
         mlrun.mlconf.httpdb.clusterization.role
         != mlrun.api.schemas.ClusterizationRole.chief
     ):
+        logger.info("Requesting to trigger migrations, re-routing to chief")
         chief_client = mlrun.api.utils.clients.chief.Client()
         return chief_client.trigger_migrations(request)
 

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -194,9 +194,7 @@ async def invoke_schedule(
             name=name,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.invoke_schedule(
-            project=project, name=name, request=request
-        )
+        return chief_client.invoke_schedule(project=project, name=name, request=request)
 
     return await get_scheduler().invoke_schedule(db_session, auth_info, project, name)
 

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -194,7 +194,7 @@ async def invoke_schedule(
             name=name,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return await chief_client.invoke_schedule(
+        return chief_client.invoke_schedule(
             project=project, name=name, request=request
         )
 

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -4,6 +4,7 @@ import fastapi.concurrency
 from fastapi import APIRouter, Depends, Response
 from sqlalchemy.orm import Session
 
+import mlrun.api.api.utils
 import mlrun.api.utils.auth.verifier
 import mlrun.api.utils.clients.chief
 import mlrun.api.utils.singletons.project_member
@@ -44,7 +45,9 @@ def create_schedule(
             schedule=schedule.dict(),
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.create_schedule(project=project, request=request)
+        return chief_client.create_schedule(
+            project=project, request=request, body=schedule.dict()
+        )
 
     if not auth_info.access_key:
         auth_info.access_key = schedule.credentials.access_key
@@ -90,7 +93,9 @@ def update_schedule(
             schedule=schedule.dict(),
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.update_schedule(project=project, name=name, request=request)
+        return chief_client.update_schedule(
+            project=project, name=name, request=request, body=schedule.dict()
+        )
 
     if not auth_info.access_key:
         auth_info.access_key = schedule.credentials.access_key

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -83,7 +83,7 @@ async def submit_job(
                 task=task,
             )
             chief_client = mlrun.api.utils.clients.chief.Client()
-            return await chief_client.submit_job(request=request, body=data)
+            return chief_client.submit_job(request=request, body=data)
 
     else:
         await fastapi.concurrency.run_in_threadpool(

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -69,7 +69,8 @@ async def submit_job(
             mlrun.api.schemas.AuthorizationAction.create,
             auth_info,
         )
-        # schedules are meant to be run solely by the chief then if schedule in run and not chief then redirect to chief
+        # schedules are meant to be run solely by the chief, then if run is configured to run as scheduled
+        # and we are in worker then we forward the request to the chief.
         # to reduce redundant load on the chief, we forward the request only if the user has permissions
         if (
             mlrun.mlconf.httpdb.clusterization.role

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -83,7 +83,7 @@ async def submit_job(
                 task=task,
             )
             chief_client = mlrun.api.utils.clients.chief.Client()
-            return await chief_client.submit_job(request=request)
+            return await chief_client.submit_job(request=request, body=data)
 
     else:
         await fastapi.concurrency.run_in_threadpool(

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -71,11 +71,17 @@ async def submit_job(
         )
         # schedules are meant to be run solely by the chief, then if run is configured to run as scheduled
         # and we are in worker then we forward the request to the chief.
-        # to reduce redundant load on the chief, we forward the request only if the user has permissions
+        # to reduce redundant load on the chief, we re-route the request only if the user has permissions
         if (
             mlrun.mlconf.httpdb.clusterization.role
             != mlrun.api.schemas.ClusterizationRole.chief
         ):
+            logger.info(
+                "Requesting to submit job with schedules, re-routing to chief",
+                function=function_dict,
+                url=function_url,
+                task=task,
+            )
             chief_client = mlrun.api.utils.clients.chief.Client()
             return await chief_client.submit_job(request=request)
 

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -183,16 +183,13 @@ async def shutdown_event():
 async def move_api_to_online():
     logger.info("Moving api to online")
     initialize_project_member()
-    await initialize_scheduler()
-    # runs cleanup/monitoring is not needed if we're not inside kubernetes cluster
-    # periodic functions should only run on the chief instance
-    if (
-        get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster()
-        and config.httpdb.clusterization.role
-        == mlrun.api.schemas.ClusterizationRole.chief
-    ):
-        _start_periodic_cleanup()
-        _start_periodic_runs_monitoring()
+    # periodic functions and scheduler should only run on the chief instance
+    if config.httpdb.clusterization.role == mlrun.api.schemas.ClusterizationRole.chief:
+        await initialize_scheduler()
+        # runs cleanup/monitoring is not needed if we're not inside kubernetes cluster
+        if get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+            _start_periodic_cleanup()
+            _start_periodic_runs_monitoring()
 
 
 def _start_periodic_cleanup():

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -96,7 +96,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
             str, mlrun.api.schemas.BackgroundTask
         ] = {}
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def create_background_task(
         self,
         background_tasks: fastapi.BackgroundTasks,
@@ -120,7 +120,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
 
         return self.get_background_task(name)
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def get_background_task(
         self,
         name: str,
@@ -133,7 +133,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         else:
             return self._generate_background_task_not_found_response(name)
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     async def background_task_wrapper(self, name: str, function, *args, **kwargs):
         try:
             if asyncio.iscoroutinefunction(function):
@@ -152,7 +152,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
                 name, mlrun.api.schemas.BackgroundTaskState.succeeded
             )
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def _update_background_task(
         self,
         name: str,
@@ -163,7 +163,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         background_task.metadata.updated = datetime.datetime.utcnow()
 
     @staticmethod
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def _generate_background_task_not_found_response(
         name: str, project: typing.Optional[str] = None
     ):
@@ -181,7 +181,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         )
 
     @staticmethod
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def _generate_background_task(
         name: str, project: typing.Optional[str] = None
     ) -> mlrun.api.schemas.BackgroundTask:

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -96,7 +96,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
             str, mlrun.api.schemas.BackgroundTask
         ] = {}
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     def create_background_task(
         self,
         background_tasks: fastapi.BackgroundTasks,
@@ -120,7 +120,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
 
         return self.get_background_task(name)
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     def get_background_task(
         self,
         name: str,
@@ -133,7 +133,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         else:
             return self._generate_background_task_not_found_response(name)
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     async def background_task_wrapper(self, name: str, function, *args, **kwargs):
         try:
             if asyncio.iscoroutinefunction(function):
@@ -152,7 +152,6 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
                 name, mlrun.api.schemas.BackgroundTaskState.succeeded
             )
 
-    @mlrun.api.utils.helpers.run_on_chief_only
     def _update_background_task(
         self,
         name: str,
@@ -163,7 +162,6 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         background_task.metadata.updated = datetime.datetime.utcnow()
 
     @staticmethod
-    @mlrun.api.utils.helpers.run_on_chief_only
     def _generate_background_task_not_found_response(
         name: str, project: typing.Optional[str] = None
     ):
@@ -181,7 +179,6 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         )
 
     @staticmethod
-    @mlrun.api.utils.helpers.run_on_chief_only
     def _generate_background_task(
         name: str, project: typing.Optional[str] = None
     ) -> mlrun.api.schemas.BackgroundTask:

--- a/mlrun/api/utils/background_tasks.py
+++ b/mlrun/api/utils/background_tasks.py
@@ -9,6 +9,7 @@ import fastapi.concurrency
 import sqlalchemy.orm
 
 import mlrun.api.schemas
+import mlrun.api.utils.helpers
 import mlrun.api.utils.singletons.db
 import mlrun.api.utils.singletons.project_member
 import mlrun.errors
@@ -95,6 +96,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
             str, mlrun.api.schemas.BackgroundTask
         ] = {}
 
+    @mlrun.api.utils.helpers.run_only_on_chief
     def create_background_task(
         self,
         background_tasks: fastapi.BackgroundTasks,
@@ -118,6 +120,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
 
         return self.get_background_task(name)
 
+    @mlrun.api.utils.helpers.run_only_on_chief
     def get_background_task(
         self,
         name: str,
@@ -130,6 +133,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         else:
             return self._generate_background_task_not_found_response(name)
 
+    @mlrun.api.utils.helpers.run_only_on_chief
     async def background_task_wrapper(self, name: str, function, *args, **kwargs):
         try:
             if asyncio.iscoroutinefunction(function):
@@ -148,6 +152,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
                 name, mlrun.api.schemas.BackgroundTaskState.succeeded
             )
 
+    @mlrun.api.utils.helpers.run_only_on_chief
     def _update_background_task(
         self,
         name: str,
@@ -158,6 +163,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         background_task.metadata.updated = datetime.datetime.utcnow()
 
     @staticmethod
+    @mlrun.api.utils.helpers.run_only_on_chief
     def _generate_background_task_not_found_response(
         name: str, project: typing.Optional[str] = None
     ):
@@ -175,6 +181,7 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         )
 
     @staticmethod
+    @mlrun.api.utils.helpers.run_only_on_chief
     def _generate_background_task(
         name: str, project: typing.Optional[str] = None
     ) -> mlrun.api.schemas.BackgroundTask:

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -110,7 +110,7 @@ class Client(
 
     def _proxy_request_to_chief(
         self, method, path, raise_on_failure: bool = False, **kwargs
-    ):
+    ) -> fastapi.Response:
         chief_response = self._send_request_to_api(
             method=method, path=path, raise_on_failure=raise_on_failure, **kwargs
         )
@@ -197,11 +197,16 @@ class Client(
             if raise_on_failure:
                 mlrun.errors.raise_for_status(response)
             return response
+        # there are some responses like NO-CONTENT which doesn't returns json body
+        try:
+            data = response.json()
+        except Exception:
+            data = response.text
         logger.debug(
             "Request to chief succeeded",
             method=method,
             url=url,
             **kwargs,
-            response=response.json(),
+            response=data,
         )
         return response

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -140,7 +140,12 @@ class Client(
         """
         when endpoint is not async, we need to open an event loop because the request.body() is an async method
         """
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError as ex:
+            if "There is no current event loop in thread" in str(ex):
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
         future = asyncio.ensure_future(request.body())
         loop.run_until_complete(future)
         return future.result()

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -1,4 +1,3 @@
-import asyncio
 import copy
 
 import fastapi
@@ -43,14 +42,10 @@ class Client(
     def get_internal_background_task(
         self, name: str, request: fastapi.Request = None
     ) -> fastapi.Response:
-        return self._proxy_request_to_chief(
-            "GET", f"background-tasks/{name}", request
-        )
+        return self._proxy_request_to_chief("GET", f"background-tasks/{name}", request)
 
     def trigger_migrations(self, request: fastapi.Request = None) -> fastapi.Response:
-        return self._proxy_request_to_chief(
-            "POST", "operations/migrations", request
-        )
+        return self._proxy_request_to_chief("POST", "operations/migrations", request)
 
     def create_schedule(
         self, project: str, request: fastapi.Request, body: dict
@@ -98,9 +93,7 @@ class Client(
         return self._proxy_request_to_chief("POST", "build/function", request, body)
 
     def delete_project(self, name, request: fastapi.Request) -> fastapi.Response:
-        return self._proxy_request_to_chief(
-            "DELETE", f"projects/{name}", request
-        )
+        return self._proxy_request_to_chief("DELETE", f"projects/{name}", request)
 
     def _proxy_request_to_chief(
         self,

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -75,19 +75,19 @@ class Client(
             "DELETE", f"projects/{project}/schedules", request
         )
 
-    async def invoke_schedule(
+    def invoke_schedule(
         self, project: str, name: str, request: fastapi.Request
     ) -> fastapi.Response:
         return self._proxy_request_to_chief(
             "POST", f"projects/{project}/schedules/{name}/invoke", request
         )
 
-    async def submit_job(
+    def submit_job(
         self, request: fastapi.Request, body: dict
     ) -> fastapi.Response:
         return self._proxy_request_to_chief("POST", "submit_job", request, body)
 
-    async def build_function(
+    def build_function(
         self, request: fastapi.Request, body: dict
     ) -> fastapi.Response:
         return self._proxy_request_to_chief("POST", "build/function", request, body)

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -142,8 +142,8 @@ class Client(
         """
         try:
             loop = asyncio.get_event_loop()
-        except RuntimeError as ex:
-            if "There is no current event loop in thread" in str(ex):
+        except RuntimeError as exc:
+            if "There is no current event loop in thread" in str(exc):
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
         future = asyncio.ensure_future(request.body())

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -82,14 +82,10 @@ class Client(
             "POST", f"projects/{project}/schedules/{name}/invoke", request
         )
 
-    def submit_job(
-        self, request: fastapi.Request, body: dict
-    ) -> fastapi.Response:
+    def submit_job(self, request: fastapi.Request, body: dict) -> fastapi.Response:
         return self._proxy_request_to_chief("POST", "submit_job", request, body)
 
-    def build_function(
-        self, request: fastapi.Request, body: dict
-    ) -> fastapi.Response:
+    def build_function(self, request: fastapi.Request, body: dict) -> fastapi.Response:
         return self._proxy_request_to_chief("POST", "build/function", request, body)
 
     def delete_project(self, name, request: fastapi.Request) -> fastapi.Response:

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -197,7 +197,7 @@ class Client(
             if raise_on_failure:
                 mlrun.errors.raise_for_status(response)
             return response
-        # there are some responses like NO-CONTENT which doesn't returns json body
+        # there are some responses like NO-CONTENT which doesn't return a json body
         try:
             data = response.json()
         except Exception:

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -102,6 +102,12 @@ class Client(
         request_kwargs = await self._resolve_request_kwargs_from_request_async(request)
         return self._proxy_request_to_chief("POST", "build/function", **request_kwargs)
 
+    def delete_project(self, name, request: fastapi.Request) -> fastapi.Response:
+        request_kwargs = self._resolve_request_kwargs_from_request(request)
+        return self._proxy_request_to_chief(
+            "DELETE", f"projects/{name}", **request_kwargs
+        )
+
     def _proxy_request_to_chief(
         self, method, path, raise_on_failure: bool = False, **kwargs
     ):

--- a/mlrun/api/utils/helpers.py
+++ b/mlrun/api/utils/helpers.py
@@ -30,7 +30,7 @@ def ensure_running_on_chief(function):
         else:
             logger.warning(
                 f"running {function.__name__} chief function on worker",
-                fail_mode=mlrun.mlconf.raise_running_chief_functions_on_worker_mode,
+                fail_mode=mlrun.mlconf.httpdb.clusterization.ensure_function_running_on_chief_mode,
             )
 
     if asyncio.iscoroutinefunction(function):

--- a/mlrun/api/utils/helpers.py
+++ b/mlrun/api/utils/helpers.py
@@ -1,19 +1,30 @@
+import asyncio
+
 import mlrun
 import mlrun.api.schemas
+from mlrun.utils import logger
 
 
-def run_only_on_chief():
-    def decorator(function):
-        def wrapper(*args, **kwargs):
-            if (
-                mlrun.mlconf.httpdb.clusterization.role
-                == mlrun.api.schemas.ClusterizationRole.chief
-            ):
-                return function(*args, **kwargs)
+def run_only_on_chief(function):
+    def wrapper(*args, **kwargs):
+        return function(*args, **kwargs)
 
+    async def async_wrapper(*args, **kwargs):
+        return await function(*args, **kwargs)
+
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.api.schemas.ClusterizationRole.chief
+    ):
+        if mlrun.mlconf.fail_on_running_chief_functions_in_worker_mode == "enabled":
             message = f"{function.__name__} is supposed to run only on chief, re-route."
             raise mlrun.errors.MLRunIncompatibleVersionError(message)
+        else:
+            logger.warning(
+                f"running {function.__name__} chief function on worker",
+                fail_mode=mlrun.mlconf.fail_on_running_chief_functions_in_worker_mode,
+            )
 
-        return wrapper
-
-    return decorator
+    if asyncio.iscoroutinefunction(function):
+        return async_wrapper
+    return wrapper

--- a/mlrun/api/utils/helpers.py
+++ b/mlrun/api/utils/helpers.py
@@ -5,7 +5,7 @@ import mlrun.api.schemas
 from mlrun.utils import logger
 
 
-def run_on_chief_only(function):
+def ensure_running_on_chief(function):
     """
     The motivation of this function is to catch development bugs in which we are accidentally using functions / flows
     that are supposed to run only in chief instance and by mistake got involved in a worker instance flow.

--- a/mlrun/api/utils/helpers.py
+++ b/mlrun/api/utils/helpers.py
@@ -5,7 +5,15 @@ import mlrun.api.schemas
 from mlrun.utils import logger
 
 
-def run_only_on_chief(function):
+def run_on_chief_only(function):
+    """
+    The motivation of this function is to catch development bugs in which we are accidentally using functions / flows
+    that are supposed to run only in chief instance and by mistake got involved in a worker instance flow.
+
+    Note that there is an option to disable this behavior, its not recommended at all, because it can cause the
+    cluster to get out of synchronization.
+    """
+
     def wrapper(*args, **kwargs):
         return function(*args, **kwargs)
 
@@ -18,11 +26,11 @@ def run_only_on_chief(function):
     ):
         if mlrun.mlconf.fail_on_running_chief_functions_in_worker_mode == "enabled":
             message = f"{function.__name__} is supposed to run only on chief, re-route."
-            raise mlrun.errors.MLRunIncompatibleVersionError(message)
+            raise mlrun.errors.MLRunConflictError(message)
         else:
             logger.warning(
                 f"running {function.__name__} chief function on worker",
-                fail_mode=mlrun.mlconf.fail_on_running_chief_functions_in_worker_mode,
+                fail_mode=mlrun.mlconf.raise_running_chief_functions_on_worker_mode,
             )
 
     if asyncio.iscoroutinefunction(function):

--- a/mlrun/api/utils/helpers.py
+++ b/mlrun/api/utils/helpers.py
@@ -1,0 +1,19 @@
+import mlrun
+import mlrun.api.schemas
+
+
+def run_only_on_chief():
+    def decorator(function):
+        def wrapper(*args, **kwargs):
+            if (
+                mlrun.mlconf.httpdb.clusterization.role
+                == mlrun.api.schemas.ClusterizationRole.chief
+            ):
+                return function(*args, **kwargs)
+
+            message = f"{function.__name__} is supposed to run only on chief, re-route."
+            raise mlrun.errors.MLRunIncompatibleVersionError(message)
+
+        return wrapper
+
+    return decorator

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -43,7 +43,7 @@ class Scheduler:
         self._min_allowed_interval = config.httpdb.scheduling.min_allowed_interval
         self._secrets_provider = schemas.SecretProviderName.kubernetes
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     async def start(self, db_session: Session):
         logger.info("Starting scheduler")
         self._scheduler.start()
@@ -64,7 +64,7 @@ class Scheduler:
         # https://github.com/agronholm/apscheduler/issues/360 - this sleep make them work
         await asyncio.sleep(0)
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     def create_schedule(
         self,
         db_session: Session,
@@ -116,7 +116,7 @@ class Scheduler:
             auth_info,
         )
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     def update_schedule(
         self,
         db_session: Session,
@@ -205,7 +205,7 @@ class Scheduler:
             db_session, db_schedule, include_last_run, include_credentials
         )
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     def delete_schedule(
         self,
         db_session: Session,
@@ -216,7 +216,7 @@ class Scheduler:
         self._remove_schedule_scheduler_resources(project, name)
         get_db().delete_schedule(db_session, project, name)
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     def delete_schedules(
         self,
         db_session: Session,
@@ -242,7 +242,7 @@ class Scheduler:
         if job:
             self._scheduler.remove_job(job_id)
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     async def invoke_schedule(
         self,
         db_session: Session,
@@ -481,7 +481,7 @@ class Scheduler:
                     f"per {self._min_allowed_interval} is allowed"
                 )
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     def _create_schedule_in_scheduler(
         self,
         project: str,
@@ -512,7 +512,7 @@ class Scheduler:
             max_instances=concurrency_limit,
         )
 
-    @mlrun.api.utils.helpers.run_only_on_chief()
+    @mlrun.api.utils.helpers.run_only_on_chief
     def _update_schedule_in_scheduler(
         self,
         project: str,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -44,7 +44,7 @@ class Scheduler:
         self._min_allowed_interval = config.httpdb.scheduling.min_allowed_interval
         self._secrets_provider = schemas.SecretProviderName.kubernetes
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     async def start(self, db_session: Session):
         logger.info("Starting scheduler")
         self._scheduler.start()
@@ -65,7 +65,7 @@ class Scheduler:
         # https://github.com/agronholm/apscheduler/issues/360 - this sleep make them work
         await asyncio.sleep(0)
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     def create_schedule(
         self,
         db_session: Session,
@@ -117,7 +117,7 @@ class Scheduler:
             auth_info,
         )
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     def update_schedule(
         self,
         db_session: Session,
@@ -206,7 +206,7 @@ class Scheduler:
             db_session, db_schedule, include_last_run, include_credentials
         )
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     def delete_schedule(
         self,
         db_session: Session,
@@ -217,7 +217,7 @@ class Scheduler:
         self._remove_schedule_scheduler_resources(project, name)
         get_db().delete_schedule(db_session, project, name)
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     def delete_schedules(
         self,
         db_session: Session,
@@ -243,7 +243,7 @@ class Scheduler:
         if job:
             self._scheduler.remove_job(job_id)
 
-    @mlrun.api.utils.helpers.run_on_chief_only
+    @mlrun.api.utils.helpers.ensure_running_on_chief
     async def invoke_schedule(
         self,
         db_session: Session,
@@ -482,7 +482,6 @@ class Scheduler:
                     f"per {self._min_allowed_interval} is allowed"
                 )
 
-    @mlrun.api.utils.helpers.run_on_chief_only
     def _create_schedule_in_scheduler(
         self,
         project: str,
@@ -513,7 +512,6 @@ class Scheduler:
             max_instances=concurrency_limit,
         )
 
-    @mlrun.api.utils.helpers.run_on_chief_only
     def _update_schedule_in_scheduler(
         self,
         project: str,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -13,6 +13,7 @@ from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
 from sqlalchemy.orm import Session
 
 import mlrun.api.utils.auth.verifier
+import mlrun.api.utils.helpers
 import mlrun.errors
 from mlrun.api import schemas
 from mlrun.api.db.session import close_session, create_session
@@ -42,6 +43,7 @@ class Scheduler:
         self._min_allowed_interval = config.httpdb.scheduling.min_allowed_interval
         self._secrets_provider = schemas.SecretProviderName.kubernetes
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     async def start(self, db_session: Session):
         logger.info("Starting scheduler")
         self._scheduler.start()
@@ -62,6 +64,7 @@ class Scheduler:
         # https://github.com/agronholm/apscheduler/issues/360 - this sleep make them work
         await asyncio.sleep(0)
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     def create_schedule(
         self,
         db_session: Session,
@@ -113,6 +116,7 @@ class Scheduler:
             auth_info,
         )
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     def update_schedule(
         self,
         db_session: Session,
@@ -201,6 +205,7 @@ class Scheduler:
             db_session, db_schedule, include_last_run, include_credentials
         )
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     def delete_schedule(
         self,
         db_session: Session,
@@ -211,6 +216,7 @@ class Scheduler:
         self._remove_schedule_scheduler_resources(project, name)
         get_db().delete_schedule(db_session, project, name)
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     def delete_schedules(
         self,
         db_session: Session,
@@ -236,6 +242,7 @@ class Scheduler:
         if job:
             self._scheduler.remove_job(job_id)
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     async def invoke_schedule(
         self,
         db_session: Session,
@@ -474,6 +481,7 @@ class Scheduler:
                     f"per {self._min_allowed_interval} is allowed"
                 )
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     def _create_schedule_in_scheduler(
         self,
         project: str,
@@ -504,6 +512,7 @@ class Scheduler:
             max_instances=concurrency_limit,
         )
 
+    @mlrun.api.utils.helpers.run_only_on_chief()
     def _update_schedule_in_scheduler(
         self,
         project: str,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -27,7 +27,8 @@ from mlrun.utils import logger
 class Scheduler:
     """
     When using scheduler for create/update/delete/invoke or any other method that effects the scheduler behavior
-    make sure you are only running them in chief. For more information head over to
+    make sure you are only running them in chief.
+    For more information head over to https://github.com/mlrun/mlrun/pull/2059
     """
 
     _secret_username_subtype = "username"
@@ -43,7 +44,7 @@ class Scheduler:
         self._min_allowed_interval = config.httpdb.scheduling.min_allowed_interval
         self._secrets_provider = schemas.SecretProviderName.kubernetes
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     async def start(self, db_session: Session):
         logger.info("Starting scheduler")
         self._scheduler.start()
@@ -64,7 +65,7 @@ class Scheduler:
         # https://github.com/agronholm/apscheduler/issues/360 - this sleep make them work
         await asyncio.sleep(0)
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def create_schedule(
         self,
         db_session: Session,
@@ -116,7 +117,7 @@ class Scheduler:
             auth_info,
         )
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def update_schedule(
         self,
         db_session: Session,
@@ -205,7 +206,7 @@ class Scheduler:
             db_session, db_schedule, include_last_run, include_credentials
         )
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def delete_schedule(
         self,
         db_session: Session,
@@ -216,7 +217,7 @@ class Scheduler:
         self._remove_schedule_scheduler_resources(project, name)
         get_db().delete_schedule(db_session, project, name)
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def delete_schedules(
         self,
         db_session: Session,
@@ -242,7 +243,7 @@ class Scheduler:
         if job:
             self._scheduler.remove_job(job_id)
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     async def invoke_schedule(
         self,
         db_session: Session,
@@ -481,7 +482,7 @@ class Scheduler:
                     f"per {self._min_allowed_interval} is allowed"
                 )
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def _create_schedule_in_scheduler(
         self,
         project: str,
@@ -512,7 +513,7 @@ class Scheduler:
             max_instances=concurrency_limit,
         )
 
-    @mlrun.api.utils.helpers.run_only_on_chief
+    @mlrun.api.utils.helpers.run_on_chief_only
     def _update_schedule_in_scheduler(
         self,
         project: str,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -24,6 +24,10 @@ from mlrun.utils import logger
 
 
 class Scheduler:
+    """
+    When using scheduler for create/update/delete/invoke or any other method that effects the scheduler behavior
+    make sure you are only running them in chief. For more information head over to
+    """
 
     _secret_username_subtype = "username"
     _secret_access_key_subtype = "access_key"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -152,6 +152,7 @@ default_config = {
                 "service": "mlrun-api-chief",
                 "port": 8080,
             },
+            "fail_on_running_chief_functions_in_worker_mode": "enabled",
         },
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -152,7 +152,8 @@ default_config = {
                 "service": "mlrun-api-chief",
                 "port": 8080,
             },
-            "fail_on_running_chief_functions_in_worker_mode": "enabled",
+            # see mlrun.api.utils.helpers.run_on_chief_only
+            "raise_running_chief_functions_on_worker_mode": "enabled",
         },
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -152,8 +152,8 @@ default_config = {
                 "service": "mlrun-api-chief",
                 "port": 8080,
             },
-            # see mlrun.api.utils.helpers.run_on_chief_only
-            "raise_running_chief_functions_on_worker_mode": "enabled",
+            # see mlrun.api.utils.helpers.ensure_running_on_chief
+            "ensure_function_running_on_chief_mode": "enabled",
         },
         "port": 8080,
         "dirpath": expanduser("~/.mlrun/db"),

--- a/tests/api/api/test_background_tasks.py
+++ b/tests/api/api/test_background_tasks.py
@@ -233,7 +233,7 @@ def test_get_internal_background_task_redirect_from_worker_to_chief_exists(
     name = "task-name"
     expected_background_task = _generate_background_task(name)
     handler_mock = mlrun.api.utils.clients.chief.Client()
-    handler_mock.get_background_task = unittest.mock.Mock(
+    handler_mock.get_internal_background_task = unittest.mock.Mock(
         return_value=expected_background_task
     )
     monkeypatch.setattr(
@@ -253,7 +253,7 @@ def test_get_internal_background_task_from_worker_redirect_to_chief_doesnt_exist
     mlrun.mlconf.httpdb.clusterization.role = "worker"
     name = "task-name"
     handler_mock = mlrun.api.utils.clients.chief.Client()
-    handler_mock.get_background_task = unittest.mock.Mock(
+    handler_mock.get_internal_background_task = unittest.mock.Mock(
         side_effect=mlrun.errors.MLRunHTTPError()
     )
     monkeypatch.setattr(

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -114,7 +114,7 @@ async def test_multiple_store_function_race_condition(
     )
 
 
-def test_redirection_from_worker_to_chief_only_if_function_with_track_models(
+def test_redirection_from_worker_to_chief_only_if_serving_function_with_track_models(
     db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,
     httpserver,
@@ -149,7 +149,7 @@ def test_redirection_from_worker_to_chief_only_if_function_with_track_models(
     assert handler_mock._proxy_request_to_chief.call_count == 1
 
 
-def test_redirection_from_worker_to_chief_submit_job_with_schedule(
+def test_redirection_from_worker_to_chief_deploy_serving_function_with_track_models(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
 ):
     mlrun.mlconf.httpdb.clusterization.role = "worker"

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -143,17 +143,12 @@ def test_redirection_from_worker_to_chief_only_if_function_with_track_models(
         "Client",
         lambda *args, **kwargs: handler_mock,
     )
-    mlrun.api.api.endpoints.functions._build_function = unittest.mock.Mock(
-        return_value=(function, True)
-    )
 
     json_body = mlrun.utils.dict_to_json(_generate_build_function_request(function))
     client.post(endpoint, data=json_body)
     # no schedule inside job body, expecting to be run in worker
-    assert mlrun.api.api.endpoints.functions._build_function.call_count == 1
     assert handler_mock._proxy_request_to_chief.call_count == 0
 
-    mlrun.api.api.endpoints.functions._build_function.reset_mock()
     function_with_track_models = mlrun.new_function(
         name=function_name,
         project=PROJECT,
@@ -162,14 +157,10 @@ def test_redirection_from_worker_to_chief_only_if_function_with_track_models(
         image="mlrun/mlrun",
     )
     function_with_track_models.spec.track_models = True
-    mlrun.api.api.endpoints.functions._build_function = unittest.mock.Mock(
-        return_value=(function_with_track_models, True)
-    )
     json_body = mlrun.utils.dict_to_json(
         _generate_build_function_request(function_with_track_models)
     )
     client.post(endpoint, data=json_body)
-    assert mlrun.api.api.endpoints.functions._build_function.call_count == 0
     assert handler_mock._proxy_request_to_chief.call_count == 1
 
 

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -1,20 +1,29 @@
-from http import HTTPStatus
+import http
+import uuid
 
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+import fastapi.testclient
+import sqlalchemy.orm
 
+import mlrun
+import mlrun.api.main
+import mlrun.api.utils.auth.verifier
+import mlrun.api.utils.singletons.project_member
+import tests.api.api.utils
 from mlrun.api import schemas
 from mlrun.api.utils.singletons.db import get_db
-from mlrun.config import config
+
+ORIGINAL_VERSIONED_API_PREFIX = mlrun.api.main.BASE_VERSIONED_API_PREFIX
 
 
 async def do_nothing():
     pass
 
 
-def test_list_schedules(db: Session, client: TestClient) -> None:
+def test_list_schedules(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
     resp = client.get("projects/default/schedules")
-    assert resp.status_code == HTTPStatus.OK.value, "status"
+    assert resp.status_code == http.HTTPStatus.OK.value, "status"
     assert "schedules" in resp.json(), "no schedules"
 
     labels_1 = {
@@ -22,7 +31,7 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
     }
     cron_trigger = schemas.ScheduleCronTrigger(year="1999")
     schedule_name = "schedule-name"
-    project = config.default_project
+    project = mlrun.mlconf.default_project
     get_db().create_schedule(
         db,
         project,
@@ -30,7 +39,7 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
         schemas.ScheduleKinds.local_function,
         do_nothing,
         cron_trigger,
-        config.httpdb.scheduling.default_concurrency_limit,
+        mlrun.mlconf.httpdb.scheduling.default_concurrency_limit,
         labels_1,
     )
 
@@ -45,7 +54,7 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
         schemas.ScheduleKinds.local_function,
         do_nothing,
         cron_trigger,
-        config.httpdb.scheduling.default_concurrency_limit,
+        mlrun.mlconf.httpdb.scheduling.default_concurrency_limit,
         labels_2,
     )
 
@@ -57,11 +66,223 @@ def test_list_schedules(db: Session, client: TestClient) -> None:
     )
 
 
+def test_redirection_from_worker_to_chief_create_schedule(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project = "test-project"
+    endpoint = f"{ORIGINAL_VERSIONED_API_PREFIX}/projects/{project}/schedules"
+
+    for test_case in [
+        # project doesn't exists, expecting to fail before forwarding to chief
+        {
+            "body": _create_schedule(),
+            "expected_status": http.HTTPStatus.NOT_FOUND.value,
+            "expected_body": {
+                "detail": {
+                    "reason": f"MLRunNotFoundError('Project {project} does not exist')"
+                }
+            },
+            "expect_response_from_chief": False,
+            "create_project": False,
+        },
+        # project exists, expecting to create
+        {
+            "body": _create_schedule(),
+            "expected_status": http.HTTPStatus.CREATED.value,
+            "expected_body": {},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+        schedule = test_case.get("body")
+        create_project = test_case.get("create_project", True)
+        expect_response_from_chief = test_case.get("expect_response_from_chief", True)
+
+        if create_project:
+            tests.api.api.utils.create_project(client, project)
+        if expect_response_from_chief:
+            httpserver.expect_ordered_request(
+                endpoint, method="POST"
+            ).respond_with_json(expected_response, status=expected_status)
+            url = httpserver.url_for("")
+            mlrun.mlconf.httpdb.clusterization.chief.url = url
+        body = mlrun.utils.dict_to_json(schedule.dict())
+        response = client.post(endpoint, data=body)
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
+
+
+def test_redirection_from_worker_to_chief_update_schedule(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project = "test-project"
+    schedule_name = "test_scheduler"
+    endpoint = (
+        f"{ORIGINAL_VERSIONED_API_PREFIX}/projects/{project}/schedules/{schedule_name}"
+    )
+
+    for test_case in [
+        # we don't check if the project exists in update schedule, but rather query from the db and raise exception
+        # if schedule doesn't exists
+        {
+            "body": _create_schedule(),
+            "expected_status": http.HTTPStatus.NOT_FOUND.value,
+            "expected_body": {
+                "detail": {
+                    "reason": f"MLRunNotFoundError('Schedule not found: project={project}, name={schedule_name}')"
+                }
+            },
+        },
+        # updating schedule failed for unknown reason
+        {
+            "body": _create_schedule(),
+            "expected_status": http.HTTPStatus.NOT_FOUND.value,
+            "expected_body": {
+                "detail": {
+                    "reason": f"MLRunNotFoundError('Schedule not found: project={project}, name={schedule_name}')"
+                }
+            },
+        },
+        # project exists, expecting to create
+        {
+            "body": _create_schedule(),
+            "expected_status": http.HTTPStatus.OK.value,
+            "expected_body": {},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+        schedule = test_case.get("body")
+
+        httpserver.expect_ordered_request(endpoint, method="PUT").respond_with_json(
+            expected_response, status=expected_status
+        )
+        url = httpserver.url_for("")
+        mlrun.mlconf.httpdb.clusterization.chief.url = url
+        body = mlrun.utils.dict_to_json(schedule.dict())
+        response = client.put(endpoint, data=body)
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
+
+
+def test_redirection_from_worker_to_chief_delete_schedule(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project = "test-project"
+    schedule_name = "test_scheduler"
+    endpoint = (
+        f"{ORIGINAL_VERSIONED_API_PREFIX}/projects/{project}/schedules/{schedule_name}"
+    )
+
+    for test_case in [
+        # deleting schedule failed for unknown reason
+        {
+            "expected_status": http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "expected_body": {"detail": {"reason": "Unknown error"}},
+        },
+        # deleting schedule succeeded
+        {
+            "expected_status": http.HTTPStatus.NOT_FOUND.value,
+            "expected_body": {},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+
+        httpserver.expect_ordered_request(endpoint, method="DELETE").respond_with_json(
+            expected_response, status=expected_status
+        )
+        url = httpserver.url_for("")
+        mlrun.mlconf.httpdb.clusterization.chief.url = url
+        response = client.delete(endpoint)
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
+
+
+def test_redirection_from_worker_to_chief_delete_schedules(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project = "test-project"
+    endpoint = f"{ORIGINAL_VERSIONED_API_PREFIX}/projects/{project}/schedules"
+
+    for test_case in [
+        # deleting schedule failed for unknown reason
+        {
+            "expected_status": http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "expected_body": {"detail": {"reason": "Unknown error"}},
+        },
+        # deleting project's schedules succeeded
+        {
+            "expected_status": http.HTTPStatus.NOT_FOUND.value,
+            "expected_body": {},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+
+        httpserver.expect_ordered_request(endpoint, method="DELETE").respond_with_json(
+            expected_response, status=expected_status
+        )
+        url = httpserver.url_for("")
+        mlrun.mlconf.httpdb.clusterization.chief.url = url
+        response = client.delete(endpoint)
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
+
+
+def test_redirection_from_worker_to_chief_invoke_schedule(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project = "test-project"
+    schedule_name = "test_scheduler"
+    endpoint = f"{ORIGINAL_VERSIONED_API_PREFIX}/projects/{project}/schedules/{schedule_name}/invoke"
+
+    for test_case in [
+        # invoking schedule failed for unknown reason
+        {
+            "expected_status": http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "expected_body": {"detail": {"reason": "unknown error"}},
+        },
+        # expecting to succeed
+        {
+            "expected_status": http.HTTPStatus.OK.value,
+            "expected_body": {},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+
+        httpserver.expect_ordered_request(endpoint, method="POST").respond_with_json(
+            expected_response, status=expected_status
+        )
+        url = httpserver.url_for("")
+        mlrun.mlconf.httpdb.clusterization.chief.url = url
+        response = client.post(endpoint)
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
+
+
 def _get_and_assert_single_schedule(
-    client: TestClient, get_params: dict, schedule_name: str
+    client: fastapi.testclient.TestClient, get_params: dict, schedule_name: str
 ):
     resp = client.get("projects/default/schedules", params=get_params)
-    assert resp.status_code == HTTPStatus.OK.value, "status"
+    assert resp.status_code == http.HTTPStatus.OK.value, "status"
     result = resp.json()["schedules"]
     assert len(result) == 1
     assert result[0]["name"] == schedule_name
+
+
+def _create_schedule(schedule_name: str = None):
+    if not schedule_name:
+        schedule_name = f"schedule-name-{str(uuid.uuid4())}"
+    return mlrun.api.schemas.ScheduleInput(
+        name=schedule_name,
+        kind=mlrun.api.schemas.ScheduleKinds.job,
+        scheduled_object={"metadata": {"name": "something"}},
+        cron_trigger=mlrun.api.schemas.ScheduleCronTrigger(year=1999),
+    )

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -262,14 +262,16 @@ def test_redirection_from_worker_to_chief_only_if_schedules_in_job(
 
     mlrun.api.api.utils._submit_run = unittest.mock.Mock(return_value=("", "", "", {}))
     submit_job_body = _create_submit_job_body_with_schedule(function, project)
-    client.post("submit_job", json=submit_job_body)
+    json_body = mlrun.utils.dict_to_json(submit_job_body)
+    client.post("submit_job", data=json_body)
     assert mlrun.api.api.utils._submit_run.call_count == 0
     assert handler_mock._proxy_request_to_chief.call_count == 1
 
     handler_mock._proxy_request_to_chief.reset_mock()
 
     submit_job_body = _create_submit_job_body(function, project)
-    client.post("submit_job", json=submit_job_body)
+    json_body = mlrun.utils.dict_to_json(submit_job_body)
+    client.post("submit_job", data=json_body)
     # no schedule inside job body, expecting to be run in worker
     assert mlrun.api.api.utils._submit_run.call_count == 1
     assert handler_mock._proxy_request_to_chief.call_count == 0

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -260,11 +260,9 @@ def test_redirection_from_worker_to_chief_only_if_schedules_in_job(
         lambda *args, **kwargs: handler_mock,
     )
 
-    mlrun.api.api.utils._submit_run = unittest.mock.Mock(return_value=("", "", "", {}))
     submit_job_body = _create_submit_job_body_with_schedule(function, project)
     json_body = mlrun.utils.dict_to_json(submit_job_body)
     client.post("submit_job", data=json_body)
-    assert mlrun.api.api.utils._submit_run.call_count == 0
     assert handler_mock._proxy_request_to_chief.call_count == 1
 
     handler_mock._proxy_request_to_chief.reset_mock()
@@ -273,7 +271,6 @@ def test_redirection_from_worker_to_chief_only_if_schedules_in_job(
     json_body = mlrun.utils.dict_to_json(submit_job_body)
     client.post("submit_job", data=json_body)
     # no schedule inside job body, expecting to be run in worker
-    assert mlrun.api.api.utils._submit_run.call_count == 1
     assert handler_mock._proxy_request_to_chief.call_count == 0
 
 

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -95,22 +95,6 @@ def pod_create_mock():
     )
 
 
-def _create_submit_job_body(function, project):
-    return {
-        "task": {
-            "spec": {"output_path": "/some/fictive/path/to/make/everybody/happy"},
-            "metadata": {"name": "task1", "project": project},
-        },
-        "function": function.to_dict(),
-    }
-
-
-def _create_submit_job_body_with_schedule(function, project):
-    job_body = _create_submit_job_body(function, project)
-    job_body["schedule"] = mlrun.api.schemas.ScheduleCronTrigger(year=1999).dict()
-    return job_body
-
-
 def test_submit_job_auto_mount(
     db: Session, client: TestClient, pod_create_mock, k8s_secrets_mock
 ) -> None:
@@ -325,6 +309,22 @@ def test_redirection_from_worker_to_chief_submit_job_with_schedule(
         response = client.post(endpoint, data=json_body)
         assert response.status_code == expected_status
         assert response.json() == expected_response
+
+
+def _create_submit_job_body(function, project):
+    return {
+        "task": {
+            "spec": {"output_path": "/some/fictive/path/to/make/everybody/happy"},
+            "metadata": {"name": "task1", "project": project},
+        },
+        "function": function.to_dict(),
+    }
+
+
+def _create_submit_job_body_with_schedule(function, project):
+    job_body = _create_submit_job_body(function, project)
+    job_body["schedule"] = mlrun.api.schemas.ScheduleCronTrigger(year=1999).dict()
+    return job_body
 
 
 def _assert_pod_env_vars(pod_create_mock, expected_env_vars):

--- a/tests/api/utils/clients/test_chief.py
+++ b/tests/api/utils/clients/test_chief.py
@@ -42,7 +42,7 @@ def test_get_background_task_from_chief_success(
     requests_mock.get(
         f"{api_url}/api/v1/background-tasks/{task_name}", json=response_body
     )
-    response = chief_client.get_background_task(task_name)
+    response = chief_client.get_internal_background_task(task_name)
     assert response.status_code == http.HTTPStatus.OK
     background_task = _transform_response_to_background_task(response)
     assert background_task.metadata.name == task_name
@@ -55,7 +55,7 @@ def test_get_background_task_from_chief_success(
     requests_mock.get(
         f"{api_url}/api/v1/background-tasks/{task_name}", json=response_body
     )
-    response = chief_client.get_background_task(task_name)
+    response = chief_client.get_internal_background_task(task_name)
     assert response.status_code == http.HTTPStatus.OK
     background_task = _transform_response_to_background_task(response)
     assert background_task.metadata.name == task_name
@@ -77,7 +77,7 @@ def test_get_background_task_from_chief_failed(
         f"{api_url}/api/v1/background-tasks/{task_name}",
         status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
     )
-    response = chief_client.get_background_task(task_name)
+    response = chief_client.get_internal_background_task(task_name)
     assert response.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR.value
 
 
@@ -178,7 +178,7 @@ def test_trigger_migrations_chief_restarted_while_executing_migrations(
     requests_mock.get(
         f"{api_url}/api/v1/background-tasks/{task_name}", json=response_body
     )
-    response = chief_client.get_background_task(task_name)
+    response = chief_client.get_internal_background_task(task_name)
     assert response.status_code == http.HTTPStatus.OK
     background_task = _transform_response_to_background_task(response)
     assert background_task.metadata.name == task_name


### PR DESCRIPTION
This PR, is part of a series of PRs making the API stateless. 
We decided that only the chief will be responsible for running the scheduler, which means that any code that had any effect on the scheduler behavior (e.g create / delete / update / invoke ) must run by the chief. 
To implement that requirement, when accessing code that affect the scheduler behavior we will check which instance type we are running inside, and if we are running inside a worker we will re-route the request to the chief.

## The re-routing endpoints are :
### Schedules:
- CREATE schedule- `/projects/{project}/schedules`
- PUT schedule - `/projects/{project}/schedules/{name}`
- DELETE schedule - `/projects/{project}/schedules/{name}`
- DELETE project schedules - `/projects/{project}/schedules`
- POST schedule - - `/projects/{project}/schedules/{name}/invoke`

We also had endpoints which weren't explicitly related to scheduling but had some features that if enabled they would use the scheduler.
### Submit Job
- CREATE  job - `submit_job` : when contains `schedule` attribute then re-route to chief.

### Functions
- CREATE build function - `/build/function` : when contains `track_models` attribute then re-route to chief.

### Projects
- DELETE project - `/projects/{name}`: as part of deleting project we are also deleting related resources, one of them is schedules, to make sure we are removing them from the chief, we are re-routing to chief.

I've also added a decorator `ensure_function_running_on_chief_mode` for functions that supposed to run only on chief, hopefully this could help us fail early when developing and using existing functions that supposed to run only on chief.  