### PR TITLE
[Serving] Fix `OneHotEncoder` nondeterministic result

### DIFF
--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -14,6 +14,7 @@
 #
 import re
 import uuid
+from collections import OrderedDict
 from typing import Any, Dict, List, Union
 
 import numpy as np
@@ -275,7 +276,8 @@ class OneHotEncoder(StepToDict, MLRunStep):
                     raise mlrun.errors.MLRunInvalidArgumentError(
                         "For OneHotEncoder you must provide int or string mapping list"
                     )
-            mapping[key] = list(set(values))
+            # Use OrderedDict to dedup without losing the original order
+            mapping[key] = list(OrderedDict.fromkeys(values).keys())
 
     def _encode(self, feature: str, value):
         encoding = self.mapping.get(feature, [])


### PR DESCRIPTION
[ML-2988](https://jira.iguazeng.com/browse/ML-2988)

This fixes sporadic test failures ([test_set_event_with_spaces_or_hyphens](https://github.com/mlrun/mlrun/blob/v1.2.0/tests/system/feature_store/test_feature_store.py#L2777) and potentially others)