### PR TITLE
[Frameworks] HuggingFace model server

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,4 +18,4 @@ scikit-learn~=1.0
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1
-transformers~=4.21
+transformers~=3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,4 +18,4 @@ scikit-learn~=1.0
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1
-transformers~=3.0
+transformers~=4.21.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,4 +18,4 @@ scikit-learn~=1.0
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1
-transformers~=4.21.0
+transformers~=4.21

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,3 +18,4 @@ scikit-learn~=1.0
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1
+transformers~=4.21

--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -1,4 +1,4 @@
 gnureadline~=8.0
-transformers~=3.0
+transformers~=4.21.0
 xgboost~=1.1
 tensorboard~=2.5

--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -2,4 +2,3 @@ gnureadline~=8.0
 transformers~=3.0
 xgboost~=1.1
 tensorboard~=2.5
-transformers~=4.21

--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -2,3 +2,4 @@ gnureadline~=8.0
 transformers~=3.0
 xgboost~=1.1
 tensorboard~=2.5
+transformers~=4.21

--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -1,4 +1,4 @@
 gnureadline~=8.0
-transformers~=4.21.0
+transformers~=4.21
 xgboost~=1.1
 tensorboard~=2.5

--- a/mlrun/frameworks/huggingface/__init__.py
+++ b/mlrun/frameworks/huggingface/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .model_server import HuggingFaceModelServer

--- a/mlrun/frameworks/huggingface/model_server.py
+++ b/mlrun/frameworks/huggingface/model_server.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib import import_module
-from typing import List
 import json
+from importlib import import_module
+from typing import Any, Dict, List
+
 from transformers import pipeline
-from typing import Any, Dict
 
 import mlrun
 from mlrun.serving.v2_serving import V2ModelServer
@@ -124,6 +124,7 @@ class HuggingFaceModelServer(V2ModelServer):
 
         :param request: The request to the model. The input to the model will be read from the "inputs" key.
 
+        :return: The model's prediction on the given input.
         """
         if self.pipe is None:
             raise ValueError("Please use `.load()`")
@@ -156,4 +157,11 @@ class HuggingFaceModelServer(V2ModelServer):
         return result
 
     def explain(self, request: Dict) -> str:
+        """
+        Return a string explaining what model is being served in this serving function and the function name.
+
+        :param request: A given request.
+
+        :return: Explanation string.
+        """
         return f"The '{self.model_name}' model serving function named '{self.name}"

--- a/mlrun/frameworks/huggingface/model_server.py
+++ b/mlrun/frameworks/huggingface/model_server.py
@@ -1,0 +1,159 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib import import_module
+from typing import List
+import json
+from transformers import pipeline
+from typing import Any, Dict
+
+import mlrun
+from mlrun.serving.v2_serving import V2ModelServer
+
+PACKAGE_MODULE = "transformers"
+
+
+def json_serializable(obj):
+    try:
+        json.dumps(obj=obj)
+        return True
+    except (TypeError, OverflowError):
+        return False
+
+
+class HuggingFaceModelServer(V2ModelServer):
+    """
+    Hugging Face Model serving class, inheriting the V2ModelServer class for being initialized automatically by the
+    model server and be able to run locally as part of a nuclio serverless function, or as part of a real-time pipeline.
+
+    Notice:
+        In order to use this serving class, please ensure that the transformers package is installed.
+    """
+
+    def __init__(
+        self,
+        context: mlrun.MLClientCtx,
+        name: str,
+        task: str,
+        model_path: str = None,
+        model_name: str = None,
+        model_class: str = None,
+        tokenizer_name: str = None,
+        tokenizer_class: str = None,
+        framework: str = None,
+        **class_args,
+    ):
+        """
+        Initialize a serving class for a Hugging face model.
+
+        :param context:         The mlrun context to work with
+        :param name:            The name of this server to be initialized
+        :param model_path:      Not in use. When adding a model pass any string value
+        :param model_name:      The model's name in the Hugging Face hub
+                                e.g., `nlptown/bert-base-multilingual-uncased-sentiment`
+        :param model_class:     The model class type object which can be passed as the class's name (string).
+                                Must be provided and to be matched with `model_name`.
+                                e.g., `AutoModelForSequenceClassification`
+        :param tokenizer_name:  The name of the tokenizer in the Hugging Face hub
+                                e.g., `nlptown/bert-base-multilingual-uncased-sentiment`
+        :param tokenizer_class: The model's class type object which can be passed as the class's name (string).
+                                Must be provided and to be matched with `model_name`.
+                                e.g., `AutoTokenizer`
+        :param framework:       The framework to use, either `"pt"` for PyTorch or `"tf"` for TensorFlow. The specified
+                                framework must be installed.
+                                If no framework is specified, will default to the one currently installed.
+                                If no framework is specified and both frameworks are installed, will default to the
+                                framework of the `model`, or to PyTorch if no model is provided
+        :param class_args:      -
+        """
+        super(HuggingFaceModelServer, self).__init__(
+            context=context,
+            name=name,
+            model_path=model_path,
+            **class_args,
+        )
+        self.task = task
+        self.model = None
+        self.tokenizer = None
+        self.model_name = model_name
+        self.tokenizer_name = tokenizer_name
+        self.model_class = model_class
+        self.tokenizer_class = tokenizer_class
+        self.framework = framework
+        self.pipe = None
+
+    def load(self):
+        """
+        loads the model and the tokenizer and initializes the pipeline based on them.
+        """
+
+        # Loading the pretrained model:
+        if self.model_class:
+            model_object = getattr(import_module(PACKAGE_MODULE), self.model_class)
+            self.model = model_object.from_pretrained(self.model_name)
+
+        # Loading the pretrained tokenizer:
+        if self.tokenizer_class:
+            tokenizer_object = getattr(
+                import_module(PACKAGE_MODULE), self.tokenizer_class
+            )
+            self.tokenizer = tokenizer_object.from_pretrained(self.tokenizer_name)
+
+        # Initializing the pipeline:
+        self.pipe = pipeline(
+            task=self.task,
+            model=self.model or self.model_name,
+            tokenizer=self.tokenizer,
+            framework=self.framework,
+        )
+
+    def predict(self, request: Dict[str, Any]) -> List:
+        """
+        Generate model predictions from sample.
+
+        :param request: The request to the model. The input to the model will be read from the "inputs" key.
+
+        """
+        if self.pipe is None:
+            raise ValueError("Please use `.load()`")
+
+        try:
+            # Predicting:
+            if isinstance(request["inputs"][0], dict):
+                result = [self.pipe(**_input) for _input in request["inputs"]]
+            else:
+                result = self.pipe(request["inputs"])
+
+            # replace list of lists of dicts into a list of dicts:
+            # The result may vary from one model to another.
+            if all(isinstance(res, list) for res in result):
+                result = [res[0] for res in result]
+
+            # Converting JSON non-serializable objects into strings:
+            non_serializable_types = []
+            for res in result:
+                for key, val in res.items():
+                    if not json_serializable(val):
+                        non_serializable_types.append(str(type(val)))
+                        res[key] = str(val)
+            if non_serializable_types:
+                self.context.logger.info(
+                    f"Non-serializable types: {non_serializable_types} were casted to strings"
+                )
+        except Exception as e:
+            raise Exception("Failed to predict %s" % e)
+        return result
+
+    def explain(self, request: Dict) -> str:
+        return f"The '{self.model_name}' model serving function named '{self.name}"

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ setup(
         "mlrun.frameworks._ml_common.loggers",
         "mlrun.frameworks._ml_common.plans",
         "mlrun.frameworks.auto_mlrun",
+        "mlrun.frameworks.huggingface",
         "mlrun.frameworks.lgbm",
         "mlrun.frameworks.lgbm.callbacks",
         "mlrun.frameworks.lgbm.mlrun_interfaces",

--- a/tests/frameworks/huggingface/__init__.py
+++ b/tests/frameworks/huggingface/__init__.py
@@ -1,10 +1,10 @@
-# Copyright 2018 Iguazio
+# Copyright 2019 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,5 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
-from .model_server import HuggingFaceModelServer

--- a/tests/frameworks/huggingface/serving.py
+++ b/tests/frameworks/huggingface/serving.py
@@ -1,0 +1,147 @@
+# Copyright 2019 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Dict
+
+import numpy as np
+import pytest
+
+import mlrun
+
+CLASS_NAME = "mlrun.frameworks.huggingface.HuggingFaceModelServer"
+
+# The PIPELINES list below contains all the NLP tasks that exists in the huggingface framework.
+# Each example is a dictionary that include:
+# - task        = the name of task
+# - example     = input for prediction
+# - result_keys = the keys that need to appear in the prediction.
+
+PIPELINES = [
+    {
+        "task": "sentiment-analysis",
+        "example": "We are very happy to show you the 🤗 Transformers library.",
+        "result_keys": ["label", "score"],
+    },
+    {
+        "task": "text-generation",
+        "example": {
+            "text_inputs": "Hello, I'm a language model",
+            "max_length": 20,
+            "num_return_sequences": 1,
+        },
+        "result_keys": ["generated_text"],
+    },
+    {
+        "task": "ner",
+        "example": "My name is Wolfgang",
+        "result_keys": ["entity", "score", "index", "word", "start", "end"],
+    },
+    {
+        "task": "question-answering",
+        "example": {
+            "question": "Where do I live?",
+            "context": "My name is Merve and I live in İstanbul.",
+        },
+        "result_keys": ["score", "start", "end", "answer"],
+    },
+    {
+        "task": "fill-mask",
+        "example": "Paris is the <mask> of France.",
+        "result_keys": ["score", "token", "token_str", "sequence"],
+    },
+    {
+        "task": "summarization",
+        "example": "Paris is the capital and most populous city of France,"
+        " with an estimated population of 2,175,601 residents as of 2018,"
+        " in an area of more than 105 square kilometres (41 square miles)."
+        " The City of Paris is the centre and seat of government of the region"
+        " and province of Île-de-France, or Paris Region, which has an estimated population of 12,174,880,"
+        " or about 18 percent of the population of France as of 2017.",
+        "result_keys": ["summary_text"],
+    },
+    {
+        "task": "translation_en_to_fr",
+        "example": "How old are you?",
+        "result_keys": ["translation_text"],
+    },
+]
+
+
+@pytest.mark.parametrize("pipeline", PIPELINES)
+def test_default_models(pipeline: Dict):
+    """
+    Test the HuggingFaceModelServer over all the NLP tasks in pipelines.
+    :param pipeline: A Dict that contains the name of the task,
+    an input for prediction and keys in the result prediction
+    """
+    serving_function = mlrun.new_function(
+        name="serving",
+        image="mlrun/ml-models",
+        kind="serving",
+        # requirements=['transformers'],
+    )
+    serving_function.add_model(
+        pipeline["task"],
+        class_name=CLASS_NAME,
+        model_path="123",  # This is not used, just for enabling the process.
+        task=pipeline["task"],
+    )
+    server = serving_function.to_mock_server()
+    result = server.test(
+        f'/v2/models/{pipeline["task"]}', body={"inputs": [pipeline["example"]]}
+    )
+    prediction = result["outputs"][0]
+    assert all(
+        result_key in prediction.keys() for result_key in pipeline["result_keys"]
+    )
+
+
+def test_local_model_serving():
+    """
+    Testing the model server with a specific model and tokenizer.
+    """
+    # Creating the serving function:
+    serving_function = mlrun.new_function(
+        name="serving",
+        image="mlrun/ml-models",
+        kind="serving",
+        # requirements=['transformers'],
+    )
+
+    # Adding model:
+    serving_function.add_model(
+        "model1",
+        class_name=CLASS_NAME,
+        model_path="123",  # This is not used, just for enabling the process.
+        task="sentiment-analysis",
+        model_class="TFAutoModelForSequenceClassification",
+        model_name="nlptown/bert-base-multilingual-uncased-sentiment",
+        tokenizer_class="AutoTokenizer",
+        tokenizer_name="nlptown/bert-base-multilingual-uncased-sentiment",
+    )
+
+    # Creating a mock server and predicting:
+    server = serving_function.to_mock_server()
+    result = server.test(
+        "/v2/models/model1",
+        body={
+            "inputs": [
+                "Nous sommes très heureux de vous présenter la bibliothèque 🤗 Transformers."
+            ]
+        },
+    )
+
+    # Checking the prediction has the required value:
+    prediction = result["outputs"][0]
+    assert prediction["label"] == "5 stars" and np.isclose(prediction["score"], 0.72727)

--- a/tests/frameworks/huggingface/serving.py
+++ b/tests/frameworks/huggingface/serving.py
@@ -89,7 +89,6 @@ def test_default_models(pipeline: Dict):
         name="serving",
         image="mlrun/ml-models",
         kind="serving",
-        # requirements=['transformers'],
     )
     serving_function.add_model(
         pipeline["task"],
@@ -116,7 +115,6 @@ def test_local_model_serving():
         name="serving",
         image="mlrun/ml-models",
         kind="serving",
-        # requirements=['transformers'],
     )
 
     # Adding model:


### PR DESCRIPTION
Built-in support for the HuggingFace framework - the transformers hub:
* Added a serving class for HuggingFace `pipeline` which is constructed from a `model` and a `tokenizer`.
* Added tests for serving.
* Updated `dev-requirements.txt` with the HuggingFace package - `transformers`