### PR TITLE
[CLI] Make ignoring unknown options configurable

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -68,7 +68,7 @@ def main():
     pass
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("url", type=str, required=False)
 @click.option(
     "--param",
@@ -387,7 +387,7 @@ def run(
         exit(1)
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("func_url", type=str, required=False)
 @click.option("--name", help="function name")
 @click.option("--project", help="project name")
@@ -543,7 +543,7 @@ def build(
         exit(1)
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("spec", type=str, required=False)
 @click.option("--source", "-s", default="", help="location/url of the source")
 @click.option(
@@ -645,7 +645,7 @@ def deploy(
         fp.write(function.status.nuclio_name)
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("pod", type=str)
 @click.option("--namespace", "-n", help="kubernetes namespace")
 @click.option(
@@ -658,7 +658,7 @@ def watch(pod, namespace, timeout):
     print(f"Pod {pod} last status is: {status}")
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("kind", type=str)
 @click.argument("name", type=str, default="", required=False)
 @click.option("--selector", "-s", default="", help="label selector")
@@ -757,7 +757,7 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
         )
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.option("--port", "-p", help="port to listen on", type=int)
 @click.option("--dirpath", "-d", help="database directory (dirpath)")
 @click.option("--dsn", "-s", help="database dsn, e.g. sqlite:///db/mlrun.db")
@@ -820,7 +820,7 @@ def version():
     print(f"MLRun version: {str(Version().get())}")
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("uid", type=str)
 @click.option("--project", "-p", help="project name")
 @click.option("--offset", type=int, default=0, help="byte offset")
@@ -840,7 +840,7 @@ def logs(uid, project, offset, db, watch):
         print(f"final state: {state}")
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("context", default="", type=str, required=False)
 @click.option("--name", "-n", help="project name")
 @click.option("--url", "-u", help="remote git or archive url")
@@ -1038,7 +1038,7 @@ def validate_kind(ctx, param, value):
     return value
 
 
-@main.command()
+@main.command(context_settings=mlconf.cli.context_settings.to_dict())
 @click.argument("kind", callback=validate_kind, default=None, required=False)
 @click.argument("object_id", metavar="id", type=str, default=None, required=False)
 @click.option("--api", help="api service url")
@@ -1086,7 +1086,9 @@ def clean(kind, object_id, api, label_selector, force, grace_period):
     )
 
 
-@main.command(name="watch-stream")
+@main.command(
+    name="watch-stream", context_settings=mlconf.cli.context_settings.to_dict()
+)
 @click.argument("url", type=str)
 @click.option(
     "--shard-ids",

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -757,7 +757,7 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
         )
 
 
-@main.command(context_settings=mlconf.cli.context_settings.to_dict())
+@main.command()
 @click.option("--port", "-p", help="port to listen on", type=int)
 @click.option("--dirpath", "-d", help="database directory (dirpath)")
 @click.option("--dsn", "-s", help="database dsn, e.g. sqlite:///db/mlrun.db")
@@ -820,7 +820,7 @@ def version():
     print(f"MLRun version: {str(Version().get())}")
 
 
-@main.command(context_settings=mlconf.cli.context_settings.to_dict())
+@main.command()
 @click.argument("uid", type=str)
 @click.option("--project", "-p", help="project name")
 @click.option("--offset", type=int, default=0, help="byte offset")
@@ -840,7 +840,7 @@ def logs(uid, project, offset, db, watch):
         print(f"final state: {state}")
 
 
-@main.command(context_settings=mlconf.cli.context_settings.to_dict())
+@main.command()
 @click.argument("context", default="", type=str, required=False)
 @click.option("--name", "-n", help="project name")
 @click.option("--url", "-u", help="remote git or archive url")
@@ -1038,7 +1038,7 @@ def validate_kind(ctx, param, value):
     return value
 
 
-@main.command(context_settings=mlconf.cli.context_settings.to_dict())
+@main.command()
 @click.argument("kind", callback=validate_kind, default=None, required=False)
 @click.argument("object_id", metavar="id", type=str, default=None, required=False)
 @click.option("--api", help="api service url")
@@ -1086,9 +1086,7 @@ def clean(kind, object_id, api, label_selector, force, grace_period):
     )
 
 
-@main.command(
-    name="watch-stream", context_settings=mlconf.cli.context_settings.to_dict()
-)
+@main.command(name="watch-stream")
 @click.argument("url", type=str)
 @click.option(
     "--shard-ids",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -455,6 +455,11 @@ default_config = {
     "debug": {
         "expose_internal_api_endpoints": False,
     },
+    "cli": {
+        "context_settings": {
+            "ignore_unknown_options": False,
+        }
+    },
 }
 
 

--- a/tests/run/test_main.py
+++ b/tests/run/test_main.py
@@ -60,6 +60,58 @@ def test_main_run_basic():
     assert out.find("state: completed") != -1, out
 
 
+def test_main_run_unknown_option():
+    with pytest.raises(Exception) as e:
+        exec_run(
+            f"{examples_path}/training.py",
+            ["--force-something"],
+            "test_main_run_basic",
+        )
+    assert "Error: No such option: --force-something" in str(e.value)
+
+
+def test_main_run_ignore_unknown_option():
+    os.environ["MLRUN_CLI__CONTEXT_SETTINGS__IGNORE_UNKNOWN_OPTIONS"] = "true"
+
+    # unknown flags must be after the url argument
+    out = exec_main(
+        "run",
+        [
+            "--name",
+            "test_main_run_basic",
+            "--dump",
+            f"{examples_path}/training.py",
+            "--some-arg",
+        ],
+    )
+    print(out)
+    assert out.find("state: completed") != -1, out
+    assert (
+        out.find(f"{examples_path}/training.py', '--some-arg']") != -1
+    ), "arg was not passed to subcommand"
+
+
+def test_main_run_pass_args_to_subcommand():
+
+    # unknown flags must be after the url argument
+    out = exec_main(
+        "run",
+        [
+            "--name",
+            "test_main_run_basic",
+            "--dump",
+            "--",
+            f"{examples_path}/training.py",
+            "--some-arg",
+        ],
+    )
+    print(out)
+    assert out.find("state: completed") != -1, out
+    assert (
+        out.find(f"{examples_path}/training.py', '--some-arg']") != -1
+    ), "arg was not passed to subcommand"
+
+
 def test_main_run_hyper():
     out = exec_run(
         f"{examples_path}/training.py",


### PR DESCRIPTION
The default configuration is to not ignore unknown options.
The general guideline is to separate the commands (POSIX like) with double-dash e.g. `mlrun run --name my_func -- /path/to/code.py --arg1 --arg2` (need to update the docs as well)
This breaks BC so we need to make sure upgrading mlrun overrides the flag to `true`.

problems:
1. need to add configuration to client-spec
2. using mlconf couples the cli with the api which we do not want
3. need to validate the url param - what is a valid url?
4. https://jira.iguazeng.com/browse/ML-2964 - will need to be addressed