### PR TITLE
[Runtimes] Add set annotations method for runtimes

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -200,7 +200,8 @@ class BaseRuntime(ModelObj):
         return self
 
     def set_annotation(self, key, value):
-        self.metadata.annotations[key] = str(value)
+        self._metadata.annotations[key] = str(value)
+        print(self._metadata.annotations)
         return self
 
     @property

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -199,6 +199,9 @@ class BaseRuntime(ModelObj):
         self.metadata.labels[key] = str(value)
         return self
 
+    def set_annotation(self, key, value):
+        self.metadata.annotations[key] = str(value)
+
     @property
     def uri(self):
         return self._function_uri()

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -201,6 +201,7 @@ class BaseRuntime(ModelObj):
 
     def set_annotation(self, key, value):
         self.metadata.annotations[key] = str(value)
+        return self
 
     @property
     def uri(self):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -199,11 +199,6 @@ class BaseRuntime(ModelObj):
         self.metadata.labels[key] = str(value)
         return self
 
-    def set_annotation(self, key, value):
-        self._metadata.annotations[key] = str(value)
-        print(self._metadata.annotations)
-        return self
-
     @property
     def uri(self):
         return self._function_uri()

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -287,7 +287,10 @@ class RemoteRuntime(KubeResource):
 
     def set_annotation(self, key, val):
         """set a key/value annotation for function"""
+        self.spec.base_spec.setdefault("metadata", {})
+        self.spec.base_spec["metadata"].setdefault("annotations", {})
         self.spec.base_spec["metadata"]["annotations"][key] = str(val)
+
         return self
 
     def add_volume(self, local, remote, name="fs", access_key="", user=""):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -285,6 +285,11 @@ class RemoteRuntime(KubeResource):
         self.spec.config[key] = value
         return self
 
+    def set_annotation(self, key, val):
+        self.spec.base_spec["metadata"]["annotations"][key] = str(val)
+        print(self.spec.base_spec)
+        return self
+
     def add_volume(self, local, remote, name="fs", access_key="", user=""):
         raise Exception("deprecated, use .apply(mount_v3io())")
 
@@ -1181,6 +1186,11 @@ def compile_function_config(
                 "spec.affinity",
                 mlrun.runtimes.pod.get_sanitized_attribute(function.spec, "affinity"),
             )
+
+    # enable annotations
+    if function.metadata.annotations:
+        config = function.spec.base_spec
+        update_in(config, "metadata.annotations", function.metadata.annotations)
 
     # don't send tolerations if nuclio is not compatible
     if validate_nuclio_version_compatibility("1.7.5"):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -286,8 +286,8 @@ class RemoteRuntime(KubeResource):
         return self
 
     def set_annotation(self, key, val):
+        """set a key/value annotation for function"""
         self.spec.base_spec["metadata"]["annotations"][key] = str(val)
-        print(self.spec.base_spec)
         return self
 
     def add_volume(self, local, remote, name="fs", access_key="", user=""):

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -877,6 +877,11 @@ class KubeResource(BaseRuntime):
             return self._set_env(name, value=str(value))
         return self._set_env(name, value_from=value_from)
 
+    def set_annotation(self, key, value):
+        """set a key/value annotation in the metadata of the pod"""
+        self.metadata.annotations[key] = str(value)
+        return self
+
     def get_env(self, name, default=None):
         """Get the pod environment variable for the given name, if not found return the default
         If it's a scalar value, will return it, if the value is from source, return the k8s struct (V1EnvVarSource)"""
@@ -1048,8 +1053,11 @@ class KubeResource(BaseRuntime):
         namespace = self._get_k8s().resolve_namespace()
 
         labels = get_resource_labels(self, runobj, runobj.spec.scrape_metrics)
-        new_meta = k8s_client.V1ObjectMeta(namespace=namespace, labels=labels)
-
+        new_meta = k8s_client.V1ObjectMeta(
+            namespace=namespace,
+            annotations=self.metadata.annotations or runobj.metadata.annotations,
+            labels=labels,
+        )
         name = runobj.metadata.name or "mlrun"
         norm_name = f"{normalize_name(name)}-"
         if unique:

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -202,6 +202,14 @@ class TestKubejobRuntime(TestRuntimeBase):
         pod = self._get_pod_creation_args()
         assert pod.spec.security_context == (security_context or {})
 
+    def test_set_annotation(self, db: Session, client: TestClient):
+        runtime = self._generate_runtime()
+        runtime.set_annotation("annotation-key", "annotation-value")
+        self.execute_function(runtime)
+
+        pod = self._get_pod_creation_args()
+        assert pod.metadata.annotations.get("annotation-key") == "annotation-value"
+
     def test_run_with_priority_class_name(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
 

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -756,6 +756,21 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         assert deploy_spec["priorityClassName"] == medium_priority_class_name
 
+    def test_set_metadata_annotations(self, db: Session, client: TestClient):
+
+        function = self._generate_runtime(self.runtime_kind)
+        function.set_annotation("annotation-key", "annotation-value")
+
+        self.execute_function(function)
+        args, _ = nuclio.deploy.deploy_config.call_args
+        deploy_metadata = args[0]["metadata"]
+
+        if deploy_metadata.get("annotations"):
+            assert (
+                deploy_metadata["annotations"].get("annotation-key")
+                == "annotation-value"
+            )
+
     def test_deploy_python_decode_string_env_var_enrichment(
         self, db: Session, client: TestClient
     ):


### PR DESCRIPTION
Add set_annotation function so users will be able to set an annotation for the different runtimes:
![image](https://user-images.githubusercontent.com/62285310/198243348-b68726e2-6ce8-4872-ab2a-efee9f760956.png)

https://jira.iguazeng.com/browse/ML-1495