### PR TITLE
Fix Docker Compose Deployment

### DIFF
--- a/docs/install/compose.with-jupyter.yaml
+++ b/docs/install/compose.with-jupyter.yaml
@@ -1,6 +1,45 @@
 services:
+  init_nuclio:
+    image: alpine:3.16
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        mkdir -p /etc/nuclio/config/platform; \
+        cat << EOF | tee /etc/nuclio/config/platform/platform.yaml
+        runtime:
+          common:
+            env:
+              MLRUN_DBPATH: http://${HOST_IP:?err}:8080
+        local:
+          defaultFunctionContainerNetworkName: mlrun
+          defaultFunctionRestartPolicy:
+            name: always
+            maxRetryCount: 0
+          defaultFunctionVolumes:
+            - volume:
+                name: mlrun-stuff
+                hostPath:
+                  path: ${SHARED_DIR:?err}
+              volumeMount:
+                name: mlrun-stuff
+                mountPath: /home/jovyan/data/
+        logger:
+          sinks:
+            myStdoutLoggerSink:
+              kind: stdout
+          system:
+            - level: debug
+              sink: myStdoutLoggerSink
+          functions:
+            - level: debug
+              sink: myStdoutLoggerSink
+        EOF
+    volumes:
+      - nuclio-platform-config:/etc/nuclio/config
+
   jupyter:
-    image: "mlrun/jupyter:${TAG:-1.0.6}"
+    image: "mlrun/jupyter:${TAG:-1.1.1}"
     ports:
       - "8080:8080"
       - "8888:8888"
@@ -22,7 +61,7 @@ services:
       - mlrun
 
   mlrun-ui:
-    image: "mlrun/mlrun-ui:${TAG:-1.0.6}"
+    image: "mlrun/mlrun-ui:${TAG:-1.1.1}"
     ports:
       - "8060:8090"
     environment:
@@ -38,11 +77,18 @@ services:
     ports:
       - "8070:8070"
     environment:
-      NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES: "${HOST_IP:-127.0.0.1}"
+      NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES: "${HOST_IP:?err}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - nuclio-platform-config:/etc/nuclio/config
+    depends_on:
+      - init_nuclio
     networks:
       - mlrun
 
+volumes:
+  nuclio-platform-config: {}
+
 networks:
-  mlrun: {}
+  mlrun:
+    name: mlrun

--- a/docs/install/compose.with-jupyter.yaml
+++ b/docs/install/compose.with-jupyter.yaml
@@ -39,7 +39,7 @@ services:
       - nuclio-platform-config:/etc/nuclio/config
 
   jupyter:
-    image: "mlrun/jupyter:${TAG:-1.1.1}"
+    image: "mlrun/jupyter:${TAG:-1.1.2}"
     ports:
       - "8080:8080"
       - "8888:8888"
@@ -61,7 +61,7 @@ services:
       - mlrun
 
   mlrun-ui:
-    image: "mlrun/mlrun-ui:${TAG:-1.1.1}"
+    image: "mlrun/mlrun-ui:${TAG:-1.1.2}"
     ports:
       - "8060:8090"
     environment:

--- a/docs/install/compose.yaml
+++ b/docs/install/compose.yaml
@@ -1,6 +1,45 @@
 services:
+  init_nuclio:
+    image: alpine:3.16
+    command:
+      - "/bin/sh"
+      - "-c"
+      - |
+        mkdir -p /etc/nuclio/config/platform; \
+        cat << EOF | tee /etc/nuclio/config/platform/platform.yaml
+        runtime:
+          common:
+            env:
+              MLRUN_DBPATH: http://${HOST_IP:?err}:8080
+        local:
+          defaultFunctionContainerNetworkName: mlrun
+          defaultFunctionRestartPolicy:
+            name: always
+            maxRetryCount: 0
+          defaultFunctionVolumes:
+            - volume:
+                name: mlrun-stuff
+                hostPath:
+                  path: ${SHARED_DIR:?err}
+              volumeMount:
+                name: mlrun-stuff
+                mountPath: /home/jovyan/data/
+        logger:
+          sinks:
+            myStdoutLoggerSink:
+              kind: stdout
+          system:
+            - level: debug
+              sink: myStdoutLoggerSink
+          functions:
+            - level: debug
+              sink: myStdoutLoggerSink
+        EOF
+    volumes:
+      - nuclio-platform-config:/etc/nuclio/config
+
   mlrun-api:
-    image: "mlrun/mlrun-api:${TAG:-1.0.6}"
+    image: "mlrun/mlrun-api:${TAG:-1.1.2}"
     ports:
       - "8080:8080"
     environment:
@@ -22,7 +61,7 @@ services:
       - mlrun
 
   mlrun-ui:
-    image: "mlrun/mlrun-ui:${TAG:-1.0.6}"
+    image: "mlrun/mlrun-ui:${TAG:-1.1.2}"
     ports:
       - "8060:8090"
     environment:
@@ -38,11 +77,18 @@ services:
     ports:
       - "8070:8070"
     environment:
-      NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES: "${HOST_IP:-127.0.0.1}"
+      NUCLIO_DASHBOARD_EXTERNAL_IP_ADDRESSES: "${HOST_IP:?err}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - nuclio-platform-config:/etc/nuclio/config
+    depends_on:
+      - init_nuclio
     networks:
       - mlrun
 
+volumes:
+  nuclio-platform-config: {}
+
 networks:
-  mlrun: {}
+  mlrun:
+    name: mlrun

--- a/docs/install/local-docker.md
+++ b/docs/install/local-docker.md
@@ -25,7 +25,7 @@ There are two installation options:
 In both cases you need to set the `SHARED_DIR` environment variable to point to a host path for storing MLRun artifacts and DB, 
 for example `export SHARED_DIR=~/mlrun-data` (or use `set SHARED_DIR=c:\mlrun-data` in windows). Make sure the directory exists.
 
-It is recommended to set the `HOST_IP` variable with your computer IP address (required for Nuclio dashboard). 
+You also need to set the `HOST_IP` variable with your computer IP address (required for Nuclio dashboard). 
 You can select a specific MLRun version with the `TAG` variable and Nuclio version with the `NUCLIO_TAG` variable.
 
 Add the `-d` flag to `docker-compose` for running in detached mode (in the background).

--- a/docs/tutorial/01-mlrun-basics.ipynb
+++ b/docs/tutorial/01-mlrun-basics.ipynb
@@ -18,7 +18,10 @@
    "metadata": {
     "tags": [
      "docs-only"
-    ]
+    ],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mlrun/mlrun/blob/development/docs/tutorial/colab/01-mlrun-basics-colab.ipynb)"
@@ -27,7 +30,11 @@
   {
    "cell_type": "markdown",
    "id": "f3d4f37f-741c-4341-af7c-4cf2747e38f9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "\n",
     "**Introduction to MLRun - Use serverless functions to train and deploy models**\n",
@@ -1362,7 +1369,7 @@
    },
    "outputs": [],
    "source": [
-    "serving_fn = mlrun.new_function(\"serving\", image=\"mlrun/mlrun\", kind=\"serving\")"
+    "serving_fn = mlrun.new_function(\"serving\", image=\"python:3.8\", kind=\"serving\", requirements=[\"mlrun[complete]\", \"scikit-learn==1.1.2\"])"
    ]
   },
   {


### PR DESCRIPTION
Fix for - https://github.com/mlrun/mlrun/issues/2102 
Fixes:
- give mlrun network explicit name
- put nuclio function containers on the `mlrun` network
- set nuclio function env var MLRUN_DBPATH to `<host ip>:8080` (mlrun-api)
- mount shared dir in nuclio functions as /home/jovyan/data
- In basics tutorial - change serving function to be based on python3.8 in order to fix the pickling issue (according to https://github.com/mlrun/mlrun/issues/2505)
- update docs to require users to set `HOST_IP`

Because the jupyter image taken in the compose is 1.1.2, and this PR will be merged for 1.2.0, the tutorial will come up still with the old 1.1.2 tutorial without the fix. But you'll still be able to change the function as done in the above issue in order to remedy this.