### PR TITLE
[FeatureStore]  On pandas fs-ingestion, skip setting the df index if it's already set to fs entity 0

### DIFF
--- a/mlrun/feature_store/ingestion.py
+++ b/mlrun/feature_store/ingestion.py
@@ -95,7 +95,8 @@ def init_featureset_graph(
         event = MockEvent(body=chunk)
         # set the entity to be the index of the df
         if featureset.spec.entities[0] and isinstance(event.body, pd.DataFrame):
-            event.body = event.body.set_index(featureset.spec.entities[0].name)
+            if event.body.index.name != featureset.spec.entities[0].name:
+                event.body = event.body.set_index(featureset.spec.entities[0].name)
         data = server.run(event, get_body=True)
         if data is not None:
             if featureset.spec.entities[0] in data:

--- a/tests/feature-store/test_steps.py
+++ b/tests/feature-store/test_steps.py
@@ -75,7 +75,8 @@ def test_set_event_random_id():
     assert resp["id"] != "XYZ", "id was not overwritten"
 
 
-def test_pandas_step_onehot(rundb_mock):
+@pytest.mark.parametrize("with_set_index", [True, False])
+def test_pandas_step_onehot(rundb_mock, with_set_index):
     data, _ = get_data()
     # One Hot Encode the newly defined mappings
     one_hot_encoder_mapping = {
@@ -88,6 +89,10 @@ def test_pandas_step_onehot(rundb_mock):
         description="feature set",
         engine="pandas",
     )
+
+    if with_set_index:
+        data.set_index("id", inplace=True)
+
     # Pre-processing grpah steps
     data_set_pandas.graph.to(OneHotEncoder(mapping=one_hot_encoder_mapping))
     data_set_pandas._run_db = rundb_mock


### PR DESCRIPTION
[ML-2673](https://jira.iguazeng.com/browse/ML-2673)