### PR TITLE
[SDK] Fix `project.log_artifact` ignores given artifact tag

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1265,7 +1265,7 @@ class MlrunProject(ModelObj):
             "project",
             self.metadata.name,
             self.metadata.name,
-            tag=self._get_hexsha() or "latest",
+            tag=self._get_hexsha() or tag or "latest",
         )
         item = am.log_artifact(
             producer,


### PR DESCRIPTION
Fix for - https://jira.iguazeng.com/browse/ML-2522 

The `project.log_artifact` method, when selecting the artifact tag, was only looking at the commit hash (if related to a git repo) or set the tag as `latest`. Fixed it so it will see if the user supplied a tag before using `latest`.