### PR TITLE
[Docker Compose] Fix models preview when running with jupyter

### DIFF
--- a/docs/install/compose.with-jupyter.yaml
+++ b/docs/install/compose.with-jupyter.yaml
@@ -10,6 +10,10 @@ services:
       MLRUN_NUCLIO_DASHBOARD_URL: http://nuclio:8070
       MLRUN_HTTPDB__DSN: "sqlite:////home/jovyan/data/mlrun.db?check_same_thread=false"
       MLRUN_UI__URL: http://localhost:8060
+      # using local storage, meaning files / artifacts are stored locally, so we want to allow access to them
+      MLRUN_HTTPDB__REAL_PATH: "/home/jovyan/data"
+      # not running on k8s meaning no need to store secrets
+      MLRUN_SECRET_STORES__KUBERNETES__AUTO_ADD_PROJECT_SECRETS: "false"
     volumes:
       - "${SHARED_DIR:?err}:/home/jovyan/data"
     networks:

--- a/docs/install/compose.yaml
+++ b/docs/install/compose.yaml
@@ -5,12 +5,15 @@ services:
       - "8080:8080"
     environment:
       MLRUN_ARTIFACT_PATH: "${SHARED_DIR}/{{project}}"
+      # using local storage, meaning files / artifacts are stored locally, so we want to allow access to them
       MLRUN_HTTPDB__REAL_PATH: /data
       MLRUN_HTTPDB__DATA_VOLUME: "${SHARED_DIR}"
       MLRUN_LOG_LEVEL: DEBUG
       MLRUN_NUCLIO_DASHBOARD_URL: http://nuclio:8070
       MLRUN_HTTPDB__DSN: "sqlite:////data/mlrun.db?check_same_thread=false"
       MLRUN_UI__URL: http://localhost:8060
+      # not running on k8s meaning no need to store secrets
+      MLRUN_SECRET_STORES__KUBERNETES__AUTO_ADD_PROJECT_SECRETS: "false"
     volumes:
       - "${SHARED_DIR:?err}:/data"
     networks:
@@ -19,7 +22,7 @@ services:
   mlrun-ui:
     image: "mlrun/mlrun-ui:${TAG:-1.0.6}"
     ports:
-      - "8060:80"
+      - "8060:8090"
     environment:
       MLRUN_API_PROXY_URL: http://mlrun-api:8080
       MLRUN_NUCLIO_MODE: enable


### PR DESCRIPTION
- We didn't set `MLRUN_HTTPDB__REAL_PATH` to the local mounted path, by default we don't want to allow accessing to local storage of the API, but because docker compose isn't using s3 yet but rather a local mount between with jupyter we need to allow access to the local storage. https://github.com/mlrun/mlrun/issues/2266#issuecomment-1219878137
- I found out I forgot to change the UI exposed port for `compose.yaml` to 8090 instead of 80, so fixed that as well.
- Added `MLRUN_SECRET_STORES__KUBERNETES__AUTO_ADD_PROJECT_SECRETS: "false"` just to avoid misleading errors from the API.