### PR TITLE
[Datastore] Fix WasbFS info to call underlying FS correctly

### DIFF
--- a/mlrun/datastore/wasbfs/fs.py
+++ b/mlrun/datastore/wasbfs/fs.py
@@ -88,7 +88,7 @@ class WasbFS(AbstractFileSystem):
 
     def info(self, path, refresh=False, **kwargs):
         az_path = self._convert_wasb_schema_to_az(path)
-        return self.azure_blob_fs.info(self._parent, az_path, refresh, **kwargs)
+        return self.azure_blob_fs.info(az_path, refresh, **kwargs)
 
     def glob(self, path, **kwargs):
         az_path = self._convert_wasb_schema_to_az(path)


### PR DESCRIPTION
[ML-2557](https://jira.iguazeng.com/browse/ML-2557)

get_offline_features fails due to error in WasbFS.info()- too many arguments