### PR TITLE
[FeatureStore] Multi index with pandas engine

### DIFF
--- a/mlrun/feature_store/ingestion.py
+++ b/mlrun/feature_store/ingestion.py
@@ -93,10 +93,22 @@ def init_featureset_graph(
     targets = [get_target_driver(target, featureset) for target in targets]
     for chunk in chunks:
         event = MockEvent(body=chunk)
-        # set the entity to be the index of the df
+        # set the entities to be the indexes of the df
         if featureset.spec.entities[0] and isinstance(event.body, pd.DataFrame):
-            if event.body.index.name != featureset.spec.entities[0].name:
-                event.body = event.body.set_index(featureset.spec.entities[0].name)
+            entities_names = [ent.name for ent in featureset.spec.entities]
+            add_to_index = []
+            for ent_name in entities_names:
+                if ent_name not in event.body.index.names:
+                    add_to_index.append(ent_name)
+            start = 0
+            if len(add_to_index) == len(entities_names):
+                # need to reset all indexes
+                event.body = event.body.set_index(add_to_index[0])
+                start = 1
+            for name in add_to_index[start:]:
+                if name in event.body.columns:
+                    event.body = event.body.set_index(name, append=True)
+
         data = server.run(event, get_body=True)
         if data is not None:
             if featureset.spec.entities[0] in data:

--- a/tests/feature-store/test_steps.py
+++ b/tests/feature-store/test_steps.py
@@ -75,8 +75,15 @@ def test_set_event_random_id():
     assert resp["id"] != "XYZ", "id was not overwritten"
 
 
-def test_pandas_step_onehot(rundb_mock):
+@pytest.mark.parametrize("entities", [["id"], ["id", "name"]])
+@pytest.mark.parametrize("set_index_before", [True, False, 0])
+def test_pandas_step_onehot(rundb_mock, entities, set_index_before):
     data, _ = get_data()
+    data_to_ingest = data.copy()
+    if set_index_before or len(entities) == 1:
+        data_to_ingest.set_index(entities, inplace=True)
+    elif isinstance(set_index_before, int) and len(entities) > 1:
+        data_to_ingest.set_index(entities[set_index_before], inplace=True)
     # One Hot Encode the newly defined mappings
     one_hot_encoder_mapping = {
         "department": list(data["department"].unique()),
@@ -84,7 +91,7 @@ def test_pandas_step_onehot(rundb_mock):
     # Define the corresponding FeatureSet
     data_set_pandas = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
         engine="pandas",
     )
@@ -102,27 +109,44 @@ def test_pandas_step_onehot(rundb_mock):
     # Ingest our dataset through our defined pipeline
     df_pandas = fs.ingest(
         data_set_pandas,
-        data,
+        data_to_ingest,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
-
-    data_ref = pd.DataFrame(
-        {
-            "name": data["name"].values,
-            "age": data["age"].values,
-            "department_IT": [1, 0, 0, 0, 1],
-            "department_RD": [0, 1, 1, 0, 0],
-            "department_Marketing": [0, 0, 0, 1, 0],
-            "timestamp": [
-                time.time(),
-                time.time(),
-                time.time(),
-                time.time(),
-                time.time(),
-            ],
-        },
-        index=data["id"].values,
-    )
+    if len(entities) == 1:
+        data_ref = pd.DataFrame(
+            {
+                "name": data["name"].values,
+                "age": data["age"].values,
+                "department_IT": [1, 0, 0, 0, 1],
+                "department_RD": [0, 1, 1, 0, 0],
+                "department_Marketing": [0, 0, 0, 1, 0],
+                "timestamp": [
+                    time.time(),
+                    time.time(),
+                    time.time(),
+                    time.time(),
+                    time.time(),
+                ],
+            },
+            index=data["id"].values,
+        )
+    else:
+        data_ref = pd.DataFrame(
+            {
+                "age": data["age"].values,
+                "department_IT": [1, 0, 0, 0, 1],
+                "department_RD": [0, 1, 1, 0, 0],
+                "department_Marketing": [0, 0, 0, 1, 0],
+                "timestamp": [
+                    time.time(),
+                    time.time(),
+                    time.time(),
+                    time.time(),
+                    time.time(),
+                ],
+            },
+            index=[data["id"].values, data["name"].values],
+        )
 
     assert isinstance(df_pandas, pd.DataFrame)
     pd.testing.assert_frame_equal(
@@ -138,7 +162,7 @@ def test_pandas_step_onehot(rundb_mock):
     # Define the corresponding FeatureSet
     data_set = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
     )
     # Pre-processing grpah steps
@@ -151,7 +175,9 @@ def test_pandas_step_onehot(rundb_mock):
 
     # Ingest our dataset through our defined pipeline
     df = fs.ingest(
-        data_set, data, targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")]
+        data_set,
+        data_to_ingest,
+        targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     pd.testing.assert_frame_equal(
         df,
@@ -164,13 +190,20 @@ def test_pandas_step_onehot(rundb_mock):
     )
 
 
-def test_pandas_step_imputer(rundb_mock):
+@pytest.mark.parametrize("set_index_before", [True, False, 0])
+@pytest.mark.parametrize("entities", [["id"], ["id", "name"]])
+def test_pandas_step_imputer(rundb_mock, entities, set_index_before):
     data, data_ref = get_data(True)
-    data_ref.set_index("id", inplace=True)
+    data_ref.set_index(entities, inplace=True)
+    data_to_ingest = data.copy()
+    if set_index_before or len(entities) == 1:
+        data_to_ingest.set_index(entities, inplace=True)
+    elif isinstance(set_index_before, int) and len(entities) > 1:
+        data_to_ingest.set_index(entities[set_index_before], inplace=True)
     # Define the corresponding FeatureSet
     data_set_pandas = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
         engine="pandas",
     )
@@ -187,7 +220,7 @@ def test_pandas_step_imputer(rundb_mock):
     # Ingest our dataset through our defined pipeline
     df_pandas = fs.ingest(
         data_set_pandas,
-        data,
+        data_to_ingest,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
 
@@ -205,7 +238,7 @@ def test_pandas_step_imputer(rundb_mock):
     # Define the corresponding FeatureSet
     data_set = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
     )
     # Pre-processing grpah steps
@@ -218,7 +251,9 @@ def test_pandas_step_imputer(rundb_mock):
 
     # Ingest our dataset through our defined pipeline
     df = fs.ingest(
-        data_set, data, targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")]
+        data_set,
+        data_to_ingest,
+        targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     pd.testing.assert_frame_equal(
         df,
@@ -231,13 +266,20 @@ def test_pandas_step_imputer(rundb_mock):
     )
 
 
+@pytest.mark.parametrize("entities", [["id"], ["id", "name"]])
 @pytest.mark.parametrize("with_original", [True, False])
-def test_pandas_step_mapval(rundb_mock, with_original):
+@pytest.mark.parametrize("set_index_before", [True, False, 0])
+def test_pandas_step_mapval(rundb_mock, with_original, entities, set_index_before):
     data, _ = get_data()
+    data_to_ingest = data.copy()
+    if set_index_before or len(entities) == 1:
+        data_to_ingest.set_index(entities, inplace=True)
+    elif isinstance(set_index_before, int) and len(entities) > 1:
+        data_to_ingest.set_index(entities[set_index_before], inplace=True)
     # Define the corresponding FeatureSet
     data_set_pandas = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
         engine="pandas",
     )
@@ -262,21 +304,22 @@ def test_pandas_step_mapval(rundb_mock, with_original):
     # Ingest our  dataset through our defined pipeline
     df_pandas = fs.ingest(
         data_set_pandas,
-        data,
+        data_to_ingest,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
 
     if with_original:
         data_ref = data.copy()
-        data_ref = data_ref.set_index("id", drop=True)
+        data_ref = data_ref.set_index(entities, drop=True)
         data_ref["age_mapped"] = ["adult", "child", "adult", "adult", "child"]
         data_ref["department_mapped"] = [1, 3, 3, 2, 1]
     else:
         age = ["adult", "child", "adult", "adult", "child"]
         department = [1, 3, 3, 2, 1]
-        data_ref = pd.DataFrame(
-            {"age": age, "department": department}, index=data["id"].values
-        )
+        index = data["id"].values
+        if len(entities) > 1:
+            index = [data[ent].values for ent in entities]
+        data_ref = pd.DataFrame({"age": age, "department": department}, index=index)
 
     assert isinstance(df_pandas, pd.DataFrame)
     pd.testing.assert_frame_equal(
@@ -291,7 +334,7 @@ def test_pandas_step_mapval(rundb_mock, with_original):
     # Define the corresponding FeatureSet
     data_set = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
     )
     # Pre-processing grpah steps
@@ -312,7 +355,9 @@ def test_pandas_step_mapval(rundb_mock, with_original):
 
     # Ingest our dataset through our defined pipeline
     df = fs.ingest(
-        data_set, data, targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")]
+        data_set,
+        data_to_ingest,
+        targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     pd.testing.assert_frame_equal(
         df,
@@ -325,12 +370,19 @@ def test_pandas_step_mapval(rundb_mock, with_original):
     )
 
 
-def test_pandas_step_data_extractor(rundb_mock):
+@pytest.mark.parametrize("entities", [["id"], ["id", "name"]])
+@pytest.mark.parametrize("set_index_before", [True, False, 0])
+def test_pandas_step_data_extractor(rundb_mock, entities, set_index_before):
     data, _ = get_data()
+    data_to_ingest = data.copy()
+    if set_index_before or len(entities) == 1:
+        data_to_ingest.set_index(entities, inplace=True)
+    elif isinstance(set_index_before, int) and len(entities) > 1:
+        data_to_ingest.set_index(entities[set_index_before], inplace=True)
     # Define the corresponding FeatureSet
     data_set_pandas = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
         engine="pandas",
     )
@@ -352,11 +404,11 @@ def test_pandas_step_data_extractor(rundb_mock):
     # Ingest our dataset through our defined pipeline
     df_pandas = fs.ingest(
         data_set_pandas,
-        data,
+        data_to_ingest,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     data_ref = data.copy()
-    data_ref = data_ref.set_index("id", drop=True)
+    data_ref = data_ref.set_index(entities, drop=True)
     data_ref["timestamp_day_of_week"] = [3, 3, 3, 3, 3]
     data_ref["timestamp_hour"] = [0, 0, 0, 0, 0]
     assert isinstance(df_pandas, pd.DataFrame)
@@ -372,7 +424,7 @@ def test_pandas_step_data_extractor(rundb_mock):
     # Define the corresponding FeatureSet
     data_set = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
     )
     # Pre-processing grpah steps
@@ -390,7 +442,9 @@ def test_pandas_step_data_extractor(rundb_mock):
 
     # Ingest our dataset through our defined pipeline
     df = fs.ingest(
-        data_set, data, targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")]
+        data_set,
+        data_to_ingest,
+        targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     pd.testing.assert_frame_equal(
         df,
@@ -403,12 +457,19 @@ def test_pandas_step_data_extractor(rundb_mock):
     )
 
 
-def test_pandas_step_data_validator(rundb_mock):
+@pytest.mark.parametrize("set_index_before", [True, False, 0])
+@pytest.mark.parametrize("entities", [["id"], ["id", "name"]])
+def test_pandas_step_data_validator(rundb_mock, entities, set_index_before):
     data, _ = get_data()
+    data_to_ingest = data.copy()
+    if set_index_before or len(entities) == 1:
+        data_to_ingest.set_index(entities, inplace=True)
+    elif isinstance(set_index_before, int) and len(entities) > 1:
+        data_to_ingest.set_index(entities[set_index_before], inplace=True)
     # Define the corresponding FeatureSet
     data_set_pandas = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
         engine="pandas",
     )
@@ -429,11 +490,11 @@ def test_pandas_step_data_validator(rundb_mock):
     # Ingest our dataset through our defined pipeline
     df_pandas = fs.ingest(
         data_set_pandas,
-        data,
+        data_to_ingest,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     data_ref = data.copy()
-    data_ref = data_ref.set_index("id", drop=True)
+    data_ref = data_ref.set_index(entities, drop=True)
     assert isinstance(df_pandas, pd.DataFrame)
     pd.testing.assert_frame_equal(
         df_pandas,
@@ -447,7 +508,7 @@ def test_pandas_step_data_validator(rundb_mock):
     # Define the corresponding FeatureSet
     data_set = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
     )
     # Pre-processing grpah steps
@@ -464,7 +525,9 @@ def test_pandas_step_data_validator(rundb_mock):
 
     # Ingest our dataset through our defined pipeline
     df = fs.ingest(
-        data_set, data, targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")]
+        data_set,
+        data_to_ingest,
+        targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     pd.testing.assert_frame_equal(
         df,
@@ -477,12 +540,19 @@ def test_pandas_step_data_validator(rundb_mock):
     )
 
 
-def test_pandas_step_drop_feature(rundb_mock):
+@pytest.mark.parametrize("set_index_before", [True, False, 0])
+@pytest.mark.parametrize("entities", [["id"], ["id", "name"]])
+def test_pandas_step_drop_feature(rundb_mock, entities, set_index_before):
     data, _ = get_data()
+    data_to_ingest = data.copy()
+    if set_index_before or len(entities) == 1:
+        data_to_ingest.set_index(entities, inplace=True)
+    elif isinstance(set_index_before, int) and len(entities) > 1:
+        data_to_ingest.set_index(entities[set_index_before], inplace=True)
     # Define the corresponding FeatureSet
     data_set_pandas = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
         engine="pandas",
     )
@@ -499,11 +569,11 @@ def test_pandas_step_drop_feature(rundb_mock):
     # Ingest our dataset through our defined pipeline
     df_pandas = fs.ingest(
         data_set_pandas,
-        data,
+        data_to_ingest,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     data_ref = data.copy()
-    data_ref = data_ref.set_index("id", drop=True)
+    data_ref = data_ref.set_index(entities, drop=True)
     data_ref.drop(columns=["age"], inplace=True)
     assert isinstance(df_pandas, pd.DataFrame)
     pd.testing.assert_frame_equal(
@@ -518,7 +588,7 @@ def test_pandas_step_drop_feature(rundb_mock):
     # Define the corresponding FeatureSet
     data_set = fs.FeatureSet(
         "fs-new",
-        entities=[fs.Entity("id")],
+        entities=[fs.Entity(ent) for ent in entities],
         description="feature set",
     )
     # Pre-processing grpah steps
@@ -531,7 +601,9 @@ def test_pandas_step_drop_feature(rundb_mock):
 
     # Ingest our dataset through our defined pipeline
     df = fs.ingest(
-        data_set, data, targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")]
+        data_set,
+        data_to_ingest,
+        targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
     pd.testing.assert_frame_equal(
         df,


### PR DESCRIPTION
This pr create option to use multi entities , when ingesting over pandas engine. In all cases the indexes of the data are became exactly as the feature set entities, and erase those entities from the features (columns).
[ML-2677](https://jira.iguazeng.com/browse/ML-2677), [ML-2703](https://jira.iguazeng.com/browse/ML-2703)