### PR TITLE
[API] Backport Fix unable to deploy dask cluster as a result of unresolved username in container [1.0.x]

### DIFF
--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -15,6 +15,11 @@ ARG MLRUN_PYTHON_VERSION=3.7.13
 
 FROM quay.io/mlrun/python:${MLRUN_PYTHON_VERSION}-slim
 
+
+ARG UID=1000
+# this creates both user and group with the same id
+RUN useradd -u $UID mlrun
+
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
(cherry picked from commit 2df2dd5eb70f981f85d96c6a3fa18cc1b10313ab)