### PR TITLE
[Run] Normalize function name in `new_function` [1.2.x]

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -35,7 +35,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from kfp import Client
-from nuclio import build_file
+from nuclio import build_file, utils
 
 import mlrun.api.schemas
 import mlrun.errors
@@ -593,11 +593,14 @@ def new_function(
             )
 
     if not name:
-        # todo: regex check for valid name
         if command and kind not in [RuntimeKinds.remote]:
             name, _ = path.splitext(path.basename(command))
         else:
             name = "mlrun-" + uuid.uuid4().hex[0:6]
+
+    # make sure function name is valid
+    name = utils.normalize_name(name)
+
     runner.metadata.name = name
     runner.metadata.project = (
         runner.metadata.project or project or mlconf.default_project

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -1299,7 +1299,7 @@ def _generate_original_function(
     volumes=None,
     volume_mounts=None,
 ):
-    function_name = "function_name"
+    function_name = "function-name"
     project = "some-project"
     function_tag = "function_tag"
     original_function = {

--- a/tests/runtimes/test_run.py
+++ b/tests/runtimes/test_run.py
@@ -304,3 +304,10 @@ def test_new_function_override_default_image_pull_secret():
         )
         == {}
     )
+
+
+def test_new_function_invalid_characters():
+    runtime = _get_runtime()
+    invalid_function_name = "invalid_name with_spaces"
+    function = mlrun.new_function(name=invalid_function_name, runtime=runtime)
+    assert function.metadata.name == "invalid-name-with-spaces"


### PR DESCRIPTION
Backport of #2696

When a function name contains illegal characters (underscores and whitespaces), code_to_function normalizes the name but new_function doesn't, which fails the function deployment.

This PR aligns new_function to normalize function names same as in code_to_function.

Fixes https://jira.iguazeng.com/browse/ML-2942