### PR TITLE
[Config] Add CE mode to config and client spec [1.1.x]

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -83,6 +83,7 @@ class ClientSpec(
             ),
             force_run_local=self._get_config_value_if_not_default("force_run_local"),
             function=self._get_config_value_if_not_default("function"),
+            ce_mode=config.ce.mode,
         )
 
     @staticmethod

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -53,3 +53,4 @@ class ClientSpec(pydantic.BaseModel):
     force_run_local: typing.Optional[str]
     function: typing.Optional[Function]
     redis_url: typing.Optional[str]
+    ce_mode: typing.Optional[str]

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -414,6 +414,10 @@ default_config = {
         "backoff_factor": 1,
         "status_codes": [500, 502, 503, 504],
     },
+    "ce": {
+        # ce mode can be one of: "", lite, full
+        "mode": "",
+    },
 }
 
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -259,6 +259,12 @@ class HTTPRunDB(RunDBInterface):
                     f"warning!, server ({server_cfg['namespace']}) and client ({config.namespace})"
                     " namespace don't match"
                 )
+            if config.ce.mode and config.ce.mode != server_cfg.get("ce_mode", ""):
+                logger.warning(
+                    f"warning!, server ({server_cfg['ce_mode']}) and client ({config.ce.mode})"
+                    " CE mode don't match"
+                )
+            config.ce.mode = server_cfg.get("ce_mode") or config.ce.mode
 
             # get defaults from remote server
             config.remote_host = config.remote_host or server_cfg.get("remote_host")


### PR DESCRIPTION
Add CE mode to config and client spec, so that mode will be present from the clients and server.

https://jira.iguazeng.com/projects/CEML/issues/CEML-32

Backport #2398