### PR TITLE
[Projects] Slack notify remote workflow

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -459,7 +459,6 @@ default_config = {
     "debug": {
         "expose_internal_api_endpoints": False,
     },
-    "default_workflow_runner_image": "mlrun/mlrun",
 }
 
 _is_running_as_api = None

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -459,6 +459,7 @@ default_config = {
     "debug": {
         "expose_internal_api_endpoints": False,
     },
+    "default_workflow_runner_image": "mlrun/mlrun",
 }
 
 _is_running_as_api = None

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -905,7 +905,7 @@ def load_and_run(
         )
     except Exception as error:
         if schedule:
-            slack_notifier = mlrun.utils.notifications.SlackNotification()
+            notification_pusher = mlrun.utils.notifications.CustomNotificationPusher()
             url = get_ui_url(project_name, context.uid)
             link = f"<{url}|*view workflow job details*>"
             message = (
@@ -914,10 +914,11 @@ def load_and_run(
             )
             # Sending Slack Notification without losing the original error:
             try:
-                slack_notifier.send(
+                notification_pusher.push(
                     message=message,
                     severity=mlrun.utils.notifications.NotificationSeverity.ERROR,
                 )
+
             except Exception as exc:
                 logger.error("Failed to send slack notification", exc=exc)
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -905,7 +905,9 @@ def load_and_run(
         )
     except Exception as error:
         if schedule:
-            notification_pusher = mlrun.utils.notifications.CustomNotificationPusher()
+            notification_pusher = mlrun.utils.notifications.CustomNotificationPusher(
+                ["slack"]
+            )
             url = get_ui_url(project_name, context.uid)
             link = f"<{url}|*view workflow job details*>"
             message = (

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -723,7 +723,7 @@ class _RemoteRunner(_PipelineRunner):
                 name=runner_name,
                 project=project.name,
                 kind="job",
-                image=mlrun.mlconf.default_workflow_runner_image,
+                image=mlrun.mlconf.default_base_image,
             )
             msg = "executing workflow "
             if workflow_spec.schedule:

--- a/mlrun/utils/notifications/notification/base.py
+++ b/mlrun/utils/notifications/notification/base.py
@@ -18,7 +18,7 @@ import typing
 import mlrun.lists
 
 
-class NotificationSeverity(enum.Enum):
+class NotificationSeverity(str, enum.Enum):
     INFO = "info"
     DEBUG = "debug"
     VERBOSE = "verbose"

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import os
 import typing
 
 import requests
@@ -42,7 +41,10 @@ class SlackNotification(NotificationBase):
         runs: typing.Union[mlrun.lists.RunList, list] = None,
         custom_html: str = None,
     ):
-        webhook = self.params.get("webhook", None) or os.environ.get("SLACK_WEBHOOK")
+        webhook = self.params.get("webhook", None) or mlrun.get_secret_or_env(
+            "SLACK_WEBHOOK"
+        )
+
         if not webhook:
             mlrun.utils.helpers.logger.debug(
                 "No slack webhook is set, skipping notification"

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -122,7 +122,7 @@ class CustomNotificationPusher(object):
 
         # get notification's inverse dependencies, and only send the notification if
         # none of its inverse dependencies are being sent
-        inverse_dependencies = notification_type.inverse_dependencies()
+        inverse_dependencies = NotificationTypes(notification_type).inverse_dependencies()
         for inverse_dependency in inverse_dependencies:
             inverse_dependency_notification = self._notifications.get(
                 inverse_dependency

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -122,7 +122,9 @@ class CustomNotificationPusher(object):
 
         # get notification's inverse dependencies, and only send the notification if
         # none of its inverse dependencies are being sent
-        inverse_dependencies = NotificationTypes(notification_type).inverse_dependencies()
+        inverse_dependencies = NotificationTypes(
+            notification_type
+        ).inverse_dependencies()
         for inverse_dependency in inverse_dependencies:
             inverse_dependency_notification = self._notifications.get(
                 inverse_dependency


### PR DESCRIPTION
1. Added also small bug fixes:

- bug 1:
> when sending `NotificationSeverity.Error` to `SlackNotification.send()` it prints "NotificationSeverity.Error" instead of the value - "error"

The correction:
> The class `NotificationSeverity`  inherit now from `str` as well.

- bug 2:
> Using str instead of NotificationType

The correction:
> Casting to the right object.

2. Example for the error in slack:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/92271540/209113665-a0cabd73-0c21-4e0a-80f5-52b6777e2fc3.png">

4. Added `schedule` parameter to `load_and_run` for avoiding double push to notifiers when we are not scheduling a workflow.

5. Updated the way of getting env/secrets with `get_secret_or_env` in `SlackNotification`
Will be BP to 1.2.x
