### PR TITLE
[API] Adding cloud storage to default allowed file paths

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -212,7 +212,7 @@ default_config = {
         "real_path": "",
         # comma delimited prefixes of paths allowed through the /files API (v3io & the real_path are always allowed).
         # These paths must be schemas (cannot be used for local files). For example "s3://mybucket,gcs://"
-        "allowed_file_paths": "",
+        "allowed_file_paths": "s3://,gcs://,gs://,az://",
         "db_type": "sqldb",
         "max_workers": 64,
         # See mlrun.api.schemas.APIStates for options

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -1223,6 +1223,7 @@ def test_get_obj_path(db: Session, client: TestClient):
         },
         {
             "path": "gcs://bucket/and/path",
+            "allowed_paths": "s3://",
             "expect_error": True,
         },
         {


### PR DESCRIPTION
The `files` API is by default blocking access to all storage except v3io. This changes the default behavior to allow access to cloud storage providers - s3, Azure and GCS.

Fixes https://jira.iguazeng.com/browse/ML-2764 (up to the documentation part)