### PR TITLE
[SDK] Fix fail to send request to MLRun API with `ConnectionResetError`

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -196,6 +196,7 @@ default_config = {
         "max_workers": 64,
         # See mlrun.api.schemas.APIStates for options
         "state": "online",
+        "retry_api_call_on_exception": "enabled",
         "db": {
             "commit_retry_timeout": 30,
             "commit_retry_interval": 3,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -154,7 +154,11 @@ class HTTPRunDB(RunDBInterface):
         return url
 
     def request_with_retry(self, method, url, **kwargs):
-        max_retries = HTTP_RETRY_AMOUNT if config.httpdb.retry_api_call_on_exception == "enabled" else 1
+        max_retries = (
+            HTTP_RETRY_AMOUNT
+            if config.httpdb.retry_api_call_on_exception == "enabled"
+            else 1
+        )
         retry_count = 0
         while True:
             try:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -55,12 +55,12 @@ def bool2str(val):
     return "yes" if val else "no"
 
 
-HTTP_RETRY_AMOUNT = 3
-HTTP_RETRY_BACKOFF = 1
+HTTP_RETRY_COUNT = 3
+HTTP_RETRY_BACKOFF_FACTOR = 1
 
 # make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
 # during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
-HTTP_RETRY_EXCEPTIONS = {
+HTTP_RETRYABLE_EXCEPTIONS = {
     # ConnectionResetError is raised when the server closes the connection prematurely during TCP handshake.
     ConnectionResetError: ["Connection reset by peer", "Connection aborted"],
     # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
@@ -70,8 +70,8 @@ HTTP_RETRY_EXCEPTIONS = {
 
 http_adapter = HTTPAdapter(
     max_retries=Retry(
-        total=HTTP_RETRY_AMOUNT,
-        backoff_factor=HTTP_RETRY_BACKOFF,
+        total=HTTP_RETRY_COUNT,
+        backoff_factor=HTTP_RETRY_BACKOFF_FACTOR,
         status_forcelist=[500, 502, 503, 504],
         # we want to retry but not to raise since we do want that last response (to parse details on the
         # error from response body) we'll handle raising ourselves
@@ -155,33 +155,31 @@ class HTTPRunDB(RunDBInterface):
 
     def request_with_retry(self, method, url, **kwargs):
         max_retries = (
-            HTTP_RETRY_AMOUNT
+            HTTP_RETRY_COUNT
             if config.httpdb.retry_api_call_on_exception == "enabled"
-            else 1
+            else 0
         )
         retry_count = 0
         while True:
             try:
                 response = self.session.request(method, url, **kwargs)
                 return response
-            except tuple(HTTP_RETRY_EXCEPTIONS.keys()) as exc:
-                retry_count += 1
+            except tuple(HTTP_RETRYABLE_EXCEPTIONS.keys()) as exc:
                 if retry_count >= max_retries:
                     logger.warning(
                         f"Maximum retries exhausted for {method} {url} request",
                         exception_type=type(exc),
                         exception_message=str(exc),
-                        retry_interval=HTTP_RETRY_BACKOFF,
+                        retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
                         retry_count=retry_count,
                         max_retries=max_retries,
                     )
                     raise exc
 
                 # only retry on exceptions with the right message
-                exception_is_retryable = False
-                for msg in HTTP_RETRY_EXCEPTIONS[type(exc)]:
-                    if msg in str(exc):
-                        exception_is_retryable = True
+                exception_is_retryable = any(
+                    [msg in str(exc) for msg in HTTP_RETRYABLE_EXCEPTIONS[type(exc)]]
+                )
 
                 if not exception_is_retryable:
                     logger.warning(
@@ -192,14 +190,15 @@ class HTTPRunDB(RunDBInterface):
                     raise exc
 
                 logger.debug(
-                    f"{method} {url} request failed on retryable exception, retrying in {HTTP_RETRY_BACKOFF} seconds",
+                    f"{method} {url} request failed on retryable exception, retrying in {HTTP_RETRY_BACKOFF_FACTOR} seconds",
                     exception_type=type(exc),
                     exception_message=str(exc),
-                    retry_interval=HTTP_RETRY_BACKOFF,
+                    retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
                     retry_count=retry_count,
                     max_retries=max_retries,
                 )
-                time.sleep(HTTP_RETRY_BACKOFF)
+                retry_count += 1
+                time.sleep(HTTP_RETRY_BACKOFF_FACTOR)
 
     def api_call(
         self,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -57,7 +57,7 @@ def bool2str(val):
 
 HTTP_RETRY_AMOUNT = 3
 HTTP_RETRY_BACKOFF = 1
-HTTP_RETRY_EXCEPTIONS = (ConnectionResetError, requests.exceptions.ConnectionError)
+HTTP_RETRY_EXCEPTIONS = (ConnectionResetError,)
 
 http_adapter = HTTPAdapter(
     max_retries=Retry(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -190,7 +190,8 @@ class HTTPRunDB(RunDBInterface):
                     raise exc
 
                 logger.debug(
-                    f"{method} {url} request failed on retryable exception, retrying in {HTTP_RETRY_BACKOFF_FACTOR} seconds",
+                    f"{method} {url} request failed on retryable exception, "
+                    f"retrying in {HTTP_RETRY_BACKOFF_FACTOR} seconds",
                     exception_type=type(exc),
                     exception_message=str(exc),
                     retry_interval=HTTP_RETRY_BACKOFF_FACTOR,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -55,10 +55,14 @@ def bool2str(val):
     return "yes" if val else "no"
 
 
+HTTP_RETRY_AMOUNT = 3
+HTTP_RETRY_BACKOFF = 1
+HTTP_RETRY_EXCEPTIONS = (ConnectionResetError, requests.exceptions.ConnectionError)
+
 http_adapter = HTTPAdapter(
     max_retries=Retry(
-        total=3,
-        backoff_factor=1,
+        total=HTTP_RETRY_AMOUNT,
+        backoff_factor=HTTP_RETRY_BACKOFF,
         status_forcelist=[500, 502, 503, 504],
         # we want to retry but not to raise since we do want that last response (to parse details on the
         # error from response body) we'll handle raising ourselves
@@ -140,6 +144,18 @@ class HTTPRunDB(RunDBInterface):
         url = f"{self.base_url}/{path_prefix}/{path}"
         return url
 
+    def request_with_retry(self, method, url, **kwargs):
+        retry_count = 0
+        while True:
+            try:
+                response = self.session.request(method, url, **kwargs)
+                return response
+            except HTTP_RETRY_EXCEPTIONS as exc:
+                retry_count += 1
+                if retry_count >= HTTP_RETRY_AMOUNT:
+                    raise exc
+                time.sleep(HTTP_RETRY_BACKOFF)
+
     def api_call(
         self,
         method,
@@ -217,7 +233,7 @@ class HTTPRunDB(RunDBInterface):
             self.session.mount("https://", http_adapter)
 
         try:
-            response = self.session.request(
+            response = self.request_with_retry(
                 method, url, timeout=timeout, verify=False, **kw
             )
         except requests.RequestException as exc:

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -43,19 +43,19 @@ def test_api_call_enum_conversion():
             "enabled",
             ConnectionError,
             "Connection aborted",
-            mlrun.db.httpdb.HTTP_RETRY_AMOUNT,
+            mlrun.db.httpdb.HTTP_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionResetError,
             "Connection reset by peer",
-            mlrun.db.httpdb.HTTP_RETRY_AMOUNT,
+            mlrun.db.httpdb.HTTP_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionRefusedError,
             "Connection refused",
-            mlrun.db.httpdb.HTTP_RETRY_AMOUNT,
+            mlrun.db.httpdb.HTTP_RETRY_COUNT,
         ),
         # feature disabled
         ("disabled", Exception, "some-error", 1),

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -5,6 +5,7 @@ import unittest.mock
 
 import pytest
 
+import mlrun.config
 import mlrun.db.httpdb
 
 
@@ -31,14 +32,61 @@ def test_api_call_enum_conversion():
             assert type(value) == str
 
 
-def test_connection_reset_causes_retries():
+@pytest.mark.parametrize(
+    "feature_config,exception_type,exception_message,call_amount",
+    [
+        # feature enabled
+        ("enabled", Exception, "some-error", 1),
+        ("enabled", ConnectionError, "some-error", 1),
+        ("enabled", ConnectionResetError, "some-error", 1),
+        (
+            "enabled",
+            ConnectionError,
+            "Connection aborted",
+            mlrun.db.httpdb.HTTP_RETRY_AMOUNT,
+        ),
+        (
+            "enabled",
+            ConnectionResetError,
+            "Connection reset by peer",
+            mlrun.db.httpdb.HTTP_RETRY_AMOUNT,
+        ),
+        (
+            "enabled",
+            ConnectionRefusedError,
+            "Connection refused",
+            mlrun.db.httpdb.HTTP_RETRY_AMOUNT,
+        ),
+        # feature disabled
+        ("disabled", Exception, "some-error", 1),
+        ("disabled", ConnectionError, "some-error", 1),
+        ("disabled", ConnectionResetError, "some-error", 1),
+        ("disabled", ConnectionError, "Connection aborted", 1),
+        (
+            "disabled",
+            ConnectionResetError,
+            "Connection reset by peer",
+            1,
+        ),
+        (
+            "disabled",
+            ConnectionRefusedError,
+            "Connection refused",
+            1,
+        ),
+    ],
+)
+def test_connection_reset_causes_retries(
+    feature_config, exception_type, exception_message, call_amount
+):
+    mlrun.config.config.httpdb.retry_api_call_on_exception = feature_config
     db = mlrun.db.httpdb.HTTPRunDB("fake-url")
     db.session = unittest.mock.Mock()
-    db.session.request.side_effect = ConnectionResetError
+    db.session.request.side_effect = exception_type(exception_message)
 
     # patch sleep to make test faster
     with unittest.mock.patch("time.sleep"):
-        with pytest.raises(ConnectionResetError):
+        with pytest.raises(exception_type):
             db.api_call("GET", "some-path")
 
-    assert db.session.request.call_count == mlrun.db.httpdb.HTTP_RETRY_AMOUNT
+    assert db.session.request.call_count == call_amount

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -43,19 +43,22 @@ def test_api_call_enum_conversion():
             "enabled",
             ConnectionError,
             "Connection aborted",
-            mlrun.db.httpdb.HTTP_RETRY_COUNT,
+            # one try + the max retries
+            1 + mlrun.db.httpdb.HTTP_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionResetError,
             "Connection reset by peer",
-            mlrun.db.httpdb.HTTP_RETRY_COUNT,
+            # one try + the max retries
+            1 + mlrun.db.httpdb.HTTP_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionRefusedError,
             "Connection refused",
-            mlrun.db.httpdb.HTTP_RETRY_COUNT,
+            # one try + the max retries
+            1 + mlrun.db.httpdb.HTTP_RETRY_COUNT,
         ),
         # feature disabled
         ("disabled", Exception, "some-error", 1),

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -2,6 +2,7 @@
 # currently we are running it in the integration tests CI step so adding this file for unit tests for the httpdb
 import enum
 import unittest.mock
+import pytest
 
 import mlrun.db.httpdb
 
@@ -27,3 +28,15 @@ def test_api_call_enum_conversion():
     for dict_key in ["headers", "params"]:
         for value in db.session.request.call_args_list[1][1][dict_key].values():
             assert type(value) == str
+
+
+def test_connection_reset_causes_retries():
+    db = mlrun.db.httpdb.HTTPRunDB("fake-url")
+    db.session = unittest.mock.Mock()
+    db.session.request.side_effect = ConnectionResetError
+
+    with unittest.mock.patch("time.sleep") as _:
+        with pytest.raises(ConnectionResetError):
+            db.api_call("GET", "some-path")
+
+    assert db.session.request.call_count == mlrun.db.httpdb.HTTP_RETRY_AMOUNT

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -35,7 +35,8 @@ def test_connection_reset_causes_retries():
     db.session = unittest.mock.Mock()
     db.session.request.side_effect = ConnectionResetError
 
-    with unittest.mock.patch("time.sleep") as _:
+    # patch sleep to make test faster
+    with unittest.mock.patch("time.sleep"):
         with pytest.raises(ConnectionResetError):
             db.api_call("GET", "some-path")
 

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -2,6 +2,7 @@
 # currently we are running it in the integration tests CI step so adding this file for unit tests for the httpdb
 import enum
 import unittest.mock
+
 import pytest
 
 import mlrun.db.httpdb


### PR DESCRIPTION
Fix for https://jira.iguazeng.com/browse/ML-2479

Add retry mechanism to `api_call` in the `HTTPDB`, so that if the sdk client experiences a connection reset, the request will be retried (similarly to the retry on error status code mechanism).