### PR TITLE
[Runtimes] Allow runtime images to run with a non-root user

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -24,6 +24,9 @@ RUN apt update -qqq \
 
 WORKDIR /mlrun
 
+# non-recursive chmod for the run to be able to create the handler file with any security context
+RUN chmod 777 /mlrun
+
 # install miniconda
 RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -29,6 +29,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 WORKDIR /mlrun
 
+# non-recursive chmod for the run to be able to create the handler file with any security context
+RUN chmod 777 /mlrun
+
 ARG MLRUN_PIP_VERSION=22.0.0
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
 

--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -120,4 +120,9 @@ RUN python -m pip install \
     -r models-gpu-image-requirements.txt
 
 COPY . .
+
+# non-recursive chmod for the run to be able to create the handler file with any security context
+# at the end of the Dockerfile for docker caching
+RUN chmod 777 /mlrun
+
 RUN python -m pip install .[complete]


### PR DESCRIPTION
For https://jira.iguazeng.com/browse/ML-2392

Change permissions of the workdir in the runtime images (`ml-base`, `mlrun`, `ml-models`* and `ml-models-gpu`), to enable any user write privileges, as the runtime needs this to create the function's code in a file. This allows us to set any security context we like for the run pods.

*`ml-models` is based `ml-base`, so running the chmod in the base image propagates down.