### PR TITLE
[Artifacts] Add category option to `list_artifact_tags`, fix to return only distinct values

### DIFF
--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -26,7 +26,6 @@ from mlrun.api import schemas
 from mlrun.api.api import deps
 from mlrun.api.api.utils import log_and_raise
 from mlrun.api.schemas.artifact import ArtifactsFormat
-from mlrun.api.utils.singletons.db import get_db
 from mlrun.config import config
 from mlrun.utils import is_legacy_artifact, logger
 
@@ -84,6 +83,7 @@ async def store_artifact(
 @router.get("/projects/{project}/artifact-tags")
 def list_artifact_tags(
     project: str,
+    category: schemas.ArtifactCategories = None,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -92,7 +92,9 @@ def list_artifact_tags(
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    tag_tuples = get_db().list_artifact_tags(db_session, project)
+    tag_tuples = mlrun.api.crud.Artifacts().list_artifact_tags(
+        db_session, project, category
+    )
     artifact_key_to_tag = {tag_tuple[1]: tag_tuple[2] for tag_tuple in tag_tuples}
     allowed_artifact_keys = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.artifact,
@@ -110,7 +112,8 @@ def list_artifact_tags(
     ]
     return {
         "project": project,
-        "tags": tags,
+        # Remove duplicities
+        "tags": list(set(tags)),
     }
 
 

--- a/mlrun/api/crud/artifacts.py
+++ b/mlrun/api/crud/artifacts.py
@@ -118,6 +118,17 @@ class Artifacts(
             for artifact in artifacts
         ]
 
+    def list_artifact_tags(
+        self,
+        db_session: sqlalchemy.orm.Session,
+        project: str = mlrun.mlconf.default_project,
+        category: mlrun.api.schemas.ArtifactCategories = None,
+    ):
+        project = project or mlrun.mlconf.default_project
+        return mlrun.api.utils.singletons.db.get_db().list_artifact_tags(
+            db_session, project, category
+        )
+
     def delete_artifact(
         self,
         db_session: sqlalchemy.orm.Session,

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -506,7 +506,7 @@ class DBInterface(ABC):
     ):
         pass
 
-    def list_artifact_tags(self, session, project):
+    def list_artifact_tags(self, session, project, category):
         return []
 
     def create_marketplace_source(

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -433,7 +433,7 @@ class FileDB(DBInterface):
     def delete_feature_vector(self, session, project, name, tag=None, uid=None):
         raise NotImplementedError()
 
-    def list_artifact_tags(self, session, project):
+    def list_artifact_tags(self, session, project, category):
         return self._transform_run_db_error(self.db.list_artifact_tags, project)
 
     def create_schedule(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -934,18 +934,31 @@ class SQLDB(DBInterface):
         return [row[0] for row in query]
 
     def list_artifact_tags(
-        self, session, project
+        self, session, project, category: schemas.ArtifactCategories = None
     ) -> typing.List[typing.Tuple[str, str, str]]:
         """
         :return: a list of Tuple of (project, artifact.key, tag)
         """
-        query = (
-            session.query(Artifact.key, Artifact.Tag.name)
-            .filter(Artifact.Tag.project == project)
-            .join(Artifact)
-            .distinct()
+        # TODO - refactor once we have the artifact kind as a field in the DB, the filtering on category can be done
+        # as a simple SQL query, and don't need to use the extra processing of listing tags etc.
+
+        artifacts = self.list_artifacts(
+            session, project=project, tag="*", category=category
         )
-        return [(project, row[0], row[1]) for row in query]
+        results = []
+        for artifact in artifacts:
+            if is_legacy_artifact(artifact):
+                results.append((project, artifact.get("db_key"), artifact.get("tag")))
+            else:
+                results.append(
+                    (
+                        project,
+                        artifact["spec"].get("db_key"),
+                        artifact["metadata"].get("tag"),
+                    )
+                )
+
+        return results
 
     def create_schedule(
         self,

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -262,7 +262,9 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def list_artifact_tags(self, project=None):
+    def list_artifact_tags(
+        self, project=None, category: Union[str, schemas.ArtifactCategories] = None
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -757,7 +757,7 @@ class FileRunDB(RunDBInterface):
     ):
         raise NotImplementedError()
 
-    def list_artifact_tags(self, project=None):
+    def list_artifact_tags(self, project=None, category=None):
         raise NotImplementedError()
 
     def create_or_patch_model_endpoint(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -749,13 +749,19 @@ class HTTPRunDB(RunDBInterface):
         endpoint_path = f"projects/{project}/artifacts"
         self.api_call("DELETE", endpoint_path, error, params=params)
 
-    def list_artifact_tags(self, project=None) -> List[str]:
+    def list_artifact_tags(
+        self,
+        project=None,
+        category: Union[str, schemas.ArtifactCategories] = None,
+    ) -> List[str]:
         """Return a list of all the tags assigned to artifacts in the scope of the given project."""
 
         project = project or config.default_project
         error_message = f"Failed listing artifact tags. project={project}"
+        params = {"category": category} if category else {}
+
         response = self.api_call(
-            "GET", f"projects/{project}/artifact-tags", error_message
+            "GET", f"projects/{project}/artifact-tags", error_message, params=params
         )
         return response.json()["tags"]
 

--- a/tests/integration/sdk_api/artifacts/test_artifact_tags.py
+++ b/tests/integration/sdk_api/artifacts/test_artifact_tags.py
@@ -40,11 +40,47 @@ class TestArtifactTags(tests.integration.sdk_api.base.TestMLRunIntegration):
         mlrun.get_run_db().store_artifact(
             key, artifact.to_dict(), uid_2, tag=tag_2, project=project_name
         )
+
+        model_key = "model-key"
+        model_uid = "model-uid"
+        model_uid_2 = "model-uid-2"
+        # Using the same tag on purpose, to make sure it's returned only once
+        model_tag = tag
+        model_tag_2 = "model-tag-2"
+        model_artifact = mlrun.artifacts.model.ModelArtifact(
+            model_key, body="a model with body"
+        )
+        mlrun.get_run_db().store_artifact(
+            model_key,
+            model_artifact.to_dict(),
+            model_uid,
+            tag=model_tag,
+            project=project_name,
+        )
+        mlrun.get_run_db().store_artifact(
+            model_key,
+            model_artifact.to_dict(),
+            model_uid_2,
+            tag=model_tag_2,
+            project=project_name,
+        )
+
         artifact_tags = mlrun.get_run_db().list_artifact_tags(project_name)
         assert (
             deepdiff.DeepDiff(
                 artifact_tags,
-                [tag, tag_2],
+                # No model_tag since it's the same as tag
+                [tag, tag_2, model_tag_2],
+                ignore_order=True,
+            )
+            == {}
+        )
+
+        model_tags = mlrun.get_run_db().list_artifact_tags(project_name, "model")
+        assert (
+            deepdiff.DeepDiff(
+                model_tags,
+                [model_tag, model_tag_2],
                 ignore_order=True,
             )
             == {}

--- a/tests/rundb/test_sqldb.py
+++ b/tests/rundb/test_sqldb.py
@@ -43,9 +43,24 @@ def test_list_artifact_tags(db: SQLDB, db_session: Session):
     db.store_artifact(db_session, "k1", {}, "1", tag="t1", project="p1")
     db.store_artifact(db_session, "k1", {}, "2", tag="t2", project="p1")
     db.store_artifact(db_session, "k1", {}, "2", tag="t2", project="p2")
+    db.store_artifact(db_session, "k2", {"kind": "model"}, "3", tag="t3", project="p1")
+    db.store_artifact(
+        db_session, "k3", {"kind": "dataset"}, "4", tag="t4", project="p2"
+    )
 
     tags = db.list_artifact_tags(db_session, "p1")
-    assert [("p1", "k1", "t1"), ("p1", "k1", "t2")] == tags
+    assert [("p1", "k1", "t1"), ("p1", "k1", "t2"), ("p1", "k2", "t3")] == tags
+
+    # filter by category
+    model_tags = db.list_artifact_tags(
+        db_session, "p1", mlrun.api.schemas.ArtifactCategories.model
+    )
+    assert [("p1", "k2", "t3")] == model_tags
+
+    model_tags = db.list_artifact_tags(
+        db_session, "p2", mlrun.api.schemas.ArtifactCategories.dataset
+    )
+    assert [("p2", "k3", "t4")] == model_tags
 
 
 def test_list_artifact_date(db: SQLDB, db_session: Session):


### PR DESCRIPTION
- The `list_artifact_tags` API now has a new `category` parameter, which is the same as for `list_artifacts` - it can be `model`, `dataset` or `other`. If not specified the current behavior remains which is to return all tags regardless of artifact types
- Fixed this API to return a list of unique values - up until now if same tag was used by multiple artifacts, the same tag would be returned several times, forcing the caller to remove duplicities
- The same functionality was added to `httpdb` for sdk usage

Example of API usage:
`GET .../projects/{project}/artifact-tags?category=model`

- Internal modification - moved the implementation to the Artifacts crud object, rather than calling the DB directly. This is in line with the rest of the functions in the endpoint.

Addresses [ML-2775](https://jira.iguazeng.com/browse/ML-2775) as part of [ML-2774](https://jira.iguazeng.com/browse/ML-2774), and fixes [ML-2756](https://jira.iguazeng.com/browse/ML-2756)