### PR TITLE
[FeatureStore] activate relations between different feature set and join according to those relations in get offline_feature

### DIFF
--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections
+import logging
 from copy import copy
 from enum import Enum
 from typing import List, Union
@@ -319,10 +320,14 @@ class FeatureVector(ModelObj):
 
         def add_feature(name, alias, feature_set_object, feature_set_full_name):
             if alias in processed_features.keys():
-                raise mlrun.errors.MLRunInvalidArgumentError(
+                logging.log(
+                    logging.WARN,
                     f"feature name/alias {alias} already specified,"
-                    " use another alias (feature-set.name [as alias])"
+                    " you need to use another alias (feature-set.name [as alias])"
+                    f" by default it changed to be {alias}_{feature_set_full_name}",
                 )
+                alias = f"{alias}_{feature_set_full_name}"
+
             feature = feature_set_object[name]
             processed_features[alias or name] = (feature_set_object, feature)
             feature_set_fields[feature_set_full_name].append((name, alias))

--- a/mlrun/feature_store/retrieval/base.py
+++ b/mlrun/feature_store/retrieval/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import abc
+from typing import Dict, List
 
 import mlrun
 from mlrun.datastore.targets import CSVTarget, ParquetTarget
@@ -24,6 +25,8 @@ class BaseMerger(abc.ABC):
     """abstract feature merger class"""
 
     def __init__(self, vector, **engine_args):
+        self._relation = dict()
+        self._join_type = "inner"
         self.vector = vector
 
         self._result_df = None
@@ -31,6 +34,7 @@ class BaseMerger(abc.ABC):
         self._index_columns = []
         self._drop_indexes = True
         self._target = None
+        self._alias = dict()
 
     def _append_drop_column(self, key):
         if key and key not in self._drop_columns:
@@ -43,6 +47,17 @@ class BaseMerger(abc.ABC):
             if self._drop_indexes:
                 self._append_drop_column(key)
 
+    def _update_alias(self, key: str = None, val: str = None, dictionary: dict = None):
+        if dictionary is not None:
+            # adding dictionary to alias
+            self._alias.update(dictionary)
+        elif val in self._alias.values():
+            # changing alias key
+            old_key = [key for key, v in self._alias.items() if v == val][0]
+            self._alias[key] = self._alias.pop(old_key)
+        else:
+            self._alias[key] = val
+
     def start(
         self,
         entity_rows=None,
@@ -54,8 +69,10 @@ class BaseMerger(abc.ABC):
         with_indexes=None,
         update_stats=None,
         query=None,
+        join_type="inner",
     ):
         self._target = target
+        self._join_type = join_type
 
         # calculate the index columns and columns we need to drop
         self._drop_columns = drop_columns or self._drop_columns
@@ -144,17 +161,29 @@ class BaseMerger(abc.ABC):
         entity_timestamp_column: str,
         featuresets: list,
         featureset_dfs: list,
+        keys: list = None,
+        all_columns: list = None,
     ):
         """join the entities and feature set features into a result dataframe"""
         merged_df = entity_df
         if entity_df is None and featureset_dfs:
             merged_df = featureset_dfs.pop(0)
             featureset = featuresets.pop(0)
+            if keys is not None:
+                keys.pop(0)
+            else:
+                keys = [[[], []]] * len(featureset_dfs)
+            if all_columns is not None:
+                all_columns.pop(0)
+            else:
+                all_columns = [[]] * len(featureset_dfs)
             entity_timestamp_column = (
                 entity_timestamp_column or featureset.spec.timestamp_key
             )
 
-        for featureset, featureset_df in zip(featuresets, featureset_dfs):
+        for featureset, featureset_df, lr_key, columns in zip(
+            featuresets, featureset_dfs, keys, all_columns
+        ):
             if featureset.spec.timestamp_key:
                 merge_func = self._asof_join
             else:
@@ -165,6 +194,9 @@ class BaseMerger(abc.ABC):
                 entity_timestamp_column,
                 featureset,
                 featureset_df,
+                lr_key[0],
+                lr_key[1],
+                columns,
             )
 
         self._result_df = merged_df
@@ -176,6 +208,9 @@ class BaseMerger(abc.ABC):
         entity_timestamp_column: str,
         featureset,
         featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
         raise NotImplementedError("_asof_join() operation not implemented in class")
 
@@ -186,6 +221,9 @@ class BaseMerger(abc.ABC):
         entity_timestamp_column: str,
         featureset,
         featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
         raise NotImplementedError("_join() operation not implemented in class")
 
@@ -208,3 +246,196 @@ class BaseMerger(abc.ABC):
         """return results as csv file"""
         size = CSVTarget(path=target_path).write_dataframe(self._result_df, **kw)
         return size
+
+    def _parse_relations(self, feature_set_objects, feature_set_fields):
+        """This method parse all feature set relations to a format such as self._relations if self._relations is None,
+        and when check if each relation as entity included"""
+        if self._relation == {}:
+            for name, _ in feature_set_fields.items():
+                feature_set = feature_set_objects[name]
+                fs_relations = feature_set.spec.relations
+                for other_fs, relation in fs_relations.items():
+                    if (
+                        f"{name}:{other_fs}" not in self._relation
+                        or f"{other_fs}:{name}" not in self._relation
+                    ):
+                        self._relation[f"{name}:{other_fs}"] = relation
+
+        # check all relations are included entities
+        for relation_name, relation in self._relation.items():
+            first_fs, second_fs = relation_name.split(":")
+            first_entities, second_entities = (
+                feature_set_objects[first_fs].spec.entities.keys(),
+                feature_set_objects[second_fs].spec.entities.keys(),
+            )
+            for key, val in relation.items():
+                if key not in first_entities and val not in second_entities:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Relation have to include entities therefore "
+                        f"the relation {key}:{val} between {first_fs} to "
+                        f"{second_fs} is not valid"
+                    )
+
+    def create_linked_relation_list(self, feature_set_objects, feature_set_fields):
+        relation_linked_lists = []
+        for name, _ in feature_set_fields.items():
+            feature_set = feature_set_objects[name]
+            relations = LinkedList()
+            main_node = Node(
+                name,
+                data={
+                    "left_keys": [],
+                    "right_keys": [],
+                    "save_cols": [],
+                    "save_index": [],
+                },
+            )
+            relations.add_first(main_node)
+
+            # build list of relation and index match for each feature set
+            for name_in, _ in feature_set_fields.items():
+                if name_in == name:
+                    continue
+                feature_set_in_entity_list = feature_set_objects[name_in].spec.entities
+                feature_set_in_entity_list_names = [*feature_set_in_entity_list.keys()]
+                entity_relation_list = [*feature_set.spec.relations.values()]
+                col_relation_list = [*feature_set.spec.relations.keys()]
+                curr_col_relation_list = []
+                relation_wise = True
+                for ent in feature_set_in_entity_list:
+                    # checking if feature_set have relation with feature_set_in
+                    if ent not in entity_relation_list:
+                        relation_wise = False
+                        break
+                    curr_col_relation_list.append(
+                        col_relation_list[entity_relation_list.index(ent)]
+                    )
+                if relation_wise:
+                    # add to the link list feature set according to the defined relation
+                    relations.add_last(
+                        Node(
+                            name_in,
+                            data={
+                                "left_keys": curr_col_relation_list,
+                                "right_keys": feature_set_in_entity_list_names,
+                                "save_cols": [],
+                                "save_index": [],
+                            },
+                        )
+                    )
+                    main_node.data["save_cols"].append(*curr_col_relation_list)
+                elif sorted(feature_set_in_entity_list_names) == sorted(
+                    feature_set.spec.entities.keys()
+                ):
+                    # add to the link list feature set according to indexes match
+                    keys = feature_set_in_entity_list_names
+                    relations.add_last(
+                        Node(
+                            name_in,
+                            data={
+                                "left_keys": keys,
+                                "right_keys": keys,
+                                "save_cols": [],
+                                "save_index": keys,
+                            },
+                        )
+                    )
+                    main_node.data["save_index"] = keys
+
+            relation_linked_lists.append(relations)
+
+        # concat all the link lists to one, for the merging process
+        link_list_iter = relation_linked_lists.__iter__()
+        return_relation = link_list_iter.__next__()
+        for relation_list in link_list_iter:
+            return_relation.concat(relation_list, ["save_cols"])
+        if return_relation.len != len(feature_set_objects):
+            raise mlrun.errors.MLRunRuntimeError("Failed to merge")
+
+        return return_relation
+
+
+class Node:
+    def __init__(self, name: str, data=None):
+        self.name = name
+        self.data = data
+        self.next = None
+
+    def __repr__(self):
+        return self.name
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+
+class LinkedList:
+    def __init__(self):
+        self.head = None
+        self.len = 0
+
+    def __repr__(self):
+        node = self.head
+        nodes = []
+        while node is not None:
+            nodes.append(node.name)
+            node = node.next
+        nodes.append("None")
+        return " -> ".join(nodes)
+
+    def __iter__(self):
+        node = self.head
+        while node is not None:
+            yield node
+            node = node.next
+
+    def add_first(self, node: Node):
+        node.next = self.head
+        self.head = node
+        self.len += 1
+        if self.head is None:
+            self.head = node
+
+    def add_last(self, node: Node):
+        if self.head is None:
+            self.head = node
+            return
+        for current_node in self:
+            pass
+        current_node.next = node
+        self.len += 1
+
+    def add_after(self, target_node_name: str, new_node: Node):
+        if self.head is None:
+            raise Exception("List is empty")
+
+        for node in self:
+            if node.name == target_node_name:
+                new_node.next = node.next
+                node.next = new_node
+                self.len += 1
+                return
+
+        raise Exception("Node with data '%s' not found" % target_node_name)
+
+    def find_node(self, target_node_name: str):
+        if self.head is None:
+            return None
+
+        for node in self:
+            if node.name == target_node_name:
+                return node
+
+    def concat(self, other, data_attributes: List[str]):
+        other_iter = other.__iter__()
+        other_head = other_iter.__next__()
+        node = self.find_node(other_head.name)
+        for atr in data_attributes:
+            node.data[atr] = other_head.data[atr]
+        if node is None:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"Can't join those {other_head.name} and {self.head.name} feature sets"
+            )
+        for other_node in other_iter:
+            if self.find_node(other_node.name) is None:
+                self.add_after(node.name, other_node)
+                node = other_node

--- a/mlrun/feature_store/retrieval/dask_merger.py
+++ b/mlrun/feature_store/retrieval/dask_merger.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import re
+
 import dask.dataframe as dd
-import pandas as pd
-from dask.dataframe.multi import merge, merge_asof
+import dask.dataframe.multi as dask_df_multi
+import numpy as np
 from dask.distributed import Client
 
 import mlrun
@@ -50,10 +52,25 @@ class DaskFeatureMerger(BaseMerger):
         # load dataframes
         feature_sets = []
         dfs = []
-        for name, columns in feature_set_fields.items():
+        keys = []
+        all_columns = list()
+
+        fs_link_list = self.create_linked_relation_list(
+            feature_set_objects, feature_set_fields
+        )
+
+        for node in fs_link_list:
+            name = node.name
             feature_set = feature_set_objects[name]
             feature_sets.append(feature_set)
+            columns = feature_set_fields[name]
             column_names = [name for name, alias in columns]
+
+            for col in node.data["save_cols"]:
+                if col not in column_names:
+                    self._append_drop_column(col)
+            column_names += node.data["save_cols"]
+
             df = feature_set.to_dataframe(
                 columns=column_names,
                 df_module=dd,
@@ -62,26 +79,61 @@ class DaskFeatureMerger(BaseMerger):
                 time_column=entity_timestamp_column,
                 index=False,
             )
-            # rename columns with aliases
-            df = df.rename(columns={name: alias for name, alias in columns if alias})
+            df = df.reset_index()
+            column_names += node.data["save_index"]
+            node.data["save_cols"] += node.data["save_index"]
 
             df = df.persist()
+            # rename columns to be unique for each feature set
+            rename_col_dict = {
+                col: f"{col}_{name}" for col in column_names if col not in saved_col
+            }
+            df = df.rename(
+                columns=rename_col_dict,
+            )
+
             dfs.append(df)
+            keys.append([node.data["left_keys"], node.data["right_keys"]])
 
-        self.merge(entity_rows, entity_timestamp_column, feature_sets, dfs)
+            # update alias according to the unique column name
+            new_columns = []
+            for col, alias in columns:
+                if col in rename_col_dict and alias:
+                    new_columns.append((rename_col_dict[col], alias))
+                elif col in rename_col_dict and not alias:
+                    new_columns.append((rename_col_dict[col], col))
+                else:
+                    new_columns.append((col, alias))
+            all_columns.append(new_columns)
+            self._update_alias(
+                dictionary={name: alias for name, alias in new_columns if alias}
+            )
 
-        # filter joined data frame by the query param
-        if query:
-            self._result_df = self._result_df.query(query)
+        self.merge(
+            entity_df=entity_rows,
+            entity_timestamp_column=entity_timestamp_column,
+            featuresets=feature_sets,
+            featureset_dfs=dfs,
+            keys=keys,
+            all_columns=all_columns,
+        )
 
         self._result_df = self._result_df.drop(
             columns=self._drop_columns, errors="ignore"
+        )
+
+        # renaming all columns according to self._alias
+        self._result_df = self._result_df.rename(
+            columns=self._alias,
         )
 
         if self.vector.status.label_column:
             self._result_df = self._result_df.dropna(
                 subset=[self.vector.status.label_column]
             )
+        # filter joined data frame by the query param
+        if query:
+            self._result_df = self._result_df.query(query)
 
         if self._drop_indexes:
             self._result_df = self._result_df.reset_index(drop=True)
@@ -100,9 +152,14 @@ class DaskFeatureMerger(BaseMerger):
         entity_df,
         entity_timestamp_column: str,
         featureset,
-        featureset_df: pd.DataFrame,
+        featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
-        indexes = list(featureset.spec.entities.keys())
+        indexes = None
+        if not right_keys:
+            indexes = list(featureset.spec.entities.keys())
 
         entity_df = self._reset_index(entity_df)
         entity_df = (
@@ -117,12 +174,14 @@ class DaskFeatureMerger(BaseMerger):
             else featureset_df.set_index(entity_timestamp_column, drop=True)
         )
 
-        merged_df = merge_asof(
+        merged_df = dask_df_multi.merge_asof(
             entity_df,
             featureset_df,
             left_index=True,
             right_index=True,
             by=indexes,
+            left_by=left_keys,
+            right_by=right_keys,
         )
 
         return merged_df
@@ -132,10 +191,24 @@ class DaskFeatureMerger(BaseMerger):
         entity_df,
         entity_timestamp_column: str,
         featureset,
-        featureset_df: pd.DataFrame,
+        featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
-        indexes = list(featureset.spec.entities.keys())
-        merged_df = merge(entity_df, featureset_df, on=indexes)
+
+        fs_name = featureset.metadata.name
+        merged_df = dask_df_multi.merge(
+            entity_df,
+            featureset_df,
+            how=self._join_type,
+            left_on=left_keys,
+            right_on=right_keys,
+            suffixes=("", f"_{fs_name}_"),
+        )
+        for col in merged_df.columns:
+            if re.findall(f"_{fs_name}_$", col):
+                self._append_drop_column(col)
         return merged_df
 
     def get_status(self):

--- a/mlrun/feature_store/retrieval/job.py
+++ b/mlrun/feature_store/retrieval/job.py
@@ -31,6 +31,7 @@ def run_merge_job(
     drop_columns=None,
     with_indexes=None,
     query=None,
+    join_type="inner",
 ):
     name = vector.metadata.name
     if not target or not hasattr(target, "to_dict"):
@@ -59,6 +60,7 @@ def run_merge_job(
             "drop_columns": drop_columns,
             "with_indexes": with_indexes,
             "query": query,
+            "join_type": join_type,
         },
         inputs={"entity_rows": entity_rows},
     )
@@ -118,7 +120,7 @@ import mlrun
 from mlrun.feature_store.retrieval import LocalFeatureMerger
 from mlrun.datastore.targets import get_target_driver
 def merge_handler(context, vector_uri, target, entity_rows=None, 
-                  timestamp_column=None, drop_columns=None, with_indexes=None, query=None):
+                  timestamp_column=None, drop_columns=None, with_indexes=None, query=None, join_type='inner'):
     vector = context.get_store_resource(vector_uri)
     store_target = get_target_driver(target, vector)
     entity_timestamp_column = timestamp_column or vector.spec.timestamp_field
@@ -128,7 +130,7 @@ def merge_handler(context, vector_uri, target, entity_rows=None,
     context.logger.info(f"starting vector merge task to {vector.uri}")
     merger = LocalFeatureMerger(vector)
     resp = merger.start(entity_rows, entity_timestamp_column, store_target, drop_columns, with_indexes=with_indexes, 
-                        query=query)
+                        query=query, join_type=join_type)
     target = vector.status.targets[store_target.name].to_dict()
     context.log_result('feature_vector', vector.uri)
     context.log_result('target', target)

--- a/mlrun/feature_store/retrieval/local_merger.py
+++ b/mlrun/feature_store/retrieval/local_merger.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pandas as pd
 
 from ..feature_vector import OfflineVectorResponse
@@ -35,10 +37,25 @@ class LocalFeatureMerger(BaseMerger):
 
         feature_sets = []
         dfs = []
-        for name, columns in feature_set_fields.items():
+        keys = []
+        all_columns = list()
+
+        fs_link_list = self.create_linked_relation_list(
+            feature_set_objects, feature_set_fields
+        )
+
+        for node in fs_link_list:
+            name = node.name
             feature_set = feature_set_objects[name]
             feature_sets.append(feature_set)
+            columns = feature_set_fields[name]
             column_names = [name for name, alias in columns]
+
+            for col in node.data["save_cols"]:
+                if col not in column_names:
+                    self._append_drop_column(col)
+            column_names += node.data["save_cols"]
+
             # handling case where there are multiple feature sets and user creates vector where entity_timestamp_
             # column is from a specific feature set (can't be entity timestamp)
             if (
@@ -56,16 +73,53 @@ class LocalFeatureMerger(BaseMerger):
                     columns=column_names,
                     time_column=entity_timestamp_column,
                 )
-            # rename columns with aliases
+            df.reset_index(inplace=True)
+            column_names += node.data["save_index"]
+            node.data["save_cols"] += node.data["save_index"]
+            # rename columns to be unique for each feature set
+            rename_col_dict = {
+                col: f"{col}_{name}"
+                for col in column_names
+                if col not in node.data["save_cols"]
+            }
             df.rename(
-                columns={name: alias for name, alias in columns if alias}, inplace=True
+                columns=rename_col_dict,
+                inplace=True,
             )
-            dfs.append(df)
 
-        self.merge(entity_rows, entity_timestamp_column, feature_sets, dfs)
+            dfs.append(df)
+            keys.append([node.data["left_keys"], node.data["right_keys"]])
+
+            # update alias according to the unique column name
+            new_columns = []
+            for col, alias in columns:
+                if col in rename_col_dict and alias:
+                    new_columns.append((rename_col_dict[col], alias))
+                elif col in rename_col_dict and not alias:
+                    new_columns.append((rename_col_dict[col], alias))
+                else:
+                    new_columns.append((col, alias))
+            all_columns.append(new_columns)
+            self._update_alias(
+                dictionary={name: alias for name, alias in new_columns if alias}
+            )
+
+        self.merge(
+            entity_df=entity_rows,
+            entity_timestamp_column=entity_timestamp_column,
+            featuresets=feature_sets,
+            featureset_dfs=dfs,
+            keys=keys,
+            all_columns=all_columns,
+        )
 
         self._result_df.drop(columns=self._drop_columns, inplace=True, errors="ignore")
 
+        # renaming all columns according to self._alias
+        self._result_df.rename(
+            columns=self._alias,
+            inplace=True,
+        )
         if self.vector.status.label_column:
             self._result_df = self._result_df.dropna(
                 subset=[self.vector.status.label_column]
@@ -87,9 +141,15 @@ class LocalFeatureMerger(BaseMerger):
         entity_df,
         entity_timestamp_column: str,
         featureset,
-        featureset_df: pd.DataFrame,
+        featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
-        indexes = list(featureset.spec.entities.keys())
+
+        indexes = None
+        if not right_keys:
+            indexes = list(featureset.spec.entities.keys())
         index_col_not_in_entity = "index" not in entity_df.columns
         index_col_not_in_featureset = "index" not in featureset_df.columns
         # Sort left and right keys
@@ -112,6 +172,8 @@ class LocalFeatureMerger(BaseMerger):
             left_on=entity_timestamp_column,
             right_on=featureset.spec.timestamp_key,
             by=indexes,
+            left_by=left_keys,
+            right_by=right_keys,
         )
 
         # Undo indexing tricks for asof merge
@@ -131,8 +193,21 @@ class LocalFeatureMerger(BaseMerger):
         entity_df,
         entity_timestamp_column: str,
         featureset,
-        featureset_df: pd.DataFrame,
+        featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
-        indexes = list(featureset.spec.entities.keys())
-        merged_df = pd.merge(entity_df, featureset_df, on=indexes)
+        fs_name = featureset.metadata.name
+        merged_df = pd.merge(
+            entity_df,
+            featureset_df,
+            how=self._join_type,
+            left_on=left_keys,
+            right_on=right_keys,
+            suffixes=("", f"_{fs_name}_"),
+        )
+        for col in merged_df.columns:
+            if re.findall(f"_{fs_name}_$", col):
+                self._append_drop_column(col)
         return merged_df

--- a/mlrun/feature_store/retrieval/spark_merger.py
+++ b/mlrun/feature_store/retrieval/spark_merger.py
@@ -123,6 +123,9 @@ class SparkFeatureMerger(BaseMerger):
         entity_timestamp_column: str,
         featureset,
         featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
 
         """Perform an as of join between entity and featureset.
@@ -194,6 +197,9 @@ class SparkFeatureMerger(BaseMerger):
         entity_timestamp_column: str,
         featureset,
         featureset_df,
+        left_keys: list,
+        right_keys: list,
+        columns: list,
     ):
 
         """

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -36,6 +36,8 @@ def _limited_string(value: str, max_size: int = 40):
 class Entity(ModelObj):
     """data entity (index)"""
 
+    kind = "entity"
+
     def __init__(
         self,
         name: str = None,
@@ -56,6 +58,9 @@ class Entity(ModelObj):
         if name and not value_type:
             self.value_type = ValueType.STRING
         self.labels = labels or {}
+
+    def __eq__(self, other):
+        return self.name == other.name
 
 
 class Feature(ModelObj):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -162,7 +162,12 @@ class ObjectDict:
 
         new_obj = cls(classes_map, default_kind)
         for name, child in children.items():
-            child_obj = new_obj._get_child_object(child, name)
+            obj_name = name
+            if hasattr(child, "name"):
+                obj_name = child.name
+            elif isinstance(child, dict) and child["name"]:
+                obj_name = child["name"]
+            child_obj = new_obj._get_child_object(child, obj_name)
             new_obj._children[name] = child_obj
 
         return new_obj


### PR DESCRIPTION
This PR added 1 argument to get_offline_feature, the changes are affects only dask and storey(local) engines.

join_type indicates the join type such as {'left', 'right', 'outer', 'inner'}, default 'outer'.

Also this PR open the ability to define relations of feature set with the relations argument, and it is look like this:
{column_name(str): Entity}, you can pass this dictionary when initialize the feature set.
And now the join preformed according to the relations and if there is no relation it preformed the join just if the indexes are the same (like it were).
 