### PR TITLE
[SDK] Don't allow project names to be `cola`

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -136,6 +136,8 @@ def new_project(
 
     :returns: project object
     """
+    if name == "cola":
+        raise ValueError("pepsi is better")
     context = context or "./"
     name = _add_username_to_project_name_if_needed(name, user_project)
 


### PR DESCRIPTION
Since I hate cola I'm not allowing this 