### PR TITLE
[Datastores] Adding option to force non-anonymous authentication when using S3

### DIFF
--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -30,8 +30,9 @@ class S3Store(DataStore):
         access_key = self._get_secret_or_env("AWS_ACCESS_KEY_ID")
         secret_key = self._get_secret_or_env("AWS_SECRET_ACCESS_KEY")
         endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
+        force_non_anonymous = self._get_secret_or_env("S3_NON_ANONYMOUS")
 
-        if access_key or secret_key:
+        if access_key or secret_key or force_non_anonymous:
             self.s3 = boto3.resource(
                 "s3",
                 region_name=region,
@@ -71,8 +72,11 @@ class S3Store(DataStore):
     def get_storage_options(self):
         key = self._get_secret_or_env("AWS_ACCESS_KEY_ID")
         secret = self._get_secret_or_env("AWS_SECRET_ACCESS_KEY")
+        force_non_anonymous = self._get_secret_or_env("S3_NON_ANONYMOUS")
 
-        storage_options = dict(anon=not (key and secret), key=key, secret=secret)
+        storage_options = dict(
+            anon=not (force_non_anonymous or (key and secret)), key=key, secret=secret
+        )
 
         endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
         if endpoint_url:

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -176,6 +176,7 @@ def mount_s3(
     endpoint_url=None,
     prefix="",
     aws_region=None,
+    non_anonymous=False,
 ):
     """Modifier function to add s3 env vars or secrets to container
 
@@ -185,6 +186,8 @@ def mount_s3(
     :param endpoint_url: s3 endpoint address (for non AWS s3)
     :param prefix: string prefix to add before the env var name (for working with multiple s3 data stores)
     :param aws_region: amazon region
+    :param non_anonymous: force the S3 API to use non-anonymous connection, even if no credentials are provided
+        (for authenticating externally, such as through IAM instance-roles)
     :return:
     """
 
@@ -216,6 +219,10 @@ def mount_s3(
         if aws_region:
             container.add_env_variable(
                 k8s_client.V1EnvVar(name=prefix + "AWS_REGION", value=aws_region)
+            )
+        if non_anonymous:
+            container.add_env_variable(
+                k8s_client.V1EnvVar(name=prefix + "S3_NON_ANONYMOUS", value="true")
             )
 
         if secret_name:

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -295,12 +295,12 @@ class RunDBMock:
         env_list = self._function["spec"]["env"]
         param_names = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
         secret_name = s3_params.get("secret_name")
+        non_anonymous = s3_params.get("non_anonymous")
 
-        attr_name = "valueFrom" if secret_name else "value"
         env_dict = {
-            item["name"]: item[attr_name]
+            item["name"]: item["valueFrom"] if "valueFrom" in item else item["value"]
             for item in env_list
-            if item["name"] in param_names
+            if item["name"] in param_names + ["S3_NON_ANONYMOUS"]
         }
 
         if secret_name:
@@ -313,6 +313,8 @@ class RunDBMock:
                 "AWS_ACCESS_KEY_ID": s3_params["aws_access_key"],
                 "AWS_SECRET_ACCESS_KEY": s3_params["aws_secret_key"],
             }
+        if non_anonymous:
+            expected_envs["S3_NON_ANONYMOUS"] = "true"
         assert expected_envs == env_dict
 
     def verify_authorization(

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -158,21 +158,25 @@ class TestAutoMount:
             runtime.apply(mlrun.auto_mount())
 
     @staticmethod
-    def _setup_s3_mount(use_secret):
+    def _setup_s3_mount(use_secret, non_anonymous):
         mlconf.storage.auto_mount_type = "s3"
         if use_secret:
-            return {
+            params = {
                 "secret_name": "s3_secret",
             }
         else:
-            return {
+            params = {
                 "aws_access_key": "some_key",
                 "aws_secret_key": "some_secret_key",
             }
+        if non_anonymous:
+            params["non_anonymous"] = True
+        return params
 
     @pytest.mark.parametrize("use_secret", [True, False])
-    def test_auto_mount_s3(self, use_secret, rundb_mock):
-        s3_params = self._setup_s3_mount(use_secret)
+    @pytest.mark.parametrize("non_anonymous", [True, False])
+    def test_auto_mount_s3(self, use_secret, non_anonymous, rundb_mock):
+        s3_params = self._setup_s3_mount(use_secret, non_anonymous)
         mlconf.storage.auto_mount_params = ",".join(
             [f"{key}={value}" for key, value in s3_params.items()]
         )


### PR DESCRIPTION
When working with IAM instance roles, we will not have any credentials (since they're handled by the instance role), but the connection to S3 mustn't work in `anon` mode. Up until now the `anon` parameter was deduced from the lack of credentials (i.e. no secret or key-id provided), which fails in this scenario. To properly connect in this case, we need the user to specify that auth is required even though no credentials are given.

- Added a new environment variable `S3_NON_ANONYMOUS` which when set will force the S3 provider to work in non-anonymous mode, even if no credentials are given.
- Also added a parameter to the `mount_s3` modifier that will set this env. variable.
- With this option, auto-mount can now work with IAM instance roles by using the `s3` auto-mount type, and setting `non_anonymous=True` as parameters.