### PR TITLE
[Runtimes] Fix submitting job with hyper-params config param to use correct credentials

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -702,7 +702,22 @@ def _submit_run(
                 "name": task["metadata"]["name"],
             }
         else:
-            run = fn.run(task, watch=False)
+            # When running in the api service and processing a hyper-param run, secrets may be needed to access the
+            # parameters file (which is accessed locally from the mlrun service pod)
+            param_file_secrets = {}
+            if mlrun.config.is_running_as_api():
+                param_file_secrets = (
+                    mlrun.api.crud.Secrets()
+                    .list_project_secrets(
+                        task["metadata"]["project"],
+                        mlrun.api.schemas.SecretProviderName.kubernetes,
+                        allow_secrets_from_k8s=True,
+                    )
+                    .secrets
+                )
+                param_file_secrets["V3IO_ACCESS_KEY"] = auth_info.access_key
+
+            run = fn.run(task, watch=False, param_file_secrets=param_file_secrets)
             run_uid = run.metadata.uid
             project = run.metadata.project
             if run:

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -191,7 +191,7 @@ class MLClientCtx(object):
             )
         self._parent.log_iteration_results(self._iteration, None, self.to_dict())
 
-    def get_store_resource(self, url):
+    def get_store_resource(self, url, secrets: dict = None):
         """get mlrun data resource (feature set/vector, artifact, item) from url
 
         example::
@@ -201,18 +201,26 @@ class MLClientCtx(object):
 
         :param url:    store resource uri/path, store://<type>/<project>/<name>:<version>
                        types: artifacts | feature-sets | feature-vectors
+        :param secrets: additional secrets to use when accessing the store resource
         """
-        return get_store_resource(url, db=self._rundb, secrets=self._secrets_manager)
+        return get_store_resource(
+            url,
+            db=self._rundb,
+            secrets=self._secrets_manager,
+            data_store_secrets=secrets,
+        )
 
-    def get_dataitem(self, url):
+    def get_dataitem(self, url, secrets: dict = None):
         """get mlrun dataitem from url
 
         example::
 
             data = context.get_dataitem("s3://my-bucket/file.csv").as_df()
 
+        :param url:    data-item uri/path
+        :param secrets: additional secrets to use when accessing the data-item
         """
-        return self._data_stores.object(url=url)
+        return self._data_stores.object(url=url, secrets=secrets)
 
     def set_logger_stream(self, stream):
         self._logger.replace_handler_stream("default", stream)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -306,6 +306,7 @@ class BaseRuntime(ModelObj):
         local=False,
         local_code_path=None,
         auto_build=None,
+        param_file_secrets: Dict[str, str] = None,
     ) -> RunObject:
         """Run a local or remote task.
 
@@ -334,7 +335,8 @@ class BaseRuntime(ModelObj):
         :param local_code_path: path of the code for local runs & debug
         :param auto_build: when set to True and the function require build it will be built on the first
                            function run, use only if you dont plan on changing the build config between runs
-
+        :param param_file_secrets: dictionary of secrets to be used only for accessing the hyper-param parameter file.
+                            These secrets are only used locally and will not be stored anywhere
         :return: run context object (RunObject) with run metadata, results and status
         """
         mlrun.utils.helpers.verify_dict_items_type("Inputs", inputs, [str], [str])
@@ -429,7 +431,9 @@ class BaseRuntime(ModelObj):
         self._verify_run_params(run.spec.parameters)
 
         # create task generator (for child runs) from spec
-        task_generator = get_generator(run.spec, execution)
+        task_generator = get_generator(
+            run.spec, execution, param_file_secrets=param_file_secrets
+        )
         if task_generator:
             # verify valid task parameters
             tasks = task_generator.generate(run)

--- a/mlrun/runtimes/generators.py
+++ b/mlrun/runtimes/generators.py
@@ -26,7 +26,7 @@ default_max_iterations = 10
 default_max_errors = 3
 
 
-def get_generator(spec: RunSpec, execution):
+def get_generator(spec: RunSpec, execution, param_file_secrets: dict = None):
     options = spec.hyper_param_options
     strategy = spec.strategy or options.strategy
     if not spec.is_hyper_job() or strategy == "custom":
@@ -46,7 +46,7 @@ def get_generator(spec: RunSpec, execution):
 
     obj = None
     if param_file:
-        obj = execution.get_dataitem(param_file)
+        obj = execution.get_dataitem(param_file, secrets=param_file_secrets)
         if not strategy and obj.suffix == ".csv":
             strategy = "list"
         if not strategy or strategy in ["grid", "random"]:

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -19,6 +19,7 @@ import unittest.mock
 from http import HTTPStatus
 
 import fastapi.testclient
+import pandas as pd
 import pytest
 import sqlalchemy.orm
 from fastapi.testclient import TestClient
@@ -303,6 +304,70 @@ def test_submit_job_service_accounts(
     assert resp
     _assert_pod_service_account(pod_create_mock, "some-sa")
     mlconf.function.spec.service_account.default = None
+
+
+class _MockDataItem:
+    def as_df(self):
+        return pd.DataFrame({"key1": [0], "key2": [1]})
+
+
+def test_submit_job_with_hyper_params_file(
+    db: Session,
+    client: TestClient,
+    pod_create_mock,
+    k8s_secrets_mock: K8sSecretsMock,
+    monkeypatch,
+):
+    project_name = "proj-with-hyper-params"
+    project_artifact_path = f"/{project_name}"
+    tests.api.api.utils.create_project(
+        client, project_name, artifact_path=project_artifact_path
+    )
+    function = mlrun.new_function(
+        name="test-function",
+        project=project_name,
+        tag="latest",
+        kind="job",
+        image="mlrun/mlrun",
+    )
+    # set default artifact path
+    mlconf.artifact_path = "/some-path"
+    submit_job_body = _create_submit_job_body(
+        function, project_name, with_output_path=False
+    )
+
+    # Create test-specific mocks
+    auth_info = mlrun.api.schemas.AuthInfo(username="user", access_key=access_key)
+    monkeypatch.setattr(
+        mlrun.api.utils.auth.verifier.AuthVerifier(),
+        "authenticate_request",
+        lambda *args, **kwargs: auth_info,
+    )
+    monkeypatch.setattr(
+        mlrun.MLClientCtx, "get_dataitem", lambda *args, **kwargs: _MockDataItem()
+    )
+    orig_get_dataitem = mlrun.MLClientCtx.get_dataitem
+    mlrun.MLClientCtx.get_dataitem = unittest.mock.Mock(return_value=_MockDataItem())
+
+    project_secrets = {"SECRET1": "VALUE1"}
+    k8s_secrets_mock.store_project_secrets(project_name, project_secrets)
+
+    # Configure hyper-param related values
+    task_spec = submit_job_body["task"]["spec"]
+    task_spec["param_file"] = "v3io://users/user1"
+    task_spec["selector"] = "max.loss"
+    task_spec["strategy"] = "list"
+
+    resp = client.post("submit_job", json=submit_job_body)
+    assert resp.status_code == http.HTTPStatus.OK.value
+
+    # Validate that secrets were properly passed to get_dataitem
+    project_secrets.update({"V3IO_ACCESS_KEY": access_key})
+    mlrun.MLClientCtx.get_dataitem.assert_called_once_with(
+        task_spec["param_file"], secrets=project_secrets
+    )
+
+    mlrun.MLClientCtx.get_dataitem = orig_get_dataitem
 
 
 def test_redirection_from_worker_to_chief_only_if_schedules_in_job(


### PR DESCRIPTION
When submitting a job with hyper-params whose config is retrieved from a config-file, the configuration file is read on the MLRun service itself. Up until now this process was happening without passing any specific secrets to the code responsible for reading the file - if the runtime had secret sources configured, it would use them to initialize, but these do not include project secrets, and do not include the v3io access-key that is read from env.
Up until recently, this worked in most cases (especially when accessing paths such as `v3io:///users/<some user>` because of the data-stores being cached in memory, including their respective secrets. So, if anyone accessed this path with the correct credentials, the same store was used to access the config file. However, now we have removed this bug and store credentials are no longer cached, so accessing the path above would be done using whatever access key is in the MLRun service pod env - resulting in access using the `pipelines` user, which obviously didn't work.

The fix is to make sure the access-key and project-secrets are passed to the code reading the config file, while ensuring they are not cached anywhere.

Fixes [ML-3058](https://jira.iguazeng.com/browse/ML-3058)