### PR TITLE
[FeatureStore] Fixing graph plot with multiple targets of same kind + adding storage kind to plot

### DIFF
--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -777,7 +777,7 @@ class FeatureSet(ModelObj):
             validate_target_placement(graph, default_final_step, self.spec.targets)
             targets = [
                 BaseStep(
-                    target.kind,
+                    f"{target.kind}/{target.name}",
                     after=target.after_step or default_final_step,
                     shape="cylinder",
                 )

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1157,7 +1157,12 @@ def _add_graphviz_flow(
     if targets:
         for target in targets or []:
             target_kind, target_name = target.name.split("/", 1)
-            label = f"<{target_name}<br/><font point-size='8'>({target_kind})</font>>"
+            if target_kind != target_name:
+                label = (
+                    f"<{target_name}<br/><font point-size='8'>({target_kind})</font>>"
+                )
+            else:
+                label = target_name
             graph.node(target.fullname, label=label, shape=target.get_shape())
             last_step = target.after or default_final_step
             if last_step:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1156,7 +1156,9 @@ def _add_graphviz_flow(
     # draw targets after the last step (if specified)
     if targets:
         for target in targets or []:
-            graph.node(target.fullname, label=target.name, shape=target.get_shape())
+            target_kind, target_name = target.name.split("/", 1)
+            label = f"<{target_name}<br/><font point-size='8'>({target_kind})</font>>"
+            graph.node(target.fullname, label=label, shape=target.get_shape())
             last_step = target.after or default_final_step
             if last_step:
                 graph.edge(last_step, target.fullname)


### PR DESCRIPTION
Small changes to feature-set graph:

* If multiple targets of the same kind were defined, the plot would show a single target with 2 arrows. Fixed that to show separate targets
* Added the target kind to the graph if the kind is not the same as the name (pretty much everything other than the default targets). 

A `before` example:
![image](https://user-images.githubusercontent.com/66667568/208292338-715899af-b99f-46dc-b807-1f0fe78cea15.png)

An `after` example of a similar, resulting graph:
![image](https://user-images.githubusercontent.com/66667568/207856081-695a5fdd-7e01-4fb4-ba72-70f60276e1f5.png)

