### PR TITLE
[SDK] Fix `submit_job` tries to update run state when run wasn't created [1.2.x]

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1341,9 +1341,15 @@ class HTTPRunDB(RunDBInterface):
                 req["schedule"] = schedule
             timeout = (int(config.submit_timeout) or 120) + 20
             resp = self.api_call("POST", "submit_job", json=req, timeout=timeout)
+
+        except requests.HTTPError as err:
+            logger.error(f"error submitting task: {err}")
+            # not creating a new exception here, in order to keep the response and status code in the exception
+            raise
+
         except OSError as err:
             logger.error(f"error submitting task: {err}")
-            raise OSError(f"error: cannot submit task, {err}")
+            raise OSError("error: cannot submit task") from err
 
         if not resp.ok:
             logger.error(f"bad resp!!\n{resp.text}")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -786,7 +786,7 @@ class BaseRuntime(ModelObj):
         # more status code handling can be added here if needed
         if error.response.status_code == http.HTTPStatus.BAD_REQUEST.value:
             raise mlrun.errors.MLRunBadRequestError(
-                "bad request", body=error.response.text
+                f"Bad request to mlrun api: {error.response.text}"
             )
 
     def _store_function(self, runspec, meta, db):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -735,15 +735,6 @@ class BaseRuntime(ModelObj):
                 result = self._update_run_state(task=runspec, err=err)
             return self._wrap_run_result(result, runspec, schedule=schedule, err=err)
 
-        except Exception as err:
-            logger.error(f"got remote run err, {err}")
-            result = None
-            # if we got a schedule no reason to do post_run stuff (it purposed to update the run status with error,
-            # but there's no run in case of schedule)
-            if not schedule:
-                result = self._update_run_state(task=runspec, err=err)
-            return self._wrap_run_result(result, runspec, schedule=schedule, err=err)
-
         if resp:
             txt = get_in(resp, "status.status_text")
             if txt:


### PR DESCRIPTION
Fix for - https://jira.iguazeng.com/browse/ML-3066
Continuation of https://jira.iguazeng.com/browse/ML-3029

During `submit_job` if an exception is raised during the http request, we try to update the run's state to `error`. However, if we receive a 400 status code from the API, the run was never created and we shouldn't try to update the run state.