### PR TITLE
[Nuclio] Simplify spec and support non py code in `code_to_function` (for Nuclio)

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -768,7 +768,26 @@ def code_to_function(
             return name
         return f"{origin}:{name}"
 
-    def update_meta(fn):
+    def update_common(fn, spec):
+        fn.spec.image = image or get_in(spec, "spec.image", "")
+        fn.spec.build.base_image = get_in(spec, "spec.build.baseImage")
+        fn.spec.build.commands = get_in(spec, "spec.build.commands")
+        fn.spec.build.secret = get_in(spec, "spec.build.secret")
+
+        if requirements:
+            fn.with_requirements(requirements)
+
+        if embed_code:
+            fn.spec.build.functionSourceCode = get_in(
+                spec, "spec.build.functionSourceCode"
+            )
+
+        if fn.kind != "local":
+            fn.spec.env = get_in(spec, "spec.env")
+            for vol in get_in(spec, "spec.volumes", []):
+                fn.spec.volumes.append(vol.get("volume"))
+                fn.spec.volume_mounts.append(vol.get("volumeMount"))
+
         fn.spec.description = description
         fn.metadata.project = project or mlconf.default_project
         fn.metadata.tag = tag
@@ -833,15 +852,11 @@ def code_to_function(
         else:
             r = RemoteRuntime()
             r.spec.function_kind = subkind
-        if image:
-            r.spec.image = image
+        handler = handler if ":" in handler else get_in(spec, "spec.handler")
         r.spec.default_handler = handler
-        if embed_code:
-            update_in(spec, "kind", "Function")
-            r.spec.base_spec = spec
-        else:
+        r.spec.function_handler = handler
+        if not embed_code:
             r.spec.source = filename
-            r.spec.function_handler = handler
         nuclio_runtime = get_in(spec, "spec.runtime")
         if nuclio_runtime and not nuclio_runtime.startswith("py"):
             r.spec.nuclio_runtime = nuclio_runtime
@@ -850,9 +865,7 @@ def code_to_function(
         r.metadata.name = name
         r.spec.build.code_origin = code_origin
         r.spec.build.origin_filename = filename or (name + ".ipynb")
-        if requirements:
-            r.with_requirements(requirements)
-        update_meta(r)
+        update_common(r, spec)
         return r
 
     if kind is None or kind in ["", "Function"]:
@@ -870,37 +883,23 @@ def code_to_function(
     r.handler = h[0] if len(h) <= 1 else h[1]
     r.metadata = get_in(spec, "spec.metadata")
     r.metadata.name = name
-    r.spec.image = image or get_in(spec, "spec.image", "")
     build = r.spec.build
     build.code_origin = code_origin
     build.origin_filename = filename or (name + ".ipynb")
-    build.base_image = get_in(spec, "spec.build.baseImage")
-    build.commands = get_in(spec, "spec.build.commands")
     build.extra = get_in(spec, "spec.build.extra")
-    if embed_code:
-        build.functionSourceCode = get_in(spec, "spec.build.functionSourceCode")
-    else:
+    if not embed_code:
         if code_output:
             r.spec.command = code_output
         else:
             r.spec.command = filename
 
     build.image = get_in(spec, "spec.build.image")
-    build.secret = get_in(spec, "spec.build.secret")
-    if requirements:
-        r.with_requirements(requirements)
+    update_common(r, spec)
     r.verify_base_image()
-
-    if r.kind != "local":
-        r.spec.env = get_in(spec, "spec.env")
-        for vol in get_in(spec, "spec.volumes", []):
-            r.spec.volumes.append(vol.get("volume"))
-            r.spec.volume_mounts.append(vol.get("volumeMount"))
 
     if with_doc:
         update_function_entry_points(r, code)
     r.spec.default_handler = handler
-    update_meta(r)
     return r
 
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -842,7 +842,9 @@ def code_to_function(
         else:
             r.spec.source = filename
             r.spec.function_handler = handler
-
+        nuclio_runtime = get_in(spec, "spec.runtime")
+        if nuclio_runtime and not nuclio_runtime.startswith("py"):
+            r.spec.nuclio_runtime = nuclio_runtime
         if not name:
             raise ValueError("name must be specified")
         r.metadata.name = name

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -212,7 +212,7 @@ class NuclioSpec(KubeResourceSpec):
         #  we need to do one of the two
         self.min_replicas = min_replicas or 1
         self.max_replicas = max_replicas or default_max_replicas
-        self.base_image_pull = None
+        self.base_image_pull: bool = None
 
     def generate_nuclio_volumes(self):
         nuclio_volumes = []

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -128,6 +128,7 @@ class NuclioSpec(KubeResourceSpec):
         "readiness_timeout",
         "function_handler",
         "nuclio_runtime",
+        "base_image_pull",
     ]
 
     def __init__(
@@ -211,6 +212,7 @@ class NuclioSpec(KubeResourceSpec):
         #  we need to do one of the two
         self.min_replicas = min_replicas or 1
         self.max_replicas = max_replicas or default_max_replicas
+        self.base_image_pull = None
 
     def generate_nuclio_volumes(self):
         nuclio_volumes = []
@@ -1206,7 +1208,8 @@ def compile_function_config(
     # https://github.com/nuclio/nuclio/blob/e4af2a000dc52ee17337e75181ecb2652b9bf4e5/pkg/processor/build/builder.go#L1073
     if function.spec.build.secret:
         nuclio_spec.set_config("spec.imagePullSecrets", function.spec.build.secret)
-
+    if function.spec.base_image_pull:
+        nuclio_spec.set_config("spec.build.noBaseImagesPull", False)
     # don't send node selections if nuclio is not compatible
     if validate_nuclio_version_compatibility("1.5.20", "1.6.10"):
         if function.spec.node_selector:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -212,6 +212,8 @@ class NuclioSpec(KubeResourceSpec):
         #  we need to do one of the two
         self.min_replicas = min_replicas or 1
         self.max_replicas = max_replicas or default_max_replicas
+        # When True it will set Nuclio spec.noBaseImagesPull to False (negative logic)
+        # indicate that the base image should be pulled from the container registry (not cached)
         self.base_image_pull: bool = None
 
     def generate_nuclio_volumes(self):

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1033,11 +1033,8 @@ class TestNuclioRuntime(TestRuntimeBase):
     def test_deploy_function_with_build_secret(self):
         fn = self._generate_runtime()
         fn.spec.build.secret = "applied"
-        fn.spec.base_spec["spec"]["imagePullSecrets"] = "not-applied"
-        self.execute_function(fn)
-        deployed_config = self._get_deployed_config()
-        # expects spec.build.secret to overwrite fn.spec.base_spec["spec"]["imagePullSecrets"]
-        # because of nuclio.config.extend_config in compile_function_config
+        _, _, deployed_config = compile_function_config(fn)
+        # expects spec.build.secret to overwrite Nuclio spec["spec"]["imagePullSecrets"]
         assert deployed_config["spec"]["imagePullSecrets"] == fn.spec.build.secret
 
     def test_nuclio_with_preemption_mode(self):

--- a/tests/assets/hello.go
+++ b/tests/assets/hello.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/nuclio/nuclio-sdk-go"
+)
+
+func Handler(context *nuclio.Context, event nuclio.Event) (interface{}, error) {
+	context.Logger.Info("This is an unstrucured %s", "log")
+
+	return nuclio.Response{
+		StatusCode:  200,
+		ContentType: "application/text",
+		Body:        []byte("Hello, from Nuclio :]"),
+	}, nil
+}

--- a/tests/test_code_to_func.py
+++ b/tests/test_code_to_func.py
@@ -16,7 +16,7 @@ from os import path
 
 from mlrun import code_to_function, get_run_db, new_model_server
 from mlrun.utils import parse_versioned_object_uri
-from tests.conftest import examples_path, results
+from tests.conftest import examples_path, results, tests_root_directory
 
 
 def test_job_nb():
@@ -104,3 +104,10 @@ def test_local_file_codeout():
     assert path.isfile(out), "output not generated"
 
     fn.run(handler="training", params={"p1": 5})
+
+
+def test_nuclio_golang():
+    name = f"{tests_root_directory}/assets/hello.go"
+    fn = code_to_function("nuclio", filename=name, kind="nuclio", handler="Handler")
+    assert fn.kind == "remote", "kind not set, test failed"
+    assert fn.spec.nuclio_runtime == "golang", "golang was not detected and set"


### PR DESCRIPTION
* align/simplify Nuclio spec to other runtimes (remove the spec.base_spec in newly generated functions)
* sets the nuclio runtime based on the code file suffix (for non python code)
* add a way to set the Nuclio noBaseImagesPull flag (spec.base_image_pull)