### PR TITLE
[Frameworks] Enable `scikit-learn` v1.2.0 to work with `mlrun.frameworks`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ nuclio-sdk~=0.3.0
 isort~=5.7
 avro~=1.11
 # needed for mlutils tests
-scikit-learn~=1.0, <1.2
+scikit-learn~=1.0
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib~=3.5
 scipy~=1.0
-scikit-learn~=1.0, <1.2
+scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib~=3.5
 scipy~=1.0
-scikit-learn~=1.0, <1.2
+scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=5.4
 matplotlib~=3.5
 graphviz~=0.20.0
-scikit-learn~=1.0, <1.2
+scikit-learn~=1.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -130,7 +130,6 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.20.2, <4"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
-        "scikit-learn": {"~=1.0, <1.2"},
     }
 
     for (


### PR DESCRIPTION
In `scikit-learn` v1.2.0 they used a new property post fitting named `_estimator` which overran my argument. I renamed the argument so now it will work (tested on 1.1.2 and 1.2.0).