### PR TITLE
[Feature Store] Fix ingest with spark with default targets

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -72,8 +72,7 @@ def default_target_names():
 def get_default_targets():
     """initialize the default feature set targets list"""
     return [
-        DataTargetBase(target, name=str(target), partitioned=(target == "parquet"))
-        for target in default_target_names()
+        DataTargetBase(target, name=str(target)) for target in default_target_names()
     ]
 
 
@@ -725,17 +724,7 @@ class ParquetTarget(BaseStoreTarget):
             after_step = after_step or after_state
 
         if partitioned is None:
-            if all(
-                value is None
-                for value in [
-                    key_bucketing_number,
-                    partition_cols,
-                    time_partitioning_granularity,
-                ]
-            ):
-                partitioned = False
-            else:
-                partitioned = True
+            partitioned = True
 
         super().__init__(
             name,

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -73,7 +73,8 @@ def default_target_names():
 def get_default_targets():
     """initialize the default feature set targets list"""
     return [
-        DataTargetBase(target, name=str(target)) for target in default_target_names()
+        DataTargetBase(target, name=str(target), partitioned=(target == "parquet"))
+        for target in default_target_names()
     ]
 
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -28,7 +28,6 @@ import mlrun.utils.helpers
 from mlrun.config import config
 from mlrun.model import DataSource, DataTarget, DataTargetBase, TargetPathObject
 from mlrun.utils import now_date
-from mlrun.utils.helpers import default_time_partitioning_granularity, legal_time_units
 from mlrun.utils.v3io_clients import get_frames_client
 
 from .. import errors
@@ -516,7 +515,7 @@ class BaseStoreTarget(DataTargetBase):
                 time_partitioning_granularity = self.time_partitioning_granularity
                 if not time_partitioning_granularity and self.partitioned:
                     time_partitioning_granularity = (
-                        default_time_partitioning_granularity
+                        mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
                     )
                 for unit, fmt in [
                     ("year", "%Y"),
@@ -748,10 +747,12 @@ class ParquetTarget(BaseStoreTarget):
 
         if (
             time_partitioning_granularity is not None
-            and time_partitioning_granularity not in legal_time_units
+            and time_partitioning_granularity
+            not in mlrun.utils.helpers.LEGAL_TIME_UNITS
         ):
             raise errors.MLRunInvalidArgumentError(
-                f"time_partitioning_granularity parameter must be one of {','.join(legal_time_units)}, "
+                f"time_partitioning_granularity parameter must be one of "
+                f"{','.join(mlrun.utils.helpers.LEGAL_TIME_UNITS)}, "
                 f"not {time_partitioning_granularity}."
             )
 
@@ -813,10 +814,12 @@ class ParquetTarget(BaseStoreTarget):
                 self.partition_cols,
             ]
         ):
-            time_partitioning_granularity = default_time_partitioning_granularity
+            time_partitioning_granularity = (
+                mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
+            )
         if time_partitioning_granularity is not None:
             partition_cols = partition_cols or []
-            for time_unit in legal_time_units:
+            for time_unit in mlrun.utils.helpers.LEGAL_TIME_UNITS:
                 partition_cols.append(f"${time_unit}")
                 if time_unit == time_partitioning_granularity:
                     break
@@ -866,9 +869,11 @@ class ParquetTarget(BaseStoreTarget):
                 and self.partitioned
                 and not self.partition_cols
             ):
-                time_partitioning_granularity = default_time_partitioning_granularity
+                time_partitioning_granularity = (
+                    mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
+                )
             if time_partitioning_granularity:
-                for unit in legal_time_units:
+                for unit in mlrun.utils.helpers.LEGAL_TIME_UNITS:
                     partition_cols.append(unit)
                     if unit == time_partitioning_granularity:
                         break

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -726,8 +726,9 @@ class ParquetTarget(BaseStoreTarget):
             )
             after_step = after_step or after_state
 
+        self.path = path
         if partitioned is None:
-            partitioned = True
+            partitioned = not self.is_single_file()
 
         super().__init__(
             name,

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -499,7 +499,7 @@ def ingest(
             spark_context,
             featureset,
             source,
-            targets,
+            targets_to_ingest,
             infer_options=infer_options,
             mlrun_context=mlrun_context,
             namespace=namespace,

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -780,11 +780,6 @@ def _ingest_with_spark(
 
         key_columns = list(featureset.spec.entities.keys())
         timestamp_key = featureset.spec.timestamp_key
-        if not targets:
-            if not featureset.spec.targets:
-                featureset.set_targets()
-            targets = featureset.spec.targets
-            targets = [get_target_driver(target, featureset) for target in targets]
 
         targets_to_ingest = copy.deepcopy(targets)
         featureset.update_targets_for_ingest(targets_to_ingest, overwrite=overwrite)

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -780,11 +780,14 @@ def _ingest_with_spark(
 
         key_columns = list(featureset.spec.entities.keys())
         timestamp_key = featureset.spec.timestamp_key
+        targets = targets or featureset.spec.targets
 
         targets_to_ingest = copy.deepcopy(targets)
         featureset.update_targets_for_ingest(targets_to_ingest, overwrite=overwrite)
 
         for target in targets_to_ingest or []:
+            if type(target) is DataTargetBase:
+                target = get_target_driver(target, featureset)
             if target.path and urlparse(target.path).scheme == "":
                 if mlrun_context:
                     mlrun_context.logger.error(

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -26,13 +26,12 @@ from ..datastore import get_store_uri
 from ..datastore.targets import (
     TargetTypes,
     convert_wasb_schema_to_az,
-    default_target_names,
     get_offline_target,
     get_online_target,
     get_target_driver,
     update_targets_run_id_for_ingest,
     validate_target_list,
-    validate_target_placement,
+    validate_target_placement, get_default_targets,
 )
 from ..features import Entity, Feature
 from ..model import (
@@ -391,7 +390,7 @@ class FeatureSet(ModelObj):
             )
         targets = targets or []
         if with_defaults:
-            targets.extend(default_target_names())
+            targets.extend(get_default_targets())
 
         validate_target_list(targets=targets)
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -20,7 +20,6 @@ from storey import EmitEveryEvent, EmitPolicy
 
 import mlrun
 import mlrun.api.schemas
-from mlrun.utils.helpers import default_time_partitions, legal_time_units
 
 from ..config import config as mlconf
 from ..datastore import get_store_uri
@@ -797,7 +796,7 @@ class FeatureSet(ModelObj):
         )
         drop_cols = []
         if target.time_partitioning_granularity:
-            for col in legal_time_units:
+            for col in mlrun.utils.helpers.LEGAL_TIME_UNITS:
                 drop_cols.append(col)
                 if col == target.time_partitioning_granularity:
                     break
@@ -806,7 +805,7 @@ class FeatureSet(ModelObj):
             and not target.partition_cols
             and not target.key_bucketing_number
         ):
-            drop_cols = default_time_partitions
+            drop_cols = mlrun.utils.helpers.DEFAULT_TIME_PARTITIONS
         if drop_cols:
             result.drop(columns=drop_cols, inplace=True)
         return result

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -20,6 +20,7 @@ from storey import EmitEveryEvent, EmitPolicy
 
 import mlrun
 import mlrun.api.schemas
+from mlrun.utils.helpers import default_time_partitions, legal_time_units
 
 from ..config import config as mlconf
 from ..datastore import get_store_uri
@@ -796,16 +797,16 @@ class FeatureSet(ModelObj):
         )
         drop_cols = []
         if target.time_partitioning_granularity:
-            for col in target._legal_time_units:
+            for col in legal_time_units:
                 drop_cols.append(col)
-                if col in target.time_partitioning_granularity:
+                if col == target.time_partitioning_granularity:
                     break
         elif (
             target.partitioned
             and not target.partition_cols
             and not target.key_bucketing_number
         ):
-            drop_cols = ["year", "month", "day", "hour"]
+            drop_cols = default_time_partitions
         if drop_cols:
             result.drop(columns=drop_cols, inplace=True)
         return result

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -47,9 +47,9 @@ _missing = object()
 hub_prefix = "hub://"
 DB_SCHEMA = "store"
 
-legal_time_units = ["year", "month", "day", "hour", "minute", "second"]
-default_time_partitions = ["year", "month", "day", "hour"]
-default_time_partitioning_granularity = "hour"
+LEGAL_TIME_UNITS = ["year", "month", "day", "hour", "minute", "second"]
+DEFAULT_TIME_PARTITIONS = ["year", "month", "day", "hour"]
+DEFAULT_TIME_PARTITIONING_GRANULARITY = "hour"
 
 
 class StorePrefix:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -47,6 +47,10 @@ _missing = object()
 hub_prefix = "hub://"
 DB_SCHEMA = "store"
 
+legal_time_units = ["year", "month", "day", "hour", "minute", "second"]
+default_time_partitions = ["year", "month", "day", "hour"]
+default_time_partitioning_granularity = "hour"
+
 
 class StorePrefix:
     """map mlrun store objects to prefixes"""

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -42,8 +42,6 @@ from mlrun.feature_store.feature_set import aggregates_step
 from mlrun.feature_store.feature_vector import FixedWindowType
 from mlrun.feature_store.steps import FeaturesetValidator, OneHotEncoder
 from mlrun.features import MinMaxValidator
-from mlrun.utils import default_time_partitioning_granularity
-from mlrun.utils.helpers import default_time_partitions
 from tests.system.base import TestMLRunSystem
 
 from .data_sample import quotes, stocks, trades
@@ -833,7 +831,9 @@ class TestFeatureStore(TestMLRunSystem):
                 time_partitioning_granularity,
             ]
         ):
-            time_partitioning_granularity = default_time_partitioning_granularity
+            time_partitioning_granularity = (
+                mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
+            )
         if time_partitioning_granularity:
             for unit in ["year", "month", "day", "hour"]:
                 expected_partitions.append(unit)
@@ -1493,7 +1493,9 @@ class TestFeatureStore(TestMLRunSystem):
         side_file_out = pd.read_csv(side_file_path)
         default_file_out = pd.read_parquet(default_file_path)
         # default parquet target is partitioned
-        default_file_out.drop(columns=default_time_partitions, inplace=True)
+        default_file_out.drop(
+            columns=mlrun.utils.helpers.DEFAULT_TIME_PARTITIONS, inplace=True
+        )
         self._split_graph_expected_default.set_index("ticker", inplace=True)
 
         assert all(self._split_graph_expected_default == default_file_out.round(2))

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1269,7 +1269,7 @@ class TestFeatureStore(TestMLRunSystem):
             }
         )
         # writing down a remote source
-        data_target = ParquetTarget()
+        data_target = ParquetTarget(partitioned=False)
         data_set = fs.FeatureSet("sched_data", entities=[Entity("first_name")])
         fs.ingest(data_set, data, targets=[data_target])
 
@@ -1377,7 +1377,7 @@ class TestFeatureStore(TestMLRunSystem):
             }
         )
         # writing down a remote source
-        target2 = ParquetTarget()
+        target2 = ParquetTarget(partitioned=False)
         data_set = fs.FeatureSet("data", entities=[Entity("first_name")])
         fs.ingest(data_set, data, targets=[target2])
 
@@ -1394,7 +1394,7 @@ class TestFeatureStore(TestMLRunSystem):
             timestamp_key="time",
         )
 
-        targets = [ParquetTarget(path="v3io:///bigdata/bla.parquet")]
+        targets = [ParquetTarget(path="v3io:///bigdata/bla.parquet", partitioned=False)]
 
         fs.ingest(
             feature_set,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -643,7 +643,7 @@ class TestFeatureStore(TestMLRunSystem):
             "mycsv", path=os.path.relpath(str(self.assets_path / "testdata.csv"))
         )
         path = str(self.results_path / _generate_random_name())
-        target = ParquetTarget(path=path)
+        target = ParquetTarget(path=path, partitioned=False)
 
         fset = fs.FeatureSet(
             name="test", entities=[Entity("patient_id")], timestamp_key="timestamp"

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -43,6 +43,7 @@ from mlrun.feature_store.feature_vector import FixedWindowType
 from mlrun.feature_store.steps import FeaturesetValidator
 from mlrun.features import MinMaxValidator
 from mlrun.utils import default_time_partitioning_granularity
+from mlrun.utils.helpers import default_time_partitions
 from tests.system.base import TestMLRunSystem
 
 from .data_sample import quotes, stocks, trades
@@ -1491,6 +1492,8 @@ class TestFeatureStore(TestMLRunSystem):
 
         side_file_out = pd.read_csv(side_file_path)
         default_file_out = pd.read_parquet(default_file_path)
+        # default parquet target is partitioned
+        default_file_out.drop(columns=default_time_partitions, inplace=True)
         self._split_graph_expected_default.set_index("ticker", inplace=True)
 
         assert all(self._split_graph_expected_default == default_file_out.round(2))

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2610,7 +2610,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         assert df_res.equals(expected_df)
 
-    @pytest.mark.skipif(kafka_brokers == "", reason="KAFKA_BROKERS must be set")
+    @pytest.mark.skipif(not kafka_brokers, reason="KAFKA_BROKERS must be set")
     def test_kafka_target(self, kafka_consumer):
 
         stocks = pd.DataFrame(

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1605,7 +1605,7 @@ class TestFeatureStore(TestMLRunSystem):
 
     def test_forced_columns_target(self):
         columns = ["time", "ask"]
-        targets = [ParquetTarget(columns=columns)]
+        targets = [ParquetTarget(columns=columns, partitioned=False)]
         quotes_set, _ = prepare_feature_set(
             "forced-columns", "ticker", quotes, timestamp_key="time", targets=targets
         )
@@ -1625,7 +1625,7 @@ class TestFeatureStore(TestMLRunSystem):
         resp = fs.get_offline_features(csv_vec)
         csv_vec_df = resp.to_dataframe()
 
-        targets = [ParquetTarget()]
+        targets = [ParquetTarget(partitioned=False)]
         parquet_align_set, _ = prepare_feature_set(
             "parquet-align", "ticker", quotes, timestamp_key="time", targets=targets
         )

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -42,6 +42,7 @@ from mlrun.feature_store.feature_set import aggregates_step
 from mlrun.feature_store.feature_vector import FixedWindowType
 from mlrun.feature_store.steps import FeaturesetValidator
 from mlrun.features import MinMaxValidator
+from mlrun.utils import default_time_partitioning_granularity
 from tests.system.base import TestMLRunSystem
 
 from .data_sample import quotes, stocks, trades
@@ -831,7 +832,7 @@ class TestFeatureStore(TestMLRunSystem):
                 time_partitioning_granularity,
             ]
         ):
-            time_partitioning_granularity = "hour"
+            time_partitioning_granularity = default_time_partitioning_granularity
         if time_partitioning_granularity:
             for unit in ["year", "month", "day", "hour"]:
                 expected_partitions.append(unit)

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -451,6 +451,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         data_set = fs.FeatureSet(
             name_spark,
             entities=[Entity("first_name"), Entity("last_name")],
+            timestamp_key="time",
             engine="spark",
         )
 
@@ -487,6 +488,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
         storey_data_set = fs.FeatureSet(
             name_storey,
+            timestamp_key="time",
             entities=[Entity("first_name"), Entity("last_name")],
         )
 


### PR DESCRIPTION
Currently, `ParquetTarget` defaults to `partitioned=False`, but the default offline target is `ParquetTarget(partitioned=True)`. This PR aligns the default to `partitioned=True`.

Fixes `TestFeatureStoreSparkEngine::test_aggregations_emit_every_event`.