### PR TITLE
[Runtimes] Add a global config (on server side) for default service account

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -451,7 +451,7 @@ def process_function_service_account(function):
 
     # If default SA was not configured for the project, try to retrieve it from global config (if exists)
     default_service_account = (
-        default_service_account or mlrun.mlconf.function.spec.service_account
+        default_service_account or mlrun.mlconf.function.spec.service_account.default
     )
 
     # Sanity check on project configuration

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -449,6 +449,11 @@ def process_function_service_account(function):
         allow_internal_secrets=True,
     )
 
+    # If default SA was not configured for the project, try to retrieve it from global config (if exists)
+    default_service_account = (
+        default_service_account or mlrun.mlconf.httpdb.default_service_account
+    )
+
     # Sanity check on project configuration
     if (
         default_service_account

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -451,7 +451,7 @@ def process_function_service_account(function):
 
     # If default SA was not configured for the project, try to retrieve it from global config (if exists)
     default_service_account = (
-        default_service_account or mlrun.mlconf.httpdb.default_service_account
+        default_service_account or mlrun.mlconf.function.spec.service_account
     )
 
     # Sanity check on project configuration

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -303,6 +303,7 @@ default_config = {
         },
         "v3io_api": "",
         "v3io_framesd": "",
+        "default_service_account": "",
     },
     "model_endpoint_monitoring": {
         "serving_stream_args": {"shard_count": 1, "retention_period_hours": 24},

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -137,7 +137,7 @@ default_config = {
                 # in camelCase format: {"runAsUser": 1000, "runAsGroup": 3000}
                 "default": "e30=",  # encoded empty dict
             },
-            "service_account": None,
+            "service_account": {"default": None},
         },
     },
     "function_defaults": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -137,6 +137,7 @@ default_config = {
                 # in camelCase format: {"runAsUser": 1000, "runAsGroup": 3000}
                 "default": "e30=",  # encoded empty dict
             },
+            "service_account": None,
         },
     },
     "function_defaults": {
@@ -303,7 +304,6 @@ default_config = {
         },
         "v3io_api": "",
         "v3io_framesd": "",
-        "default_service_account": "",
     },
     "model_endpoint_monitoring": {
         "serving_stream_args": {"shard_count": 1, "retention_period_hours": 24},

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -214,13 +214,13 @@ def test_submit_job_service_accounts(
 
     # Validate that a global service account works as expected
     pod_create_mock.reset_mock()
-    mlconf.httpdb.default_service_account = "some-sa"
+    mlconf.function.spec.service_account = "some-sa"
     function.spec.service_account = None
     submit_job_body = _create_submit_job_body(function, project)
     resp = client.post("submit_job", json=submit_job_body)
     assert resp
     _assert_pod_service_account(pod_create_mock, "some-sa")
-    mlconf.httpdb.default_service_account = ""
+    mlconf.function.spec.service_account = None
 
 
 def test_redirection_from_worker_to_chief_only_if_schedules_in_job(

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -214,13 +214,13 @@ def test_submit_job_service_accounts(
 
     # Validate that a global service account works as expected
     pod_create_mock.reset_mock()
-    mlconf.function.spec.service_account = "some-sa"
+    mlconf.function.spec.service_account.default = "some-sa"
     function.spec.service_account = None
     submit_job_body = _create_submit_job_body(function, project)
     resp = client.post("submit_job", json=submit_job_body)
     assert resp
     _assert_pod_service_account(pod_create_mock, "some-sa")
-    mlconf.function.spec.service_account = None
+    mlconf.function.spec.service_account.default = None
 
 
 def test_redirection_from_worker_to_chief_only_if_schedules_in_job(

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -212,6 +212,16 @@ def test_submit_job_service_accounts(
     assert resp
     _assert_pod_service_account(pod_create_mock, "sa3")
 
+    # Validate that a global service account works as expected
+    pod_create_mock.reset_mock()
+    mlconf.httpdb.default_service_account = "some-sa"
+    function.spec.service_account = None
+    submit_job_body = _create_submit_job_body(function, project)
+    resp = client.post("submit_job", json=submit_job_body)
+    assert resp
+    _assert_pod_service_account(pod_create_mock, "some-sa")
+    mlconf.httpdb.default_service_account = ""
+
 
 def test_redirection_from_worker_to_chief_only_if_schedules_in_job(
     db: sqlalchemy.orm.Session,

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -471,18 +471,19 @@ class TestNuclioRuntime(TestRuntimeBase):
             _build_function(db, None, function)
 
         # verify that project SA overrides the global SA
-        mlconf.httpdb.default_service_account = "some-other-sa"
+        mlconf.function.spec.service_account = "some-other-sa"
         function.spec.service_account = "sa2"
         _build_function(db, None, function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_service_account="sa2"
         )
+        mlconf.function.spec.service_account = None
 
     def test_deploy_with_global_service_account(
         self, db: Session, k8s_secrets_mock: K8sSecretsMock
     ):
         service_account_name = "default-sa"
-        mlconf.httpdb.default_service_account = service_account_name
+        mlconf.function.spec.service_account = service_account_name
 
         function = self._generate_runtime(self.runtime_kind)
         # Need to call _build_function, since service-account enrichment is happening only on server side, before the
@@ -492,7 +493,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_class=self.class_name,
             expected_service_account=service_account_name,
         )
-        mlconf.httpdb.default_service_account = ""
+        mlconf.function.spec.service_account = None
 
     def test_deploy_basic_function(self, db: Session, client: TestClient):
         function = self._generate_runtime(self.runtime_kind)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -471,19 +471,19 @@ class TestNuclioRuntime(TestRuntimeBase):
             _build_function(db, None, function)
 
         # verify that project SA overrides the global SA
-        mlconf.function.spec.service_account = "some-other-sa"
+        mlconf.function.spec.service_account.default = "some-other-sa"
         function.spec.service_account = "sa2"
         _build_function(db, None, function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_service_account="sa2"
         )
-        mlconf.function.spec.service_account = None
+        mlconf.function.spec.service_account.default = None
 
     def test_deploy_with_global_service_account(
         self, db: Session, k8s_secrets_mock: K8sSecretsMock
     ):
         service_account_name = "default-sa"
-        mlconf.function.spec.service_account = service_account_name
+        mlconf.function.spec.service_account.default = service_account_name
 
         function = self._generate_runtime(self.runtime_kind)
         # Need to call _build_function, since service-account enrichment is happening only on server side, before the
@@ -493,7 +493,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_class=self.class_name,
             expected_service_account=service_account_name,
         )
-        mlconf.function.spec.service_account = None
+        mlconf.function.spec.service_account.default = None
 
     def test_deploy_basic_function(self, db: Session, client: TestClient):
         function = self._generate_runtime(self.runtime_kind)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -452,7 +452,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_class=self.class_name, expected_env_from_secrets=expected_secrets
         )
 
-    def test_deploy_with_service_accounts(
+    def test_deploy_with_project_service_accounts(
         self, db: Session, k8s_secrets_mock: K8sSecretsMock
     ):
         k8s_secrets_mock.set_service_account_keys(self.project, "sa1", ["sa1", "sa2"])
@@ -470,11 +470,29 @@ class TestNuclioRuntime(TestRuntimeBase):
         with pytest.raises(HTTPException):
             _build_function(db, None, function)
 
+        # verify that project SA overrides the global SA
+        mlconf.httpdb.default_service_account = "some-other-sa"
         function.spec.service_account = "sa2"
         _build_function(db, None, function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_service_account="sa2"
         )
+
+    def test_deploy_with_global_service_account(
+        self, db: Session, k8s_secrets_mock: K8sSecretsMock
+    ):
+        service_account_name = "default-sa"
+        mlconf.httpdb.default_service_account = service_account_name
+
+        function = self._generate_runtime(self.runtime_kind)
+        # Need to call _build_function, since service-account enrichment is happening only on server side, before the
+        # call to deploy_nuclio_function
+        _build_function(db, None, function)
+        self._assert_deploy_called_basic_config(
+            expected_class=self.class_name,
+            expected_service_account=service_account_name,
+        )
+        mlconf.httpdb.default_service_account = ""
 
     def test_deploy_basic_function(self, db: Session, client: TestClient):
         function = self._generate_runtime(self.runtime_kind)


### PR DESCRIPTION
Use case: when deploying in AWS and using instance roles to allow access to S3 resources without need for creds (and also other use-cases which similarly utilize k8s service-accounts), we want every pod that is being launched by MLRun to use a default service account. This default SA should not be user-configurable, but only on the MLRun service configuration.

To support this, added a global config parameter `function.spec.service_account.default` which is `None` by default.
The SA logic now becomes:
1. If the job has a SA set in the spec, it is the one used
2. Otherwise, if the project has a default SA set in its project-secrets, assign it
3. Else, check if the global SA is set - if it does, assign it

There are no other changes to the validation flow, meaning that every SA selected will still be validated by the allowed-SAs per project (if they are configured).