### PR TITLE
[Test] fix mkdir race condition - round 2

### DIFF
--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -44,13 +44,7 @@ from mlrun.config import config
 from mlrun.runtimes import BaseRuntime
 from mlrun.runtimes.function import NuclioStatus
 from mlrun.runtimes.utils import global_context
-from tests.conftest import (
-    logs_path,
-    results,
-    root_path,
-    rundb_path,
-    tests_root_directory,
-)
+from tests.conftest import logs_path, results, root_path, rundb_path
 
 session_maker: Callable
 

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import shutil
 import unittest
 from http import HTTPStatus
 from os import environ
+from pathlib import Path
 from typing import Callable, Generator
 from unittest.mock import Mock
 
@@ -42,7 +44,13 @@ from mlrun.config import config
 from mlrun.runtimes import BaseRuntime
 from mlrun.runtimes.function import NuclioStatus
 from mlrun.runtimes.utils import global_context
-from tests.conftest import logs_path, root_path, rundb_path
+from tests.conftest import (
+    logs_path,
+    results,
+    root_path,
+    rundb_path,
+    tests_root_directory,
+)
 
 session_maker: Callable
 
@@ -50,6 +58,13 @@ session_maker: Callable
 @pytest.fixture(autouse=True)
 # if we'll just call it config it may be overridden by other fixtures with the same name
 def config_test_base():
+
+    # recreating the test results path on each test instead of running it on conftest since
+    # it is not a threadsafe operation. if we'll run it on conftest it will be called multiple times
+    # in parallel and may cause errors.
+    shutil.rmtree(results, ignore_errors=True, onerror=None)
+    Path(f"{results}/kfp").mkdir(parents=True, exist_ok=True)
+
     environ["PYTHONPATH"] = root_path
     environ["MLRUN_DBPATH"] = rundb_path
     environ["MLRUN_httpdb__dirpath"] = rundb_path
@@ -63,13 +78,13 @@ def config_test_base():
     # reload config so that values overridden by tests won't pass to other tests
     mlrun.config.config.reload()
 
-    # remove the run db cache so it won't pass between tests
+    # remove the run db cache, so it won't pass between tests
     mlrun.db._run_db = None
     mlrun.db._last_db_url = None
     mlrun.datastore.store_manager._db = None
     mlrun.datastore.store_manager._stores = {}
 
-    # remove the is_running_as_api cache so it won't pass between tests
+    # remove the is_running_as_api cache, so it won't pass between tests
     mlrun.config._is_running_as_api = None
     # remove singletons in case they were changed (we don't want changes to pass between tests)
     mlrun.utils.singleton.Singleton._instances = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shutil
 import traceback
 import typing
 from datetime import datetime
@@ -31,11 +30,8 @@ tests_root_directory = Path(__file__).absolute().parent
 results = tests_root_directory / "test_results"
 is_ci = "CI" in environ
 
-shutil.rmtree(results, ignore_errors=True, onerror=None)
-Path(f"{results}/kfp").mkdir(parents=True, exist_ok=True)
 environ["KFPMETA_OUT_DIR"] = f"{results}/kfp/"
 environ["KFP_ARTIFACTS_DIR"] = f"{results}/kfp/"
-print(f"KFP: {results}/kfp/")
 
 rundb_path = f"{results}/rundb"
 logs_path = f"{results}/logs"

--- a/tests/run/assets/__init__.py
+++ b/tests/run/assets/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/run/assets/hyper_func.py
+++ b/tests/run/assets/hyper_func.py
@@ -1,3 +1,19 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 def hyper_func(context, p1, p2, p3):
     print(f"p2={p2}, p3={p3}")
     context.log_result("r1", p2 * p3)

--- a/tests/run/assets/hyper_func.py
+++ b/tests/run/assets/hyper_func.py
@@ -1,0 +1,3 @@
+def hyper_func(context, p1, p2, p3):
+    print(f"p2={p2}, p3={p3}")
+    context.log_result("r1", p2 * p3)

--- a/tests/run/test_hyper.py
+++ b/tests/run/test_hyper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import pathlib
 
 import pandas as pd
@@ -20,6 +21,7 @@ import mlrun
 from mlrun import new_function, new_task
 from tests.conftest import out_path, tag_test, tests_root_directory, verify_state
 
+from .assets.hyper_func import hyper_func
 from .common import my_func
 
 base_spec = new_task(params={"p1": 8}, out_path=out_path)
@@ -29,16 +31,10 @@ input_file_path = str(
 base_spec.spec.inputs = {"infile.txt": str(input_file_path)}
 
 
-def hyper_func(context, p1, p2, p3):
-    print(f"p2={p2}, p3={p3}")
-    context.log_result("r1", p2 * p3)
-
-
 def test_handler_hyper():
     run_spec = tag_test(base_spec, "test_handler_hyper")
     run_spec.with_hyper_params({"p1": [1, 5, 3]}, selector="max.accuracy")
     result = new_function().run(run_spec, handler=my_func)
-    print(result)
     assert len(result.status.iterations) == 3 + 1, "hyper parameters test failed"
     assert (
         result.status.results["best_iteration"] == 2


### PR DESCRIPTION
moved hyper param test func out - when using `new_function().run(...handler=Y)` with dask, it pickles the object and once being distributed (parallel >1), each worker loads the pickled object along with its import, thus, since the function was part of the module which imported conftest, it then imported and executed `conftest` multiple times in parallel. 
2 things was done on this pr to avoid this scenario

1. moved the hyper func to be in its own module (wont import conftest and/or execute any independent code)
2. ensured no non thread-safe code is executed when importing conftest
