### PR TITLE
[Project] Fix `load_project` log message

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -357,7 +357,7 @@ def get_or_create_project(
                 user_project=user_project,
                 save=save,
             )
-            message = f"loaded project {name} from {url} or context"
+            message = f"loaded project {name} from {url or context}"
             if save:
                 message = f"{message} and saved in MLRun DB"
             logger.info(message)


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3064
If url is None, the context will be logged:
```
> 2022-12-27 12:15:14,513 [info] loaded project my-project from ./ and saved in MLRun DB
```