### PR TITLE
[Artifacts] Fix tag artifacts when logging artifacts through `project.log_artifact`

### DIFF
--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -153,6 +153,7 @@ class DBInterface(ABC):
         iter: int = None,
         best_iteration: bool = False,
         as_records: bool = False,
+        tag_to_uid: bool = None,
     ):
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -153,7 +153,7 @@ class DBInterface(ABC):
         iter: int = None,
         best_iteration: bool = False,
         as_records: bool = False,
-        tag_to_uid: bool = None,
+        use_tag_as_uid: bool = None,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -173,7 +173,7 @@ class FileDB(DBInterface):
         iter: int = None,
         best_iteration: bool = False,
         as_records: bool = False,
-        tag_to_uid: bool = None,
+        use_tag_as_uid: bool = None,
     ):
         return self._transform_run_db_error(
             self.db.list_artifacts, name, project, tag, labels, since, until

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -173,6 +173,7 @@ class FileDB(DBInterface):
         iter: int = None,
         best_iteration: bool = False,
         as_records: bool = False,
+        tag_to_uid: bool = None,
     ):
         return self._transform_run_db_error(
             self.db.list_artifacts, name, project, tag, labels, since, until

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -614,7 +614,6 @@ class SQLDB(DBInterface):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "best-iteration cannot be used when iter is specified"
             )
-        print("tag", tag)
         # TODO: Refactor this area
         # in case where tag is not given ids will be "latest" to mark to _find_artifacts to find the latest using the
         # old way - by the updated field
@@ -634,10 +633,10 @@ class SQLDB(DBInterface):
         # use_tag_as_uid == None is keeping the old behavior
         # use_tag_as_uid == False also keeps the old behavior for now, but left that option to be able to change later
         # use_tag_as_uid == True saying to the list artifacts that the tag is actually the uid
+        # only if tag we will use the tag as uid
         if use_tag_as_uid and tag:
-            print("here")
             ids = tag
-        print(ids)
+
         artifacts = ArtifactList()
         artifact_records = self._find_artifacts(
             session,


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-2746
- changed the way we are currently listing artifacts for when we run `tag` actions
- added `use_tag_as_uid` to note to the `list_artifacts` to use the tag it receives as `uid` because currently `list_artifacts` doesn't receives uid explicitly but rather through the `tag` argument and then has some logic to infer whether it got uid or actual tag, this becomes problematic where the uid of an artifact can be `latest` which also matches tags. 