### PR TITLE
[API] Add project-scope `files`/`filestat` API that work with project secrets

### DIFF
--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -18,7 +18,9 @@ from http import HTTPStatus
 import fastapi
 
 import mlrun.api.api.deps
+import mlrun.api.crud.secrets
 import mlrun.api.schemas
+import mlrun.api.utils.auth.verifier
 from mlrun.api.api.utils import get_obj_path, get_secrets, log_and_raise
 from mlrun.datastore import store_manager
 from mlrun.utils import logger
@@ -37,6 +39,80 @@ def get_files(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
+    return _get_files(schema, objpath, user, size, offset, auth_info)
+
+
+@router.get("/projects/{project}/files")
+def get_files_with_project_secrets(
+    project: str,
+    schema: str = "",
+    objpath: str = fastapi.Query("", alias="path"),
+    user: str = "",
+    size: int = 0,
+    offset: int = 0,
+    use_secrets: bool = fastapi.Query(True, alias="use-secrets"),
+    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+):
+    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+        project,
+        mlrun.api.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+
+    secrets = {}
+    if use_secrets:
+        secrets = _verify_and_get_project_secrets(project, auth_info)
+
+    return _get_files(schema, objpath, user, size, offset, auth_info, secrets=secrets)
+
+
+@router.get("/filestat")
+def get_filestat(
+    schema: str = "",
+    path: str = "",
+    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+    user: str = "",
+):
+    return _get_filestat(schema, path, user, auth_info)
+
+
+@router.get("/projects/{project}/filestat")
+def get_filestat_with_project_secrets(
+    project: str,
+    schema: str = "",
+    path: str = "",
+    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+    user: str = "",
+    use_secrets: bool = fastapi.Query(True, alias="use-secrets"),
+):
+    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+        project,
+        mlrun.api.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+
+    secrets = {}
+    if use_secrets:
+        secrets = _verify_and_get_project_secrets(project, auth_info)
+
+    return _get_filestat(schema, path, user, auth_info, secrets=secrets)
+
+
+def _get_files(
+    schema: str,
+    objpath: str,
+    user: str,
+    size: int,
+    offset: int,
+    auth_info: mlrun.api.schemas.AuthInfo,
+    secrets: dict = None,
+):
     _, filename = objpath.split(objpath)
 
     objpath = get_obj_path(schema, objpath, user=user)
@@ -49,7 +125,9 @@ def get_files(
 
     logger.debug("Got get files request", path=objpath)
 
-    secrets = get_secrets(auth_info)
+    secrets = secrets or {}
+    secrets.update(get_secrets(auth_info))
+
     body = None
     try:
         obj = store_manager.object(url=objpath, secrets=secrets)
@@ -74,14 +152,12 @@ def get_files(
     )
 
 
-@router.get("/filestat")
-def get_filestat(
-    schema: str = "",
-    path: str = "",
-    auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
-        mlrun.api.api.deps.authenticate_request
-    ),
-    user: str = "",
+def _get_filestat(
+    schema: str,
+    path: str,
+    user: str,
+    auth_info: mlrun.api.schemas.AuthInfo,
+    secrets: dict = None,
 ):
     _, filename = path.split(path)
 
@@ -93,7 +169,9 @@ def get_filestat(
 
     logger.debug("Got get filestat request", path=path)
 
-    secrets = get_secrets(auth_info)
+    secrets = secrets or {}
+    secrets.update(get_secrets(auth_info))
+
     stat = None
     try:
         stat = store_manager.object(url=path, secrets=secrets).stat()
@@ -109,3 +187,18 @@ def get_filestat(
         "modified": stat.modified,
         "mimetype": ctype,
     }
+
+
+def _verify_and_get_project_secrets(project, auth_info):
+    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.secret,
+        project,
+        mlrun.api.schemas.SecretProviderName.kubernetes,
+        mlrun.api.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+    return mlrun.api.crud.Secrets().list_project_secrets(
+        project,
+        mlrun.api.schemas.SecretProviderName.kubernetes,
+        allow_secrets_from_k8s=True,
+    )

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -197,8 +197,9 @@ def _verify_and_get_project_secrets(project, auth_info):
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    return mlrun.api.crud.Secrets().list_project_secrets(
+    secrets_data = mlrun.api.crud.Secrets().list_project_secrets(
         project,
         mlrun.api.schemas.SecretProviderName.kubernetes,
         allow_secrets_from_k8s=True,
     )
+    return secrets_data.secrets or {}

--- a/tests/api/api/test_files.py
+++ b/tests/api/api/test_files.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
+import unittest.mock
 from http import HTTPStatus
 
 import pytest
@@ -19,10 +21,13 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 # fixtures for test, aren't used directly so we need to ignore the lint here
+import mlrun
 from tests.common_fixtures import (  # noqa: F401
     patch_file_forbidden,
     patch_file_not_found,
 )
+
+from mlrun.api.api.utils import get_secrets
 
 
 @pytest.mark.usefixtures("patch_file_forbidden")
@@ -44,3 +49,52 @@ def validate_files_status_code(client: TestClient, status_code: int):
 
     resp = client.get("filestat?schema=v3io&path=mybucket/files.txt")
     assert resp.status_code == status_code
+
+
+class DatastoreObjectMock:
+    def get(self, size, offset):
+        return "dummy body"
+
+    def listdir(self):
+        return ["file1", "file2", "dir1/file3"]
+
+
+@pytest.fixture
+def files_mock():
+    old_object = mlrun.store_manager.object
+    mlrun.store_manager.object = unittest.mock.Mock(return_value=DatastoreObjectMock())
+
+    yield mlrun.store_manager.object
+
+    mlrun.store_manager.object = old_object
+
+
+def test_files(db: Session, client: TestClient, files_mock, k8s_secrets_mock) -> None:
+    path = "s3://somebucket/some/path/file"
+    project = "proj1"
+
+    env_secrets = {"V3IO_ACCESS_KEY": None}
+    project_secrets = {"secret1": "value1", "secret2": "value2"}
+    full_secrets = project_secrets.copy()
+    full_secrets.update(env_secrets)
+    k8s_secrets_mock.store_project_secrets(project, project_secrets)
+
+    resp = client.get(f"files?path={path}")
+    assert resp
+    files_mock.assert_called_once_with(url=path, secrets=env_secrets)
+    files_mock.reset_mock()
+
+    resp = client.get(f"projects/{project}/files?path={path}")
+    assert resp
+    files_mock.assert_called_once_with(url=path, secrets=full_secrets)
+    files_mock.reset_mock()
+
+    resp = client.get(f"projects/wrong-project/files?path={path}")
+    assert resp
+    files_mock.assert_called_once_with(url=path, secrets=env_secrets)
+    files_mock.reset_mock()
+
+    resp = client.get(f"projects/wrong-project/files?path={path}&use-secrets=false")
+    assert resp
+    files_mock.assert_called_once_with(url=path, secrets=env_secrets)
+    files_mock.reset_mock()

--- a/tests/api/api/test_files.py
+++ b/tests/api/api/test_files.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import unittest.mock
 from http import HTTPStatus
 
@@ -26,8 +25,6 @@ from tests.common_fixtures import (  # noqa: F401
     patch_file_forbidden,
     patch_file_not_found,
 )
-
-from mlrun.api.api.utils import get_secrets
 
 
 @pytest.mark.usefixtures("patch_file_forbidden")

--- a/tests/api/api/test_files.py
+++ b/tests/api/api/test_files.py
@@ -91,7 +91,7 @@ def test_files(db: Session, client: TestClient, files_mock, k8s_secrets_mock) ->
     files_mock.assert_called_once_with(url=path, secrets=env_secrets)
     files_mock.reset_mock()
 
-    resp = client.get(f"projects/wrong-project/files?path={path}&use-secrets=false")
+    resp = client.get(f"projects/{project}/files?path={path}&use-secrets=false")
     assert resp
     files_mock.assert_called_once_with(url=path, secrets=env_secrets)
     files_mock.reset_mock()


### PR DESCRIPTION
The `files` API allows MLRun UI to download files that are stored in data-stores supported by MLRun, but did not have any way to provide credentials to these data-stores. This limited the artifacts that can be shown to those stored on v3io (which had a special way to extract access-key for it) or stores that don't require credentials.
This PR adds new `files` and `filestat` APIs which are project-scoped (rather than global like the previous APIs) and are retrieving files using any project secrets that are defined for the project. This way, if a project stores artifacts on S3 and has the S3 credentials stored as project secrets (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) the new APIs will use those when accessing storage, thus allow access to the S3 bucket in question.
The APIs also allow to not use project secrets by using `use-secrets=false` which makes them equivalent to the existing APIs.

APIs are:
`GET .../projects/<project-name>/files`
`GET .../projects/<project-name>/filestat`

In terms of parameters, the APIs support the same parameters as the current APIs (with the additional project-name, of course).

This provides the back-end infrastructure needed for [ML-2959](https://jira.iguazeng.com/browse/ML-2959) - the UI will need to utilize these APIs for full support.