### PR TITLE
[Docker] Change base models gpu image

### DIFF
--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 ARG CUDA_VER=11.2
 
-FROM nvidia/cuda:${CUDA_VER}-cudnn8-devel-ubuntu18.04
+FROM quay.io/mlrun/cuda:${CUDA_VER}-cudnn8-devel-ubuntu18.04
 
 # need to be redeclared since used in the from
 ARG CUDA_VER


### PR DESCRIPTION
Nvidia removed the image we were building the models-gpu image from, pushed the image to `quay.io/mlrun/cuda` and `mlrun/cuda`.