### PR TITLE
[Functions] Fix Git Branches with Slashes not Supported

### DIFF
--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -111,14 +111,21 @@ def clone_git(url, context, secrets=None, clone=True):
         clone_path = f"https://{host}{url_obj.path}"
 
     branch = None
+    tag = None
     if url_obj.fragment:
         refs = url_obj.fragment
-        if refs.startswith("refs/"):
-            branch = refs[refs.rfind("/") + 1 :]
+        if refs.startswith("refs/heads/"):
+            branch = refs.replace("refs/heads/", "")
+        elif refs.startswith("refs/tags/"):
+            tag = refs.replace("refs/tags/", "")
         else:
             url = url.replace("#" + refs, f"#refs/heads/{refs}")
+            branch = refs
 
     repo = Repo.clone_from(clone_path, context, single_branch=True, b=branch)
+    if tag:
+        repo.git.checkout(tag)
+
     return url, repo
 
 

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -205,7 +205,7 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         project.set_function(
             name="myjob",
             handler="rootfn.job_handler",
-            image="mlrun/mlrun",
+            image=base_image,
             kind="job",
             with_repo=True,
         )
@@ -223,7 +223,7 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         project.set_function(
             name="mynuclio",
             handler="rootfn:nuclio_handler",
-            image="mlrun/mlrun",
+            image=base_image,
             kind="nuclio",
             with_repo=True,
         )

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -1,0 +1,29 @@
+import unittest.mock
+
+import pytest
+import mlrun.utils.clones
+
+
+@pytest.mark.parametrize(
+    "ref,ref_type",
+    [
+        ("without-slash", "branch"),
+        ("with/slash", "branch"),
+        ("without-slash", "tag"),
+        ("without/slash", "tag"),
+    ],
+)
+def test_clone_git_refs(ref, ref_type):
+    repo = "github.com/some-git-project/some-git-repo.git"
+    url = f"git://{repo}#refs/{'heads' if ref_type == 'branch' else 'tags'}/{ref}"
+    context = "non-existent-dir"
+    branch = ref if ref_type == "branch" else None
+    tag = ref if ref_type == "tag" else None
+
+    with unittest.mock.patch("git.Repo.clone_from") as clone_from:
+        _, repo_obj = mlrun.utils.clones.clone_git(url, context)
+        clone_from.assert_called_once_with(
+            f"https://{repo}", context, single_branch=True, b=branch
+        )
+        if tag:
+            repo_obj.git.checkout.assert_called_once_with(tag)

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest.mock
 
 import pytest

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -1,6 +1,7 @@
 import unittest.mock
 
 import pytest
+
 import mlrun.utils.clones
 
 


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/ML-2417

Fix `clone_git` method to look at the `refs` in the url properly, and accept branch names with or without `/`s.
Also added support for checking out specific git tags.