### PR TITLE
[SDK] Fix submit_job tries to update run state when run wasn't created

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1340,9 +1340,15 @@ class HTTPRunDB(RunDBInterface):
                 req["schedule"] = schedule
             timeout = (int(config.submit_timeout) or 120) + 20
             resp = self.api_call("POST", "submit_job", json=req, timeout=timeout)
+
+        except requests.HTTPError as err:
+            logger.error(f"error submitting task: {err_to_str(err)}")
+            # not creating a new exception here, in order to keep the response and status code in the exception
+            raise
+
         except OSError as err:
             logger.error(f"error submitting task: {err_to_str(err)}")
-            raise OSError(f"error: cannot submit task, {err_to_str(err)}")
+            raise OSError("error: cannot submit task") from err
 
         if not resp.ok:
             logger.error(f"bad resp!!\n{resp.text}")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import getpass
+import http
 import os
 import traceback
 import typing
@@ -26,6 +27,7 @@ from os import environ
 from typing import Dict, List, Optional, Tuple, Union
 
 import IPython
+import requests.exceptions
 from kubernetes.client.rest import ApiException
 from nuclio.build import mlrun_footer
 from sqlalchemy.orm import Session
@@ -720,8 +722,13 @@ class BaseRuntime(ModelObj):
             if schedule:
                 logger.info(f"task scheduled, {resp}")
                 return
-        except Exception as err:
+
+        except (requests.HTTPError, Exception) as err:
             logger.error(f"got remote run err, {err_to_str(err)}")
+
+            if isinstance(err, requests.HTTPError):
+                self._handle_submit_job_http_error(err)
+
             result = None
             # if we got a schedule no reason to do post_run stuff (it purposed to update the run status with error,
             # but there's no run in case of schedule)
@@ -763,6 +770,16 @@ class BaseRuntime(ModelObj):
             resp = self._get_db_run(runspec)
 
         return self._wrap_run_result(resp, runspec, schedule=schedule)
+
+    @staticmethod
+    def _handle_submit_job_http_error(error: requests.HTTPError):
+        # if we receive a 400 status code, this means the request was invalid and the run wasn't created in the DB.
+        # so we don't need to update the run state and we can just raise the error.
+        # more status code handling can be added here if needed
+        if error.response.status_code == http.HTTPStatus.BAD_REQUEST.value:
+            raise mlrun.errors.MLRunBadRequestError(
+                f"Bad request to mlrun api: {error.response.text}"
+            )
 
     def _store_function(self, runspec, meta, db):
         db_str = "self" if self._is_api_server else self.spec.rundb


### PR DESCRIPTION
porting - https://github.com/mlrun/mlrun/pull/2822 

During submit_job if an exception is raised during the http request, we try to update the run's state to error. However, if we receive a 400 status code from the API, the run was never created and we shouldn't try to update the run state.