### PR TITLE
[Run] Ignore bokeh installation with warning on import error

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1531,7 +1531,6 @@ class OutputsLogger:
                     "Bokeh installation is ignored. If needed, "
                     "make sure you have the required version with `pip install mlrun[bokeh]`"
                 )
-                pass
 
         # Log the artifact:
         if artifact is None:
@@ -1845,7 +1844,6 @@ class ContextHandler:
                 "Bokeh installation is ignored. If needed, "
                 "make sure you have the required version with `pip install mlrun[bokeh]`"
             )
-            pass
 
     @classmethod
     def _init_outputs_logging_map(cls):

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1528,7 +1528,7 @@ class OutputsLogger:
                 pass
             except ImportError:
                 logger.warn(
-                    "bokeh installation is ignored. if needed, "
+                    "Bokeh installation is ignored. If needed, "
                     "make sure you have the required version with `pip install mlrun[bokeh]`"
                 )
                 pass
@@ -1842,7 +1842,7 @@ class ContextHandler:
             pass
         except ImportError:
             logger.warn(
-                "bokeh installation is ignored. if needed, "
+                "Bokeh installation is ignored. If needed, "
                 "make sure you have the required version with `pip install mlrun[bokeh]`"
             )
             pass

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1529,7 +1529,7 @@ class OutputsLogger:
             except ImportError:
                 logger.warn(
                     "bokeh installation is ignored. "
-                    "make sure you have the required version with `pip install mlrun[bokeh]"
+                    "make sure you have the required version with `pip install mlrun[bokeh]`"
                 )
                 pass
 
@@ -1843,7 +1843,7 @@ class ContextHandler:
         except ImportError:
             logger.warn(
                 "bokeh installation is ignored. "
-                "make sure you have the required version with `pip install mlrun[bokeh]"
+                "make sure you have the required version with `pip install mlrun[bokeh]`"
             )
             pass
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1526,6 +1526,12 @@ class OutputsLogger:
                     artifact = BokehArtifact(key=key, figure=obj)
             except ModuleNotFoundError:
                 pass
+            except ImportError:
+                logger.warn(
+                    "bokeh installation is ignored. "
+                    "make sure you have the required version with `pip install mlrun[bokeh]"
+                )
+                pass
 
         # Log the artifact:
         if artifact is None:
@@ -1833,6 +1839,12 @@ class ContextHandler:
                 bokeh_plt.Figure
             ] = ArtifactType.PLOT
         except ModuleNotFoundError:
+            pass
+        except ImportError:
+            logger.warn(
+                "bokeh installation is ignored. "
+                "make sure you have the required version with `pip install mlrun[bokeh]"
+            )
             pass
 
     @classmethod

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1528,7 +1528,7 @@ class OutputsLogger:
                 pass
             except ImportError:
                 logger.warn(
-                    "bokeh installation is ignored. "
+                    "bokeh installation is ignored. if needed, "
                     "make sure you have the required version with `pip install mlrun[bokeh]`"
                 )
                 pass
@@ -1842,7 +1842,7 @@ class ContextHandler:
             pass
         except ImportError:
             logger.warn(
-                "bokeh installation is ignored. "
+                "bokeh installation is ignored. if needed, "
                 "make sure you have the required version with `pip install mlrun[bokeh]`"
             )
             pass


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3069
due to incompatibility between bokeh 2.0.2 (currently shipped with iguazio jupyter until moving to python 3.9) and Jinjja2 3.1.2 we get an import error when importing bokeh.
we don't want to explode because bokeh is not always needed. log an error to let the user know how to install the correct version of bokeh and continue.