### PR TITLE
[CI] Fix Open Source System Tests Fail Deploy

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -187,7 +187,6 @@ jobs:
             --debug \
             --wait \
             --timeout 600s \
-            -f https://raw.githubusercontent.com/mlrun/ce/development/charts/mlrun-ce/override-full.yaml \
             --set kube-prometheus-stack.enabled=false \
             --set mlrun.httpDB.dbType="sqlite" \
             --set mlrun.httpDB.dirPath="/mlrun/db" \


### PR DESCRIPTION
Remove full deployment flag from MLRun CE deployment in open source system tests. The new development chart (`0.5.1-rc1` and up) doesn't support the flag and always installs the full deployment now.