### PR TITLE
[Docs] Fix error in Azure datastore doc

### DIFF
--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -101,7 +101,7 @@ here:
 ```{note}
 The `AZURE_STORAGE_CONNECTION_STRING` configuration uses the `BlobServiceClient` to access objects. This has
 limited functionality and cannot be used to access Azure Datalake storage objects. In this case use one of the other 
-authentication methods instead, which utilize the `fsspec` mechanism. 
+authentication methods that use the `fsspec` mechanism. 
 ```
 
 ### Google cloud storage

--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -17,7 +17,7 @@ Data stores are referred to using the schema prefix (e.g. `s3://my-bucket/path`)
 * **http, https** &mdash; read data from HTTP sources (read-only), format: `https://host/path/to/file`
 * **s3** &mdash; S3 objects (AWS or other endpoints), format: `s3://<bucket>/path/to/file`
 * **v3io, v3ios** &mdash; Iguazio v3io data fabric, format: `v3io://[<remote-host>]/<data-container>/path/to/file`
-* **az** &mdash; Azure Blob storage, format: `az://<bucket>/path/to/file`
+* **az** &mdash; Azure Blob storage, format: `az://<container>/path/to/file`
 * **gs, gcs** &mdash; Google Cloud Storage objects, format: `gs://<bucket>/path/to/file`
 * **store** &mdash; MLRun versioned artifacts [(see Artifacts)](./artifacts.html), format: `store://artifacts/<project>/<artifact-name>[:tag]`
 * **memory** &mdash; in memory data registry for passing data within the same process, format `memory://key`, use `mlrun.datastore.set_in_memory_item(key, value)` to register in memory data items (byte buffers or DataFrames).
@@ -95,8 +95,14 @@ here:
 |-----------------------|------------|
 | [Connection string](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string) | `AZURE_STORAGE_CONNECTION_STRING` |
 | [SAS token](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview#sas-token) | `AZURE_STORAGE_ACCOUNT_NAME`<br/>`AZURE_STORAGE_SAS_TOKEN` |
-| [Account key](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal) | `AZURE_STORAGE_ACCOUNT_NAME`<br/>`AZURE_STORAGE_ACCOUNT_KEY` |
+| [Account key](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal) | `AZURE_STORAGE_ACCOUNT_NAME`<br/>`AZURE_STORAGE_KEY` |
 | [Service principal with a client secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal) | `AZURE_STORAGE_ACCOUNT_NAME`<br/>`AZURE_STORAGE_CLIENT_ID`<br/>`AZURE_STORAGE_CLIENT_SECRET`<br/>`AZURE_STORAGE_TENANT_ID` |
+
+```{note}
+The `AZURE_STORAGE_CONNECTION_STRING` configuration uses the `BlobServiceClient` to access objects. This has
+limited functionality and cannot be used to access Azure Datalake storage objects. In this case use one of the other 
+authentication methods instead, which utilize the `fsspec` mechanism. 
+```
 
 ### Google cloud storage
 * `GOOGLE_APPLICATION_CREDENTIALS` &mdash; path to the application credentials to use (in the form of a JSON file). This can


### PR DESCRIPTION
Wrong env. variable was specified. Also added note on usage of blob-client vs. using fsspec.