### PR TITLE
[Migrations] Fix failure in backup as a result of a big blob

### DIFF
--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -97,6 +97,7 @@ class DBBackupUtil(object):
         dsn_data = mlrun.api.utils.db.mysql.MySQLUtil.get_mysql_dsn_data()
         self._run_shell_command(
             "mysqldump --single-transaction --routines --triggers "
+            f"--max_allowed_packet={mlconf.httpdb.db.backup.max_allowed_packet} "
             f"-h {dsn_data['host']} "
             f"-P {dsn_data['port']} "
             f"-u {dsn_data['username']} "

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -218,8 +218,8 @@ default_config = {
                 "file_format": "db_backup_%Y%m%d%H%M.db",
                 "use_rotation": True,
                 "rotation_limit": 3,
-                # default is 64MB, max 1G, for more info https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
-                "max_allowed_packet": 512000000,  # 512MB
+                # default is 16MB, max 1G, for more info https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
+                "max_allowed_packet": 64000000,  # 64MB
             },
             # None will set this to be equal to the httpdb.max_workers
             "connections_pool_size": None,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -218,6 +218,8 @@ default_config = {
                 "file_format": "db_backup_%Y%m%d%H%M.db",
                 "use_rotation": True,
                 "rotation_limit": 3,
+                # default is 64MB, max 1G, for more info https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
+                "max_allowed_packet": 512000000,  # 512MB
             },
             # None will set this to be equal to the httpdb.max_workers
             "connections_pool_size": None,

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -32,7 +32,7 @@ class Constants:
 
     mysql_dsn = "mysql+pymysql://root@mlrun-db:3306/mlrun"
     mysql_backup_command = (
-        "mysqldump --single-transaction --routines --triggers --max_allowed_packet=512000000 "
+        "mysqldump --single-transaction --routines --triggers --max_allowed_packet=64000000 "
         "-h mlrun-db -P 3306 -u root mlrun > {0}"
     )
     mysql_load_backup_command = "mysql -h mlrun-db -P 3306 -u root mlrun < {0}"

--- a/tests/api/utils/test_db_backup.py
+++ b/tests/api/utils/test_db_backup.py
@@ -32,7 +32,7 @@ class Constants:
 
     mysql_dsn = "mysql+pymysql://root@mlrun-db:3306/mlrun"
     mysql_backup_command = (
-        "mysqldump --single-transaction --routines --triggers "
+        "mysqldump --single-transaction --routines --triggers --max_allowed_packet=512000000 "
         "-h mlrun-db -P 3306 -u root mlrun > {0}"
     )
     mysql_load_backup_command = "mysql -h mlrun-db -P 3306 -u root mlrun < {0}"


### PR DESCRIPTION
On one of our systems, migrations failed with the following error when trying to take backup of the database: 
```
mysqldump: Error 2020: Got packet bigger than 'max_allowed_packet' when dumping table `runs` at row: 4315
```

Looking at the runs table found the following lines:
```
mysql> select id, uid, OCTET_LENGTH(body), project, iteration, state, start_time, name, updated from runs where OCTET_LENGTH(body) >= 15000000;
+-------+----------------------------------+--------------------+--------------------------------+-----------+-----------+-------------------------+--------------------+-------------------------+
| id    | uid                              | OCTET_LENGTH(body) | project                        | iteration | state     | start_time              | name               | updated                 |
+-------+----------------------------------+--------------------+--------------------------------+-----------+-----------+-------------------------+--------------------+-------------------------+
| 12389 | 38943b9de9344f9b83436ac1f7578e7e |           16777215 | batch-predict-test             |         0 | completed | 2022-07-27 11:47:36.072 | training           | 2022-07-27 11:50:48.717 |
```
As we can see only the body of that run is 16MB which means the entire line is greater than 16MB which caused the backup to fail.
> If you are using the [mysql](https://dev.mysql.com/doc/refman/8.0/en/mysql.html) client program, its default [max_allowed_packet](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) variable is 16MB.

Adding `--max_allowed_packet=64MB` to the `mysqldump --single-transaction --max_allowed_packet=64MB --routines --triggers -h mlrun-db -P 3306 -u root mlrun` command solved the issue.

To fix that in the environment the migration happen I didn't had an option to modify that parameter so to resolve that issue I had to delete the row before the backup and then return it after the upgrade, to be able to deal with that issue in future upgrades I've added `mlconf.httpdb.db.backup.max_allowed_packet` which will allow to increase that param.

For more information: 
- mysql docs https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
- https://stackoverflow.com/questions/8815445/mysqldump-error-got-packet-bigger-than-max-allowed-packet