### PR TITLE
[Artifacts] Don't resolve artifact `target_path` if explicitly request `upload=False`

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -177,12 +177,16 @@ class ArtifactManager:
         item.iter = producer.iteration
         item.project = producer.project
 
+        # if target_path is provided and not relative, then no need to upload the artifact as it already exists
         if target_path:
             if is_relative_path(target_path):
                 raise ValueError(
                     f"target_path ({target_path}) param cannot be relative"
                 )
             upload = False
+
+        # if target_path wasn't provided, but src_path is not relative, then no need to upload the artifact as it
+        # already exists. In this case set the target_path to the src_path and set upload to False
         elif src_path and "://" in src_path:
             if upload:
                 raise ValueError(f"Cannot upload from remote path {src_path}")
@@ -193,7 +197,13 @@ class ArtifactManager:
         # didn't pass target_path explicitly then we won't use `generate_target_path` to calculate the target path,
         # but rather use the `resolve_<body/file>_target_hash_path` in the `item.upload` method.
         elif (
-            not item.is_inline()
+            # if the user didn't pass target_path explicitly but asked for upload (or didn't set upload at all)
+            # and the other conditions match we will enrich the target_path.
+            # generally we don't want to enrich target_path if there is no matching artifact in target_path either
+            # there is already a remote artifact in target_path ( that was previously uploaded ) or the user asked
+            # to upload the artifact.
+            (upload or upload is None)
+            and not item.is_inline()
             and not mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash
         ):
             target_path = item.generate_target_path(artifact_path, producer)

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -263,6 +263,28 @@ def test_log_artifact(
         assert expected_hash in logged_artifact.target_path
 
 
+def test_log_artifact_with_target_path_and_upload_options():
+    for target_path in ["s3://some/path", None]:
+        # True and None expected to upload
+        for upload_options in [False, True, None]:
+            artifact = mlrun.artifacts.Artifact(
+                key="some-artifact", body="asdasdasdasdas", format="parquet"
+            )
+            logged_artifact = mlrun.get_or_create_ctx("test").log_artifact(
+                artifact, target_path=target_path, upload=upload_options
+            )
+            print(logged_artifact)
+            if not target_path and (upload_options or upload_options is None):
+                # if no target path was given, and upload is True or None, we expect the artifact to get uploaded
+                # and a target path to be generated
+                assert logged_artifact.target_path is not None
+                assert logged_artifact.metadata.hash is not None
+            elif target_path:
+                # if target path is given, we don't upload and therefore don't calculate hash
+                assert logged_artifact.target_path == target_path
+                assert logged_artifact.metadata.hash is None
+
+
 @pytest.mark.parametrize(
     "artifact,artifact_path,expected_hash,expected_target_path,expected_error",
     [

--- a/tests/artifacts/test_model.py
+++ b/tests/artifacts/test_model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pathlib
+
 import pandas as pd
 
 import mlrun
@@ -51,11 +53,15 @@ def test_infer():
 
 
 def test_model_update():
-    model = ModelArtifact("my-model", model_file="a.pkl")
+    path = pathlib.Path(__file__).absolute().parent
+    model = ModelArtifact(
+        "my-model", model_dir=str(path / "assets"), model_file="model.pkl"
+    )
+
     target_path = results_dir + "model/"
 
     project = mlrun.new_project("test-proj", save=False)
-    artifact = project.log_artifact(model, upload=False, artifact_path=target_path)
+    artifact = project.log_artifact(model, upload=True, artifact_path=target_path)
 
     artifact_uri = f"store://artifacts/{artifact.project}/{artifact.db_key}"
     updated_model_spec = update_model(
@@ -73,7 +79,7 @@ def test_model_update():
     print(updated_model_spec.to_yaml())
 
     model_path, model, extra_dataitems = get_model(artifact_uri)
-    # print(model_spec.to_yaml())
+
     assert model_path.endswith(f"model/{model.model_file}"), "illegal model path"
     assert model.parameters == {"a": 1}, "wrong parameters"
     assert model.metrics == {"test-b": 2}, "wrong metrics"


### PR DESCRIPTION
…t `upload=False` [1.2.x] (#2704)

(cherry picked from commit 2dc67dbd66949ec9fdc11cd4aaaef9aee97c93fa)