### PR TITLE
[Requirements] Bump v3io version to 0.5.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ requests~=2.22
 sqlalchemy~=1.3
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6
-v3io~=0.5.19
+v3io~=0.5.20
 pydantic~=1.5
 orjson~=3.3
 # 1.6.0 introduced some bug and we were just about to release a version TODO: find the root cause for the problems


### PR DESCRIPTION
[ML-2859](https://jira.iguazeng.com/browse/ML-2859)