### PR TITLE
[Schedules] Fix label handling when reloading schedules (ML-3014)

### DIFF
--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -687,9 +687,7 @@ class Scheduler:
                     )
 
                     # Append the auth key label to the schedule labels in the DB.
-                    labels = {
-                        label["name"]: label["value"] for label in db_schedule.labels
-                    }
+                    labels = {label.name: label.value for label in db_schedule.labels}
                     labels = self._append_access_key_secret_to_labels(
                         labels, secret_name
                     )


### PR DESCRIPTION
Fix incorrect label handling when reloading from DB and converting from old schedules, when the schedules had labels - was assuming each label is a dict while they are objects. Modified tests to cover this flow.
Fix [ML-3014](https://jira.iguazeng.com/browse/ML-3014)