### PR TITLE
[API] Add Fields to Client Spec for Use in UI

### DIFF
--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -81,9 +81,9 @@ def get_frontend_spec(
         default_artifact_path=config.artifact_path,
         default_function_pod_resources=mlrun.mlconf.default_function_pod_resources.to_dict(),
         default_function_preemption_mode=mlrun.mlconf.function_defaults.preemption_mode,
-        feature_store_data_prefixes=config.feature_store.default_prefixes,
-        ce_mode=config.httpdb.ce_mode,
-        ce_version=config.httpdb.ce_version,
+        feature_store_data_prefixes=config.feature_store.data_prefixes.to_dict(),
+        ce_mode=config.ce.mode,
+        ce_version=config.ce.version,
     )
 
 

--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -83,7 +83,7 @@ def get_frontend_spec(
         default_function_preemption_mode=mlrun.mlconf.function_defaults.preemption_mode,
         feature_store_data_prefixes=config.feature_store.data_prefixes.to_dict(),
         ce_mode=config.ce.mode,
-        ce_version=config.ce.version,
+        ce_version=config.ce.release,
     )
 
 

--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -81,6 +81,9 @@ def get_frontend_spec(
         default_artifact_path=config.artifact_path,
         default_function_pod_resources=mlrun.mlconf.default_function_pod_resources.to_dict(),
         default_function_preemption_mode=mlrun.mlconf.function_defaults.preemption_mode,
+        feature_store_data_prefixes=config.feature_store.default_prefixes,
+        ce_mode=config.httpdb.ce_mode,
+        ce_version=config.httpdb.ce_version,
     )
 
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -31,6 +31,7 @@ class ClientSpec(
             mpijob_crd_version=mpijob_crd_version,
             ui_url=config.resolve_ui_url(),
             artifact_path=config.artifact_path,
+            default_feature_store_data_prefix=config.feature_store.data_prefixes.default,
             spark_app_image=config.spark_app_image,
             spark_app_image_tag=config.spark_app_image_tag,
             spark_history_server_path=config.spark_history_server_path,
@@ -87,6 +88,7 @@ class ClientSpec(
             force_run_local=self._get_config_value_if_not_default("force_run_local"),
             function=self._get_config_value_if_not_default("function"),
             ce_mode=config.ce.mode,
+            ce_version=config.ce.version,
             logs=self._get_config_value_if_not_default("httpdb.logs"),
         )
 

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -87,7 +87,7 @@ class ClientSpec(
             force_run_local=self._get_config_value_if_not_default("force_run_local"),
             function=self._get_config_value_if_not_default("function"),
             ce_mode=config.ce.mode,
-            ce_version=config.ce.version,
+            ce_version=config.ce.release,
             logs=self._get_config_value_if_not_default("httpdb.logs"),
             feature_store_data_prefixes=self._get_config_value_if_not_default(
                 "feature_store.data_prefixes"

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -31,7 +31,6 @@ class ClientSpec(
             mpijob_crd_version=mpijob_crd_version,
             ui_url=config.resolve_ui_url(),
             artifact_path=config.artifact_path,
-            default_feature_store_data_prefix=config.feature_store.data_prefixes.default,
             spark_app_image=config.spark_app_image,
             spark_app_image_tag=config.spark_app_image_tag,
             spark_history_server_path=config.spark_history_server_path,
@@ -90,6 +89,9 @@ class ClientSpec(
             ce_mode=config.ce.mode,
             ce_version=config.ce.version,
             logs=self._get_config_value_if_not_default("httpdb.logs"),
+            feature_store_data_prefixes=self._get_config_value_if_not_default(
+                "feature_store.data_prefixes"
+            ),
         )
 
     @staticmethod

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -28,7 +28,7 @@ class ClientSpec(pydantic.BaseModel):
     mpijob_crd_version: typing.Optional[str]
     ui_url: typing.Optional[str]
     artifact_path: typing.Optional[str]
-    default_feature_store_data_prefix: typing.Optional[str]
+    feature_store_data_prefixes: typing.Optional[typing.Dict[str, str]]
     spark_app_image: typing.Optional[str]
     spark_app_image_tag: typing.Optional[str]
     spark_history_server_path: typing.Optional[str]

--- a/mlrun/api/schemas/client_spec.py
+++ b/mlrun/api/schemas/client_spec.py
@@ -28,6 +28,7 @@ class ClientSpec(pydantic.BaseModel):
     mpijob_crd_version: typing.Optional[str]
     ui_url: typing.Optional[str]
     artifact_path: typing.Optional[str]
+    default_feature_store_data_prefix: typing.Optional[str]
     spark_app_image: typing.Optional[str]
     spark_app_image_tag: typing.Optional[str]
     spark_history_server_path: typing.Optional[str]
@@ -55,6 +56,7 @@ class ClientSpec(pydantic.BaseModel):
     redis_url: typing.Optional[str]
     redis_type: typing.Optional[str]
     ce_mode: typing.Optional[str]
+    ce_version: typing.Optional[str]
     # not passing them as one object as it possible client user would like to override only one of the params
     calculate_artifact_hash: typing.Optional[str]
     generate_artifact_target_path_from_artifact_hash: typing.Optional[str]

--- a/mlrun/api/schemas/frontend_spec.py
+++ b/mlrun/api/schemas/frontend_spec.py
@@ -65,3 +65,6 @@ class FrontendSpec(pydantic.BaseModel):
     default_artifact_path: str
     default_function_pod_resources: Resources = Resources()
     default_function_preemption_mode: str
+    feature_store_data_prefixes: typing.Optional[typing.Dict[str, str]]
+    ce_mode: typing.Optional[str]
+    ce_version: typing.Optional[str]

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -455,6 +455,7 @@ default_config = {
     "ce": {
         # ce mode can be one of: "", lite, full
         "mode": "",
+        "version": "",
     },
     "debug": {
         "expose_internal_api_endpoints": False,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -455,7 +455,10 @@ default_config = {
     "ce": {
         # ce mode can be one of: "", lite, full
         "mode": "",
-        "version": "",
+
+        # not possible to call this "version" because the Config class has a "version" property
+        # which returns the version from the version.json file
+        "release": "",
     },
     "debug": {
         "expose_internal_api_endpoints": False,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -455,7 +455,6 @@ default_config = {
     "ce": {
         # ce mode can be one of: "", lite, full
         "mode": "",
-
         # not possible to call this "version" because the Config class has a "version" property
         # which returns the version from the version.json file
         "release": "",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -277,8 +277,8 @@ class HTTPRunDB(RunDBInterface):
                 "artifact_path"
             )
             config.feature_store.data_prefixes.default = (
-                config.feature_store.data_prefixes.default
-                or server_cfg.get("default_feature_store_data_prefix")
+                config.feature_store.data_prefixes
+                or server_cfg.get("feature_store_data_prefixes")
             )
             config.spark_app_image = config.spark_app_image or server_cfg.get(
                 "spark_app_image"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -276,7 +276,7 @@ class HTTPRunDB(RunDBInterface):
             config.artifact_path = config.artifact_path or server_cfg.get(
                 "artifact_path"
             )
-            config.feature_store.data_prefixes.default = (
+            config.feature_store.data_prefixes = (
                 config.feature_store.data_prefixes
                 or server_cfg.get("feature_store_data_prefixes")
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -265,6 +265,7 @@ class HTTPRunDB(RunDBInterface):
                     " CE mode don't match"
                 )
             config.ce.mode = server_cfg.get("ce_mode") or config.ce.mode
+            config.ce.version = server_cfg.get("ce_version") or config.ce.version
 
             # get defaults from remote server
             config.remote_host = config.remote_host or server_cfg.get("remote_host")
@@ -274,6 +275,10 @@ class HTTPRunDB(RunDBInterface):
             config.ui.url = config.resolve_ui_url() or server_cfg.get("ui_url")
             config.artifact_path = config.artifact_path or server_cfg.get(
                 "artifact_path"
+            )
+            config.feature_store.data_prefixes.default = (
+                config.feature_store.data_prefixes.default
+                or server_cfg.get("default_feature_store_data_prefix")
             )
             config.spark_app_image = config.spark_app_image or server_cfg.get(
                 "spark_app_image"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -265,7 +265,7 @@ class HTTPRunDB(RunDBInterface):
                     " CE mode don't match"
                 )
             config.ce.mode = server_cfg.get("ce_mode") or config.ce.mode
-            config.ce.version = server_cfg.get("ce_version") or config.ce.version
+            config.ce.release = server_cfg.get("ce_version") or config.ce.release
 
             # get defaults from remote server
             config.remote_host = config.remote_host or server_cfg.get("remote_host")

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -41,6 +41,19 @@ def test_client_spec(
     mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
         json.dumps(node_selector).encode("utf-8")
     )
+    ce_mode = "some-ce-mode"
+    ce_version = "y.y.y"
+    mlrun.mlconf.ce.mode = ce_mode
+    mlrun.mlconf.ce.release = ce_version
+
+    feature_store_data_prefix_default = "feature-store-data-prefix-default"
+    feature_store_data_prefix_nosql = "feature-store-data-prefix-nosql"
+    feature_store_data_prefix_redisnosql = "feature-store-data-prefix-redisnosql"
+    mlrun.mlconf.feature_store.data_prefixes.default = feature_store_data_prefix_default
+    mlrun.mlconf.feature_store.data_prefixes.nosql = feature_store_data_prefix_nosql
+    mlrun.mlconf.feature_store.data_prefixes.redisnosql = (
+        feature_store_data_prefix_redisnosql
+    )
 
     tolerations = [
         kubernetes.client.V1Toleration(
@@ -99,3 +112,15 @@ def test_client_spec(
 
     assert response_body["logs"] == mlrun.mlconf.httpdb.logs.to_dict()
     assert response_body["logs"]["pipelines"]["pull_state"]["mode"] == "enabled"
+
+    assert response_body["feature_store_data_prefixes"]["default"] == (
+        feature_store_data_prefix_default
+    )
+    assert response_body["feature_store_data_prefixes"]["nosql"] == (
+        feature_store_data_prefix_nosql
+    )
+    assert response_body["feature_store_data_prefixes"]["redisnosql"] == (
+        feature_store_data_prefix_redisnosql
+    )
+    assert response_body["ce_mode"] == ce_mode
+    assert response_body["ce_version"] == ce_version

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -233,14 +233,14 @@ def test_get_frontend_spec_feature_store_data_prefixes(
     assert response.status_code == http.HTTPStatus.OK.value
     frontend_spec = mlrun.api.schemas.FrontendSpec(**response.json())
     assert (
-            frontend_spec.feature_store_data_prefixes["default"]
-            == feature_store_data_prefix_default
+        frontend_spec.feature_store_data_prefixes["default"]
+        == feature_store_data_prefix_default
     )
     assert (
-            frontend_spec.feature_store_data_prefixes["nosql"]
-            == feature_store_data_prefix_nosql
+        frontend_spec.feature_store_data_prefixes["nosql"]
+        == feature_store_data_prefix_nosql
     )
     assert (
-            frontend_spec.feature_store_data_prefixes["redisnosql"]
-            == feature_store_data_prefix_redisnosql
+        frontend_spec.feature_store_data_prefixes["redisnosql"]
+        == feature_store_data_prefix_redisnosql
     )

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -200,3 +200,47 @@ def test_get_frontend_spec_nuclio_streams(
         assert frontend_spec.feature_flags.nuclio_streams == test_case.get(
             "expected_feature_flag"
         )
+
+
+def test_get_frontend_spec_ce(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    ce_mode = "some-ce-mode"
+    ce_version = "y.y.y"
+    mlrun.mlconf.ce.mode = ce_mode
+    mlrun.mlconf.ce.release = ce_version
+
+    response = client.get("frontend-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    frontend_spec = mlrun.api.schemas.FrontendSpec(**response.json())
+
+    assert frontend_spec.ce_version == ce_version
+    assert frontend_spec.ce_mode == ce_mode
+
+
+def test_get_frontend_spec_feature_store_data_prefixes(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    feature_store_data_prefix_default = "feature-store-data-prefix-default"
+    feature_store_data_prefix_nosql = "feature-store-data-prefix-nosql"
+    feature_store_data_prefix_redisnosql = "feature-store-data-prefix-redisnosql"
+    mlrun.mlconf.feature_store.data_prefixes.default = feature_store_data_prefix_default
+    mlrun.mlconf.feature_store.data_prefixes.nosql = feature_store_data_prefix_nosql
+    mlrun.mlconf.feature_store.data_prefixes.redisnosql = (
+        feature_store_data_prefix_redisnosql
+    )
+    response = client.get("frontend-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    frontend_spec = mlrun.api.schemas.FrontendSpec(**response.json())
+    assert (
+            frontend_spec.feature_store_data_prefixes["default"]
+            == feature_store_data_prefix_default
+    )
+    assert (
+            frontend_spec.feature_store_data_prefixes["nosql"]
+            == feature_store_data_prefix_nosql
+    )
+    assert (
+            frontend_spec.feature_store_data_prefixes["redisnosql"]
+            == feature_store_data_prefix_redisnosql
+    )


### PR DESCRIPTION
Added to the client spec the fields:
- "default_feature_store_data_prefix"
- "ce_version" (in addition to "ce_mode")

So the UI can display the correct values depending on the deployment in which it exists