### PR TITLE
[Frameworks] Fixed bug of no validation set in training

### DIFF
--- a/mlrun/frameworks/_dl_common/loggers/logger.py
+++ b/mlrun/frameworks/_dl_common/loggers/logger.py
@@ -201,17 +201,6 @@ class Logger:
         """
         self._validation_iterations += 1
 
-    def log_metric(self, metric_name: str):
-        """
-        Log a new metric, noting it in the results and summary dictionaries.
-
-        :param metric_name: The metric name to log.
-        """
-        self._training_results[metric_name] = []
-        self._validation_results[metric_name] = []
-        self._training_summaries[metric_name] = []
-        self._validation_summaries[metric_name] = []
-
     def log_training_result(self, metric_name: str, result: float):
         """
         Log the given metric result in the training results dictionary at the current epoch.
@@ -219,6 +208,8 @@ class Logger:
         :param metric_name: The metric name as it was logged in 'log_metric'.
         :param result:      The metric result to log.
         """
+        if metric_name not in self._training_results:
+            self._training_results[metric_name] = [[]]
         self._training_results[metric_name][-1].append(result)
 
     def log_validation_result(self, metric_name: str, result: float):
@@ -228,6 +219,8 @@ class Logger:
         :param metric_name: The metric name as it was logged in 'log_metric'.
         :param result:      The metric result to log.
         """
+        if metric_name not in self._validation_results:
+            self._validation_results[metric_name] = [[]]
         self._validation_results[metric_name][-1].append(result)
 
     def log_training_summary(self, metric_name: str, result: float):
@@ -237,6 +230,8 @@ class Logger:
         :param metric_name: The metric name as it was logged in 'log_metric'.
         :param result:      The metric result to log.
         """
+        if metric_name not in self._training_summaries:
+            self._training_summaries[metric_name] = []
         self._training_summaries[metric_name].append(result)
 
     def log_validation_summary(self, metric_name: str, result: float):
@@ -246,6 +241,8 @@ class Logger:
         :param metric_name: The metric name as it was logged in 'log_metric'.
         :param result:      The metric result to log.
         """
+        if metric_name not in self._validation_summaries:
+            self._validation_summaries[metric_name] = []
         self._validation_summaries[metric_name].append(result)
 
     def log_static_hyperparameter(

--- a/mlrun/frameworks/pytorch/callbacks/logging_callback.py
+++ b/mlrun/frameworks/pytorch/callbacks/logging_callback.py
@@ -205,20 +205,7 @@ class LoggingCallback(Callback):
         After the run begins, this method will be called to setup the results and hyperparameters dictionaries for
         logging, noting the metrics names and logging the initial hyperparameters values (epoch 0).
         """
-        # Setup the results and summaries dictionaries:
-        # # Loss:
-        self._logger.log_metric(
-            metric_name=self._get_metric_name(
-                metric_function=self._objects[self._ObjectKeys.LOSS_FUNCTION],
-            )
-        )
-        # # Metrics:
-        for metric_function in self._objects[self._ObjectKeys.METRIC_FUNCTIONS]:
-            self._logger.log_metric(
-                metric_name=self._get_metric_name(metric_function=metric_function)
-            )
-
-        # Setup the hyperparameters dictionaries:
+        # Set up the hyperparameters dictionaries:
         if self._auto_log:
             self._add_auto_hyperparameters()
         # # Static hyperparameters:

--- a/mlrun/frameworks/pytorch/mlrun_interface.py
+++ b/mlrun/frameworks/pytorch/mlrun_interface.py
@@ -206,7 +206,7 @@ class PyTorchMLRunInterface:
                 ):
                     break
 
-            # End of a epoch callbacks:
+            # End of an epoch callbacks:
             if not self._callbacks_handler.on_epoch_end(epoch=epoch):
                 break
             print()


### PR DESCRIPTION
Fix for the training of PyTorch using MLRun's interface without validation sets.

Jira: https://jira.iguazeng.com/browse/ML-2511
