### PR TITLE
[Project] Add option to overwrite workflow schedule

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -903,6 +903,12 @@ def logs(uid, project, offset, db, watch):
     "https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron."
     "For using the pre-defined workflow's schedule, set --schedule 'true'",
 )
+@click.option(
+    "--overwrite-schedule",
+    "-os",
+    is_flag=True,
+    help="Overwrite a schedule when submitting a new one with the same name.",
+)
 def project(
     context,
     name,
@@ -928,6 +934,7 @@ def project(
     timeout,
     ensure_project,
     schedule,
+    overwrite_schedule,
 ):
     """load and/or run a project"""
     if env_file:
@@ -1006,6 +1013,7 @@ def project(
                 local=local,
                 schedule=schedule,
                 timeout=timeout,
+                overwrite=overwrite_schedule,
             )
         except Exception as exc:
             print(traceback.format_exc())

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -729,9 +729,7 @@ class _RemoteRunner(_PipelineRunner):
         msg = "executing workflow "
         if workflow_spec.schedule:
             msg += "scheduling "
-        logger.info(
-            f"{msg}'{runner_name}' remotely with {workflow_spec.engine} engine"
-        )
+        logger.info(f"{msg}'{runner_name}' remotely with {workflow_spec.engine} engine")
         runspec = mlrun.RunObject.from_dict(
             {
                 "spec": {
@@ -742,8 +740,7 @@ class _RemoteRunner(_PipelineRunner):
                         "workflow_path": workflow_spec.path,
                         "workflow_arguments": workflow_spec.args,
                         "artifact_path": artifact_path,
-                        "workflow_handler": workflow_handler
-                        or workflow_spec.handler,
+                        "workflow_handler": workflow_handler or workflow_spec.handler,
                         "namespace": namespace,
                         "ttl": workflow_spec.ttl,
                         "engine": workflow_spec.engine,

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -72,6 +72,7 @@ class WorkflowSpec(mlrun.model.ModelObj):
         ttl=None,
         args_schema: dict = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger] = None,
+        overwrite: bool = None,
     ):
         self.engine = engine
         self.code = code
@@ -84,6 +85,7 @@ class WorkflowSpec(mlrun.model.ModelObj):
         self.run_local = False
         self._tmp_path = None
         self.schedule = schedule
+        self.overwrite = overwrite
 
     def get_source_file(self, context=""):
         if not self.code and not self.path:
@@ -711,45 +713,68 @@ class _RemoteRunner(_PipelineRunner):
         runner_name = f"workflow-runner-{workflow_name}"
         run_id = None
 
-        try:
-            # Creating the load project and workflow running function:
-            load_and_run_fn = mlrun.new_function(
-                name=runner_name,
-                project=project.name,
-                kind="job",
-                image=mlrun.mlconf.default_base_image,
-            )
-            msg = "executing workflow "
-            if workflow_spec.schedule:
-                msg += "scheduling "
-            logger.info(
-                f"{msg}'{runner_name}' remotely with {workflow_spec.engine} engine"
-            )
-            runspec = mlrun.RunObject.from_dict(
-                {
-                    "spec": {
-                        "parameters": {
-                            "url": project.spec.source,
-                            "project_name": project.name,
-                            "workflow_name": workflow_name or workflow_spec.name,
-                            "workflow_path": workflow_spec.path,
-                            "workflow_arguments": workflow_spec.args,
-                            "artifact_path": artifact_path,
-                            "workflow_handler": workflow_handler
-                            or workflow_spec.handler,
-                            "namespace": namespace,
-                            "ttl": workflow_spec.ttl,
-                            "engine": workflow_spec.engine,
-                            "local": workflow_spec.run_local,
-                        },
-                        "handler": "mlrun.projects.load_and_run",
+        # Creating the load project and workflow running function:
+        load_and_run_fn = mlrun.new_function(
+            name=runner_name,
+            project=project.name,
+            kind="job",
+            image=mlrun.mlconf.default_base_image,
+        )
+
+        runspec = mlrun.RunObject.from_dict(
+            {
+                "spec": {
+                    "parameters": {
+                        "url": project.spec.source,
+                        "project_name": project.name,
+                        "workflow_name": workflow_name or workflow_spec.name,
+                        "workflow_path": workflow_spec.path,
+                        "workflow_arguments": workflow_spec.args,
+                        "artifact_path": artifact_path,
+                        "workflow_handler": workflow_handler or workflow_spec.handler,
+                        "namespace": namespace,
+                        "ttl": workflow_spec.ttl,
+                        "engine": workflow_spec.engine,
+                        "local": workflow_spec.run_local,
                     },
-                    "metadata": {"name": workflow_name},
-                }
-            )
-            runspec = runspec.set_label("job-type", "workflow-runner").set_label(
-                "workflow", workflow_name
-            )
+                    "handler": "mlrun.projects.load_and_run",
+                },
+                "metadata": {"name": workflow_name},
+            }
+        )
+        runspec = runspec.set_label("job-type", "workflow-runner").set_label(
+            "workflow", workflow_name
+        )
+        if workflow_spec.schedule:
+            is_scheduled = True
+            schedule_name = runspec.spec.parameters.get("workflow_name")
+            run_db = mlrun.get_run_db()
+
+            try:
+                run_db.get_schedule(project.name, schedule_name)
+            except mlrun.errors.MLRunNotFoundError:
+                is_scheduled = False
+
+            if workflow_spec.overwrite:
+                if is_scheduled:
+                    logger.info(f"Deleting schedule {schedule_name}")
+                    run_db.delete_schedule(project.name, schedule_name)
+                else:
+                    logger.info(
+                        f"No schedule by name '{schedule_name}' was found, nothing to overwrite."
+                    )
+            elif is_scheduled:
+                raise mlrun.errors.MLRunConflictError(
+                    f"There is already a schedule for workflow {schedule_name}."
+                    " If you want to overwrite this schedule use 'overwrite = True'"
+                )
+
+        msg = "executing workflow "
+        if workflow_spec.schedule:
+            msg += "scheduling "
+        logger.info(f"{msg}'{runner_name}' remotely with {workflow_spec.engine} engine")
+
+        try:
             run = load_and_run_fn.run(
                 runspec=runspec,
                 local=False,

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -719,38 +719,35 @@ class _RemoteRunner(_PipelineRunner):
                 f"The project's source: {project.spec.source} is not a remote one e.g., git."
             )
 
-        try:
-            # Creating the load project and workflow running function:
-            load_and_run_fn = mlrun.new_function(
-                name=runner_name,
-                project=project.name,
-                kind="job",
-                image=mlrun.mlconf.default_base_image,
-            )
-            msg = "executing workflow "
-            if workflow_spec.schedule:
-                msg += "scheduling "
-            logger.info(
-                f"{msg}'{runner_name}' remotely with {workflow_spec.engine} engine"
-            )
-            runspec = mlrun.RunObject.from_dict(
-                {
-                    "spec": {
-                        "parameters": {
-                            "url": project.spec.source,
-                            "project_name": project.name,
-                            "workflow_name": workflow_name or workflow_spec.name,
-                            "workflow_path": workflow_spec.path,
-                            "workflow_arguments": workflow_spec.args,
-                            "artifact_path": artifact_path,
-                            "workflow_handler": workflow_handler
-                            or workflow_spec.handler,
-                            "namespace": namespace,
-                            "ttl": workflow_spec.ttl,
-                            "engine": workflow_spec.engine,
-                            "local": workflow_spec.run_local,
-                        },
-                        "handler": "mlrun.projects.load_and_run",
+        # Creating the load project and workflow running function:
+        load_and_run_fn = mlrun.new_function(
+            name=runner_name,
+            project=project.name,
+            kind="job",
+            image=mlrun.mlconf.default_base_image,
+        )
+        msg = "executing workflow "
+        if workflow_spec.schedule:
+            msg += "scheduling "
+        logger.info(
+            f"{msg}'{runner_name}' remotely with {workflow_spec.engine} engine"
+        )
+        runspec = mlrun.RunObject.from_dict(
+            {
+                "spec": {
+                    "parameters": {
+                        "url": project.spec.source,
+                        "project_name": project.name,
+                        "workflow_name": workflow_name or workflow_spec.name,
+                        "workflow_path": workflow_spec.path,
+                        "workflow_arguments": workflow_spec.args,
+                        "artifact_path": artifact_path,
+                        "workflow_handler": workflow_handler
+                        or workflow_spec.handler,
+                        "namespace": namespace,
+                        "ttl": workflow_spec.ttl,
+                        "engine": workflow_spec.engine,
+                        "local": workflow_spec.run_local,
                     },
                     "handler": "mlrun.projects.load_and_run",
                 },

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2024,6 +2024,7 @@ class MlrunProject(ModelObj):
         if not inner_engine and engine == "remote":
             inner_engine = get_workflow_engine(workflow_spec.engine, local).engine
         workflow_spec.engine = inner_engine or workflow_engine.engine
+
         run = workflow_engine.run(
             self,
             workflow_spec,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1936,6 +1936,7 @@ class MlrunProject(ModelObj):
         local: bool = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger, bool] = None,
         timeout: int = None,
+        overwrite: bool = False,
     ) -> _PipelineRunStatus:
         """run a workflow using kubeflow pipelines
 
@@ -1964,6 +1965,7 @@ class MlrunProject(ModelObj):
                           https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
                           for using the pre-defined workflow's schedule, set `schedule=True`
         :param timeout:   timeout in seconds to wait for pipeline completion (used when watch=True)
+        :param overwrite: replacing the schedule of the same workflow (under the same name) if exists with the new one.
         :returns: run id
         """
 
@@ -2003,6 +2005,7 @@ class MlrunProject(ModelObj):
         artifact_path = artifact_path or self._enrich_artifact_path_with_workflow_uid()
 
         if schedule:
+            workflow_spec.overwrite = overwrite or workflow_spec.overwrite
             # Schedule = True -> use workflow_spec.schedule
             if not isinstance(schedule, bool):
                 workflow_spec.schedule = schedule
@@ -2021,7 +2024,6 @@ class MlrunProject(ModelObj):
         if not inner_engine and engine == "remote":
             inner_engine = get_workflow_engine(workflow_spec.engine, local).engine
         workflow_spec.engine = inner_engine or workflow_engine.engine
-
         run = workflow_engine.run(
             self,
             workflow_spec,
@@ -2031,12 +2033,16 @@ class MlrunProject(ModelObj):
             artifact_path=artifact_path,
             namespace=namespace,
         )
-        run_msg = f"started run workflow {name} "
         # run is None when scheduling
-        if run:
-            run_msg += f"with run id = '{run.run_id}' "
-        run_msg += f"by {workflow_engine.engine} engine"
-        logger.info(run_msg)
+        if (
+            run
+            and run.state != mlrun.run.RunStatuses.failed
+            and not workflow_spec.schedule
+        ):
+            # Failure and schedule messages already logged
+            logger.info(
+                f"started run workflow {name} with run id = '{run.run_id}' by {workflow_engine.engine} engine"
+            )
         workflow_spec.clear_tmp()
         if watch and not workflow_spec.schedule:
             workflow_engine.get_run_status(project=self, run=run, timeout=timeout)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -606,3 +606,55 @@ class TestProject(TestMLRunSystem):
         project.set_secrets(file_path=env_file)
         secrets = db.list_project_secret_keys(name, provider="kubernetes")
         assert secrets.secret_keys == ["ENV_ARG1", "ENV_ARG2"]
+
+    def test_overwrite_schedule(self):
+        name = "overwrite-test"
+        project_dir = f"{projects_dir}/{name}"
+        workflow_name = "main"
+        self.custom_project_names_to_delete.append(name)
+        project = mlrun.load_project(
+            project_dir,
+            "git://github.com/mlrun/project-demo.git",
+            name=name,
+        )
+
+        schedules = ["*/30 * * * *", "*/40 * * * *", "*/50 * * * *"]
+        # overwriting nothing
+        project.run(workflow_name, schedule=schedules[0], overwrite=True)
+        schedule = self._run_db.get_schedule(name, workflow_name)
+        assert (
+            schedule.scheduled_object["schedule"] == schedules[0]
+        ), "Failed to overwrite nothing"
+
+        # overwriting schedule:
+        project.run(workflow_name, schedule=schedules[1], dirty=True, overwrite=True)
+        schedule = self._run_db.get_schedule(name, workflow_name)
+        assert (
+            schedule.scheduled_object["schedule"] == schedules[1]
+        ), "Failed to overwrite existing schedule"
+
+        # submit schedule when one exists without overwrite - fail:
+        with pytest.raises(mlrun.errors.MLRunConflictError):
+            project.run(
+                workflow_name,
+                schedule=schedules[1],
+                dirty=True,
+            )
+
+        # overwriting schedule from cli:
+        args = [
+            project_dir,
+            "-n",
+            name,
+            "-d",
+            "-r",
+            workflow_name,
+            "-os",  # stands for overwrite-schedule
+            "--schedule",
+            f"'{schedules[2]}'",
+        ]
+        exec_project(args)
+        schedule = self._run_db.get_schedule(name, workflow_name)
+        assert (
+            schedule.scheduled_object["schedule"] == schedules[2]
+        ), "Failed to overwrite from CLI"


### PR DESCRIPTION
By setting `overwrite=True` when submitting a workflow with schedule, the old schedule of the workflow is deleted before creating the new one.
1.1.x and 1.2.x will support this mechanism that is implemented on the SDK part.
1.3 should contain the refactor for this mechanism into the API with `store_schedule`, `_submit_run`, ...
[ML-2873](https://jira.iguazeng.com/browse/ML-2873)