### PR TITLE
[Docs] Better docstring for `mount_s3`, added warnings (#2737) [1.2.x]

### DIFF
--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -183,15 +183,21 @@ def mount_s3(
 ):
     """Modifier function to add s3 env vars or secrets to container
 
+    **Warning:**
+    Using this function to configure AWS credentials will expose these credentials in the pod spec of the runtime
+    created. It is recommended to use the `secret_name` parameter, or set the credentials as project-secrets and avoid
+    using this function.
+
     :param secret_name: kubernetes secret name (storing the access/secret keys)
-    :param aws_access_key: AWS_ACCESS_KEY_ID value
-    :param aws_secret_key: AWS_SECRET_ACCESS_KEY value
+    :param aws_access_key: AWS_ACCESS_KEY_ID value. If this parameter is not specified and AWS_ACCESS_KEY_ID env.
+                            variable is defined, the value will be taken from the env. variable
+    :param aws_secret_key: AWS_SECRET_ACCESS_KEY value. If this parameter is not specified and AWS_SECRET_ACCESS_KEY
+                            env. variable is defined, the value will be taken from the env. variable
     :param endpoint_url: s3 endpoint address (for non AWS s3)
     :param prefix: string prefix to add before the env var name (for working with multiple s3 data stores)
     :param aws_region: amazon region
     :param non_anonymous: force the S3 API to use non-anonymous connection, even if no credentials are provided
         (for authenticating externally, such as through IAM instance-roles)
-    :return:
     """
 
     if secret_name and (aws_access_key or aws_secret_key):
@@ -199,7 +205,12 @@ def mount_s3(
             "can use k8s_secret for credentials or specify them (aws_access_key, aws_secret_key) not both"
         )
 
-    if aws_access_key or aws_secret_key:
+    if not secret_name and (
+        aws_access_key
+        or os.environ.get(prefix + "AWS_ACCESS_KEY_ID")
+        or aws_secret_key
+        or os.environ.get(prefix + "AWS_SECRET_ACCESS_KEY")
+    ):
         logger.warning(
             "it is recommended to use k8s secret (specify secret_name), "
             "specifying the aws_access_key/aws_secret_key directly is unsafe"


### PR DESCRIPTION
(cherry picked from commit bdaf21fd52db996c7658740a26a119567bc3e877)

Back-porting #2737 