### PR TITLE
[Client-spec] Fix configuration passing of artifacts

### DIFF
--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -52,7 +52,7 @@ class ClientSpec(pydantic.BaseModel):
     default_preemption_mode: typing.Optional[str]
     force_run_local: typing.Optional[str]
     function: typing.Optional[Function]
+    redis_url: typing.Optional[str]
     # not passing them as one object as it possible client user would like to override only one of the params
     calculate_artifact_hash: typing.Optional[str]
     generate_artifact_target_path_from_artifact_hash: typing.Optional[str]
-    redis_url: typing.Optional[str]

--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -339,7 +339,7 @@ class Artifact(ModelObj):
     def _upload_body(self, body, target=None, artifact_path: str = None):
         body_hash = None
         if not target and not self.spec.target_path:
-            if not mlrun.mlconf.should_generate_target_path_from_artifact_hash():
+            if not mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     "Unable to resolve target path, no target path is defined and "
                     "mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash is set to false"
@@ -348,7 +348,7 @@ class Artifact(ModelObj):
                 body, artifact_path
             )
 
-        if mlrun.mlconf.should_calculate_artifact_hash():
+        if mlrun.mlconf.artifacts.calculate_hash:
             self.metadata.hash = body_hash or calculate_blob_hash(body)
         self.spec.size = len(body)
 
@@ -359,7 +359,7 @@ class Artifact(ModelObj):
     ):
         file_hash = None
         if not target_path and not self.spec.target_path:
-            if not mlrun.mlconf.should_generate_target_path_from_artifact_hash():
+            if not mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     "Unable to resolve target path, no target path is defined and "
                     "mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash is set to false"
@@ -367,7 +367,7 @@ class Artifact(ModelObj):
             file_hash, self.spec.target_path = self.resolve_file_target_hash_path(
                 source_path, artifact_path
             )
-        if mlrun.mlconf.should_calculate_artifact_hash():
+        if mlrun.mlconf.artifacts.calculate_hash:
             self.metadata.hash = file_hash or calculate_local_file_hash(source_path)
         self.spec.size = os.stat(source_path).st_size
 
@@ -908,7 +908,7 @@ class DirArtifact(Artifact):
 
             if self.spec.target_path:
                 target_path = os.path.join(self.spec.target_path, file_name)
-            elif mlrun.mlconf.should_generate_target_path_from_artifact_hash():
+            elif mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash:
                 _, target_path = self.resolve_file_target_hash_path(
                     source_path=file_path, artifact_path=artifact_path
                 )
@@ -1118,13 +1118,13 @@ class LegacyArtifact(ModelObj):
                 self._upload_file(src_path)
 
     def _upload_body(self, body, target=None):
-        if mlrun.mlconf.should_calculate_artifact_hash():
+        if mlrun.mlconf.artifacts.calculate_hash:
             self.hash = calculate_blob_hash(body)
         self.size = len(body)
         store_manager.object(url=target or self.target_path).put(body)
 
     def _upload_file(self, src, target=None):
-        if mlrun.mlconf.should_calculate_artifact_hash():
+        if mlrun.mlconf.artifacts.calculate_hash:
             self.hash = calculate_local_file_hash(src)
         self.size = os.stat(src).st_size
         store_manager.object(url=target or self.target_path).upload(src)

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -190,12 +190,12 @@ class ArtifactManager:
             target_path = src_path
             upload = False
 
-        # if mlrun.mlconf.should_generate_target_path_from_artifact_hash() outputs True and the user
+        # if mlrun.mlconf.generate_target_path_from_artifact_hash outputs True and the user
         # didn't pass target_path explicitly then we won't use `generate_target_path` to calculate the target path,
         # but rather use the `resolve_<body/file>_target_hash_path` in the `item.upload` method.
         elif (
             not item.is_inline()
-            and not mlrun.mlconf.should_generate_target_path_from_artifact_hash()
+            and not mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash
         ):
             target_path = item.generate_target_path(artifact_path, producer)
 

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -431,7 +431,7 @@ class ModelArtifact(Artifact):
         internal, upload to target store
         :param artifact_path: required only for when generating target_path from artifact hash
         """
-        # if mlrun.mlconf.should_generate_target_path_from_artifact_hash() outputs True and the user
+        # if mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash outputs True and the user
         # didn't pass target_path explicitly, then target_path will be calculated right before uploading the artifact
         # using `resolve_<body/file>_target_hash_path`
         target_model_path = (
@@ -477,14 +477,14 @@ class ModelArtifact(Artifact):
         spec_body = self.to_yaml()
         spec_target_path = None
 
-        if mlrun.mlconf.should_generate_target_path_from_artifact_hash():
+        if mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash:
 
             # resolving target_path for the model spec
             _, spec_target_path = self.resolve_body_target_hash_path(
                 body=spec_body, artifact_path=artifact_path
             )
 
-            # if mlrun.mlconf.should_generate_target_path_from_artifact_hash() outputs True, then target_path will be
+            # if mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash outputs True, then target_path will be
             # will point to the artifact path which is where the model and all its extra data are stored
             self.spec.target_path = (
                 artifact_path + "/"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -102,11 +102,12 @@ default_config = {
     # Add {{workflow.uid}} to artifact_path unless user specified a path manually
     "enrich_artifact_path_with_workflow_id": True,
     "artifacts": {
-        # None is handled as True, reason is that we want the client to have precedence on both params bellow
-        # for example if the user logs a big artifact and the calculation get stuck for some reason, or it doesn't want
-        # the hash to be calculated so we want the client to be able to configure that ( passed in client-spec )
-        "calculate_hash": None,
-        "generate_target_path_from_artifact_hash": False,
+        "calculate_hash": True,
+        # None is handled as False, reason we set None instead of False is that if the server have set the value to
+        # some value while the client didn't change it, the server value will be applied.
+        # But if both the server and the client set some value, we want the client to take precedence over the server.
+        # By setting the default to None we are able to differentiate between the two cases.
+        "generate_target_path_from_artifact_hash": None,
     },
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to
     #  configure this values on field systems, for newer system this will be configured correctly
@@ -611,19 +612,6 @@ class Config:
             # like 3.0_b177_20210806003728
             semver_compatible_igz_version = config.igz_version.split("_")[0]
             return semver.VersionInfo.parse(f"{semver_compatible_igz_version}.0")
-
-    @staticmethod
-    def should_generate_target_path_from_artifact_hash() -> bool:
-        return (
-            config.artifacts.generate_target_path_from_artifact_hash is None
-            or config.artifacts.generate_target_path_from_artifact_hash
-        )
-
-    @staticmethod
-    def should_calculate_artifact_hash() -> bool:
-        return (
-            config.artifacts.calculate_hash is None or config.artifacts.calculate_hash
-        )
 
     def verify_security_context_enrichment_mode_is_allowed(self):
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -302,8 +302,7 @@ class HTTPRunDB(RunDBInterface):
             )
             config.artifacts.generate_target_path_from_artifact_hash = (
                 config.artifacts.generate_target_path_from_artifact_hash
-                if config.artifacts.generate_artifact_target_path_from_artifact_hash
-                is not None
+                if config.artifacts.generate_target_path_from_artifact_hash is not None
                 else server_cfg.get("generate_artifact_target_path_from_artifact_hash")
             )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1894,7 +1894,7 @@ class MlrunProject(ModelObj):
             # no need to add workflow.uid to the artifact path for uniqueness,
             # this is already being handled by generating
             # the artifact target path from the artifact content hash ( body / file etc...)
-            or mlrun.mlconf.should_generate_target_path_from_artifact_hash()
+            or mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash
             # if the artifact path already contains workflow.uid, no need to add it again
             or workflow_uid_string in artifact_path
         ):


### PR DESCRIPTION
Fixed the way `generate_target_path_from_artifact_hash` were passed.

Motivation:
This configuration changes the behavior of the client, meaning I want the server to "suggest" his behavior but if the client wishes to use other option than it can override the server configuration.

This was done by allowing three params into the `generate_target_path_from_artifact_hash` param:
- None ( behaves as False ) **Default**
- False
- True

If server sets True and the client is set to default ( None ), then server configuration will be applied.
If server sets True and the client sets to False, then client configuration will be applied.
For all use-cases head to the test I added.

This method of setting the default to None instead of False, allow us to be able to apply server configuration on old clients without the need to upgrade them, for example if I had default to False (both client server) in version 1.1.0 and in 1.2.0 I decided to change the default to True, then the server configuration will never apply because we have no way to differentiate on client side whether False is the default or manually set param by the user.
But if the default is None, and the server sets to True, and client sets to False we are able to differentiate between the default and the manually set value. 