### PR TITLE
[Serving] Fixing - OneHotEncoder with pandas engine - fails when the values has spaces or hyphens in them

### DIFF
--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -310,7 +310,10 @@ class OneHotEncoder(StepToDict, MLRunStep):
         for key, values in self.mapping.items():
             event[key] = pd.Categorical(event[key], categories=list(values))
             encoded = pd.get_dummies(event[key], prefix=key, dtype=np.int64)
-            col_rename = {name: OneHotEncoder._sanitized_category(name) for name in encoded.columns}
+            col_rename = {
+                name: OneHotEncoder._sanitized_category(name)
+                for name in encoded.columns
+            }
             encoded.rename(columns=col_rename, inplace=True)
             event = pd.concat([event.loc[:, :key], encoded, event.loc[:, key:]], axis=1)
         event.drop(columns=list(self.mapping.keys()), inplace=True)

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -170,7 +170,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         self._logger.info(f"stocks spec: {stocks_set.to_yaml()}")
         assert (
-                stocks_set.spec.features["name"].description == "some name"
+            stocks_set.spec.features["name"].description == "some name"
         ), "description was not set"
         assert len(df) == len(stocks), "dataframe size doesnt match"
         assert stocks_set.status.stats["exchange"], "stats not created"
@@ -228,10 +228,10 @@ class TestFeatureStore(TestMLRunSystem):
             features
         ), "unexpected num of requested features"
         assert (
-                len(vector.status.features) == features_size
+            len(vector.status.features) == features_size
         ), "unexpected num of returned features"
         assert (
-                len(vector.status.stats) == features_size
+            len(vector.status.stats) == features_size
         ), "unexpected num of feature stats"
         assert vector.status.label_column == "xx", "unexpected label_column name"
 
@@ -257,7 +257,7 @@ class TestFeatureStore(TestMLRunSystem):
             # check that passing a dict (without list) works
             resp = svc.get({"ticker": "GOOG"})
             assert (
-                    resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
+                resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
 
             try:
@@ -275,11 +275,11 @@ class TestFeatureStore(TestMLRunSystem):
             resp = svc.get([{"ticker": "GOOG"}, {"ticker": "MSFT"}])
             resp = svc.get([{"ticker": "AAPL"}])
             assert (
-                    resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
+                resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
             resp2 = svc.get([{"ticker": "AAPL"}], as_list=True)
             assert (
-                    len(resp2[0]) == features_size - 1
+                len(resp2[0]) == features_size - 1
             ), "unexpected online vector size"  # -1 label
 
     def test_ingest_and_query(self):
@@ -298,7 +298,7 @@ class TestFeatureStore(TestMLRunSystem):
             "stocks.*",
         ]
         features_size = (
-                len(features) + 1 + 1
+            len(features) + 1 + 1
         )  # (*) returns 2 features, label adds 1 feature
 
         # test fetch with the pandas merger engine
@@ -352,7 +352,7 @@ class TestFeatureStore(TestMLRunSystem):
         assert default_df.index.name is None, "index column is not of default type"
         assert "time" not in default_df.columns, "'time' column shouldn't be present"
         assert (
-                "ticker" not in default_df.columns
+            "ticker" not in default_df.columns
         ), "'ticker' column shouldn't be present"
 
         # with_indexes = False, entity_timestamp_column = "time"
@@ -375,10 +375,10 @@ class TestFeatureStore(TestMLRunSystem):
         assert df_no_time.index.name is None, "index column is not of default type"
         assert "time" not in df_no_time.columns, "'time' column should not be present"
         assert (
-                "ticker" not in df_no_time.columns
+            "ticker" not in df_no_time.columns
         ), "'ticker' column shouldn't be present"
         assert (
-                "another_time" in df_no_time.columns
+            "another_time" in df_no_time.columns
         ), "'another_time' column should be present"
 
         # with_indexes = False, entity_timestamp_column = "invalid" - should return the timestamp column
@@ -390,11 +390,11 @@ class TestFeatureStore(TestMLRunSystem):
         ), "index column is not of default type"
         assert df_with_time.index.name is None, "index column is not of default type"
         assert (
-                "ticker" not in df_with_time.columns
+            "ticker" not in df_with_time.columns
         ), "'ticker' column shouldn't be present"
         assert "time" in df_with_time.columns, "'time' column should be present"
         assert (
-                "another_time" not in df_with_time.columns
+            "another_time" not in df_with_time.columns
         ), "'another_time' column should not be present"
 
         vector.spec.with_indexes = True
@@ -412,13 +412,13 @@ class TestFeatureStore(TestMLRunSystem):
             (f"v3io:///bigdata/{project_name}/gof_wt.parquet", False),  # single file
             (f"v3io:///bigdata/{project_name}/gof_wt/", False),  # directory
             (
-                    f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
-                    True,
+                f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
+                True,
             ),  # with run_id
         ],
     )
     def test_different_target_paths_for_get_offline_features(
-            self, target_path, should_raise_error
+        self, target_path, should_raise_error
     ):
         stocks = pd.DataFrame(
             {
@@ -456,7 +456,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_storey_engines(
-            self, should_succeed, is_parquet, is_partitioned, target_path
+        self, should_succeed, is_parquet, is_partitioned, target_path
     ):
         fset = FeatureSet("fsname", entities=[Entity("ticker")], engine="storey")
         target = (
@@ -488,7 +488,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_pandas_engines(
-            self, should_succeed, is_parquet, is_partitioned, target_path, chunks
+        self, should_succeed, is_parquet, is_partitioned, target_path, chunks
     ):
         source = CSVSource(
             "mycsv", path=os.path.relpath(str(self.assets_path / "testdata.csv"))
@@ -536,11 +536,11 @@ class TestFeatureStore(TestMLRunSystem):
         fs.ingest(fset, df, infer_options=fs.InferOptions.default(), **ingest_kw)
 
         assert fset.status.targets[
-                   0
-               ].get_path().get_absolute_path() == fset.get_target_path("parquet")
+            0
+        ].get_path().get_absolute_path() == fset.get_target_path("parquet")
         assert fset.status.targets[
-                   1
-               ].get_path().get_absolute_path() == fset.get_target_path("nosql")
+            1
+        ].get_path().get_absolute_path() == fset.get_target_path("nosql")
 
     def test_feature_set_db(self):
         name = "stocks_test"
@@ -795,7 +795,7 @@ class TestFeatureStore(TestMLRunSystem):
     @pytest.mark.parametrize("partition_cols", [None, ["department"]])
     @pytest.mark.parametrize("time_partitioning_granularity", [None, "day"])
     def test_ingest_partitioned_by_key_and_time(
-            self, key_bucketing_number, partition_cols, time_partitioning_granularity
+        self, key_bucketing_number, partition_cols, time_partitioning_granularity
     ):
         name = f"measurements_{uuid.uuid4()}"
         key = "patient_id"
@@ -849,12 +849,12 @@ class TestFeatureStore(TestMLRunSystem):
             expected_partitions = [f"hash{key_bucketing_number}_key"]
         expected_partitions += partition_cols or []
         if all(
-                value is None
-                for value in [
-                    key_bucketing_number,
-                    partition_cols,
-                    time_partitioning_granularity,
-                ]
+            value is None
+            for value in [
+                key_bucketing_number,
+                partition_cols,
+                time_partitioning_granularity,
+            ]
         ):
             time_partitioning_granularity = (
                 mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
@@ -1475,7 +1475,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         vector = fs.FeatureVector("my-vec", features)
         with fs.get_online_feature_service(
-                vector, fixed_window_type=fixed_window_type
+            vector, fixed_window_type=fixed_window_type
         ) as svc:
             resp = svc.get([{"first_name": "moshe"}])
             if fixed_window_type == FixedWindowType.CurrentOpenWindow:
@@ -1823,8 +1823,8 @@ class TestFeatureStore(TestMLRunSystem):
         csv_df = pd.read_csv(csv_path)
         assert (
             df1.set_index(keys="name")
-                .sort_index()
-                .equals(csv_df.set_index(keys="name").sort_index())
+            .sort_index()
+            .equals(csv_df.set_index(keys="name").sort_index())
         )
 
         parquet_path = fset.get_target_path(name="parquet")
@@ -1841,8 +1841,8 @@ class TestFeatureStore(TestMLRunSystem):
         csv_df = pd.read_csv(csv_path)
         assert (
             df1.set_index(keys="name")
-                .sort_index()
-                .equals(csv_df.set_index(keys="name").sort_index())
+            .sort_index()
+            .equals(csv_df.set_index(keys="name").sort_index())
         )
 
         parquet_path = fset.get_target_path(name="parquet")
@@ -1871,8 +1871,8 @@ class TestFeatureStore(TestMLRunSystem):
 
         assert (
             df1.set_index(keys="name")
-                .sort_index()
-                .equals(off1.to_dataframe().sort_index())
+            .sort_index()
+            .equals(off1.to_dataframe().sort_index())
         )
         assert df1.set_index(keys="name").sort_index().equals(dfout1.sort_index())
 
@@ -1882,8 +1882,8 @@ class TestFeatureStore(TestMLRunSystem):
         dfout2 = pd.read_parquet(target.get_target_path())
         assert (
             df2.set_index(keys="name")
-                .sort_index()
-                .equals(off2.to_dataframe().sort_index())
+            .sort_index()
+            .equals(off2.to_dataframe().sort_index())
         )
         assert df2.set_index(keys="name").sort_index().equals(dfout2.sort_index())
 
@@ -2036,7 +2036,7 @@ class TestFeatureStore(TestMLRunSystem):
             if config.v3io_api:
                 api = config.v3io_api
                 if "//" in api:
-                    api = api[api.find("//") + 2:]
+                    api = api[api.find("//") + 2 :]
                 if ":" in api:
                     api = api[: api.find(":")]
             return api
@@ -2490,7 +2490,7 @@ class TestFeatureStore(TestMLRunSystem):
         # create vector and online service with imputing policy
         vector = fs.FeatureVector("vectori", features)
         with fs.get_online_feature_service(
-                vector, impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4}
+            vector, impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4}
         ) as svc:
             print(svc.vector.status.to_yaml())
 
@@ -2607,7 +2607,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_deploy_ingestion_service_with_different_targets(
-            self, targets, feature_set_targets, expected_target_names
+        self, targets, feature_set_targets, expected_target_names
     ):
         fset_name = "dis-set"
         fset = FeatureSet(f"{fset_name}", entities=[Entity("ticker")])
@@ -2998,7 +2998,7 @@ class TestFeatureStore(TestMLRunSystem):
             request_url, json=request_body, headers=headers, verify=False
         )
         assert (
-                response.status_code == 200
+            response.status_code == 200
         ), f"Failed to patch feature vector: {response}"
 
         service = fs.get_online_feature_service(vector_name)
@@ -3190,7 +3190,7 @@ def verify_target_list_fail(targets, with_defaults=None):
 
 
 def verify_ingest(
-        base_data, keys, infer=False, targets=None, infer_options=fs.InferOptions.default()
+    base_data, keys, infer=False, targets=None, infer_options=fs.InferOptions.default()
 ):
     if isinstance(keys, str):
         keys = [keys]
@@ -3212,7 +3212,7 @@ def verify_ingest(
 
 
 def prepare_feature_set(
-        name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
+    name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
 ):
     df_source = mlrun.datastore.sources.DataFrameSource(data, entity, timestamp_key)
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -170,7 +170,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         self._logger.info(f"stocks spec: {stocks_set.to_yaml()}")
         assert (
-            stocks_set.spec.features["name"].description == "some name"
+                stocks_set.spec.features["name"].description == "some name"
         ), "description was not set"
         assert len(df) == len(stocks), "dataframe size doesnt match"
         assert stocks_set.status.stats["exchange"], "stats not created"
@@ -228,10 +228,10 @@ class TestFeatureStore(TestMLRunSystem):
             features
         ), "unexpected num of requested features"
         assert (
-            len(vector.status.features) == features_size
+                len(vector.status.features) == features_size
         ), "unexpected num of returned features"
         assert (
-            len(vector.status.stats) == features_size
+                len(vector.status.stats) == features_size
         ), "unexpected num of feature stats"
         assert vector.status.label_column == "xx", "unexpected label_column name"
 
@@ -257,7 +257,7 @@ class TestFeatureStore(TestMLRunSystem):
             # check that passing a dict (without list) works
             resp = svc.get({"ticker": "GOOG"})
             assert (
-                resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
+                    resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
 
             try:
@@ -275,11 +275,11 @@ class TestFeatureStore(TestMLRunSystem):
             resp = svc.get([{"ticker": "GOOG"}, {"ticker": "MSFT"}])
             resp = svc.get([{"ticker": "AAPL"}])
             assert (
-                resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
+                    resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
             resp2 = svc.get([{"ticker": "AAPL"}], as_list=True)
             assert (
-                len(resp2[0]) == features_size - 1
+                    len(resp2[0]) == features_size - 1
             ), "unexpected online vector size"  # -1 label
 
     def test_ingest_and_query(self):
@@ -298,7 +298,7 @@ class TestFeatureStore(TestMLRunSystem):
             "stocks.*",
         ]
         features_size = (
-            len(features) + 1 + 1
+                len(features) + 1 + 1
         )  # (*) returns 2 features, label adds 1 feature
 
         # test fetch with the pandas merger engine
@@ -352,7 +352,7 @@ class TestFeatureStore(TestMLRunSystem):
         assert default_df.index.name is None, "index column is not of default type"
         assert "time" not in default_df.columns, "'time' column shouldn't be present"
         assert (
-            "ticker" not in default_df.columns
+                "ticker" not in default_df.columns
         ), "'ticker' column shouldn't be present"
 
         # with_indexes = False, entity_timestamp_column = "time"
@@ -375,10 +375,10 @@ class TestFeatureStore(TestMLRunSystem):
         assert df_no_time.index.name is None, "index column is not of default type"
         assert "time" not in df_no_time.columns, "'time' column should not be present"
         assert (
-            "ticker" not in df_no_time.columns
+                "ticker" not in df_no_time.columns
         ), "'ticker' column shouldn't be present"
         assert (
-            "another_time" in df_no_time.columns
+                "another_time" in df_no_time.columns
         ), "'another_time' column should be present"
 
         # with_indexes = False, entity_timestamp_column = "invalid" - should return the timestamp column
@@ -390,11 +390,11 @@ class TestFeatureStore(TestMLRunSystem):
         ), "index column is not of default type"
         assert df_with_time.index.name is None, "index column is not of default type"
         assert (
-            "ticker" not in df_with_time.columns
+                "ticker" not in df_with_time.columns
         ), "'ticker' column shouldn't be present"
         assert "time" in df_with_time.columns, "'time' column should be present"
         assert (
-            "another_time" not in df_with_time.columns
+                "another_time" not in df_with_time.columns
         ), "'another_time' column should not be present"
 
         vector.spec.with_indexes = True
@@ -412,13 +412,13 @@ class TestFeatureStore(TestMLRunSystem):
             (f"v3io:///bigdata/{project_name}/gof_wt.parquet", False),  # single file
             (f"v3io:///bigdata/{project_name}/gof_wt/", False),  # directory
             (
-                f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
-                True,
+                    f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
+                    True,
             ),  # with run_id
         ],
     )
     def test_different_target_paths_for_get_offline_features(
-        self, target_path, should_raise_error
+            self, target_path, should_raise_error
     ):
         stocks = pd.DataFrame(
             {
@@ -456,7 +456,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_storey_engines(
-        self, should_succeed, is_parquet, is_partitioned, target_path
+            self, should_succeed, is_parquet, is_partitioned, target_path
     ):
         fset = FeatureSet("fsname", entities=[Entity("ticker")], engine="storey")
         target = (
@@ -488,7 +488,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_pandas_engines(
-        self, should_succeed, is_parquet, is_partitioned, target_path, chunks
+            self, should_succeed, is_parquet, is_partitioned, target_path, chunks
     ):
         source = CSVSource(
             "mycsv", path=os.path.relpath(str(self.assets_path / "testdata.csv"))
@@ -536,11 +536,11 @@ class TestFeatureStore(TestMLRunSystem):
         fs.ingest(fset, df, infer_options=fs.InferOptions.default(), **ingest_kw)
 
         assert fset.status.targets[
-            0
-        ].get_path().get_absolute_path() == fset.get_target_path("parquet")
+                   0
+               ].get_path().get_absolute_path() == fset.get_target_path("parquet")
         assert fset.status.targets[
-            1
-        ].get_path().get_absolute_path() == fset.get_target_path("nosql")
+                   1
+               ].get_path().get_absolute_path() == fset.get_target_path("nosql")
 
     def test_feature_set_db(self):
         name = "stocks_test"
@@ -795,7 +795,7 @@ class TestFeatureStore(TestMLRunSystem):
     @pytest.mark.parametrize("partition_cols", [None, ["department"]])
     @pytest.mark.parametrize("time_partitioning_granularity", [None, "day"])
     def test_ingest_partitioned_by_key_and_time(
-        self, key_bucketing_number, partition_cols, time_partitioning_granularity
+            self, key_bucketing_number, partition_cols, time_partitioning_granularity
     ):
         name = f"measurements_{uuid.uuid4()}"
         key = "patient_id"
@@ -849,12 +849,12 @@ class TestFeatureStore(TestMLRunSystem):
             expected_partitions = [f"hash{key_bucketing_number}_key"]
         expected_partitions += partition_cols or []
         if all(
-            value is None
-            for value in [
-                key_bucketing_number,
-                partition_cols,
-                time_partitioning_granularity,
-            ]
+                value is None
+                for value in [
+                    key_bucketing_number,
+                    partition_cols,
+                    time_partitioning_granularity,
+                ]
         ):
             time_partitioning_granularity = (
                 mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
@@ -1475,7 +1475,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         vector = fs.FeatureVector("my-vec", features)
         with fs.get_online_feature_service(
-            vector, fixed_window_type=fixed_window_type
+                vector, fixed_window_type=fixed_window_type
         ) as svc:
             resp = svc.get([{"first_name": "moshe"}])
             if fixed_window_type == FixedWindowType.CurrentOpenWindow:
@@ -1823,8 +1823,8 @@ class TestFeatureStore(TestMLRunSystem):
         csv_df = pd.read_csv(csv_path)
         assert (
             df1.set_index(keys="name")
-            .sort_index()
-            .equals(csv_df.set_index(keys="name").sort_index())
+                .sort_index()
+                .equals(csv_df.set_index(keys="name").sort_index())
         )
 
         parquet_path = fset.get_target_path(name="parquet")
@@ -1841,8 +1841,8 @@ class TestFeatureStore(TestMLRunSystem):
         csv_df = pd.read_csv(csv_path)
         assert (
             df1.set_index(keys="name")
-            .sort_index()
-            .equals(csv_df.set_index(keys="name").sort_index())
+                .sort_index()
+                .equals(csv_df.set_index(keys="name").sort_index())
         )
 
         parquet_path = fset.get_target_path(name="parquet")
@@ -1871,8 +1871,8 @@ class TestFeatureStore(TestMLRunSystem):
 
         assert (
             df1.set_index(keys="name")
-            .sort_index()
-            .equals(off1.to_dataframe().sort_index())
+                .sort_index()
+                .equals(off1.to_dataframe().sort_index())
         )
         assert df1.set_index(keys="name").sort_index().equals(dfout1.sort_index())
 
@@ -1882,8 +1882,8 @@ class TestFeatureStore(TestMLRunSystem):
         dfout2 = pd.read_parquet(target.get_target_path())
         assert (
             df2.set_index(keys="name")
-            .sort_index()
-            .equals(off2.to_dataframe().sort_index())
+                .sort_index()
+                .equals(off2.to_dataframe().sort_index())
         )
         assert df2.set_index(keys="name").sort_index().equals(dfout2.sort_index())
 
@@ -2036,7 +2036,7 @@ class TestFeatureStore(TestMLRunSystem):
             if config.v3io_api:
                 api = config.v3io_api
                 if "//" in api:
-                    api = api[api.find("//") + 2 :]
+                    api = api[api.find("//") + 2:]
                 if ":" in api:
                     api = api[: api.find(":")]
             return api
@@ -2490,7 +2490,7 @@ class TestFeatureStore(TestMLRunSystem):
         # create vector and online service with imputing policy
         vector = fs.FeatureVector("vectori", features)
         with fs.get_online_feature_service(
-            vector, impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4}
+                vector, impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4}
         ) as svc:
             print(svc.vector.status.to_yaml())
 
@@ -2607,7 +2607,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_deploy_ingestion_service_with_different_targets(
-        self, targets, feature_set_targets, expected_target_names
+            self, targets, feature_set_targets, expected_target_names
     ):
         fset_name = "dis-set"
         fset = FeatureSet(f"{fset_name}", entities=[Entity("ticker")])
@@ -2755,7 +2755,8 @@ class TestFeatureStore(TestMLRunSystem):
 
         assert df_res_2.equals(expected_df)
 
-    def test_set_event_with_spaces_or_hyphens(self):
+    @pytest.mark.parametrize("engine", ["pandas", "storey"])
+    def test_set_event_with_spaces_or_hyphens(self, engine):
 
         lst_1 = [
             " Private",
@@ -2773,7 +2774,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         # Define the corresponding FeatureSet
         data_set = FeatureSet(
-            "test", entities=[Entity("id")], description="feature set"
+            "test", entities=[Entity("id")], description="feature set", engine=engine
         )
 
         data_set.graph.to(OneHotEncoder(mapping=one_hot_encoder_mapping))
@@ -2997,7 +2998,7 @@ class TestFeatureStore(TestMLRunSystem):
             request_url, json=request_body, headers=headers, verify=False
         )
         assert (
-            response.status_code == 200
+                response.status_code == 200
         ), f"Failed to patch feature vector: {response}"
 
         service = fs.get_online_feature_service(vector_name)
@@ -3189,7 +3190,7 @@ def verify_target_list_fail(targets, with_defaults=None):
 
 
 def verify_ingest(
-    base_data, keys, infer=False, targets=None, infer_options=fs.InferOptions.default()
+        base_data, keys, infer=False, targets=None, infer_options=fs.InferOptions.default()
 ):
     if isinstance(keys, str):
         keys = [keys]
@@ -3211,7 +3212,7 @@ def verify_ingest(
 
 
 def prepare_feature_set(
-    name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
+        name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
 ):
     df_source = mlrun.datastore.sources.DataFrameSource(data, entity, timestamp_key)
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2994?filter=-1&jql=resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(currentUser())%20order%20by%20updated%20DESC

includes #2712 changes

[ML-2994](https://jira.iguazeng.com/browse/ML-2994)