### PR TITLE
[Requirements] Scikit-learn upper bound

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ nuclio-sdk~=0.3.0
 isort~=5.7
 avro~=1.11
 # needed for mlutils tests
-scikit-learn~=1.0
+scikit-learn~=1.0, <1.2
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=1.0
+scikit-learn~=1.0, <1.2
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=1.0
+scikit-learn~=1.0, <1.2
 seaborn~=0.11.0
 scikit-plot~=0.3.7

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=5.4
 matplotlib~=3.0
 graphviz~=0.16.0
-scikit-learn~=1.0
+scikit-learn~=1.0, <1.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -99,7 +99,7 @@ def test_requirement_specifiers_convention():
         "bokeh": {"~=2.4, >=2.4.2"},
         "typing-extensions": {">=3.10.0,<5"},
         "sphinx": {"~=4.3.0"},
-        "google-cloud": {"~=0.34"},
+        "click": {"~=8.0.0"},
         # These 2 are used in a tests that is purposed to test requirement without specifiers
         "faker": {""},
         "python-dotenv": {""},
@@ -115,7 +115,6 @@ def test_requirement_specifiers_convention():
         "gcsfs": {"~=2021.8.1"},
         "distributed": {"~=2021.11.2"},
         "dask": {"~=2021.11.2"},
-        "click": {"~=8.0.0"},
         # All of these are actually valid, they just don't use ~= so the test doesn't "understand" that
         # TODO: make test smart enough to understand that
         "urllib3": {">=1.25.4, <1.27"},
@@ -130,6 +129,7 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.20.2, <4"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
+        "scikit-learn": {"~=1.0, <1.2"},
     }
 
     for (


### PR DESCRIPTION
In scikit-learn 1.2 the constructor parameter base_estimator was renamed to estimator in the following classes: [ensemble.BaggingClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.BaggingClassifier.html#sklearn.ensemble.BaggingClassifier), [ensemble.BaggingRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.BaggingRegressor.html#sklearn.ensemble.BaggingRegressor), [ensemble.AdaBoostClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostClassifier.html#sklearn.ensemble.AdaBoostClassifier), [ensemble.AdaBoostRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.AdaBoostRegressor.html#sklearn.ensemble.AdaBoostRegressor).

https://scikit-learn.org/stable/whats_new/v1.2.html#sklearn-ensemble