### PR TITLE
[FeatureStore] Redis target: cleanup config logic

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -39,6 +39,7 @@ class ClientSpec(
             api_url=config.httpdb.api_url,
             nuclio_version=resolve_nuclio_version(),
             spark_operator_version=config.spark_operator_version,
+            redis_url=config.redis.url,
             # These don't have a default value, but we don't send them if they are not set to allow the client to know
             # when to use server value and when to use client value (server only if set). Since their default value is
             # empty and not set is also empty we can use the same _get_config_value_if_not_default

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -52,3 +52,4 @@ class ClientSpec(pydantic.BaseModel):
     default_preemption_mode: typing.Optional[str]
     force_run_local: typing.Optional[str]
     function: typing.Optional[Function]
+    redis_url: typing.Optional[str]

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -104,7 +104,9 @@ default_config = {
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to
     #  configure this values on field systems, for newer system this will be configured correctly
     "v3io_api": "http://v3io-webapi:8081",
-    "redis_url": "redis://localhost:6379",
+    "redis": {
+        "url": "",
+    },
     "v3io_framesd": "http://framesd:8080",
     "datastore": {"async_source_mode": "disabled"},
     # default node selector to be applied to all functions - json string base64 encoded format

--- a/mlrun/datastore/redis.py
+++ b/mlrun/datastore/redis.py
@@ -41,7 +41,7 @@ class RedisStore(DataStore):
         super().__init__(parent, name, schema, endpoint)
         self.headers = None
 
-        self.endpoint = self.endpoint or mlrun.mlconf.redis_url
+        self.endpoint = self.endpoint or mlrun.mlconf.redis.url
 
         if self.endpoint.startswith("rediss://"):
             self.endpoint = self.endpoint[len("rediss://") :]
@@ -49,7 +49,7 @@ class RedisStore(DataStore):
         elif self.endpoint.startswith("redis://"):
             self.endpoint = self.endpoint[len("redis://") :]
             self.secure = False
-        else:
+        elif self.endpoint == "":
             raise NotImplementedError(f"invalid endpoint: {endpoint}")
 
         self._redis_url = f"{schema}://{self.endpoint}"

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -90,6 +90,7 @@ class ResourceCache:
             from storey.redis_driver import RedisDriver
 
             endpoint, uri = parse_path(uri)
+            endpoint = endpoint or mlrun.mlconf.redis.url
             self._tabels[uri] = Table(
                 uri,
                 RedisDriver(redis_url=endpoint, key_prefix="/"),

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1159,6 +1159,7 @@ class RedisNoSqlTarget(NoSqlBaseTarget):
         from storey.redis_driver import RedisDriver
 
         endpoint, uri = parse_path(self.get_target_path())
+        endpoint = endpoint or mlrun.mlconf.redis.url
         return Table(
             uri,
             RedisDriver(redis_url=endpoint, key_prefix="/"),

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -295,6 +295,8 @@ class HTTPRunDB(RunDBInterface):
                 config.valid_function_priority_class_names
                 or server_cfg.get("valid_function_priority_class_names")
             )
+            config.redis.url = config.redis.url or server_cfg.get("redis.url")
+
             # These have a default value, therefore local config will always have a value, prioritize the
             # API value first
             config.ui.projects_prefix = (

--- a/tests/system/datastore/test_redis.py
+++ b/tests/system/datastore/test_redis.py
@@ -19,15 +19,26 @@ import pytest
 import mlrun.datastore
 from tests.system.base import TestMLRunSystem
 
+redis_endpoints = ["redis://", "redis://localhost:6379"]
 
+
+@pytest.fixture(params=redis_endpoints)
+def redis_endpoint(request):
+    return request.param
+
+
+@pytest.mark.skipif(
+    not mlrun.mlconf.redis.url,
+    reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",
+)
 class TestRedisDataStore(TestMLRunSystem):
     @staticmethod
     def _skip_set_environment():
         return True
 
-    def test_redis_put_get_object(self):
+    def test_redis_put_get_object(self, redis_endpoint):
 
-        redis_path = "redis:///redis_object"
+        redis_path = redis_endpoint + "/redis_object"
         data_item = mlrun.datastore.store_manager.object(redis_path)
 
         data_item.delete()

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1978,6 +1978,10 @@ class TestFeatureStore(TestMLRunSystem):
 
         verify_purge(fset, targets_to_purge)
 
+    @pytest.mark.skipif(
+        not mlrun.mlconf.redis.url,
+        reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",
+    )
     def test_purge_redis(self):
         key = "patient_id"
         fset = fs.FeatureSet("purge", entities=[Entity(key)], timestamp_key="timestamp")


### PR DESCRIPTION
- make sure redis_url is used as default in all redis-related places
- introduce "redis" as root in config (redis_url => redis.url)
- add redis.url to the ConfigSpec, to be available across clients (client has priority over api)
- solves ML-2583 (for 1.1.x)