### PR TITLE
[System Tests] Change order of system tests cleanup and add datanode docker registry restart

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -53,6 +53,48 @@ on:
 
 concurrency: one-at-a-time
 jobs:
+  system-test-cleanup:
+    name: System Test Cleanup
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # let's not run this on every fork, change to your fork when developing
+    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
+
+    steps:
+    - name: cleanup docker images from registries
+      # SSH to datanode and delete all docker images created by the system tests by restarting the docker-registry
+      # deployment and the datanode docker-registry
+      run: |
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          ssh \
+          -o StrictHostKeyChecking=no \
+          -o ServerAliveInterval=180 \
+          -o ServerAliveCountMax=3 \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          kubectl -n default-tenant rollout restart deployment docker-registry
+
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          scp \
+          automation/system_test/cleanup.py \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/home/iguazio/cleanup.py
+
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          ssh \
+          -o StrictHostKeyChecking=no \
+          -o ServerAliveInterval=180 \
+          -o ServerAliveCountMax=3 \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+            LC_ALL=en_US.utf8 LANG=en_US.utf8 /bin/python3 \
+              /home/iguazio/cleanup.py \
+              docker-images \
+              http://localhost:8009 \
+              igz0.docker_registry.0 \
+              "ghcr.io/mlrun/mlrun-api,ghcr.io/mlrun/mlrun-ui,ghcr.io/mlrun/mlrun,ghcr.io/mlrun/ml-models,ghcr.io/mlrun/ml-base"
+
+
   prepare-system-tests-enterprise-ci:
     # When increasing the timeout make sure it's not larger than the schedule cron interval
     timeout-minutes: 55
@@ -210,36 +252,3 @@ jobs:
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
         MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
           make test-system-dockerized
-#    - name: System Test Cleanup
-#      # SSH to datanode and delete all docker images created by the system
-#      # tests by restarting the docker-registry deployment
-#      run: |
-#        sshpass \
-#          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-#          ssh \
-#          -o StrictHostKeyChecking=no \
-#          -o ServerAliveInterval=180 \
-#          -o ServerAliveCountMax=3 \
-#          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-#          kubectl -n default-tenant rollout restart deployment docker-registry
-#
-#        sshpass \
-#          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-#          scp \
-#          automation/system_test/cleanup.py \
-#          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/home/iguazio/cleanup.py
-#
-#        sshpass \
-#          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-#          ssh \
-#          -o StrictHostKeyChecking=no \
-#          -o ServerAliveInterval=180 \
-#          -o ServerAliveCountMax=3 \
-#          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-#            LC_ALL=en_US.utf8 LANG=en_US.utf8 /bin/python3 \
-#              /home/iguazio/cleanup.py \
-#              docker-images \
-#              http://localhost:8009 \
-#              igz0.docker_registry.0 \
-#              "ghcr.io/mlrun/mlrun-api,ghcr.io/mlrun/mlrun-ui,ghcr.io/mlrun/mlrun,ghcr.io/mlrun/ml-models,ghcr.io/mlrun/ml-base"
-#

--- a/automation/system_test/cleanup.py
+++ b/automation/system_test/cleanup.py
@@ -43,6 +43,9 @@ def docker_images(registry_url: str, registry_container_name: str, images: str):
     click.echo("Removed all tags. Running garbage collection...")
     _run_registry_garbage_collection(registry_container_name)
 
+    click.echo("Restarting datanode docker registry...")
+    _restart_docker_registry(registry_container_name)
+
     click.echo("Cleaning images from local Docker cache...")
     _clean_images_from_local_docker_cache(tags)
 
@@ -114,6 +117,11 @@ def _run_registry_garbage_collection(registry_container_name: str) -> None:
             "/etc/docker/registry/config.yml",
         ]
     )
+
+
+def _restart_docker_registry(registry_container_name: str) -> None:
+    """Restart Docker registry."""
+    subprocess.run(["docker", "restart", registry_container_name])
 
 
 def _clean_images_from_local_docker_cache(


### PR DESCRIPTION
- No actual need to run the cleanup of the docker registry after each type of system tests, rather just at the start of a new CI run.
- We experienced issues regarding the datanode docker registry caching, this was caused after deleting multiple images from the datanode docker registry, we weren't able to pull specific layers of images needed for the run. Found [this ](https://stackoverflow.com/questions/55971691/docker-pull-fails-for-some-layers-from-self-hosted-registry) , for us seems like restarting the container was enough to resolve the issue.