### PR TITLE
[Secrets] Fix `get_secret_or_env`

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -467,7 +467,7 @@ class MLClientCtx(object):
 
             access_key = context.get_secret("ACCESS_KEY")
         """
-        return mlrun.get_secret_or_env(key, secret_store=self._secrets_manager)
+        return mlrun.get_secret_or_env(key, secret_provider=self._secrets_manager)
 
     def _set_input(self, key, url=""):
         if url is None:

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -151,8 +151,7 @@ class SecretsStore:
 
 def get_secret_or_env(
     key: str,
-    secret_provider: Union[Dict, Callable, None] = None,
-    secret_store: Optional[SecretsStore] = None,
+    secret_provider: Union[Dict, SecretsStore, Callable, None] = None,
     default: Optional[str] = None,
 ) -> str:
     """Retrieve value of a secret, either from a user-provided secret store, or from environment variables.
@@ -177,24 +176,20 @@ def get_secret_or_env(
         secret = get_secret_or_env("KEY1", secret_provider=my_secret_provider, default="TOO-MANY-SECRETS")
 
     :param key: Secret key to look for
-    :param secret_provider: Dictionary or callable to extract the secret value from. If using a callable, it must
-        use the signature `callable(key:str)`
-    :param secret_store: An MLRun `SecretsStore`. Function will attempt to `get()` the secret from the store
+    :param secret_provider: Dictionary, callable or `SecretsStore` to extract the secret value from. If using a
+        callable, it must use the signature `callable(key:str)`
     :param default: Default value to return if secret was not available through any other means
     :return: The secret value if found in any of the sources, or `default` if provided.
     """
 
     value = None
     if secret_provider:
-        if isinstance(secret_provider, Dict):
+        if isinstance(secret_provider, (Dict, SecretsStore)):
             value = secret_provider.get(key)
         else:
             value = secret_provider(key)
         if value:
             return value
-
-    if secret_store:
-        value = secret_store.get(key)
 
     return (
         value

--- a/tests/utils/test_get_secrets.py
+++ b/tests/utils/test_get_secrets.py
@@ -51,14 +51,13 @@ def test_get_secret_from_env():
     # Use a SecretsStore
     store = SecretsStore()
     store.add_source("inline", local_secrets)
-    assert mlrun.get_secret_or_env(key, secret_store=store) == override_value
+    assert mlrun.get_secret_or_env(key, secret_provider=store) == override_value
 
     # Verify that default is used if nothing else is found
     assert (
         mlrun.get_secret_or_env(
             "SOME_GIBBERISH",
-            secret_store=store,
-            secret_provider=local_secrets,
+            secret_provider=store,
             default="not gibberish",
         )
         == "not gibberish"


### PR DESCRIPTION
`get_secret_or_env` now has a single parameter `secret_provider` which can also be a `SecretsStore`.
This fixes a flow in `clone_git` which could get either a dict or a `SecretsStore` and passed it in the wrong parameter.