### PR TITLE
[Tags] Add endpoints for tagging objects

### DIFF
--- a/mlrun/api/api/api.py
+++ b/mlrun/api/api/api.py
@@ -38,6 +38,7 @@ from mlrun.api.api.endpoints import (
     schedules,
     secrets,
     submit,
+    tags,
 )
 
 api_router = APIRouter(dependencies=[Depends(mlrun.api.api.deps.verify_api_state)])
@@ -129,5 +130,10 @@ api_router.include_router(
 api_router.include_router(
     operations.router,
     tags=["operations"],
+    dependencies=[Depends(mlrun.api.api.deps.authenticate_request)],
+)
+api_router.include_router(
+    tags.router,
+    tags=["tags"],
     dependencies=[Depends(mlrun.api.api.deps.authenticate_request)],
 )

--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -35,7 +35,7 @@ router = APIRouter()
 
 # TODO /artifact/{project}/{uid}/{key:path} should be deprecated in 1.4
 @router.post("/artifact/{project}/{uid}/{key:path}")
-@router.post("/projects/{project}/artifacts/{uid}/{key}")
+@router.post("/projects/{project}/artifacts/{uid}/{key:path}")
 async def store_artifact(
     request: Request,
     project: str,
@@ -116,7 +116,7 @@ def list_artifact_tags(
 
 # TODO /projects/{project}/artifact/{key:path} should be deprecated in 1.4
 @router.get("/projects/{project}/artifact/{key:path}")
-@router.get("/projects/{project}/artifacts/{key}")
+@router.get("/projects/{project}/artifacts/{key:path}")
 def get_artifact(
     project: str,
     key: str,
@@ -143,50 +143,14 @@ def get_artifact(
 
 # TODO /artifact/{project}/{uid} should be deprecated in 1.4
 @router.delete("/artifact/{project}/{uid}")
-def delete_artifact_legacy(
-    project: str,
-    uid: str,
-    key: str,
-    tag: str = "",
-    auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
-    db_session: Session = Depends(deps.get_db_session),
-):
-    return _delete_artifact(
-        project=project,
-        uid=uid,
-        key=key,
-        tag=tag,
-        auth_info=auth_info,
-        db_session=db_session,
-    )
-
-
 @router.delete("/projects/{project}/artifacts/{uid}")
-def delete_artifact(
+def delete_artifacts(
     project: str,
     uid: str,
     key: str,
     tag: str = "",
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
-):
-    return _delete_artifact(
-        project=project,
-        uid=uid,
-        key=key,
-        tag=tag,
-        auth_info=auth_info,
-        db_session=db_session,
-    )
-
-
-def _delete_artifact(
-    project: str,
-    uid: str,
-    key: str,
-    tag: str = "",
-    auth_info: mlrun.api.schemas.AuthInfo = None,
-    db_session: Session = None,
 ):
     mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.artifact,
@@ -201,34 +165,6 @@ def _delete_artifact(
 
 # TODO /artifacts should be deprecated in 1.4
 @router.get("/artifacts")
-def list_artifacts_legacy(
-    project: str = None,
-    name: str = None,
-    tag: str = None,
-    kind: str = None,
-    category: schemas.ArtifactCategories = None,
-    labels: List[str] = Query([], alias="label"),
-    iter: int = Query(None, ge=0),
-    best_iteration: bool = Query(False, alias="best-iteration"),
-    format_: ArtifactsFormat = Query(ArtifactsFormat.legacy, alias="format"),
-    auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
-    db_session: Session = Depends(deps.get_db_session),
-):
-    return _list_artifacts(
-        project=project,
-        name=name,
-        tag=tag,
-        kind=kind,
-        category=category,
-        labels=labels,
-        iter=iter,
-        best_iteration=best_iteration,
-        format_=format_,
-        auth_info=auth_info,
-        db_session=db_session,
-    )
-
-
 @router.get("/projects/{project}/artifacts")
 def list_artifacts(
     project: str = None,
@@ -242,34 +178,6 @@ def list_artifacts(
     format_: ArtifactsFormat = Query(ArtifactsFormat.legacy, alias="format"),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
-):
-    return _list_artifacts(
-        project=project,
-        name=name,
-        tag=tag,
-        kind=kind,
-        category=category,
-        labels=labels,
-        iter=iter,
-        best_iteration=best_iteration,
-        format_=format_,
-        auth_info=auth_info,
-        db_session=db_session,
-    )
-
-
-def _list_artifacts(
-    project: str = None,
-    name: str = None,
-    tag: str = None,
-    kind: str = None,
-    category: schemas.ArtifactCategories = None,
-    labels: List[str] = None,
-    iter: int = None,
-    best_iteration: bool = False,
-    format_: ArtifactsFormat = ArtifactsFormat.full,
-    auth_info: mlrun.api.schemas.AuthInfo = None,
-    db_session: Session = None,
 ):
     if project is None:
         project = config.default_project

--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -144,7 +144,7 @@ def get_artifact(
 # TODO /artifact/{project}/{uid} should be deprecated in 1.4
 @router.delete("/artifact/{project}/{uid}")
 @router.delete("/projects/{project}/artifacts/{uid}")
-def delete_artifacts(
+def delete_artifact(
     project: str,
     uid: str,
     key: str,

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -26,7 +26,7 @@ router = fastapi.APIRouter()
 
 
 @router.post("/projects/{project}/tags/{tag}")
-async def store_tag(
+async def overwrite_object_tags_with_tag(
     project: str,
     tag: str,
     objects: mlrun.api.schemas.TagsObjects,
@@ -55,6 +55,51 @@ async def store_tag(
             auth_info=auth_info,
         )
 
-    return mlrun.api.crud.Tags().overwrite_object_tags_with_tag(
-        db_session, project=project, tag=tag, objects=objects.objects
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
+        db_session,
+        project,
+        tag,
+        objects.objects,
     )
+    return {}
+
+
+@router.put("/projects/{project}/tags/{tag}")
+async def append_tag_to_objects(
+    project: str,
+    tag: str,
+    objects: mlrun.api.schemas.TagsObjects,
+    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        mlrun.api.api.deps.get_db_session
+    ),
+):
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
+    )
+
+    for object_list in objects.objects:
+        # check permission per object type
+        await fastapi.concurrency.run_in_threadpool(
+            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+            getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
+            project,
+            resource_name=None,
+            action=mlrun.api.schemas.AuthorizationAction.store,
+            auth_info=auth_info,
+        )
+
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.crud.Tags().append_tag_to_objects,
+        db_session,
+        project,
+        tag,
+        objects.objects,
+    )
+    return {}

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -51,7 +51,8 @@ async def overwrite_object_tags_with_tag(
             getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
             project,
             resource_name=None,
-            action=mlrun.api.schemas.AuthorizationAction.store,
+            # not actually overwriting objects, just overwriting the objects tags
+            action=mlrun.api.schemas.AuthorizationAction.update,
             auth_info=auth_info,
         )
 
@@ -91,12 +92,53 @@ async def append_tag_to_objects(
             getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
             project,
             resource_name=None,
-            action=mlrun.api.schemas.AuthorizationAction.store,
+            action=mlrun.api.schemas.AuthorizationAction.update,
             auth_info=auth_info,
         )
 
     await fastapi.concurrency.run_in_threadpool(
         mlrun.api.crud.Tags().append_tag_to_objects,
+        db_session,
+        project,
+        tag,
+        objects.objects,
+    )
+    return {}
+
+
+@router.delete("/projects/{project}/tags/{tag}")
+async def delete_tag_from_objects(
+    project: str,
+    tag: str,
+    objects: mlrun.api.schemas.TagsObjects,
+    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        mlrun.api.api.deps.get_db_session
+    ),
+):
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
+    )
+
+    for object_list in objects.objects:
+        # check permission per object type
+        await fastapi.concurrency.run_in_threadpool(
+            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+            getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
+            project,
+            resource_name=None,
+            # not actually deleting objects, just deleting the objects tags
+            action=mlrun.api.schemas.AuthorizationAction.update,
+            auth_info=auth_info,
+        )
+
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.crud.Tags().delete_tag_from_objects,
         db_session,
         project,
         tag,

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import fastapi
 import fastapi.concurrency
 import sqlalchemy.orm

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -1,0 +1,44 @@
+import typing
+
+import fastapi
+import fastapi.concurrency
+import sqlalchemy.orm
+from fastapi import APIRouter, Depends, Query, Request
+
+import mlrun.api.api.deps
+import mlrun.api.schemas
+import mlrun.api.utils.auth.verifier
+import mlrun.api.utils.singletons.project_member
+
+router = fastapi.APIRouter()
+
+
+@router.post("/projects/{project}/tags/{tag}")
+async def store_tag(
+    project: str,
+    tag: str,
+    objects: mlrun.api.schemas.TagsObjects,
+    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        mlrun.api.api.deps.get_db_session
+    ),
+):
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
+    )
+
+    for object_list in objects.objects:
+        # check permission per object type
+        await fastapi.concurrency.run_in_threadpool(
+            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+            object_list.kind,
+            project,
+            object_list.kind,  # we don't really check per object, just the kind, so passing kind just as a place holder
+            mlrun.api.schemas.AuthorizationAction.store,
+            auth_info,
+        )

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import http
+
 import fastapi
 import fastapi.concurrency
 import sqlalchemy.orm
@@ -25,11 +27,11 @@ import mlrun.api.utils.singletons.project_member
 router = fastapi.APIRouter()
 
 
-@router.post("/projects/{project}/tags/{tag}")
+@router.post("/projects/{project}/tags/{tag}", response_model=mlrun.api.schemas.Tag)
 async def overwrite_object_tags_with_tag(
     project: str,
     tag: str,
-    objects: mlrun.api.schemas.TagsObjects,
+    tag_objects: mlrun.api.schemas.TagObjects,
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
     ),
@@ -44,33 +46,32 @@ async def overwrite_object_tags_with_tag(
         auth_info=auth_info,
     )
 
-    for object_list in objects.objects:
-        # check permission per object type
-        await fastapi.concurrency.run_in_threadpool(
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
-            getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
-            project,
-            resource_name=None,
-            # not actually overwriting objects, just overwriting the objects tags
-            action=mlrun.api.schemas.AuthorizationAction.update,
-            auth_info=auth_info,
-        )
+    # check permission per object type
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+        getattr(mlrun.api.schemas.AuthorizationResourceTypes, tag_objects.kind),
+        project,
+        resource_name=None,
+        # not actually overwriting objects, just overwriting the objects tags
+        action=mlrun.api.schemas.AuthorizationAction.update,
+        auth_info=auth_info,
+    )
 
     await fastapi.concurrency.run_in_threadpool(
         mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
         db_session,
         project,
         tag,
-        objects.objects,
+        tag_objects,
     )
-    return {}
+    return mlrun.api.schemas.Tag(name=tag, project=project)
 
 
-@router.put("/projects/{project}/tags/{tag}")
+@router.put("/projects/{project}/tags/{tag}", response_model=mlrun.api.schemas.Tag)
 async def append_tag_to_objects(
     project: str,
     tag: str,
-    objects: mlrun.api.schemas.TagsObjects,
+    tag_objects: mlrun.api.schemas.TagObjects,
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
     ),
@@ -85,32 +86,32 @@ async def append_tag_to_objects(
         auth_info=auth_info,
     )
 
-    for object_list in objects.objects:
-        # check permission per object type
-        await fastapi.concurrency.run_in_threadpool(
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
-            getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
-            project,
-            resource_name=None,
-            action=mlrun.api.schemas.AuthorizationAction.update,
-            auth_info=auth_info,
-        )
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+        getattr(mlrun.api.schemas.AuthorizationResourceTypes, tag_objects.kind),
+        project,
+        resource_name=None,
+        action=mlrun.api.schemas.AuthorizationAction.update,
+        auth_info=auth_info,
+    )
 
     await fastapi.concurrency.run_in_threadpool(
         mlrun.api.crud.Tags().append_tag_to_objects,
         db_session,
         project,
         tag,
-        objects.objects,
+        tag_objects,
     )
-    return {}
+    return mlrun.api.schemas.Tag(name=tag, project=project)
 
 
-@router.delete("/projects/{project}/tags/{tag}")
+@router.delete(
+    "/projects/{project}/tags/{tag}", status_code=http.HTTPStatus.NO_CONTENT.value
+)
 async def delete_tag_from_objects(
     project: str,
     tag: str,
-    objects: mlrun.api.schemas.TagsObjects,
+    tag_objects: mlrun.api.schemas.TagObjects,
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
     ),
@@ -125,23 +126,20 @@ async def delete_tag_from_objects(
         auth_info=auth_info,
     )
 
-    for object_list in objects.objects:
-        # check permission per object type
-        await fastapi.concurrency.run_in_threadpool(
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
-            getattr(mlrun.api.schemas.AuthorizationResourceTypes, object_list.kind),
-            project,
-            resource_name=None,
-            # not actually deleting objects, just deleting the objects tags
-            action=mlrun.api.schemas.AuthorizationAction.update,
-            auth_info=auth_info,
-        )
+    await fastapi.concurrency.run_in_threadpool(
+        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+        getattr(mlrun.api.schemas.AuthorizationResourceTypes, tag_objects.kind),
+        project,
+        resource_name=None,
+        # not actually deleting objects, just deleting the objects tags
+        action=mlrun.api.schemas.AuthorizationAction.update,
+        auth_info=auth_info,
+    )
 
     await fastapi.concurrency.run_in_threadpool(
         mlrun.api.crud.Tags().delete_tag_from_objects,
         db_session,
         project,
         tag,
-        objects.objects,
+        tag_objects,
     )
-    return {}

--- a/mlrun/api/crud/__init__.py
+++ b/mlrun/api/crud/__init__.py
@@ -25,3 +25,4 @@ from .projects import Projects  # noqa: F401
 from .runs import Runs  # noqa: F401
 from .runtime_resources import RuntimeResources  # noqa: F401
 from .secrets import Secrets, SecretsClientType  # noqa: F401
+from .tags import Tags  # noqa: F401

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -16,6 +16,7 @@ import typing
 
 import sqlalchemy.orm
 
+import mlrun.api.db.sqldb.db
 import mlrun.api.schemas
 import mlrun.api.utils.projects.remotes.follower
 import mlrun.api.utils.singletons.db
@@ -26,9 +27,9 @@ import mlrun.utils.singleton
 
 kind_to_function = {
     "artifact": {
-        "overwrite": "overwrite_artifacts_with_tag",
-        "append": "append_tag_to_artifacts",
-        "delete": "delete_tag_from_artifacts",
+        "overwrite": mlrun.api.db.sqldb.db.SQLDB.overwrite_artifacts_with_tag.__name__,
+        "append": mlrun.api.db.sqldb.db.SQLDB.append_tag_to_artifacts.__name__,
+        "delete": mlrun.api.db.sqldb.db.SQLDB.delete_tag_from_artifacts.__name__,
     }
 }
 

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -12,7 +12,7 @@ import mlrun.utils.singleton
 
 kind_to_function = {
     "artifact": {
-        "overwrite": mlrun.api.utils.singletons.db.get_db().overwrite_artifacts_with_tag,
+        "overwrite": "overwrite_artifacts_with_tag",
         # "append": mlrun.api.utils.singletons.db.get_db().update_artifact_tags,
     }
 }
@@ -29,10 +29,8 @@ class Tags(
         objects: typing.List[mlrun.api.schemas.TagObject],
     ):
         for obj in objects:
-            overwrite_func: callable = kind_to_function.get(obj.kind, {}).get(
-                "overwrite"
-            )
-            overwrite_func(
+            overwrite_func = kind_to_function.get(obj.kind, {}).get("overwrite")
+            getattr(mlrun.api.utils.singletons.db.get_db(), overwrite_func)(
                 session=db_session,
                 project=project,
                 tag=tag,

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import typing
-
 import sqlalchemy.orm
 
 import mlrun.api.db.sqldb.db

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -27,7 +27,8 @@ import mlrun.utils.singleton
 kind_to_function = {
     "artifact": {
         "overwrite": "overwrite_artifacts_with_tag",
-        # "append": mlrun.api.utils.singletons.db.get_db().update_artifact_tags,
+        "append": "append_tag_to_artifacts",
+        "delete": "delete_tag_from_artifacts",
     }
 }
 
@@ -54,8 +55,15 @@ class Tags(
     @staticmethod
     def append_tag_to_objects(
         db_session: sqlalchemy.orm.Session,
+        project: str,
         tag: str,
         objects: typing.List[mlrun.api.schemas.TagObject],
     ):
         for obj in objects:
-            pass
+            append_func = kind_to_function.get(obj.kind, {}).get("append")
+            getattr(mlrun.api.utils.singletons.db.get_db(), append_func)(
+                session=db_session,
+                project=project,
+                tag=tag,
+                identifiers=obj.identifiers,
+            )

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -68,8 +68,8 @@ class Tags(
                 identifiers=obj.identifiers,
             )
 
+    @staticmethod
     def delete_tag_from_objects(
-        self,
         db_session: sqlalchemy.orm.Session,
         project: str,
         tag: str,

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -42,45 +42,42 @@ class Tags(
         db_session: sqlalchemy.orm.Session,
         project: str,
         tag: str,
-        objects: typing.List[mlrun.api.schemas.TagObject],
+        tag_objects: mlrun.api.schemas.TagObjects,
     ):
-        for obj in objects:
-            overwrite_func = kind_to_function.get(obj.kind, {}).get("overwrite")
-            getattr(mlrun.api.utils.singletons.db.get_db(), overwrite_func)(
-                session=db_session,
-                project=project,
-                tag=tag,
-                identifiers=obj.identifiers,
-            )
+        overwrite_func = kind_to_function.get(tag_objects.kind, {}).get("overwrite")
+        getattr(mlrun.api.utils.singletons.db.get_db(), overwrite_func)(
+            session=db_session,
+            project=project,
+            tag=tag,
+            identifiers=tag_objects.identifiers,
+        )
 
     @staticmethod
     def append_tag_to_objects(
         db_session: sqlalchemy.orm.Session,
         project: str,
         tag: str,
-        objects: typing.List[mlrun.api.schemas.TagObject],
+        tag_objects: mlrun.api.schemas.TagObjects,
     ):
-        for obj in objects:
-            append_func = kind_to_function.get(obj.kind, {}).get("append")
-            getattr(mlrun.api.utils.singletons.db.get_db(), append_func)(
-                session=db_session,
-                project=project,
-                tag=tag,
-                identifiers=obj.identifiers,
-            )
+        append_func = kind_to_function.get(tag_objects.kind, {}).get("append")
+        getattr(mlrun.api.utils.singletons.db.get_db(), append_func)(
+            session=db_session,
+            project=project,
+            tag=tag,
+            identifiers=tag_objects.identifiers,
+        )
 
     @staticmethod
     def delete_tag_from_objects(
         db_session: sqlalchemy.orm.Session,
         project: str,
         tag: str,
-        objects: typing.List[mlrun.api.schemas.TagObject],
+        tag_objects: mlrun.api.schemas.TagObjects,
     ):
-        for obj in objects:
-            delete_func = kind_to_function.get(obj.kind, {}).get("delete")
-            getattr(mlrun.api.utils.singletons.db.get_db(), delete_func)(
-                session=db_session,
-                project=project,
-                tag=tag,
-                identifiers=obj.identifiers,
-            )
+        delete_func = kind_to_function.get(tag_objects.kind, {}).get("delete")
+        getattr(mlrun.api.utils.singletons.db.get_db(), delete_func)(
+            session=db_session,
+            project=project,
+            tag=tag,
+            identifiers=tag_objects.identifiers,
+        )

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -43,6 +43,10 @@ class Tags(
         tag_objects: mlrun.api.schemas.TagObjects,
     ):
         overwrite_func = kind_to_function.get(tag_objects.kind, {}).get("overwrite")
+        if not overwrite_func:
+            raise mlrun.errors.MLRunNotFoundError(
+                f"couldn't find overwrite function for object kind: {tag_objects.kind}"
+            )
         getattr(mlrun.api.utils.singletons.db.get_db(), overwrite_func)(
             session=db_session,
             project=project,
@@ -58,6 +62,10 @@ class Tags(
         tag_objects: mlrun.api.schemas.TagObjects,
     ):
         append_func = kind_to_function.get(tag_objects.kind, {}).get("append")
+        if not append_func:
+            raise mlrun.errors.MLRunNotFoundError(
+                f"couldn't find append function for object kind: {tag_objects.kind}"
+            )
         getattr(mlrun.api.utils.singletons.db.get_db(), append_func)(
             session=db_session,
             project=project,
@@ -73,6 +81,10 @@ class Tags(
         tag_objects: mlrun.api.schemas.TagObjects,
     ):
         delete_func = kind_to_function.get(tag_objects.kind, {}).get("delete")
+        if not delete_func:
+            raise mlrun.errors.MLRunNotFoundError(
+                f"couldn't find delete function for object kind: {tag_objects.kind}"
+            )
         getattr(mlrun.api.utils.singletons.db.get_db(), delete_func)(
             session=db_session,
             project=project,

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -23,7 +23,7 @@ import mlrun.config
 import mlrun.errors
 import mlrun.utils.singleton
 
-kind_to_function = {
+kind_to_function_names = {
     "artifact": {
         "overwrite": mlrun.api.db.sqldb.db.SQLDB.overwrite_artifacts_with_tag.__name__,
         "append": mlrun.api.db.sqldb.db.SQLDB.append_tag_to_artifacts.__name__,
@@ -42,7 +42,9 @@ class Tags(
         tag: str,
         tag_objects: mlrun.api.schemas.TagObjects,
     ):
-        overwrite_func = kind_to_function.get(tag_objects.kind, {}).get("overwrite")
+        overwrite_func = kind_to_function_names.get(tag_objects.kind, {}).get(
+            "overwrite"
+        )
         if not overwrite_func:
             raise mlrun.errors.MLRunNotFoundError(
                 f"couldn't find overwrite function for object kind: {tag_objects.kind}"
@@ -61,7 +63,7 @@ class Tags(
         tag: str,
         tag_objects: mlrun.api.schemas.TagObjects,
     ):
-        append_func = kind_to_function.get(tag_objects.kind, {}).get("append")
+        append_func = kind_to_function_names.get(tag_objects.kind, {}).get("append")
         if not append_func:
             raise mlrun.errors.MLRunNotFoundError(
                 f"couldn't find append function for object kind: {tag_objects.kind}"
@@ -80,7 +82,7 @@ class Tags(
         tag: str,
         tag_objects: mlrun.api.schemas.TagObjects,
     ):
-        delete_func = kind_to_function.get(tag_objects.kind, {}).get("delete")
+        delete_func = kind_to_function_names.get(tag_objects.kind, {}).get("delete")
         if not delete_func:
             raise mlrun.errors.MLRunNotFoundError(
                 f"couldn't find delete function for object kind: {tag_objects.kind}"

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -1,0 +1,49 @@
+import typing
+
+import sqlalchemy.orm
+
+import mlrun.api.schemas
+import mlrun.api.utils.projects.remotes.follower
+import mlrun.api.utils.singletons.db
+import mlrun.api.utils.singletons.project_member
+import mlrun.config
+import mlrun.errors
+import mlrun.utils.singleton
+
+kind_to_function = {
+    "artifact": {
+        "overwrite": mlrun.api.utils.singletons.db.get_db().overwrite_artifacts_with_tag,
+        # "append": mlrun.api.utils.singletons.db.get_db().update_artifact_tags,
+    }
+}
+
+
+class Tags(
+    metaclass=mlrun.utils.singleton.Singleton,
+):
+    @staticmethod
+    def overwrite_object_tags_with_tag(
+        db_session: sqlalchemy.orm.Session,
+        project: str,
+        tag: str,
+        objects: typing.List[mlrun.api.schemas.TagObject],
+    ):
+        for obj in objects:
+            overwrite_func: callable = kind_to_function.get(obj.kind, {}).get(
+                "overwrite"
+            )
+            overwrite_func(
+                session=db_session,
+                project=project,
+                tag=tag,
+                identifiers=obj.identifiers,
+            )
+
+    @staticmethod
+    def append_tag_to_objects(
+        db_session: sqlalchemy.orm.Session,
+        tag: str,
+        objects: typing.List[mlrun.api.schemas.TagObject],
+    ):
+        for obj in objects:
+            pass

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import typing
 
 import sqlalchemy.orm

--- a/mlrun/api/crud/tags.py
+++ b/mlrun/api/crud/tags.py
@@ -67,3 +67,19 @@ class Tags(
                 tag=tag,
                 identifiers=obj.identifiers,
             )
+
+    def delete_tag_from_objects(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        project: str,
+        tag: str,
+        objects: typing.List[mlrun.api.schemas.TagObject],
+    ):
+        for obj in objects:
+            delete_func = kind_to_function.get(obj.kind, {}).get("delete")
+            getattr(mlrun.api.utils.singletons.db.get_db(), delete_func)(
+                session=db_session,
+                project=project,
+                tag=tag,
+                identifiers=obj.identifiers,
+            )

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -134,6 +134,7 @@ class DBInterface(ABC):
         category: schemas.ArtifactCategories = None,
         iter: int = None,
         best_iteration: bool = False,
+        as_records: bool = False,
     ):
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -99,7 +99,7 @@ class DBInterface(ABC):
         session,
         project: str,
         tag: str,
-        identifiers: List[schemas.ArtifactObject],
+        identifiers: List[schemas.ArtifactIdentifier],
     ):
         pass
 
@@ -108,7 +108,7 @@ class DBInterface(ABC):
         session,
         project: str,
         tag: str,
-        identifiers: List[schemas.ArtifactObject],
+        identifiers: List[schemas.ArtifactIdentifier],
     ):
         pass
 
@@ -117,7 +117,7 @@ class DBInterface(ABC):
         session,
         project: str,
         tag: str,
-        identifiers: List[schemas.ArtifactObject],
+        identifiers: List[schemas.ArtifactIdentifier],
     ):
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -94,6 +94,15 @@ class DBInterface(ABC):
     def del_runs(self, session, name="", project="", labels=None, state="", days_ago=0):
         pass
 
+    def overwrite_artifacts_with_tag(
+        self,
+        session,
+        project: str,
+        tag: str,
+        identifiers: List[schemas.ArtifactObject],
+    ):
+        pass
+
     @abstractmethod
     def store_artifact(
         self,

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -103,6 +103,24 @@ class DBInterface(ABC):
     ):
         pass
 
+    def append_tag_to_artifacts(
+        self,
+        session,
+        project: str,
+        tag: str,
+        identifiers: List[schemas.ArtifactObject],
+    ):
+        pass
+
+    def delete_tag_from_artifacts(
+        self,
+        session,
+        project: str,
+        tag: str,
+        identifiers: List[schemas.ArtifactObject],
+    ):
+        pass
+
     @abstractmethod
     def store_artifact(
         self,

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -113,6 +113,15 @@ class FileDB(DBInterface):
             self.db.del_runs, name, project, labels, state, days_ago
         )
 
+    def overwrite_artifacts_with_tag(
+        self,
+        session,
+        project: str,
+        tag: str,
+        identifiers: List[schemas.ArtifactObject],
+    ):
+        raise NotImplementedError()
+
     def store_artifact(
         self,
         session,

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -154,6 +154,7 @@ class FileDB(DBInterface):
         category: schemas.ArtifactCategories = None,
         iter: int = None,
         best_iteration: bool = False,
+        as_records: bool = False,
     ):
         return self._transform_run_db_error(
             self.db.list_artifacts, name, project, tag, labels, since, until

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -122,6 +122,24 @@ class FileDB(DBInterface):
     ):
         raise NotImplementedError()
 
+    def append_tag_to_artifacts(
+        self,
+        session,
+        project: str,
+        tag: str,
+        identifiers: List[schemas.ArtifactObject],
+    ):
+        raise NotImplementedError()
+
+    def delete_tag_from_artifacts(
+        self,
+        session,
+        project: str,
+        tag: str,
+        identifiers: List[schemas.ArtifactObject],
+    ):
+        raise NotImplementedError()
+
     def store_artifact(
         self,
         session,

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -118,7 +118,7 @@ class FileDB(DBInterface):
         session,
         project: str,
         tag: str,
-        identifiers: List[schemas.ArtifactObject],
+        identifiers: List[schemas.ArtifactIdentifier],
     ):
         raise NotImplementedError()
 
@@ -127,7 +127,7 @@ class FileDB(DBInterface):
         session,
         project: str,
         tag: str,
-        identifiers: List[schemas.ArtifactObject],
+        identifiers: List[schemas.ArtifactIdentifier],
     ):
         raise NotImplementedError()
 
@@ -136,7 +136,7 @@ class FileDB(DBInterface):
         session,
         project: str,
         tag: str,
-        identifiers: List[schemas.ArtifactObject],
+        identifiers: List[schemas.ArtifactIdentifier],
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -357,7 +357,7 @@ class SQLDB(DBInterface):
         session: Session,
         project: str,
         tag: str,
-        identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
+        identifiers: typing.List[mlrun.api.schemas.ArtifactIdentifier],
     ):
         # query all artifacts which match the identifiers
         artifacts = []
@@ -366,8 +366,6 @@ class SQLDB(DBInterface):
                 session,
                 project=project,
                 name=identifier.name,
-                tag=identifier.tag,
-                labels=identifier.labels,
                 kind=identifier.kind,
                 iter=identifier.iter,
                 as_records=True,
@@ -385,7 +383,7 @@ class SQLDB(DBInterface):
         session: Session,
         project: str,
         tag: str,
-        identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
+        identifiers: typing.List[mlrun.api.schemas.ArtifactIdentifier],
     ):
         # query all artifacts which match the identifiers
         artifacts = []
@@ -394,8 +392,6 @@ class SQLDB(DBInterface):
                 session,
                 project=project,
                 name=identifier.name,
-                tag=identifier.tag,
-                labels=identifier.labels,
                 kind=identifier.kind,
                 iter=identifier.iter,
                 as_records=True,
@@ -407,7 +403,7 @@ class SQLDB(DBInterface):
         session: Session,
         project: str,
         tag: str,
-        identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
+        identifiers: typing.List[mlrun.api.schemas.ArtifactIdentifier],
     ):
         # query all artifacts which match the identifiers
         artifacts = []
@@ -416,8 +412,6 @@ class SQLDB(DBInterface):
                 session,
                 project=project,
                 name=identifier.name,
-                tag=identifier.tag,
-                labels=identifier.labels,
                 kind=identifier.kind,
                 iter=identifier.iter,
                 as_records=True,

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -367,6 +367,10 @@ class SQLDB(DBInterface):
                 name=identifier.name,
                 kind=identifier.kind,
                 iter=identifier.iter,
+                # will be changed to uid, after refactoring the code, currently to list artifacts by uid
+                # we are passing it into the tag param and resolve whether it's a uid or a tag in the
+                # list_artifacts method (_resolve_tag)
+                tag=identifier.uid,
                 as_records=True,
             )
         # TODO remove duplicates artifacts entries
@@ -393,6 +397,10 @@ class SQLDB(DBInterface):
                 name=identifier.name,
                 kind=identifier.kind,
                 iter=identifier.iter,
+                # will be changed to uid, after refactoring the code, currently to list artifacts by uid
+                # we are passing it into the tag param and resolve whether it's a uid or a tag in the
+                # list_artifacts method (_resolve_tag)
+                tag=identifier.uid,
                 as_records=True,
             )
         self.tag_artifacts(session, artifacts, project, name=tag)
@@ -413,6 +421,10 @@ class SQLDB(DBInterface):
                 name=identifier.name,
                 kind=identifier.kind,
                 iter=identifier.iter,
+                # will be changed to uid, after refactoring the code, currently to list artifacts by uid
+                # we are passing it into the tag param and resolve whether it's a uid or a tag in the
+                # list_artifacts method (_resolve_tag)
+                tag=identifier.uid,
                 as_records=True,
             )
         self._delete_artifacts_tags(session, project, artifacts, tags=[tag])

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -14,6 +14,7 @@
 #
 import asyncio
 import collections
+import functools
 import re
 import typing
 from copy import deepcopy
@@ -96,6 +97,7 @@ def retry_on_conflict(function):
     This why we implemented this retry as a decorator that comes "around" the existing functions
     """
 
+    @functools.wraps(function)
     def wrapper(*args, **kwargs):
         def _try_function():
             try:
@@ -125,6 +127,7 @@ def retry_on_conflict(function):
         else:
             return function(*args, **kwargs)
 
+    # wrapper.__name__ = function.__name__
     return wrapper
 
 
@@ -356,7 +359,6 @@ class SQLDB(DBInterface):
         tag: str,
         identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
     ):
-        """Note: this function is being used by mlrun.api.crud.Tags.overwrite_artifacts_with_tag"""
         # query all artifacts which match the identifiers
         artifacts = []
         for identifier in identifiers:
@@ -385,7 +387,6 @@ class SQLDB(DBInterface):
         tag: str,
         identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
     ):
-        """Note: this function is being used by mlrun.api.crud.Tags.append_tag_to_artifacts"""
         # query all artifacts which match the identifiers
         artifacts = []
         for identifier in identifiers:
@@ -408,7 +409,6 @@ class SQLDB(DBInterface):
         tag: str,
         identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
     ):
-        """Note: this function is being used by mlrun.api.crud.Tags.delete_tag_from_objects"""
         # query all artifacts which match the identifiers
         artifacts = []
         for identifier in identifiers:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -364,7 +364,7 @@ class SQLDB(DBInterface):
             artifacts += self.list_artifacts(
                 session,
                 project=project,
-                name=identifier.name,
+                name=identifier.key,
                 kind=identifier.kind,
                 iter=identifier.iter,
                 # will be changed to uid, after refactoring the code, currently to list artifacts by uid
@@ -394,7 +394,7 @@ class SQLDB(DBInterface):
             artifacts += self.list_artifacts(
                 session,
                 project=project,
-                name=identifier.name,
+                name=identifier.key,
                 kind=identifier.kind,
                 iter=identifier.iter,
                 # will be changed to uid, after refactoring the code, currently to list artifacts by uid
@@ -418,7 +418,7 @@ class SQLDB(DBInterface):
             artifacts += self.list_artifacts(
                 session,
                 project=project,
-                name=identifier.name,
+                name=identifier.key,
                 kind=identifier.kind,
                 iter=identifier.iter,
                 # will be changed to uid, after refactoring the code, currently to list artifacts by uid
@@ -627,7 +627,7 @@ class SQLDB(DBInterface):
         )
         if as_records:
             if best_iteration:
-                raise mlrun.errors.MLRunConflictError(
+                raise mlrun.errors.MLRunInvalidArgumentError(
                     "as_records is not supported with best_iteration=True"
                 )
             return artifact_records

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -356,6 +356,7 @@ class SQLDB(DBInterface):
         tag: str,
         identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
     ):
+        """Note: this function is being used by mlrun.api.crud.Tags.overwrite_artifacts_with_tag"""
         # query all artifacts which match the identifiers
         artifacts = []
         for identifier in identifiers:
@@ -384,6 +385,7 @@ class SQLDB(DBInterface):
         tag: str,
         identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
     ):
+        """Note: this function is being used by mlrun.api.crud.Tags.append_tag_to_artifacts"""
         # query all artifacts which match the identifiers
         artifacts = []
         for identifier in identifiers:
@@ -406,6 +408,7 @@ class SQLDB(DBInterface):
         tag: str,
         identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
     ):
+        """Note: this function is being used by mlrun.api.crud.Tags.delete_tag_from_objects"""
         # query all artifacts which match the identifiers
         artifacts = []
         for identifier in identifiers:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -127,7 +127,6 @@ def retry_on_conflict(function):
         else:
             return function(*args, **kwargs)
 
-    # wrapper.__name__ = function.__name__
     return wrapper
 
 
@@ -615,6 +614,10 @@ class SQLDB(DBInterface):
             session, project, ids, labels, since, until, name, kind, category, iter
         )
         if as_records:
+            if best_iteration:
+                raise mlrun.errors.MLRunConflictError(
+                    "as_records is not supported with best_iteration=True"
+                )
             return artifact_records
         indexed_artifacts = {artifact.key: artifact for artifact in artifact_records}
         for artifact in artifact_records:
@@ -691,8 +694,6 @@ class SQLDB(DBInterface):
             )
         )
         if tags:
-            if isinstance(tags, str):
-                tags = [tags]
             query = query.filter(Artifact.Tag.name.in_(tags))
         for tag in query:
             session.delete(tag)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -376,6 +376,28 @@ class SQLDB(DBInterface):
         # tag artifacts with tag
         self.tag_artifacts(session, artifacts, project, name=tag)
 
+    def append_tag_to_artifacts(
+        self,
+        session: Session,
+        project: str,
+        tag: str,
+        identifiers: typing.List[mlrun.api.schemas.ArtifactObject],
+    ):
+        # query all artifacts which match the identifiers
+        artifacts = []
+        for identifier in identifiers:
+            artifacts += self.list_artifacts(
+                session,
+                project=project,
+                name=identifier.name,
+                tag=identifier.tag,
+                labels=identifier.labels,
+                kind=identifier.kind,
+                iter=identifier.iter,
+                as_records=True,
+            )
+        self.tag_artifacts(session, artifacts, project, name=tag)
+
     @retry_on_conflict
     def store_artifact(
         self,

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -148,4 +148,4 @@ from .secret import (
     SecretsData,
     UserSecretCreationRequest,
 )
-from .tag import TagObject, TagsObjects
+from .tag import Tag, TagObjects

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -14,7 +14,7 @@
 #
 # flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
-from .artifact import ArtifactCategories, ArtifactsFormat
+from .artifact import ArtifactCategories, ArtifactObject, ArtifactsFormat
 from .auth import (
     AuthInfo,
     AuthorizationAction,
@@ -148,3 +148,4 @@ from .secret import (
     SecretsData,
     UserSecretCreationRequest,
 )
+from .tag import TagObject, TagsObjects

--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -14,7 +14,7 @@
 #
 # flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
-from .artifact import ArtifactCategories, ArtifactObject, ArtifactsFormat
+from .artifact import ArtifactCategories, ArtifactIdentifier, ArtifactsFormat
 from .auth import (
     AuthInfo,
     AuthorizationAction,

--- a/mlrun/api/schemas/artifact.py
+++ b/mlrun/api/schemas/artifact.py
@@ -47,10 +47,12 @@ class ArtifactCategories(str, enum.Enum):
 
 class ArtifactObject(pydantic.BaseModel):
     kind: typing.Optional[str]
+    # name actually maps to key in the DB (_find_artifacts for reference), should we rename it?
     name: typing.Optional[str]
     tag: typing.Optional[str]
-    labels: typing.Optional[typing.List[str]]
+    labels: typing.Optional[typing.Dict[str, str]]
     iter: typing.Optional[str]
+    # TODO support more identifiers like below
     # uid: typing.Optional[str]
     # key: typing.Optional[str]
     # path: typing.Optional[str]

--- a/mlrun/api/schemas/artifact.py
+++ b/mlrun/api/schemas/artifact.py
@@ -45,17 +45,14 @@ class ArtifactCategories(str, enum.Enum):
             )
 
 
-class ArtifactObject(pydantic.BaseModel):
+class ArtifactIdentifier(pydantic.BaseModel):
+    # artifact kind
     kind: typing.Optional[str]
     # name actually maps to key in the DB (_find_artifacts for reference), should we rename it?
     name: typing.Optional[str]
-    tag: typing.Optional[str]
-    labels: typing.Optional[typing.Dict[str, str]]
     iter: typing.Optional[str]
     # TODO support more identifiers like below
     # uid: typing.Optional[str]
-    # key: typing.Optional[str]
-    # path: typing.Optional[str]
     # hash: typing.Optional[str]
 
 

--- a/mlrun/api/schemas/artifact.py
+++ b/mlrun/api/schemas/artifact.py
@@ -15,6 +15,8 @@
 import enum
 import typing
 
+import pydantic
+
 
 class ArtifactCategories(str, enum.Enum):
     model = "model"
@@ -41,6 +43,18 @@ class ArtifactCategories(str, enum.Enum):
                 ],
                 True,
             )
+
+
+class ArtifactObject(pydantic.BaseModel):
+    kind: typing.Optional[str]
+    name: typing.Optional[str]
+    tag: typing.Optional[str]
+    labels: typing.Optional[typing.List[str]]
+    iter: typing.Optional[str]
+    # uid: typing.Optional[str]
+    # key: typing.Optional[str]
+    # path: typing.Optional[str]
+    # hash: typing.Optional[str]
 
 
 class ArtifactsFormat(str, enum.Enum):

--- a/mlrun/api/schemas/artifact.py
+++ b/mlrun/api/schemas/artifact.py
@@ -51,6 +51,7 @@ class ArtifactIdentifier(pydantic.BaseModel):
     # name actually maps to key in the DB (_find_artifacts for reference), should we rename it?
     name: typing.Optional[str]
     iter: typing.Optional[str]
+    uid: typing.Optional[str]
     # TODO support more identifiers like below
     # uid: typing.Optional[str]
     # hash: typing.Optional[str]

--- a/mlrun/api/schemas/artifact.py
+++ b/mlrun/api/schemas/artifact.py
@@ -48,12 +48,10 @@ class ArtifactCategories(str, enum.Enum):
 class ArtifactIdentifier(pydantic.BaseModel):
     # artifact kind
     kind: typing.Optional[str]
-    # name actually maps to key in the DB (_find_artifacts for reference), should we rename it?
-    name: typing.Optional[str]
+    key: typing.Optional[str]
     iter: typing.Optional[str]
     uid: typing.Optional[str]
-    # TODO support more identifiers like below
-    # uid: typing.Optional[str]
+    # TODO support hash once saved as a column in the artifacts table
     # hash: typing.Optional[str]
 
 

--- a/mlrun/api/schemas/tag.py
+++ b/mlrun/api/schemas/tag.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import typing
 
 import pydantic

--- a/mlrun/api/schemas/tag.py
+++ b/mlrun/api/schemas/tag.py
@@ -19,17 +19,14 @@ import pydantic
 from .artifact import ArtifactObject
 
 
-class TagObject(pydantic.BaseModel):
+class Tag(pydantic.BaseModel):
+    name: str
+    project: str
+
+
+class TagObjects(pydantic.BaseModel):
     """Tag object"""
 
     kind: str
     # TODO: Add more types to the list for new supported tagged objects
     identifiers: typing.List[typing.Union[ArtifactObject]]
-
-
-class TagsObjects(pydantic.BaseModel):
-    """
-    Tags objects list
-    """
-
-    objects: typing.List[TagObject]

--- a/mlrun/api/schemas/tag.py
+++ b/mlrun/api/schemas/tag.py
@@ -1,0 +1,43 @@
+import typing
+
+import pydantic
+
+from .artifact import ArtifactObject
+
+
+class TagObject(pydantic.BaseModel):
+    """Tag object"""
+
+    kind: str
+    identifiers: typing.List[typing.Union[ArtifactObject]]
+
+
+class TagsObjects(pydantic.BaseModel):
+    """
+    Tags objects list
+    """
+
+    objects: typing.List[TagObject]
+
+
+"""
+{
+  "objects": [
+        {
+          "kind": artifact,
+          "identifiers": [
+                {
+                  "id": "123",
+                },
+                {
+                  "path": "path",
+                  "tag": "tag",
+                },
+                {
+                  "key": "key",
+                }
+           ],
+        }
+    ]
+}
+"""

--- a/mlrun/api/schemas/tag.py
+++ b/mlrun/api/schemas/tag.py
@@ -23,6 +23,7 @@ class TagObject(pydantic.BaseModel):
     """Tag object"""
 
     kind: str
+    # TODO: Add more types to the list for new supported tagged objects
     identifiers: typing.List[typing.Union[ArtifactObject]]
 
 
@@ -32,26 +33,3 @@ class TagsObjects(pydantic.BaseModel):
     """
 
     objects: typing.List[TagObject]
-
-
-"""
-{
-  "objects": [
-        {
-          "kind": artifact,
-          "identifiers": [
-                {
-                  "id": "123",
-                },
-                {
-                  "path": "path",
-                  "tag": "tag",
-                },
-                {
-                  "key": "key",
-                }
-           ],
-        }
-    ]
-}
-"""

--- a/mlrun/api/schemas/tag.py
+++ b/mlrun/api/schemas/tag.py
@@ -16,7 +16,7 @@ import typing
 
 import pydantic
 
-from .artifact import ArtifactObject
+from .artifact import ArtifactIdentifier
 
 
 class Tag(pydantic.BaseModel):
@@ -29,4 +29,4 @@ class TagObjects(pydantic.BaseModel):
 
     kind: str
     # TODO: Add more types to the list for new supported tagged objects
-    identifiers: typing.List[typing.Union[ArtifactObject]]
+    identifiers: typing.List[typing.Union[ArtifactIdentifier]]

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1067,15 +1067,16 @@ def is_legacy_artifact(artifact):
 
 
 def get_in_artifact(artifact, key, default=None):
+    """ artifact can be dict or Artifact object """
     if is_legacy_artifact(artifact):
-        return artifact.get(key, default)
+        return getattr(artifact, key, default)
     else:
         if hasattr(artifact.metadata, key):
-            return artifact.metadata.key or default
+            return getattr(artifact.metadata, key, default)
         if hasattr(artifact.spec, key):
-            return artifact.spec.key or default
+            return getattr(artifact.spec, key, default)
         if hasattr(artifact.status, key):
-            return artifact.status.key or default
+            return getattr(artifact.status, key, default)
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"invalid artifact couldn't get key {key} in {artifact}"
         )

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1067,7 +1067,7 @@ def is_legacy_artifact(artifact):
 
 
 def get_in_artifact(artifact, key, default=None):
-    """ artifact can be dict or Artifact object """
+    """artifact can be dict or Artifact object"""
     if is_legacy_artifact(artifact):
         return getattr(artifact, key, default)
     else:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1070,18 +1070,12 @@ def get_in_artifact(artifact, key, default=None):
     if is_legacy_artifact(artifact):
         return artifact.get(key, default)
     else:
-        try:
-            return artifact.metadata.get(key, default)
-        except AttributeError:
-            pass
-        try:
-            return artifact.spec.get(key, default)
-        except AttributeError:
-            pass
-        try:
-            return artifact.status.get(key, default)
-        except AttributeError:
-            pass
+        if hasattr(artifact.metadata, key):
+            return artifact.metadata.key or default
+        if hasattr(artifact.spec, key):
+            return artifact.spec.key or default
+        if hasattr(artifact.status, key):
+            return artifact.status.key or default
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"invalid artifact couldn't get key {key} in {artifact}"
         )

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1318,6 +1318,27 @@ def is_legacy_artifact(artifact):
         return not hasattr(artifact, "metadata")
 
 
+def get_in_artifact(artifact, key, default=None):
+    if is_legacy_artifact(artifact):
+        return artifact.get(key, default)
+    else:
+        try:
+            return artifact.metadata.get(key, default)
+        except AttributeError:
+            pass
+        try:
+            return artifact.spec.get(key, default)
+        except AttributeError:
+            pass
+        try:
+            return artifact.status.get(key, default)
+        except AttributeError:
+            pass
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"invalid artifact couldn't get key {key} in {artifact}"
+        )
+
+
 def set_paths(pythonpath=""):
     """update the sys path"""
     if not pythonpath:

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 import mlrun.api.schemas
 
 PROJECT = "prj"
-KEY = "some-key"
+KEY = "some-key/with-slash"
 UID = "some-uid"
 TAG = "some-tag"
 LEGACY_API_PROJECTS_PATH = "projects"

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -1,0 +1,83 @@
+import http
+import uuid
+
+import fastapi.testclient
+import sqlalchemy.orm
+
+import mlrun.api.schemas
+
+API_ARTIFACTS_PATH = "projects/{project}/artifacts"
+API_TAGS_PATH = "/projects/{project}/tags/{tag}"
+STORE_API_ARTIFACTS_PATH = API_ARTIFACTS_PATH + "/" + "{uid}/{key}?tag={tag}"
+
+
+class TestTags:
+    project = "test-project"
+
+    def test_overwrite_tags(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+        self._store_artifact(client, tag="tag1")
+        self._store_artifact(client, tag="tag1")
+
+        resp = client.get(API_ARTIFACTS_PATH.format(project=self.project))
+        assert resp.status_code == http.HTTPStatus.OK.value
+        assert len(resp.json()["artifacts"]) == 2
+        self._assert_tag(resp.json()["artifacts"], "tag1")
+
+        # resp = client.post(API_TAGS_PATH.format(project=self.project, tag="tag2"), json={
+        #     "objects": [
+        #         {
+        #             "kind": "artifact",
+        #             "identifiers": [
+        #                 {
+        #                     "tag": "tag1",
+        #                 }
+        #             ],
+        #         }
+        #     ]
+        # })
+        #
+
+    @staticmethod
+    def _assert_tag(artifacts, expected_tag):
+        for artifact in artifacts:
+            artifact_tag = mlrun.utils.get_in_artifact(artifact, "tag")
+            assert artifact_tag == expected_tag
+
+    def _create_project(
+        self, client: fastapi.testclient.TestClient, project_name: str = None
+    ):
+        project = mlrun.api.schemas.Project(
+            metadata=mlrun.api.schemas.ProjectMetadata(
+                name=project_name or self.project
+            ),
+            spec=mlrun.api.schemas.ProjectSpec(
+                description="banana", source="source", goals="some goals"
+            ),
+        )
+        resp = client.post("/projects", json=project.dict())
+        assert resp.status_code == http.HTTPStatus.CREATED.value
+        return resp
+
+    def _store_artifact(
+        self,
+        client: fastapi.testclient.TestClient,
+        project: str = None,
+        uid: str = None,
+        key: str = None,
+        tag: str = "tag1",
+        data: str = "{}",
+    ):
+        uid = uid or str(uuid.uuid4())
+        key = key or str(uuid.uuid4())
+
+        resp = client.post(
+            STORE_API_ARTIFACTS_PATH.format(
+                project=project or self.project, uid=uid, key=key, tag=tag
+            ),
+            data=data,
+        )
+        assert resp.status_code == http.HTTPStatus.OK.value
+        return resp

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -28,7 +28,7 @@ API_TAGS_PATH = "projects/{project}/tags/{tag}"
 STORE_API_ARTIFACTS_PATH = API_ARTIFACTS_PATH + "/" + "{uid}/{key}?tag={tag}"
 
 
-class TestTags:
+class TestArtifactTags:
     project = "test-project"
 
     def test_overwrite_artifact_tags_by_tag_identifier(
@@ -193,6 +193,183 @@ class TestTags:
 
         response_body = self._list_artifacts_and_assert(
             client, tag=overwrite_tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+    def test_append_artifact_tags_by_labels_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        new_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.put(
+            API_TAGS_PATH.format(project=self.project, tag=new_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "labels": {"artifact_name": "artifact1"},
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=new_tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact1_name
+
+    def test_append_artifact_tags_by_tag_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        new_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.put(
+            API_TAGS_PATH.format(project=self.project, tag=new_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "tag": tag,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=new_tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+    def test_append_artifact_tags_by_name_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        new_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.put(
+            API_TAGS_PATH.format(project=self.project, tag=new_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=new_tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact1_name
+
+    def test_append_artifact_tags_by_multiple_name_identifiers(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        new_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.put(
+            API_TAGS_PATH.format(project=self.project, tag=new_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                            {
+                                "name": artifact2_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=new_tag, expected_number_of_artifacts=2
         )
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -14,6 +14,7 @@
 #
 import http
 import json
+import typing
 import uuid
 
 import fastapi.testclient
@@ -31,7 +32,7 @@ STORE_API_ARTIFACTS_PATH = API_ARTIFACTS_PATH + "/" + "{uid}/{key}?tag={tag}"
 class TestArtifactTags:
     project = "test-project"
 
-    def test_overwrite_artifact_tags_by_name_identifier(
+    def test_overwrite_artifact_tags_by_key_identifier(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
@@ -46,16 +47,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                ],
-            },
+        response = self._overwrite_artifact_tags(
+            client=client,
+            tag=overwrite_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -84,16 +81,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "uid": artifact1_uid,
-                    },
-                ],
-            },
+        response = self._overwrite_artifact_tags(
+            client=client,
+            tag=overwrite_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(uid=artifact1_uid),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -122,19 +115,13 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "uid": artifact1_uid,
-                    },
-                    {
-                        "uid": artifact2_uid,
-                    },
-                ],
-            },
+        response = self._overwrite_artifact_tags(
+            client=client,
+            tag=overwrite_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(uid=artifact1_uid),
+                mlrun.api.schemas.ArtifactIdentifier(uid=artifact2_uid),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -146,7 +133,7 @@ class TestArtifactTags:
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]
 
-    def test_overwrite_artifact_tags_by_multiple_name_identifiers(
+    def test_overwrite_artifact_tags_by_multiple_key_identifiers(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
@@ -161,19 +148,13 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                    {
-                        "name": artifact2_key,
-                    },
-                ],
-            },
+        response = self._overwrite_artifact_tags(
+            client=client,
+            tag=overwrite_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact2_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -185,7 +166,7 @@ class TestArtifactTags:
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]
 
-    def test_append_artifact_tags_by_name_identifier(
+    def test_append_artifact_tags_by_key_identifier(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
@@ -200,16 +181,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                ],
-            },
+        response = self._append_artifact_tag(
+            client=client,
+            tag=new_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -239,16 +216,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "uid": artifact1_uid,
-                    },
-                ],
-            },
+        response = self._append_artifact_tag(
+            client=client,
+            tag=new_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(uid=artifact1_uid),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -263,7 +236,7 @@ class TestArtifactTags:
         )
         assert response_body["artifacts"][0]["name"] == artifact1_name
 
-    def test_append_artifact_tags_by_multiple_name_identifiers(
+    def test_append_artifact_tags_by_multiple_key_identifiers(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
@@ -278,19 +251,13 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                    {
-                        "name": artifact2_key,
-                    },
-                ],
-            },
+        response = self._append_artifact_tag(
+            client=client,
+            tag=new_tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact2_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -320,16 +287,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                ],
-            },
+        response = self._append_artifact_tag(
+            client=client,
+            tag=tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.OK.value
 
@@ -339,7 +302,7 @@ class TestArtifactTags:
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]
 
-    def test_delete_artifact_tag_by_name_identifier(
+    def test_delete_artifact_tag_by_key_identifier(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
@@ -353,16 +316,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.delete(
-            API_TAGS_PATH.format(project=self.project, tag=tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                ],
-            },
+        response = self._delete_artifact_tag(
+            client=client,
+            tag=tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
@@ -384,16 +343,12 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.delete(
-            API_TAGS_PATH.format(project=self.project, tag=tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "uid": artifact1_uid,
-                    },
-                ],
-            },
+        response = self._delete_artifact_tag(
+            client=client,
+            tag=tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(uid=artifact1_uid),
+            ],
         )
         assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
@@ -402,7 +357,7 @@ class TestArtifactTags:
         )
         assert response_body["artifacts"][0]["name"] == artifact2_name
 
-    def test_delete_artifact_tag_by_multiple_name_identifiers(
+    def test_delete_artifact_tag_by_multiple_key_identifiers(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
@@ -416,19 +371,13 @@ class TestArtifactTags:
             client, tag=tag
         )
 
-        response = client.delete(
-            API_TAGS_PATH.format(project=self.project, tag=tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                    {
-                        "name": artifact2_key,
-                    },
-                ],
-            },
+        response = self._delete_artifact_tag(
+            client=client,
+            tag=tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact2_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
@@ -450,23 +399,77 @@ class TestArtifactTags:
 
         self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
 
-        response = client.delete(
-            API_TAGS_PATH.format(project=self.project, tag=tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                    },
-                    {
-                        "name": artifact2_key,
-                    },
-                ],
-            },
+        response = self._delete_artifact_tag(
+            client=client,
+            tag=tag,
+            identifiers=[
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact1_key),
+                mlrun.api.schemas.ArtifactIdentifier(key=artifact2_key),
+            ],
         )
         assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
         self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
+
+    def _delete_artifact_tag(
+        self,
+        client,
+        tag: str,
+        identifiers: typing.List[
+            typing.Union[typing.Dict, mlrun.api.schemas.ArtifactIdentifier]
+        ],
+        project: str = None,
+    ):
+        return client.delete(
+            API_TAGS_PATH.format(project=project or self.project, tag=tag),
+            json=self._generate_tag_identifiers_json(identifiers=identifiers),
+        )
+
+    def _append_artifact_tag(
+        self,
+        client,
+        tag: str,
+        identifiers: typing.List[
+            typing.Union[typing.Dict, mlrun.api.schemas.ArtifactIdentifier]
+        ],
+        project: str = None,
+    ):
+        return client.put(
+            API_TAGS_PATH.format(project=project or self.project, tag=tag),
+            json=self._generate_tag_identifiers_json(identifiers=identifiers),
+        )
+
+    def _overwrite_artifact_tags(
+        self,
+        client,
+        tag: str,
+        identifiers: typing.List[
+            typing.Union[typing.Dict, mlrun.api.schemas.ArtifactIdentifier]
+        ],
+        project: str = None,
+    ):
+        return client.post(
+            API_TAGS_PATH.format(project=project or self.project, tag=tag),
+            json=self._generate_tag_identifiers_json(identifiers=identifiers),
+        )
+
+    @staticmethod
+    def _generate_tag_identifiers_json(
+        identifiers: typing.List[
+            typing.Union[typing.Dict, mlrun.api.schemas.ArtifactIdentifier]
+        ],
+    ):
+        return {
+            "kind": "artifact",
+            "identifiers": [
+                (
+                    identifier.dict()
+                    if isinstance(identifier, mlrun.api.schemas.ArtifactIdentifier)
+                    else identifier
+                )
+                for identifier in identifiers
+            ],
+        }
 
     def _list_artifacts_and_assert(
         self,

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import http
+import json
 import uuid
 
 import fastapi.testclient
@@ -30,23 +31,24 @@ STORE_API_ARTIFACTS_PATH = API_ARTIFACTS_PATH + "/" + "{uid}/{key}?tag={tag}"
 class TestTags:
     project = "test-project"
 
-    def test_overwrite_tags(
+    def test_overwrite_artifact_tags_by_tag_identifier(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
         self._create_project(client)
+
         tag = "tag1"
-        self._store_artifact(client, tag=tag)
-        self._store_artifact(client, tag=tag)
-
-        resp = client.get(
-            API_ARTIFACTS_PATH_WITH_TAG.format(project=self.project, tag=tag)
-        )
-        assert resp.status_code == http.HTTPStatus.OK.value
-        assert len(resp.json()["artifacts"]) == 2
-        self._assert_tag(resp.json()["artifacts"], tag)
-
         overwrite_tag = "tag2"
-        resp = client.post(
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=2)
+
+        response = client.post(
             API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
             json={
                 "objects": [
@@ -61,20 +63,155 @@ class TestTags:
                 ]
             },
         )
-        assert resp.status_code == http.HTTPStatus.OK.value
+        assert response.status_code == http.HTTPStatus.OK.value
 
-        resp = client.get(
-            API_ARTIFACTS_PATH_WITH_TAG.format(project=self.project, tag=tag)
+        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
+        self._list_artifacts_and_assert(
+            client, tag=overwrite_tag, expected_number_of_artifacts=2
         )
-        assert resp.status_code == http.HTTPStatus.OK.value
-        assert len(resp.json()["artifacts"]) == 0
 
-        resp = client.get(
-            API_ARTIFACTS_PATH_WITH_TAG.format(project=self.project, tag=overwrite_tag)
+    def test_overwrite_artifact_tags_by_labels_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        overwrite_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
         )
-        assert resp.status_code == http.HTTPStatus.OK.value
-        assert len(resp.json()["artifacts"]) == 2
-        self._assert_tag(resp.json()["artifacts"], overwrite_tag)
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.post(
+            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "labels": {"artifact_name": "artifact1"},
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact2_name
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=overwrite_tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact1_name
+
+    def test_overwrite_artifact_tags_by_name_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        overwrite_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.post(
+            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact2_name
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=overwrite_tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact1_name
+
+    def test_overwrite_artifact_tags_by_multiple_name_identifiers(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        overwrite_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.post(
+            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                            {
+                                "name": artifact2_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=overwrite_tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+    def _list_artifacts_and_assert(
+        self,
+        client,
+        tag: str,
+        expected_number_of_artifacts: int,
+        expected_status_code: http.HTTPStatus = http.HTTPStatus.OK,
+        assert_tag: bool = False,
+    ):
+        response = self._list_artifacts(client, tag=tag)
+        response_body = response.json()
+        assert response.status_code == expected_status_code
+        assert len(response_body["artifacts"]) == expected_number_of_artifacts
+        if assert_tag and expected_number_of_artifacts > 0:
+            self._assert_tag(artifacts=response_body["artifacts"], expected_tag=tag)
+        return response_body
 
     @staticmethod
     def _assert_tag(artifacts, expected_tag):
@@ -93,27 +230,49 @@ class TestTags:
                 description="banana", source="source", goals="some goals"
             ),
         )
-        resp = client.post(API_PROJECTS_PATH, json=project.dict())
-        assert resp.status_code == http.HTTPStatus.CREATED.value
-        return resp
+        response = client.post(API_PROJECTS_PATH, json=project.dict())
+        assert response.status_code == http.HTTPStatus.CREATED.value
+        return response
+
+    def _list_artifacts(self, client, project: str = None, tag: str = None):
+        project = project or self.project
+        if tag:
+            return client.get(
+                API_ARTIFACTS_PATH_WITH_TAG.format(project=project, tag=tag)
+            )
+        return client.get(API_ARTIFACTS_PATH.format(project=project))
 
     def _store_artifact(
         self,
         client: fastapi.testclient.TestClient,
+        name: str = None,
         project: str = None,
         uid: str = None,
         key: str = None,
         tag: str = None,
-        data: str = "{}",
+        data: dict = None,
+        labels: dict = None,
+        kind: str = "artifact",
     ):
         uid = uid or str(uuid.uuid4())
         key = key or str(uuid.uuid4())
+        name = name or str(uuid.uuid4())
 
-        resp = client.post(
+        if not data:
+            data = {
+                "metadata": {"name": name},
+                "spec": {"src_path": "/some/path"},
+                "kind": kind,
+                "status": {"bla": "blabla"},
+            }
+        if labels:
+            data["metadata"]["labels"] = labels
+
+        response = client.post(
             STORE_API_ARTIFACTS_PATH.format(
                 project=project or self.project, uid=uid, key=key, tag=tag
             ),
-            data=data,
+            data=json.dumps(data),
         )
-        assert resp.status_code == http.HTTPStatus.OK.value
-        return resp
+        assert response.status_code == http.HTTPStatus.OK.value
+        return response, project, name, uid, key, tag, data

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -374,6 +374,216 @@ class TestArtifactTags:
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]
 
+    def test_append_artifact_existing_tag(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.put(
+            API_TAGS_PATH.format(project=self.project, tag=tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+    def test_delete_artifact_tag_by_tag_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        new_tag = "tag2"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.put(
+            API_TAGS_PATH.format(project=self.project, tag=new_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "tag": tag,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        self._list_artifacts_and_assert(
+            client, tag=new_tag, expected_number_of_artifacts=2
+        )
+
+        response = client.delete(
+            API_TAGS_PATH.format(project=self.project, tag=new_tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "tag": tag,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=2
+        )
+        for artifact in response_body["artifacts"]:
+            assert artifact["name"] in [artifact1_name, artifact2_name]
+
+        self._list_artifacts_and_assert(
+            client, tag=new_tag, expected_number_of_artifacts=0
+        )
+
+    def test_delete_artifact_tag_by_name_identifier(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.delete(
+            API_TAGS_PATH.format(project=self.project, tag=tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        response_body = self._list_artifacts_and_assert(
+            client, tag=tag, expected_number_of_artifacts=1
+        )
+        assert response_body["artifacts"][0]["name"] == artifact2_name
+
+    def test_delete_artifact_tag_by_multiple_name_identifiers(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, tag=tag, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client, tag=tag
+        )
+
+        response = client.delete(
+            API_TAGS_PATH.format(project=self.project, tag=tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                            {
+                                "name": artifact2_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
+
+    def test_delete_artifact_tag_but_artifact_has_no_tag(
+        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    ):
+        self._create_project(client)
+
+        tag = "tag1"
+        artifact1_labels = {"artifact_name": "artifact1"}
+        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
+            client, labels=artifact1_labels
+        )
+        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
+            client
+        )
+
+        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
+
+        response = client.delete(
+            API_TAGS_PATH.format(project=self.project, tag=tag),
+            json={
+                "objects": [
+                    {
+                        "kind": "artifact",
+                        "identifiers": [
+                            {
+                                "name": artifact1_key,
+                            },
+                            {
+                                "name": artifact2_key,
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+
+        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
+
     def _list_artifacts_and_assert(
         self,
         client,

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -31,79 +31,6 @@ STORE_API_ARTIFACTS_PATH = API_ARTIFACTS_PATH + "/" + "{uid}/{key}?tag={tag}"
 class TestArtifactTags:
     project = "test-project"
 
-    def test_overwrite_artifact_tags_by_tag_identifier(
-        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-    ):
-        self._create_project(client)
-
-        tag = "tag1"
-        overwrite_tag = "tag2"
-        artifact1_labels = {"artifact_name": "artifact1"}
-        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
-            client, tag=tag, labels=artifact1_labels
-        )
-        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
-            client, tag=tag
-        )
-
-        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=2)
-
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "tag": tag,
-                    }
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.OK.value
-
-        self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
-        self._list_artifacts_and_assert(
-            client, tag=overwrite_tag, expected_number_of_artifacts=2
-        )
-
-    def test_overwrite_artifact_tags_by_labels_identifier(
-        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-    ):
-        self._create_project(client)
-
-        tag = "tag1"
-        overwrite_tag = "tag2"
-        artifact1_labels = {"artifact_name": "artifact1"}
-        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
-            client, tag=tag, labels=artifact1_labels
-        )
-        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
-            client, tag=tag
-        )
-
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "labels": {"artifact_name": "artifact1"},
-                    },
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.OK.value
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=tag, expected_number_of_artifacts=1
-        )
-        assert response_body["artifacts"][0]["name"] == artifact2_name
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=overwrite_tag, expected_number_of_artifacts=1
-        )
-        assert response_body["artifacts"][0]["name"] == artifact1_name
-
     def test_overwrite_artifact_tags_by_name_identifier(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
@@ -142,45 +69,6 @@ class TestArtifactTags:
         )
         assert response_body["artifacts"][0]["name"] == artifact1_name
 
-    def test_overwrite_artifact_tags_by_identifier_with_multiple_params(
-        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-    ):
-        self._create_project(client)
-
-        tag = "tag1"
-        overwrite_tag = "tag2"
-        artifact1_labels = {"artifact_name": "artifact1"}
-        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
-            client, tag=tag, labels=artifact1_labels
-        )
-        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
-            client, tag=tag
-        )
-        # expected not to overwrite any artifact because there is no artifact with those labels and artifact name
-        response = client.post(
-            API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "name": artifact1_key,
-                        "tag": overwrite_tag,
-                    },
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.OK.value
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=tag, expected_number_of_artifacts=2
-        )
-        for artifact in response_body["artifacts"]:
-            assert artifact["name"] in [artifact1_name, artifact2_name]
-
-        self._list_artifacts_and_assert(
-            client, tag=overwrite_tag, expected_number_of_artifacts=0
-        )
-
     def test_overwrite_artifact_tags_by_multiple_name_identifiers(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
     ):
@@ -216,85 +104,6 @@ class TestArtifactTags:
 
         response_body = self._list_artifacts_and_assert(
             client, tag=overwrite_tag, expected_number_of_artifacts=2
-        )
-        for artifact in response_body["artifacts"]:
-            assert artifact["name"] in [artifact1_name, artifact2_name]
-
-    def test_append_artifact_tags_by_labels_identifier(
-        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-    ):
-        self._create_project(client)
-
-        tag = "tag1"
-        new_tag = "tag2"
-        artifact1_labels = {"artifact_name": "artifact1"}
-        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
-            client, tag=tag, labels=artifact1_labels
-        )
-        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
-            client, tag=tag
-        )
-
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "labels": {"artifact_name": "artifact1"},
-                    },
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.OK.value
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=tag, expected_number_of_artifacts=2
-        )
-        for artifact in response_body["artifacts"]:
-            assert artifact["name"] in [artifact1_name, artifact2_name]
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=new_tag, expected_number_of_artifacts=1
-        )
-        assert response_body["artifacts"][0]["name"] == artifact1_name
-
-    def test_append_artifact_tags_by_tag_identifier(
-        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-    ):
-        self._create_project(client)
-
-        tag = "tag1"
-        new_tag = "tag2"
-        artifact1_labels = {"artifact_name": "artifact1"}
-        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
-            client, tag=tag, labels=artifact1_labels
-        )
-        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
-            client, tag=tag
-        )
-
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "tag": tag,
-                    },
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.OK.value
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=tag, expected_number_of_artifacts=2
-        )
-        for artifact in response_body["artifacts"]:
-            assert artifact["name"] in [artifact1_name, artifact2_name]
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=new_tag, expected_number_of_artifacts=2
         )
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]
@@ -413,61 +222,6 @@ class TestArtifactTags:
         )
         for artifact in response_body["artifacts"]:
             assert artifact["name"] in [artifact1_name, artifact2_name]
-
-    def test_delete_artifact_tag_by_tag_identifier(
-        self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-    ):
-        self._create_project(client)
-
-        tag = "tag1"
-        new_tag = "tag2"
-        artifact1_labels = {"artifact_name": "artifact1"}
-        _, _, artifact1_name, artifact1_uid, artifact1_key, _, _ = self._store_artifact(
-            client, tag=tag, labels=artifact1_labels
-        )
-        _, _, artifact2_name, artifact2_uid, artifact2_key, _, _ = self._store_artifact(
-            client, tag=tag
-        )
-
-        response = client.put(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "tag": tag,
-                    },
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.OK.value
-
-        self._list_artifacts_and_assert(
-            client, tag=new_tag, expected_number_of_artifacts=2
-        )
-
-        response = client.delete(
-            API_TAGS_PATH.format(project=self.project, tag=new_tag),
-            json={
-                "kind": "artifact",
-                "identifiers": [
-                    {
-                        "tag": tag,
-                    },
-                ],
-            },
-        )
-        assert response.status_code == http.HTTPStatus.NO_CONTENT.value
-
-        response_body = self._list_artifacts_and_assert(
-            client, tag=tag, expected_number_of_artifacts=2
-        )
-        for artifact in response_body["artifacts"]:
-            assert artifact["name"] in [artifact1_name, artifact2_name]
-
-        self._list_artifacts_and_assert(
-            client, tag=new_tag, expected_number_of_artifacts=0
-        )
 
     def test_delete_artifact_tag_by_name_identifier(
         self, db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import http
 import uuid
 

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -51,16 +51,12 @@ class TestArtifactTags:
         response = client.post(
             API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "tag": tag,
-                            }
-                        ],
+                        "tag": tag,
                     }
-                ]
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -88,16 +84,12 @@ class TestArtifactTags:
         response = client.post(
             API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "labels": {"artifact_name": "artifact1"},
-                            },
-                        ],
-                    }
-                ]
+                        "labels": {"artifact_name": "artifact1"},
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -130,16 +122,12 @@ class TestArtifactTags:
         response = client.post(
             API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -172,17 +160,13 @@ class TestArtifactTags:
         response = client.post(
             API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                                "tag": overwrite_tag,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                        "tag": overwrite_tag,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -215,19 +199,15 @@ class TestArtifactTags:
         response = client.post(
             API_TAGS_PATH.format(project=self.project, tag=overwrite_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                            {
-                                "name": artifact2_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                    {
+                        "name": artifact2_key,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -258,16 +238,12 @@ class TestArtifactTags:
         response = client.put(
             API_TAGS_PATH.format(project=self.project, tag=new_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "labels": {"artifact_name": "artifact1"},
-                            },
-                        ],
-                    }
-                ]
+                        "labels": {"artifact_name": "artifact1"},
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -301,16 +277,12 @@ class TestArtifactTags:
         response = client.put(
             API_TAGS_PATH.format(project=self.project, tag=new_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "tag": tag,
-                            },
-                        ],
-                    }
-                ]
+                        "tag": tag,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -345,16 +317,12 @@ class TestArtifactTags:
         response = client.put(
             API_TAGS_PATH.format(project=self.project, tag=new_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -388,19 +356,15 @@ class TestArtifactTags:
         response = client.put(
             API_TAGS_PATH.format(project=self.project, tag=new_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                            {
-                                "name": artifact2_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                    {
+                        "name": artifact2_key,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -434,16 +398,12 @@ class TestArtifactTags:
         response = client.put(
             API_TAGS_PATH.format(project=self.project, tag=tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -472,16 +432,12 @@ class TestArtifactTags:
         response = client.put(
             API_TAGS_PATH.format(project=self.project, tag=new_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "tag": tag,
-                            },
-                        ],
-                    }
-                ]
+                        "tag": tag,
+                    },
+                ],
             },
         )
         assert response.status_code == http.HTTPStatus.OK.value
@@ -493,19 +449,15 @@ class TestArtifactTags:
         response = client.delete(
             API_TAGS_PATH.format(project=self.project, tag=new_tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "tag": tag,
-                            },
-                        ],
-                    }
-                ]
+                        "tag": tag,
+                    },
+                ],
             },
         )
-        assert response.status_code == http.HTTPStatus.OK.value
+        assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
         response_body = self._list_artifacts_and_assert(
             client, tag=tag, expected_number_of_artifacts=2
@@ -534,19 +486,15 @@ class TestArtifactTags:
         response = client.delete(
             API_TAGS_PATH.format(project=self.project, tag=tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                ],
             },
         )
-        assert response.status_code == http.HTTPStatus.OK.value
+        assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
         response_body = self._list_artifacts_and_assert(
             client, tag=tag, expected_number_of_artifacts=1
@@ -570,22 +518,18 @@ class TestArtifactTags:
         response = client.delete(
             API_TAGS_PATH.format(project=self.project, tag=tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                            {
-                                "name": artifact2_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                    {
+                        "name": artifact2_key,
+                    },
+                ],
             },
         )
-        assert response.status_code == http.HTTPStatus.OK.value
+        assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
         self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
 
@@ -608,22 +552,18 @@ class TestArtifactTags:
         response = client.delete(
             API_TAGS_PATH.format(project=self.project, tag=tag),
             json={
-                "objects": [
+                "kind": "artifact",
+                "identifiers": [
                     {
-                        "kind": "artifact",
-                        "identifiers": [
-                            {
-                                "name": artifact1_key,
-                            },
-                            {
-                                "name": artifact2_key,
-                            },
-                        ],
-                    }
-                ]
+                        "name": artifact1_key,
+                    },
+                    {
+                        "name": artifact2_key,
+                    },
+                ],
             },
         )
-        assert response.status_code == http.HTTPStatus.OK.value
+        assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
         self._list_artifacts_and_assert(client, tag=tag, expected_number_of_artifacts=0)
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2579

Added the following endpoints: 
```
# the tag is the tag you want to apply the method on
( POST / PUT / DELETE ) - /projects/{project}/tags/{tag} 
```
Those endpoints expects the following body: 
```
{
    "kind": <artifact>,
    "identifiers": [
       {"name": "artifact-name", "iter": "1"},
       {"uid": "adasdads123n1lk23l"},
    ],
} 
```

**Currently those endpoints support only artifact tagging, but in the future those endpoints will serve all objects which can be tagged**
Each element in the identifiers list is treated separately, meaning inside an identifier element we are aggregating all together, but each identifier element is queried separately (OR). 

