### PR TITLE
[DataStore] Fix get_or_create_store() to use netloc instead of endpoint

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -182,6 +182,7 @@ class StoreManager:
         if store_key in self._stores.keys():
             return self._stores[store_key], subpath
 
-        store = schema_to_store(schema)(self, schema, store_key, endpoint)
+        # support u/p embedding in url (as done in redis) by setting netloc as the "endpoint" parameter
+        store = schema_to_store(schema)(self, schema, store_key, parsed_url.netloc)
         self._stores[store_key] = store
         return store, subpath

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1991,7 +1991,7 @@ class TestFeatureStore(TestMLRunSystem):
         not mlrun.mlconf.redis.url,
         reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",
     )
-    @pytest.mark.parametrize("target_redis, ", ["", "localhost:6379"])
+    @pytest.mark.parametrize("target_redis, ", ["", "redis://:aaa@localhost:6379"])
     def test_purge_redis(self, target_redis):
         key = "patient_id"
         fset = fs.FeatureSet("purge", entities=[Entity(key)], timestamp_key="timestamp")
@@ -2007,7 +2007,7 @@ class TestFeatureStore(TestMLRunSystem):
             ParquetTarget(partitioned=True, partition_cols=["timestamp"]),
             RedisNoSqlTarget()
             if target_redis == ""
-            else RedisNoSqlTarget(target_redis),
+            else RedisNoSqlTarget(path=target_redis),
         ]
         fset.set_targets(
             targets=targets,


### PR DESCRIPTION
[ML-2779](https://jira.iguazeng.com/browse/ML-2779)