### PR TITLE
[API] Optimize HTTP Retry Mechanism

### DIFF
--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -107,7 +107,7 @@ class HTTPSessionWithRetry(requests.Session):
 
                 # only retry on exceptions with the right message
                 exception_is_retryable = any(
-                    [msg in str(exc) for msg in self.HTTP_RETRYABLE_EXCEPTION_STRINGS]
+                    msg in str(exc) for msg in self.HTTP_RETRYABLE_EXCEPTION_STRINGS
                 )
 
                 if not exception_is_retryable:


### PR DESCRIPTION
Optimize logic by using a generator instead of compiling to a list first
```
▶ python3 -m timeit 'all(x for x in range(1000))'  
500000 loops, best of 5: 531 nsec per loop
▶ python3 -m timeit 'all([x for x in range(1000)])'
10000 loops, best of 5: 40.6 usec per loop
```