### PR TITLE
[Serving] Support mock of deploy_function() to run demo/tutorials w/o real Nuclio

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -123,6 +123,8 @@ default_config = {
     "ignored_notebook_tags": "",
     # when set it will force the local=True in run_function(), set to "auto" will run local if there is no k8s
     "force_run_local": "auto",
+    # when set it will force the mock=True in deploy_function(), TBD allow "auto" to detect Nuclio
+    "mock_nuclio_deployment": "",
     "background_tasks": {
         # enabled / disabled
         "timeout_mode": "enabled",

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -310,7 +310,7 @@ def deploy_function(
             for model_args in models:
                 function.add_model(**model_args)
 
-        mock = True if mlrun.mlconf.mock_nuclio_deployment else mock
+        mock = True if mlrun.mlconf.mock_nuclio_deployment and mock is None else mock
         function._set_as_mock(mock)
         if mock:
             return DeployStatus(

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -319,10 +319,6 @@ def deploy_function(
                 function=function,
             )
 
-        if getattr(function, "_mock_server", None):
-            function._mock_server = None
-            function.invoke = function._old_invoke
-
         address = function.deploy(
             dashboard=dashboard, tag=tag, verbose=verbose, builder_env=builder_env
         )

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2254,6 +2254,7 @@ class MlrunProject(ModelObj):
         tag: str = None,
         verbose: bool = None,
         builder_env: dict = None,
+        mock: bool = None,
     ):
         """deploy real-time (nuclio based) functions
 
@@ -2264,6 +2265,7 @@ class MlrunProject(ModelObj):
         :param tag:        extra version tag
         :param verbose     add verbose prints/logs
         :param builder_env: env vars dict for source archive config/credentials e.g. builder_env={"GIT_TOKEN": token}
+        :param mock:       deploy mock server vs a real Nuclio function (for local simulations)
         """
         return deploy_function(
             function,
@@ -2274,6 +2276,7 @@ class MlrunProject(ModelObj):
             verbose=verbose,
             builder_env=builder_env,
             project_object=self,
+            mock=mock,
         )
 
     def get_artifact(self, key, tag=None, iter=None):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -268,6 +268,7 @@ class NuclioStatus(FunctionStatus):
 class RemoteRuntime(KubeResource):
     kind = "remote"
     _is_nested = False
+    _mock_server = None
 
     @property
     def spec(self) -> NuclioSpec:
@@ -1031,6 +1032,13 @@ class RemoteRuntime(KubeResource):
                 new_env.append(remote_env)
 
         self.spec.env = new_env
+
+    def _set_as_mock(self, enable):
+        # todo: create mock_server for Nuclio
+        if enable:
+            raise NotImplementedError(
+                "Mock (simulation) is currently not supported for Nuclio"
+            )
 
 
 def parse_logs(logs):

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -721,3 +721,29 @@ class ServingRuntime(RemoteRuntime):
         :return: graphviz graph object
         """
         return self.spec.graph.plot(filename, format=format, source=source, **kw)
+
+    def _set_as_mock(self, enable):
+        if not enable:
+            if self._mock_server:
+                self.invoke = self._old_invoke
+            self._mock_server = None
+            return
+
+        logger.info(
+            "Deploying function MOCK (for simulation)...\n"
+            "Turn off the mock (mock=False) for real deployment to Nuclio"
+        )
+        server = self.to_mock_server()
+        self._mock_server = server
+        self._old_invoke = self.invoke
+
+        def invoke(
+            path: str,
+            body=None,
+            method: str = None,
+            headers: dict = None,
+            **kwargs,
+        ):
+            return self._mock_server.test(path, body, method, headers)
+
+        self.invoke = invoke

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -19,7 +19,6 @@ import time
 
 import pandas as pd
 import pytest
-import requests
 from nuclio_sdk import Context as NuclioContext
 from sklearn.datasets import load_iris
 
@@ -468,7 +467,7 @@ def test_mock_deploy():
     assert resp["outputs"] == 5 * 100, f"wrong data response {resp}"
 
     # test that it tries real deployment when turned off
-    with pytest.raises(requests.exceptions.MissingSchema):
+    with pytest.raises(Exception):
         mlrun.deploy_function(fn, dashboard="bad-address")
         fn.invoke("/v2/models/my/infer", testdata)
 


### PR DESCRIPTION

Examples:

```python
    fn = mlrun.new_function("fake", kind="serving")
    fn.add_model("my", model, class_name=ModelClass())

    # use mock deployment
    mlrun.deploy_function(fn, mock=True)
    resp = fn.invoke("/v2/models/my/infer", testdata)

    # set the mock through the config
    mlrun.mlconf.mock_nuclio_deployment = "1"
    mlrun.deploy_function(fn)
    resp = fn.invoke("/v2/models/my/infer", data)
```