### PR TITLE
[Projects] Fix saving project by default when loading project from db 

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -328,7 +328,8 @@ def get_or_create_project(
             subpath=subpath,
             clone=clone,
             user_project=user_project,
-            save=save,
+            # only loading project from db so no need to save it
+            save=False,
         )
         logger.info(f"loaded project {name} from MLRun DB")
         return project


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-2550

`get_or_create_project` has default `save=True` which we were passing for both `load_project` (we have one for first trying to load it from db and second for if we don't find so we are trying to load it from source).

The bug was that we were passing `save=True` when loading from DB which is redundant as we just loaded it from db, this also caused a bug for users with only read permissions as it is unable to "save" ( write ) to the project.  