### PR TITLE
[Jupyter] Remove Enterprise Demos from Open Source Image

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -40,7 +40,8 @@ RUN cd /tmp/mlrun && python -m pip install ".[complete-api]"
 
 # This will usually cause a cache miss - so keep it in the last layers
 ARG MLRUN_CACHE_DATE=initial
-RUN git clone --branch 1.0.x https://github.com/mlrun/demos.git $HOME/demos
+RUN git clone --branch 1.1.x https://github.com/mlrun/demos.git $HOME/demos && \
+    cd $HOME/demos && ./community_edition_align.sh && cd -
 RUN git clone --branch master https://github.com/mlrun/functions.git $HOME/functions
 
 ENV JUPYTER_ENABLE_LAB=yes \


### PR DESCRIPTION
Some of the demos currently only work in iguazio enterprise. 
In the demos repo we added a script which removes the relevant demos. So when building open source jupyter image, we run the script so only the working demos will remain.