### PR TITLE
[Requirements] Add Jinja2 explictly

### DIFF
--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -1,9 +1,9 @@
 # In our docker images we're copying the requirements files and pip installing them before copying and installing the
-# whole code. We're doing that to levarage docker build cache so that we won't need to actually install all of the
+# whole code. We're doing that to leverage docker build cache so that we won't need to actually install all the
 # requirements for every change in the code (which causes a cache miss in the copy command for the whole code) but we'll
-# get "requirement is already satisified" which causes the pip install of the mlrun package itself to be very quick.
+# get "requirement is already satisfied" which causes the pip install of the mlrun package itself to be very quick.
 # The extras requirements definition sits in the setup.py itself, therefore without this file these requirements were
-# installed only in the last phase of installing mlrun, which causes this step to be longer and lower the effectivness
+# installed only in the last phase of installing mlrun, which causes this step to be longer and lowers the effectiveness
 # of the above trick. To overcome this we have this file, which is a copy of all the requirements defined in the extras
 # in setup.py so that we'll be able to copy and install this in the layer with all other requirements making the last
 # layer (which is most commonly being re-built) as thin as possible

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,9 @@ kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
 nuclio-jupyter~=0.9.1
+# nuclio-jupyter 0.9.3 requires nbconvert 6.4 which requires Jinja2>=3.0
+# for some reason when installing mlrun on a venv that already had lower version of jinja2 it didn't upgrade it
+# therefore adding it explictly (~=3.1 to match mlrun docs requirements)
 Jinja2~=3.1
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ protobuf>=3.20.1, !=3.20.2, <4
 kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
-nuclio-jupyter~=0.9.1
+git+https://github.com/AlonMaor14/nuclio-jupyter@jijna2
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
 # limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ protobuf>=3.20.1, !=3.20.2, <4
 kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
-git+https://github.com/AlonMaor14/nuclio-jupyter@jijna2
+git+https://github.com/AlonMaor14/nuclio-jupyter@jijna2#egg=nuclio-jupyter
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
 # limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ click~=8.0.0
 # kfp 1.8.13 requires typing-extensions>=3.7.4,<5
 # for some reason when installing mlrun on a venv that already had typing-extensions==3.7.4.3 it didn't upgrade it to
 # >=3.10.0 although it was installing starlette 0.19.1
-# therefore adding it explictly
+# therefore adding it explicitly
 typing-extensions>=3.10.0,<5
 # in some environments for some reason the protobuf installed was 3.20.0 instead of 3.20.1,
 # when installing google-cloud-storage which required >=3.20.1, <5 it was upgrading the protobuf version to the latest
@@ -26,8 +26,8 @@ nest-asyncio~=1.0
 ipython~=7.0
 nuclio-jupyter~=0.9.1
 # nuclio-jupyter 0.9.3 requires nbconvert 6.4 which requires Jinja2>=3.0
-# for some reason when installing mlrun on a venv that already had lower version of jinja2 it didn't upgrade it
-# therefore adding it explictly (~=3.1 to match mlrun docs requirements)
+# for some reason when installing mlrun on a venv that already had a lower version of jinja2 it didn't upgrade it
+# therefore adding it explicitly (~=3.1 to match mlrun docs requirements)
 Jinja2~=3.1
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,8 @@ protobuf>=3.20.1, !=3.20.2, <4
 kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
-git+https://github.com/AlonMaor14/nuclio-jupyter@jijna2#egg=nuclio-jupyter
+nuclio-jupyter~=0.9.1
+Jinja2~=3.1
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
 # limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us


### PR DESCRIPTION
nuclio-jupyter 0.9.3 requires nbconvert 6.4 which requires Jinja2>=3.0 
for some reason when installing mlrun on a venv that already had a lower version of jinja2 it didn't upgrade it 
therefore adding it explicitly (~=3.1 to match mlrun docs requirements)
ticket - https://jira.iguazeng.com/browse/ML-2653

precedent - https://github.com/mlrun/mlrun/pull/2036