### PR TITLE
[CI] Bump CI actions versions 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: set-matrix
         run: |
           skipImages=,${{ github.event.inputs.skip_images }},
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git hash, ref and latest version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2
@@ -60,7 +60,7 @@ jobs:
     name: Run Dockerized Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # TODO: re-use the next 2 actions instead of duplicating
     - name: Extract git branch
       id: git_info
@@ -79,7 +79,7 @@ jobs:
     name: Run Dockerized Integration Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # TODO: re-use the next 2 actions instead of duplicating
     - name: Extract git branch
       id: git_info
@@ -98,7 +98,7 @@ jobs:
     name: Run Dockerized Migrations Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # TODO: re-use the next 2 actions instead of duplicating
       - name: Extract git branch
         id: git_info
@@ -120,9 +120,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v2
@@ -141,7 +141,7 @@ jobs:
     name: Build Project Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # TODO: re-use the next 2 actions instead of duplicating
       - name: Extract git branch
         id: git_info
@@ -176,12 +176,12 @@ jobs:
         run: |
             echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
       - name: Checkout PR Base (target) Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.resolve_base_branch.outputs.branch }}
           path: base/mlrun
       - name: Checkout Merge Commit (requested branch merged with the target branch)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: head/mlrun
       - name: Resolve docker cache tag
@@ -199,7 +199,7 @@ jobs:
     name: Check Copyright Existence
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check License Lines
         uses: kt3k/license_checker@v1.0.6
       - name: Instructions For Adding Copyright
@@ -228,10 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run make install-requirements
       run: make install-requirements
     - name: Run make install-complete-requirements

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,13 +65,13 @@ jobs:
     - name: Extract git branch
       id: git_info
       run: |
-        echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+        echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
     - name: Resolve docker cache tag
       id: docker_cache
       run: |
         export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-        echo "::set-output name=tag::$(echo $unstable_tag)"
+        echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
     - name: Run Dockerized tests
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
 
@@ -84,13 +84,13 @@ jobs:
     - name: Extract git branch
       id: git_info
       run: |
-        echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+        echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
     - name: Resolve docker cache tag
       id: docker_cache
       run: |
         export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-        echo "::set-output name=tag::$(echo $unstable_tag)"
+        echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
     - name: Run Dockerized tests
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-integration-dockerized
 
@@ -103,13 +103,13 @@ jobs:
       - name: Extract git branch
         id: git_info
         run: |
-          echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+          echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
       - name: Resolve docker cache tag
         id: docker_cache
         run: |
           export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-          echo "::set-output name=tag::$(echo $unstable_tag)"
+          echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
       - name: Run Dockerized DB Migration tests
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
 
@@ -146,13 +146,13 @@ jobs:
       - name: Extract git branch
         id: git_info
         run: |
-          echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+          echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
       - name: Resolve docker cache tag
         id: docker_cache
         run: |
           export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-          echo "::set-output name=tag::$(echo $unstable_tag)"
+          echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
       - name: Generate HTML docs
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make html-docs-dockerized
       - name: Upload generated docs
@@ -174,7 +174,7 @@ jobs:
     steps:
       - id: resolve_base_branch
         run: |
-            echo "::set-output name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})"
+            echo "name=branch::$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
       - name: Checkout PR Base (target) Branch
         uses: actions/checkout@v3
         with:
@@ -189,7 +189,7 @@ jobs:
         run: |
           export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
-          echo "::set-output name=tag::$(echo $unstable_tag)"
+          echo "name=tag::$(echo $unstable_tag)" >> $GITHUB_OUTPUT
       - name: Run Backward Compatibility Tests
         run: |
           cd head/mlrun

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         # we can't use the default token coming with the action cause GH prevents from create or updating workflows
         # which might be part of the release contents
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install curl and jq
         run: sudo apt-get install curl jq
       - name: Run script file

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,10 +73,10 @@ jobs:
     needs: [trigger-and-wait-for-ui-image-building, trigger-and-wait-for-mlrun-image-building]
     steps:
       - name: Set up python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build & push to pypi
         run: |
           pip install twine

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -210,36 +210,36 @@ jobs:
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
         MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
           make test-system-dockerized
-    - name: System Test Cleanup
-      # SSH to datanode and delete all docker images created by the system
-      # tests by restarting the docker-registry deployment
-      run: |  
-        sshpass \
-          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-          ssh \
-          -o StrictHostKeyChecking=no \
-          -o ServerAliveInterval=180 \
-          -o ServerAliveCountMax=3 \
-          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-          kubectl -n default-tenant rollout restart deployment docker-registry
-        
-        sshpass \
-          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-          scp \
-          automation/system_test/cleanup.py \
-          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/home/iguazio/cleanup.py
-        
-        sshpass \
-          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-          ssh \
-          -o StrictHostKeyChecking=no \
-          -o ServerAliveInterval=180 \
-          -o ServerAliveCountMax=3 \
-          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-            LC_ALL=en_US.utf8 LANG=en_US.utf8 /bin/python3 \
-              /home/iguazio/cleanup.py \
-              docker-images \
-              http://localhost:8009 \
-              igz0.docker_registry.0 \
-              "ghcr.io/mlrun/mlrun-api,ghcr.io/mlrun/mlrun-ui,ghcr.io/mlrun/mlrun,ghcr.io/mlrun/ml-models,ghcr.io/mlrun/ml-base"
-
+#    - name: System Test Cleanup
+#      # SSH to datanode and delete all docker images created by the system
+#      # tests by restarting the docker-registry deployment
+#      run: |
+#        sshpass \
+#          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+#          ssh \
+#          -o StrictHostKeyChecking=no \
+#          -o ServerAliveInterval=180 \
+#          -o ServerAliveCountMax=3 \
+#          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+#          kubectl -n default-tenant rollout restart deployment docker-registry
+#
+#        sshpass \
+#          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+#          scp \
+#          automation/system_test/cleanup.py \
+#          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/home/iguazio/cleanup.py
+#
+#        sshpass \
+#          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+#          ssh \
+#          -o StrictHostKeyChecking=no \
+#          -o ServerAliveInterval=180 \
+#          -o ServerAliveCountMax=3 \
+#          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+#            LC_ALL=en_US.utf8 LANG=en_US.utf8 /bin/python3 \
+#              /home/iguazio/cleanup.py \
+#              docker-images \
+#              http://localhost:8009 \
+#              igz0.docker_registry.0 \
+#              "ghcr.io/mlrun/mlrun-api,ghcr.io/mlrun/mlrun-ui,ghcr.io/mlrun/mlrun,ghcr.io/mlrun/ml-models,ghcr.io/mlrun/ml-base"
+#

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -63,9 +63,9 @@ jobs:
     if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
@@ -184,9 +184,9 @@ jobs:
         test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
     steps:
     # checking out to the commit hash that the preparation step executed on
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -66,9 +66,9 @@ jobs:
     if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - name: Install automation scripts dependencies and add mlrun to dev packages
@@ -148,11 +148,11 @@ jobs:
           input_system_tests_clean_resources=${{ github.event.inputs.clean_resources_in_teardown }} && \
           echo ${input_system_tests_clean_resources:-true})"
 
-    - uses: azure/setup-helm@v1
+    - uses: azure/setup-helm@v3
       with:
         version: "v3.9.1"
 
-    - uses: manusa/actions-setup-minikube@v2.4.2
+    - uses: manusa/actions-setup-minikube@v2.7.1
       with:
         minikube version: "v1.26.0"
         kubernetes version: "v1.23.9"

--- a/docs/projects/ci-integration.md
+++ b/docs/projects/ci-integration.md
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
         architecture: 'x64'


### PR DESCRIPTION
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, azure/setup-helm, manusa/actions-setup-minikube, actions/checkout`
and 
`The "set-output" command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
`