### PR TITLE
[API] Fix requests to Projects Leader fail with `Connection Aborted`

### DIFF
--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -64,6 +64,7 @@ from .frontend_spec import (
     ProjectMembershipFeatureFlag,
 )
 from .function import FunctionState, PreemptionModes, SecurityContextEnrichmentModes
+from .http import HTTPSessionRetryMode
 from .k8s import NodeSelectorOperator, Resources, ResourceSpec
 from .marketplace import (
     IndexedMarketplaceSource,

--- a/mlrun/api/schemas/http.py
+++ b/mlrun/api/schemas/http.py
@@ -1,0 +1,6 @@
+import enum
+
+
+class HTTPSessionRetryMode(str, enum.Enum):
+    enabled = "enabled"
+    disabled = "disabled"

--- a/mlrun/api/utils/auth/providers/opa.py
+++ b/mlrun/api/utils/auth/providers/opa.py
@@ -19,7 +19,7 @@ class Provider(
 ):
     def __init__(self) -> None:
         super().__init__()
-        self._session = mlrun.utils.HTTPSessionWithRetry()
+        self._session = mlrun.utils.HTTPSessionWithRetry(verbose=True)
         self._api_url = mlrun.mlconf.httpdb.authorization.opa.address
         self._permission_query_path = (
             mlrun.mlconf.httpdb.authorization.opa.permission_query_path

--- a/mlrun/api/utils/auth/providers/opa.py
+++ b/mlrun/api/utils/auth/providers/opa.py
@@ -3,8 +3,6 @@ import datetime
 import typing
 
 import humanfriendly
-import requests.adapters
-import urllib3
 
 import mlrun.api.schemas
 import mlrun.api.utils.auth.providers.base
@@ -21,12 +19,7 @@ class Provider(
 ):
     def __init__(self) -> None:
         super().__init__()
-        http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
-            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers),
-        )
-        self._session = requests.Session()
-        self._session.mount("http://", http_adapter)
+        self._session = mlrun.utils.HTTPSessionWithRetry()
         self._api_url = mlrun.mlconf.httpdb.authorization.opa.address
         self._permission_query_path = (
             mlrun.mlconf.httpdb.authorization.opa.permission_query_path

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -28,8 +28,10 @@ class Client(
     def __init__(self) -> None:
         super().__init__()
         self._session = mlrun.utils.HTTPSessionWithRetry(
-            # when the request is forwarded to the chief, if we receive a 500 error, the code will be forwarded to the
-            # client, and the client will retry the request. So no need to retry the request to the chief here.
+            # when the request is forwarded to the chief, if we receive a 5XX error, the code will be forwarded to the
+            # client. if the client is the SDK, it will retry the request. if the client is UI, it will receive the
+            # error without retry. so no need to retry the request to the chief on status codes, only exceptions for
+            # failed handshakes.
             retry_on_status=False,
             verbose=True,
         )

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -31,6 +31,7 @@ class Client(
             # when the request is forwarded to the chief, if we receive a 500 error, the code will be forwarded to the
             # client, and the client will retry the request. So no need to retry the request to the chief here.
             retry_on_status=False,
+            verbose=True,
         )
         self._api_url = mlrun.mlconf.resolve_chief_api_url()
         # remove backslash from end of api url

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -61,7 +61,8 @@ class Client(
         super().__init__()
         self._session = mlrun.utils.HTTPSessionWithRetry(
             retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
-            == "enabled"
+            == mlrun.api.schemas.HTTPSessionRetryMode.enabled.value,
+            verbose=True,
         )
         self._api_url = mlrun.mlconf.iguazio_api_url
         # The job is expected to be completed in less than 5 seconds. If 10 seconds have passed and the job

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -60,7 +60,7 @@ class Client(
     def __init__(self) -> None:
         super().__init__()
         self._session = mlrun.utils.HTTPSessionWithRetry(
-            retry_on_exception=mlrun.mlconf.projects.retry_leader_request_on_exception
+            retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
             == "enabled"
         )
         self._api_url = mlrun.mlconf.iguazio_api_url

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -59,7 +59,10 @@ class Client(
 ):
     def __init__(self) -> None:
         super().__init__()
-        self._session = mlrun.utils.SessionWithRetry()
+        self._session = mlrun.utils.HTTPSessionWithRetry(
+            retry_on_exception=mlrun.mlconf.projects.retry_leader_request_on_exception
+            == "enabled"
+        )
         self._api_url = mlrun.mlconf.iguazio_api_url
         # The job is expected to be completed in less than 5 seconds. If 10 seconds have passed and the job
         # has not been completed, increase the interval to retry every 5 seconds

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -8,7 +8,6 @@ import urllib.parse
 
 import fastapi
 import requests.adapters
-import urllib3
 
 import mlrun.api.schemas
 import mlrun.api.utils.projects.remotes.leader
@@ -60,13 +59,7 @@ class Client(
 ):
     def __init__(self) -> None:
         super().__init__()
-        http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
-            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers),
-        )
-        self._session = requests.Session()
-        self._session.mount("http://", http_adapter)
-        self._session.mount("https://", http_adapter)
+        self._session = mlrun.utils.SessionWithRetry()
         self._api_url = mlrun.mlconf.iguazio_api_url
         # The job is expected to be completed in less than 5 seconds. If 10 seconds have passed and the job
         # has not been completed, increase the interval to retry every 5 seconds

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -19,7 +19,7 @@ class Client(
 ):
     def __init__(self) -> None:
         super().__init__()
-        self._session = mlrun.utils.HTTPSessionWithRetry()
+        self._session = mlrun.utils.HTTPSessionWithRetry(verbose=True)
         self._api_url = mlrun.config.config.nuclio_dashboard_url
 
     def create_project(

--- a/mlrun/api/utils/clients/nuclio.py
+++ b/mlrun/api/utils/clients/nuclio.py
@@ -5,7 +5,6 @@ import typing
 
 import requests.adapters
 import sqlalchemy.orm
-import urllib3
 
 import mlrun.api.schemas
 import mlrun.api.utils.projects.remotes.follower
@@ -20,12 +19,7 @@ class Client(
 ):
     def __init__(self) -> None:
         super().__init__()
-        http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=urllib3.util.retry.Retry(total=3, backoff_factor=1),
-            pool_maxsize=int(mlrun.mlconf.httpdb.max_workers),
-        )
-        self._session = requests.Session()
-        self._session.mount("http://", http_adapter)
+        self._session = mlrun.utils.HTTPSessionWithRetry()
         self._api_url = mlrun.config.config.nuclio_dashboard_url
 
     def create_project(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -403,6 +403,11 @@ default_config = {
         # encoded empty list
         "tolerations": "W10=",
     },
+    "http_retry_defaults": {
+        "max_retries": 3,
+        "backoff_factor": 1,
+        "status_codes": [500, 502, 503, 504],
+    },
 }
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -274,6 +274,7 @@ default_config = {
         },
         "projects": {
             "leader": "mlrun",
+            "retry_leader_request_on_exception": "enabled",
             "followers": "",
             # This is used as the interval for the sync loop both when mlrun is leader and follower
             "periodic_sync_interval": "1 minute",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -200,7 +200,7 @@ class HTTPRunDB(RunDBInterface):
         if not self.session:
             self.session = mlrun.utils.HTTPSessionWithRetry(
                 retry_on_exception=mlrun.config.config.httpdb.retry_api_call_on_exception
-                == "enabled"
+                == mlrun.api.schemas.HTTPSessionRetryMode.enabled.value
             )
 
         try:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -25,8 +25,6 @@ from typing import Dict, List, Optional, Union
 import kfp
 import requests
 import semver
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 import mlrun
 import mlrun.projects
@@ -53,31 +51,6 @@ _artifact_keys = [
 
 def bool2str(val):
     return "yes" if val else "no"
-
-
-HTTP_RETRY_COUNT = 3
-HTTP_RETRY_BACKOFF_FACTOR = 1
-
-# make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
-# during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
-HTTP_RETRYABLE_EXCEPTIONS = {
-    # ConnectionResetError is raised when the server closes the connection prematurely during TCP handshake.
-    ConnectionResetError: ["Connection reset by peer", "Connection aborted"],
-    # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
-    ConnectionError: ["Connection aborted", "Connection refused"],
-    ConnectionRefusedError: ["Connection refused"],
-}
-
-http_adapter = HTTPAdapter(
-    max_retries=Retry(
-        total=HTTP_RETRY_COUNT,
-        backoff_factor=HTTP_RETRY_BACKOFF_FACTOR,
-        status_forcelist=[500, 502, 503, 504],
-        # we want to retry but not to raise since we do want that last response (to parse details on the
-        # error from response body) we'll handle raising ourselves
-        raise_on_status=False,
-    ),
-)
 
 
 class HTTPRunDB(RunDBInterface):
@@ -153,54 +126,6 @@ class HTTPRunDB(RunDBInterface):
         url = f"{self.base_url}/{path_prefix}/{path}"
         return url
 
-    def request_with_retry(self, method, url, **kwargs):
-        max_retries = (
-            HTTP_RETRY_COUNT
-            if config.httpdb.retry_api_call_on_exception == "enabled"
-            else 0
-        )
-        retry_count = 0
-        while True:
-            try:
-                response = self.session.request(method, url, **kwargs)
-                return response
-            except tuple(HTTP_RETRYABLE_EXCEPTIONS.keys()) as exc:
-                if retry_count >= max_retries:
-                    logger.warning(
-                        f"Maximum retries exhausted for {method} {url} request",
-                        exception_type=type(exc),
-                        exception_message=str(exc),
-                        retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
-                        retry_count=retry_count,
-                        max_retries=max_retries,
-                    )
-                    raise exc
-
-                # only retry on exceptions with the right message
-                exception_is_retryable = any(
-                    [msg in str(exc) for msg in HTTP_RETRYABLE_EXCEPTIONS[type(exc)]]
-                )
-
-                if not exception_is_retryable:
-                    logger.warning(
-                        f"{method} {url} request failed on non-retryable exception",
-                        exception_type=type(exc),
-                        exception_message=str(exc),
-                    )
-                    raise exc
-
-                logger.debug(
-                    f"{method} {url} request failed on retryable exception, "
-                    f"retrying in {HTTP_RETRY_BACKOFF_FACTOR} seconds",
-                    exception_type=type(exc),
-                    exception_message=str(exc),
-                    retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
-                    retry_count=retry_count,
-                    max_retries=max_retries,
-                )
-                retry_count += 1
-                time.sleep(HTTP_RETRY_BACKOFF_FACTOR)
-
     def api_call(
         self,
         method,
@@ -273,12 +198,10 @@ class HTTPRunDB(RunDBInterface):
                         dict_[key] = dict_[key].value
 
         if not self.session:
-            self.session = requests.Session()
-            self.session.mount("http://", http_adapter)
-            self.session.mount("https://", http_adapter)
+            self.session = mlrun.utils.SessionWithRetry()
 
         try:
-            response = self.request_with_retry(
+            response = self.session.request(
                 method, url, timeout=timeout, verify=False, **kw
             )
         except requests.RequestException as exc:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -198,7 +198,10 @@ class HTTPRunDB(RunDBInterface):
                         dict_[key] = dict_[key].value
 
         if not self.session:
-            self.session = mlrun.utils.SessionWithRetry()
+            self.session = mlrun.utils.HTTPSessionWithRetry(
+                retry_on_exception=mlrun.config.config.httpdb.retry_api_call_on_exception
+                == "enabled"
+            )
 
         try:
             response = self.session.request(

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -158,7 +158,8 @@ class RemoteStep(storey.SendToHttp):
         if not self._session:
             self._session = mlrun.utils.HTTPSessionWithRetry(
                 self.retries,
-                self.backoff_factor or mlrun.config.config.http_retry_defaults.backoff_factor,
+                self.backoff_factor
+                or mlrun.config.config.http_retry_defaults.backoff_factor,
                 retry_on_exception=False,
                 retry_on_status=self.retries > 0,
                 retry_on_post=True,

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -158,7 +158,7 @@ class RemoteStep(storey.SendToHttp):
         if not self._session:
             self._session = mlrun.utils.HTTPSessionWithRetry(
                 self.retries,
-                self.backoff_factor or mlrun.utils.DEFAULT_RETRY_BACKOFF,
+                self.backoff_factor or mlrun.config.config.http_retry_defaults.backoff_factor,
                 retry_on_exception=False,
                 retry_on_status=self.retries > 0,
                 retry_on_post=True,

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -158,9 +158,10 @@ class RemoteStep(storey.SendToHttp):
         if not self._session:
             self._session = mlrun.utils.HTTPSessionWithRetry(
                 self.retries,
-                self.backoff_factor,
+                self.backoff_factor or mlrun.utils.DEFAULT_RETRY_BACKOFF,
                 retry_on_exception=False,
                 retry_on_status=self.retries > 0,
+                retry_on_post=True,
             )
 
         body = _extract_input_data(self._input_path, event.body)

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -4,9 +4,7 @@ import json
 import aiohttp
 import requests
 import storey
-from requests.adapters import HTTPAdapter
 from storey.flow import _ConcurrentJobExecution
-from urllib3.util.retry import Retry
 
 import mlrun
 from mlrun.utils import logger
@@ -20,21 +18,6 @@ from .utils import (
 
 default_retries = 6
 default_backoff_factor = 1
-
-
-def get_http_adapter(retries, backoff_factor):
-    if retries != 0:
-        retry = Retry(
-            total=retries or default_retries,
-            backoff_factor=default_backoff_factor
-            if backoff_factor is None
-            else backoff_factor,
-            status_forcelist=[500, 502, 503, 504],
-            method_whitelist=False,
-        )
-    else:
-        retry = Retry(0, read=False)
-    return HTTPAdapter(max_retries=retry)
 
 
 class RemoteStep(storey.SendToHttp):
@@ -173,10 +156,12 @@ class RemoteStep(storey.SendToHttp):
     def do_event(self, event):
         # sync implementation (without storey)
         if not self._session:
-            self._session = requests.Session()
-            http_adapter = get_http_adapter(self.retries, self.backoff_factor)
-            self._session.mount("http://", http_adapter)
-            self._session.mount("https://", http_adapter)
+            self._session = mlrun.utils.HTTPSessionWithRetry(
+                self.retries,
+                self.backoff_factor,
+                retry_on_exception=False,
+                retry_on_status=self.retries > 0,
+            )
 
         body = _extract_input_data(self._input_path, event.body)
         method, url, headers, body = self._generate_request(event, body)

--- a/mlrun/utils/__init__.py
+++ b/mlrun/utils/__init__.py
@@ -14,5 +14,6 @@
 
 from .azure_vault import AzureVaultStore  # noqa
 from .helpers import *  # noqa
+from .http import *  # noqa
 from .logger import *  # noqa
 from .vault import *  # noqa

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -12,6 +12,9 @@ DEFAULT_RETRY_BACKOFF = 1
 
 
 class HTTPSessionWithRetry(requests.Session):
+    """
+    Extend requests.Session to add retry logic on both error statuses and certain exceptions.
+    """
 
     # make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
     # during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
@@ -30,12 +33,23 @@ class HTTPSessionWithRetry(requests.Session):
         retry_on_exception=True,
         retry_on_status=True,
         retry_on_post=False,
+        verbose=False,
     ):
+        """
+        Initialize a new HTTP session with retry logic.
+        :param max_retries: Maximum number of retries to attempt.
+        :param retry_backoff_factor: Wait interval retries in seconds.
+        :param retry_on_exception: Retry on the HTTP_RETRYABLE_EXCEPTIONS. defaults to True.
+        :param retry_on_status: Retry on error status codes. defaults to True.
+        :param retry_on_post: Retry on POST requests. defaults to False.
+        :param verbose: Print debug messages.
+        """
         super().__init__()
 
         self.max_retries = max_retries
         self.retry_backoff_factor = retry_backoff_factor
         self.retry_on_exception = retry_on_exception
+        self.verbose = verbose
 
         if retry_on_status:
             http_adapter = requests.adapters.HTTPAdapter(
@@ -43,9 +57,7 @@ class HTTPSessionWithRetry(requests.Session):
                     total=self.max_retries,
                     backoff_factor=self.retry_backoff_factor,
                     status_forcelist=[500, 502, 503, 504],
-                    method_whitelist=False
-                    if retry_on_post
-                    else urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST,
+                    method_whitelist=self._get_retry_methods(retry_on_post),
                     # we want to retry but not to raise since we do want that last response (to parse details on the
                     # error from response body) we'll handle raising ourselves
                     raise_on_status=False,
@@ -101,14 +113,24 @@ class HTTPSessionWithRetry(requests.Session):
                     )
                     raise exc
 
-                logger.debug(
-                    f"{method} {url} request failed on retryable exception, "
-                    f"retrying in {self.retry_backoff_factor} seconds",
-                    exception_type=type(exc),
-                    exception_message=str(exc),
-                    retry_interval=self.retry_backoff_factor,
-                    retry_count=retry_count,
-                    max_retries=self.max_retries,
-                )
+                if self.verbose:
+                    logger.debug(
+                        f"{method} {url} request failed on retryable exception, "
+                        f"retrying in {self.retry_backoff_factor} seconds",
+                        exception_type=type(exc),
+                        exception_message=str(exc),
+                        retry_interval=self.retry_backoff_factor,
+                        retry_count=retry_count,
+                        max_retries=self.max_retries,
+                    )
                 retry_count += 1
                 time.sleep(self.retry_backoff_factor)
+
+    @staticmethod
+    def _get_retry_methods(retry_on_post=False):
+        return (
+            # setting to False in order to retry on all methods, otherwise every method except POST.
+            False
+            if retry_on_post
+            else urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST
+        )

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -29,6 +29,7 @@ class HTTPSessionWithRetry(requests.Session):
         retry_backoff_factor=DEFAULT_RETRY_BACKOFF,
         retry_on_exception=True,
         retry_on_status=True,
+        retry_on_post=False,
     ):
         super().__init__()
 
@@ -42,6 +43,9 @@ class HTTPSessionWithRetry(requests.Session):
                     total=self.max_retries,
                     backoff_factor=self.retry_backoff_factor,
                     status_forcelist=[500, 502, 503, 504],
+                    method_whitelist=False
+                    if retry_on_post
+                    else urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST,
                     # we want to retry but not to raise since we do want that last response (to parse details on the
                     # error from response body) we'll handle raising ourselves
                     raise_on_status=False,

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -7,64 +7,86 @@ import urllib3.util.retry
 from ..config import config
 from . import logger
 
-HTTP_RETRY_COUNT = 3
-HTTP_RETRY_BACKOFF_FACTOR = 1
-
-# make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
-# during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
-HTTP_RETRYABLE_EXCEPTIONS = {
-    # ConnectionResetError is raised when the server closes the connection prematurely during TCP handshake.
-    ConnectionResetError: ["Connection reset by peer", "Connection aborted"],
-    # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
-    ConnectionError: ["Connection aborted", "Connection refused"],
-    ConnectionRefusedError: ["Connection refused"],
-}
-
-http_adapter = requests.adapters.HTTPAdapter(
-    max_retries=urllib3.util.retry.Retry(
-        total=HTTP_RETRY_COUNT,
-        backoff_factor=HTTP_RETRY_BACKOFF_FACTOR,
-        status_forcelist=[500, 502, 503, 504],
-        # we want to retry but not to raise since we do want that last response (to parse details on the
-        # error from response body) we'll handle raising ourselves
-        raise_on_status=False,
-    ),
-    pool_maxsize=int(config.httpdb.max_workers),
-)
+DEFAULT_RETRY_COUNT = 3
+DEFAULT_RETRY_BACKOFF = 1
 
 
-class SessionWithRetry(requests.Session):
-    def __init__(self):
+class HTTPSessionWithRetry(requests.Session):
+
+    # make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
+    # during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
+    HTTP_RETRYABLE_EXCEPTIONS = {
+        # ConnectionResetError is raised when the server closes the connection prematurely during TCP handshake.
+        ConnectionResetError: ["Connection reset by peer", "Connection aborted"],
+        # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
+        ConnectionError: ["Connection aborted", "Connection refused"],
+        ConnectionRefusedError: ["Connection refused"],
+    }
+
+    def __init__(
+        self,
+        max_retries=DEFAULT_RETRY_COUNT,
+        retry_backoff_factor=DEFAULT_RETRY_BACKOFF,
+        retry_on_exception=True,
+        retry_on_status=True,
+    ):
         super().__init__()
-        self.mount("http://", http_adapter)
-        self.mount("https://", http_adapter)
+
+        self.max_retries = max_retries
+        self.retry_backoff_factor = retry_backoff_factor
+        self.retry_on_exception = retry_on_exception
+
+        if retry_on_status:
+            http_adapter = requests.adapters.HTTPAdapter(
+                max_retries=urllib3.util.retry.Retry(
+                    total=self.max_retries,
+                    backoff_factor=self.retry_backoff_factor,
+                    status_forcelist=[500, 502, 503, 504],
+                    # we want to retry but not to raise since we do want that last response (to parse details on the
+                    # error from response body) we'll handle raising ourselves
+                    raise_on_status=False,
+                ),
+                pool_maxsize=int(config.httpdb.max_workers),
+            )
+
+            self.mount("http://", http_adapter)
+            self.mount("https://", http_adapter)
 
     def request(self, method, url, **kwargs):
-        max_retries = (
-            HTTP_RETRY_COUNT
-            if config.httpdb.retry_api_call_on_exception == "enabled"
-            else 0
-        )
         retry_count = 0
         while True:
             try:
                 response = super().request(method, url, **kwargs)
                 return response
-            except tuple(HTTP_RETRYABLE_EXCEPTIONS.keys()) as exc:
-                if retry_count >= max_retries:
+            except tuple(self.HTTP_RETRYABLE_EXCEPTIONS.keys()) as exc:
+                if not self.retry_on_exception:
+                    logger.warning(
+                        f"{method} {url} request failed, http retries disabled, raising exception: {exc}",
+                        exception_type=type(exc),
+                        exception_message=str(exc),
+                        retry_interval=self.retry_backoff_factor,
+                        retry_count=retry_count,
+                        max_retries=self.max_retries,
+                    )
+                    raise exc
+
+                if retry_count >= self.max_retries:
                     logger.warning(
                         f"Maximum retries exhausted for {method} {url} request",
                         exception_type=type(exc),
                         exception_message=str(exc),
-                        retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
+                        retry_interval=self.retry_backoff_factor,
                         retry_count=retry_count,
-                        max_retries=max_retries,
+                        max_retries=self.max_retries,
                     )
                     raise exc
 
                 # only retry on exceptions with the right message
                 exception_is_retryable = any(
-                    [msg in str(exc) for msg in HTTP_RETRYABLE_EXCEPTIONS[type(exc)]]
+                    [
+                        msg in str(exc)
+                        for msg in self.HTTP_RETRYABLE_EXCEPTIONS[type(exc)]
+                    ]
                 )
 
                 if not exception_is_retryable:
@@ -77,12 +99,12 @@ class SessionWithRetry(requests.Session):
 
                 logger.debug(
                     f"{method} {url} request failed on retryable exception, "
-                    f"retrying in {HTTP_RETRY_BACKOFF_FACTOR} seconds",
+                    f"retrying in {self.retry_backoff_factor} seconds",
                     exception_type=type(exc),
                     exception_message=str(exc),
-                    retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
+                    retry_interval=self.retry_backoff_factor,
                     retry_count=retry_count,
-                    max_retries=max_retries,
+                    max_retries=self.max_retries,
                 )
                 retry_count += 1
-                time.sleep(HTTP_RETRY_BACKOFF_FACTOR)
+                time.sleep(self.retry_backoff_factor)

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -1,0 +1,88 @@
+import time
+
+import requests
+import requests.adapters
+import urllib3.util.retry
+
+from ..config import config
+from . import logger
+
+HTTP_RETRY_COUNT = 3
+HTTP_RETRY_BACKOFF_FACTOR = 1
+
+# make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
+# during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
+HTTP_RETRYABLE_EXCEPTIONS = {
+    # ConnectionResetError is raised when the server closes the connection prematurely during TCP handshake.
+    ConnectionResetError: ["Connection reset by peer", "Connection aborted"],
+    # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
+    ConnectionError: ["Connection aborted", "Connection refused"],
+    ConnectionRefusedError: ["Connection refused"],
+}
+
+http_adapter = requests.adapters.HTTPAdapter(
+    max_retries=urllib3.util.retry.Retry(
+        total=HTTP_RETRY_COUNT,
+        backoff_factor=HTTP_RETRY_BACKOFF_FACTOR,
+        status_forcelist=[500, 502, 503, 504],
+        # we want to retry but not to raise since we do want that last response (to parse details on the
+        # error from response body) we'll handle raising ourselves
+        raise_on_status=False,
+    ),
+    pool_maxsize=int(config.httpdb.max_workers),
+)
+
+
+class SessionWithRetry(requests.Session):
+    def __init__(self):
+        super().__init__()
+        self.mount("http://", http_adapter)
+        self.mount("https://", http_adapter)
+
+    def request(self, method, url, **kwargs):
+        max_retries = (
+            HTTP_RETRY_COUNT
+            if config.httpdb.retry_api_call_on_exception == "enabled"
+            else 0
+        )
+        retry_count = 0
+        while True:
+            try:
+                response = super().request(method, url, **kwargs)
+                return response
+            except tuple(HTTP_RETRYABLE_EXCEPTIONS.keys()) as exc:
+                if retry_count >= max_retries:
+                    logger.warning(
+                        f"Maximum retries exhausted for {method} {url} request",
+                        exception_type=type(exc),
+                        exception_message=str(exc),
+                        retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                    )
+                    raise exc
+
+                # only retry on exceptions with the right message
+                exception_is_retryable = any(
+                    [msg in str(exc) for msg in HTTP_RETRYABLE_EXCEPTIONS[type(exc)]]
+                )
+
+                if not exception_is_retryable:
+                    logger.warning(
+                        f"{method} {url} request failed on non-retryable exception",
+                        exception_type=type(exc),
+                        exception_message=str(exc),
+                    )
+                    raise exc
+
+                logger.debug(
+                    f"{method} {url} request failed on retryable exception, "
+                    f"retrying in {HTTP_RETRY_BACKOFF_FACTOR} seconds",
+                    exception_type=type(exc),
+                    exception_message=str(exc),
+                    retry_interval=HTTP_RETRY_BACKOFF_FACTOR,
+                    retry_count=retry_count,
+                    max_retries=max_retries,
+                )
+                retry_count += 1
+                time.sleep(HTTP_RETRY_BACKOFF_FACTOR)

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -45,21 +45,21 @@ def test_api_call_enum_conversion():
             ConnectionError,
             "Connection aborted",
             # one try + the max retries
-            1 + mlrun.utils.DEFAULT_RETRY_COUNT,
+            1 + mlrun.config.config.http_retry_defaults.max_retries,
         ),
         (
             "enabled",
             ConnectionResetError,
             "Connection reset by peer",
             # one try + the max retries
-            1 + mlrun.utils.DEFAULT_RETRY_COUNT,
+            1 + mlrun.config.config.http_retry_defaults.max_retries,
         ),
         (
             "enabled",
             ConnectionRefusedError,
             "Connection refused",
             # one try + the max retries
-            1 + mlrun.utils.DEFAULT_RETRY_COUNT,
+            1 + mlrun.config.config.http_retry_defaults.max_retries,
         ),
         # feature disabled
         ("disabled", Exception, "some-error", 1),

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -45,21 +45,21 @@ def test_api_call_enum_conversion():
             ConnectionError,
             "Connection aborted",
             # one try + the max retries
-            1 + mlrun.utils.HTTP_RETRY_COUNT,
+            1 + mlrun.utils.DEFAULT_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionResetError,
             "Connection reset by peer",
             # one try + the max retries
-            1 + mlrun.utils.HTTP_RETRY_COUNT,
+            1 + mlrun.utils.DEFAULT_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionRefusedError,
             "Connection refused",
             # one try + the max retries
-            1 + mlrun.utils.HTTP_RETRY_COUNT,
+            1 + mlrun.utils.DEFAULT_RETRY_COUNT,
         ),
         # feature disabled
         ("disabled", Exception, "some-error", 1),

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -85,6 +85,7 @@ def test_connection_reset_causes_retries(
 ):
     mlrun.config.config.httpdb.retry_api_call_on_exception = feature_config
     db = mlrun.db.httpdb.HTTPRunDB("fake-url")
+    original_request = requests.Session.request
     requests.Session.request = unittest.mock.Mock()
     requests.Session.request.side_effect = exception_type(exception_message)
 
@@ -94,3 +95,4 @@ def test_connection_reset_causes_retries(
             db.api_call("GET", "some-path")
 
     assert requests.Session.request.call_count == call_amount
+    requests.Session.request = original_request

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -4,6 +4,7 @@ import enum
 import unittest.mock
 
 import pytest
+import requests
 
 import mlrun.config
 import mlrun.db.httpdb
@@ -44,21 +45,21 @@ def test_api_call_enum_conversion():
             ConnectionError,
             "Connection aborted",
             # one try + the max retries
-            1 + mlrun.db.httpdb.HTTP_RETRY_COUNT,
+            1 + mlrun.utils.HTTP_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionResetError,
             "Connection reset by peer",
             # one try + the max retries
-            1 + mlrun.db.httpdb.HTTP_RETRY_COUNT,
+            1 + mlrun.utils.HTTP_RETRY_COUNT,
         ),
         (
             "enabled",
             ConnectionRefusedError,
             "Connection refused",
             # one try + the max retries
-            1 + mlrun.db.httpdb.HTTP_RETRY_COUNT,
+            1 + mlrun.utils.HTTP_RETRY_COUNT,
         ),
         # feature disabled
         ("disabled", Exception, "some-error", 1),
@@ -84,12 +85,12 @@ def test_connection_reset_causes_retries(
 ):
     mlrun.config.config.httpdb.retry_api_call_on_exception = feature_config
     db = mlrun.db.httpdb.HTTPRunDB("fake-url")
-    db.session = unittest.mock.Mock()
-    db.session.request.side_effect = exception_type(exception_message)
+    requests.Session.request = unittest.mock.Mock()
+    requests.Session.request.side_effect = exception_type(exception_message)
 
     # patch sleep to make test faster
     with unittest.mock.patch("time.sleep"):
         with pytest.raises(exception_type):
             db.api_call("GET", "some-path")
 
-    assert db.session.request.call_count == call_amount
+    assert requests.Session.request.call_count == call_amount


### PR DESCRIPTION
Moved the "request with retries" mechanism to a general MLRun util, so it can be used in multiple places.
Now in addition to using it in the SDK for requests against the API:
- The API now uses it for requests against the project leader.
- The opa client uses it for requests against opa.
- The nuclio client uses it for requests against nuclio.
- The worker uses it for requests against the chief.