### PR TITLE
[SDK] Fix fail to send request to MLRun API with `ConnectionResetError` [1.0.x]

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -55,10 +55,14 @@ def bool2str(val):
     return "yes" if val else "no"
 
 
+HTTP_RETRY_AMOUNT = 3
+HTTP_RETRY_BACKOFF = 1
+HTTP_RETRY_EXCEPTIONS = (ConnectionResetError, requests.exceptions.ConnectionError)
+
 http_adapter = HTTPAdapter(
     max_retries=Retry(
-        total=3,
-        backoff_factor=1,
+        total=HTTP_RETRY_AMOUNT,
+        backoff_factor=HTTP_RETRY_BACKOFF,
         status_forcelist=[500, 502, 503, 504],
         # we want to retry but not to raise since we do want that last response (to parse details on the
         # error from response body) we'll handle raising ourselves
@@ -140,6 +144,18 @@ class HTTPRunDB(RunDBInterface):
         url = f"{self.base_url}/{path_prefix}/{path}"
         return url
 
+    def request_with_retry(self, method, url, **kwargs):
+        retry_count = 0
+        while True:
+            try:
+                response = self.session.request(method, url, **kwargs)
+                return response
+            except HTTP_RETRY_EXCEPTIONS as exc:
+                retry_count += 1
+                if retry_count >= HTTP_RETRY_AMOUNT:
+                    raise exc
+                time.sleep(HTTP_RETRY_BACKOFF)
+
     def api_call(
         self,
         method,
@@ -217,7 +233,7 @@ class HTTPRunDB(RunDBInterface):
             self.session.mount("https://", http_adapter)
 
         try:
-            response = self.session.request(
+            response = self.request_with_retry(
                 method, url, timeout=timeout, verify=False, **kw
             )
         except requests.RequestException as exc:

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -2,6 +2,7 @@
 # currently we are running it in the integration tests CI step so adding this file for unit tests for the httpdb
 import enum
 import unittest.mock
+import pytest
 
 import mlrun.db.httpdb
 
@@ -27,3 +28,15 @@ def test_api_call_enum_conversion():
     for dict_key in ["headers", "params"]:
         for value in db.session.request.call_args_list[1][1][dict_key].values():
             assert type(value) == str
+
+
+def test_connection_reset_causes_retries():
+    db = mlrun.db.httpdb.HTTPRunDB("fake-url")
+    db.session = unittest.mock.Mock()
+    db.session.request.side_effect = ConnectionResetError
+
+    with unittest.mock.patch("time.sleep") as _:
+        with pytest.raises(ConnectionResetError):
+            db.api_call("GET", "some-path")
+
+    assert db.session.request.call_count == mlrun.db.httpdb.HTTP_RETRY_AMOUNT

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -35,7 +35,8 @@ def test_connection_reset_causes_retries():
     db.session = unittest.mock.Mock()
     db.session.request.side_effect = ConnectionResetError
 
-    with unittest.mock.patch("time.sleep") as _:
+    # patch sleep to make test faster
+    with unittest.mock.patch("time.sleep"):
         with pytest.raises(ConnectionResetError):
             db.api_call("GET", "some-path")
 


### PR DESCRIPTION
Fix for https://jira.iguazeng.com/browse/ML-2479

Add retry mechanism to `api_call` in the `HTTPDB`, so that if the sdk client experiences a connection reset, the request will be retried (similarly to the retry on error status code mechanism).