### PR TITLE
[Projects] Fix project deletion in system tests

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -414,7 +414,6 @@ class TestProject(TestMLRunSystem):
         # Skipping until mlrun/project-demo will contain newflow workflow in project
         workflow_names = [workflow["name"] for workflow in project.spec.workflows]
         if workflow_name not in workflow_names:
-            self._delete_test_project()
             return
         run = project.run(
             workflow_name,
@@ -425,29 +424,34 @@ class TestProject(TestMLRunSystem):
 
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
         assert run.run_id, "workflow's run id failed to fetch"
-        self._delete_test_project()
 
     def test_remote_pipeline_with_kfp_engine_from_github(self):
+        project_name = "rmtpipe-kfp-github"
+        self.custom_project_names_to_delete.append(project_name)
+
         self._test_remote_pipeline_from_github(
-            name="rmtpipe-kfp-github",
+            name=project_name,
             workflow_name="main",
             engine="remote",
             watch=True,
         )
         self._test_remote_pipeline_from_github(
-            name="rmtpipe-kfp-github", workflow_name="main", engine="remote:kfp"
+            name=project_name, workflow_name="main", engine="remote:kfp"
         )
 
     def test_remote_pipeline_with_local_engine_from_github(self):
+        project_name = "rmtpipe-local-github"
+        self.custom_project_names_to_delete.append(project_name)
+
         self._test_remote_pipeline_from_github(
-            name="rmtpipe-local-github",
+            name=project_name,
             workflow_name="newflow",
             engine="remote:local",
             watch=True,
         )
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             self._test_remote_pipeline_from_github(
-                name="rmtpipe-local-github",
+                name=project_name,
                 workflow_name="newflow",
                 engine="remote",
                 local=True,

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -411,10 +411,6 @@ class TestProject(TestMLRunSystem):
         project = mlrun.load_project(
             project_dir, "git://github.com/mlrun/project-demo.git", name=name
         )
-        # Skipping until mlrun/project-demo will contain newflow workflow in project
-        workflow_names = [workflow["name"] for workflow in project.spec.workflows]
-        if workflow_name not in workflow_names:
-            return
         run = project.run(
             workflow_name,
             watch=watch,

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -50,6 +50,7 @@ need_private_git = pytest.mark.skipif(
 class TestArchiveSources(tests.system.base.TestMLRunSystem):
 
     project_name = "git-tests"
+    custom_project_names_to_delete = []
 
     def custom_setup(self):
         self.remote_code_dir = f"v3io:///projects/{self.project_name}/code/"
@@ -61,6 +62,10 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
                     "GIT_TOKEN": os.environ["MLRUN_SYSTEM_TESTS_PRIVATE_GIT_TOKEN"],
                 }
             )
+
+    def custom_teardown(self):
+        for name in self.custom_project_names_to_delete:
+            self._delete_test_project(name)
 
     def _upload_code_to_cluster(self):
         if not self.uploaded_code:
@@ -212,8 +217,10 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         assert "tag=" in resp.decode()
 
     def test_job_project(self):
-        project_name = "git-proj-job1"
-        project = mlrun.new_project(project_name, user_project=True)
+        project = mlrun.new_project("git-proj-job1", user_project=True)
+
+        # using project.name because this is a user project meaning the project name get concatenated with the user name
+        self.custom_project_names_to_delete.append(project.name)
         project.save()
         project.set_source(f"{git_uri}#main", True)  # , workdir="gtst")
         project.set_function(
@@ -227,11 +234,12 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         run = project.run_function("myjob")
         assert run.state() == "completed"
         assert run.output("tag")
-        self._delete_test_project(project_name)
 
     def test_nuclio_project(self):
-        project_name = "git-proj-nuc"
-        project = mlrun.new_project(project_name, user_project=True)
+        project = mlrun.new_project("git-proj-nuc", user_project=True)
+        # using project.name because this is a user project meaning the project name get concatenated with the user name
+        self.custom_project_names_to_delete.append(project.name)
+
         project.save()
         project.set_source(f"{git_uri}#main")
         project.set_function(
@@ -245,19 +253,19 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         deployment = project.deploy_function("mynuclio")
         resp = deployment.function.invoke("")
         assert "tag=" in resp.decode()
-        self._delete_test_project(project_name)
 
     def test_project_subdir(self):
-        project_name = "git-proj2"
-
         # load project into a tmp dir, look for the project.yaml in the subpath
         project = mlrun.load_project(
             tempfile.mkdtemp(),
             f"{git_uri}#main",
-            project_name,
+            name="git-proj2",
             user_project=True,
             subpath="subdir",
         )
+        # using project.name because this is a user project meaning the project name get concatenated with the user name
+        self.custom_project_names_to_delete.append(project.name)
+
         project.save()
         # run job locally (from cloned source)
         run = project.run_function("myjob", local=True)
@@ -274,5 +282,3 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         deployment = project.deploy_function("mynuclio")
         resp = deployment.function.invoke("")
         assert "tag=" in resp.decode()
-
-        self._delete_test_project(project_name)


### PR DESCRIPTION
Found a bug in the way we were deleting projects which had `user_project=True`. 
This caused because we were deleting `project_name` instead of `project.name`.
When defining `user_project=True` the project name get concatenated with the user name which results to `<project-name>-<user-name>`.