### PR TITLE
[Artifacts] Fix `del_artifact` to properly support providing a tag

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -592,12 +592,10 @@ class SQLDB(DBInterface):
         if tag:
             query = query.join(Artifact.Tag).filter(Artifact.Tag.name == tag)
 
-        objects_deleted = False
-        for artifact in query:
-            objects_deleted = True
-            session.delete(artifact)
-
-        if not objects_deleted:
+        # Cannot delete yet, because tag and label deletion queries join with the artifacts table, so the objects
+        # still need to be there.
+        artifacts = query.all()
+        if not artifacts:
             return
 
         # deleting tags and labels, because in sqlite the relationships aren't necessarily cascading
@@ -605,6 +603,8 @@ class SQLDB(DBInterface):
         self._delete_class_labels(
             session, Artifact, project=project, key=key, commit=False
         )
+        for artifact in artifacts:
+            session.delete(artifact)
         session.commit()
 
     def _delete_artifact_tags(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -586,15 +586,12 @@ class SQLDB(DBInterface):
     def del_artifact(self, session, key, tag="", project=""):
         project = project or config.default_project
 
-        query = session.query(Artifact)
-        filters = [Artifact.key == key]
-        if project:
-            filters.append(Artifact.project == project)
+        query = session.query(Artifact).filter(
+            Artifact.key == key, Artifact.project == project
+        )
         if tag:
-            filters.append(Artifact.Tag.name == tag)
-            query = query.join(Artifact.Tag)
+            query = query.join(Artifact.Tag).filter(Artifact.Tag.name == tag)
 
-        query = query.filter(*filters)
         objects_deleted = False
         for artifact in query:
             objects_deleted = True


### PR DESCRIPTION
When trying to delete an artifact and specifying a tag, the code created a query that used a non-existing field `tag` in the `artifacts` table. Fixed it to use the correct SQL query.

Fixes https://jira.iguazeng.com/browse/ML-2638