### PR TITLE
[Project] Support empty serving functions with project.set_function()

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2651,7 +2651,6 @@ class MlrunProjectLegacy(ModelObj):
 
 
 def _init_function_from_dict(f, project):
-
     name = f.get("name", "")
     url = f.get("url", "")
     kind = f.get("kind", "")
@@ -2690,8 +2689,8 @@ def _init_function_from_dict(f, project):
         if image:
             func.spec.image = image
     elif url.endswith(".ipynb"):
-        # not defaulting kind to job here cause kind might come from magic annotations in the notebook
         raise_no_image()
+        # not defaulting kind to job here cause kind might come from magic annotations in the notebook
         func = code_to_function(
             name, filename=url, image=image, kind=kind, handler=handler
         )

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -239,6 +239,13 @@ def test_set_func_requirements():
     ]
 
 
+def test_set_empty_serving():
+    project = mlrun.projects.MlrunProject("newproj")
+    project.set_function(name="srv", kind="serving", image="mlrun/mlrun")
+    function = project.get_function("srv", enrich=True)
+    assert function.kind == "serving"
+
+
 def test_function_run_cli():
     # run function stored in the project spec
     project_dir_path = pathlib.Path(tests.conftest.results) / "project-run-func"


### PR DESCRIPTION
serving functions dont need to have code (can use built-in classes and handles), this PR allows registering serving functions without code (using `project.set_function()`), if a user wants to use the current notebook as the source he should pass "." in the func source attribute.