### PR TITLE
[API] Fix delete runtime resources doesn't return 403 on insufficient permissions

### DIFF
--- a/mlrun/api/api/endpoints/runtime_resources.py
+++ b/mlrun/api/api/endpoints/runtime_resources.py
@@ -222,6 +222,13 @@ def _delete_runtime_resources(
         object_id,
         mlrun.api.schemas.AuthorizationAction.delete,
     )
+
+    if not_allowed_projects_exist:
+        # some resources are not allowed, return 403
+        raise mlrun.errors.MLRunAccessDeniedError(
+            "Access denied to one or more runtime resources"
+        )
+
     # if nothing allowed, simply return empty response
     if allowed_projects:
         permissions_label_selector = _generate_label_selector_for_allowed_projects(
@@ -250,15 +257,6 @@ def _delete_runtime_resources(
             label_selector,
             force,
             grace_period,
-        )
-    if (
-        not_allowed_projects_exist
-        and not allowed_projects
-        and not is_non_project_runtime_resource_exists
-    ):
-        # no resource are allowed, return 403
-        raise mlrun.errors.MLRunAccessDeniedError(
-            "Cannot delete the requested runtime resources, insufficient permissions"
         )
     if return_body:
         filtered_projects = copy.deepcopy(allowed_projects)

--- a/mlrun/api/api/endpoints/runtime_resources.py
+++ b/mlrun/api/api/endpoints/runtime_resources.py
@@ -251,7 +251,11 @@ def _delete_runtime_resources(
             force,
             grace_period,
         )
-    if not_allowed_projects_exist and not allowed_projects and not is_non_project_runtime_resource_exists:
+    if (
+        not_allowed_projects_exist
+        and not allowed_projects
+        and not is_non_project_runtime_resource_exists
+    ):
         # no resource are allowed, return 403
         raise mlrun.errors.MLRunAccessDeniedError(
             "Cannot delete the requested runtime resources, insufficient permissions"
@@ -306,7 +310,10 @@ def _get_runtime_resources_allowed_projects(
     object_id: typing.Optional[str] = None,
     action: mlrun.api.schemas.AuthorizationAction = mlrun.api.schemas.AuthorizationAction.read,
 ) -> typing.Tuple[
-    typing.List[str], mlrun.api.schemas.GroupedByProjectRuntimeResourcesOutput, bool, bool
+    typing.List[str],
+    mlrun.api.schemas.GroupedByProjectRuntimeResourcesOutput,
+    bool,
+    bool,
 ]:
     if project != "*":
         mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(

--- a/mlrun/api/api/endpoints/runtime_resources.py
+++ b/mlrun/api/api/endpoints/runtime_resources.py
@@ -223,8 +223,13 @@ def _delete_runtime_resources(
         mlrun.api.schemas.AuthorizationAction.delete,
     )
 
+    # TODO: once we have more granular permissions, we should check if the user is allowed to delete the specific
+    #  runtime resources and not just the project in general
     if not_allowed_projects_exist:
-        # some resources are not allowed, return 403
+
+        # if the user is not allowed to delete at least one of the projects, we return 403 as to:
+        # 1. not leak information about the existence of not allowed projects
+        # 2. not allow the user to do a partial delete action (delete some projects' resources and not others)
         raise mlrun.errors.MLRunAccessDeniedError(
             "Access denied to one or more runtime resources"
         )

--- a/tests/api/api/test_runtime_resources.py
+++ b/tests/api/api/test_runtime_resources.py
@@ -324,7 +324,7 @@ def test_delete_runtime_resources_nothing_allowed(
     mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
         return_value=[]
     )
-    _assert_empty_responses_in_delete_endpoints(client)
+    _assert_forbidden_responses_in_delete_endpoints(client)
 
 
 def test_delete_runtime_resources_no_resources(
@@ -596,6 +596,29 @@ def _assert_empty_responses_in_delete_endpoints(client: fastapi.testclient.TestC
         f"runtimes/{mlrun.runtimes.RuntimeKinds.job}/some-id",
     )
     assert response.status_code == http.HTTPStatus.NO_CONTENT.value
+
+
+def _assert_forbidden_responses_in_delete_endpoints(client: fastapi.testclient.TestClient):
+    response = client.delete(
+        "projects/*/runtime-resources",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
+
+    # legacy endpoints
+    response = client.delete(
+        "runtimes",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
+
+    response = client.delete(
+        f"runtimes/{mlrun.runtimes.RuntimeKinds.job}",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
+
+    response = client.delete(
+        f"runtimes/{mlrun.runtimes.RuntimeKinds.job}/some-id",
+    )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
 
 
 def _generate_grouped_by_project_runtime_resources_with_legacy_builder_output():

--- a/tests/api/api/test_runtime_resources.py
+++ b/tests/api/api/test_runtime_resources.py
@@ -369,26 +369,15 @@ def test_delete_runtime_resources_opa_filtering(
     response = client.delete(
         "projects/*/runtime-resources",
     )
-    body = response.json()
-    expected_body = (
-        _filter_allowed_projects_from_grouped_by_project_runtime_resources_output(
-            allowed_projects, grouped_by_project_runtime_resources_output
-        )
-    )
-    assert (
-        deepdiff.DeepDiff(
-            body,
-            expected_body,
-            ignore_order=True,
-        )
-        == {}
-    )
+
+    # if at least one project isn't allowed, the response should be forbidden
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
 
     # legacy endpoint
     response = client.delete(
         "runtimes",
     )
-    assert response.status_code == http.HTTPStatus.NO_CONTENT.value
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
 
 
 def test_delete_runtime_resources_with_legacy_builder_pod_opa_filtering(
@@ -417,26 +406,15 @@ def test_delete_runtime_resources_with_legacy_builder_pod_opa_filtering(
     response = client.delete(
         "projects/*/runtime-resources",
     )
-    body = response.json()
-    expected_body = (
-        _filter_allowed_projects_from_grouped_by_project_runtime_resources_output(
-            [""], grouped_by_project_runtime_resources_output
-        )
-    )
-    assert (
-        deepdiff.DeepDiff(
-            body,
-            expected_body,
-            ignore_order=True,
-        )
-        == {}
-    )
+
+    # if at least one project isn't allowed, the response should be forbidden
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
 
     # legacy endpoint
     response = client.delete(
         "runtimes",
     )
-    assert response.status_code == http.HTTPStatus.NO_CONTENT.value
+    assert response.status_code == http.HTTPStatus.FORBIDDEN.value
 
 
 def test_delete_runtime_resources_with_kind(

--- a/tests/api/api/test_runtime_resources.py
+++ b/tests/api/api/test_runtime_resources.py
@@ -598,7 +598,9 @@ def _assert_empty_responses_in_delete_endpoints(client: fastapi.testclient.TestC
     assert response.status_code == http.HTTPStatus.NO_CONTENT.value
 
 
-def _assert_forbidden_responses_in_delete_endpoints(client: fastapi.testclient.TestClient):
+def _assert_forbidden_responses_in_delete_endpoints(
+    client: fastapi.testclient.TestClient,
+):
     response = client.delete(
         "projects/*/runtime-resources",
     )


### PR DESCRIPTION
Fix for - https://jira.iguazeng.com/browse/ML-1432, https://jira.iguazeng.com/browse/ML-2541 and https://jira.iguazeng.com/browse/ML-1276
If all the resources are allowed to be deleted by the user, the request will be successful and the resource will be delete. 
If at least 1 resource exists but is forbidden to be deleted, the action will fail, nothing will be deleted and the user will get a 403 response (and the SDK will raise an exception).