### PR TITLE
[Serving] Fixing `impute` failures when using `get_online_feature_service` with a feature-vector uri

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -256,7 +256,7 @@ def get_online_feature_service(
     :param fixed_window_type: determines how to query the fixed window values which were previously inserted by ingest
     :param update_stats:      update features statistics from the requested feature sets on the vector. Default: False.
     """
-    if isinstance(feature_vector, FeatureVector):
+    if isinstance(feature_vector, FeatureVector) or impute_policy:
         update_stats = True
     feature_vector = _features_to_vector_and_check_permissions(
         feature_vector, update_stats

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2457,7 +2457,8 @@ class TestFeatureStore(TestMLRunSystem):
 
         fs.get_offline_features(vector)
 
-    def test_online_impute(self):
+    @pytest.mark.parametrize("pass_vector_as_uri", [True, False])
+    def test_online_impute(self, pass_vector_as_uri):
         data = pd.DataFrame(
             {
                 "time_stamp": [
@@ -2489,8 +2490,11 @@ class TestFeatureStore(TestMLRunSystem):
 
         # create vector and online service with imputing policy
         vector = fs.FeatureVector("vectori", features)
+        vector.save()
+
         with fs.get_online_feature_service(
-            vector, impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4}
+            vector.uri if pass_vector_as_uri else vector,
+            impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4},
         ) as svc:
             print(svc.vector.status.to_yaml())
 


### PR DESCRIPTION
When calling `get_online_feature_service` with an `impute_policy`, the code would not set `update_stats` to `True` if the fvec was passed as a uri.
The result is that if the fvec was created and it doesn't have stats yet (for example, if `get_offline_features` was never called on it), the impute would fail because it relies on the stats, which doesn't exist yet.
The fix is to force `update_stats=True` when an `impute_policy` is passed, even if the fvec is given as a uri.
Modified existing system-test to cover this use-case (was only passing fvec as object so far).

Fixes [ML-2898](https://jira.iguazeng.com/browse/ML-2898)