### PR TITLE
[CI] Run Docker Image Cleanup After System Tests

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -136,6 +136,7 @@ jobs:
         python automation/system_test/prepare.py run \
           "${{ steps.computed_params.outputs.mlrun_version }}" \
           "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
           "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           "${{ secrets.LATEST_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }}" \
           "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" \
@@ -210,5 +211,5 @@ jobs:
           -o StrictHostKeyChecking=no \
           -o ServerAliveInterval=180 \
           -o ServerAliveCountMax=3 \
-          iguazio@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
           kubectl -n default-tenant rollout restart deployment docker-registry

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -200,3 +200,15 @@ jobs:
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
         MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
           make test-system-dockerized
+    - name: System Test Cleanup
+      # SSH to datanode and delete all docker images created by the system
+      # tests by restarting the docker-registry deployment
+      run: |  
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          ssh \
+          -o StrictHostKeyChecking=no \
+          -o ServerAliveInterval=180 \
+          -o ServerAliveCountMax=3 \
+          iguazio@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          kubectl -n default-tenant rollout restart deployment docker-registry

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -34,8 +34,6 @@ logging.getLogger("paramiko").setLevel(logging.DEBUG)
 
 class SystemTestPreparer:
     class Constants:
-        ssh_username = "iguazio"
-
         ci_dir_name = "mlrun-automation"
         homedir = pathlib.Path("/home/iguazio/")
         workdir = homedir / ci_dir_name
@@ -55,6 +53,7 @@ class SystemTestPreparer:
         override_image_repo: str = None,
         override_mlrun_images: str = None,
         data_cluster_ip: str = None,
+        data_cluster_ssh_username: str = None,
         data_cluster_ssh_password: str = None,
         app_cluster_ssh_password: str = None,
         github_access_token: str = None,
@@ -80,6 +79,7 @@ class SystemTestPreparer:
         self._override_image_repo = override_image_repo
         self._override_mlrun_images = override_mlrun_images
         self._data_cluster_ip = data_cluster_ip
+        self._data_cluster_ssh_username = data_cluster_ssh_username
         self._data_cluster_ssh_password = data_cluster_ssh_password
         self._app_cluster_ssh_password = app_cluster_ssh_password
         self._github_access_token = github_access_token
@@ -108,7 +108,7 @@ class SystemTestPreparer:
             self._ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy)
             self._ssh_client.connect(
                 self._data_cluster_ip,
-                username=self.Constants.ssh_username,
+                username=self._data_cluster_ssh_username,
                 password=self._data_cluster_ssh_password,
             )
 
@@ -533,6 +533,7 @@ def main():
     help="The commit (in mlrun/mlrun) of the tested mlrun version.",
 )
 @click.argument("data-cluster-ip", type=str, required=True)
+@click.argument("data-cluster-ssh-username", type=str, required=True)
 @click.argument("data-cluster-ssh-password", type=str, required=True)
 @click.argument("app-cluster-ssh-password", type=str, required=True)
 @click.argument("github-access-token", type=str, required=True)
@@ -557,6 +558,7 @@ def run(
     override_image_repo: str,
     override_mlrun_images: str,
     data_cluster_ip: str,
+    data_cluster_ssh_username: str,
     data_cluster_ssh_password: str,
     app_cluster_ssh_password: str,
     github_access_token: str,
@@ -577,6 +579,7 @@ def run(
         override_image_repo,
         override_mlrun_images,
         data_cluster_ip,
+        data_cluster_ssh_username,
         data_cluster_ssh_password,
         app_cluster_ssh_password,
         github_access_token,


### PR DESCRIPTION
When running the system tests, almost every test builds a docker image which is saved to the deafult-tenant docker registry. This causes a massive usage of the app node disk space, causing the node to receive a `disk-pressure` taint and pods commence restarting themselves.
Luckily, this docker registry has volatile storage, so in order to fix this, after each system test component, we restart the docker registry deployment which instantly cleans up all the docker images within.