### PR TITLE
[CI] Cleanup DataNode Docker Registry and Local Docker post System Tests

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -222,3 +222,23 @@ jobs:
           -o ServerAliveCountMax=3 \
           ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
           kubectl -n default-tenant rollout restart deployment docker-registry
+        
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          scp \
+          automation/system_test/cleanup.py \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:~/cleanup.py
+        
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          ssh \
+          -o StrictHostKeyChecking=no \
+          -o ServerAliveInterval=180 \
+          -o ServerAliveCountMax=3 \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+            /bin/python3 \
+              ~/cleanup.py \
+              http://localhost:8009 \
+              igz0.docker_registry.0 \
+              "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }},ghcr.io/mlrun/mlrun:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/ml-models:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/ml-base:${{ steps.computed_params.outputs.mlrun_docker_tag }}"
+

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -240,5 +240,5 @@ jobs:
               ~/cleanup.py \
               http://localhost:8009 \
               igz0.docker_registry.0 \
-              "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }},ghcr.io/mlrun/mlrun:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/ml-models:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/ml-base:${{ steps.computed_params.outputs.mlrun_docker_tag }}"
+              "ghcr.io/mlrun/mlrun-api,ghcr.io/mlrun/mlrun-ui,ghcr.io/mlrun/mlrun,ghcr.io/mlrun/ml-models,ghcr.io/mlrun/ml-base"
 

--- a/automation/system_test/cleanup.py
+++ b/automation/system_test/cleanup.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import asyncio
 import subprocess
 import typing

--- a/automation/system_test/cleanup.py
+++ b/automation/system_test/cleanup.py
@@ -1,0 +1,110 @@
+import asyncio
+import subprocess
+import typing
+
+import aiohttp
+import click
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command()
+@click.argument("registry-url", type=str, required=True)
+@click.argument("registry-container-name", type=str, required=True)
+@click.argument(
+    "images",
+    type=str,
+    required=True,
+)
+def docker_images(registry_url: str, registry_container_name: str, images: str):
+    images = images.split(",")
+    loop = asyncio.get_event_loop()
+    tags = loop.run_until_complete(_collect_image_tags(registry_url, images))
+    for image, image_tags in tags.items():
+        click.echo(f"Deleting {image} tags")
+        for tag in image_tags:
+            loop.run_until_complete(_delete_image_tag(registry_url, image, tag))
+
+    click.echo("Removed all tags. Running garbage collection...")
+    _run_registry_garbage_collection(registry_container_name)
+
+    click.echo("Cleaning images from local Docker cache...")
+    _clean_images_from_local_docker_cache(tags)
+
+
+async def _collect_image_tags(
+    registry: str, images: typing.List[str]
+) -> typing.Dict[str, typing.List[str]]:
+    """Collect all image tags from Docker Hub."""
+    tags = {}
+    async with aiohttp.ClientSession() as session:
+        for image in images:
+            async with session.get(f"{registry}/v2/{image}/tags/list") as response:
+                if response.status != 200:
+                    click.echo(
+                        f"Unable to fetch tags for {image}: {response.status}, skipping"
+                    )
+                    continue
+                data = await response.json()
+                if data.get("tags"):
+                    tags[image] = data["tags"]
+    return tags
+
+
+async def _delete_image_tag(registry: str, image: str, tag: str) -> None:
+    """Delete a single image tag."""
+    digest = await _get_tag_digest(registry, image, tag)
+    async with aiohttp.ClientSession() as session:
+        click.echo(f"\tDeleting {image}:{tag} ({digest})")
+        async with session.delete(
+            f"{registry}/v2/{image}/manifests/{digest}"
+        ) as response:
+            if response.status != 202:
+                raise RuntimeError(f"Unable to delete {image}:{tag}: {response.status}")
+
+
+async def _get_tag_digest(registry: str, image: str, tag: str) -> str:
+    """Get the digest for a single image tag."""
+    async with aiohttp.ClientSession() as session:
+        async with session.head(
+            f"{registry}/v2/{image}/manifests/{tag}",
+            headers={"Accept": "application/vnd.docker.distribution.manifest.v2+json"},
+        ) as response:
+            if response.status != 200:
+                raise RuntimeError(
+                    f"Unable to fetch digest for {image}:{tag}: {response.status}"
+                )
+            return response.headers["Docker-Content-Digest"]
+
+
+def _run_registry_garbage_collection(registry_container_name: str) -> None:
+    """Run Docker registry garbage collection."""
+    subprocess.run(
+        [
+            "docker",
+            "exec",
+            registry_container_name,
+            "registry",
+            "garbage-collect",
+            "--delete-untagged=true",
+            "/etc/docker/registry/config.yml",
+        ]
+    )
+
+
+def _clean_images_from_local_docker_cache(
+    tags: typing.Dict[str, typing.List[str]]
+) -> None:
+    """Clean images from local Docker cache."""
+    command = ["docker", "rmi", "-f"]
+    command.extend(
+        [f"{image}:{tag}" for image, image_tags in tags.items() for tag in image_tags]
+    )
+    subprocess.run(command)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
During the preparation of the Enterprise System Tests, mlrun's docker images are loaded on the data node and then pushed to a local docker registry on the data node. This builds up over time, using up more and more storage on the data node.

Created a script which removes the docker images from the local docker registry and from the docker daemon on the data node. The script will run at the end of each system-test run, conserving the storage usage of the system.