### PR TITLE
[Runtimes] Add patch option for `with_requests` &  `with_limits`

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -432,18 +432,20 @@ class DaskCluster(KubejobRuntime):
         self.with_worker_limits(mem, cpu, gpus, gpu_type)
 
     def with_scheduler_limits(
-        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"
+        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
     ):
         """set scheduler pod resources limits"""
         self.spec._verify_and_set_limits(
-            "scheduler_resources", mem, cpu, gpus, gpu_type
+            "scheduler_resources", mem, cpu, gpus, gpu_type, override=override
         )
 
     def with_worker_limits(
-        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"
+        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
     ):
         """set worker pod resources limits"""
-        self.spec._verify_and_set_limits("worker_resources", mem, cpu, gpus, gpu_type)
+        self.spec._verify_and_set_limits(
+            "worker_resources", mem, cpu, gpus, gpu_type, override=override
+        )
 
     def with_requests(self, mem=None, cpu=None):
         warnings.warn(
@@ -458,13 +460,17 @@ class DaskCluster(KubejobRuntime):
         self.with_scheduler_requests(mem, cpu)
         self.with_worker_requests(mem, cpu)
 
-    def with_scheduler_requests(self, mem=None, cpu=None):
+    def with_scheduler_requests(self, mem=None, cpu=None, override=True):
         """set scheduler pod resources requests"""
-        self.spec._verify_and_set_requests("scheduler_resources", mem, cpu)
+        self.spec._verify_and_set_requests(
+            "scheduler_resources", mem, cpu, override=override
+        )
 
-    def with_worker_requests(self, mem=None, cpu=None):
+    def with_worker_requests(self, mem=None, cpu=None, override=True):
         """set worker pod resources requests"""
-        self.spec._verify_and_set_requests("worker_resources", mem, cpu)
+        self.spec._verify_and_set_requests(
+            "worker_resources", mem, cpu, override=override
+        )
 
     def _run(self, runobj: RunObject, execution):
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -437,11 +437,14 @@ class DaskCluster(KubejobRuntime):
         cpu: str = None,
         gpus: int = None,
         gpu_type: str = "nvidia.com/gpu",
-        override: bool = True,
+        patch: bool = False,
     ):
-        """set scheduler pod resources limits"""
+        """
+        set scheduler pod resources limits
+        by default it overrides the whole limits section, if you wish to patch specific resources use `patch=True`.
+        """
         self.spec._verify_and_set_limits(
-            "scheduler_resources", mem, cpu, gpus, gpu_type, override=override
+            "scheduler_resources", mem, cpu, gpus, gpu_type, patch=patch
         )
 
     def with_worker_limits(
@@ -450,11 +453,14 @@ class DaskCluster(KubejobRuntime):
         cpu: str = None,
         gpus: int = None,
         gpu_type: str = "nvidia.com/gpu",
-        override: bool = True,
+        patch: bool = False,
     ):
-        """set worker pod resources limits"""
+        """
+        set worker pod resources limits
+        by default it overrides the whole limits section, if you wish to patch specific resources use `patch=True`.
+        """
         self.spec._verify_and_set_limits(
-            "worker_resources", mem, cpu, gpus, gpu_type, override=override
+            "worker_resources", mem, cpu, gpus, gpu_type, patch=patch
         )
 
     def with_requests(self, mem=None, cpu=None):
@@ -471,20 +477,22 @@ class DaskCluster(KubejobRuntime):
         self.with_worker_requests(mem, cpu)
 
     def with_scheduler_requests(
-        self, mem: str = None, cpu: str = None, override: bool = True
+        self, mem: str = None, cpu: str = None, patch: bool = False
     ):
-        """set scheduler pod resources requests"""
-        self.spec._verify_and_set_requests(
-            "scheduler_resources", mem, cpu, override=override
-        )
+        """
+        set scheduler pod resources requests
+        by default it overrides the whole requests section, if you wish to patch specific resources use `patch=True`.
+        """
+        self.spec._verify_and_set_requests("scheduler_resources", mem, cpu, patch=patch)
 
     def with_worker_requests(
-        self, mem: str = None, cpu: str = None, override: bool = True
+        self, mem: str = None, cpu: str = None, patch: bool = False
     ):
-        """set worker pod resources requests"""
-        self.spec._verify_and_set_requests(
-            "worker_resources", mem, cpu, override=override
-        )
+        """
+        set worker pod resources requests
+        by default it overrides the whole requests section, if you wish to patch specific resources use `patch=True`.
+        """
+        self.spec._verify_and_set_requests("worker_resources", mem, cpu, patch=patch)
 
     def _run(self, runobj: RunObject, execution):
 

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -432,7 +432,12 @@ class DaskCluster(KubejobRuntime):
         self.with_worker_limits(mem, cpu, gpus, gpu_type)
 
     def with_scheduler_limits(
-        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+        self,
+        mem: str = None,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        override: bool = True,
     ):
         """set scheduler pod resources limits"""
         self.spec._verify_and_set_limits(
@@ -440,7 +445,12 @@ class DaskCluster(KubejobRuntime):
         )
 
     def with_worker_limits(
-        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+        self,
+        mem: str = None,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        override: bool = True,
     ):
         """set worker pod resources limits"""
         self.spec._verify_and_set_limits(
@@ -460,13 +470,17 @@ class DaskCluster(KubejobRuntime):
         self.with_scheduler_requests(mem, cpu)
         self.with_worker_requests(mem, cpu)
 
-    def with_scheduler_requests(self, mem=None, cpu=None, override=True):
+    def with_scheduler_requests(
+        self, mem: str = None, cpu: str = None, override: bool = True
+    ):
         """set scheduler pod resources requests"""
         self.spec._verify_and_set_requests(
             "scheduler_resources", mem, cpu, override=override
         )
 
-    def with_worker_requests(self, mem=None, cpu=None, override=True):
+    def with_worker_requests(
+        self, mem: str = None, cpu: str = None, override: bool = True
+    ):
         """set worker pod resources requests"""
         self.spec._verify_and_set_requests(
             "worker_resources", mem, cpu, override=override

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -283,11 +283,11 @@ class KubeResourceSpec(FunctionSpec):
     def _verify_and_set_limits(
         self,
         resources_field_name,
-        mem=None,
-        cpu=None,
-        gpus=None,
-        gpu_type="nvidia.com/gpu",
-        override=True,
+        mem: str = None,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        override: bool = True,
     ):
         resources = verify_limits(
             resources_field_name, mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type
@@ -317,9 +317,9 @@ class KubeResourceSpec(FunctionSpec):
     def _verify_and_set_requests(
         self,
         resources_field_name,
-        mem=None,
-        cpu=None,
-        override=True,
+        mem: str = None,
+        cpu: str = None,
+        override: bool = True,
     ):
         resources = verify_requests(resources_field_name, mem=mem, cpu=cpu)
         if override:
@@ -337,14 +337,19 @@ class KubeResourceSpec(FunctionSpec):
                 )
 
     def with_limits(
-        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+        self,
+        mem: str = None,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        override: bool = True,
     ):
         """set pod cpu/memory/gpu limits"""
         self._verify_and_set_limits(
             "resources", mem, cpu, gpus, gpu_type, override=override
         )
 
-    def with_requests(self, mem=None, cpu=None, override=True):
+    def with_requests(self, mem: str = None, cpu: str = None, override: bool = True):
         """set requested (desired) pod cpu/memory resources"""
         self._verify_and_set_requests("resources", mem, cpu, override)
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -287,12 +287,12 @@ class KubeResourceSpec(FunctionSpec):
         cpu: str = None,
         gpus: int = None,
         gpu_type: str = "nvidia.com/gpu",
-        override: bool = True,
+        patch: bool = False,
     ):
         resources = verify_limits(
             resources_field_name, mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type
         )
-        if override:
+        if not patch:
             update_in(
                 getattr(self, resources_field_name),
                 "limits",
@@ -319,10 +319,10 @@ class KubeResourceSpec(FunctionSpec):
         resources_field_name,
         mem: str = None,
         cpu: str = None,
-        override: bool = True,
+        patch: bool = False,
     ):
         resources = verify_requests(resources_field_name, mem=mem, cpu=cpu)
-        if override:
+        if not patch:
             update_in(
                 getattr(self, resources_field_name),
                 "requests",
@@ -342,16 +342,20 @@ class KubeResourceSpec(FunctionSpec):
         cpu: str = None,
         gpus: int = None,
         gpu_type: str = "nvidia.com/gpu",
-        override: bool = True,
+        patch: bool = False,
     ):
-        """set pod cpu/memory/gpu limits"""
-        self._verify_and_set_limits(
-            "resources", mem, cpu, gpus, gpu_type, override=override
-        )
+        """
+        set pod cpu/memory/gpu limits
+        by default it overrides the whole limits section, if you wish to patch specific resources use `patch=True`.
+        """
+        self._verify_and_set_limits("resources", mem, cpu, gpus, gpu_type, patch=patch)
 
-    def with_requests(self, mem: str = None, cpu: str = None, override: bool = True):
-        """set requested (desired) pod cpu/memory resources"""
-        self._verify_and_set_requests("resources", mem, cpu, override)
+    def with_requests(self, mem: str = None, cpu: str = None, patch: bool = False):
+        """
+        set requested (desired) pod cpu/memory resources
+        by default it overrides the whole requests section, if you wish to patch specific resources use `patch=True`.
+        """
+        self._verify_and_set_requests("resources", mem, cpu, patch)
 
     def enrich_resources_with_default_pod_resources(
         self, resources_field_name: str, resources: dict
@@ -966,14 +970,25 @@ class KubeResource(BaseRuntime):
         update_in(self.spec.resources, ["limits", gpu_type], gpus)
 
     def with_limits(
-        self, mem=None, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+        self,
+        mem: str = None,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        patch: bool = False,
     ):
-        """set pod cpu/memory/gpu limits"""
-        self.spec.with_limits(mem, cpu, gpus, gpu_type, override=override)
+        """
+        set pod cpu/memory/gpu limits
+        by default it overrides the whole limits section, if you wish to patch specific resources use `patch=True`.
+        """
+        self.spec.with_limits(mem, cpu, gpus, gpu_type, patch=patch)
 
-    def with_requests(self, mem=None, cpu=None, override=True):
-        """set requested (desired) pod cpu/memory resources"""
-        self.spec.with_requests(mem, cpu, override=override)
+    def with_requests(self, mem: str = None, cpu: str = None, patch: bool = False):
+        """
+        set requested (desired) pod cpu/memory resources
+        by default it overrides the whole requests section, if you wish to patch specific resources use `patch=True`.
+        """
+        self.spec.with_requests(mem, cpu, patch=patch)
 
     def with_node_selection(
         self,

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -703,14 +703,20 @@ with ctx:
             )
         super().with_node_selection(node_name, node_selector, affinity, tolerations)
 
-    def with_executor_requests(self, mem=None, cpu=None, override=True):
+    def with_executor_requests(
+        self, mem: str = None, cpu: str = None, override: bool = True
+    ):
         """set executor pod required cpu/memory/gpu resources"""
         self.spec._verify_and_set_requests(
             "executor_resources", mem, cpu, override=override
         )
 
     def with_executor_limits(
-        self, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+        self,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        override: bool = True,
     ):
         """set executor pod limits"""
         # in spark operator there is only use of mem passed through requests,
@@ -719,14 +725,20 @@ with ctx:
             "executor_resources", None, cpu, gpus, gpu_type, override=override
         )
 
-    def with_driver_requests(self, mem=None, cpu=None, override=True):
+    def with_driver_requests(
+        self, mem: str = None, cpu: str = None, override: bool = True
+    ):
         """set driver pod required cpu/memory/gpu resources"""
         self.spec._verify_and_set_requests(
             "driver_resources", mem, cpu, override=override
         )
 
     def with_driver_limits(
-        self, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+        self,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        override: bool = True,
     ):
         """set driver pod cpu limits"""
         # in spark operator there is only use of mem passed through requests,

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -703,27 +703,37 @@ with ctx:
             )
         super().with_node_selection(node_name, node_selector, affinity, tolerations)
 
-    def with_executor_requests(self, mem=None, cpu=None):
+    def with_executor_requests(self, mem=None, cpu=None, override=True):
         """set executor pod required cpu/memory/gpu resources"""
-        self.spec._verify_and_set_requests("executor_resources", mem, cpu)
+        self.spec._verify_and_set_requests(
+            "executor_resources", mem, cpu, override=override
+        )
 
-    def with_executor_limits(self, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def with_executor_limits(
+        self, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+    ):
         """set executor pod limits"""
         # in spark operator there is only use of mem passed through requests,
         # limits is set to the same value so passing mem=None
         self.spec._verify_and_set_limits(
-            "executor_resources", None, cpu, gpus, gpu_type
+            "executor_resources", None, cpu, gpus, gpu_type, override=override
         )
 
-    def with_driver_requests(self, mem=None, cpu=None):
+    def with_driver_requests(self, mem=None, cpu=None, override=True):
         """set driver pod required cpu/memory/gpu resources"""
-        self.spec._verify_and_set_requests("driver_resources", mem, cpu)
+        self.spec._verify_and_set_requests(
+            "driver_resources", mem, cpu, override=override
+        )
 
-    def with_driver_limits(self, cpu=None, gpus=None, gpu_type="nvidia.com/gpu"):
+    def with_driver_limits(
+        self, cpu=None, gpus=None, gpu_type="nvidia.com/gpu", override=True
+    ):
         """set driver pod cpu limits"""
         # in spark operator there is only use of mem passed through requests,
         # limits is set to the same value so passing mem=None
-        self.spec._verify_and_set_limits("driver_resources", None, cpu, gpus, gpu_type)
+        self.spec._verify_and_set_limits(
+            "driver_resources", None, cpu, gpus, gpu_type, override=override
+        )
 
     def with_restart_policy(
         self,

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -704,47 +704,55 @@ with ctx:
         super().with_node_selection(node_name, node_selector, affinity, tolerations)
 
     def with_executor_requests(
-        self, mem: str = None, cpu: str = None, override: bool = True
+        self, mem: str = None, cpu: str = None, patch: bool = False
     ):
-        """set executor pod required cpu/memory/gpu resources"""
-        self.spec._verify_and_set_requests(
-            "executor_resources", mem, cpu, override=override
-        )
+        """
+        set executor pod required cpu/memory/gpu resources
+        by default it overrides the whole requests section, if you wish to patch specific resources use `patch=True`.
+        """
+        self.spec._verify_and_set_requests("executor_resources", mem, cpu, patch=patch)
 
     def with_executor_limits(
         self,
         cpu: str = None,
         gpus: int = None,
         gpu_type: str = "nvidia.com/gpu",
-        override: bool = True,
+        patch: bool = False,
     ):
-        """set executor pod limits"""
+        """
+        set executor pod limits
+        by default it overrides the whole limits section, if you wish to patch specific resources use `patch=True`.
+        """
         # in spark operator there is only use of mem passed through requests,
         # limits is set to the same value so passing mem=None
         self.spec._verify_and_set_limits(
-            "executor_resources", None, cpu, gpus, gpu_type, override=override
+            "executor_resources", None, cpu, gpus, gpu_type, patch=patch
         )
 
     def with_driver_requests(
-        self, mem: str = None, cpu: str = None, override: bool = True
+        self, mem: str = None, cpu: str = None, patch: bool = False
     ):
-        """set driver pod required cpu/memory/gpu resources"""
-        self.spec._verify_and_set_requests(
-            "driver_resources", mem, cpu, override=override
-        )
+        """
+        set driver pod required cpu/memory/gpu resources
+        by default it overrides the whole requests section, if you wish to patch specific resources use `patch=True`.
+        """
+        self.spec._verify_and_set_requests("driver_resources", mem, cpu, patch=patch)
 
     def with_driver_limits(
         self,
         cpu: str = None,
         gpus: int = None,
         gpu_type: str = "nvidia.com/gpu",
-        override: bool = True,
+        patch: bool = False,
     ):
-        """set driver pod cpu limits"""
+        """
+        set driver pod cpu limits
+        by default it overrides the whole limits section, if you wish to patch specific resources use `patch=True`.
+        """
         # in spark operator there is only use of mem passed through requests,
         # limits is set to the same value so passing mem=None
         self.spec._verify_and_set_limits(
-            "driver_resources", None, cpu, gpus, gpu_type, override=override
+            "driver_resources", None, cpu, gpus, gpu_type, patch=patch
         )
 
     def with_restart_policy(

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -149,9 +149,7 @@ class TestDaskRuntime(TestRuntimeBase):
         )
         self._assert_scheduler_pod_args()
 
-    def test_dask_runtime_with_resources_override(
-        self, db: Session, client: TestClient
-    ):
+    def test_dask_runtime_with_resources_patch(self, db: Session, client: TestClient):
         runtime: mlrun.runtimes.DaskCluster = self._generate_runtime()
         runtime.with_scheduler_requests(mem="2G", cpu="3")
         runtime.with_worker_requests(mem="2G", cpu="3")
@@ -160,11 +158,11 @@ class TestDaskRuntime(TestRuntimeBase):
         runtime.with_scheduler_limits(mem="4G", cpu="5", gpu_type=gpu_type, gpus=2)
         runtime.with_worker_limits(mem="4G", cpu="5", gpu_type=gpu_type, gpus=2)
 
-        runtime.with_scheduler_limits(gpus=3)  # default override = True
-        runtime.with_scheduler_requests(cpu="4", override=False)
+        runtime.with_scheduler_limits(gpus=3)  # default patch = False
+        runtime.with_scheduler_requests(cpu="4", patch=True)
 
-        runtime.with_worker_limits(cpu="10", override=False)
-        runtime.with_worker_requests(mem="3G")  # default override = True
+        runtime.with_worker_limits(cpu="10", patch=True)
+        runtime.with_worker_requests(mem="3G")  # default patch = False
         _ = runtime.client
 
         self.kube_cluster_mock.assert_called_once()

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -158,11 +158,11 @@ def test_with_requests():
     )
 
 
-def test_with_request_override():
+def test_with_request_patch():
     runtime = _get_runtime()
     runtime["spec"]["resources"] = {"requests": {"cpu": "50mi"}}
     function = mlrun.new_function(runtime=runtime)
-    function.with_requests(mem="9G", override=False)
+    function.with_requests(mem="9G", patch=True)
     expected = {
         "requests": {"cpu": "50mi", "memory": "9G"},
         "limits": {},
@@ -175,7 +175,7 @@ def test_with_request_override():
         )
         == {}
     )
-    function.with_requests(cpu="15")  # default override = True
+    function.with_requests(cpu="15")  # default patch = False
     expected = {
         "requests": {"cpu": "15"},
         "limits": {},
@@ -190,7 +190,7 @@ def test_with_request_override():
     )
 
 
-def test_with_limits_override():
+def test_with_limits_patch():
     runtime = _get_runtime()
     runtime["spec"]["resources"] = {"requests": {"cpu": "50mi"}}
     mlrun.mlconf.default_function_pod_resources = {
@@ -198,7 +198,7 @@ def test_with_limits_override():
         "limits": {"cpu": "1", "memory": "1G", "gpu": None},
     }
     function = mlrun.new_function(runtime=runtime)
-    function.with_limits(mem="9G", override=False)
+    function.with_limits(mem="9G", patch=True)
     expected = {
         "requests": {"cpu": "50mi", "memory": "1M"},
         "limits": {"cpu": "1", "memory": "9G"},
@@ -212,7 +212,7 @@ def test_with_limits_override():
         == {}
     )
 
-    function.with_limits(mem="9G")  # default override = True
+    function.with_limits(mem="9G")  # default patch = False
     expected = {
         "requests": {"cpu": "50mi", "memory": "1M"},
         "limits": {"memory": "9G"},

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -158,6 +158,75 @@ def test_with_requests():
     )
 
 
+def test_with_request_override():
+    runtime = _get_runtime()
+    runtime["spec"]["resources"] = {"requests": {"cpu": "50mi"}}
+    function = mlrun.new_function(runtime=runtime)
+    function.with_requests(mem="9G", override=False)
+    expected = {
+        "requests": {"cpu": "50mi", "memory": "9G"},
+        "limits": {},
+    }
+    assert (
+        DeepDiff(
+            function.spec.resources,
+            expected,
+            ignore_order=True,
+        )
+        == {}
+    )
+    function.with_requests(cpu="15")  # default override = True
+    expected = {
+        "requests": {"cpu": "15"},
+        "limits": {},
+    }
+    assert (
+        DeepDiff(
+            function.spec.resources,
+            expected,
+            ignore_order=True,
+        )
+        == {}
+    )
+
+
+def test_with_limits_override():
+    runtime = _get_runtime()
+    runtime["spec"]["resources"] = {"requests": {"cpu": "50mi"}}
+    mlrun.mlconf.default_function_pod_resources = {
+        "requests": {"cpu": "25mi", "memory": "1M", "gpu": None},
+        "limits": {"cpu": "1", "memory": "1G", "gpu": None},
+    }
+    function = mlrun.new_function(runtime=runtime)
+    function.with_limits(mem="9G", override=False)
+    expected = {
+        "requests": {"cpu": "50mi", "memory": "1M"},
+        "limits": {"cpu": "1", "memory": "9G"},
+    }
+    assert (
+        DeepDiff(
+            function.spec.resources,
+            expected,
+            ignore_order=True,
+        )
+        == {}
+    )
+
+    function.with_limits(mem="9G")  # default override = True
+    expected = {
+        "requests": {"cpu": "50mi", "memory": "1M"},
+        "limits": {"memory": "9G"},
+    }
+    assert (
+        DeepDiff(
+            function.spec.resources,
+            expected,
+            ignore_order=True,
+        )
+        == {}
+    )
+
+
 def test_with_limits():
     runtime = _get_runtime()
     runtime["spec"]["resources"] = {"requests": {"cpu": "50mi"}}


### PR DESCRIPTION
Per https://jira.iguazeng.com/browse/ML-2523 request.

By default when setting `with_requests(cpu="2")` this will override all the resources in the requests section.
Added option to set `with_requests(cpu="2", patch=True)` which will patch defined resources inside the requests section. 

Note that in the example I refer to `with_requests` but this applies to all `with_x_requests/limits`.