### PR TITLE
[Spark] Disable security context enrichment for remote spark [1.0.x]

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -486,9 +486,8 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         == SecurityContextEnrichmentModes.disabled.value
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
-        # We do not enrich remote spark security context,
-        # as its image currently supports running only with user 1000 or root
-        # and by default it runs with user 1000 (even when not setting security context)
+        # remote spark image currently requires running with user 1000 or root
+        # and by default it runs with user 1000 (when security context is not set)
         or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()
     ):

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -486,7 +486,9 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         == SecurityContextEnrichmentModes.disabled.value
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
-        # We do not currently enrich remote spark because its image was created by user 1000(iguazio)
+        # We do not enrich remote spark security context,
+        # as its image contains dirs and files with user 1000(iguazio) as owner,
+        # so the running user must either be 1000 or root
         or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()
     ):

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -487,8 +487,8 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
         # We do not enrich remote spark security context,
-        # as its image contains dirs and files with user 1000(iguazio) as owner,
-        # so the running user must either be 1000 or root
+        # as its image currently supports running only with user 1000 or root
+        # and by default it runs with user 1000 (even when not setting security context)
         or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()
     ):

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -486,6 +486,7 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         == SecurityContextEnrichmentModes.disabled.value
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
+        or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()
     ):
         return

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -486,7 +486,6 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         == SecurityContextEnrichmentModes.disabled.value
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
-
         # We do not currently enrich remote spark because its image was created by user 1000(iguazio)
         or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -486,6 +486,8 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         == SecurityContextEnrichmentModes.disabled.value
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
+
+        # We do not currently enrich remote spark because its image was created by user 1000(iguazio)
         or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()
     ):

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -17,8 +17,8 @@ from subprocess import run
 
 import kubernetes.client
 
-from mlrun.config import config
 import mlrun.errors
+from mlrun.config import config
 
 from ..model import RunObject
 from ..platforms.iguazio import mount_v3io_extended, mount_v3iod

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -15,7 +15,10 @@ import re
 import typing
 from subprocess import run
 
+import kubernetes.client
+
 from mlrun.config import config
+import mlrun.errors
 
 from ..model import RunObject
 from ..platforms.iguazio import mount_v3io_extended, mount_v3iod
@@ -143,6 +146,18 @@ class RemoteSparkRuntime(KubejobRuntime):
                     v3io_config_configmap=spark_service + "-submit",
                 )
             )
+
+    def with_security_context(
+        self, security_context: kubernetes.client.V1SecurityContext
+    ):
+        """
+        With security context is not supported for spark runtime.
+        Driver / Executor processes run with uid / gid 1000 as long as security context is not defined.
+        If in the future we want to support setting security context it will work only from spark version 3.2 onwards.
+        """
+        raise mlrun.errors.MLRunInvalidArgumentTypeError(
+            "with_security_context is not supported with spark operator"
+        )
 
     @property
     def _resolve_default_base_image(self):

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -156,7 +156,7 @@ class RemoteSparkRuntime(KubejobRuntime):
         If in the future we want to support setting security context it will work only from spark version 3.2 onwards.
         """
         raise mlrun.errors.MLRunInvalidArgumentTypeError(
-            "with_security_context is not supported with spark operator"
+            "with_security_context is not supported with remote spark"
         )
 
     @property


### PR DESCRIPTION
fix for: https://jira.iguazeng.com/browse/ML-2467

- Added validation on server side when enriching security context
- Raising exception when trying to set security context for remote spark