### PR TITLE
[API] Add elapsed time attribute to API logs

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -14,6 +14,7 @@
 #
 import asyncio
 import concurrent.futures
+import datetime
 import traceback
 import uuid
 
@@ -122,6 +123,7 @@ async def log_request_response(request: fastapi.Request, call_next):
     path_with_query_string = uvicorn.protocols.utils.get_path_with_query_string(
         request.scope
     )
+    start_time = datetime.datetime.now()
     if not any(
         silent_logging_path in path_with_query_string
         for silent_logging_path in silent_logging_paths
@@ -151,6 +153,7 @@ async def log_request_response(request: fastapi.Request, call_next):
         )
         raise
     else:
+        elapsed_time_in_seconds = (datetime.datetime.now() - start_time).total_seconds()
         if not any(
             silent_logging_path in path_with_query_string
             for silent_logging_path in silent_logging_paths
@@ -159,6 +162,7 @@ async def log_request_response(request: fastapi.Request, call_next):
                 "Sending response",
                 status_code=response.status_code,
                 request_id=request_id,
+                elapsed_time=elapsed_time_in_seconds,
                 uri=path_with_query_string,
                 method=request.method,
             )

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -14,7 +14,7 @@
 #
 import asyncio
 import concurrent.futures
-import datetime
+import time
 import traceback
 import uuid
 
@@ -123,7 +123,7 @@ async def log_request_response(request: fastapi.Request, call_next):
     path_with_query_string = uvicorn.protocols.utils.get_path_with_query_string(
         request.scope
     )
-    start_time = datetime.datetime.now()
+    start_time = time.perf_counter_ns()
     if not any(
         silent_logging_path in path_with_query_string
         for silent_logging_path in silent_logging_paths
@@ -153,7 +153,10 @@ async def log_request_response(request: fastapi.Request, call_next):
         )
         raise
     else:
-        elapsed_time_in_seconds = (datetime.datetime.now() - start_time).total_seconds()
+        # convert from nano seconds to seconds
+        elapsed_time_in_seconds = (
+            (time.perf_counter_ns() - start_time) / 1000 / 1000 / 1000
+        )
         if not any(
             silent_logging_path in path_with_query_string
             for silent_logging_path in silent_logging_paths


### PR DESCRIPTION
```
> 2022-11-03 14:34:52,614 [debug] Received request: {'method': 'GET', 'client_address': '10.201.136.120:35788', 'http_version': '1.0', 'request_id': '519df661-7c28-4f3b-a74f-7bfa2c968691', 'uri': '/api/v1/frontend-spec'}
> 2022-11-03 14:34:52,634 [debug] Getting grafana service url from Iguazio
> 2022-11-03 14:34:53,048 [debug] Sending response: {'status_code': 200, 'request_id': '519df661-7c28-4f3b-a74f-7bfa2c968691', 'elapsed_time': 0.433912261, 'uri': '/api/v1/frontend-spec', 'method': 'GET'}
```