### PR TITLE
[SDK] Fix no exception when using `set_env_from_file` with non-existent file

### DIFF
--- a/docs/install/remote.md
+++ b/docs/install/remote.md
@@ -133,7 +133,7 @@ function.set_envs(file_path=env_file)
 
 1. Create an env file similar to the example, with lines in the form KEY=VALUE, and comment lines starting with "#".
 2. Use `--env-file <env file path>` in mlrun run/build/deploy/project CLI commands to load the config and credential env vars from file.
-2. Set the `MLRUN_SET_ENV_FILE=<env file path>` env var to point to a default env file (which will be loaded on import).
+2. Set the `MLRUN_ENV_FILE=<env file path>` env var to point to a default env file (which will be loaded on import).
    If the `MLRUN_DBPATH` points to a remote iguazio cluster and the `V3IO_API` and/or `V3IO_FRAMESD` vars are not set, they will be inferred from the DBPATH.
 2. Add the default `env` file template in the Jupyter container `~/env` (to allow quick setup of remote demos).
 

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -194,6 +194,7 @@ def set_env_from_file(env_file: str, return_dict: bool = False):
     :param return_dict: set to True to return the env as a dict
     :return: None or env dict
     """
+    env_file = path.expanduser(env_file)
     if not path.isfile(env_file):
         raise MLRunInvalidArgumentError(f"env file {env_file} does not exist")
     env_vars = dotenv.dotenv_values(env_file)

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -17,7 +17,6 @@
 __all__ = ["get_version", "set_environment", "code_to_function", "import_function"]
 
 import getpass
-import os.path
 from os import environ, path
 
 import dotenv
@@ -195,7 +194,7 @@ def set_env_from_file(env_file: str, return_dict: bool = False):
     :param return_dict: set to True to return the env as a dict
     :return: None or env dict
     """
-    if not os.path.isfile(env_file):
+    if not path.isfile(env_file):
         raise MLRunInvalidArgumentError(f"env file {env_file} does not exist")
     env_vars = dotenv.dotenv_values(env_file)
     if None in env_vars.values():

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -24,7 +24,7 @@ import dotenv
 from .config import config as mlconf
 from .datastore import DataItem, store_manager
 from .db import get_run_db
-from .errors import MLRunInvalidArgumentError
+from .errors import MLRunNotFoundError, MLRunInvalidArgumentError
 from .execution import MLClientCtx
 from .model import NewTask, RunObject, RunTemplate, new_task
 from .platforms import (
@@ -196,7 +196,7 @@ def set_env_from_file(env_file: str, return_dict: bool = False):
     """
     env_file = path.expanduser(env_file)
     if not path.isfile(env_file):
-        raise MLRunInvalidArgumentError(f"env file {env_file} does not exist")
+        raise MLRunNotFoundError(f"env file {env_file} does not exist")
     env_vars = dotenv.dotenv_values(env_file)
     if None in env_vars.values():
         raise MLRunInvalidArgumentError("env file lines must be in the form key=value")

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -17,6 +17,7 @@
 __all__ = ["get_version", "set_environment", "code_to_function", "import_function"]
 
 import getpass
+import os.path
 from os import environ, path
 
 import dotenv
@@ -194,6 +195,8 @@ def set_env_from_file(env_file: str, return_dict: bool = False):
     :param return_dict: set to True to return the env as a dict
     :return: None or env dict
     """
+    if not os.path.isfile(env_file):
+        raise MLRunInvalidArgumentError(f"env file {env_file} does not exist")
     env_vars = dotenv.dotenv_values(env_file)
     if None in env_vars.values():
         raise MLRunInvalidArgumentError("env file lines must be in the form key=value")

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -24,7 +24,7 @@ import dotenv
 from .config import config as mlconf
 from .datastore import DataItem, store_manager
 from .db import get_run_db
-from .errors import MLRunNotFoundError, MLRunInvalidArgumentError
+from .errors import MLRunInvalidArgumentError, MLRunNotFoundError
 from .execution import MLClientCtx
 from .model import NewTask, RunObject, RunTemplate, new_task
 from .platforms import (

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -787,7 +787,8 @@ def _do_populate(env=None):
     global config
 
     if "MLRUN_ENV_FILE" in os.environ:
-        dotenv.load_dotenv(os.environ["MLRUN_ENV_FILE"], override=True)
+        env_file = os.path.expanduser(os.environ["MLRUN_ENV_FILE"])
+        dotenv.load_dotenv(env_file, override=True)
 
     if not config:
         config = Config.from_dict(default_config)

--- a/tests/test_convenince_methods.py
+++ b/tests/test_convenince_methods.py
@@ -52,6 +52,11 @@ def test_bad_env_files():
             mlrun.set_env_from_file(str(assets_path / env))
 
 
+def test_env_file_does_not_exist():
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.set_env_from_file("some-nonexistent-path")
+
+
 def test_auto_load_env_file():
     os.environ["MLRUN_ENV_FILE"] = str(assets_path / "envfile")
     mlrun.mlconf.reload()

--- a/tests/test_convenince_methods.py
+++ b/tests/test_convenince_methods.py
@@ -53,7 +53,7 @@ def test_bad_env_files():
 
 
 def test_env_file_does_not_exist():
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
         mlrun.set_env_from_file("some-nonexistent-path")
 
 


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-2384

Raise `MLRunNotFoundError ` when using `set_env_from_file` if file doesn't exist