### PR TITLE
[CI] Increase helm Install timeout to open source system tests

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -153,6 +153,7 @@ jobs:
             install mlrun-kit \
             --debug \
             --wait \
+            --timeout 600 \
             --set global.registry.url=$(minikube ip):5000 \
             --set global.registry.secretName="" \
             --set global.externalHostAddress=$(minikube ip) \


### PR DESCRIPTION
Latest MLRun CE will require more than 5 minutes to install the chart. So in order for the CI to succeed running the system tests, increasing the timeout to 10 minutes.