### PR TITLE
[Run] Fix labels initialization in `code_to_function`

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -792,7 +792,7 @@ def code_to_function(
         fn.metadata.project = project or mlconf.default_project
         fn.metadata.tag = tag
         fn.metadata.categories = categories
-        fn.metadata.labels = labels
+        fn.metadata.labels = labels or {}
 
     def resolve_nuclio_subkind(kind):
         is_nuclio = kind.startswith("nuclio")

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -792,7 +792,7 @@ def code_to_function(
         fn.metadata.project = project or mlconf.default_project
         fn.metadata.tag = tag
         fn.metadata.categories = categories
-        fn.metadata.labels = labels or {}
+        fn.metadata.labels = labels or fn.metadata.labels
 
     def resolve_nuclio_subkind(kind):
         is_nuclio = kind.startswith("nuclio")

--- a/tests/test_code_to_func.py
+++ b/tests/test_code_to_func.py
@@ -54,6 +54,7 @@ def test_job_file():
     assert fn.kind == "job", "kind not set, test failed"
     assert fn.spec.build.functionSourceCode, "code not embedded"
     assert fn.spec.build.origin_filename == filename, "did not record filename"
+    assert type(fn.metadata.labels) == dict, "metadata labels were not set"
     run = fn.run(workdir=str(examples_path), local=True)
 
     project, uri, tag, hash_key = parse_versioned_object_uri(run.spec.function)


### PR DESCRIPTION
If labels are not specified in `code_to_function` arguments, they default to `None` and override the labels of the created runtime object, or the labels in `spec.metadata`.

https://jira.iguazeng.com/browse/ML-2627