### PR TITLE
[Spark] Shut local spark context down when `ingest` completes

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -882,6 +882,7 @@ def _ingest_with_spark(
     finally:
         if created_spark_context:
             spark.stop()
+            spark.sparkContext.stop()
             # We shouldn't return a dataframe that depends on a stopped context
             df = None
     if return_df:


### PR DESCRIPTION
Backport of #2692.

Only if we created it in the first place. This shuts the Java gateway down as well, so that a subsequent ingest will get the latest environment variables.

[ML-2933](https://jira.iguazeng.com/browse/ML-2933)