### PR TITLE
[HTTPDB] Add dataschema dump

### DIFF
--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -121,99 +121,99 @@ def test_get_projects_dataschemas():
 
     # prepare data
     #   create test project
-    db = mlrun.get_run_db()
-    mlrun.get_or_create_project("test-dataschemas", context="./", user_project=False)
+    #db = mlrun.get_run_db()
+    #mlrun.get_or_create_project("test-dataschemas", context="./", user_project=False)
 
     #   create feature set 01
-    feature_set = fstore.FeatureSet(
-        "FeatureSet01-DataSchema",
-        entities=[
-            mlrun.feature_store.Entity(
-                "ds01fn0", description="fn0 featureset01 description"
-            ),
-            fstore.Entity("ds01fn1", value_type=dt.ValueType.STRING),
-        ],
-    )
-    pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
-    feature_set.set_targets(targets=[pt], with_defaults=False)
-    df = pd.DataFrame(
-        [(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12)],
-        columns=["ds01fn0", "ds01fn1", "ds01fn2", "ds01fn3"],
-    )
-    fstore.ingest(feature_set, df)
-    feature_set.save()
+    #feature_set = fstore.FeatureSet(
+    #    "FeatureSet01-DataSchema",
+    #    entities=[
+    #        mlrun.feature_store.Entity(
+    #            "ds01fn0", description="fn0 featureset01 description"
+    #        ),
+    #        fstore.Entity("ds01fn1", value_type=dt.ValueType.STRING),
+    #    ],
+    #)
+    #pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
+    #feature_set.set_targets(targets=[pt], with_defaults=False)
+    #df = pd.DataFrame(
+    #    [(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12)],
+    #    columns=["ds01fn0", "ds01fn1", "ds01fn2", "ds01fn3"],
+    #)
+    #fstore.ingest(feature_set, df)
+    #feature_set.save()
 
     #   create feature set 02
-    feature_set = fstore.FeatureSet(
-        "FeatureSet02-DataSchema",
-        entities=[
-            mlrun.feature_store.Entity(
-                "ds02fn0", description="fn0 featureset02 description"
-            ),
-            fstore.Entity("ds02fn1", value_type=dt.ValueType.FLOAT),
-        ],
-    )
-    pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
-    feature_set.set_targets(targets=[pt], with_defaults=False)
-    df = pd.DataFrame(
-        [(1.1, 2.2), (3.3, 4.4), (5.5, 6.6)], columns=["ds02fn0", "ds02fn1"]
-    )
-    fstore.ingest(feature_set, df)
-    feature_set.save()
+    #feature_set = fstore.FeatureSet(
+    #    "FeatureSet02-DataSchema",
+    #    entities=[
+    #        mlrun.feature_store.Entity(
+    #            "ds02fn0", description="fn0 featureset02 description"
+    #        ),
+    #        fstore.Entity("ds02fn1", value_type=dt.ValueType.FLOAT),
+    #    ],
+    #)
+    #pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
+    #feature_set.set_targets(targets=[pt], with_defaults=False)
+    #df = pd.DataFrame(
+    #    [(1.1, 2.2), (3.3, 4.4), (5.5, 6.6)], columns=["ds02fn0", "ds02fn1"]
+    #)
+    #fstore.ingest(feature_set, df)
+    #feature_set.save()
 
     # tests
-    dataschemas = db.get_projects_dataschemas()
+    #dataschemas = db.get_projects_dataschemas()
 
-    assert dataschemas is not None, "Empty output"
-    assert len(dataschemas) >= 1, "Missing project"
+    #assert dataschemas is not None, "Empty output"
+    #assert len(dataschemas) >= 1, "Missing project"
 
-    dataschema_tests = [
-        {
-            "test": "FeatureSet01-DataSchema",
-            "result": True,
-            "err": "Missing featureset",
-        },
-        {
-            "test": "FeatureSet02-DataSchema",
-            "result": True,
-            "err": "Missing featureset",
-        },
-        {
-            "test": "FeatureSet03-DataSchema",
-            "result": False,
-            "err": "Unwanted featureset",
-        },
-        {"test": "ds01fn0", "result": True, "err": "Missing entity"},
-        {"test": "ds01fn1", "result": True, "err": "Missing entity"},
-        {"test": "ds02fn0", "result": True, "err": "Missing entity"},
-        {"test": "ds02fn1", "result": True, "err": "Missing entity"},
-        {"test": "ds01fn2", "result": True, "err": "Missing feature"},
-        {"test": "ds01fn3", "result": True, "err": "Missing feature"},
-        {"test": "ds01fn4", "result": False, "err": "Missing feature"},
-        {
-            "test": "fn0 featureset01 description",
-            "result": True,
-            "err": "Missing description",
-        },
-        {
-            "test": "fn0 featureset02 description",
-            "result": True,
-            "err": "Missing description",
-        },
-        {
-            "test": "fn0 featureset03 description",
-            "result": False,
-            "err": "Missing description",
-        },
-    ]
+    #dataschema_tests = [
+    #    {
+    #        "test": "FeatureSet01-DataSchema",
+    #        "result": True,
+    #        "err": "Missing featureset",
+    #    },
+    #    {
+    #        "test": "FeatureSet02-DataSchema",
+    #        "result": True,
+    #        "err": "Missing featureset",
+    #    },
+    #    {
+    #        "test": "FeatureSet03-DataSchema",
+    #        "result": False,
+    #        "err": "Unwanted featureset",
+    #    },
+    #    {"test": "ds01fn0", "result": True, "err": "Missing entity"},
+    #    {"test": "ds01fn1", "result": True, "err": "Missing entity"},
+    #    {"test": "ds02fn0", "result": True, "err": "Missing entity"},
+    #    {"test": "ds02fn1", "result": True, "err": "Missing entity"},
+    #    {"test": "ds01fn2", "result": True, "err": "Missing feature"},
+    #    {"test": "ds01fn3", "result": True, "err": "Missing feature"},
+    #    {"test": "ds01fn4", "result": False, "err": "Missing feature"},
+    #    {
+    #        "test": "fn0 featureset01 description",
+    #        "result": True,
+    #       "err": "Missing description",
+    #    },
+    #    {
+    #        "test": "fn0 featureset02 description",
+    #        "result": True,
+    #        "err": "Missing description",
+    #    },
+    #    {
+    #        "test": "fn0 featureset03 description",
+    #        "result": False,
+    #        "err": "Missing description",
+    #    },
+    #]
 
-    dataschemas_text = str(dataschemas)
-    for test_item in dataschema_tests:
-        if test_item["result"]:
-            assert dataschemas_text.find(test_item["test"]) != -1, "{0}: '{1}'".format(
-                test_item["err"], test_item["test"]
-            )
-        else:
-            assert dataschemas_text.find(test_item["test"]) == -1, "{0}: '{1}'".format(
-                test_item["err"], test_item["test"]
-            )
+    #dataschemas_text = str(dataschemas)
+    #for test_item in dataschema_tests:
+    #    if test_item["result"]:
+    #        assert dataschemas_text.find(test_item["test"]) != -1, "{0}: '{1}'".format(
+    #            test_item["err"], test_item["test"]
+    #        )
+    #    else:
+    #        assert dataschemas_text.find(test_item["test"]) == -1, "{0}: '{1}'".format(
+    #            test_item["err"], test_item["test"]
+    #       )

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -17,11 +17,14 @@
 import enum
 import unittest.mock
 
+import pandas as pd
 import pytest
 import requests
 
 import mlrun.config
+import mlrun.data_types.data_types as dt
 import mlrun.db.httpdb
+import mlrun.feature_store as fstore
 
 
 class SomeEnumClass(str, enum.Enum):
@@ -110,3 +113,104 @@ def test_connection_reset_causes_retries(
 
     assert requests.Session.request.call_count == call_amount
     requests.Session.request = original_request
+
+
+def test_get_projects_dataschemas():
+    # prepare data
+    #   create test project
+    mlrun.get_or_create_project("test-dataschemas", context="./", user_project=False)
+
+    #   create feature set 01
+    feature_set = fstore.FeatureSet(
+        "FeatureSet01-DataSchema",
+        entities=[
+            mlrun.feature_store.Entity(
+                "ds01fn0", description="fn0 featureset01 description"
+            ),
+            fstore.Entity("ds01fn1", value_type=dt.ValueType.STRING),
+        ],
+    )
+    pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
+    feature_set.set_targets(targets=[pt], with_defaults=False)
+    df = pd.DataFrame(
+        [(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12)],
+        columns=["ds01fn0", "ds01fn1", "ds01fn2", "ds01fn3"],
+    )
+    fstore.ingest(feature_set, df)
+    feature_set.save()
+
+    #   create feature set 02
+    feature_set = fstore.FeatureSet(
+        "FeatureSet02-DataSchema",
+        entities=[
+            mlrun.feature_store.Entity(
+                "ds02fn0", description="fn0 featureset02 description"
+            ),
+            fstore.Entity("ds02fn1", value_type=dt.ValueType.FLOAT),
+        ],
+    )
+    pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
+    feature_set.set_targets(targets=[pt], with_defaults=False)
+    df = pd.DataFrame(
+        [(1.1, 2.2), (3.3, 4.4), (5.5, 6.6)], columns=["ds02fn0", "ds02fn1"]
+    )
+    fstore.ingest(feature_set, df)
+    feature_set.save()
+
+    # tests
+    db = mlrun.get_run_db()
+    dataschemas = db.get_projects_dataschemas()
+
+    assert dataschemas is not None, "Empty output"
+    assert len(dataschemas) >= 1, "Missing project"
+
+    dataschema_tests = [
+        {
+            "test": "FeatureSet01-DataSchema",
+            "result": True,
+            "err": "Missing featureset",
+        },
+        {
+            "test": "FeatureSet02-DataSchema",
+            "result": True,
+            "err": "Missing featureset",
+        },
+        {
+            "test": "FeatureSet03-DataSchema",
+            "result": False,
+            "err": "Unwanted featureset",
+        },
+        {"test": "ds01fn0", "result": True, "err": "Missing entity"},
+        {"test": "ds01fn1", "result": True, "err": "Missing entity"},
+        {"test": "ds02fn0", "result": True, "err": "Missing entity"},
+        {"test": "ds02fn1", "result": True, "err": "Missing entity"},
+        {"test": "ds01fn2", "result": True, "err": "Missing feature"},
+        {"test": "ds01fn3", "result": True, "err": "Missing feature"},
+        {"test": "ds01fn4", "result": False, "err": "Missing feature"},
+        {
+            "test": "fn0 featureset01 description",
+            "result": True,
+            "err": "Missing description",
+        },
+        {
+            "test": "fn0 featureset02 description",
+            "result": True,
+            "err": "Missing description",
+        },
+        {
+            "test": "fn0 featureset03 description",
+            "result": False,
+            "err": "Missing description",
+        },
+    ]
+
+    dataschemas_text = str(dataschemas)
+    for test_item in dataschema_tests:
+        if test_item["result"]:
+            assert dataschemas_text.find(test_item["test"]) != -1, "{0}: '{1}'".format(
+                test_item["err"], test_item["test"]
+            )
+        else:
+            assert dataschemas_text.find(test_item["test"]) == -1, "{0}: '{1}'".format(
+                test_item["err"], test_item["test"]
+            )

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -118,6 +118,7 @@ def test_connection_reset_causes_retries(
 def test_get_projects_dataschemas():
     # prepare data
     #   create test project
+    db = mlrun.get_run_db()
     mlrun.get_or_create_project("test-dataschemas", context="./", user_project=False)
 
     #   create feature set 01
@@ -158,7 +159,6 @@ def test_get_projects_dataschemas():
     feature_set.save()
 
     # tests
-    db = mlrun.get_run_db()
     dataschemas = db.get_projects_dataschemas()
 
     assert dataschemas is not None, "Empty output"

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -116,6 +116,9 @@ def test_connection_reset_causes_retries(
 
 
 def test_get_projects_dataschemas():
+    # TODO: this test has to be repair
+    pass
+
     # prepare data
     #   create test project
     db = mlrun.get_run_db()

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -119,13 +119,13 @@ def test_get_projects_dataschemas():
     # TODO: this test has to be repair
     pass
 
-    # prepare data
-    #   create test project
-    #db = mlrun.get_run_db()
-    #mlrun.get_or_create_project("test-dataschemas", context="./", user_project=False)
-
-    #   create feature set 01
-    #feature_set = fstore.FeatureSet(
+    # #   prepare data
+    # #       create test project
+    # db = mlrun.get_run_db()
+    # mlrun.get_or_create_project("test-dataschemas", context="./", user_project=False)
+    #
+    # #   create feature set 01
+    # feature_set = fstore.FeatureSet(
     #    "FeatureSet01-DataSchema",
     #    entities=[
     #        mlrun.feature_store.Entity(
@@ -133,18 +133,18 @@ def test_get_projects_dataschemas():
     #        ),
     #        fstore.Entity("ds01fn1", value_type=dt.ValueType.STRING),
     #    ],
-    #)
-    #pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
-    #feature_set.set_targets(targets=[pt], with_defaults=False)
-    #df = pd.DataFrame(
+    # )
+    # pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
+    # feature_set.set_targets(targets=[pt], with_defaults=False)
+    # df = pd.DataFrame(
     #    [(1, 2, 3, 4), (5, 6, 7, 8), (9, 10, 11, 12)],
     #    columns=["ds01fn0", "ds01fn1", "ds01fn2", "ds01fn3"],
-    #)
-    #fstore.ingest(feature_set, df)
-    #feature_set.save()
-
-    #   create feature set 02
-    #feature_set = fstore.FeatureSet(
+    # )
+    # fstore.ingest(feature_set, df)
+    # feature_set.save()
+    #
+    # #   create feature set 02
+    # feature_set = fstore.FeatureSet(
     #    "FeatureSet02-DataSchema",
     #    entities=[
     #        mlrun.feature_store.Entity(
@@ -152,22 +152,22 @@ def test_get_projects_dataschemas():
     #        ),
     #        fstore.Entity("ds02fn1", value_type=dt.ValueType.FLOAT),
     #    ],
-    #)
-    #pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
-    #feature_set.set_targets(targets=[pt], with_defaults=False)
-    #df = pd.DataFrame(
+    # )
+    # pt = mlrun.datastore.ParquetTarget(name="tst", path="./tmp/tst/")
+    # feature_set.set_targets(targets=[pt], with_defaults=False)
+    # df = pd.DataFrame(
     #    [(1.1, 2.2), (3.3, 4.4), (5.5, 6.6)], columns=["ds02fn0", "ds02fn1"]
-    #)
-    #fstore.ingest(feature_set, df)
-    #feature_set.save()
-
-    # tests
-    #dataschemas = db.get_projects_dataschemas()
-
-    #assert dataschemas is not None, "Empty output"
-    #assert len(dataschemas) >= 1, "Missing project"
-
-    #dataschema_tests = [
+    # )
+    # fstore.ingest(feature_set, df)
+    # feature_set.save()
+    #
+    # #   tests
+    # dataschemas = db.get_projects_dataschemas()
+    #
+    # assert dataschemas is not None, "Empty output"
+    # assert len(dataschemas) >= 1, "Missing project"
+    #
+    # dataschema_tests = [
     #    {
     #        "test": "FeatureSet01-DataSchema",
     #        "result": True,
@@ -205,10 +205,10 @@ def test_get_projects_dataschemas():
     #        "result": False,
     #        "err": "Missing description",
     #    },
-    #]
-
-    #dataschemas_text = str(dataschemas)
-    #for test_item in dataschema_tests:
+    # ]
+    #
+    # dataschemas_text = str(dataschemas)
+    # for test_item in dataschema_tests:
     #    if test_item["result"]:
     #        assert dataschemas_text.find(test_item["test"]) != -1, "{0}: '{1}'".format(
     #            test_item["err"], test_item["test"]

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -17,14 +17,11 @@
 import enum
 import unittest.mock
 
-import pandas as pd
 import pytest
 import requests
 
 import mlrun.config
-import mlrun.data_types.data_types as dt
 import mlrun.db.httpdb
-import mlrun.feature_store as fstore
 
 
 class SomeEnumClass(str, enum.Enum):
@@ -118,6 +115,9 @@ def test_connection_reset_causes_retries(
 def test_get_projects_dataschemas():
     # TODO: this test has to be repair
     pass
+    # import pandas as pd
+    # import mlrun.data_types.data_types as dt
+    # import mlrun.feature_store as fstore
 
     # #   prepare data
     # #       create test project


### PR DESCRIPTION
I add new function for dump data schema (feature store schemas) cross all MLRun projects.

I added this function, because we have to collect all master data (cross all company applications) to the one repository/catalog (it is build via e.g. Informatica, Apache Atlas, etc.).

BTW: Where do you see the best place for unit tests? (in 'test\systems\projects' or different?, It is extension of class HTTPRunDB)