### PR TITLE
[Projects] Pass `artifact_path` to the function runner

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -754,6 +754,7 @@ class _RemoteRunner(_PipelineRunner):
                 runspec=runspec,
                 local=False,
                 schedule=workflow_spec.schedule,
+                artifact_path=artifact_path,
             )
             if workflow_spec.schedule:
                 return


### PR DESCRIPTION
Passing `artifact_path` to the runner of `load_and_run` and not just as parameter to the function.