### PR TITLE
[API] Re-organize the way we are enriching functions on the backend

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -506,10 +506,10 @@ def _build_function(
         fn.set_db_connection(run_db)
         fn.save(versioned=False)
         if fn.kind in RuntimeKinds.nuclio_runtimes():
-            mlrun.api.api.utils.ensure_function_has_auth_set(fn, auth_info)
-            mlrun.api.api.utils.process_function_service_account(fn)
-            mlrun.api.api.utils.mask_sensitive_data(fn, auth_info)
-            mlrun.api.api.utils.ensure_function_security_context(fn, auth_info)
+
+            mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
+                fn, auth_info, perform_auto_mount=False
+            )
 
             if fn.kind == RuntimeKinds.serving:
                 # Handle model monitoring
@@ -610,10 +610,10 @@ def _start_function(
         try:
             run_db = get_run_db_instance(db_session)
             function.set_db_connection(run_db)
-            mlrun.api.api.utils.ensure_function_has_auth_set(function, auth_info)
-            mlrun.api.api.utils.process_function_service_account(function)
-            mlrun.api.api.utils.mask_sensitive_data(function, auth_info)
-            mlrun.api.api.utils.ensure_function_security_context(function, auth_info)
+            mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
+                function, auth_info, perform_auto_mount=False
+            )
+
             #  resp = resource["start"](fn)  # TODO: handle resp?
             resource["start"](function, client_version=client_version)
             function.save(versioned=False)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -508,7 +508,8 @@ def _build_function(
         if fn.kind in RuntimeKinds.nuclio_runtimes():
 
             mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
-                fn, auth_info, perform_auto_mount=False
+                fn,
+                auth_info,
             )
 
             if fn.kind == RuntimeKinds.serving:
@@ -611,7 +612,8 @@ def _start_function(
             run_db = get_run_db_instance(db_session)
             function.set_db_connection(run_db)
             mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
-                function, auth_info, perform_auto_mount=False
+                function,
+                auth_info,
             )
 
             #  resp = resource["start"](fn)  # TODO: handle resp?

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -186,6 +186,8 @@ def apply_enrichment_and_validation_on_function(
     ensure_security_context: bool = True,
 ):
     """
+    This function should be used only on server side.
+
     This function is utilized in several flows as a consequence of different endpoints in MLRun for deploying different
     runtimes such as dask and nuclio, depends on the flow and runtime we decide which util functions we
     want to apply on the runtime.

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -185,6 +185,14 @@ def apply_enrichment_and_validation_on_function(
     mask_sensitive_data: bool = True,
     ensure_security_context: bool = True,
 ):
+    """
+    This function is utilized in several flows as a consequence of different endpoints in MLRun for deploying different
+    runtimes such as dask and nuclio, depends on the flow and runtime we decide which util functions we
+    want to apply on the runtime.
+
+    When adding a new util function, go through the other flows that utilize the function
+    and make sure to specify the appropriate flag for each runtime.
+    """
     # if auth given in request ensure the function pod will have these auth env vars set, otherwise the job won't
     # be able to communicate with the api
     if ensure_auth:

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -164,19 +164,8 @@ def _generate_function_and_task_from_submit_run_body(
             # assign values from it to the main function object
             function = enrich_function_from_dict(function, function_dict)
 
-    # if auth given in request ensure the function pod will have these auth env vars set, otherwise the job won't
-    # be able to communicate with the api
-    ensure_function_has_auth_set(function, auth_info)
+    apply_enrichment_and_validation_on_function(function, auth_info)
 
-    # if this was triggered by the UI, we will need to attempt auto-mount based on auto-mount config and params passed
-    # in the auth_info. If this was triggered by the SDK, then auto-mount was already attempted and will be skipped.
-    try_perform_auto_mount(function, auth_info)
-
-    # Validate function's service-account, based on allowed SAs for the project, if existing in a project-secret.
-    process_function_service_account(function)
-
-    mask_sensitive_data(function, auth_info)
-    ensure_function_security_context(function, auth_info)
     return function, task
 
 
@@ -187,7 +176,37 @@ async def submit_run(db_session: Session, auth_info: mlrun.api.schemas.AuthInfo,
     return response
 
 
-def mask_sensitive_data(function, auth_info: mlrun.api.schemas.AuthInfo):
+def apply_enrichment_and_validation_on_function(
+    function,
+    auth_info: mlrun.api.schemas.AuthInfo,
+    ensure_auth: bool = True,
+    perform_auto_mount: bool = True,
+    validate_service_account: bool = True,
+    mask_sensitive_data: bool = True,
+    ensure_security_context: bool = True,
+):
+    # if auth given in request ensure the function pod will have these auth env vars set, otherwise the job won't
+    # be able to communicate with the api
+    if ensure_auth:
+        ensure_function_has_auth_set(function, auth_info)
+
+    # if this was triggered by the UI, we will need to attempt auto-mount based on auto-mount config and params passed
+    # in the auth_info. If this was triggered by the SDK, then auto-mount was already attempted and will be skipped.
+    if perform_auto_mount:
+        try_perform_auto_mount(function, auth_info)
+
+    # Validate function's service-account, based on allowed SAs for the project, if existing in a project-secret.
+    if validate_service_account:
+        process_function_service_account(function)
+
+    if mask_sensitive_data:
+        mask_function_sensitive_data(function, auth_info)
+
+    if ensure_security_context:
+        ensure_function_security_context(function, auth_info)
+
+
+def mask_function_sensitive_data(function, auth_info: mlrun.api.schemas.AuthInfo):
     if not mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind):
         _mask_v3io_access_key_env_var(function, auth_info)
         _mask_v3io_volume_credentials(function)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -456,11 +456,11 @@ class TestNuclioRuntime(TestRuntimeBase):
         self, db: Session, k8s_secrets_mock: K8sSecretsMock
     ):
         k8s_secrets_mock.set_service_account_keys(self.project, "sa1", ["sa1", "sa2"])
-
+        auth_info = mlrun.api.schemas.AuthInfo()
         function = self._generate_runtime(self.runtime_kind)
         # Need to call _build_function, since service-account enrichment is happening only on server side, before the
         # call to deploy_nuclio_function
-        _build_function(db, None, function)
+        _build_function(db, auth_info, function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_service_account="sa1"
         )
@@ -468,12 +468,12 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         function.spec.service_account = "bad-sa"
         with pytest.raises(HTTPException):
-            _build_function(db, None, function)
+            _build_function(db, auth_info, function)
 
         # verify that project SA overrides the global SA
         mlconf.function.spec.service_account.default = "some-other-sa"
         function.spec.service_account = "sa2"
-        _build_function(db, None, function)
+        _build_function(db, auth_info, function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_service_account="sa2"
         )
@@ -509,11 +509,11 @@ class TestNuclioRuntime(TestRuntimeBase):
     ):
         service_account_name = "default-sa"
         mlconf.function.spec.service_account.default = service_account_name
-
+        auth_info = mlrun.api.schemas.AuthInfo()
         function = self._generate_runtime(self.runtime_kind)
         # Need to call _build_function, since service-account enrichment is happening only on server side, before the
         # call to deploy_nuclio_function
-        _build_function(db, None, function)
+        _build_function(db, auth_info, function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name,
             expected_service_account=service_account_name,

--- a/tests/api/runtimes/test_serving.py
+++ b/tests/api/runtimes/test_serving.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+import unittest.mock
 from http import HTTPStatus
 
 import deepdiff
@@ -9,6 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+import mlrun.api.api.utils
 import tests.api.api.utils
 from mlrun import mlconf, new_function
 from mlrun.api.utils.singletons.k8s import get_k8s
@@ -230,6 +232,7 @@ class TestServingRuntime(TestNuclioRuntime):
     def test_serving_with_secrets_remote_build(self, db: Session, client: TestClient):
         orig_function = get_k8s()._get_project_secrets_raw_data
         get_k8s()._get_project_secrets_raw_data = unittest.mock.Mock(return_value={})
+        mlrun.api.api.utils.mask_function_sensitive_data = unittest.mock.Mock()
 
         function = self._create_serving_function()
         tests.api.api.utils.create_project(client, self.project)


### PR DESCRIPTION
If we had this we wouldn't encounter the bug we fixed in https://github.com/mlrun/mlrun/pull/2228. 
Eventually moved all enrichments and validations util functions under one function with feature flag for each of them, so that different runtimes could define the enrichment required depends on their need.