### PR TITLE
[CLI] Add set project cli - for 1.1.x

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -951,7 +951,7 @@ def project(
     if secrets:
         secrets = line2keylist(secrets, "kind", "source")
         secret_store = SecretsStore.from_list(secrets)
-        #TODO: check if we still need to set proj._secrets if we use proj.set_secrets(secrets)
+        # TODO: check if we still need to set proj._secrets if we use proj.set_secrets(secrets)
         proj._secrets = secret_store
         proj.set_secrets(secret_store._secrets)
     print(proj.to_yaml())

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -951,6 +951,7 @@ def project(
     if secrets:
         secrets = line2keylist(secrets, "kind", "source")
         secret_store = SecretsStore.from_list(secrets)
+        #TODO: check if we still need to set proj._secrets if we use proj.set_secrets(secrets)
         proj._secrets = secret_store
         proj.set_secrets(secret_store._secrets)
     print(proj.to_yaml())

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -950,7 +950,9 @@ def project(
         proj.spec.params["commit_id"] = commit
     if secrets:
         secrets = line2keylist(secrets, "kind", "source")
-        proj._secrets = SecretsStore.from_list(secrets)
+        secret_store = SecretsStore.from_list(secrets)
+        proj._secrets = secret_store
+        proj.set_secrets(secret_store._secrets)
     print(proj.to_yaml())
 
     if run:


### PR DESCRIPTION
Until now when a user set secrets in the CLI (mlrun project function) it added the secrets to the proj object but does not save it in the project itself (does not present in the UI under secrets) causing an issue when a user will try to run for example scheduling workflow that needs those secret it will not found any secrets because they are saved only in the proj object.

I kept the original code lines and add proj,.set_secrets to take the secrets and save them in the project for later use

for 1.1.3

