### PR TITLE
[Feature Store] Skip `test_purge_nosql`

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        test_component: [api,runtimes,feature_store,projects,model_monitoring,examples,demos,backward_compatibility]
+        test_component: [api,runtimes,projects,model_monitoring,examples,demos,backward_compatibility,feature_store]
     steps:
     - uses: actions/checkout@v2
     - name: Set up python 3.7

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1926,6 +1926,9 @@ class TestFeatureStore(TestMLRunSystem):
         targets_to_purge = targets[:-1]
         verify_purge(fset, targets_to_purge)
 
+    # After moving to run on a new system test environment this test was running for 75 min and then failing
+    # skipping until it get fixed as this results all the suite to run much longer
+    @pytest.mark.skip("FIX_ME")
     def test_purge_nosql(self):
         def get_v3io_api_host():
             """Return only the host out of v3io_api


### PR DESCRIPTION
This test is running for more than an hour and fails at the end, skipping this test until it gets fixed.
https://github.com/mlrun/mlrun/runs/7664264987?check_suite_focus=true

```
4555.18s call     test_feature_store.py::TestFeatureStore::test_purge_nosql
FAILED tests/system/feature_store/test_feature_store.py::TestFeatureStore::test_purge_nosql
```
