### PR TITLE
[FeatureStore] Revert addition of config.artifacts [1.1.x]

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -301,16 +301,6 @@ class HTTPRunDB(RunDBInterface):
                 config.valid_function_priority_class_names
                 or server_cfg.get("valid_function_priority_class_names")
             )
-            config.artifacts.calculate_hash = (
-                config.artifacts.calculate_hash
-                if config.artifacts.calculate_hash is not None
-                else server_cfg.get("calculate_artifact_hash")
-            )
-            config.artifacts.generate_target_path_from_artifact_hash = (
-                config.artifacts.generate_target_path_from_artifact_hash
-                if config.artifacts.generate_target_path_from_artifact_hash is not None
-                else server_cfg.get("generate_artifact_target_path_from_artifact_hash")
-            )
 
             config.redis.url = config.redis.url or server_cfg.get("redis_url")
             # allow client to set the default partial WA for lack of support of per-target auxiliary options


### PR DESCRIPTION
[ML-2647](https://jira.iguazeng.com/browse/ML-2647)
Revert 1.1.1 backport merge breakage - remove config.artifacts from httpdb.py connect().