### PR TITLE
[Spark] Disable security context enrichment for remote spark

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -545,6 +545,9 @@ def ensure_function_security_context(function, auth_info: mlrun.api.schemas.Auth
         == SecurityContextEnrichmentModes.disabled.value
         or mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind)
         or function.kind == mlrun.runtimes.RuntimeKinds.spark
+        # remote spark image currently requires running with user 1000 or root
+        # and by default it runs with user 1000 (when security context is not set)
+        or function.kind == mlrun.runtimes.RuntimeKinds.remotespark
         or not mlrun.mlconf.is_running_on_iguazio()
     ):
         return

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -15,6 +15,9 @@ import re
 import typing
 from subprocess import run
 
+import kubernetes.client
+
+import mlrun.errors
 from mlrun.config import config
 
 from ..model import RunObject
@@ -143,6 +146,18 @@ class RemoteSparkRuntime(KubejobRuntime):
                     v3io_config_configmap=spark_service + "-submit",
                 )
             )
+
+    def with_security_context(
+        self, security_context: kubernetes.client.V1SecurityContext
+    ):
+        """
+        With security context is not supported for spark runtime.
+        Driver / Executor processes run with uid / gid 1000 as long as security context is not defined.
+        If in the future we want to support setting security context it will work only from spark version 3.2 onwards.
+        """
+        raise mlrun.errors.MLRunInvalidArgumentTypeError(
+            "with_security_context is not supported with remote spark"
+        )
 
     @property
     def _resolve_default_base_image(self):


### PR DESCRIPTION
fix for: https://jira.iguazeng.com/browse/ML-2467

- Added validation on server side when enriching security context
- Raising exception when trying to set security context for remote spark