### PR TITLE
[CLI] Support default .env file location + CLI "config set" command

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -22,11 +22,10 @@ __all__ = [
     "handler",
     "ArtifactType",
     "get_secret_or_env",
-    "is_running_as_api",
 ]
 
 import json
-from os import environ, getenv, path
+from os import environ, path
 
 import dotenv
 
@@ -87,19 +86,6 @@ if "IGZ_NAMESPACE_DOMAIN" in environ:
     kfp_ep = f"https://dashboard.{igz_domain}/pipelines"
     environ["KF_PIPELINES_UI_ENDPOINT"] = kfp_ep
     mlconf.remote_host = mlconf.remote_host or igz_domain
-
-_is_running_as_api = None
-
-
-def is_running_as_api():
-    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
-    global _is_running_as_api
-
-    if _is_running_as_api is None:
-        # os.getenv will load the env var as string, and json.loads will convert it to a bool
-        _is_running_as_api = json.loads(getenv("MLRUN_IS_API_SERVER", "false"))
-
-    return _is_running_as_api
 
 
 def set_environment(

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -26,6 +26,7 @@ from sys import executable
 from urllib.parse import urlparse
 
 import click
+import dotenv
 import pandas as pd
 import yaml
 from tabulate import tabulate
@@ -765,7 +766,8 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
 @click.option("--data-volume", "-v", help="path prefix to the location of artifacts")
 @click.option("--verbose", is_flag=True, help="verbose log")
 @click.option("--background", "-b", is_flag=True, help="run in background process")
-def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
+@click.option("--artifact-path", "-a", help="default artifact path")
+def db(port, dirpath, dsn, logs_path, data_volume, verbose, background, artifact_path):
     """Run HTTP api/database server"""
     env = environ.copy()
     # ignore client side .env file (so import mlrun in server will not try to connect to local/remote DB)
@@ -784,6 +786,8 @@ def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
         env["MLRUN_HTTPDB__DATA_VOLUME"] = data_volume
     if verbose:
         env["MLRUN_LOG_LEVEL"] = "DEBUG"
+    if artifact_path:
+        env["MLRUN_ARTIFACT_PATH"] = path.realpath(path.expanduser(artifact_path))
 
     env["MLRUN_IS_API_SERVER"] = "true"
 
@@ -805,7 +809,8 @@ def db(port, dirpath, dsn, logs_path, data_volume, verbose, background):
             start_new_session=True,
         )
         print(
-            f"background pid: {child.pid}, logs written to mlrun-stdout.log and mlrun-stderr.log"
+            f"background pid: {child.pid}, logs written to mlrun-stdout.log and mlrun-stderr.log\n"
+            f"use: kill {child.pid}, to stop the mlrun service process (in linux/mac)"
         )
     else:
         child = Popen(cmd, env=env)
@@ -1118,9 +1123,88 @@ def watch_stream(url, shard_ids, seek, interval, is_json):
 
 
 @main.command(name="config")
-def show_config():
-    """Show configuration & exit"""
-    print(mlconf.dump_yaml())
+@click.argument("command", type=str, default="", required=False)
+@click.option(
+    "--env-file",
+    "-f",
+    default="",
+    help="path to the mlrun .env file (defaults to '~/.mlrun.env')",
+)
+@click.option("--api", "-a", type=str, help="api service url")
+@click.option("--artifact-path", "-p", help="default artifacts path")
+@click.option("--username", "-u", help="username (for remote access)")
+@click.option("--access-key", "-k", help="access key (for remote access)")
+@click.option(
+    "--env-vars",
+    "-e",
+    default=[],
+    multiple=True,
+    help="additional env vars, e.g. -e AWS_ACCESS_KEY_ID=<key-id>",
+)
+def show_or_set_config(
+    command, env_file, api, artifact_path, username, access_key, env_vars
+):
+    """get or set mlrun config
+
+    \b
+    Commands:
+        get (default) - list the local or remote configuration
+                        (can specify the remote api + credentials or an env_file)
+        set           - set configuration parameters in mlrun default or specified .env file
+
+    \b
+    Examples:
+        # read the default config
+        mlrun config
+        # read config using an env file (with connection details)
+        mlrun config -f mymlrun.env
+        # set configuration and write it to the default env file (~/.mlrun.env)
+        mlrun config set -a http://localhost:8080 -u joe -k mykey -e AWS_ACCESS_KEY_ID=<key-id>
+
+    """
+    op = command.lower()
+    if not op or op == "get":
+        # print out the configuration (default or based on the specified env/api)
+        if env_file and not path.isfile(path.expanduser(env_file)):
+            print(f"error, env file {env_file} does not exist")
+            exit(1)
+        if env_file or api:
+            mlrun.set_environment(
+                api,
+                artifact_path=artifact_path,
+                access_key=access_key,
+                username=username,
+                env_file=env_file,
+            )
+        print(mlconf.dump_yaml())
+
+    elif op == "set":
+        # update the env settings in the default or specified .env file
+        filename = path.expanduser(env_file or mlrun.config.default_env_file)
+        if not path.isfile(filename):
+            print(
+                f".env file {filename} not found, creating new and setting configuration"
+            )
+        else:
+            print(f"updating configuration in .env file {filename}")
+        env_dict = {
+            "MLRUN_DBPATH": api,
+            "MLRUN_ARTIFACT_PATH": artifact_path,
+            "V3IO_USERNAME": username,
+            "V3IO_ACCESS_KEY": access_key,
+        }
+        for key, value in env_dict.items():
+            if value:
+                dotenv.set_key(filename, key, value, quote_mode="")
+        if env_vars:
+            for key, value in list2dict(env_vars).items():
+                dotenv.set_key(filename, key, value, quote_mode="")
+        if env_file:
+            # if its not the default file print the usage details
+            print(
+                f"to use the {env_file} .env file add the following to your development environment:\n"
+                f"MLRUN_ENV_FILE={env_file}"
+            )
 
 
 def fill_params(params, params_dict=None):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -43,7 +43,7 @@ env_prefix = "MLRUN_"
 env_file_key = f"{env_prefix}CONFIG_FILE"
 _load_lock = Lock()
 _none_type = type(None)
-
+default_env_file = "~/.mlrun.env"
 
 default_config = {
     "namespace": "",  # default kubernetes namespace
@@ -456,6 +456,19 @@ default_config = {
         "expose_internal_api_endpoints": False,
     },
 }
+
+_is_running_as_api = None
+
+
+def is_running_as_api():
+    # MLRUN_IS_API_SERVER is set when running the api server which is being done through the CLI command mlrun db
+    global _is_running_as_api
+
+    if _is_running_as_api is None:
+        # os.getenv will load the env var as string, and json.loads will convert it to a bool
+        _is_running_as_api = json.loads(os.getenv("MLRUN_IS_API_SERVER", "false"))
+
+    return _is_running_as_api
 
 
 class Config:
@@ -901,9 +914,14 @@ def _populate():
 def _do_populate(env=None):
     global config
 
-    if "MLRUN_ENV_FILE" in os.environ:
-        env_file = os.path.expanduser(os.environ["MLRUN_ENV_FILE"])
-        dotenv.load_dotenv(env_file, override=True)
+    if not os.environ.get("MLRUN_IGNORE_ENV_FILE") and not is_running_as_api():
+        if "MLRUN_ENV_FILE" in os.environ:
+            env_file = os.path.expanduser(os.environ["MLRUN_ENV_FILE"])
+            dotenv.load_dotenv(env_file, override=True)
+        else:
+            env_file = os.path.expanduser(default_env_file)
+            if os.path.isfile(env_file):
+                dotenv.load_dotenv(env_file, override=True)
 
     if not config:
         config = Config.from_dict(default_config)

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -191,7 +191,7 @@ class StoreManager:
                 raise ValueError(f"no such store ({endpoint})")
 
         store_key = f"{schema}://{endpoint}"
-        if not secrets and not mlrun.is_running_as_api():
+        if not secrets and not mlrun.config.is_running_as_api():
             if store_key in self._stores.keys():
                 return self._stores[store_key], subpath
 
@@ -201,6 +201,6 @@ class StoreManager:
         store = schema_to_store(schema)(
             self, schema, store_key, parsed_url.netloc, secrets=secrets
         )
-        if not secrets and not mlrun.is_running_as_api():
+        if not secrets and not mlrun.config.is_running_as_api():
             self._stores[store_key] = store
         return store, subpath

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -45,7 +45,7 @@ def db() -> Generator:
     config.httpdb.db_type = "sqldb"
     dsn = f"sqlite:///{db_file.name}?check_same_thread=false"
     config.httpdb.dsn = dsn
-    mlrun._is_running_as_api = True
+    mlrun.config._is_running_as_api = True
 
     # TODO: make it simpler - doesn't make sense to call 3 different functions to initialize the db
     # we need to force re-init the engine cause otherwise it is cached between tests

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -70,7 +70,7 @@ def config_test_base():
     mlrun.datastore.store_manager._stores = {}
 
     # remove the is_running_as_api cache so it won't pass between tests
-    mlrun._is_running_as_api = None
+    mlrun.config._is_running_as_api = None
     # remove singletons in case they were changed (we don't want changes to pass between tests)
     mlrun.utils.singleton.Singleton._instances = {}
 

--- a/tests/test_convenince_methods.py
+++ b/tests/test_convenince_methods.py
@@ -166,8 +166,11 @@ def test_set_and_load_default_config():
     if env_body:
         with open(env_path, "w") as fp:
             fp.write(env_body)
-    del os.environ["YYYY"]
-    del os.environ["MLRUN_KFP_TTL"]
+    print(os.environ)
+    if "YYYY" in os.environ:
+        del os.environ["YYYY"]
+    if "MLRUN_KFP_TTL" in os.environ:
+        del os.environ["MLRUN_KFP_TTL"]
 
 
 def _exec_mlrun(cmd, cwd=None):

--- a/tests/test_convenince_methods.py
+++ b/tests/test_convenince_methods.py
@@ -14,11 +14,15 @@
 #
 import os
 import pathlib
+import subprocess
+import sys
 
+import dotenv
 import pytest
 
 import mlrun
 import mlrun.projects.project
+from tests.conftest import out_path
 
 assets_path = pathlib.Path(__file__).parent / "assets"
 
@@ -117,3 +121,60 @@ def test_deduct_v3io_paths():
     conf = mlrun.config.read_env({"MLRUN_DBPATH": "https://mlrun-api" + cluster})
     assert conf["v3io_api"] == "https://webapi" + cluster
     assert conf["v3io_framesd"] == "https://framesd" + cluster
+
+
+def test_set_config():
+    env_path = f"{out_path}/env/myenv.env"
+    api = "http://localhost:8080"
+    pathlib.Path(env_path).parent.mkdir(parents=True, exist_ok=True)
+    _exec_mlrun(
+        f"config set -f {env_path} -a {api} -u joe -k mykey -p /c/y -e XXX=myvar"
+    )
+
+    expected = {
+        "MLRUN_DBPATH": api,
+        "MLRUN_ARTIFACT_PATH": "/c/y",
+        "V3IO_USERNAME": "joe",
+        "V3IO_ACCESS_KEY": "mykey",
+        "XXX": "myvar",
+    }
+    env_vars = dotenv.dotenv_values(env_path)
+    assert len(env_vars) == 5
+    for key, val in expected.items():
+        assert env_vars[key] == val
+
+
+def test_set_and_load_default_config():
+    env_path = os.path.expanduser(mlrun.config.default_env_file)
+    env_body = None
+    if os.path.isfile(env_path):
+        with open(env_path, "r") as fp:
+            env_body = fp.read()
+
+    # set two config (mlrun and custom vars) and read/verify the default .env file
+    _exec_mlrun("config set -e YYYY=myvar -e MLRUN_KFP_TTL=12345")
+    env_vars = dotenv.dotenv_values(env_path)
+    assert env_vars["YYYY"] == "myvar"
+    assert env_vars["MLRUN_KFP_TTL"] == "12345"
+
+    # verify the new env impact mlrun config
+    mlrun.mlconf.reload()
+    assert mlrun.mlconf.kfp_ttl == 12345
+
+    # write back old content and del env vars
+    os.remove(env_path)
+    if env_body:
+        with open(env_path, "w") as fp:
+            fp.write(env_body)
+    del os.environ["YYYY"]
+    del os.environ["MLRUN_KFP_TTL"]
+
+
+def _exec_mlrun(cmd, cwd=None):
+    cmd = [sys.executable, "-m", "mlrun"] + cmd.split()
+    out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd)
+    if out.returncode != 0:
+        print(out.stderr.decode("utf-8"), file=sys.stderr)
+        print(out.stdout.decode("utf-8"), file=sys.stderr)
+        raise Exception(out.stderr.decode("utf-8"))
+    return out.stdout.decode("utf-8")

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -259,7 +259,7 @@ def test_forbidden_file_access():
 
 
 def test_verify_data_stores_are_not_cached_in_api_when_not_needed():
-    mlrun._is_running_as_api = True
+    mlrun.config._is_running_as_api = True
 
     user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
     user1_objpath = "v3io://some-system/some-dir/user1"


### PR DESCRIPTION
* MLRun will look for env file in `~/.mlrun.env` upon import (if the MLRUN_ENV_FILE var was not set)
* use new `mlrun config set` command to update the default or specified .env files