### PR TITLE
[Feature store] Changed fset status targets to have partitioning related fields

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -610,6 +610,7 @@ class BaseStoreTarget(DataTargetBase):
         target.updated = now_date().isoformat()
         target.size = size
         target.producer = producer or target.producer
+        target.partitioned = self.partitioned
 
         self._resource.status.update_target(target)
         return target

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -612,6 +612,9 @@ class BaseStoreTarget(DataTargetBase):
         target.producer = producer or target.producer
         # Copy partitioning-related fields to the status, since these are needed if reading the actual data that
         # is related to the specific target.
+        # TODO - instead of adding more fields to the status targets, we should consider changing any functionality
+        #       that depends on "spec-fields" to use a merge between the status and the spec targets. One such place
+        #       is the fset.to_dataframe() function.
         target.partitioned = self.partitioned
         target.key_bucketing_number = self.key_bucketing_number
         target.partition_cols = self.partition_cols

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -610,7 +610,12 @@ class BaseStoreTarget(DataTargetBase):
         target.updated = now_date().isoformat()
         target.size = size
         target.producer = producer or target.producer
+        # Copy partitioning-related fields to the status, since these are needed if reading the actual data that
+        # is related to the specific target.
         target.partitioned = self.partitioned
+        target.key_bucketing_number = self.key_bucketing_number
+        target.partition_cols = self.partition_cols
+        target.time_partitioning_granularity = self.time_partitioning_granularity
 
         self._resource.status.update_target(target)
         return target

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1234,6 +1234,7 @@ class DataTarget(DataTargetBase):
         "size",
         "last_written",
         "run_id",
+        "partitioned",
     ]
 
     def __init__(

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1235,6 +1235,9 @@ class DataTarget(DataTargetBase):
         "last_written",
         "run_id",
         "partitioned",
+        "key_bucketing_number",
+        "partition_cols",
+        "time_partitioning_granularity",
     ]
 
     def __init__(


### PR DESCRIPTION
The `fset.status.targets` field has objects of type `DataTarget` which is different than the targets in `fset.spec.targets`. The `partitioned` field which indicates whether this target is partitioned was missing, along with other fields which describe the partitioning scheme - these fields were not copied from the spec target, and also not persisted in `to_dict()` and `from_dict()`.
Because some feature-store functionality such as `fset.to_dataframe()` rely on the targets which are in the fset status, this caused undesirable behavior - it did not remove the partitioning fields from the result DF.
Among other things, this caused the `test_aggregations_emit_every_event` system test to fail.