### PR TITLE
[Run] Fix handler param in `run_function` was overwritten by default handler

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -768,6 +768,7 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
 def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
     """Run HTTP api/database server"""
     env = environ.copy()
+    env["MLRUN_ENV_FILE"] = ""  # ignore .env files
     if port is not None:
         env["MLRUN_httpdb__port"] = str(port)
     if dirpath is not None:

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -768,7 +768,7 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
 def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
     """Run HTTP api/database server"""
     env = environ.copy()
-    env["MLRUN_ENV_FILE"] = ""  # ignore .env files
+    env.pop("MLRUN_ENV_FILE", None)  # ignore .env files
     if port is not None:
         env["MLRUN_httpdb__port"] = str(port)
     if dirpath is not None:

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -768,7 +768,8 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
 def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
     """Run HTTP api/database server"""
     env = environ.copy()
-    env.pop("MLRUN_ENV_FILE", None)  # ignore .env files
+    # ignore client side .env file (so import mlrun in server will not try to connect to local/remote DB)
+    env.pop("MLRUN_ENV_FILE", None)
     if port is not None:
         env["MLRUN_httpdb__port"] = str(port)
     if dirpath is not None:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -171,6 +171,8 @@ def run_local(
     command, runtime = load_func_code(command, workdir, secrets=secrets, name=name)
 
     if runtime:
+        if task:
+            handler = handler or task.spec.handler_name
         handler = handler or runtime.spec.default_handler or ""
         meta = runtime.metadata.copy()
         meta.project = project or meta.project

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -172,7 +172,7 @@ def run_local(
 
     if runtime:
         if task:
-            handler = handler or task.spec.handler_name
+            handler = handler or task.spec.handler
         handler = handler or runtime.spec.default_handler or ""
         meta = runtime.metadata.copy()
         meta.project = project or meta.project

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -343,9 +343,11 @@ class BaseRuntime(ModelObj):
 
         self._enrich_function()
 
+        run = self._create_run_object(runspec)
+
         if local:
             return self._run_local(
-                runspec,
+                run,
                 schedule,
                 local_code_path,
                 project,
@@ -356,8 +358,6 @@ class BaseRuntime(ModelObj):
                 inputs,
                 artifact_path,
             )
-
-        run = self._create_run_object(runspec)
 
         run = self._enrich_run(
             run,

--- a/tests/run/assets/handler.py
+++ b/tests/run/assets/handler.py
@@ -25,6 +25,10 @@ def myhandler(context: mlrun.MLClientCtx, p1, p2=3, p3=4):
     context.log_artifact("file_result", body=b"abc123", local_path="result.txt")
 
 
+def handler2(context: mlrun.MLClientCtx):
+    context.log_result("handler", "2")
+
+
 def env_file_test(context: mlrun.MLClientCtx):
     context.log_result("ENV_ARG1", os.environ.get("ENV_ARG1"))
     context.log_result("kfp_ttl", mlrun.mlconf.kfp_ttl)

--- a/tests/run/test_run_local.py
+++ b/tests/run/test_run_local.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import getpass
+import pathlib
 from os import environ, makedirs, path
 
 import mlrun
@@ -123,3 +124,16 @@ def test_force_run_local():
     assert not result.metadata.labels["kind"]
 
     mlrun.mlconf.force_run_local = old_force
+
+
+def test_default_handler():
+    function_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
+    project = mlrun.new_project("test-handler", save=False)
+    project.set_function(
+        function_path, "myfunc", handler="myhandler", image="mlrun/mlrun"
+    )
+
+    run = project.run_function("myfunc", handler="handler2", local=True)
+    assert (
+        run.output("handler") == "2"
+    )  # verify that the 2nd handler was running (not the default)

--- a/tests/run/test_run_local.py
+++ b/tests/run/test_run_local.py
@@ -134,6 +134,5 @@ def test_default_handler():
     )
 
     run = project.run_function("myfunc", handler="handler2", local=True)
-    assert (
-        run.output("handler") == "2"
-    )  # verify that the 2nd handler was running (not the default)
+    # verify that the 2nd handler was running (not the default)
+    assert run.output("handler") == "2"


### PR DESCRIPTION
when default_handler was set in the function handler arg in run_function() method was ignored