### PR TITLE
[Docs] Improve `log_dataset` docstring wrt `local_path` flag

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -675,8 +675,9 @@ class MLClientCtx(object):
         :param key:           artifact key
         :param df:            dataframe object
         :param label_column:  name of the label column (the one holding the target (y) values)
-        :param local_path:    path to the local file we upload, will also be use
-                              as the destination subpath (under "artifact_path")
+        :param local_path:    path to the local dataframe file that exists locally.
+                              The given file extension will be used to save the dataframe to a file
+                              If the file exists, it will be uploaded to the datastore instead of the given df.
         :param artifact_path: target artifact path (when not using the default)
                               to define a subpath under the default location use:
                               `artifact_path=context.artifact_subpath('data')`

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1341,9 +1341,10 @@ class MlrunProject(ModelObj):
         :param key:           artifact key
         :param df:            dataframe object
         :param label_column:  name of the label column (the one holding the target (y) values)
-        :param local_path:    path to the local file we upload, will also be use
-                              as the destination subpath (under "artifact_path")
-        :param artifact_path: target artifact path (when not using the default)
+        :param local_path:    path to the local dataframe file that exists locally.
+                              The given file extension will be used to save the dataframe to a file
+                              If the file exists, it will be uploaded to the datastore instead of the given df.
+        :param artifact_path: target artifact path (when not using the default).
                               to define a subpath under the default location use:
                               `artifact_path=context.artifact_subpath('data')`
         :param tag:           version tag


### PR DESCRIPTION
Port #2743 to development

The `local_path` flag in `log_dataset` accepts a path to a local dataframe file, which will be uploaded to the datastore if exists.
This wasn't portrayed well in the docstring and caused some confusion.

https://jira.iguazeng.com/browse/ML-2900