### PR TITLE
[CI] Remove demos from system tests

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        test_component: [api,runtimes,projects,model_monitoring,examples,demos,backwards_compatibility,feature_store]
+        test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
     steps:
     - uses: actions/checkout@v2
     - name: Set up python 3.7

--- a/tests/system/demos/churn/test_churn.py
+++ b/tests/system/demos/churn/test_churn.py
@@ -6,6 +6,7 @@ from tests.system.demos.base import TestDemo
 
 
 # Marked as enterprise because of v3io mount and pipelines
+@pytest.mark.skip("not up to date demos needs to run demos from mlrun/demos repo")
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestChurn(TestDemo):

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -8,6 +8,7 @@ from tests.system.demos.base import TestDemo
 
 
 # Marked as enterprise because of v3io mount and pipelines
+@pytest.mark.skip("not up to date demos needs to run demos from mlrun/demos repo")
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestHorovodTFv2(TestDemo):

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -6,6 +6,7 @@ from tests.system.demos.base import TestDemo
 
 
 # Marked as enterprise because of v3io mount and pipelines
+@pytest.mark.skip("not up to date demos needs to run demos from mlrun/demos repo")
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestSKLearn(TestDemo):


### PR DESCRIPTION
Demos in the system tests were not up to date for a long time, currently the way the demos are being tests is by QA suits which runs the demos on each released version including RC. 
Todo: Connect CI between `mlrun/demos` with `mlrun/mlrun` and run demos for each merged commit to development.