### PR TITLE
[Scheduler] Fix failing schedules with security context enrichment

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -755,7 +755,7 @@ def _process_model_monitoring_secret(db_session, project_name: str, secret_key: 
                 db_session, project_name
             )
 
-            secret_value = project_owner.session
+            secret_value = project_owner.access_key
             if not secret_value:
                 raise MLRunRuntimeError(
                     f"No model monitoring access key. Failed to generate one for owner of project {project_name}",

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -389,6 +389,12 @@ def ensure_function_has_auth_set(function, auth_info: mlrun.api.schemas.AuthInfo
                 auth_info.access_key = mlrun.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key(
                     auth_info.session
                 )
+                # created an access key with control and data session plane, so enriching auth_info with those planes
+                auth_info.planes = [
+                    mlrun.api.utils.clients.iguazio.SessionPlanes.control,
+                    mlrun.api.utils.clients.iguazio.SessionPlanes.data,
+                ]
+
             function.metadata.credentials.access_key = auth_info.access_key
         if not function.metadata.credentials.access_key:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -79,7 +79,7 @@ class Project(pydantic.BaseModel):
 
 class ProjectOwner(pydantic.BaseModel):
     username: str
-    session: str
+    access_key: str
 
 
 class ProjectSummary(pydantic.BaseModel):

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -98,5 +98,5 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
     ) -> mlrun.api.schemas.ProjectOwner:
         project = self.get_project(session, name)
         return mlrun.api.schemas.ProjectOwner(
-            username=project.spec.owner, session=self.project_owner_session
+            username=project.spec.owner, access_key=self.project_owner_session
         )

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -11,7 +11,7 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
     def __init__(self) -> None:
         super().__init__()
         self.db_session = None
-        self.project_owner_session = ""
+        self.project_owner_access_key = ""
         self._project_role = mlrun.api.schemas.ProjectsRole.nop
 
     def create_project(
@@ -98,5 +98,5 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
     ) -> mlrun.api.schemas.ProjectOwner:
         project = self.get_project(session, name)
         return mlrun.api.schemas.ProjectOwner(
-            username=project.spec.owner, access_key=self.project_owner_session
+            username=project.spec.owner, access_key=self.project_owner_access_key
         )

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -576,9 +576,9 @@ class Scheduler:
                     mlrun.api.schemas.AuthInfo(
                         username=username,
                         access_key=access_key,
+                        # enriching with control plane tag because scheduling a function requires control plane
                         planes=[
                             mlrun.api.utils.clients.iguazio.SessionPlanes.control,
-                            mlrun.api.utils.clients.iguazio.SessionPlanes.data,
                         ],
                     ),
                 )
@@ -750,9 +750,9 @@ class Scheduler:
                 mlrun.api.schemas.AuthInfo(
                     username=project_owner.username,
                     access_key=project_owner.access_key,
+                    # enriching with control plane tag because scheduling a function requires control plane
                     planes=[
                         mlrun.api.utils.clients.iguazio.SessionPlanes.control,
-                        mlrun.api.utils.clients.iguazio.SessionPlanes.data,
                     ],
                 ),
                 project_name,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -13,6 +13,7 @@ from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
 from sqlalchemy.orm import Session
 
 import mlrun.api.utils.auth.verifier
+import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.helpers
 import mlrun.errors
 from mlrun.api import schemas
@@ -258,6 +259,7 @@ class Scheduler:
         db_schedule = await fastapi.concurrency.run_in_threadpool(
             get_db().get_schedule, db_session, project, name
         )
+        self._ensure_auth_info_has_access_key(auth_info, db_schedule.kind)
         function, args, kwargs = self._resolve_job_function(
             db_schedule.kind,
             db_schedule.scheduled_object,
@@ -567,7 +569,12 @@ class Scheduler:
                     db_schedule.cron_trigger,
                     db_schedule.concurrency_limit,
                     mlrun.api.schemas.AuthInfo(
-                        username=username, access_key=access_key
+                        username=username,
+                        access_key=access_key,
+                        planes=[
+                            mlrun.api.utils.clients.iguazio.SessionPlanes.control,
+                            mlrun.api.utils.clients.iguazio.SessionPlanes.data,
+                        ],
                     ),
                 )
             except Exception as exc:
@@ -736,7 +743,12 @@ class Scheduler:
             scheduler.update_schedule(
                 db_session,
                 mlrun.api.schemas.AuthInfo(
-                    username=project_owner.username, access_key=project_owner.session
+                    username=project_owner.username,
+                    access_key=project_owner.access_key,
+                    planes=[
+                        mlrun.api.utils.clients.iguazio.SessionPlanes.control,
+                        mlrun.api.utils.clients.iguazio.SessionPlanes.data,
+                    ],
                 ),
                 project_name,
                 schedule_name,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -288,6 +288,11 @@ class Scheduler:
                     auth_info.session
                 )
             )
+            # created an access key with control and data session plane, so enriching auth_info with those planes
+            auth_info.planes = [
+                mlrun.api.utils.clients.iguazio.SessionPlanes.control,
+                mlrun.api.utils.clients.iguazio.SessionPlanes.data,
+            ]
 
     def _store_schedule_secrets(
         self,

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -249,7 +249,7 @@ def test_get_project_owner(
         project.metadata.name,
     )
     assert project_owner.username == owner_username
-    assert project_owner.session == owner_access_key
+    assert project_owner.access_key == owner_access_key
 
 
 def test_list_project_with_updated_after(

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -238,8 +238,8 @@ def test_get_project_owner(
     nop_leader: mlrun.api.utils.projects.remotes.leader.Member,
 ):
     owner = "some-username"
-    owner_session = "some-session"
-    nop_leader.project_owner_session = owner_session
+    owner_access_key = "some-access-key"
+    nop_leader.project_owner_access_key = owner_access_key
     project = _generate_project(owner=owner)
     projects_follower.create_project(
         db,
@@ -247,7 +247,7 @@ def test_get_project_owner(
     )
     project_owner = projects_follower.get_project_owner(db, project.metadata.name)
     assert project_owner.username == owner
-    assert project_owner.session == owner_session
+    assert project_owner.access_key == owner_access_key
 
 
 def test_list_project(

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -291,11 +291,11 @@ async def test_schedule_upgrade_from_scheduler_without_credentials_store(
     # at this point the schedule is inside the scheduler without auth_info, so the first trigger should try to generate
     # auth info, mock the functions for this
     username = "some-username"
-    session = "some-session"
+    access_key = "some-access_key"
     mlrun.api.utils.singletons.project_member.get_project_member().get_project_owner = (
         unittest.mock.Mock(
             return_value=mlrun.api.schemas.ProjectOwner(
-                username=username, session=session
+                username=username, access_key=access_key
             )
         )
     )


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2468

* When enriching auth info we weren't adding the relevant plane session tags, fixed that in 4 places:
    *  When reloading schedules we are loading the access key from the secret, and to be able to run schedules the minimum is control plane session, so added a control plane session tag when creating that auth info.
    * In `submit_run_wrapper` when access key isn't set we are enriching the auth info with the project owner access key, so as well added a control plane session tag to the auth info created. 
    * In `ensure_function_has_auth_set` when access key isn't defined we are getting / creating an access key with control and data plane, so added a control and data plane session tag to the auth info.
    * In `_ensure_auth_info_has_access_key` ( Scheduler ) enriched with both control and data plane.

* In `ensure_function_security_context` instead of straight raising an error if auth info doesn't contain a control plane session tag, which we saw above happened in almost every flow we had, I've added a try mechanism which if control plane session tag isn't set we are still trying to get the user unix id with the session and if succeeded enriching the auth 
info with both user unix id and control plane session tag, else raising an exception.

* Refactored the `ProjectOwner` class, there was a whole confusion between access key and session it was used as the same thing, so changed the class and related flows to be consistent with using `access_key`.
