### PR TITLE
[Projects] Add timeout attribute to run method

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -819,6 +819,11 @@ def logs(uid, project, offset, db, watch):
 @click.option("--engine", default=None, help="workflow engine (kfp/local)")
 @click.option("--local", is_flag=True, help="try to run workflow functions locally")
 @click.option(
+    "--timeout",
+    default=None,
+    help="timeout in seconds for waiting for pipeline completion (used when watch=True)",
+)
+@click.option(
     "--env-file", default="", help="path to .env file to load config/variables from"
 )
 def project(
@@ -843,6 +848,7 @@ def project(
     engine,
     local,
     env_file,
+    timeout,
 ):
     """load and/or run a project"""
     if env_file:
@@ -923,7 +929,7 @@ def project(
             exit(1)
 
         if watch and run_result and run_result.workflow.engine == "kfp":
-            proj.get_run_status(run_result)
+            proj.get_run_status(run_result, timeout=timeout)
 
     elif sync:
         print("saving project functions to db ..")

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -822,7 +822,7 @@ def logs(uid, project, offset, db, watch):
     "--timeout",
     type=int,
     default=None,
-    help="timeout in seconds for waiting for pipeline completion (used when watch=True)",
+    help="timeout in seconds to wait for pipeline completion (used when watch=True)",
 )
 @click.option(
     "--env-file", default="", help="path to .env file to load config/variables from"

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -820,6 +820,7 @@ def logs(uid, project, offset, db, watch):
 @click.option("--local", is_flag=True, help="try to run workflow functions locally")
 @click.option(
     "--timeout",
+    type=int,
     default=None,
     help="timeout in seconds for waiting for pipeline completion (used when watch=True)",
 )

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1860,7 +1860,7 @@ class MlrunProject(ModelObj):
         :param ttl:       pipeline ttl in secs (after that the pods will be removed)
         :param engine:    workflow engine running the workflow. supported values are 'kfp' (default) or 'local'
         :param local:     run local pipeline with local functions (set local=True in function.run())
-        :param timeout:   timeout in seconds for waiting for pipeline completion (used when watch=True)
+        :param timeout:   timeout in seconds to wait for pipeline completion (used when watch=True)
 
         :returns: run id
         """

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1839,6 +1839,7 @@ class MlrunProject(ModelObj):
         ttl=None,
         engine=None,
         local=None,
+        timeout=None,
     ) -> _PipelineRunStatus:
         """run a workflow using kubeflow pipelines
 
@@ -1859,6 +1860,7 @@ class MlrunProject(ModelObj):
         :param ttl:       pipeline ttl in secs (after that the pods will be removed)
         :param engine:    workflow engine running the workflow. supported values are 'kfp' (default) or 'local'
         :param local:     run local pipeline with local functions (set local=True in function.run())
+        :param timeout:   timeout in seconds for waiting for pipeline completion (used when watch=True)
 
         :returns: run id
         """
@@ -1911,7 +1913,7 @@ class MlrunProject(ModelObj):
         )
         workflow_spec.clear_tmp()
         if watch and workflow_engine.engine == "kfp":
-            self.get_run_status(run)
+            self.get_run_status(run, timeout=timeout)
         return run
 
     def save_workflow(self, name, target, artifact_path=None, ttl=None):


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2341
Currently when using MLRun CLI for `project run` and setting `watch=True` the default timeout value is 60 min which in not configurable from outside. This PR will allow to set the timeout from outside.