### PR TITLE
[Artifacts] Set dataset stats according to `stats` flag in `log_dataset`

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -268,9 +268,11 @@ class DatasetArtifact(Artifact):
         artifact.spec.header = preview_df.columns.values.tolist()
         artifact.status.preview = preview_df.values.tolist()
         artifact.spec.schema = build_table_schema(preview_df)
-        if (
-            stats
-            or (
+
+        # set artifact stats if stats is explicitly set to true, or if stats is None and the dataframe is small
+        if stats or (
+            stats is None
+            and (
                 artifact.spec.length < max_csv and len(df.columns) < max_preview_columns
             )
             or ignore_preview_limits

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -652,7 +652,7 @@ class MLClientCtx(object):
         labels=None,
         format="",
         preview=None,
-        stats=False,
+        stats=None,
         db_key=None,
         target_path="",
         extra_data=None,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1301,7 +1301,7 @@ class MlrunProject(ModelObj):
         labels=None,
         format="",
         preview=None,
-        stats=False,
+        stats=None,
         target_path="",
         extra_data=None,
         label_column: str = None,

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -182,6 +182,54 @@ def test_resolve_dataset_hash_path():
         assert test_case.get("expected_file_target") == target_path
 
 
+def test_dataset_stats():
+    raw_data = {
+        "first_name": ["Jason", "Molly", "Tina", "Jake", "Amy"],
+        "last_name": ["Miller", "Jacobson", "Ali", "Milner", "Cooze"],
+        "age": [42, 52, 36, 24, 73],
+        "testScore": [25, 94, 57, 62, 70],
+    }
+    df = pandas.DataFrame(
+        raw_data, columns=["first_name", "last_name", "age", "testScore"]
+    )
+    for test_case in [
+        {
+            # status is not set
+            "df": df,
+            "stats": None,
+            "expected_none_status_stats": False,
+        },
+        {
+            # status is set to True
+            "df": df,
+            "stats": True,
+            "expected_none_status_stats": False,
+        },
+        {
+            # status is set to False
+            "df": df,
+            "stats": False,
+            "expected_none_status_stats": True,
+        },
+        {
+            # status is not set and df is very large
+            "df": pandas.DataFrame(
+                raw_data, columns=[f"column-title-{i}" for i in range(200)]
+            ),
+            "stats": None,
+            "expected_none_status_stats": True,
+        },
+    ]:
+        dataset_artifact = mlrun.artifacts.dataset.DatasetArtifact(
+            df=test_case.get("df"), stats=test_case.get("stats")
+        )
+
+        if test_case["expected_none_status_stats"]:
+            assert dataset_artifact.status.stats is None
+        else:
+            assert dataset_artifact.status.stats is not None
+
+
 def _generate_dataset_artifact(format_):
     data_frame = pandas.DataFrame({"x": [1, 2]})
     target_path = pathlib.Path(tests.conftest.results) / "dataset"


### PR DESCRIPTION
Port to development of #2698 .

Change the behavior of the `stats` argument in `log_dataset()` accordingly:

- if `stats=False` explicity: do not set the artifact stats.
- if `stats=True` explicitly: set the artifact stats.
- if `stats` is None (not given): set the artifact's stats only if the dataframe is small (columns <= 100, artifact length < 1000)

Also added unit tests.

Fixes https://jira.iguazeng.com/browse/ML-2901