### PR TITLE
[DataStore] Fix how we resolve if running as API

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -22,10 +22,11 @@ __all__ = [
     "handler",
     "ArtifactType",
     "get_secret_or_env",
+    "is_running_as_api",
 ]
 
-import getpass
-from os import environ, path
+import json
+from os import environ, getenv, path
 
 import dotenv
 
@@ -86,6 +87,19 @@ if "IGZ_NAMESPACE_DOMAIN" in environ:
     kfp_ep = f"https://dashboard.{igz_domain}/pipelines"
     environ["KF_PIPELINES_UI_ENDPOINT"] = kfp_ep
     mlconf.remote_host = mlconf.remote_host or igz_domain
+
+_is_running_as_api = None
+
+
+def is_running_as_api():
+    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
+    global _is_running_as_api
+
+    if _is_running_as_api is None:
+        # os.getenv will load the env var as string, and json.loads will convert it to a bool
+        _is_running_as_api = json.loads(getenv("MLRUN_IS_API_SERVER", "false"))
+
+    return _is_running_as_api
 
 
 def set_environment(

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "handler",
     "ArtifactType",
     "get_secret_or_env",
+    "is_running_as_api",
 ]
 
 import getpass

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -25,7 +25,8 @@ __all__ = [
 ]
 
 import getpass
-from os import environ, path
+import json
+from os import environ, getenv, path
 
 import dotenv
 
@@ -86,6 +87,17 @@ if "IGZ_NAMESPACE_DOMAIN" in environ:
     kfp_ep = f"https://dashboard.{igz_domain}/pipelines"
     environ["KF_PIPELINES_UI_ENDPOINT"] = kfp_ep
     mlconf.remote_host = mlconf.remote_host or igz_domain
+
+
+def is_running_as_api():
+    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
+    global _is_running_as_api
+
+    if not _is_running_as_api:
+        # os.getenv will load the env var as string, and json.loads will convert it to a bool
+        _is_running_as_api = json.loads(getenv("MLRUN_IS_API_SERVER", "false"))
+
+    return _is_running_as_api
 
 
 def set_environment(

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -88,12 +88,14 @@ if "IGZ_NAMESPACE_DOMAIN" in environ:
     environ["KF_PIPELINES_UI_ENDPOINT"] = kfp_ep
     mlconf.remote_host = mlconf.remote_host or igz_domain
 
+_is_running_as_api = None
+
 
 def is_running_as_api():
     # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
     global _is_running_as_api
 
-    if not _is_running_as_api:
+    if _is_running_as_api is None:
         # os.getenv will load the env var as string, and json.loads will convert it to a bool
         _is_running_as_api = json.loads(getenv("MLRUN_IS_API_SERVER", "false"))
 

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -22,12 +22,10 @@ __all__ = [
     "handler",
     "ArtifactType",
     "get_secret_or_env",
-    "is_running_as_api",
 ]
 
 import getpass
-import json
-from os import environ, getenv, path
+from os import environ, path
 
 import dotenv
 
@@ -88,19 +86,6 @@ if "IGZ_NAMESPACE_DOMAIN" in environ:
     kfp_ep = f"https://dashboard.{igz_domain}/pipelines"
     environ["KF_PIPELINES_UI_ENDPOINT"] = kfp_ep
     mlconf.remote_host = mlconf.remote_host or igz_domain
-
-_is_running_as_api = None
-
-
-def is_running_as_api():
-    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
-    global _is_running_as_api
-
-    if _is_running_as_api is None:
-        # os.getenv will load the env var as string, and json.loads will convert it to a bool
-        _is_running_as_api = json.loads(getenv("MLRUN_IS_API_SERVER", "false"))
-
-    return _is_running_as_api
 
 
 def set_environment(

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -785,6 +785,8 @@ def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
     if verbose:
         env["MLRUN_LOG_LEVEL"] = "DEBUG"
 
+    env["MLRUN_IS_API_SERVER"] = "true"
+
     # create the DB dir if needed
     dsn = dsn or mlconf.httpdb.dsn
     if dsn and dsn.startswith("sqlite:///"):

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -191,7 +191,7 @@ class StoreManager:
                 raise ValueError(f"no such store ({endpoint})")
 
         store_key = f"{schema}://{endpoint}"
-        if not secrets and not mlrun.is_running_as_api():
+        if not secrets and not mlrun.utils.is_running_as_api():
             if store_key in self._stores.keys():
                 return self._stores[store_key], subpath
 
@@ -201,6 +201,6 @@ class StoreManager:
         store = schema_to_store(schema)(
             self, schema, store_key, parsed_url.netloc, secrets=secrets
         )
-        if not secrets and not mlrun.is_running_as_api():
+        if not secrets and not mlrun.utils.is_running_as_api():
             self._stores[store_key] = store
         return store, subpath

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -191,7 +191,7 @@ class StoreManager:
                 raise ValueError(f"no such store ({endpoint})")
 
         store_key = f"{schema}://{endpoint}"
-        if not secrets and not mlrun.utils.is_running_as_api():
+        if not secrets and not mlrun.is_running_as_api():
             if store_key in self._stores.keys():
                 return self._stores[store_key], subpath
 
@@ -201,6 +201,6 @@ class StoreManager:
         store = schema_to_store(schema)(
             self, schema, store_key, parsed_url.netloc, secrets=secrets
         )
-        if not secrets and not mlrun.utils.is_running_as_api():
+        if not secrets and not mlrun.is_running_as_api():
             self._stores[store_key] = store
         return store, subpath

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -50,6 +50,7 @@ functions_dir = "functions"
 schedules_dir = "schedules"
 
 
+# TODO: remove fileDB, doesn't needs to be used anymore
 class FileRunDB(RunDBInterface):
     kind = "file"
 
@@ -58,12 +59,23 @@ class FileRunDB(RunDBInterface):
         self.dirpath = dirpath
         self._datastore = None
         self._subpath = None
+        self._secrets = None
         makedirs(self.schedules_dir, exist_ok=True)
 
     def connect(self, secrets=None):
-        sm = store_manager.set(secrets)
+        self._secrets = secrets
+        return self
+
+    def _connect(self, secrets=None):
+        sm = store_manager.set(secrets or self._secrets)
         self._datastore, self._subpath = sm.get_or_create_store(self.dirpath)
         return self
+
+    @property
+    def datastore(self):
+        if not self._datastore:
+            self._connect()
+        return self._datastore
 
     def store_log(self, uid, project="", body=None, append=False):
         filepath = self._filepath(run_logs, project, uid, "") + ".log"
@@ -95,7 +107,7 @@ class FileRunDB(RunDBInterface):
             self._filepath(run_logs, project, self._run_path(uid, iter), "")
             + self.format
         )
-        self._datastore.put(filepath, data)
+        self.datastore.put(filepath, data)
 
     def update_run(self, updates: dict, uid, project="", iter=0):
         run = self.read_run(uid, project, iter=iter)
@@ -115,7 +127,7 @@ class FileRunDB(RunDBInterface):
         )
         if not pathlib.Path(filepath).is_file():
             raise mlrun.errors.MLRunNotFoundError(uid)
-        data = self._datastore.get(filepath)
+        data = self.datastore.get(filepath)
         return self._loads(data)
 
     def list_runs(
@@ -221,11 +233,11 @@ class FileRunDB(RunDBInterface):
         if iter:
             key = f"{iter}-{key}"
         filepath = self._filepath(artifacts_dir, project, key, uid) + self.format
-        self._datastore.put(filepath, data)
+        self.datastore.put(filepath, data)
         filepath = (
             self._filepath(artifacts_dir, project, key, tag or "latest") + self.format
         )
-        self._datastore.put(filepath, data)
+        self.datastore.put(filepath, data)
 
     def read_artifact(self, key, tag="", iter=None, project=""):
         tag = tag or "latest"
@@ -235,7 +247,7 @@ class FileRunDB(RunDBInterface):
 
         if not pathlib.Path(filepath).is_file():
             raise RunDBError(key)
-        data = self._datastore.get(filepath)
+        data = self.datastore.get(filepath)
         return self._loads(data)
 
     def list_artifacts(
@@ -327,7 +339,7 @@ class FileRunDB(RunDBInterface):
             )
             + self.format
         )
-        self._datastore.put(filepath, data)
+        self.datastore.put(filepath, data)
         if versioned:
 
             # the "hash_key" version should not include the status
@@ -346,7 +358,7 @@ class FileRunDB(RunDBInterface):
                 + self.format
             )
             data = self._dumps(function)
-            self._datastore.put(filepath, data)
+            self.datastore.put(filepath, data)
         return hash_key
 
     def get_function(self, name, project="", tag="", hash_key=""):
@@ -365,7 +377,7 @@ class FileRunDB(RunDBInterface):
         if not pathlib.Path(filepath).is_file():
             function_uri = generate_object_uri(project, name, tag, hash_key)
             raise mlrun.errors.MLRunNotFoundError(f"Function not found {function_uri}")
-        data = self._datastore.get(filepath)
+        data = self.datastore.get(filepath)
         parsed_data = self._loads(data)
 
         # tag should be filled only when queried by tag

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -381,6 +381,7 @@ def run_exec(cmd, args, env=None, cwd=None):
     out = ""
     if env and "SYSTEMROOT" in os.environ:
         env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+    print("running:", cmd)
     process = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ, cwd=cwd)
     while True:
         nextline = process.stdout.readline()

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -16,13 +16,13 @@ import enum
 import hashlib
 import inspect
 import json
+import os
 import re
 import sys
 import time
 import typing
 from datetime import datetime, timezone
 from importlib import import_module
-from os import path
 from types import ModuleType
 from typing import Any, List, Optional, Tuple
 
@@ -120,6 +120,20 @@ if is_ipython and config.nest_asyncio_enabled in ["1", "True"]:
     import nest_asyncio
 
     nest_asyncio.apply()
+
+
+_is_running_as_api = None
+
+
+def is_running_as_api():
+    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
+    global _is_running_as_api
+
+    if _is_running_as_api is None:
+        # os.getenv will load the env var as string, and json.loads will convert it to a bool
+        _is_running_as_api = json.loads(os.getenv("MLRUN_IS_API_SERVER", "false"))
+
+    return _is_running_as_api
 
 
 class run_keys:
@@ -385,7 +399,7 @@ def list2dict(lines: list):
         key, value = line[:i].strip(), line[i + 1 :].strip()
         if key is None:
             raise ValueError("cannot find key in line (key=value)")
-        value = path.expandvars(value)
+        value = os.path.expandvars(value)
         out[key] = value
     return out
 
@@ -1091,7 +1105,7 @@ def set_paths(pythonpath=""):
         return
     paths = pythonpath.split(":")
     for p in paths:
-        abspath = path.abspath(p)
+        abspath = os.path.abspath(p)
         if abspath not in sys.path:
             sys.path.append(abspath)
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -16,13 +16,13 @@ import enum
 import hashlib
 import inspect
 import json
-import os
 import re
 import sys
 import time
 import typing
 from datetime import datetime, timezone
 from importlib import import_module
+from os import path
 from types import ModuleType
 from typing import Any, List, Optional, Tuple
 
@@ -120,20 +120,6 @@ if is_ipython and config.nest_asyncio_enabled in ["1", "True"]:
     import nest_asyncio
 
     nest_asyncio.apply()
-
-
-_is_running_as_api = None
-
-
-def is_running_as_api():
-    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
-    global _is_running_as_api
-
-    if _is_running_as_api is None:
-        # os.getenv will load the env var as string, and json.loads will convert it to a bool
-        _is_running_as_api = json.loads(os.getenv("MLRUN_IS_API_SERVER", "false"))
-
-    return _is_running_as_api
 
 
 class run_keys:
@@ -399,7 +385,7 @@ def list2dict(lines: list):
         key, value = line[:i].strip(), line[i + 1 :].strip()
         if key is None:
             raise ValueError("cannot find key in line (key=value)")
-        value = os.path.expandvars(value)
+        value = path.expandvars(value)
         out[key] = value
     return out
 
@@ -1105,7 +1091,7 @@ def set_paths(pythonpath=""):
         return
     paths = pythonpath.split(":")
     for p in paths:
-        abspath = os.path.abspath(p)
+        abspath = path.abspath(p)
         if abspath not in sys.path:
             sys.path.append(abspath)
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -45,6 +45,7 @@ def db() -> Generator:
     config.httpdb.db_type = "sqldb"
     dsn = f"sqlite:///{db_file.name}?check_same_thread=false"
     config.httpdb.dsn = dsn
+    mlrun._is_running_as_api = True
 
     # TODO: make it simpler - doesn't make sense to call 3 different functions to initialize the db
     # we need to force re-init the engine cause otherwise it is cached between tests

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -69,6 +69,8 @@ def config_test_base():
     mlrun.datastore.store_manager._db = None
     mlrun.datastore.store_manager._stores = {}
 
+    # remove the is_running_as_api cache so it won't pass between tests
+    mlrun._is_running_as_api = None
     # remove singletons in case they were changed (we don't want changes to pass between tests)
     mlrun.utils.singleton.Singleton._instances = {}
 

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -259,6 +259,8 @@ def test_forbidden_file_access():
 
 
 def test_verify_data_stores_are_not_cached_in_api_when_not_needed():
+    mlrun._is_running_as_api = True
+
     user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
     user1_objpath = "v3io://some-system/some-dir/user1"
 
@@ -280,6 +282,42 @@ def test_verify_data_stores_are_not_cached_in_api_when_not_needed():
     obj3 = store.object(url=user3_objpath)
     assert store._stores == {}
     assert obj3._store._secrets == {}
+
+
+def test_verify_data_stores_are_cached_when_not_api():
+    user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
+    user1_objpath = "v3io://some-system/some-dir/user1"
+
+    user2_secrets = {"V3IO_ACCESS_KEY": "user2-access-key"}
+    user2_objpath = "v3io://some-system/some-dir/user2"
+
+    user3_objpath = "v3io://some-system/some-dir/user3"
+    store = mlrun.datastore.datastore.StoreManager(
+        secrets={"V3IO_ACCESS_KEY": "api-access-key"}
+    )
+    # if secrets provided then store is not cached
+    obj = store.object(url=user1_objpath, secrets=user1_secrets)
+    assert store._stores == {}
+    assert obj._store._secrets == user1_secrets
+
+    # if secrets provided then store is not cached
+    obj2 = store.object(url=user2_objpath, secrets=user2_secrets)
+    assert store._stores == {}
+    assert obj2._store._secrets == user2_secrets
+
+    # if no secrets provided then store is cached
+    obj3 = store.object(url=user3_objpath)
+    assert len(store._stores) == 1
+    assert store._stores["v3io://some-system"] is not None
+    assert obj3._store._secrets == {}
+
+    # if secrets provided then store is not cached
+    obj2 = store.object(url=user2_objpath, secrets=user2_secrets)
+    assert len(store._stores) == 1
+    assert obj2._store._secrets == user2_secrets
+    # the store is not cached so the secrets are not updated, because this is the same store type as the one cached,
+    # so we verify that the secrets are not updated
+    assert store._stores["v3io://some-system"]._secrets == {}
 
 
 def test_fsspec():


### PR DESCRIPTION
Added global variable for resolving whether we are running as the API, this is being done by passing `MLRUN_IS_API_SERVER` when executing `mlrun db` CLI.

## Reason for changing stuff in FileDB
Had to change the fileDB implementation due to order of imports caused by fileDB.
To resolve the import issue, I had to change the way that we currently "connect" to the datastore inside the fileDB.

Error I experienced:
```
2022-12-06T16:56:00.6419351Z [1m[31mE                 File "/mlrun/mlrun/config.py", line 1068, in <module>[0m
2022-12-06T16:56:00.6419540Z [1m[31mE                   _populate()[0m
2022-12-06T16:56:00.6419823Z [1m[31mE                 File "/mlrun/mlrun/config.py", line 898, in _populate[0m
2022-12-06T16:56:00.6420016Z [1m[31mE                   _do_populate()[0m
2022-12-06T16:56:00.6420305Z [1m[31mE                 File "/mlrun/mlrun/config.py", line 924, in _do_populate[0m
2022-12-06T16:56:00.6420496Z [1m[31mE                   config.update(data)[0m
2022-12-06T16:56:00.6420773Z [1m[31mE                 File "/mlrun/mlrun/config.py", line 499, in update[0m
2022-12-06T16:56:00.6420997Z [1m[31mE                   setattr(self, key, value)[0m
2022-12-06T16:56:00.6421282Z [1m[31mE                 File "/mlrun/mlrun/config.py", line 482, in __setattr__[0m
2022-12-06T16:56:00.6421514Z [1m[31mE                   super().__setattr__(attr, value)[0m
2022-12-06T16:56:00.6421787Z [1m[31mE                 File "/mlrun/mlrun/config.py", line 839, in dbpath[0m
2022-12-06T16:56:00.6422065Z [1m[31mE                   mlrun.db.get_run_db(value, force_reconnect=True)[0m
2022-12-06T16:56:00.6422352Z [1m[31mE                 File "/mlrun/mlrun/db/__init__.py", line 87, in get_run_db[0m
2022-12-06T16:56:00.6422573Z [1m[31mE                   _run_db.connect(secrets=secrets)[0m
2022-12-06T16:56:00.6422883Z [1m[31mE                 File "/mlrun/mlrun/db/filedb.py", line 65, in connect[0m
2022-12-06T16:56:00.6423215Z [1m[31mE                   self._datastore, self._subpath = sm.get_or_create_store(self.dirpath)[0m
2022-12-06T16:56:00.6423628Z [1m[31mE                 File "/mlrun/mlrun/datastore/datastore.py", line 194, in get_or_create_store[0m
2022-12-06T16:56:00.6423910Z [1m[31mE                   if not secrets and not mlrun.is_running_as_api():[0m
2022-12-06T16:56:00.6424235Z [1m[31mE               AttributeError: module 'mlrun' has no attribute 'is_running_as_api
```
Here are the tests that are still running with FileDB:
```
2022-12-06T20:54:22.9303101Z FAILED tests/test_code_to_func.py::test_job_file - mlrun.runtimes.utils.RunEr...
2022-12-06T20:54:22.9303334Z FAILED tests/test_code_to_func.py::test_local_file_noembed - mlrun.runtimes.u...
2022-12-06T20:54:22.9303577Z FAILED tests/test_dask.py::test_dask_local - mlrun.runtimes.utils.RunError: m...
2022-12-06T20:54:22.9303763Z FAILED tests/test_datastores.py::test_verify_data_stores_are_not_cached_in_api_when_not_needed
2022-12-06T20:54:22.9304000Z FAILED tests/test_examples.py::test_example[training.py] - AssertionError: ba...
2022-12-06T20:54:22.9304226Z FAILED tests/projects/test_project.py::test_function_run_cli - Exception: Tra...
2022-12-06T20:54:22.9304495Z FAILED tests/run/test_hyper.py::test_hyper_grid_parallel - AttributeError: mo...
2022-12-06T20:54:22.9304722Z FAILED tests/run/test_hyper.py::test_hyper_parallel_with_stop - AttributeErro...
2022-12-06T20:54:22.9304940Z FAILED tests/run/test_main.py::test_main_run_basic - Exception: Traceback (mo...
2022-12-06T20:54:22.9305164Z FAILED tests/run/test_main.py::test_main_run_hyper - Exception: Traceback (mo...
2022-12-06T20:54:22.9305380Z FAILED tests/run/test_main.py::test_main_run_args - Exception: Traceback (mos...
2022-12-06T20:54:22.9305597Z FAILED tests/run/test_main.py::test_main_run_args_from_env - Exception: Trace...
2022-12-06T20:54:22.9305826Z FAILED tests/run/test_main.py::test_main_run_nonpy_from_env - Exception: Trac...
2022-12-06T20:54:22.9306055Z FAILED tests/run/test_main.py::test_main_run_pass - Exception: Traceback (mos...
2022-12-06T20:54:22.9306267Z FAILED tests/run/test_main.py::test_main_run_pass_args - Exception: Traceback...
2022-12-06T20:54:22.9306487Z FAILED tests/run/test_main.py::test_main_run_archive - Exception: Traceback (...
2022-12-06T20:54:22.9306708Z FAILED tests/run/test_main.py::test_main_local_source - assert "source must b...
2022-12-06T20:54:22.9306928Z FAILED tests/run/test_main.py::test_main_run_archive_subdir - Exception: Trac...
2022-12-06T20:54:22.9307146Z FAILED tests/run/test_main.py::test_main_local_project - Exception: Traceback...
2022-12-06T20:54:22.9307363Z FAILED tests/run/test_main.py::test_main_local_flag - Exception: Traceback (m...
2022-12-06T20:54:22.9307580Z FAILED tests/run/test_main.py::test_main_run_class - Exception: Traceback (mo...
2022-12-06T20:54:22.9307798Z FAILED tests/run/test_main.py::test_run_from_module - Exception: Traceback (m...
2022-12-06T20:54:22.9308018Z FAILED tests/run/test_main.py::test_main_env_file - Exception: Traceback (mos...
2022-12-06T20:54:22.9308240Z FAILED tests/run/test_run.py::test_local_runtime - mlrun.runtimes.utils.RunEr...
2022-12-06T20:54:22.9308467Z FAILED tests/run/test_run.py::test_local_runtime_hyper - mlrun.runtimes.utils...
2022-12-06T20:54:22.9308698Z FAILED tests/run/test_run_local.py::test_run_local - mlrun.runtimes.utils.Run...
2022-12-06T20:54:22.9308927Z FAILED tests/run/test_run_local.py::test_run_local_with_uid_does_not_exist - ...
```