### PR TITLE
[System Tests] Allow running system tests by test suite/component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ test-migrations: clean ## Run mlrun db migrations tests
 test-system-dockerized: build-test-system ## Run mlrun system tests in docker container
 	docker run \
 		--env MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=$(MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES) \
-		--env MLRUN_SYSTEM_TESTS_COMPONENT=$(MLRUN_SYSTEM_TESTS_COMPONENT) \
+		--env MLRUN_SYSTEM_TESTS_COMMAND_SUFFIX=$(MLRUN_SYSTEM_TESTS_COMMAND_SUFFIX) \
 		-t \
 		--rm \
 		$(MLRUN_SYSTEM_TEST_IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ MLRUN_PUSH_DOCKER_CACHE_IMAGE ?=
 MLRUN_GIT_ORG ?= mlrun
 MLRUN_RELEASE_BRANCH ?= master
 MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES ?= true
+MLRUN_SYSTEM_TESTS_COMPONENT ?=
 MLRUN_CUDA_VERSION = 11.0
 MLRUN_TENSORFLOW_VERSION = 2.4.1
 MLRUN_HOROVOD_VERSION = 0.22.1
@@ -452,7 +453,12 @@ test-migrations: clean ## Run mlrun db migrations tests
 
 .PHONY: test-system-dockerized
 test-system-dockerized: build-test-system ## Run mlrun system tests in docker container
-	docker run --env MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=$(MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES) -t --rm $(MLRUN_SYSTEM_TEST_IMAGE_NAME)
+	docker run \
+		--env MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=$(MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES) \
+		--env MLRUN_SYSTEM_TESTS_COMPONENT=$(MLRUN_SYSTEM_TESTS_COMPONENT) \
+		-t \
+		--rm \
+		$(MLRUN_SYSTEM_TEST_IMAGE_NAME)
 
 .PHONY: test-system
 test-system: ## Run mlrun system tests
@@ -461,7 +467,7 @@ test-system: ## Run mlrun system tests
 		--disable-warnings \
 		--durations=100 \
 		-rf \
-		tests/system
+		tests/system/$(MLRUN_SYSTEM_TESTS_COMPONENT)
 
 .PHONY: test-system-open-source
 test-system-open-source: update-version-file ## Run mlrun system tests with opensource configuration
@@ -471,7 +477,7 @@ test-system-open-source: update-version-file ## Run mlrun system tests with open
 		--durations=100 \
 		-rf \
 		-m "not enterprise" \
-		tests/system
+		tests/system/$(MLRUN_SYSTEM_TESTS_COMPONENT)
 
 .PHONY: test-package
 test-package: ## Run mlrun package tests


### PR DESCRIPTION
The system tests have, over time, grown larger and larger so that they last longer than github's job timeout.
To remedy this, we want to run the tests in smaller chunks.

Added an optional env var `MLRUN_SYSTEM_TESTS_COMPONENT` which when set will select the test chunk to run.
If `MLRUN_SYSTEM_TESTS_COMPONENT` isn't set, we'll run all system tests.
If `MLRUN_SYSTEM_TESTS_COMPONENT` is set, we'll run only the system tests for the given component.
If `MLRUN_SYSTEM_TESTS_COMPONENT` starts with "no_", we'll ignore that component in the system tests.

As of now the available values are: (no value), `api`, `backward_compatibility`, `demos`, `examples`, `feature_store`, `model_monitoring`, `projects` `runtimes`, `no_api`, `no_backward_compatibility`, `no_demos`, `no_examples`, `no_feature_store`, `no_model_monitoring`, `no_projects` and `no_runtimes`.