### PR TITLE
[CI] Perform cleanup prior to build images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,12 @@ jobs:
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     steps:
     - uses: actions/checkout@v3
+
+      # since github-actions gives us 14G only, and fills it up with some garbage
+      # we will free up some space for our build process
+    - name: Freeing up disk space
+      run: |
+        "${GITHUB_WORKSPACE}/hack/ci/free-space.sh"
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git hash, ref and latest version

--- a/Makefile
+++ b/Makefile
@@ -559,8 +559,8 @@ html-docs-dockerized: build-test ## Build html docs dockerized
 .PHONY: fmt
 fmt: ## Format the code (using black and isort)
 	@echo "Running black fmt..."
-	python -m black .
-	python -m isort .
+	python -m black . --exclude=venv*
+	python -m isort . --skip-glob=venv*
 
 .PHONY: lint
 lint: flake8 fmt-check ## Run lint on the code
@@ -568,8 +568,8 @@ lint: flake8 fmt-check ## Run lint on the code
 .PHONY: fmt-check
 fmt-check: ## Format and check the code (using black)
 	@echo "Running black+isort fmt check..."
-	python -m black --check --diff .
-	python -m isort --check --diff .
+	python -m black --check --diff . --exclude=venv*
+	python -m isort --check --diff . --skip-glob=venv*
 
 .PHONY: flake8
 flake8: ## Run flake8 lint

--- a/hack/ci/free-space.sh
+++ b/hack/ci/free-space.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+print_free_space() {
+  df --human-readable
+}
+
+# before cleanup
+print_free_space
+
+# clean unneeded os packages and misc
+sudo apt-get remove --yes '^dotnet-.*' 'php.*' azure-cli google-cloud-sdk google-chrome-stable firefox powershell
+sudo apt-get autoremove --yes
+sudo apt clean
+
+# cleanup unneeded share dirs ~30GB
+sudo rm --recursive --force \
+    /usr/local/lib/android \
+    /usr/share/dotnet \
+    /usr/share/miniconda \
+    /usr/share/dotnet \
+    /usr/share/swift
+
+# clean unneeded docker images
+docker system prune --all --force
+
+# post cleanup
+print_free_space


### PR DESCRIPTION
Looks like our models-gpu failed to be built/pushed due to lack of space. removed some unneeded packages prior to building/pushing images