### PR TITLE
[Frameworks] Add alias for the SciKit-Learn model server

### DIFF
--- a/mlrun/frameworks/sklearn/__init__.py
+++ b/mlrun/frameworks/sklearn/__init__.py
@@ -27,6 +27,8 @@ from .utils import SKLearnTypes, SKLearnUtils
 
 # Placeholders as the SciKit-Learn API is commonly used among all ML frameworks:
 SKLearnModelServer = PickleModelServer
+# TODO: Change in docs to the correct naming and add warning for this one:
+SklearnModelServer = SKLearnModelServer
 SKLearnArtifactsLibrary = MLArtifactsLibrary
 
 


### PR DESCRIPTION
Added alias for the SciKit-Learn model server - both `SKLearnModelServer` and `SklearnModelServer` (notice the small k and l)