### PR TITLE
[Project] Return `get_run_status` with deprecation warning

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2010,7 +2010,8 @@ class MlrunProject(ModelObj):
         notifiers: RunNotifications = None,
     ):
         warnings.warn(
-            "This method is deprecated. Use `timeout` parameter in `project.run()` method instead",
+            "This will be deprecated in 1.4.0, and will be removed in 1.6.0"
+            "Use `timeout` parameter in `project.run()` method instead",
             PendingDeprecationWarning,
         )
         return run._engine.get_run_status(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2003,11 +2003,11 @@ class MlrunProject(ModelObj):
         workflow_engine.save(self, workflow_spec, target, artifact_path=artifact_path)
 
     def get_run_status(
-            self,
-            run,
-            timeout=None,
-            expected_statuses=None,
-            notifiers: RunNotifications = None,
+        self,
+        run,
+        timeout=None,
+        expected_statuses=None,
+        notifiers: RunNotifications = None,
     ):
         warnings.warn(
             "This method is deprecated. Use `timeout` parameter in `project.run()` method instead",

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2018,7 +2018,7 @@ class MlrunProject(ModelObj):
             run=run,
             timeout=timeout,
             expected_statuses=expected_statuses,
-            notifiers=notifiers
+            notifiers=notifiers,
         )
 
     def clear_context(self):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2002,6 +2002,25 @@ class MlrunProject(ModelObj):
         workflow_engine = get_workflow_engine(workflow_spec.engine)
         workflow_engine.save(self, workflow_spec, target, artifact_path=artifact_path)
 
+    def get_run_status(
+            self,
+            run,
+            timeout=None,
+            expected_statuses=None,
+            notifiers: RunNotifications = None,
+    ):
+        warnings.warn(
+            "This method is deprecated. Use `timeout` parameter in `project.run()` method instead",
+            PendingDeprecationWarning,
+        )
+        return run._engine.get_run_status(
+            project=self,
+            run=run,
+            timeout=timeout,
+            expected_statuses=expected_statuses,
+            notifiers=notifiers
+        )
+
     def clear_context(self):
         """delete all files and clear the context dir"""
         if (

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2010,7 +2010,7 @@ class MlrunProject(ModelObj):
         notifiers: RunNotifications = None,
     ):
         warnings.warn(
-            "This will be deprecated in 1.4.0, and will be removed in 1.6.0"
+            "This will be deprecated in 1.4.0, and will be removed in 1.6.0. "
             "Use `timeout` parameter in `project.run()` method instead",
             PendingDeprecationWarning,
         )


### PR DESCRIPTION
returning project.get_run_status() supporting remote engine with a deprecation warning