### PR TITLE
[CI] Fix system test long failing reports

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -196,7 +196,8 @@ class TestMLRunSystem:
 
             if value:
                 os.environ[env_var] = value
-        # reload the config so changes to the env vars will take affect
+
+        # reload the config so changes to the env vars will take effect
         mlrun.config.config.reload()
 
     @classmethod

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -46,11 +46,9 @@ def post_report_to_slack(report: TestReport, slack_webhook_url: str):
         "attachments": [
             {
                 "color": "danger",
-                "title": "System test failure details",
                 "fields": [
                     {
-                        "title": "Failure",
-                        "value": f"```{report.longreprtext}```",
+                        "value": f"```{report.longreprtext[-1000:]}```",
                         "short": False,
                     },
                 ],


### PR DESCRIPTION
adhere to slack limitation of how long text messages can be and taking the last part of report, with the assertion failure