### PR TITLE
[Runtimes] Set Kafka consumer group from function name

### DIFF
--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -447,6 +447,7 @@ class ServingRuntime(RemoteRuntime):
                     trigger = KafkaTrigger(
                         brokers=brokers,
                         topics=[topic],
+                        consumer_group=f"{function_name}-consumer-group",
                         **trigger_args,
                     )
                     child_function.function_object.add_trigger("kafka", trigger)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -618,11 +618,15 @@ class QueueStep(BaseStep):
         name: str = None,
         path: str = None,
         after: list = None,
+        shards: int = None,
+        retention_in_hours: int = None,
         trigger_args: dict = None,
         **options,
     ):
         super().__init__(name, after)
         self.path = path
+        self.shards = shards
+        self.retention_in_hours = retention_in_hours
         self.options = options
         self.trigger_args = trigger_args
         self._stream = None
@@ -633,6 +637,8 @@ class QueueStep(BaseStep):
         if self.path:
             self._stream = get_stream_pusher(
                 self.path,
+                shards=self.shards,
+                retention_in_hours=self.retention_in_hours,
                 **self.options,
             )
         self._set_error_handler()

--- a/tests/system/runtimes/assets/child_function.py
+++ b/tests/system/runtimes/assets/child_function.py
@@ -1,3 +1,9 @@
 class Identity:
     def do(self, x):
         return x
+
+
+class Augment:
+    def do(self, x):
+        x["more_stuff"] = 5
+        return x

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -74,7 +74,7 @@ class TestNuclioRuntime(tests.system.base.TestMLRunSystem):
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestNuclioRuntimeWithStream(tests.system.base.TestMLRunSystem):
-    project_name = "nuclio-stream-project"
+    project_name = "stream-project"
     stream_container = "bigdata"
     stream_path = "/test_nuclio/test_serving_with_child_function/"
 
@@ -116,7 +116,7 @@ class TestNuclioRuntimeWithStream(tests.system.base.TestMLRunSystem):
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
-    project_name = "nuclio-kafka-project"
+    project_name = "kafka-project"
     topic_uuid_part = uuid.uuid4()
     topic = f"TestNuclioRuntimeWithKafka-{topic_uuid_part}"
     topic_out = f"TestNuclioRuntimeWithKafka-out-{topic_uuid_part}"
@@ -171,8 +171,17 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
             name="child", class_name="Identity", function="child"
         ).to(">>", "out", path=self.topic_out, kafka_bootstrap_servers=self.brokers)
 
+        graph.add_step(
+            name="other-child", class_name="Augment", after="q1", function="other-child"
+        ).to(">>", "out2", path=self.topic_out, kafka_bootstrap_servers=self.brokers)
+
         function.add_child_function(
             "child",
+            child_code_path,
+            image="mlrun/mlrun",
+        )
+        function.add_child_function(
+            "other-child",
             child_code_path,
             image="mlrun/mlrun",
         )
@@ -186,8 +195,17 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Waiting for data to arrive in output topic")
         kafka_consumer.subscribe([self.topic_out])
-        record = next(kafka_consumer)
-        assert record.value == b'{"hello": "world"}'
+        record1 = next(kafka_consumer)
+        assert (
+            record1.value == b'{"hello": "world"}'
+            or record1.value == b'{"hello": "world", "more_stuff": 5}'
+        )
+        record2 = next(kafka_consumer)
+        assert (
+            record2.value == b'{"hello": "world"}'
+            or record2.value == b'{"hello": "world", "more_stuff": 5}'
+        )
+        assert record1 != record2
 
 
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured


### PR DESCRIPTION
to avoid multiple downstreams using the same consumer group.

[ML-2408](https://jira.iguazeng.com/browse/ML-2408)