### PR TITLE
[Datastore] Support S3 authentication using local profile or assuming an IAM role

### DIFF
--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -88,6 +88,12 @@ authenticate, it is used in several use-cases, such as resolving paths to the ho
   parameters
 * `S3_ENDPOINT_URL` &mdash; the S3 endpoint to use. If not specified, it defaults to AWS. For example, to access 
   a storage bucket in Wasabi storage, use `S3_ENDPOINT_URL = "https://s3.wasabisys.com"`
+* `AWS_ROLE_ARN` &mdash; [IAM role to assume](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html). 
+  Connect to AWS using the secret key and access key, and assume the role whose ARN is provided. The 
+  ARN must be of the format `arn:aws:iam::<account-of-role-to-assume>:role/<name-of-role>`
+* `AWS_PROFILE` &mdash; name of credentials profile. The profile needs to be defined in the local AWS credentials file. 
+  When using a profile, the authentication secrets (if defined) are ignored, and credentials are retrieved from the 
+  local credentials file
 
 ### Azure Blob storage
 The Azure Blob storage can utilize several methods of authentication. Each requires a different set of parameters as listed

--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -91,9 +91,10 @@ authenticate, it is used in several use-cases, such as resolving paths to the ho
 * `AWS_ROLE_ARN` &mdash; [IAM role to assume](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html). 
   Connect to AWS using the secret key and access key, and assume the role whose ARN is provided. The 
   ARN must be of the format `arn:aws:iam::<account-of-role-to-assume>:role/<name-of-role>`
-* `AWS_PROFILE` &mdash; name of credentials profile. The profile needs to be defined in the local AWS credentials file. 
+* `AWS_PROFILE` &mdash; name of credentials profile from a local AWS credentials file. 
   When using a profile, the authentication secrets (if defined) are ignored, and credentials are retrieved from the 
-  local credentials file
+  file. This option should be used for local development where AWS credentials already exist (created by `aws` CLI, for
+  example)
 
 ### Azure Blob storage
 The Azure Blob storage can utilize several methods of authentication. Each requires a different set of parameters as listed

--- a/tests/integration/aws_s3/test-aws-s3.yml
+++ b/tests/integration/aws_s3/test-aws-s3.yml
@@ -18,3 +18,6 @@ env:
   # Access key parameters as created by AWS IAM secret key mechanism
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
+  # Role ARN to use AssumeRole with, or profile for use with local credentials file
+  AWS_ROLE_ARN:
+  AWS_PROFILE:


### PR DESCRIPTION
Two new env variables added:
* `AWS_ROLE_ARN`- Connect to AWS using the secret key and access key, and assume the role whose ARN is provided. The ARN must be of the format `arn:aws:iam::<account-of-role-to-assume>:role/<name-of-role>`
* `AWS_PROFILE` - name of credentials profile. The profile needs to be defined in the local AWS credentials file. When using a profile, the authentication secrets (if defined) are ignored, and credentials are retrieved from the local credentials file

This allows users to connect to S3 using a role, either with local credentials file (for local development, for example if the `aws` cli created a local cred file) or using role ARN (useful for running jobs etc.) which can be passed to jobs as a secret or env variable.