### PR TITLE
[Datastore] Fix handling of DataItem path in windows + support path mappings

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -431,6 +431,10 @@ default_config = {
         # 1. A string of comma-separated parameters, using this format: "param1=value1,param2=value2"
         # 2. A base-64 encoded json dictionary containing the list of parameters
         "auto_mount_params": "",
+        # map file data items starting with virtual path to the real path, used when consumers have different mounts
+        # e.g. Windows client (on host) and Linux container (Jupyter, Nuclio..) need to access the same files/artifacts
+        # need to map container path to host windows paths, e.g. "\data::c:\\mlrun_data" ("::" used as splitter)
+        "virtual_to_real_path": "",
     },
     "default_function_pod_resources": {
         "requests": {"cpu": None, "memory": None, "gpu": None},

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -203,4 +203,5 @@ class StoreManager:
         )
         if not secrets and not mlrun.config.is_running_as_api():
             self._stores[store_key] = store
-        return store, subpath
+        # in file stores in windows path like c:\a\b the drive letter is dropped from the path, so we return the url
+        return store, url if store.kind == "file" else subpath

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -333,3 +333,21 @@ def test_fsspec():
         assert len(files) == 2, "2 test files were not written"
         assert files[0].endswith("x.txt"), "wrong file name"
         assert fs.open(tmpdir + "/1x.txt", "r").read() == "123", "wrong file content"
+
+
+@pytest.mark.parametrize("virtual_path", ["/dummy/path", "c:\\dummy\\path"])
+def test_virtual_to_real_map(virtual_path):
+    # test that the virtual dir (/dummy/path) is replaced with a real dir
+    virtual_to_real_map = mlrun.mlconf.storage.virtual_to_real_path
+
+    with TemporaryDirectory() as tmpdir:
+        print(tmpdir)
+        mlrun.mlconf.storage.virtual_to_real_path = f"{virtual_path}::{tmpdir}"
+
+        data = mlrun.run.get_dataitem(f"{virtual_path}/test1.txt")
+        data.put("abc")
+        assert data.get() == b"abc", "failed put/get test"
+        assert data.stat().size == 3, "got wrong file size"
+        assert os.path.isfile(os.path.join(tmpdir, "test1.txt"))
+
+    mlrun.mlconf.storage.virtual_to_real_path = virtual_to_real_map


### PR DESCRIPTION
- fix incorrect handeling of windows paths (c:\a\b)
- add config param for mapping between virtual path (in the artifact or url) to the real local path for files