### PR TITLE
[API] Better configuration for allowed paths in the `/files` API

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -48,6 +48,7 @@ def project_logs_path(project) -> Path:
 
 
 def get_obj_path(schema, path, user=""):
+    real_path = config.httpdb.real_path
     if path.startswith("/User/"):
         user = user or environ.get("V3IO_USERNAME", "admin")
         path = "v3io:///users/" + user + path[5:]
@@ -59,19 +60,29 @@ def get_obj_path(schema, path, user=""):
         data_volume_prefix = config.httpdb.data_volume
         if data_volume_prefix.endswith("/"):
             data_volume_prefix = data_volume_prefix[:-1]
-        if config.httpdb.real_path:
+        if real_path:
             path_from_volume = path[len(data_volume_prefix) :]
             if path_from_volume.startswith("/"):
                 path_from_volume = path_from_volume[1:]
-            path = str(Path(config.httpdb.real_path) / Path(path_from_volume))
+            path = str(Path(real_path) / Path(path_from_volume))
     if schema:
         schema_prefix = schema + "://"
         if not path.startswith(schema_prefix):
             path = f"{schema_prefix}{path}"
-    if not path.startswith("v3io://") and (
-        not config.httpdb.real_path
-        or (config.httpdb.real_path and not path.startswith(config.httpdb.real_path))
-    ):
+
+    # Check if path is allowed - v3io:// is always allowed, and also the real_path parameter if specified.
+    # We never allow local files in the allowed paths list. Allowed paths must contain a schema (://)
+    allowed_file_paths = config.httpdb.allowed_file_paths
+    allowed_paths_list = (
+        [path.strip() for path in allowed_file_paths.split(",") if "://" in path]
+        if allowed_file_paths
+        else []
+    )
+    if real_path:
+        allowed_paths_list.append(real_path)
+    allowed_paths_list.append("v3io://")
+
+    if not any(path.startswith(allowed_path) for allowed_path in allowed_paths_list):
         raise mlrun.errors.MLRunAccessDeniedError("Unauthorized path")
     return path
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -186,8 +186,12 @@ default_config = {
         "password": "",
         "token": "",
         "logs_path": "./db/logs",
+        # when set, these will replace references to the data_volume with the real_path
         "data_volume": "",
         "real_path": "",
+        # comma delimited prefixes of paths allowed through the /files API (v3io & the real_path are always allowed).
+        # These paths must be schemas (cannot be used for local files). For example "s3://mybucket,gcs://"
+        "allowed_file_paths": "",
         "db_type": "sqldb",
         "max_workers": 64,
         # See mlrun.api.schemas.APIStates for options


### PR DESCRIPTION
For security reasons, we have limited the URLs accessible through the `/files` API such that only `v3io://` paths are allowed by default. There is one additional tweak, where the parameters `httpdb.data_volume` and `httpdb.real_path` can be specified. These were intended such that if the path is prefixed with `data_volume`, it will be replaced with the `real_path`. As a side-effect, the `real_path` is allowed for the `/files` API, so specifying something like `gcs` there will allow access to paths beginning with `gcs` (even if `data_volume` is omitted).

This is not flexible enough, as users may want to specify paths to specific buckets, for example. The current mechanism does not allow that since only a single prefix can be provided.

The PR adds a new parameter - `httpdb.allowed_file_paths` which contains a comma separated prefixes of paths that will be allowed. For example, to access the buckets `bucket1` and `another_bucket` on gcs, the following value can be provided: `"gcs://bucket1,gcs://another_bucket"`. Values provided must contain schemas (must have `://` in them) to prevent abuse such as specifying `/` to access local files. By default this value is empty, and it should be modified with care for specific usages. 
It is fully backwards compatible since the `real_path` is still considered an allowed path, as well as `v3io://`.