### PR TITLE
[API] Fix run paramaters larger than int64 corrupting projects

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -251,6 +251,7 @@ class MLClientCtx(object):
         host=None,
         log_stream=None,
         is_api=False,
+        update_db=True,
     ):
         """create execution context from dict"""
 
@@ -305,7 +306,8 @@ class MLClientCtx(object):
         if start:
             self._start_time = start
         self._state = "running"
-        self._update_db(commit=True)
+        if update_db:
+            self._update_db(commit=True)
         return self
 
     @property

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1157,7 +1157,7 @@ class BaseRuntime(ModelObj):
                 self.verify_run_params(param_value)
 
             # verify that integer parameters don't exceed a int64
-            if isinstance(param_value, int) and param_value >= 2**64:
+            if isinstance(param_value, int) and abs(param_value) >= 2**63:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"parameter {param_name} value {param_name} exceeds int64"
                 )

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1154,7 +1154,7 @@ class BaseRuntime(ModelObj):
     def verify_run_params(run: RunObject):
         # verify that integer parameters don't exceed a int64
         for param in run.spec.parameters:
-            if isinstance(param.value, int) and param.value > 2 ** 63:
+            if isinstance(param.value, int) and param.value > 2**63:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"parameter {param.name} value {param.value} exceeds int64"
                 )

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -832,7 +832,6 @@ class BaseRuntime(ModelObj):
         results = RunList()
         num_errors = 0
         tasks = generator.generate(runobj)
-
         for task in tasks:
             try:
                 self.store_run(task)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1157,7 +1157,7 @@ class BaseRuntime(ModelObj):
                 self.verify_run_params(param_value)
 
             # verify that integer parameters don't exceed a int64
-            if isinstance(param_value, int) and param_value > 2**63:
+            if isinstance(param_value, int) and param_value >= 2**64:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"parameter {param_name} value {param_name} exceeds int64"
                 )

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -418,7 +418,11 @@ class BaseRuntime(ModelObj):
             )
 
         execution = MLClientCtx.from_dict(
-            run.to_dict(), autocommit=False, is_api=self._is_api_server, update_db=False
+            run.to_dict(),
+            db,
+            autocommit=False,
+            is_api=self._is_api_server,
+            update_db=False,
         )
 
         self._verify_run_params(run.spec.parameters)

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -406,10 +406,10 @@ def test_redirection_from_worker_to_chief_submit_job_with_schedule(
 @pytest.mark.parametrize(
     "task_name,parameters,hyperparameters",
     [
-        ("param-pos", {"x": 2**63}, None),
-        ("param-neg", {"x": -(2**63)}, None),
-        ("hyperparam-pos", None, {"x": [1, 2**63]}),
-        ("hyperparam-neg", None, {"x": [1, -(2**63)]}),
+        ("param-pos", {"x": 2**63 + 1}, None),
+        ("param-neg", {"x": -(2**63 + 1)}, None),
+        ("hyperparam-pos", None, {"x": [1, 2**63 + 1]}),
+        ("hyperparam-neg", None, {"x": [1, -(2**63 + 1)]}),
     ],
 )
 def test_submit_job_failure_params_exceed_int64(
@@ -442,6 +442,10 @@ def test_submit_job_failure_params_exceed_int64(
 
     assert resp.status_code == HTTPStatus.BAD_REQUEST.value
     assert "exceeds int64" in resp.json()["detail"]["reason"]
+
+    resp = client.get("runs", params={"project": project_name})
+    # assert the run wasn't saved to the DB
+    assert len(resp.json()["runs"]) == 0
 
 
 def _create_submit_job_body(function, project, with_output_path=True):

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -441,7 +441,7 @@ def test_submit_job_failure_params_exceed_int64(
     resp = client.post("submit_job", json=submit_job_body)
 
     assert resp.status_code == HTTPStatus.BAD_REQUEST.value
-    assert f"exceeds int64" in resp.json()["detail"]["reason"]
+    assert "exceeds int64" in resp.json()["detail"]["reason"]
 
 
 def _create_submit_job_body(function, project, with_output_path=True):

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -14,6 +14,7 @@
 #
 import http
 import json
+import typing
 import unittest.mock
 from http import HTTPStatus
 
@@ -400,6 +401,47 @@ def test_redirection_from_worker_to_chief_submit_job_with_schedule(
         response = client.post(endpoint, data=json_body)
         assert response.status_code == expected_status
         assert response.json() == expected_response
+
+
+@pytest.mark.parametrize(
+    "task_name,parameters,hyperparameters",
+    [
+        ("param-pos", {"x": 2**63}, None),
+        ("param-neg", {"x": -(2**63)}, None),
+        ("hyperparam-pos", None, {"x": [1, 2**63]}),
+        ("hyperparam-neg", None, {"x": [1, -(2**63)]}),
+    ],
+)
+def test_submit_job_failure_params_exceed_int64(
+    db: Session,
+    client: TestClient,
+    pod_create_mock,
+    task_name: str,
+    parameters: typing.Dict[str, int],
+    hyperparameters: typing.Dict[str, typing.List[int]],
+) -> None:
+    project_name = "params-exceed-int64"
+    project_artifact_path = f"/{project_name}"
+    tests.api.api.utils.create_project(
+        client, project_name, artifact_path=project_artifact_path
+    )
+    function = mlrun.new_function(
+        name="test-function",
+        project=project_name,
+        tag="latest",
+        kind="job",
+        image="mlrun/mlrun",
+    )
+    submit_job_body = _create_submit_job_body(function, project_name)
+    submit_job_body["task"]["metadata"]["name"] = task_name
+    if parameters:
+        submit_job_body["task"]["spec"]["parameters"] = parameters
+    if hyperparameters:
+        submit_job_body["task"]["spec"]["hyperparams"] = hyperparameters
+    resp = client.post("submit_job", json=submit_job_body)
+
+    assert resp.status_code == HTTPStatus.BAD_REQUEST.value
+    assert f"exceeds int64" in resp.json()["detail"]["reason"]
 
 
 def _create_submit_job_body(function, project, with_output_path=True):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -644,7 +644,6 @@ def test_project_ops():
     ],
 )
 def test_validating_large_int_params(parameters, hyperparameters, expectation):
-    # verify that project ops (run_function, ..) will use the right project (and not the pipeline_context)
     func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
     proj1 = mlrun.new_project("proj1", save=False)
     proj1.set_function(func_path, "f1", image="mlrun/mlrun", handler="myhandler")

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -621,14 +621,26 @@ def test_project_ops():
 @pytest.mark.parametrize(
     "parameters,hyperparameters,expectation",
     [
-        ({"x": 2**64}, None, pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        ({"x": 2**64 - 1}, None, does_not_raise()),
+        ({"x": 2**63}, None, pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         (
+            {"x": -(2**63)},
             None,
-            {"x": [1, 2**64]},
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
-        (None, {"x": [3, 2**64 - 1]}, does_not_raise()),
+        ({"x": 2**63 - 1}, None, does_not_raise()),
+        ({"x": -(2**63) + 1}, None, does_not_raise()),
+        (
+            None,
+            {"x": [1, 2**63]},
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        (
+            None,
+            {"x": [1, -(2**63)]},
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        (None, {"x": [3, 2**63 - 1]}, does_not_raise()),
+        (None, {"x": [3, -(2**63) + 1]}, does_not_raise()),
     ],
 )
 def test_validating_large_int_params(parameters, hyperparameters, expectation):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -622,13 +622,13 @@ def test_project_ops():
     "parameters,hyperparameters,expectation",
     [
         ({"x": 2**64}, None, pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        ({"x": 2**63}, None, does_not_raise()),
+        ({"x": 2**64 - 1}, None, does_not_raise()),
         (
             None,
             {"x": [1, 2**64]},
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
-        (None, {"x": [3, 2**63]}, does_not_raise()),
+        (None, {"x": [3, 2**64 - 1]}, does_not_raise()),
     ],
 )
 def test_validating_large_int_params(parameters, hyperparameters, expectation):


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-2862

There is a bug in `orjson` which allows int128 variables to be deserialized from JSONs but not serialize back to JSONs. (https://github.com/ijl/orjson/issues/116)
This causes a bug in which we get a request for a run with a large int as one of its parameters, it is properly received, run and saved in the database. However any and all responses which contain the parameter, fail to serialize and cause a 500 error response, effectively denying service for the most requests in the relating project.

As this bug isn't easily remedied, and `orjson` have no plans on fixing it, we need to validate upon run requests that no int parameter is larger than int64. We need to do this for both the parameters and hyperparameters, which is why the validation is added in both code flows, while in the hyperparameters flow we validate it after the parameters have been distributed.