### PR TITLE
[Projects] Fix Project Sync Failing Due To `can't compare offset-naive and offset-aware datetimes`

### DIFF
--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 #
 import datetime
-import pytz
 import traceback
 import typing
 
 import humanfriendly
 import mergedeep
+import pytz
 import sqlalchemy.orm
 
 import mlrun.api.crud

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import datetime
+import pytz
 import traceback
 import typing
 
@@ -353,7 +354,7 @@ class Member(
 
                 # sanity and defensive programming - if the leader returned a latest_updated_at that is older
                 # than the epoch, we'll set it to the epoch
-                epoch = datetime.datetime.utcfromtimestamp(0)
+                epoch = pytz.UTC.localize(datetime.datetime.utcfromtimestamp(0))
                 if latest_updated_at < epoch:
                     latest_updated_at = epoch
                 self._synced_until_datetime = latest_updated_at


### PR DESCRIPTION
Localize the epoch time for the defensive programming in the project sync mechanism.

Fixes - https://jira.iguazeng.com/browse/ML-2660
