### PR TITLE
[Requirements] Explicitly require importlib-metadata >= 3.6 [1.1.x]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,10 +25,10 @@ kfp~=1.8.0
 nest-asyncio~=1.0
 ipython~=7.0
 nuclio-jupyter~=0.9.1
-# nuclio-jupyter 0.9.3 requires nbconvert 6.4 which requires Jinja2>=3.0
-# for some reason when installing mlrun on a venv that already had a lower version of jinja2 it didn't upgrade it
-# therefore adding it explicitly (~=3.1 to match mlrun docs requirements)
-Jinja2~=3.1
+# nuclio-jupyter 0.9.3 requires nbconvert 6.4.5 which requires importlib_metadata>=3.6
+# when installing mlrun with old version of pip on a venv that already had a lower version of importlib_metadata it didn't upgrade it
+# therefore adding it explicitly
+importlib_metadata>=3.6
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
 # limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -122,13 +122,12 @@ def test_requirement_specifiers_convention():
         "numpy": {">=1.16.5, <1.23.0"},
         "alembic": {"~=1.4,<1.6.0"},
         "boto3": {"~=1.9, <1.17.107"},
-        "azure-core": {"~=1.23"},
-        "azure-storage-blob": {"~=12.13"},
         "dask-ml": {"~=1.4,<1.9.0"},
         "pyarrow": {">=1,<7"},
         "nbclassic": {">=0.2.8"},
         "protobuf": {">=3.20.1, !=3.20.2, <4"},
         "pandas": {"~=1.2, <1.5.0"},
+        "importlib_metadata": {">=3.6"},
     }
 
     for (


### PR DESCRIPTION
backports https://github.com/mlrun/mlrun/pull/2482