### PR TITLE
[Images] Models GPU download miniconda python 3.7 instead of latest

### DIFF
--- a/dockerfiles/models-gpu/Dockerfile
+++ b/dockerfiles/models-gpu/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG CUDA_VER=11.2
+ARG CUDA_VER=11.0
 
 FROM quay.io/mlrun/cuda:${CUDA_VER}-cudnn8-devel-ubuntu18.04
 
@@ -42,7 +42,7 @@ RUN apt-get update && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/installconda.sh && \
+RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \
     rm ~/installconda.sh && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
@@ -81,7 +81,7 @@ RUN mkdir /tmp/openmpi && \
     make -j`nproc` all && \
     make install && \
     ldconfig && \
-    rm -rf /tmp/openmpi    
+    rm -rf /tmp/openmpi
 
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1


### PR DESCRIPTION
The actual CUDA_VER used in models-gpu py 3.7 is 11.0 (it was being overridden by the makefile) hence the "downgrade"