### PR TITLE
[Runtimes] Add a global config for default service account [1.0.x backport]

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -449,6 +449,11 @@ def process_function_service_account(function):
         allow_internal_secrets=True,
     )
 
+    # If default SA was not configured for the project, try to retrieve it from global config (if exists)
+    default_service_account = (
+        default_service_account or mlrun.mlconf.function.spec.service_account.default
+    )
+
     # Sanity check on project configuration
     if (
         default_service_account

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -132,6 +132,7 @@ default_config = {
     "function": {
         "spec": {
             "image_pull_secret": {"default": None},
+            "service_account": {"default": None},
         },
     },
     "function_defaults": {

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -205,6 +205,16 @@ def test_submit_job_service_accounts(
     assert resp
     _assert_pod_service_account(pod_create_mock, "sa3")
 
+    # Validate that a global service account works as expected
+    pod_create_mock.reset_mock()
+    mlconf.function.spec.service_account.default = "some-sa"
+    function.spec.service_account = None
+    submit_job_body = _create_submit_job_body(function, project)
+    resp = client.post("submit_job", json=submit_job_body)
+    assert resp
+    _assert_pod_service_account(pod_create_mock, "some-sa")
+    mlconf.function.spec.service_account.default = None
+
 
 def _assert_pod_env_vars(pod_create_mock, expected_env_vars):
     pod_create_mock.assert_called_once()


### PR DESCRIPTION
Backporting #2151 to 1.0.x