### PR TITLE
[Builder] Add service account to kaniko pod

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -524,6 +524,7 @@ def resolve_project_default_service_account(project_name: str):
             service_account.strip()
             for service_account in allowed_service_accounts.split(",")
         ]
+
     default_service_account = mlrun.api.crud.secrets.Secrets().get_project_secret(
         project_name,
         SecretProviderName.kubernetes,
@@ -533,10 +534,12 @@ def resolve_project_default_service_account(project_name: str):
         allow_secrets_from_k8s=True,
         allow_internal_secrets=True,
     )
+
     # If default SA was not configured for the project, try to retrieve it from global config (if exists)
     default_service_account = (
         default_service_account or mlrun.mlconf.function.spec.service_account.default
     )
+
     # Sanity check on project configuration
     if (
         default_service_account
@@ -547,6 +550,7 @@ def resolve_project_default_service_account(project_name: str):
             f"Default service account {default_service_account} is not in list of allowed "
             + f"service accounts {allowed_service_accounts}"
         )
+
     return allowed_service_accounts, default_service_account
 
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 
 from kubernetes import client
 
+import mlrun.api.schemas
 import mlrun.errors
 import mlrun.runtimes.utils
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -390,6 +390,7 @@ def get_kaniko_spec_attributes_from_runtime():
         "affinity",
         "tolerations",
         "priority_class_name",
+        "service_account",
     ]
 
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -92,11 +92,6 @@ def make_kaniko_pod(
     for attribute in get_kaniko_spec_attributes_from_runtime():
         attr_value = getattr(runtime_spec, attribute, None)
         if attribute == "service_account":
-            # If we're not running inside k8s, skip setting the SA to the kaniko pod.
-            # (This should only happen in unit tests, as in the real world we won't use kaniko without k8s)
-            if not get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
-                continue
-
             from mlrun.api.api.utils import resolve_project_default_service_account
 
             (

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -91,6 +91,7 @@ def make_kaniko_pod(
     # set kaniko's spec attributes from the runtime spec
     for attribute in get_kaniko_spec_attributes_from_runtime():
         attr_value = getattr(runtime_spec, attribute, None)
+        logger.info("ALON", attribute=attribute, value=attr_value)
         if attr_value:
             extra_runtime_spec[attribute] = attr_value
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -92,6 +92,11 @@ def make_kaniko_pod(
     for attribute in get_kaniko_spec_attributes_from_runtime():
         attr_value = getattr(runtime_spec, attribute, None)
         if attribute == "service_account":
+            # If we're not running inside k8s, skip setting the SA to the kaniko pod.
+            # (This should only happen in unit tests, as in the real world we won't use kaniko without k8s)
+            if not get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
+                continue
+
             from mlrun.api.api.utils import resolve_project_default_service_account
 
             (

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -140,6 +140,9 @@ class FunctionSpec(ModelObj):
     def enrich_function_preemption_spec(self):
         pass
 
+    def validate_service_account(self, allowed_service_accounts):
+        pass
+
 
 class BaseRuntime(ModelObj):
     kind = "base"

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -158,6 +158,8 @@ class KubeResourceSpec(FunctionSpec):
 
         self.replicas = replicas
         self.image_pull_policy = image_pull_policy
+        # default service account is set in mlrun.utils.process_function_service_account
+        # due to project specific defaults
         self.service_account = service_account
         self.image_pull_secret = (
             image_pull_secret or mlrun.mlconf.function.spec.image_pull_secret.default
@@ -265,6 +267,16 @@ class KubeResourceSpec(FunctionSpec):
         if volume_mounts:
             for volume_mount in volume_mounts:
                 self._set_volume_mount(volume_mount, volume_mounts_field_name)
+
+    def validate_service_account(self, allowed_service_accounts):
+        if (
+            allowed_service_accounts
+            and self.service_account not in allowed_service_accounts
+        ):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Function service account {self.service_account} is not in allowed "
+                + f"service accounts {allowed_service_accounts}"
+            )
 
     def _get_affinity_as_k8s_class_instance(self):
         pass
@@ -1269,16 +1281,8 @@ class KubeResource(BaseRuntime):
                 logger.info(
                     f"Setting default service account to function: {default_service_account}"
                 )
-            return
 
-        if (
-            allowed_service_accounts
-            and self.spec.service_account not in allowed_service_accounts
-        ):
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Function service account {self.spec.service_account} is not in allowed "
-                + f"service accounts {allowed_service_accounts}"
-            )
+        self.spec.validate_service_account(allowed_service_accounts)
 
 
 def kube_resource_spec_to_pod_spec(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -21,10 +21,10 @@ import pytest
 
 import mlrun
 import mlrun.api.schemas
+import mlrun.api.utils.singletons.k8s
 import mlrun.builder
 import mlrun.k8s_utils
 import mlrun.utils.version
-import mlrun.api.utils.singletons.k8s
 from mlrun.config import config
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -781,7 +781,6 @@ def test_kaniko_pod_spec_default_service_account_enrichment(monkeypatch):
         "some-tag",
         image="mlrun/mlrun",
         kind="job",
-        requirements=["some-package"],
     )
     mlrun.builder.build_runtime(
         mlrun.api.schemas.AuthInfo(),
@@ -811,7 +810,6 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
         "some-tag",
         image="mlrun/mlrun",
         kind="job",
-        requirements=["some-package"],
     )
     service_account = "my-actual-sa"
     function.spec.service_account = service_account


### PR DESCRIPTION
Service account (default or not) will apply on both the function pod and kaniko image builder pod.
This is useful to give ECR permissions via service account on EKS with cloudformation (mlrun CE).
Default service account is resolved fro project's configuration or from the mlrun global config.