### PR TITLE
[API] Read session verification data from both body and headers

### DIFF
--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -499,17 +499,18 @@ class Client(
             planes,
             user_unix_id,
             user_id,
-            gids,
+            group_ids,
         ) = self._resolve_params_from_response_headers(response)
 
-        user_id_from_body, group_ids = self._resolve_params_from_response_body(response)
+        (
+            user_id_from_body,
+            group_ids_from_body,
+        ) = self._resolve_params_from_response_body(response)
 
         # from iguazio version >= 3.5.2, user and group ids are included in the response body
         # if not, get them from the headers
-        if user_id_from_body:
-            user_id = user_id_from_body
-        if not group_ids:
-            group_ids = gids
+        user_id = user_id_from_body or user_id
+        group_ids = group_ids_from_body or group_ids
 
         auth_info = mlrun.api.schemas.AuthInfo(
             username=username,

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -503,7 +503,7 @@ class Client(
         if x_unix_uid and x_unix_uid.lower() != "unknown":
             user_unix_id = int(x_unix_uid)
 
-        user_id, group_ids = Client._resolve_user_and_group_ids(response)
+        user_id, group_ids = Client._resolve_params_from_response_body(response)
 
         auth_info = mlrun.api.schemas.AuthInfo(
             username=response.headers["x-remote-user"],
@@ -518,7 +518,7 @@ class Client(
         return auth_info
 
     @staticmethod
-    def _resolve_user_and_group_ids(response: requests.Response):
+    def _resolve_params_from_response_body(response: requests.Response):
 
         # from iguazio version >= 3.5.2, user and group ids are included in the response body
         # if not, get them from the headers

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -68,14 +68,44 @@ def test_verify_request_session_success(
         context.headers = mock_response_headers
         return {}
 
-    requests_mock.post(
-        f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}",
-        json=_verify_session_mock,
-    )
-    auth_info = iguazio_client.verify_request_session(mock_request)
-    _assert_auth_info_from_session_verification_mock_response_headers(
-        auth_info, mock_response_headers
-    )
+    def _verify_session_with_body_mock(request, context):
+        for header_key, header_value in mock_request_headers.items():
+            assert request.headers[header_key] == header_value
+        context.headers = mock_response_headers
+        return {
+            "data": {
+                "attributes": {
+                    "username": "some-user",
+                    "context": {
+                        "authentication": {
+                            "user_id": "some-user-id",
+                            "tenant_id": "some-tenant-id",
+                            "group_ids": [
+                                "some-group-id-1,some-group-id-2",
+                            ],
+                            "mode": "normal",
+                        }
+                    },
+                }
+            }
+        }
+
+    for test_case in [
+        {
+            "response_json": _verify_session_mock,
+        },
+        {
+            "response_json": _verify_session_with_body_mock,
+        },
+    ]:
+        requests_mock.post(
+            f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}",
+            json=test_case["response_json"],
+        )
+        auth_info = iguazio_client.verify_request_session(mock_request)
+        _assert_auth_info_from_session_verification_mock_response_headers(
+            auth_info, mock_response_headers
+        )
 
 
 def test_verify_request_session_failure(


### PR DESCRIPTION
For the response headers to be lighter, user and groups ids are included in the response body from `/sessions/verifications` (see https://github.com/iguazio/zebo/pull/6032).

Change Iguazio authentication to read this info from the body instead of headers, and fallback to the headers in case body is missing.

JIRA: https://jira.iguazeng.com/browse/IG-21097
