### PR TITLE
[DB] Change transaction isolation mode to `READ COMMITED`

### DIFF
--- a/mlrun/api/db/sqldb/session.py
+++ b/mlrun/api/db/sqldb/session.py
@@ -60,7 +60,7 @@ def _init_engine(dsn=None):
         kwargs = {
             "pool_size": pool_size,
             "max_overflow": max_overflow,
-            "isolation_level": config.db.isolation_level,
+            "isolation_level": config.httpdb.db.isolation_level,
         }
     engine = create_engine(dsn, **kwargs)
     _init_session_maker()

--- a/mlrun/api/db/sqldb/session.py
+++ b/mlrun/api/db/sqldb/session.py
@@ -60,6 +60,7 @@ def _init_engine(dsn=None):
         kwargs = {
             "pool_size": pool_size,
             "max_overflow": max_overflow,
+            "isolation_level": config.db.isolation_level,
         }
     engine = create_engine(dsn, **kwargs)
     _init_session_maker()

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -124,7 +124,10 @@ class Member(
                 # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
                 # TODO: remove this commit in (1.4.0), if we feel we're stable with the
                 #  new isolation level(READ COMMITTED)
-                if commit_before_get and mlrun.mlconf.db.isolation_level != "READ COMMITTED":
+                if (
+                    commit_before_get
+                    and mlrun.mlconf.db.isolation_level != "READ COMMITTED"
+                ):
                     db_session.commit()
 
                 created_project = self.get_project(

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -122,7 +122,7 @@ class Member(
                 # for further read: https://docs-sqlalchemy.readthedocs.io/ko/latest/faq/sessions.html
                 # https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
                 # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
-                # TODO: remove this commit in (1.4.0), if we feel we're stable with the
+                # TODO: remove this condition in (1.4.0), if we feel we're stable with the
                 #  new isolation level(READ COMMITTED)
                 if (
                     commit_before_get

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -126,7 +126,7 @@ class Member(
                 #  new isolation level(READ COMMITTED)
                 if (
                     commit_before_get
-                    and mlrun.mlconf.db.isolation_level != "READ COMMITTED"
+                    and mlrun.mlconf.httpdb.db.isolation_level != "READ COMMITTED"
                 ):
                     db_session.commit()
 

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -122,9 +122,9 @@ class Member(
                 # for further read: https://docs-sqlalchemy.readthedocs.io/ko/latest/faq/sessions.html
                 # https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
                 # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
-                # TODO: there are multiple isolation level we can choose, READ COMMITTED seems to solve our issue
-                #  but will require deeper investigation and more test coverage
-                if commit_before_get:
+                # TODO: remove this commit in (1.4.0), if we feel we're stable with the
+                #  new isolation level(READ COMMITTED)
+                if commit_before_get and mlrun.mlconf.db.isolation_level != "READ COMMITTED":
                     db_session.commit()
 
                 created_project = self.get_project(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -238,6 +238,9 @@ default_config = {
             # None will set this to be equal to the httpdb.max_workers
             "connections_pool_size": None,
             "connections_pool_max_overflow": None,
+            # for more options head to
+            # https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
+            "isolation_level": "READ_COMMITTED",
         },
         "jobs": {
             # whether to allow to run local runtimes in the API - configurable to allow the scheduler testing to work

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -240,7 +240,7 @@ default_config = {
             "connections_pool_max_overflow": None,
             # for more options head to
             # https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
-            "isolation_level": "READ_COMMITTED",
+            "isolation_level": "READ COMMITTED",
         },
         "jobs": {
             # whether to allow to run local runtimes in the API - configurable to allow the scheduler testing to work

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,8 @@ from urllib.request import URLError, urlopen
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from mlrun.config import config
+
 tests_root_directory = Path(__file__).absolute().parent
 results = tests_root_directory / "test_results"
 is_ci = "CI" in environ
@@ -127,7 +129,8 @@ def freeze(f, **kwargs):
 
 
 def init_sqldb(dsn):
-    engine = create_engine(dsn)
+    kwargs = {"isolation_level": config.httpdb.db.isolation_level}
+    engine = create_engine(dsn, **kwargs)
     Base.metadata.create_all(bind=engine)
     return sessionmaker(bind=engine)
 


### PR DESCRIPTION
Due to more use cases where we need to query the database multiple times in the same session, which caused as to add `.commit()` after a read query, I've changed the default isolation level to `READ COMMITTED` which allows consistent read, even within the same transaction, sets and reads its own fresh snapshot. 
For more information - https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html