### PR TITLE
[Iguazio] Backport Fix `max_workers` adapter wasn't applied on https endpoint on iguazio client [1.0.x]

### DIFF
--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -66,6 +66,7 @@ class Client(
         )
         self._session = requests.Session()
         self._session.mount("http://", http_adapter)
+        self._session.mount("https://", http_adapter)
         self._api_url = mlrun.mlconf.iguazio_api_url
         # The job is expected to be completed in less than 5 seconds. If 10 seconds have passed and the job
         # has not been completed, increase the interval to retry every 5 seconds


### PR DESCRIPTION

(cherry picked from commit d0aeb064d86efca89967544fd2f2418b5ff65693)