### PR TITLE
[Run] Fix outputs wait for completion

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -817,10 +817,10 @@ class RunObject(RunTemplate):
         show_logs=False,
     ):
         """
-        Wait for the run to complete to fetch run outputs.
-        When runs a function with watch=False, and wants to pass the outputs to another function,
+        Wait for the run to complete fetching the run outputs.
+        When running a function with watch=False, and passing the outputs to another function,
         the outputs will not be available until the run is completed.
-        :param show_logs: default False, because we don't want to print the logs of the run when user asks for outputs
+        :param show_logs: default False, avoid spamming unwanted logs of the run when the user asks for outputs
         """
         if self.outputs_wait_for_completion:
             self.wait_for_completion(
@@ -912,7 +912,7 @@ class RunObject(RunTemplate):
         state = self.state()
         if state not in mlrun.runtimes.constants.RunStates.terminal_states():
             logger.info(
-                f"run {self.metadata.name} is not in terminal state, waiting for it to reach terminal state",
+                f"run {self.metadata.name} is not completed yet, waiting for it to complete",
                 current_state=state,
             )
         while True:


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2907

When calling `run.outputs/run.output/run.artifacts` we were waiting until that run reaches terminal state, because only then the run actually contains the outputs. This was spamming the user with the run logs because we were pulling the run state using get logs rather than get state. Changed the behavior to pull state when calling those functions. 
Also added a log message explaining why calling those methods might take time when the run is not in terminal state.

Before:
<img width="1165" alt="Screen Shot 2022-12-05 at 15 03 15" src="https://user-images.githubusercontent.com/59158507/205715254-f416cd9b-bcc5-4587-b7b9-01bfbc4cbe2c.png">
Now:
<img width="1345" alt="Screen Shot 2022-12-05 at 20 31 02" src="https://user-images.githubusercontent.com/59158507/205715258-3fdc6455-55c9-468f-a37e-0733eeec9803.png">


