### PR TITLE
[Artifacts] Fix for `plotly` and `bokeh` artifacts init method

### DIFF
--- a/mlrun/artifacts/plots.py
+++ b/mlrun/artifacts/plots.py
@@ -370,8 +370,6 @@ class LegacyBokehArtifact(LegacyArtifact):
         :param key:         Key for the artifact to be stored in the database.
         :param target_path: Path to save the artifact.
         """
-        super().__init__(key=key, target_path=target_path, viewer="bokeh")
-
         # Validate input:
         try:
             from bokeh.plotting import Figure
@@ -379,11 +377,14 @@ class LegacyBokehArtifact(LegacyArtifact):
             raise Error(
                 "Using 'BokehArtifact' requires bokeh package. Use pip install mlrun[bokeh] to install it."
             )
-        if not isinstance(figure, Figure):
+        if figure is not None and not isinstance(figure, Figure):
             raise ValueError(
                 "BokehArtifact requires the figure parameter to be a "
                 "'bokeh.plotting.Figure' but received '{}'".format(type(figure))
             )
+
+        # Call the artifact initializer:
+        super().__init__(key=key, target_path=target_path, viewer="bokeh")
 
         # Continue initializing the bokeh artifact:
         self._figure = figure
@@ -419,19 +420,29 @@ class LegacyPlotlyArtifact(LegacyArtifact):
         :param key:         Key for the artifact to be stored in the database.
         :param target_path: Path to save the artifact.
         """
+        # Validate the plotly package:
+        try:
+            from plotly.graph_objs import Figure
+        except ModuleNotFoundError:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "Using `PlotlyArtifact` requires plotly package. Use `pip install mlrun[plotly]` to install it."
+            )
+        except ImportError:
+            import plotly
+
+            raise mlrun.errors.MLRunMissingDependencyError(
+                f"Using `PlotlyArtifact` requires plotly version >= 5.4.0 but found version {plotly.__version__}. "
+                f"Use `pip install -U mlrun[plotly]` to install it."
+            )
+
+        # Call the artifact initializer:
         super().__init__(key=key, target_path=target_path, viewer="plotly")
 
         # Validate input:
-        try:
-            from plotly.graph_objs import Figure
-        except (ModuleNotFoundError, ImportError) as Error:
-            raise Error(
-                "Using 'PlotlyArtifact' requires plotly package. Use pip install mlrun[plotly] to install it."
-            )
-        if not isinstance(figure, Figure):
-            raise ValueError(
-                "PlotlyArtifact requires the figure parameter to be a "
-                "'plotly.graph_objs.Figure' but received '{}'".format(type(figure))
+        if figure is not None and not isinstance(figure, Figure):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"PlotlyArtifact requires the figure parameter to be a "
+                f"`plotly.graph_objs.Figure` but received '{type(figure)}'"
             )
 
         # Continue initializing the plotly artifact:

--- a/mlrun/artifacts/plots.py
+++ b/mlrun/artifacts/plots.py
@@ -360,7 +360,7 @@ class LegacyBokehArtifact(LegacyArtifact):
 
     def __init__(
         self,
-        figure,
+        figure=None,
         key: str = None,
         target_path: str = None,
     ):
@@ -409,7 +409,7 @@ class LegacyPlotlyArtifact(LegacyArtifact):
 
     def __init__(
         self,
-        figure,
+        figure=None,
         key: str = None,
         target_path: str = None,
     ):

--- a/mlrun/artifacts/plots.py
+++ b/mlrun/artifacts/plots.py
@@ -141,7 +141,7 @@ class BokehArtifact(Artifact):
 
     def __init__(
         self,
-        figure,
+        figure=None,
         key: str = None,
         target_path: str = None,
     ):
@@ -152,8 +152,6 @@ class BokehArtifact(Artifact):
         :param key:         Key for the artifact to be stored in the database.
         :param target_path: Path to save the artifact.
         """
-        super().__init__(key=key, target_path=target_path, viewer="bokeh")
-
         # Validate input:
         try:
             from bokeh.plotting import Figure
@@ -161,11 +159,14 @@ class BokehArtifact(Artifact):
             raise Error(
                 "Using 'BokehArtifact' requires bokeh package. Use pip install mlrun[bokeh] to install it."
             )
-        if not isinstance(figure, Figure):
+        if figure is not None and not isinstance(figure, Figure):
             raise ValueError(
                 "BokehArtifact requires the figure parameter to be a "
                 "'bokeh.plotting.Figure' but received '{}'".format(type(figure))
             )
+
+        # Call the artifact initializer:
+        super().__init__(key=key, target_path=target_path, viewer="bokeh")
 
         # Continue initializing the bokeh artifact:
         self._figure = figure
@@ -192,7 +193,7 @@ class PlotlyArtifact(Artifact):
 
     def __init__(
         self,
-        figure,
+        figure=None,
         key: str = None,
         target_path: str = None,
     ):
@@ -222,7 +223,7 @@ class PlotlyArtifact(Artifact):
         super().__init__(key=key, target_path=target_path, viewer="plotly")
 
         # Validate input:
-        if not isinstance(figure, Figure):
+        if figure is not None and not isinstance(figure, Figure):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"PlotlyArtifact requires the figure parameter to be a "
                 f"`plotly.graph_objs.Figure` but received '{type(figure)}'"


### PR DESCRIPTION
Changed the `figure` to be an optional argument so it won't fail when reading the artifacts from DB.