### PR TITLE
[Secrets] Add a global `get_secret_or_env` function to retrieve secret values

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "import_function",
     "handler",
     "ArtifactType",
+    "get_secret_or_env",
 ]
 
 import getpass
@@ -69,6 +70,7 @@ from .run import (
     wait_for_pipeline_completion,
 )
 from .runtimes import new_model_server
+from .secrets import get_secret_or_env
 from .utils.version import Version
 
 __version__ = Version().get()["version"]

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -14,7 +14,7 @@
 import sys
 import tempfile
 from base64 import b64encode
-from os import getenv, path, remove
+from os import path, remove
 
 import dask.dataframe as dd
 import fsspec
@@ -24,7 +24,6 @@ import requests
 import urllib3
 
 import mlrun.errors
-from mlrun.secrets import SecretsStore
 from mlrun.utils import is_ipython, logger
 
 verify_ssl = False

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -81,12 +81,8 @@ class DataStore:
 
     def _get_secret_or_env(self, key, default=None):
         # Project-secrets are mounted as env variables whose name can be retrieved from SecretsStore
-        return (
-            self._get_secret(key)
-            or self._get_parent_secret(key)
-            or getenv(key)
-            or getenv(SecretsStore.k8s_env_variable_name_for_secret(key))
-            or default
+        return mlrun.get_secret_or_env(
+            key, secret_provider=self._get_secret, default=default
         )
 
     def get_storage_options(self):
@@ -106,7 +102,7 @@ class DataStore:
         return self._parent.secret(self.secret_pfx + key)
 
     def _get_secret(self, key: str, default=None):
-        return self._secrets.get(key, default)
+        return self._secrets.get(key, default) or self._get_parent_secret(key)
 
     @property
     def url(self):

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -467,9 +467,7 @@ class MLClientCtx(object):
 
             access_key = context.get_secret("ACCESS_KEY")
         """
-        if self._secrets_manager:
-            return self._secrets_manager.get(key)
-        return None
+        return mlrun.get_secret_or_env(key, secret_store=self._secrets_manager)
 
     def _set_input(self, key, url=""):
         if url is None:

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -187,7 +187,7 @@ def get_secret_or_env(
     value = None
     if secret_provider:
         if isinstance(secret_provider, Dict):
-            value = secret_provider.get(key, default)
+            value = secret_provider.get(key)
         else:
             value = secret_provider(key)
         if value:

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -157,13 +157,14 @@ def get_secret_or_env(
 ) -> str:
     """Retrieve value of a secret, either from a user-provided secret store, or from environment variables.
     The function will retrieve a secret value, attempting to find it according to the following order:
+
     1. If `secret_provider` was provided, will attempt to retrieve the secret from it
     2. If an MLRun `SecretsStore` was provided, query it for the secret key
-    2. An environment variable with the same key
-    3. An MLRun-generated env. variable, mounted from a project secret (to be used in MLRun runtimes)
-    4. The default value
+    3. An environment variable with the same key
+    4. An MLRun-generated env. variable, mounted from a project secret (to be used in MLRun runtimes)
+    5. The default value
 
-    example::
+    Example::
 
         secrets = { "KEY1": "VALUE1" }
         secret = get_secret_or_env("KEY1", secret_provider=secrets)
@@ -179,7 +180,7 @@ def get_secret_or_env(
     :param secret_provider: Dictionary or callable to extract the secret value from. If using a callable, it must
         use the signature `callable(key:str)`
     :param secret_store: An MLRun `SecretsStore`. Function will attempt to `get()` the secret from the store
-    :default: Default value to return if secret was not available through any other means
+    :param default: Default value to return if secret was not available through any other means
     :return: The secret value if found in any of the sources, or `default` if provided.
     """
 

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -14,7 +14,7 @@
 
 from ast import literal_eval
 from os import environ, getenv
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Optional, Union
 
 from .utils import AzureVaultStore, VaultStore, list2dict
 
@@ -150,10 +150,10 @@ class SecretsStore:
 
 
 def get_secret_or_env(
-    key,
-    secret_provider: Union[Dict, Callable] = None,
-    secret_store: SecretsStore = None,
-    default=None,
+    key: str,
+    secret_provider: Union[Dict, Callable, None] = None,
+    secret_store: Optional[SecretsStore] = None,
+    default: Optional[str] = None,
 ) -> str:
     """Retrieve value of a secret, either from a user-provided secret store, or from environment variables.
     The function will retrieve a secret value, attempting to find it according to the following order:

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from ast import literal_eval
-from os import environ
+from os import environ, getenv
+from typing import Callable, Dict, Union
 
 from .utils import AzureVaultStore, VaultStore, list2dict
 
@@ -146,3 +147,57 @@ class SecretsStore:
                     for secret in source["source"]
                 }
         return None
+
+
+def get_secret_or_env(
+    key,
+    secret_provider: Union[Dict, Callable] = None,
+    secret_store: SecretsStore = None,
+    default=None,
+) -> str:
+    """Retrieve value of a secret, either from a user-provided secret store, or from environment variables.
+    The function will retrieve a secret value, attempting to find it according to the following order:
+    1. If `secret_provider` was provided, will attempt to retrieve the secret from it
+    2. If an MLRun `SecretsStore` was provided, query it for the secret key
+    2. An environment variable with the same key
+    3. An MLRun-generated env. variable, mounted from a project secret (to be used in MLRun runtimes)
+    4. The default value
+
+    example::
+
+        secrets = { "KEY1": "VALUE1" }
+        secret = get_secret_or_env("KEY1", secret_provider=secrets)
+
+        # Using a function to retrieve a secret
+        def my_secret_provider(key):
+            # some internal logic to retrieve secret
+            return value
+
+        secret = get_secret_or_env("KEY1", secret_provider=my_secret_provider, default="TOO-MANY-SECRETS")
+
+    :param key: Secret key to look for
+    :param secret_provider: Dictionary or callable to extract the secret value from. If using a callable, it must
+        use the signature `callable(key:str)`
+    :param secret_store: An MLRun `SecretsStore`. Function will attempt to `get()` the secret from the store
+    :default: Default value to return if secret was not available through any other means
+    :return: The secret value if found in any of the sources, or `default` if provided.
+    """
+
+    value = None
+    if secret_provider:
+        if isinstance(secret_provider, Dict):
+            value = secret_provider.get(key, default)
+        else:
+            value = secret_provider(key)
+        if value:
+            return value
+
+    if secret_store:
+        value = secret_store.get(key)
+
+    return (
+        value
+        or getenv(key)
+        or getenv(SecretsStore.k8s_env_variable_name_for_secret(key))
+        or default
+    )

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -95,7 +95,7 @@ def clone_git(url, context, secrets=None, clone=True):
     secrets = secrets or {}
 
     def get_secret(key):
-        return os.environ.get(key, secrets.get(key))
+        return mlrun.get_secret_or_env(key, secret_provider=secrets)
 
     url_obj = urlparse(url)
     if not context:

--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -75,7 +75,11 @@ class GitNotification(NotificationBase):
         """
         if ("CI_PROJECT_ID" in os.environ) or (server and "gitlab" in server):
             gitlab = True
-        token = token or os.environ.get("GITHUB_TOKEN") or os.environ.get("GIT_TOKEN")
+        token = (
+            token
+            or mlrun.get_secret_or_env("GITHUB_TOKEN")
+            or mlrun.get_secret_or_env("GIT_TOKEN")
+        )
 
         if gitlab:
             server = server or "gitlab.com"

--- a/tests/utils/test_get_secrets.py
+++ b/tests/utils/test_get_secrets.py
@@ -1,0 +1,65 @@
+# Copyright 2022 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+
+import mlrun
+from mlrun.secrets import SecretsStore
+
+
+def reverser(key):
+    return key[::-1]
+
+
+def test_get_secret_from_env():
+    key = "SOME_KEY"
+    value = "SOME_VALUE"
+    project_secret_value = "SOME_OTHER_VALUE"
+    override_value = "SOME_OVERRIDE"
+
+    # Use an env variable
+    os.environ[key] = value
+    assert mlrun.get_secret_or_env(key) == value
+
+    os.environ[
+        SecretsStore.k8s_env_variable_name_for_secret(key)
+    ] = project_secret_value
+    # Project secrets should not override directly set env variables
+    assert mlrun.get_secret_or_env(key) == value
+
+    del os.environ[key]
+    assert mlrun.get_secret_or_env(key) == project_secret_value
+
+    # Use a local override dictionary
+    local_secrets = {key: override_value}
+    assert mlrun.get_secret_or_env(key, secret_provider=local_secrets) == override_value
+
+    # Use a callable
+    assert mlrun.get_secret_or_env(key, secret_provider=reverser) == reverser(key)
+
+    # Use a SecretsStore
+    store = SecretsStore()
+    store.add_source("inline", local_secrets)
+    assert mlrun.get_secret_or_env(key, secret_store=store) == override_value
+
+    # Verify that default is used if nothing else is found
+    assert (
+        mlrun.get_secret_or_env(
+            "SOME_GIBBERISH",
+            secret_store=store,
+            secret_provider=local_secrets,
+            default="not gibberish",
+        )
+        == "not gibberish"
+    )


### PR DESCRIPTION
Created a global function `get_secret_or_env` that will attempt to retrieve a secret value from the various locations that we support today:
- An MLRun `SecretsStore`
- A dictionary provided by the user
- Env variables, both "generic" and one with the MLRun prefix for project secrets

Modified some of the code that retrieves secrets to utilize this new function - next steps would be to detect other locations which do the same and transform them to use it.