### PR TITLE
[FeatureStore] Fix Redis server-type config and limit pandas to <1.5.0 (#2418)

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -40,6 +40,7 @@ class ClientSpec(
             nuclio_version=resolve_nuclio_version(),
             spark_operator_version=config.spark_operator_version,
             redis_url=config.redis.url,
+            redis_type=config.redis.type,
             # These don't have a default value, but we don't send them if they are not set to allow the client to know
             # when to use server value and when to use client value (server only if set). Since their default value is
             # empty and not set is also empty we can use the same _get_config_value_if_not_default

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -53,4 +53,5 @@ class ClientSpec(pydantic.BaseModel):
     force_run_local: typing.Optional[str]
     function: typing.Optional[Function]
     redis_url: typing.Optional[str]
+    redis_type: typing.Optional[str]
     ce_mode: typing.Optional[str]

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -106,6 +106,7 @@ default_config = {
     "v3io_api": "http://v3io-webapi:8081",
     "redis": {
         "url": "",
+        "type": "standalone",  # can be "standalone" or "cluster"
     },
     "v3io_framesd": "http://framesd:8080",
     "datastore": {"async_source_mode": "disabled"},

--- a/mlrun/datastore/redis.py
+++ b/mlrun/datastore/redis.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import redis
 import redis.cluster
 from storey.redis_driver import RedisType
@@ -56,10 +54,14 @@ class RedisStore(DataStore):
 
         self._redis = None
 
-        if os.environ.get("MLRUN_REDIS_TYPE") == "cluster":
+        if mlrun.mlconf.redis.type == "standalone":
+            self._redis_type = RedisType.STANDALONE
+        elif mlrun.mlconf.redis.type == "cluster":
             self._redis_type = RedisType.CLUSTER
         else:
-            self._redis_type = RedisType.STANDALONE
+            raise NotImplementedError(
+                f"invalid redis type {mlrun.mlconf.redis.type} - should be one of {'cluster', 'standalone'})"
+            )
 
     @property
     def redis(self):
@@ -135,6 +137,7 @@ class RedisStore(DataStore):
             key = key[len("redis://") :]
 
         if recursive:
+            key += "*" if key.endswith("/") else "/*"
             for key in self.redis.scan_iter(key):
                 self.redis.delete(key)
         else:

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1156,13 +1156,22 @@ class RedisNoSqlTarget(NoSqlBaseTarget):
 
     def get_table_object(self):
         from storey import Table
-        from storey.redis_driver import RedisDriver
+        from storey.redis_driver import RedisDriver, RedisType
 
         endpoint, uri = parse_path(self.get_target_path())
         endpoint = endpoint or mlrun.mlconf.redis.url
+        if mlrun.mlconf.redis.type == "standalone":
+            redis_type = RedisType.STANDALONE
+        elif mlrun.mlconf.redis.type == "cluster":
+            redis_type = RedisType.CLUSTER
+        else:
+            raise NotImplementedError(
+                f"invalid redis type {mlrun.mlconf.redis.type} - should be one of {'cluster', 'standalone'})"
+            )
+
         return Table(
             uri,
-            RedisDriver(redis_url=endpoint, key_prefix="/"),
+            RedisDriver(redis_type=redis_type, redis_url=endpoint, key_prefix="/"),
             flush_interval_secs=mlrun.mlconf.feature_store.flush_interval,
         )
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -301,7 +301,20 @@ class HTTPRunDB(RunDBInterface):
                 config.valid_function_priority_class_names
                 or server_cfg.get("valid_function_priority_class_names")
             )
-            config.redis.url = config.redis.url or server_cfg.get("redis.url")
+            config.artifacts.calculate_hash = (
+                config.artifacts.calculate_hash
+                if config.artifacts.calculate_hash is not None
+                else server_cfg.get("calculate_artifact_hash")
+            )
+            config.artifacts.generate_target_path_from_artifact_hash = (
+                config.artifacts.generate_target_path_from_artifact_hash
+                if config.artifacts.generate_target_path_from_artifact_hash is not None
+                else server_cfg.get("generate_artifact_target_path_from_artifact_hash")
+            )
+
+            config.redis.url = config.redis.url or server_cfg.get("redis_url")
+            # allow client to set the default partial WA for lack of support of per-target auxiliary options
+            config.redis.type = config.redis.type or server_cfg.get("redis_type")
 
             # These have a default value, therefore local config will always have a value, prioritize the
             # API value first

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ ipython~=7.0
 nuclio-jupyter~=0.9.1
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
-pandas~=1.2
+# limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us
+pandas~=1.2, <1.5.0
 # used as a the engine for parquet files by pandas
 pyarrow>=1,<7
 pyyaml~=5.1

--- a/tests/system/datastore/test_redis.py
+++ b/tests/system/datastore/test_redis.py
@@ -110,3 +110,11 @@ class TestRedisDataStore(TestMLRunSystem):
         assert set(expected) == set(
             actual
         ), f"expected != actual,\n actual:{actual}\nexpected:{expected}"
+
+        # clean test objects
+        dir_item.store.rm("/dir-0/", recursive=True)
+        expected = []
+        actual = dir_item.listdir()
+        assert set(expected) == set(
+            actual
+        ), f"expected != actual,\n actual:{actual}\nexpected:{expected}"

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,6 +128,7 @@ def test_requirement_specifiers_convention():
         "pyarrow": {">=1,<7"},
         "nbclassic": {">=0.2.8"},
         "protobuf": {">=3.20.1, !=3.20.2, <4"},
+        "pandas": {"~=1.2, <1.5.0"},
     }
 
     for (


### PR DESCRIPTION
* fix redis.url config-spec sync

* clean test_redis_listdir objects at test end

* set redis-type according to mlrun env-var convention

* address tom's comments

* limit pandas to <1.5.0

* addressing Adam's comment