### PR TITLE
[Projects] Support GH fine grained tokens

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -31,6 +31,7 @@ from nuclio.triggers import V3IOStreamTrigger
 import mlrun.errors
 from mlrun.datastore import parse_s3_bucket_and_key
 from mlrun.db import RunDBError
+from mlrun.utils import get_git_username_password_from_token
 
 from ..api.schemas import AuthInfo
 from ..config import config as mlconf
@@ -1534,10 +1535,13 @@ def _compile_nuclio_archive_config(
             code_entry_attributes["branch"] = branch
 
         password = get_secret("GIT_PASSWORD")
+        username = get_secret("GIT_USERNAME")
+
         token = get_secret("GIT_TOKEN")
         if token:
-            password = "x-oauth-basic"
-        code_entry_attributes["username"] = token or get_secret("GIT_USERNAME")
+            username, password = get_git_username_password_from_token(token)
+
+        code_entry_attributes["username"] = username
         code_entry_attributes["password"] = password
 
     # populate spec with relevant fields

--- a/mlrun/utils/__init__.py
+++ b/mlrun/utils/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .azure_vault import AzureVaultStore  # noqa
-from .clones import get_git_username_password_from_token # noqa
+from .clones import get_git_username_password_from_token  # noqa
 from .helpers import *  # noqa
 from .http import *  # noqa
 from .logger import *  # noqa

--- a/mlrun/utils/__init__.py
+++ b/mlrun/utils/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .azure_vault import AzureVaultStore  # noqa
+from .clones import get_git_username_password_from_token
 from .helpers import *  # noqa
 from .http import *  # noqa
 from .logger import *  # noqa

--- a/mlrun/utils/__init__.py
+++ b/mlrun/utils/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .azure_vault import AzureVaultStore  # noqa
-from .clones import get_git_username_password_from_token
+from .clones import get_git_username_password_from_token # noqa
 from .helpers import *  # noqa
 from .http import *  # noqa
 from .logger import *  # noqa

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -47,6 +47,19 @@ def _prep_dir(source, target_dir, suffix, secrets, clone):
     return temp_file
 
 
+def get_git_username_password_from_token(token):
+    # Github's access tokens have a known prefix according to their type. See
+    # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
+    # We distinguish new fine-grained access tokens (begin with "github_pat_" from classic tokens.
+    if token.startswith("github_pat_"):
+        username = "oauth2"
+        password = token
+    else:
+        username = token
+        password = "x-oauth-basic"
+    return username, password
+
+
 def clone_zip(source, target_dir, secrets=None, clone=True):
     tmpfile = _prep_dir(source, target_dir, ".zip", secrets, clone)
     with zipfile.ZipFile(tmpfile, "r") as zf:
@@ -116,8 +129,7 @@ def clone_git(url, context, secrets=None, clone=True):
     )
     token = get_secret("GIT_TOKEN")
     if token:
-        username = token
-        password = "x-oauth-basic"
+        username, password = get_git_username_password_from_token(token)
 
     clone_path = f"https://{host}{url_obj.path}"
     enriched_clone_path = ""


### PR DESCRIPTION
When working with fine-grained-tokens, the existing way of embedding token in the URL is not working anymore. Instead, one has to use `oauth2:<token>`. 
This fix identifies the type of token based on the token prefix as noted [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats), and if it is a fine-grained-token, shifts to using the new format.

*Note:* The git notifications flow is using a different mechanism to work with Git (issuing direct REST calls, rather than work with `GitPython`), and uses command headers to submit tokens. I haven't modified this flow, as it is expected to continue working even with fine-grained tokens.

Fixes https://jira.iguazeng.com/browse/ML-2766