### PR TITLE
[Schedules] Scheduled tasks access-key usage refactor

### DIFF
--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -63,7 +63,7 @@ def create_schedule(
             project=project, request=request, json=schedule.dict()
         )
 
-    if not auth_info.access_key:
+    if schedule.credentials.access_key:
         auth_info.access_key = schedule.credentials.access_key
     get_scheduler().create_schedule(
         db_session,
@@ -111,7 +111,7 @@ def update_schedule(
             project=project, name=name, request=request, json=schedule.dict()
         )
 
-    if not auth_info.access_key:
+    if schedule.credentials.access_key:
         auth_info.access_key = schedule.credentials.access_key
     get_scheduler().update_schedule(
         db_session,

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -39,7 +39,6 @@ class Secrets(
     internal_secrets_key_prefix = "mlrun."
     # make it a subset of internal since key map are by definition internal
     key_map_secrets_key_prefix = f"{internal_secrets_key_prefix}map."
-    secret_reference_prefix = "$ref:"
 
     def generate_client_project_secret_key(
         self, client_type: SecretsClientType, name: str, subtype=None
@@ -53,9 +52,6 @@ class Secrets(
         self, client_type: SecretsClientType
     ):
         return f"{self.key_map_secrets_key_prefix}{client_type.value}"
-
-    def generate_secret_ref(self, secret_name: str) -> str:
-        return f"{self.secret_reference_prefix}{secret_name}"
 
     @staticmethod
     def validate_project_secret_key_regex(
@@ -117,6 +113,17 @@ class Secrets(
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Provider requested is not supported. provider = {secrets.provider}"
             )
+
+    def read_auth_secret(self, secret_name) -> mlrun.api.schemas.AuthSecretData:
+        (
+            username,
+            access_key,
+        ) = mlrun.api.utils.singletons.k8s.get_k8s().read_auth_secret(secret_name)
+        return mlrun.api.schemas.AuthSecretData(
+            provider=mlrun.api.schemas.SecretProviderName.kubernetes,
+            username=username,
+            access_key=access_key,
+        )
 
     def store_auth_secret(
         self,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -386,6 +386,8 @@ class Scheduler:
             )
             return secret_name
 
+    # TODO - this function is no longer used except to simulate "the old way" in tests. Remove this once we
+    #       are sure we are far enough that it's no longer going to be used (or keep, and use for other things).
     def _store_schedule_secrets(
         self,
         auth_info: mlrun.api.schemas.AuthInfo,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -48,6 +48,7 @@ class Scheduler:
 
     _secret_username_subtype = "username"
     _secret_access_key_subtype = "access_key"
+    _db_record_auth_label = "auth_key"
 
     def __init__(self):
         scheduler_config = json.loads(config.httpdb.scheduling.scheduler_config)
@@ -83,6 +84,20 @@ class Scheduler:
         # https://github.com/agronholm/apscheduler/issues/360 - this sleep make them work
         await asyncio.sleep(0)
 
+    def _append_access_key_secret_to_labels(self, labels, secret_name):
+        if secret_name:
+            labels = labels or {}
+            labels[self._db_record_auth_label] = secret_name
+        return labels
+
+    def _get_access_key_secret_name_from_db_record(
+        self, db_schedule: schemas.ScheduleRecord
+    ):
+        schedule_labels = db_schedule.dict()["labels"]
+        for label in schedule_labels:
+            if label["name"] == self._db_record_auth_label:
+                return label["value"]
+
     @mlrun.api.utils.helpers.ensure_running_on_chief
     def create_schedule(
         self,
@@ -114,7 +129,10 @@ class Scheduler:
             concurrency_limit=concurrency_limit,
         )
         self._ensure_auth_info_has_access_key(auth_info, kind)
-        self._store_schedule_secrets(auth_info, project, name)
+        secret_name = self._store_schedule_secrets_using_auth_secret(auth_info)
+        # We use the schedule labels to keep track of the access-key to use. Note that this is the name of the secret,
+        # not the secret value itself. Therefore it can be kept in a non-secure field.
+        labels = self._append_access_key_secret_to_labels(labels, secret_name)
         get_db().create_schedule(
             db_session,
             project,
@@ -173,6 +191,12 @@ class Scheduler:
             labels=labels,
             concurrency_limit=concurrency_limit,
         )
+
+        db_schedule = get_db().get_schedule(db_session, project, name)
+        self._ensure_auth_info_has_access_key(auth_info, db_schedule.kind)
+        secret_name = self._store_schedule_secrets_using_auth_secret(auth_info)
+        labels = self._append_access_key_secret_to_labels(labels, secret_name)
+
         get_db().update_schedule(
             db_session,
             project,
@@ -183,12 +207,11 @@ class Scheduler:
             concurrency_limit,
         )
         db_schedule = get_db().get_schedule(db_session, project, name)
+
         updated_schedule = self._transform_and_enrich_db_schedule(
             db_session, db_schedule
         )
 
-        self._ensure_auth_info_has_access_key(auth_info, db_schedule.kind)
-        self._store_schedule_secrets(auth_info, project, name)
         self._update_schedule_in_scheduler(
             project,
             name,
@@ -267,6 +290,9 @@ class Scheduler:
 
     def _remove_schedule_scheduler_resources(self, project, name):
         self._remove_schedule_from_scheduler(project, name)
+        # This is kept for backwards compatibility - if schedule was using the "old" format of storing secrets, then
+        # this is a good opportunity to remove them. Using the new method we don't remove secrets since they are per
+        # access-key and there may be other entities (runtimes, for example) using the same secret.
         self._remove_schedule_secrets(project, name)
 
     def _remove_schedule_from_scheduler(self, project, name):
@@ -304,24 +330,61 @@ class Scheduler:
         auth_info: mlrun.api.schemas.AuthInfo,
         kind: schemas.ScheduleKinds,
     ):
+        import mlrun.api.crud
+
         if (
             kind not in schemas.ScheduleKinds.local_kinds()
             and mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required()
-            and (
+        ):
+            if (
                 not auth_info.access_key
                 or auth_info.access_key == mlrun.model.Credentials.generate_access_key
-            )
-        ):
-            auth_info.access_key = (
-                mlrun.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key(
+            ):
+                auth_info.access_key = mlrun.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key(
                     auth_info.session
                 )
+                # created an access key with control and data session plane, so enriching auth_info with those planes
+                auth_info.planes = [
+                    mlrun.api.utils.clients.iguazio.SessionPlanes.control,
+                    mlrun.api.utils.clients.iguazio.SessionPlanes.data,
+                ]
+            # Support receiving access-key reference ($ref:...), for example when updating existing schedule
+            if auth_info.access_key.startswith(
+                mlrun.model.Credentials.secret_reference_prefix
+            ):
+                secret_name = auth_info.access_key.lstrip(
+                    mlrun.model.Credentials.secret_reference_prefix
+                )
+                secret = mlrun.api.crud.Secrets().read_auth_secret(secret_name)
+                auth_info.access_key = secret.access_key
+                auth_info.username = secret.username
+
+    def _store_schedule_secrets_using_auth_secret(
+        self,
+        auth_info: mlrun.api.schemas.AuthInfo,
+    ) -> str:
+        # import here to avoid circular imports
+        import mlrun.api.crud
+
+        if mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required():
+            # sanity
+            if not auth_info.access_key:
+                raise mlrun.errors.MLRunAccessDeniedError(
+                    "Access key is required to create schedules in OPA authorization mode"
+                )
+
+            # Pydantic doesn't allow username to be None (may happen in tests)
+            if auth_info.username is None:
+                auth_info.username = ""
+
+            secret_name = mlrun.api.crud.Secrets().store_auth_secret(
+                mlrun.api.schemas.AuthSecretData(
+                    provider=mlrun.api.schemas.SecretProviderName.kubernetes,
+                    username=auth_info.username,
+                    access_key=auth_info.access_key,
+                )
             )
-            # created an access key with control and data session plane, so enriching auth_info with those planes
-            auth_info.planes = [
-                mlrun.api.utils.clients.iguazio.SessionPlanes.control,
-                mlrun.api.utils.clients.iguazio.SessionPlanes.data,
-            ]
+            return secret_name
 
     def _store_schedule_secrets(
         self,
@@ -591,10 +654,47 @@ class Scheduler:
 
                 access_key = None
                 username = None
+                need_to_update_credentials = False
                 if mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required():
-                    username, access_key = self._get_schedule_secrets(
-                        db_schedule.project, db_schedule.name
+                    secret_name = self._get_access_key_secret_name_from_db_record(
+                        db_schedule
                     )
+                    if secret_name:
+                        secret = mlrun.api.crud.Secrets().read_auth_secret(secret_name)
+                        username = secret.username
+                        access_key = secret.access_key
+                    else:
+                        username, access_key = self._get_schedule_secrets(
+                            db_schedule.project, db_schedule.name
+                        )
+                        if access_key:
+                            need_to_update_credentials = True
+
+                auth_info = mlrun.api.schemas.AuthInfo(
+                    username=username,
+                    access_key=access_key,
+                    # enriching with control plane tag because scheduling a function requires control plane
+                    planes=[mlrun.api.utils.clients.iguazio.SessionPlanes.control],
+                )
+
+                # Schedule was created using the old method. Transform schedule secrets to using auth secrets
+                # and remove the old secrets. Need to also add the label to the DB object identifying the auth
+                # secret
+                if need_to_update_credentials:
+                    secret_name = self._store_schedule_secrets_using_auth_secret(
+                        auth_info
+                    )
+                    labels = self._append_access_key_secret_to_labels(
+                        db_schedule.labels, secret_name
+                    )
+                    get_db().update_schedule(
+                        db_session,
+                        db_schedule.project,
+                        db_schedule.name,
+                        labels=labels,
+                    )
+                    self._remove_schedule_secrets(db_schedule.project, db_schedule.name)
+
                 self._create_schedule_in_scheduler(
                     db_schedule.project,
                     db_schedule.name,
@@ -602,14 +702,7 @@ class Scheduler:
                     db_schedule.scheduled_object,
                     db_schedule.cron_trigger,
                     db_schedule.concurrency_limit,
-                    mlrun.api.schemas.AuthInfo(
-                        username=username,
-                        access_key=access_key,
-                        # enriching with control plane tag because scheduling a function requires control plane
-                        planes=[
-                            mlrun.api.utils.clients.iguazio.SessionPlanes.control,
-                        ],
-                    ),
+                    auth_info,
                 )
             except Exception as exc:
                 logger.warn(
@@ -665,9 +758,11 @@ class Scheduler:
     def _enrich_schedule_with_credentials(
         self, schedule_output: schemas.ScheduleOutput
     ):
-        _, schedule_output.credentials.access_key = self._get_schedule_secrets(
-            schedule_output.project, schedule_output.name, include_username=False
-        )
+        secret_name = schedule_output.labels.get(self._db_record_auth_label)
+        if secret_name:
+            schedule_output.credentials.access_key = (
+                mlrun.model.Credentials.secret_reference_prefix + secret_name
+            )
 
     def _resolve_job_function(
         self,

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -906,7 +906,10 @@ async def test_schedule_access_key_reference_handling(
     username = "some-user-name"
     access_key = "some-access-key"
 
-    secret_ref = "$ref:" + k8s_secrets_mock.store_auth_secret(username, access_key)
+    secret_ref = (
+        mlrun.model.Credentials.secret_reference_prefix
+        + k8s_secrets_mock.store_auth_secret(username, access_key)
+    )
     auth_info = mlrun.api.schemas.AuthInfo()
     auth_info.access_key = secret_ref
 
@@ -1227,8 +1230,11 @@ def _assert_schedule_get_and_list_credentials_enrichment(
         include_credentials=True,
     )
 
-    secret_ref = "$ref:" + tests.api.conftest.K8sSecretsMock.get_auth_secret_name(
-        expected_username, expected_access_key
+    secret_ref = (
+        mlrun.model.Credentials.secret_reference_prefix
+        + tests.api.conftest.K8sSecretsMock.get_auth_secret_name(
+            expected_username, expected_access_key
+        )
     )
     assert schedule.credentials.access_key == secret_ref
     schedules = scheduler.list_schedules(


### PR DESCRIPTION
Refactor the way scheduled-tasks access-keys were maintained and exposed. The access-keys were kept as a special type of project-secrets, and were exposed to the user if performing `GET` REST APIs with the `include-credentials` parameter.
After this change, the access-keys are using the MLRun auth-secret mechanism, which generates k8s secrets per access key, and exposes to the user a reference to the access-key with a one-way hash value that identifies it. This aligns with the way access-keys are maintained in MLRun runtimes. Now, even when asking to `include-credentials` the actual access-key is not exposed but rather just the key reference.
Other changes done as part of this fix:

* The user can specify an access-key when creating/modifying a schedule. This value (passed in the `credentials` part of the payload) was only used if there was no access-key in the actual REST call header, which is practically never. The correct behavior should be that if the user asked for a specific access-key, it would be honored. This was fixed in the endpoint code
* As part of the change, the reference to the secret now needs to be kept along with the schedule object in the DB. This is done by adding an `mlrun-auth-key` label to the objects which contains the access-key reference
* When reloading the schedule objects from the DB, any schedule that was using the legacy method of storing access-keys is now converted to the new method, and non-needed k8s secrets are removed. Key labels are added to the DB objects as part of this transition. This is expected to only happen once when MLRun is upgraded
* The `$generate` keyword for auto-creating an access-key was already supported, added support for the `$ref:` prefix
* Added tests and modified the existing tests that were related to secret handling.
* There's now a fairly large amount of code in the scheduling Crud object which is no longer in use, other than for testing to simulate the legacy mode of work. In the future this code should be removed unless we utilize it for other functionality (a `TODO` was added to mark that)

Fixes [ML-2955](https://jira.iguazeng.com/browse/ML-2955)