### PR TITLE
[CLI][projects] Workflow schedule overwrite [1.1.x]

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -887,6 +887,12 @@ def logs(uid, project, offset, db, watch):
     "https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron."
     "For using the pre-defined workflow's schedule, set --schedule 'true'",
 )
+@click.option(
+    "--overwrite",
+    "-o",
+    is_flag=True,
+    help="overwrite a schedule when submitting a new one with the same name",
+)
 def project(
     context,
     name,
@@ -912,6 +918,7 @@ def project(
     timeout,
     ensure_project,
     schedule,
+    overwrite,
 ):
     """load and/or run a project"""
     if env_file:
@@ -984,6 +991,7 @@ def project(
                 engine=engine,
                 local=local,
                 schedule=schedule,
+                overwrite=overwrite,
             )
         except Exception as exc:
             print(traceback.format_exc())

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -455,6 +455,7 @@ class _PipelineRunner(abc.ABC):
         secrets=None,
         artifact_path=None,
         namespace=None,
+        overwrite=None,
     ) -> _PipelineRunStatus:
         return None
 
@@ -530,6 +531,7 @@ class _KFPRunner(_PipelineRunner):
         secrets=None,
         artifact_path=None,
         namespace=None,
+        overwrite=None,
     ) -> _PipelineRunStatus:
         pipeline_context.set(project, workflow_spec)
         workflow_handler = _PipelineRunner._get_handler(
@@ -640,6 +642,7 @@ class _LocalRunner(_PipelineRunner):
         secrets=None,
         artifact_path=None,
         namespace=None,
+        overwrite=None,
     ) -> _PipelineRunStatus:
         pipeline_context.set(project, workflow_spec)
         workflow_handler = _PipelineRunner._get_handler(
@@ -708,6 +711,7 @@ class _RemoteRunner(_PipelineRunner):
         secrets=None,
         artifact_path=None,
         namespace=None,
+        overwrite=None,
     ) -> typing.Optional[_PipelineRunStatus]:
         workflow_name = name.split("-")[-1] if f"{project.name}-" in name else name
         runner_name = f"workflow-runner-{workflow_name}"
@@ -752,6 +756,11 @@ class _RemoteRunner(_PipelineRunner):
             runspec = runspec.set_label("job-type", "workflow-runner").set_label(
                 "workflow", workflow_name
             )
+            if workflow_spec.schedule and overwrite:
+                run_db = mlrun.get_run_db()
+                run_db.delete_schedule(
+                    project=project.metadata.name, name=workflow_name
+                )
             run = load_and_run_fn.run(
                 runspec=runspec,
                 local=False,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1911,6 +1911,7 @@ class MlrunProject(ModelObj):
         local: bool = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger, bool] = None,
         timeout: int = None,
+        overwrite: bool = False,
     ) -> _PipelineRunStatus:
         """run a workflow using kubeflow pipelines
 
@@ -1939,6 +1940,7 @@ class MlrunProject(ModelObj):
                           https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
                           for using the pre-defined workflow's schedule, set `schedule=True`
         :param timeout:   timeout in seconds to wait for pipeline completion (used when watch=True)
+        :param overwrite: delete schedule when submitting a new one with the same name
         :returns: run id
         """
 
@@ -2005,6 +2007,7 @@ class MlrunProject(ModelObj):
             secrets=self._secrets,
             artifact_path=artifact_path,
             namespace=namespace,
+            overwrite=overwrite,
         )
         run_msg = f"started run workflow {name} "
         # run is None when scheduling

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -557,3 +557,41 @@ class TestProject(TestMLRunSystem):
         project.set_secrets(file_path=env_file)
         secrets = db.list_project_secret_keys(name, provider="kubernetes")
         assert secrets.secret_keys == ["ENV_ARG1", "ENV_ARG2"]
+
+    def test_overwrite_schedule(self):
+        name = "overwrite-test"
+        project_dir = f"{projects_dir}/{name}"
+        workflow_name = "main"
+        self.custom_project_names_to_delete.append(name)
+        project = mlrun.load_project(
+            project_dir,
+            "git://github.com/mlrun/project-demo.git",
+            name=name,
+        )
+
+        schedules = ["*/30 * * * *", "*/40 * * * *", "*/50 * * * *"]
+        # overwriting nothing
+        project.run(workflow_name, schedule=schedules[0], overwrite=True)
+        schedule = self._run_db.get_schedule(name, workflow_name)
+        assert schedule.scheduled_object["schedule"] == schedules[0]
+
+        # overwriting schedule:
+        project.run(workflow_name, schedule=schedules[1], dirty=True, overwrite=True)
+        schedule = self._run_db.get_schedule(name, workflow_name)
+        assert schedule.scheduled_object["schedule"] == schedules[1]
+
+        # overwriting schedule from cli:
+        args = [
+            project_dir,
+            "-n",
+            name,
+            "-d",
+            "-r",
+            workflow_name,
+            "-o",  # stands for overwrite
+            "--schedule",
+            f"'{schedules[2]}'",
+        ]
+        exec_project(args)
+        schedule = self._run_db.get_schedule(name, workflow_name)
+        assert schedule.scheduled_object["schedule"] == schedules[2]


### PR DESCRIPTION
By setting `overwrite=True` when submitting a workflow with schedule, the old schedule of the workflow is deleted before creating the new one.
[ML-2873](https://jira.iguazeng.com/browse/ML-2873)