### PR TITLE
[CI] Optimize Jupyter image caching, Improve release workflow usability and fix unstable tag maintenance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,7 @@ jobs:
         echo "::set-output name=mlrun_docker_registries::$( \
           input_docker_registries=${{ github.event.inputs.docker_registries }} && \
           echo ${input_docker_registries:-ghcr.io/})"
+        echo "::set-output name=mlrun_cache_date::$(date +%s)"
     - name: Docker login
       # all suffixed with "| true" to allow failures if secrets are not defined (fork)
       run: |
@@ -88,6 +89,7 @@ jobs:
       run: |
         for registry in $(echo ${{ steps.computed_params.outputs.mlrun_docker_registries }} | sed "s/,/ /g"); \
           do \
+            MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
             MLRUN_DOCKER_REGISTRY=$registry \
             MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
             MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
@@ -105,6 +107,7 @@ jobs:
       run: |
         for registry in "ghcr.io/" "quay.io/" "registry.hub.docker.com/"; \
           do \
+            MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
             MLRUN_DOCKER_REGISTRY=$registry \
             MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
             MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
@@ -116,6 +119,7 @@ jobs:
       # When version is given we're probably in a release process, we don't need the test image in that case
       if: matrix.image-name == 'test' && github.event.inputs.version == ''
       run: |
+        MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
         MLRUN_DOCKER_REGISTRY=ghcr.io/ \
         MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
         MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
 
       # we don't need to have unstable tag for the test image
       # And we don't need to run this when triggered manually (workflow dispatch)
-      if: matrix.image-name != 'test' && github.event_name != 'workflow_dispatch' && steps.git_info.outputs.branch == 'development'
+      if: matrix.image-name != 'test' && github.event_name != 'workflow_dispatch' && github.ref_name == 'development'
       run: |
         for registry in "ghcr.io/" "quay.io/" "registry.hub.docker.com/"; \
           do \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,6 @@ on:
       version:
         description: 'The version to release, without prefix v (e.g. 1.1.0)'
         required: true
-      branch:
-        description: 'The branch to release from (e.g. 1.0.x)'
-        required: true
-        default: 'master'
 
 jobs:
   trigger-and-wait-for-mlrun-image-building:
@@ -23,7 +19,7 @@ jobs:
           repo: mlrun
           github_token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
           workflow_file_name: build.yaml
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.ref_name }}
           wait_interval: 60
           client_payload: '{"docker_registries": "ghcr.io/,quay.io/,registry.hub.docker.com/", "version": "${{ github.event.inputs.version }}"}'
 
@@ -38,7 +34,7 @@ jobs:
           repo: ui
           github_token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
           workflow_file_name: build.yaml
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.ref_name }}
           wait_interval: 60
           client_payload: '{"docker_registries": "ghcr.io/,quay.io/,registry.hub.docker.com/", "version": "${{ github.event.inputs.version }}"}'
 
@@ -69,11 +65,11 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           tag: v${{ github.event.inputs.version }}
-          commit: ${{ github.event.inputs.branch }}
+          commit: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
       - uses: ncipollo/release-action@v1
         with:
           repo: ui
           tag: v${{ github.event.inputs.version }}
-          commit: ${{ github.event.inputs.branch }}
+          commit: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -27,10 +27,6 @@ COPY --chown=$NB_UID:$NB_GID ./docs/tutorial $HOME/tutorial
 COPY --chown=$NB_UID:$NB_GID ./docs/_static/images/tutorial $HOME/_static/images/tutorial
 COPY --chown=$NB_UID:$NB_GID ./docs/_static/images/MLRun-logo.png $HOME/_static/images
 
-ARG MLRUN_CACHE_DATE=initial
-RUN git clone --branch 1.0.x https://github.com/mlrun/demos.git $HOME/demos
-RUN git clone --branch master https://github.com/mlrun/functions.git $HOME/functions
-
 RUN mkdir data
 
 COPY --chown=$NB_UID:$NB_GID ./dockerfiles/jupyter/requirements.txt /tmp/requirements/jupyter-requirements.txt
@@ -45,6 +41,11 @@ RUN python -m pip install \
 
 COPY --chown=$NB_UID:$NB_GID . /tmp/mlrun
 RUN cd /tmp/mlrun && python -m pip install ".[complete-api]"
+
+# This will usually cause a cache miss - so keep it in the last layers
+ARG MLRUN_CACHE_DATE=initial
+RUN git clone --branch 1.0.x https://github.com/mlrun/demos.git $HOME/demos
+RUN git clone --branch master https://github.com/mlrun/functions.git $HOME/functions
 
 ENV JUPYTER_ENABLE_LAB=yes \
     MLRUN_HTTPDB__DATA_VOLUME=$HOME/data \


### PR DESCRIPTION
Several fixes to the Build & Release workflows:
1. In the build step, we are iterating the registries, and running `make push-<image-name>` for each registry, which means that `docker build` is called again and again for each registry, this is basically fine as we have docker cache, but, the Jupyter image is using the `MLRUN_CACHE_DATE` argument, so setting it from outside in the workflow file
2. To improve how much cache misses we're getting from this `MLRUN_CACHE_DATE` usage, I moved the clones that happens after it to be closer to the end of the dockerfile
3. I removed the branch input from the release workflow, we can simply use the github ref name
4. In https://github.com/mlrun/mlrun/pull/2101/files#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L45 I removed the line that generated the `branch` output in the `git_info` step, therefore, the condition of the step that is maintaining the unstable, that had `steps.git_info.outputs.branch == 'development'` was always evaluating to true, causing unstable tags to stop being pushed, fixed the condition