### PR TITLE
[Datastore] Changing code to use `MLRUN_AWS_ROLE_ARN` instead of `AWS_ROLE_ARN` [1.1.x]

### DIFF
--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -88,7 +88,7 @@ authenticate, it is used in several use-cases, such as resolving paths to the ho
   parameters
 * `S3_ENDPOINT_URL` &mdash; the S3 endpoint to use. If not specified, it defaults to AWS. For example, to access 
   a storage bucket in Wasabi storage, use `S3_ENDPOINT_URL = "https://s3.wasabisys.com"`
-* `AWS_ROLE_ARN` &mdash; [IAM role to assume](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html). 
+* `MLRUN_AWS_ROLE_ARN` &mdash; [IAM role to assume](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html). 
   Connect to AWS using the secret key and access key, and assume the role whose ARN is provided. The 
   ARN must be of the format `arn:aws:iam::<account-of-role-to-assume>:role/<name-of-role>`
 * `AWS_PROFILE` &mdash; name of credentials profile from a local AWS credentials file. 

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -34,7 +34,7 @@ class S3Store(DataStore):
         endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
         force_non_anonymous = self._get_secret_or_env("S3_NON_ANONYMOUS")
         profile_name = self._get_secret_or_env("AWS_PROFILE")
-        assume_role_arn = self._get_secret_or_env("AWS_ROLE_ARN")
+        assume_role_arn = self._get_secret_or_env("MLRUN_AWS_ROLE_ARN")
 
         # If user asks to assume a role, this needs to go through the STS client and retrieve temporary creds
         if assume_role_arn:

--- a/tests/integration/aws_s3/test-aws-s3.yml
+++ b/tests/integration/aws_s3/test-aws-s3.yml
@@ -19,5 +19,5 @@ env:
   AWS_ACCESS_KEY_ID:
   AWS_SECRET_ACCESS_KEY:
   # Role ARN to use AssumeRole with, or profile for use with local credentials file
-  AWS_ROLE_ARN:
+  MLRUN_AWS_ROLE_ARN:
   AWS_PROFILE:

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -136,12 +136,12 @@ class TestAwsS3:
         self._perform_aws_s3_tests(secrets=secrets)
 
     @pytest.mark.skipif(
-        not aws_s3_configured(extra_params=["AWS_ROLE_ARN"]),
+        not aws_s3_configured(extra_params=["MLRUN_AWS_ROLE_ARN"]),
         reason="Role ARN not configured",
     )
     def test_using_role_arn(self):
         params = credential_params.copy()
-        params.append("AWS_ROLE_ARN")
+        params.append("MLRUN_AWS_ROLE_ARN")
         for param in params:
             os.environ[param] = config["env"][param]
             os.environ.pop(SecretsStore.k8s_env_variable_name_for_secret(param), None)


### PR DESCRIPTION
Back-porting #2461 to 1.1.x.