### PR TITLE
[Runtimes] Bump the default spark operator version to `spark-3`

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -72,7 +72,7 @@ default_config = {
     "spark_app_image": "",  # image to use for spark operator app runtime
     "spark_app_image_tag": "",  # image tag to use for spark operator app runtime
     "spark_history_server_path": "",  # spark logs directory for spark history server
-    "spark_operator_version": "spark-2",  # the version of the spark operator in use
+    "spark_operator_version": "spark-3",  # the version of the spark operator in use
     "builder_alpine_image": "alpine:3.13.1",  # builder alpine image (as kaniko's initContainer)
     "package_path": "mlrun",  # mlrun pip package
     "default_base_image": "mlrun/mlrun",  # default base image when doing .deploy()

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -55,7 +55,7 @@ _sparkjob_template = {
         "mode": "cluster",
         "image": "",
         "mainApplicationFile": "",
-        "sparkVersion": "2.4.5",
+        "sparkVersion": "3.1.2",
         "restartPolicy": {
             "type": "OnFailure",
             "onFailureRetries": 0,


### PR DESCRIPTION
Spark-2 is pretty much deprecated. Changing the default configuration to be `spark-3`. Not yet removing support for Spark 2, can be configured manually if needed.