### PR TITLE
[API] Simplify env and Nuclio mock setting

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -93,6 +93,7 @@ def set_environment(
     access_key: str = None,
     user_project=False,
     username: str = None,
+    env_file: str = None,
 ):
     """set and test default config for: api path, artifact_path and project
 
@@ -107,6 +108,7 @@ def set_environment(
         from os import path
         project_name, artifact_path = set_environment(project='my-project')
         set_environment("http://localhost:8080", artifact_path="./")
+        set_environment(env_file="mlrun.env")
         set_environment("<remote-service-url>", access_key="xyz", username="joe")
 
     :param api_path:       location/url of mlrun api service
@@ -115,11 +117,15 @@ def set_environment(
     :param access_key:     set the remote cluster access key (V3IO_ACCESS_KEY)
     :param user_project:   add the current user name to the provided project name (making it unique per user)
     :param username:       name of the user to authenticate
+    :param env_file:       path/url to .env file (holding MLRun config and other env vars), see: set_env_from_file()
 
     :returns:
         default project name
         actual artifact path/url, can be used to create subpaths per task or group of artifacts
     """
+    if env_file:
+        set_env_from_file(env_file)
+
     # set before the dbpath (so it will re-connect with the new credentials)
     if access_key:
         environ["V3IO_ACCESS_KEY"] = access_key
@@ -147,7 +153,9 @@ def set_environment(
         get_or_create_project(mlconf.default_project, "./")
 
     if not mlconf.artifact_path and not artifact_path:
-        raise ValueError("please specify a valid artifact_path")
+        raise ValueError(
+            "default artifact_path was not configures, please specify a valid artifact_path"
+        )
 
     if artifact_path:
         if artifact_path.startswith("./"):

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -94,6 +94,7 @@ def set_environment(
     user_project=False,
     username: str = None,
     env_file: str = None,
+    mock_functions: str = None,
 ):
     """set and test default config for: api path, artifact_path and project
 
@@ -118,7 +119,8 @@ def set_environment(
     :param user_project:   add the current user name to the provided project name (making it unique per user)
     :param username:       name of the user to authenticate
     :param env_file:       path/url to .env file (holding MLRun config and other env vars), see: set_env_from_file()
-
+    :param mock_functions: set to True to create local/mock functions instead of real containers,
+                           set to "auto" to auto determine based on the presence of k8s/Nuclio
     :returns:
         default project name
         actual artifact path/url, can be used to create subpaths per task or group of artifacts
@@ -135,6 +137,11 @@ def set_environment(
     mlconf.dbpath = mlconf.dbpath or api_path
     if not mlconf.dbpath:
         raise ValueError("DB/API path was not detected, please specify its address")
+
+    if mock_functions is not None:
+        mock_functions = "1" if mock_functions is True else mock_functions
+        mlconf.force_run_local = mock_functions
+        mlconf.mock_nuclio_deployment = mock_functions
 
     # check connectivity and load remote defaults
     get_run_db()
@@ -154,7 +161,7 @@ def set_environment(
 
     if not mlconf.artifact_path and not artifact_path:
         raise ValueError(
-            "default artifact_path was not configures, please specify a valid artifact_path"
+            "default artifact_path was not configured, please specify a valid artifact_path"
         )
 
     if artifact_path:

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -134,7 +134,7 @@ def set_environment(
     if username:
         environ["V3IO_USERNAME"] = username
 
-    mlconf.dbpath = mlconf.dbpath or api_path
+    mlconf.dbpath = api_path or mlconf.dbpath
     if not mlconf.dbpath:
         raise ValueError("DB/API path was not detected, please specify its address")
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -848,6 +848,7 @@ class Config:
         return True if mlrun.mlconf.namespace else False
 
     def is_nuclio_detected(self):
+        # determine is Nuclio service is detected, when the nuclio_version is not set
         return True if mlrun.mlconf.nuclio_version else False
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -131,8 +131,9 @@ default_config = {
     "ignored_notebook_tags": "",
     # when set it will force the local=True in run_function(), set to "auto" will run local if there is no k8s
     "force_run_local": "auto",
-    # when set it will force the mock=True in deploy_function(), TBD allow "auto" to detect Nuclio
-    "mock_nuclio_deployment": "",
+    # when set it will force the mock=True in deploy_function(),
+    # set to "auto" will use mock of Nuclio is not detected (no nuclio_version)
+    "mock_nuclio_deployment": "auto",
     "background_tasks": {
         # enabled / disabled
         "timeout_mode": "enabled",
@@ -845,6 +846,9 @@ class Config:
         # determine if the API service is attached to K8s cluster
         # when there is a cluster the .namespace is set
         return True if mlrun.mlconf.namespace else False
+
+    def is_nuclio_detected(self):
+        return True if mlrun.mlconf.nuclio_version else False
 
 
 # Global configuration

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -131,9 +131,9 @@ default_config = {
     "ignored_notebook_tags": "",
     # when set it will force the local=True in run_function(), set to "auto" will run local if there is no k8s
     "force_run_local": "auto",
-    # when set it will force the mock=True in deploy_function(),
-    # set to "auto" will use mock of Nuclio is not detected (no nuclio_version)
-    "mock_nuclio_deployment": "auto",
+    # when set (True or non empty str) it will force the mock=True in deploy_function(),
+    # set to "auto" will use mock of Nuclio if not detected (no nuclio_version)
+    "mock_nuclio_deployment": "",
     "background_tasks": {
         # enabled / disabled
         "timeout_mode": "enabled",

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -310,7 +310,10 @@ def deploy_function(
             for model_args in models:
                 function.add_model(**model_args)
 
-        mock = True if mlrun.mlconf.mock_nuclio_deployment and mock is None else mock
+        mock_nuclio = mlrun.mlconf.mock_nuclio_deployment
+        if mock_nuclio and mock_nuclio == "auto":
+            mock_nuclio = not mlrun.mlconf.is_nuclio_detected()
+        mock = True if mock_nuclio and mock is None else mock
         function._set_as_mock(mock)
         if mock:
             return DeployStatus(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1037,7 +1037,8 @@ class RemoteRuntime(KubeResource):
         # todo: create mock_server for Nuclio
         if enable:
             raise NotImplementedError(
-                "Mock (simulation) is currently not supported for Nuclio"
+                "Mock (simulation) is currently not supported for Nuclio, Turn off the mock (mock=False) "
+                "and make sure Nuclio is installed for real deployment to Nuclio"
             )
 
 

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -730,8 +730,8 @@ class ServingRuntime(RemoteRuntime):
             return
 
         logger.info(
-            "Deploying function MOCK (for simulation)...\n"
-            "Turn off the mock (mock=False) for real deployment to Nuclio"
+            "Deploying serving function MOCK (for simulation)...\n"
+            "Turn off the mock (mock=False) and make sure Nuclio is installed for real deployment to Nuclio"
         )
         server = self.to_mock_server()
         self._mock_server = server

--- a/tests/test_convenince_methods.py
+++ b/tests/test_convenince_methods.py
@@ -57,6 +57,14 @@ def test_env_from_file():
     for key in env_dict.keys():
         del os.environ[key]
 
+    # test setting env_file using set_environment()
+    artifact_path = mlrun.mlconf.artifact_path or "./"
+    mlrun.set_environment(env_file=env_path, artifact_path=artifact_path)
+    for key, value in env_dict.items():
+        assert os.environ[key] == value
+    for key in env_dict.keys():
+        del os.environ[key]
+
 
 def test_bad_env_files():
     bad_envs = ["badenv1"]

--- a/tests/test_convenince_methods.py
+++ b/tests/test_convenince_methods.py
@@ -66,6 +66,24 @@ def test_env_from_file():
         del os.environ[key]
 
 
+def test_mock_functions():
+    mock_nuclio_config = mlrun.mlconf.mock_nuclio_deployment
+    local_config = mlrun.mlconf.force_run_local
+
+    # test setting env_file using set_environment()
+    artifact_path = mlrun.mlconf.artifact_path or "./"
+    mlrun.set_environment(mock_functions=True, artifact_path=artifact_path)
+    assert mlrun.mlconf.mock_nuclio_deployment == "1"
+    assert mlrun.mlconf.force_run_local == "1"
+
+    mlrun.set_environment(mock_functions="auto", artifact_path=artifact_path)
+    assert mlrun.mlconf.mock_nuclio_deployment == "auto"
+    assert mlrun.mlconf.force_run_local == "auto"
+
+    mlrun.mlconf.mock_nuclio_deployment = mock_nuclio_config
+    mlrun.mlconf.force_run_local = local_config
+
+
 def test_bad_env_files():
     bad_envs = ["badenv1"]
 


### PR DESCRIPTION
* allow use of env_file in mlrun.set_environment()
* auto detect if Nuclio is not installed and use Mock when is "auto" mock mode