### PR TITLE
[Artifacts] Serialize `DirArtifact` to dictionary using new format

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -868,17 +868,6 @@ class DirArtifactSpec(ArtifactSpec):
 class DirArtifact(Artifact):
     kind = "dir"
 
-    _dict_fields = [
-        "key",
-        "kind",
-        "iter",
-        "tree",
-        "src_path",
-        "target_path",
-        "description",
-        "db_key",
-    ]
-
     @property
     def spec(self) -> DirArtifactSpec:
         return self._spec


### PR DESCRIPTION
Code had a leftover `_dict_fields` in `DirArtifact` which caused dir artifacts to serialize themselves to dictionary as legacy artifacts. This caused almost no issues since we're fully backwards compatible, except for calling `export()` on the artifact which is not supported in legacy artifacts.

Fixes https://jira.iguazeng.com/browse/ML-3073