### PR TITLE
[SDK] Fix console notification being printed when also ipython notification is displayed

### DIFF
--- a/mlrun/api/utils/auth/verifier.py
+++ b/mlrun/api/utils/auth/verifier.py
@@ -191,7 +191,6 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     def authenticate_request(
         self, request: fastapi.Request
     ) -> mlrun.api.schemas.AuthInfo:
-        raise Exception("ADAM have a look here")
         auth_info = mlrun.api.schemas.AuthInfo()
         header = request.headers.get("Authorization", "")
         if self._basic_auth_configured():

--- a/mlrun/api/utils/auth/verifier.py
+++ b/mlrun/api/utils/auth/verifier.py
@@ -191,6 +191,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     def authenticate_request(
         self, request: fastapi.Request
     ) -> mlrun.api.schemas.AuthInfo:
+        raise Exception("ADAM have a look here")
         auth_info = mlrun.api.schemas.AuthInfo()
         header = request.headers.get("Authorization", "")
         if self._basic_auth_configured():

--- a/mlrun/utils/notifications/notification/__init__.py
+++ b/mlrun/utils/notifications/notification/__init__.py
@@ -36,6 +36,16 @@ class NotificationTypes(str, enum.Enum):
             self.slack: SlackNotification,
         }.get(self)
 
+    def inverse_dependencies(self) -> typing.List[str]:
+        """
+        Some notifications should only run if another notification type didn't run.
+        Per given notification type, return a list of notification types that should not run in order for this
+        notification to run.
+        """
+        return {
+            self.console: [self.ipython],
+        }.get(self, [])
+
     @classmethod
     def all(cls) -> typing.List[str]:
         return list(

--- a/mlrun/utils/notifications/notification/base.py
+++ b/mlrun/utils/notifications/notification/base.py
@@ -33,6 +33,10 @@ class NotificationBase:
     ):
         self.params = params or {}
 
+    @property
+    def active(self) -> bool:
+        return True
+
     def send(
         self,
         message: str,

--- a/mlrun/utils/notifications/notification/ipython.py
+++ b/mlrun/utils/notifications/notification/ipython.py
@@ -53,7 +53,7 @@ class IPythonNotification(NotificationBase):
         custom_html: str = None,
     ):
         if not self._ipython:
-            mlrun.utils.helpers.logger.warn(
+            mlrun.utils.helpers.logger.debug(
                 "Not in IPython environment, skipping notification"
             )
             return

--- a/mlrun/utils/notifications/notification/ipython.py
+++ b/mlrun/utils/notifications/notification/ipython.py
@@ -41,6 +41,10 @@ class IPythonNotification(NotificationBase):
         except ImportError:
             pass
 
+    @property
+    def active(self) -> bool:
+        return self._ipython is not None
+
     def send(
         self,
         message: str,

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -44,7 +44,7 @@ class SlackNotification(NotificationBase):
     ):
         webhook = self.params.get("webhook", None) or os.environ.get("SLACK_WEBHOOK")
         if not webhook:
-            mlrun.utils.helpers.logger.warn(
+            mlrun.utils.helpers.logger.debug(
                 "No slack webhook is set, skipping notification"
             )
             return

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -101,8 +101,9 @@ class CustomNotificationPusher(object):
         runs: typing.Union[mlrun.lists.RunList, list] = None,
         custom_html: str = None,
     ):
-        for notification in self._notifications.values():
-            notification.send(message, severity, runs, custom_html)
+        for notification_type, notification in self._notifications.items():
+            if self.should_send_notification(notification_type):
+                notification.send(message, severity, runs, custom_html)
 
     def add_notification(
         self, notification_type: str, params: typing.Dict[str, str] = None
@@ -113,6 +114,26 @@ class CustomNotificationPusher(object):
             self._notifications[notification_type] = NotificationTypes(
                 notification_type
             ).get_notification()(params)
+
+    def should_send_notification(self, notification_type):
+        notification = self._notifications.get(notification_type)
+        if not notification or not notification.active:
+            return False
+
+        # get notification's inverse dependencies, and only send the notification if
+        # none of its inverse dependencies are being sent
+        inverse_dependencies = notification_type.inverse_dependencies()
+        for inverse_dependency in inverse_dependencies:
+            inverse_dependency_notification = self._notifications.get(
+                inverse_dependency
+            )
+            if (
+                inverse_dependency_notification
+                and inverse_dependency_notification.active
+            ):
+                return False
+
+        return True
 
     def push_pipeline_start_message(
         self,

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -220,3 +220,40 @@ def test_git_notification(monkeypatch, params, expected_url, expected_headers):
     requests_mock.assert_called_once_with(
         url=expected_url, json={"body": expected_body}, headers=expected_headers
     )
+
+
+@pytest.mark.parametrize(
+    "ipython_active,expected_console_call_amount,expected_ipython_call_amount",
+    [
+        (True, 0, 1),
+        (False, 1, 0),
+    ],
+)
+def test_inverse_dependencies(
+    monkeypatch,
+    ipython_active,
+    expected_console_call_amount,
+    expected_ipython_call_amount,
+):
+    custom_notification_pusher = mlrun.utils.notifications.CustomNotificationPusher(
+        [
+            mlrun.utils.notifications.NotificationTypes.console,
+            mlrun.utils.notifications.NotificationTypes.ipython,
+        ]
+    )
+
+    mock_console_send = unittest.mock.MagicMock()
+    mock_ipython_send = unittest.mock.MagicMock()
+    monkeypatch.setattr(
+        mlrun.utils.notifications.ConsoleNotification, "send", mock_console_send
+    )
+    monkeypatch.setattr(
+        mlrun.utils.notifications.IPythonNotification, "send", mock_ipython_send
+    )
+    monkeypatch.setattr(
+        mlrun.utils.notifications.IPythonNotification, "active", ipython_active
+    )
+
+    custom_notification_pusher.push("test-message", "info", [])
+    assert mock_console_send.call_count == expected_console_call_amount
+    assert mock_ipython_send.call_count == expected_ipython_call_amount


### PR DESCRIPTION
If the ipython notification is displayed, the console notification shouldn't be printed.
Added an inverse dependency mechanism to the notifications in order to implement this and allow more inverse dependencies like this in the future.