### PR TITLE
[Spark] Fix backwards-comp issue with `spark-2` and `spark-3` in 0.10 client and 1.1 server

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -38,6 +38,7 @@ class ClientSpec(
             dask_kfp_image=config.dask_kfp_image,
             api_url=config.httpdb.api_url,
             nuclio_version=resolve_nuclio_version(),
+            spark_operator_version=config.spark_operator_version,
             # These don't have a default value, but we don't send them if they are not set to allow the client to know
             # when to use server value and when to use client value (server only if set). Since their default value is
             # empty and not set is also empty we can use the same _get_config_value_if_not_default
@@ -63,9 +64,6 @@ class ClientSpec(
             ),
             auto_mount_params=self._get_config_value_if_not_default(
                 "storage.auto_mount_params"
-            ),
-            spark_operator_version=self._get_config_value_if_not_default(
-                "spark_operator_version"
             ),
             default_tensorboard_logs_path=self._get_config_value_if_not_default(
                 "default_tensorboard_logs_path"


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-2533, issue discovered when running with 0.10 client against a new 1.1 service:
The spark op version on the client side is either what is defined in the client config (which for 0.10 is by default `spark-2`) or what is reported from the MLRun service, if reported.
However, the service is only reporting the spark-op version if it differs from the default configuration. Up until now, the default config on the server was `spark-2` and it was overridden to be `spark-3`. However, with the change I entered in #2269, the default is now `spark-3`, and the override value is the same, so the service is not reporting this version to the client. This causes the client to remain with its default of `spark-2`, causing this issue.
Fix is to modify the service code to always report the spark-op version, regardless if it was overridden or not. For the long term we need to deprecate `spark-2`.