### PR TITLE
[Datastore] Fix redis-store rm for single file deletion

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -104,7 +104,7 @@ default_config = {
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to
     #  configure this values on field systems, for newer system this will be configured correctly
     "v3io_api": "http://v3io-webapi:8081",
-    "redis_url": "redis://local-host:6379",
+    "redis_url": "redis://localhost:6379",
     "v3io_framesd": "http://framesd:8080",
     "datastore": {"async_source_mode": "disabled"},
     # default node selector to be applied to all functions - json string base64 encoded format

--- a/mlrun/datastore/redis.py
+++ b/mlrun/datastore/redis.py
@@ -134,8 +134,6 @@ class RedisStore(DataStore):
         elif key.startswith("rediss://"):
             key = key[len("redis://") :]
 
-        key += "*" if key.endswith("/") else "/*"
-
         if recursive:
             for key in self.redis.scan_iter(key):
                 self.redis.delete(key)


### PR DESCRIPTION
also fix redis url in mlrun-config. still need to propagate it to redis-driver in case env-var is not configured.