### PR TITLE
[Spark] Shut spark context down when `ingest` completes

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import os
 from datetime import datetime
 from typing import List, Optional, Union
 from urllib.parse import urlparse
@@ -787,9 +786,6 @@ def _ingest_with_spark(
                     f"{featureset.metadata.project}-{featureset.metadata.name}"
                 )
 
-            for k, v in os.environ.items():
-                print(k, "=", v)
-            print()
             spark = pyspark.sql.SparkSession.builder.appName(session_name).getOrCreate()
             created_spark_context = True
 

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import os
 from datetime import datetime
 from typing import List, Optional, Union
 from urllib.parse import urlparse
@@ -786,6 +787,9 @@ def _ingest_with_spark(
                     f"{featureset.metadata.project}-{featureset.metadata.name}"
                 )
 
+            for k, v in os.environ.items():
+                print(k, "=", v)
+            print()
             spark = pyspark.sql.SparkSession.builder.appName(session_name).getOrCreate()
             created_spark_context = True
 
@@ -882,6 +886,7 @@ def _ingest_with_spark(
     finally:
         if created_spark_context:
             spark.stop()
+            spark.sparkContext.stop()
             # We shouldn't return a dataframe that depends on a stopped context
             df = None
     if return_df:


### PR DESCRIPTION
Only if we created it in the first place. This shuts the Java gateway down as well, so that a subsequent `ingest` will get the latest environment variables. 

[ML-2933](https://jira.iguazeng.com/browse/ML-2933)