### PR TITLE
[Project] Change default `new_project` to create instead of store

### DIFF
--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -136,7 +136,8 @@ class Projects(
         mlrun.api.crud.ModelEndpoints().delete_model_endpoints_resources(name)
 
         # delete project secrets - passing None will delete all secrets
-        mlrun.api.utils.singletons.k8s.get_k8s().delete_project_secrets(name, None)
+        if mlrun.mlconf.is_api_running_on_k8s():
+            mlrun.api.utils.singletons.k8s.get_k8s().delete_project_secrets(name, None)
 
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -98,7 +98,12 @@ class Projects(
         # an MLRun resource (such as model-endpoints) was already verified in previous checks. Therefore, any internal
         # secret existing here is something that the user needs to be notified about, as MLRun didn't generate it.
         # Therefore, this check should remain at the end of the verification flow.
-        if mlrun.api.utils.singletons.k8s.get_k8s().get_project_secret_keys(project):
+        if (
+            mlrun.mlconf.is_api_running_on_k8s()
+            and mlrun.api.utils.singletons.k8s.get_k8s().get_project_secret_keys(
+                project
+            )
+        ):
             raise mlrun.errors.MLRunPreconditionFailedError(
                 f"Project {project} can not be deleted since related resources found: project secrets"
             )

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -176,18 +176,18 @@ def new_project(
     pipeline_context.set(project)
     if save and mlrun.mlconf.dbpath:
         try:
-            logger.debug(f"Creating project {name}")
             project.save(create_only=True)
         except mlrun.errors.MLRunConflictError as exc:
             raise mlrun.errors.MLRunConflictError(
                 f"Project with name {name} already exists. "
                 "Use override=True to override the existing project."
             ) from exc
-        logger.debug(
-            f"Created project {name}",
+        logger.info(
+            f"Created and saved project {name}",
             from_template=from_template,
             override=override,
             context=context,
+            save=save,
         )
     return project
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -157,7 +157,7 @@ def new_project(
     else:
         if override:
             try:
-                _delete_project_from_db(name, secrets, user_project)
+                _delete_project_from_db(name, secrets)
                 logger.info(f"Deleted project {name} from MLRun DB")
             except mlrun.errors.MLRunNotFoundError:
                 logger.debug(f"Project {name} does not exist, creating")
@@ -415,11 +415,8 @@ def _load_project_from_db(url, secrets, user_project=False):
     return db.get_project(project_name)
 
 
-def _delete_project_from_db(url, secrets, user_project=False):
+def _delete_project_from_db(project_name, secrets):
     db = mlrun.db.get_run_db(secrets=secrets)
-    project_name = _add_username_to_project_name_if_needed(
-        url.replace("db://", ""), user_project
-    )
     return db.delete_project(project_name)
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -178,7 +178,13 @@ def new_project(
     mlrun.mlconf.default_project = project.metadata.name
     pipeline_context.set(project)
     if save and mlrun.mlconf.dbpath:
-        project.save(create_only=True)
+        try:
+            project.save(create_only=True)
+        except mlrun.errors.MLRunConflictError as exc:
+            raise mlrun.errors.MLRunConflictError(
+                f"Project with name {name} already exists. "
+                "Use override=True to override the existing project."
+            ) from exc
     return project
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -156,11 +156,8 @@ def new_project(
         project.metadata.name = name
     else:
         if override:
-            try:
-                _delete_project_from_db(name, secrets)
-                logger.info(f"Deleted project {name} from MLRun DB")
-            except mlrun.errors.MLRunNotFoundError:
-                logger.debug(f"Project {name} does not exist, creating")
+            logger.info(f"Deleting project {name} from MLRun DB due to override")
+            _delete_project_from_db(name, secrets)
 
         project = MlrunProject(name=name)
     project.spec.context = context
@@ -179,12 +176,19 @@ def new_project(
     pipeline_context.set(project)
     if save and mlrun.mlconf.dbpath:
         try:
+            logger.debug(f"Creating project {name}")
             project.save(create_only=True)
         except mlrun.errors.MLRunConflictError as exc:
             raise mlrun.errors.MLRunConflictError(
                 f"Project with name {name} already exists. "
                 "Use override=True to override the existing project."
             ) from exc
+        logger.debug(
+            f"Created project {name}",
+            from_template=from_template,
+            override=override,
+            context=context,
+        )
     return project
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2039,7 +2039,7 @@ class MlrunProject(ModelObj):
             shutil.rmtree(self.spec.context)
 
     def save(self, filepath=None, store=True):
-        """export project to yaml and save project to database
+        """export project to yaml file and save project in database
 
         :store: if True, allow updating in case project already exists
         """

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -156,6 +156,7 @@ def test_delete_project_with_resources(
     # need to set this to False, otherwise impl will try to delete k8s resources, and will need many more
     # mocks to overcome this.
     k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
+    mlrun.mlconf.namespace = "test-namespace"
     project_to_keep = "project-to-keep"
     project_to_remove = "project-to-remove"
     _create_resources_of_all_kinds(db, k8s_secrets_mock, project_to_keep)

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -617,6 +617,7 @@ def test_delete_project_deletion_strategy_check_external_resource(
     project_member_mode: str,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
 ) -> None:
+    mlrun.mlconf.namespace = "test-namespace"
     project = mlrun.api.schemas.Project(
         metadata=mlrun.api.schemas.ProjectMetadata(name="project-name"),
         spec=mlrun.api.schemas.ProjectSpec(),

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -24,7 +24,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         with pytest.raises(mlrun.errors.MLRunConflictError) as exc:
             mlrun.new_project(project_name)
         assert (
-            f"Project with name {project_name} already exists. Use overwrite=True to override the existing project."
+            f"Project with name {project_name} already exists. Use overwrite=True to overwrite the existing project."
             in str(exc.value)
         )
 
@@ -58,7 +58,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
                     versioned=True,
                 )
 
-        # create several artifacts with several tags
+        # create several artifacts
         artifact = {
             "test": "artifact",
             "labels": labels,

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -136,6 +136,27 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         assert projects[0].list_functions() is None
         assert projects[0].metadata.created > old_creation_time
 
+    def test_overwrite_project_failure(self):
+        project_name = "some-project"
+
+        mlrun.new_project(project_name)
+        db = mlrun.get_run_db()
+
+        projects = db.list_projects()
+        assert len(projects) == 1
+        assert projects[0].metadata.name == project_name
+        old_creation_time = projects[0].metadata.created
+
+        # overwrite with invalid from_template value
+        with pytest.raises(ValueError):
+            mlrun.new_project(project_name, from_template="bla", overwrite=True)
+
+        # ensure project was not deleted
+        projects = db.list_projects()
+        assert len(projects) == 1
+        assert projects[0].metadata.name == project_name
+        assert projects[0].metadata.created == old_creation_time
+
     def test_load_project_from_db(self):
         project_name = "some-project"
         mlrun.new_project(project_name)

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -1,4 +1,3 @@
-import json
 import pathlib
 
 import deepdiff
@@ -25,7 +24,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         with pytest.raises(mlrun.errors.MLRunConflictError) as exc:
             mlrun.new_project(project_name)
         assert (
-            f"Project with name {project_name} already exists. Use override=True to override the existing project."
+            f"Project with name {project_name} already exists. Use overwrite=True to override the existing project."
             in str(exc.value)
         )
 

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -17,7 +17,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
 
-    def test_create_existing_project_failure(self):
+    def test_create_project_failure_already_exists(self):
         project_name = "some-project"
         mlrun.new_project(project_name)
 
@@ -42,8 +42,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
 
     def test_load_project_from_db(self):
         project_name = "some-project"
-        project = mlrun.new_project(project_name)
-        project.save_to_db()
+        mlrun.new_project(project_name)
         mlrun.load_project(".", f"db://{project_name}")
 
     def test_load_project_with_save(self):

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -1,5 +1,4 @@
 import pathlib
-import time
 
 import deepdiff
 import pytest

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -1,4 +1,5 @@
 import pathlib
+import time
 
 import deepdiff
 import pytest
@@ -30,18 +31,20 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
 
     def test_override_project(self):
         project_name = "some-project"
-        mlrun.new_project(project_name)
+
+        # verify override does not fail if project does not exist
+        mlrun.new_project(project_name, override=True)
         projects = mlrun.get_run_db().list_projects()
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
-        old_created_time = projects[0].metadata.created
+        old_creation_time = projects[0].metadata.created
 
         mlrun.new_project(project_name, override=True)
         projects = mlrun.get_run_db().list_projects()
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
 
-        assert projects[0].metadata.created > old_created_time
+        assert projects[0].metadata.created > old_creation_time
 
     def test_load_project_from_db(self):
         project_name = "some-project"

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -12,11 +12,33 @@ import tests.integration.sdk_api.base
 class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
     def test_create_project(self):
         project_name = "some-project"
-        project = mlrun.new_project(project_name)
-        project.save_to_db()
+        mlrun.new_project(project_name)
         projects = mlrun.get_run_db().list_projects()
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
+
+    def test_create_existing_project_failure(self):
+        project_name = "some-project"
+        mlrun.new_project(project_name)
+
+        with pytest.raises(mlrun.errors.MLRunConflictError) as exc:
+            mlrun.new_project(project_name)
+        assert "Conflict - Project already exists: some-project" in str(exc.value)
+
+    def test_override_project(self):
+        project_name = "some-project"
+        mlrun.new_project(project_name)
+        projects = mlrun.get_run_db().list_projects()
+        assert len(projects) == 1
+        assert projects[0].metadata.name == project_name
+        old_created_time = projects[0].metadata.created
+
+        mlrun.new_project(project_name, override=True)
+        projects = mlrun.get_run_db().list_projects()
+        assert len(projects) == 1
+        assert projects[0].metadata.name == project_name
+
+        assert projects[0].metadata.created > old_created_time
 
     def test_load_project_from_db(self):
         project_name = "some-project"

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -23,7 +23,10 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         with pytest.raises(mlrun.errors.MLRunConflictError) as exc:
             mlrun.new_project(project_name)
-        assert "Conflict - Project already exists: some-project" in str(exc.value)
+        assert (
+            f"Project with name {project_name} already exists. Use override=True to override the existing project."
+            in str(exc.value)
+        )
 
     def test_override_project(self):
         project_name = "some-project"

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -44,9 +44,14 @@ def pipe_test():
 @pytest.mark.enterprise
 class TestProject(TestMLRunSystem):
     project_name = "project-system-test-project"
+    custom_project_names_to_delete = []
 
     def custom_setup(self):
         pass
+
+    def custom_teardown(self):
+        for name in self.custom_project_names_to_delete:
+            self._delete_test_project(name)
 
     @property
     def assets_path(self):
@@ -86,6 +91,7 @@ class TestProject(TestMLRunSystem):
 
     def test_run(self):
         name = "pipe1"
+        self.custom_project_names_to_delete.append(name)
         # create project in context
         self._create_project(name)
 
@@ -112,10 +118,9 @@ class TestProject(TestMLRunSystem):
         assert len(functions) == 3  # prep-data, train, test
         assert functions[0].metadata.project == name
 
-        self._delete_test_project(name)
-
     def test_run_artifact_path(self):
         name = "pipe1"
+        self.custom_project_names_to_delete.append(name)
         # create project in context
         self._create_project(name)
 
@@ -134,11 +139,11 @@ class TestProject(TestMLRunSystem):
                 run_object = db.read_run(uid=graph_step["run_uid"], project=name)
                 output_path = run_object["spec"]["output_path"]
                 assert output_path == f"v3io:///projects/{name}/{run_id}"
-        self._delete_test_project(name)
 
     def test_run_git_load(self):
         # load project from git
         name = "pipe2"
+        self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
 
@@ -152,10 +157,10 @@ class TestProject(TestMLRunSystem):
         run = project2.run("main", artifact_path=f"v3io:///projects/{name}")
         run.wait_for_completion()
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
-        self._delete_test_project(name)
 
     def test_run_git_build(self):
         name = "pipe3"
+        self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
 
@@ -173,7 +178,6 @@ class TestProject(TestMLRunSystem):
         )
         run.wait_for_completion()
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
-        self._delete_test_project(name)
 
     @staticmethod
     def _assert_cli_output(output: str, project_name: str):
@@ -189,6 +193,7 @@ class TestProject(TestMLRunSystem):
     def test_run_cli(self):
         # load project from git
         name = "pipe4"
+        self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
 
@@ -205,6 +210,7 @@ class TestProject(TestMLRunSystem):
 
         # load the project from local dir and change a workflow
         project2 = mlrun.load_project(project_dir)
+        self.custom_project_names_to_delete.append(project2.metadata.name)
         project2.spec.workflows = {}
         project2.set_workflow("kf", "./kflow.py")
         project2.save()
@@ -224,12 +230,11 @@ class TestProject(TestMLRunSystem):
         ]
         out = exec_project(args)
         self._assert_cli_output(out, name)
-        self._delete_test_project(name)
-        self._delete_test_project(project2.metadata.name)
 
     def test_cli_with_remote(self):
         # load project from git
         name = "pipermtcli"
+        self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
 
@@ -260,10 +265,10 @@ class TestProject(TestMLRunSystem):
         ]
         out = exec_project(args)
         self._assert_cli_output(out, name)
-        self._delete_test_project(name)
 
     def test_inline_pipeline(self):
         name = "pipe5"
+        self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
         project = self._create_project(name, True)
@@ -273,11 +278,11 @@ class TestProject(TestMLRunSystem):
         )
         run.wait_for_completion()
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
-        self._delete_test_project(name)
 
     def test_get_or_create(self):
         # create project and save to DB
         name = "newproj73"
+        self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         shutil.rmtree(project_dir, ignore_errors=True)
         project = mlrun.get_or_create_project(name, project_dir)
@@ -294,7 +299,6 @@ class TestProject(TestMLRunSystem):
         # get project should read from context (project.yaml)
         project = mlrun.get_or_create_project(name, project_dir)
         assert project.spec.description == "mytest", "failed to get project"
-        self._delete_test_project(name)
 
     def test_new_project_overwrite(self):
         # create project and save to DB
@@ -359,6 +363,7 @@ class TestProject(TestMLRunSystem):
 
     def _test_new_pipeline(self, name, engine):
         project = self._create_project(name)
+        self.custom_project_names_to_delete.append(name)
         project.set_function(
             "gen_iris.py",
             "gen-iris",
@@ -377,7 +382,6 @@ class TestProject(TestMLRunSystem):
         fn = project.get_function("gen-iris", ignore_cache=True)
         assert fn.status.state == "ready"
         assert fn.spec.image, "image path got cleared"
-        self._delete_test_project(name)
 
     def test_local_pipeline(self):
         self._test_new_pipeline("lclpipe", engine="local")
@@ -437,6 +441,7 @@ class TestProject(TestMLRunSystem):
 
     def test_remote_from_archive(self):
         name = "pipe6"
+        self.custom_project_names_to_delete.append(name)
         project = self._create_project(name)
         archive_path = f"v3io:///projects/{project.name}/archive1.zip"
         project.export(archive_path)
@@ -450,11 +455,11 @@ class TestProject(TestMLRunSystem):
         )
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
         assert run.run_id, "workflow's run id failed to fetch"
-        self._delete_test_project()
 
     def test_local_cli(self):
         # load project from git
         name = "lclclipipe"
+        self.custom_project_names_to_delete.append(name)
         project = self._create_project(name)
         project.set_function(
             "gen_iris.py",
@@ -481,11 +486,11 @@ class TestProject(TestMLRunSystem):
         out = exec_project(args)
         print("OUT:\n", out)
         assert out.find("pipeline run finished, state=Succeeded"), "pipeline failed"
-        self._delete_test_project(name)
 
     def test_build_and_run(self):
         # test that build creates a proper image and run will use the updated function (with the built image)
         name = "buildandrun"
+        self.custom_project_names_to_delete.append(name)
         project = mlrun.new_project(name, context=str(self.assets_path))
 
         # test with user provided function object
@@ -527,10 +532,9 @@ class TestProject(TestMLRunSystem):
         assert fn.spec.image, "image path got cleared"
         assert run_result.output("score")
 
-        self._delete_test_project(name)
-
     def test_set_secrets(self):
         name = "set-secrets"
+        self.custom_project_names_to_delete.append(name)
         project = mlrun.new_project(name, context=str(self.assets_path))
         project.save()
         env_file = str(self.assets_path / "envfile")
@@ -539,7 +543,3 @@ class TestProject(TestMLRunSystem):
         project.set_secrets(file_path=env_file)
         secrets = db.list_project_secret_keys(name, provider="kubernetes")
         assert secrets.secret_keys == ["ENV_ARG1", "ENV_ARG2"]
-
-        # Cleanup
-        self._run_db.delete_project_secrets(self.project_name, provider="kubernetes")
-        self._delete_test_project(name)


### PR DESCRIPTION
When creating new project allow only creation instead of update.
Add `override` option to delete existing project with the same name before creation.
https://jira.iguazeng.com/browse/ML-2320