### PR TITLE
[API] Configure Uvicorn Keep Alive Timeout

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -363,6 +363,7 @@ def main():
         port=config.httpdb.port,
         debug=config.httpdb.debug,
         access_log=False,
+        timeout_keep_alive=config.httpdb.http_connection_timeout_keep_alive,
     )
 
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -218,6 +218,7 @@ default_config = {
         # See mlrun.api.schemas.APIStates for options
         "state": "online",
         "retry_api_call_on_exception": "enabled",
+        "http_connection_timeout_keep_alive": 11,
         "db": {
             "commit_retry_timeout": 30,
             "commit_retry_interval": 3,


### PR DESCRIPTION
Added config variable to select uvicorn's keep alive timeout, set it by default to `11`.

While debugging an issue where mlrun was being throttled by cpu (it had 500m cpu limit on the api pod), we noticed some requests would only arrive at the API more than 5 seconds after being by from the client.
This caused the api to drop the client connections upon receiving them as the default keep alive timeout was 5 seconds. While the cpu limit indeed was too small and we subsequently removed it, we still want to increase the default timeout just a bit to give the application some more leeway just in case.