### PR TITLE
[Projects] Fix project querying caching

### DIFF
--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -88,6 +88,7 @@ class Member(
             )
             created_project = None
             if not is_running_in_background:
+                db_session.commit()
                 created_project = self.get_project(
                     db_session, project.metadata.name, leader_session
                 )

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -88,7 +88,22 @@ class Member(
             )
             created_project = None
             if not is_running_in_background:
+                # as part of the store_project flow we encountered an error related to the isolation level we use.
+                # We use the default isolation level, I wasn't able to find exactly what is the default that sql alchemy
+                # sets but its serializable(once you SELECT a series of rows in a transaction, you will get the
+                # identical data back each time you re-emit that SELECT) or repeatable read isolation (you’ll see newly
+                # added rows (and no longer see deleted rows), but for rows that you’ve already loaded, you won’t see
+                # any change). Eventually, in the store_project flow, we already queried get_project and at the second
+                # time(below), after the project created, we failed because we got the same result from first query.
+                # Using session.commit ends the current transaction and start a new one which will result in a
+                # new query to the DB.
+                # for further read: https://docs-sqlalchemy.readthedocs.io/ko/latest/faq/sessions.html
+                # https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
+                # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
+                # TODO: there are multiple isolation level we can choose, READ COMMITTED seems to solve our issue
+                #  but will require deeper investigation and more test coverage
                 db_session.commit()
+
                 created_project = self.get_project(
                     db_session, project.metadata.name, leader_session
                 )


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-2344.
We encountered an error related to the sqlalchemy session isolation level. 
It seems we use the default isolation mode which is serializable ( probably ) which eventually means that if we query the db and then will run the same query the second try won't query the DB but rather will use the latest query result ( kind of cache ). 
To fix this issue there are a few options : 
- session.commit() before repeating queries - this will ends the current transaction and start a new one which will result in a new query to the DB.
- change the isolation level - we should strive to achieve that ( won't be part of this PR ) will require further investigation and more test coverage. 

Here are some information related to the topic : 
https://docs-sqlalchemy.readthedocs.io/ko/latest/faq/sessions.html
https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html 