### PR TITLE
[Runtimes] Adding a modifier and auto-mount option to configure multiple env variables

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -383,7 +383,7 @@ default_config = {
         },
     },
     "storage": {
-        # What type of auto-mount to use for functions. Can be one of: none, auto, v3io_credentials, v3io_fuse, pvc, s3.
+        # What type of auto-mount to use for functions. One of: none, auto, v3io_credentials, v3io_fuse, pvc, s3, env.
         # Default is auto - which is v3io_credentials when running on Iguazio. If not Iguazio: pvc if the
         # MLRUN_PVC_MOUNT env is configured or auto_mount_params contain "pvc_name". Otherwise will do nothing (none).
         "auto_mount_type": "auto",

--- a/mlrun/platforms/__init__.py
+++ b/mlrun/platforms/__init__.py
@@ -29,11 +29,11 @@ from .iguazio import (
 from .other import (
     auto_mount,
     mount_configmap,
-    mount_env_variables,
     mount_hostpath,
     mount_pvc,
     mount_s3,
     mount_secret,
+    set_env_variables,
 )
 
 

--- a/mlrun/platforms/__init__.py
+++ b/mlrun/platforms/__init__.py
@@ -29,6 +29,7 @@ from .iguazio import (
 from .other import (
     auto_mount,
     mount_configmap,
+    mount_env_variables,
     mount_hostpath,
     mount_pvc,
     mount_s3,

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -267,6 +267,7 @@ def set_env_variables(env_vars_dict: Dict[str, str] = None, **kwargs):
     """
     Modifier function to apply a set of environment variables to a runtime. Variables may be passed
     as either a dictionary of name-value pairs, or as arguments to the function.
+    See `KubeResource.apply` for more information on modifiers.
 
     Usage::
 

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -263,12 +263,12 @@ def mount_s3(
     return _use_s3_cred
 
 
-def mount_env_variables(env_vars_dict: Dict[str, str] = None, **kwargs):
+def set_env_variables(env_vars_dict: Dict[str, str] = None, **kwargs):
     env_data = env_vars_dict.copy() if env_vars_dict else {}
     for key, value in kwargs.items():
         env_data[key] = value
 
-    def _mount_env_variables(container_op: kfp.dsl.ContainerOp):
+    def _set_env_variables(container_op: kfp.dsl.ContainerOp):
         from kubernetes import client as k8s_client
 
         for _key, _value in env_data.items():
@@ -277,4 +277,4 @@ def mount_env_variables(env_vars_dict: Dict[str, str] = None, **kwargs):
             )
         return container_op
 
-    return _mount_env_variables
+    return _set_env_variables

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -264,6 +264,20 @@ def mount_s3(
 
 
 def set_env_variables(env_vars_dict: Dict[str, str] = None, **kwargs):
+    """
+    Modifier function to apply a set of environment variables to a runtime. Variables may be passed
+    as either a dictionary of name-value pairs, or as arguments to the function.
+
+    Usage::
+
+        function.apply(set_env_variables({"ENV1": "value1", "ENV2": "value2"}))
+        or
+        function.apply(set_env_variables(ENV1=value1, ENV2=value2))
+
+    :param env_vars_dict: dictionary of env. variables
+    :param kwargs: environment variables passed as args
+    """
+
     env_data = env_vars_dict.copy() if env_vars_dict else {}
     for key, value in kwargs.items():
         env_data[key] = value

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -794,6 +794,7 @@ class AutoMountType(str, Enum):
     v3io_fuse = "v3io_fuse"
     pvc = "pvc"
     s3 = "s3"
+    env = "env"
 
     @classmethod
     def _missing_(cls, value):
@@ -817,6 +818,7 @@ class AutoMountType(str, Enum):
             mlrun.platforms.other.mount_pvc.__name__,
             mlrun.auto_mount.__name__,
             mlrun.platforms.mount_s3.__name__,
+            mlrun.platforms.mount_env_variables.__name__,
         ]
 
     @classmethod
@@ -850,6 +852,7 @@ class AutoMountType(str, Enum):
             AutoMountType.pvc: mlrun.platforms.other.mount_pvc,
             AutoMountType.auto: self._get_auto_modifier(),
             AutoMountType.s3: mlrun.platforms.mount_s3,
+            AutoMountType.env: mlrun.platforms.mount_env_variables,
         }[self]
 
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -818,7 +818,7 @@ class AutoMountType(str, Enum):
             mlrun.platforms.other.mount_pvc.__name__,
             mlrun.auto_mount.__name__,
             mlrun.platforms.mount_s3.__name__,
-            mlrun.platforms.mount_env_variables.__name__,
+            mlrun.platforms.set_env_variables.__name__,
         ]
 
     @classmethod
@@ -852,7 +852,7 @@ class AutoMountType(str, Enum):
             AutoMountType.pvc: mlrun.platforms.other.mount_pvc,
             AutoMountType.auto: self._get_auto_modifier(),
             AutoMountType.s3: mlrun.platforms.mount_s3,
-            AutoMountType.env: mlrun.platforms.mount_env_variables,
+            AutoMountType.env: mlrun.platforms.set_env_variables,
         }[self]
 
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -895,6 +895,15 @@ class KubeResource(BaseRuntime):
         return struct
 
     def apply(self, modify):
+        """
+        Apply a modifier to the runtime which is used to change the runtime's k8s object's spec.
+        Modifiers can be either KFP modifiers or MLRun modifiers (which are compatible with KFP). All modifiers accept
+        a `kfp.dsl.ContainerOp` object, apply some changes on its spec and return it so modifiers can be chained
+        one after the other.
+
+        :param modify: a modifier runnable object
+        :return: the runtime (self) after the modifications
+        """
 
         # Kubeflow pipeline have a hook to add the component to the DAG on ContainerOp init
         # we remove the hook to suppress kubeflow op registration and return it after the apply()

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -337,6 +337,13 @@ class RunDBMock:
             expected_envs["S3_NON_ANONYMOUS"] = "true"
         assert expected_envs == env_dict
 
+    def assert_env_variables(self, expected_env_dict):
+        env_list = self._function["spec"]["env"]
+        env_dict = {item["name"]: item["value"] for item in env_list}
+
+        for key, value in expected_env_dict.items():
+            assert env_dict[key] == value
+
     def verify_authorization(
         self,
         authorization_verification_input: mlrun.api.schemas.AuthorizationVerificationInput,

--- a/tests/platforms/test_other.py
+++ b/tests/platforms/test_other.py
@@ -116,7 +116,7 @@ def test_mount_s3():
     }
 
 
-def test_mount_env_variables():
+def test_set_env_variables():
     env_variables = {
         "some_env_1": "some-value",
         "SOMETHING": "ELSE",
@@ -129,7 +129,7 @@ def test_mount_env_variables():
     assert function.spec.env == []
 
     # Using a dictionary
-    function.apply(mlrun.platforms.mount_env_variables(env_variables))
+    function.apply(mlrun.platforms.set_env_variables(env_variables))
     env_dict = {var["name"]: var.get("value") for var in function.spec.env}
 
     assert env_dict == env_variables
@@ -140,7 +140,7 @@ def test_mount_env_variables():
     assert function.spec.env == []
 
     # And using key=value parameters
-    function.apply(mlrun.platforms.mount_env_variables(**env_variables))
+    function.apply(mlrun.platforms.set_env_variables(**env_variables))
     env_dict = {var["name"]: var.get("value") for var in function.spec.env}
 
     assert env_dict == env_variables

--- a/tests/platforms/test_other.py
+++ b/tests/platforms/test_other.py
@@ -100,3 +100,33 @@ def test_mount_s3():
             "secretKeyRef": {"key": "AWS_SECRET_ACCESS_KEY", "name": "s"}
         },
     }
+
+
+def test_mount_env_variables():
+    env_variables = {
+        "some_env_1": "some-value",
+        "SOMETHING": "ELSE",
+        "and_another": "like_this",
+    }
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    assert function.spec.env == []
+
+    # Using a dictionary
+    function.apply(mlrun.platforms.mount_env_variables(env_variables))
+    env_dict = {var["name"]: var.get("value") for var in function.spec.env}
+
+    assert env_dict == env_variables
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    assert function.spec.env == []
+
+    # And using key=value parameters
+    function.apply(mlrun.platforms.mount_env_variables(**env_variables))
+    env_dict = {var["name"]: var.get("value") for var in function.spec.env}
+
+    assert env_dict == env_variables


### PR DESCRIPTION
Added a modifier function `set_env_variables` to add multiple env. variables to a runtime. Also added an `env` auto-mount option to use this function automatically. This can be used to mount an arbitrary set of env variables to every runtime in a project.
While there are existing ways through MLRun/KFP-modifiers to add env. variables to runtimes, they have some short-comings, which this function solves:
* Since it's a modifier, it can be used with `RunConfig` which has an option to apply modifiers, but does not have ways to set env. variables on the `RunConfig` itself. Also, since auto-mount option is available, it can be used for every job submitted without having to tweak the `RunConfig` parameters
* It accepts multiple env. variables in a single execution. This makes it flexible and suitable to use in auto-mount where there's a single default modifier which can be configured
* The variables can be passed as a dictionary or as kwargs. Again, this makes it easier to configure it as auto-mount function. For example, you can call:
`function.apply(set_env_variables({"ENV1": "value1", "ENV2": "value2"}))`
and can also do the same with:
`function.apply(set_env_variables(ENV1="value1", ENV2="value2"))`
The kwargs option is more limited and should be used for simple keys/values, while the dictionary option can be used for keys which do not pass as Python parameter names etc.