### PR TITLE
[Runtimes] Fix run fails after deploying function without defined image

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -518,10 +518,9 @@ def build_runtime(
     )
     runtime.status.build_pod = None
     if status == "skipped":
-        # using the base_image, and not the enriched one so we won't have the client version in the image, useful for
-        # exports and other cases where we don't want to have the client version in the image, but rather enriched on
-        # API level
-        runtime.spec.image = base_image
+        # using enriched base image for the runtime spec image, because this will be the image that the function will
+        # run with
+        runtime.spec.image = enriched_base_image
         runtime.status.state = mlrun.api.schemas.FunctionState.ready
         return True
 

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -489,13 +489,14 @@ def build_runtime(
 
     name = normalize_name(f"mlrun-build-{runtime.metadata.name}")
     base_image = enrich_image_url(
-        build.base_image or config.default_base_image, client_version
+        build.base_image or runtime.spec.image or config.default_base_image,
+        client_version,
     )
 
     status = build_image(
         auth_info,
         project,
-        build.image,
+        image_target=build.image,
         base_image=base_image,
         commands=build.commands,
         namespace=namespace,
@@ -521,6 +522,7 @@ def build_runtime(
     if status.startswith("build:"):
         runtime.status.state = mlrun.api.schemas.FunctionState.deploying
         runtime.status.build_pod = status[6:]
+        runtime.spec.build.base_image = base_image
         return False
 
     logger.info(f"build completed with {status}")

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -491,7 +491,7 @@ def build_runtime(
     base_image: str = (
         build.base_image or runtime.spec.image or config.default_base_image
     )
-    base_image_enriched = enrich_image_url(
+    enriched_base_image = enrich_image_url(
         base_image,
         client_version,
     )
@@ -500,7 +500,7 @@ def build_runtime(
         auth_info,
         project,
         image_target=build.image,
-        base_image=base_image_enriched,
+        base_image=enriched_base_image,
         commands=build.commands,
         namespace=namespace,
         # inline_code=inline,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1031,9 +1031,14 @@ class BaseRuntime(ModelObj):
 
         if (
             self.kind not in mlrun.runtimes.RuntimeKinds.nuclio_runtimes()
+            # TODO: need a better way to decide whether a function requires a build
             and require_build
             and image
             and not self.spec.build.base_image
+            # when submitting a run we are loading the function from the db, and using new_function for it,
+            # this results reaching here, but we are already after deploy of the image, meaning we don't need to prepare
+            # the base image for deployment
+            and self._is_remote_api()
         ):
             # when the function require build use the image as the base_image for the build
             self.spec.build.base_image = image

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1021,14 +1021,21 @@ class BaseRuntime(ModelObj):
         require_build = build.commands or (
             build.source and not build.load_source_on_run
         )
+        image = self.spec.image
+        # we allow users to not set an image, in that case we'll use the default
+        if not image and self.kind in mlrun.mlconf.function_defaults.image_by_kind.to_dict():
+            image = (
+                mlrun.mlconf.function_defaults.image_by_kind.to_dict()[self.kind]
+            )
+
         if (
-            self.kind not in mlrun.runtimes.RuntimeKinds.nuclio_runtimes()
-            and require_build
-            and self.spec.image
-            and not self.spec.build.base_image
+                self.kind not in mlrun.runtimes.RuntimeKinds.nuclio_runtimes()
+                and require_build
+                and image
+                and not self.spec.build.base_image
         ):
             # when the function require build use the image as the base_image for the build
-            self.spec.build.base_image = self.spec.image
+            self.spec.build.base_image = image
             self.spec.image = ""
 
     def export(self, target="", format=".yaml", secrets=None, strip=True):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1023,16 +1023,17 @@ class BaseRuntime(ModelObj):
         )
         image = self.spec.image
         # we allow users to not set an image, in that case we'll use the default
-        if not image and self.kind in mlrun.mlconf.function_defaults.image_by_kind.to_dict():
-            image = (
-                mlrun.mlconf.function_defaults.image_by_kind.to_dict()[self.kind]
-            )
+        if (
+            not image
+            and self.kind in mlrun.mlconf.function_defaults.image_by_kind.to_dict()
+        ):
+            image = mlrun.mlconf.function_defaults.image_by_kind.to_dict()[self.kind]
 
         if (
-                self.kind not in mlrun.runtimes.RuntimeKinds.nuclio_runtimes()
-                and require_build
-                and image
-                and not self.spec.build.base_image
+            self.kind not in mlrun.runtimes.RuntimeKinds.nuclio_runtimes()
+            and require_build
+            and image
+            and not self.spec.build.base_image
         ):
             # when the function require build use the image as the base_image for the build
             self.spec.build.base_image = image

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -202,6 +202,9 @@ class KubejobRuntime(KubeResource):
             )
             self.status = data["data"].get("status", None)
             self.spec.image = get_in(data, "data.spec.image")
+            self.spec.build.base_image = self.spec.build.base_image or get_in(
+                data, "data.spec.build.base_image"
+            )
             ready = data.get("ready", False)
             if not ready:
                 logger.info(

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -53,7 +53,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         assert function.spec.image == expected_spec_image
         function.run()
 
-    def test_deploy_function_with_requirements(self):
+    def test_deploy_function_with_source_archive(self):
         code_path = str(self.assets_path / "kubejob_function.py")
         expected_spec_image = ".mlrun/func-kubejob-system-test-simple-function:latest"
         expected_base_image = "mlrun/mlrun"

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -36,6 +36,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         function.deploy()
 
     def test_deploy_function_without_image_with_requirements(self):
+        # ML-2669
         code_path = str(self.assets_path / "kubejob_function.py")
         expected_spec_image = ".mlrun/func-kubejob-system-test-simple-function:latest"
         expected_base_image = "mlrun/mlrun"
@@ -54,6 +55,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         function.run()
 
     def test_deploy_function_with_source_archive(self):
+        # ML-2669
         # this test is to verify that the image that is being defined as the image of the function isn't being
         # overwritten by the default image in configuration at the API level
         code_path = str(self.assets_path / "kubejob_function.py")
@@ -78,6 +80,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         assert function.spec.build.base_image.startswith(expected_base_image)
 
     def test_deploy_function_after_deploy(self):
+        # ML-2701
         code_path = str(self.assets_path / "kubejob_function.py")
         expected_spec_image = ".mlrun/func-kubejob-system-test-simple-function:latest"
         expected_base_image = "mlrun/mlrun"

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -71,13 +71,12 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
 
         function.deploy()
         assert function.spec.image == expected_spec_image
-        # the image prefix is being enriched at the API level ( depends on the server version )
-        assert function.spec.build.base_image.startswith(expected_base_image)
+        assert function.spec.build.base_image == expected_base_image
 
         function.run()
         function.deploy()
         assert function.spec.image == expected_spec_image
-        assert function.spec.build.base_image.startswith(expected_base_image)
+        assert function.spec.build.base_image == expected_base_image
 
     def test_deploy_function_after_deploy(self):
         # ML-2701

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -54,30 +54,6 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         assert function.spec.image == expected_spec_image
         function.run()
 
-    def test_deploy_function_with_source_archive(self):
-        # ML-2669
-        # this test is to verify that the image that is being defined as the image of the function isn't being
-        # overwritten by the default image in configuration at the API level
-        code_path = str(self.assets_path / "kubejob_function.py")
-        expected_spec_image = ".mlrun/func-kubejob-system-test-simple-function:latest"
-        expected_base_image = "mlrun/mlrun-api"
-
-        function = mlrun.code_to_function(
-            "simple-function", kind="job", image="mlrun/mlrun-api", filename=code_path
-        )
-        function.with_source_archive("v3io:///users/shapira/Varonish/archive")
-        assert function.spec.build.base_image is None
-        assert function.spec.image == expected_base_image
-
-        function.deploy()
-        assert function.spec.image == expected_spec_image
-        assert function.spec.build.base_image == expected_base_image
-
-        function.run()
-        function.deploy()
-        assert function.spec.image == expected_spec_image
-        assert function.spec.build.base_image == expected_base_image
-
     def test_deploy_function_after_deploy(self):
         # ML-2701
         code_path = str(self.assets_path / "kubejob_function.py")

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -48,9 +48,11 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         assert function.spec.image == ""
         assert function.spec.build.base_image == "mlrun/mlrun"
         function.deploy()
-        assert function.spec.image == ".mlrun/func-kubejob-system-test-simple-function:latest"
+        assert (
+            function.spec.image
+            == ".mlrun/func-kubejob-system-test-simple-function:latest"
+        )
         function.run()
-
 
     def test_function_with_param(self):
         code_path = str(self.assets_path / "function_with_params.py")

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -35,6 +35,23 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         self._logger.debug("Deploying kubejob function")
         function.deploy()
 
+    def test_deploy_function_without_image_with_requirements(self):
+        code_path = str(self.assets_path / "kubejob_function.py")
+
+        function = mlrun.code_to_function(
+            name="simple-function",
+            kind="job",
+            project=self.project_name,
+            filename=code_path,
+            requirements=["pandas"],
+        )
+        assert function.spec.image == ""
+        assert function.spec.build.base_image == "mlrun/mlrun"
+        function.deploy()
+        assert function.spec.image == ".mlrun/func-kubejob-system-test-simple-function:latest"
+        function.run()
+
+
     def test_function_with_param(self):
         code_path = str(self.assets_path / "function_with_params.py")
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2669
https://jira.iguazeng.com/browse/ML-2701

- Fixes problem of running a function which its image wasn't defined  after deploy. 
- Fixes problem of deploying a function twice in a row ( .deploy() and afterwards .deploy() again).
- Fixes problem of running a function after deploying a function which had `with_source_archive`.
- Another bug which was found while debugging and now tested is that when we were declaring an image, and then applying`with_source_archive`, we weren't using that image as base when building, but rather the function type default (mlrun/mlrun) that is why I test with `mlrun-api`.
