### PR TITLE
[SDK] Fix Access Key saved as clear text when deploying a serving function

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -993,7 +993,9 @@ class RemoteRuntime(KubeResource):
             return f"http://{self.status.address}/{path}"
 
     def _update_credentials_from_remote_build(self, remote_data):
-        self.metadata.credentials = remote_data.get("metadata", {}).get("credentials", {})
+        self.metadata.credentials = remote_data.get("metadata", {}).get(
+            "credentials", {}
+        )
 
         credentials_env_var_names = ["V3IO_ACCESS_KEY", "MLRUN_AUTH_SESSION"]
         new_env = []
@@ -1009,7 +1011,6 @@ class RemoteRuntime(KubeResource):
                 new_env.append(remote_env)
 
         self.spec.env = new_env
-
 
 
 def parse_logs(logs):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -528,6 +528,8 @@ class RemoteRuntime(KubeResource):
             logger.info("Starting remote function deploy")
             data = db.remote_builder(self, False, builder_env=builder_env)
             self.status = data["data"].get("status")
+            self.metadata = data["data"].get("metadata")
+            self.spec = data["data"].get("spec")
             self._wait_for_function_deployment(db, verbose=verbose)
 
             # NOTE: on older mlrun versions & nuclio versions, function are exposed via NodePort

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1002,7 +1002,14 @@ class RemoteRuntime(KubeResource):
 
         # remove existing credentials env vars
         for env in self.spec.env:
-            if env["name"] not in credentials_env_var_names:
+            if isinstance(env, dict):
+                env_name = env["name"]
+            elif isinstance(env, client.V1EnvVar):
+                env_name = env.name
+            else:
+                continue
+
+            if env_name not in credentials_env_var_names:
                 new_env.append(env)
 
         # add credentials env vars from remote build

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -527,6 +527,10 @@ class RemoteRuntime(KubeResource):
             db = self._get_db()
             logger.info("Starting remote function deploy")
             data = db.remote_builder(self, False, builder_env=builder_env)
+
+            # updating the function's metadata and spec (in addition to the status) according to the remote build
+            # result, so any enrichment / masking done by the remote build will be applied to the function later when
+            # saved.
             self.status = data["data"].get("status")
             self.metadata = data["data"].get("metadata")
             self.spec = data["data"].get("spec")

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -527,13 +527,8 @@ class RemoteRuntime(KubeResource):
             db = self._get_db()
             logger.info("Starting remote function deploy")
             data = db.remote_builder(self, False, builder_env=builder_env)
-
-            # updating the function's metadata and spec (in addition to the status) according to the remote build
-            # result, so any enrichment / masking done by the remote build will be applied to the function later when
-            # saved.
             self.status = data["data"].get("status")
-            self.metadata = data["data"].get("metadata")
-            self.spec = data["data"].get("spec")
+            self._update_credentials_from_remote_build(data["data"])
             self._wait_for_function_deployment(db, verbose=verbose)
 
             # NOTE: on older mlrun versions & nuclio versions, function are exposed via NodePort
@@ -996,6 +991,25 @@ class RemoteRuntime(KubeResource):
             return f"http://{self.status.external_invocation_urls[0]}/{path}"
         else:
             return f"http://{self.status.address}/{path}"
+
+    def _update_credentials_from_remote_build(self, remote_data):
+        self.metadata.credentials = remote_data.get("metadata", {}).get("credentials", {})
+
+        credentials_env_var_names = ["V3IO_ACCESS_KEY", "MLRUN_AUTH_SESSION"]
+        new_env = []
+
+        # remove existing credentials env vars
+        for env in self.spec.env:
+            if env["name"] not in credentials_env_var_names:
+                new_env.append(env)
+
+        # add credentials env vars from remote build
+        for remote_env in remote_data.get("spec", {}).get("env", []):
+            if remote_env.get("name") in credentials_env_var_names:
+                new_env.append(remote_env)
+
+        self.spec.env = new_env
+
 
 
 def parse_logs(logs):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1000,6 +1000,15 @@ class RemoteRuntime(KubeResource):
         credentials_env_var_names = ["V3IO_ACCESS_KEY", "MLRUN_AUTH_SESSION"]
         new_env = []
 
+        # the env vars in the local spec and remote spec are in the format of a list of dicts
+        # e.g.:
+        # env = [
+        #   {
+        #     "name": "V3IO_ACCESS_KEY",
+        #     "value": "some-value"
+        #   },
+        #   ...
+        # ]
         # remove existing credentials env vars
         for env in self.spec.env:
             if isinstance(env, dict):

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -205,7 +205,13 @@ class RunDBMock:
             state="ready",
             nuclio_name="test-nuclio-name",
         )
-        return {"data": {"status": status.to_dict()}}
+        return {
+            "data": {
+                "status": status.to_dict(),
+                "metadata": self._function.get("metadata"),
+                "spec": self._function.get("spec"),
+            }
+        }
 
     def get_builder_status(
         self,

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -57,7 +57,6 @@ class TestAutoMount:
         runtime = self._generate_runtime(disable_auto_mount=True)
         self._execute_run(runtime)
         rundb_mock.assert_no_mount_or_creds_configured()
-        rundb_mock.reset()
 
     def test_fill_credentials(self, rundb_mock):
         os.environ[

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -57,6 +57,7 @@ class TestAutoMount:
         runtime = self._generate_runtime(disable_auto_mount=True)
         self._execute_run(runtime)
         rundb_mock.assert_no_mount_or_creds_configured()
+        rundb_mock.reset()
 
     def test_fill_credentials(self, rundb_mock):
         os.environ[

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -1,4 +1,5 @@
 import pathlib
+import pytest
 import sys
 
 from deepdiff import DeepDiff
@@ -163,7 +164,8 @@ def test_resolve_git_reference_from_source():
         assert expected == _resolve_git_reference_from_source(source)
 
 
-def test_update_credentials_from_remote_build():
+@pytest.mark.parametrize("function_kind", ["serving", "remote"])
+def test_update_credentials_from_remote_build(function_kind):
     secret_name = "secret-name"
     remote_data = {
         "metadata": {"credentials": {"access_key": secret_name}},
@@ -175,7 +177,7 @@ def test_update_credentials_from_remote_build():
         },
     }
 
-    function = mlrun.new_function("tst", kind="nuclio")
+    function = mlrun.new_function("tst", kind=function_kind)
     function.metadata.credentials.access_key = "access_key"
     function.spec.env = [
         {"name": "V3IO_ACCESS_KEY", "value": "access_key"},

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -161,3 +161,27 @@ def test_resolve_git_reference_from_source():
     ]
     for source, expected in cases:
         assert expected == _resolve_git_reference_from_source(source)
+
+
+def test_update_credentials_from_remote_build():
+    secret_name = "secret-name"
+    remote_data = {
+        "metadata": {"credentials": {"access_key": secret_name}},
+        "spec": {
+            "env": [
+                {"name": "V3IO_ACCESS_KEY", "value": secret_name},
+                {"name": "MLRUN_AUTH_SESSION", "value": secret_name},
+            ],
+        },
+    }
+
+    function = mlrun.new_function("tst", kind="nuclio")
+    function.metadata.credentials.access_key = "access_key"
+    function.spec.env = [
+        {"name": "V3IO_ACCESS_KEY", "value": "access_key"},
+        {"name": "MLRUN_AUTH_SESSION", "value": "access_key"},
+    ]
+    function._update_credentials_from_remote_build(remote_data)
+
+    assert function.metadata.credentials.access_key == secret_name
+    assert function.spec.env == remote_data["spec"]["env"]

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -1,7 +1,7 @@
 import pathlib
-import pytest
 import sys
 
+import pytest
 from deepdiff import DeepDiff
 
 import mlrun


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/ML-2164

When deploying a serving function, the SDK creates the function via the API, and then polls its status. Once the status is ready the SDK saves the function to the DB. The API masks the access key with a reference to a secret, but the SDK does not do this, so when it saves the function it is saved with clear text access key.
Fixed the polling so that not only the state gets updated but also all the relevant env vars and fields relating to credentials. That way the access key gets the masked version from the API. As seen in the example image:
<img width="1014" alt="Screen Shot 2022-08-18 at 11 18 06" src="https://user-images.githubusercontent.com/12761913/185346802-6b7102d6-b547-46bc-99ac-72132f9a3330.png">