### PR TITLE
[CI] Fix System Test Cleanup Failing On Unicode Support For Click

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -236,7 +236,8 @@ jobs:
           -o ServerAliveInterval=180 \
           -o ServerAliveCountMax=3 \
           ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-            /bin/python3 \
+            LC_ALL=en_US.utf8 LANG=en_US.utf8 /bin/python3 \
+              docker-images \
               /home/iguazio/cleanup.py \
               http://localhost:8009 \
               igz0.docker_registry.0 \


### PR DESCRIPTION
When running the cleanup script from the github runner via ssh (ssh from different machines works well), for some reason the python isn't configured to use utf-8 and we get this error from the `click` package:
```
RuntimeError: Click will abort further execution because Python was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/unicode-support/ for mitigation steps.
```

According to the provided docs page, added the env-vars to configure python to use utf-8.

In addition the script was missing a positional argument in the command.