### PR TITLE
[Feature Store] Fix `set_targets(["parquet"])`

### DIFF
--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -402,7 +402,9 @@ class FeatureSet(ModelObj):
                     f"target kind is not supported, use one of: {','.join(TargetTypes.all())}"
                 )
             if not hasattr(target, "kind"):
-                target = DataTargetBase(target, name=str(target))
+                target = DataTargetBase(
+                    target, name=str(target), partitioned=(target == "parquet")
+                )
             if target.path is not None and (
                 target.path.startswith("wasb") or target.path.startswith("wasbs")
             ):

--- a/tests/feature-store/test_ingest.py
+++ b/tests/feature-store/test_ingest.py
@@ -49,3 +49,32 @@ def test_columns_with_illegal_characters_error():
 
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
         fs.ingest(fset, df)
+
+
+def test_set_targets_with_string():
+    fset = fs.FeatureSet(
+        "myset",
+        entities=[fs.Entity("ticker")],
+    )
+
+    fset.set_targets(["parquet", "nosql"], with_defaults=False)
+
+    targets = fset.spec.targets
+
+    assert len(targets) == 2
+
+    parquet_target = None
+    nosql_target = None
+    for target in fset.spec.targets:
+        if target.name == "parquet":
+            parquet_target = target
+        elif target.name == "nosql":
+            nosql_target = target
+
+    assert parquet_target.name == "parquet"
+    assert parquet_target.kind == "parquet"
+    assert parquet_target.partitioned
+
+    assert nosql_target.name == "nosql"
+    assert nosql_target.kind == "nosql"
+    assert not nosql_target.partitioned


### PR DESCRIPTION
`set_targets(["parquet"])` should create the default parquet target, which is partitioned.

Fixes [ML-2527](https://jira.iguazeng.com/browse/ML-2527).