### PR TITLE
[MPIJob] Update run state by "Launcher" CRD instead of workers

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -451,7 +451,7 @@ def resolve_mlrun_install_command(mlrun_version_specifier=None, client_version=N
     unstable_versions = ["unstable", "0.0.0+unstable"]
     unstable_mlrun_version_specifier = (
         f"{config.package_path}[complete] @ git+"
-        f"https://github.com/mlrun/mlrun@development"
+        f"https://github.com/AlonMaor14/mlrun@get_run_results_in_run_many"
     )
     if not mlrun_version_specifier:
         if config.httpdb.builder.mlrun_version_specifier:

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -113,6 +113,7 @@ class MLClientCtx(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
+        logger.info("where am I setting state to completed?")
         self.commit(completed=False)
 
     def get_child_context(self, with_parent_params=False, **params):
@@ -844,6 +845,8 @@ class MLClientCtx(object):
             self._annotations["message"] = message
         if completed:
             self._state = "completed"
+
+        logger.info("Is it here?", state=self._state)
 
         if self._parent:
             self._parent.update_child_iterations()

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -512,6 +512,7 @@ class MLClientCtx(object):
         :param commit: commit (write to DB now vs wait for the end of the run)
         """
         self._results[str(key)] = _cast_result(value)
+        logger.info("logging single result", results=self._results)
         self._update_db(commit=commit)
 
     def log_results(self, results: dict, commit=False):

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -115,9 +115,9 @@ class MLClientCtx(object):
             self.set_state(error=exc_value, commit=False)
 
         # mpi workers should not set the run as completed, only the launcher
-        kind = self._labels.get("kind", "")
-        mark_as_completed = kind != ["mpijob"]
-        self.commit(completed=mark_as_completed)
+        # kind = self._labels.get("kind", "")
+        # mark_as_completed = kind != ["mpijob"]
+        self.commit(completed=False)
 
     def get_child_context(self, with_parent_params=False, **params):
         """get child context (iteration)

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -840,13 +840,14 @@ class MLClientCtx(object):
         :param message:   commit message to save in the run
         :param completed: mark run as completed
         """
+        logger.info("Is it here 1?", state=self._state, completed=completed)
         completed = completed and self._state == "running"
         if message:
             self._annotations["message"] = message
         if completed:
             self._state = "completed"
 
-        logger.info("Is it here?", state=self._state)
+        logger.info("Is it here 2?", state=self._state)
 
         if self._parent:
             self._parent.update_child_iterations()

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -516,7 +516,6 @@ class MLClientCtx(object):
         :param commit: commit (write to DB now vs wait for the end of the run)
         """
         self._results[str(key)] = _cast_result(value)
-        logger.info("logging single result", results=self._results)
         self._update_db(commit=commit)
 
     def log_results(self, results: dict, commit=False):
@@ -536,7 +535,6 @@ class MLClientCtx(object):
 
         for p in results.keys():
             self._results[str(p)] = _cast_result(results[p])
-        logger.info("logging results", results=self._results)
         self._update_db(commit=commit)
 
     def log_iteration_results(self, best, summary: list, task: dict, commit=False):

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -113,7 +113,6 @@ class MLClientCtx(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
-        logger.info("where am I setting state to completed?")
         self.commit(completed=False)
 
     def get_child_context(self, with_parent_params=False, **params):
@@ -834,20 +833,17 @@ class MLClientCtx(object):
         """update an artifact object in the cache and the DB"""
         self._artifacts_manager.update_artifact(self, artifact_object)
 
-    def commit(self, message: str = "", completed=True):
+    def commit(self, message: str = "", completed=False):
         """save run state and optionally add a commit message
 
         :param message:   commit message to save in the run
         :param completed: mark run as completed
         """
-        logger.info("Is it here 1?", state=self._state, completed=completed)
         completed = completed and self._state == "running"
         if message:
             self._annotations["message"] = message
         if completed:
             self._state = "completed"
-
-        logger.info("Is it here 2?", state=self._state)
 
         if self._parent:
             self._parent.update_child_iterations()

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -110,12 +110,14 @@ class MLClientCtx(object):
     def __enter__(self):
         return self
 
-    # is this the problem?
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
-        logger.info("Exiting context")
-        self.commit(completed=False)
+
+        # mpi workers should not set the run as completed, only the launcher
+        kind = self._labels.get("kind", "")
+        mark_as_completed = kind != ["mpijob"]
+        self.commit(completed=mark_as_completed)
 
     def get_child_context(self, with_parent_params=False, **params):
         """get child context (iteration)

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -110,10 +110,11 @@ class MLClientCtx(object):
     def __enter__(self):
         return self
 
+    # is this the problem?
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
-        self.commit()
+        self.commit(completed=False)
 
     def get_child_context(self, with_parent_params=False, **params):
         """get child context (iteration)

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -113,10 +113,6 @@ class MLClientCtx(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
-
-        # mpi workers should not set the run as completed, only the launcher
-        # kind = self._labels.get("kind", "")
-        # mark_as_completed = kind != ["mpijob"]
         self.commit(completed=False)
 
     def get_child_context(self, with_parent_params=False, **params):

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -114,6 +114,7 @@ class MLClientCtx(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if exc_value:
             self.set_state(error=exc_value, commit=False)
+        logger.info("Exiting context")
         self.commit(completed=False)
 
     def get_child_context(self, with_parent_params=False, **params):
@@ -513,6 +514,7 @@ class MLClientCtx(object):
         :param commit: commit (write to DB now vs wait for the end of the run)
         """
         self._results[str(key)] = _cast_result(value)
+        logger.info("logging single result", results=self._results)
         self._update_db(commit=commit)
 
     def log_results(self, results: dict, commit=False):
@@ -532,6 +534,7 @@ class MLClientCtx(object):
 
         for p in results.keys():
             self._results[str(p)] = _cast_result(results[p])
+        logger.info("logging results", results=self._results)
         self._update_db(commit=commit)
 
     def log_iteration_results(self, best, summary: list, task: dict, commit=False):

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1775,7 +1775,10 @@ class ContextHandler:
                 if len(instructions) > 2:
                     logging_kwargs = instructions[2]
             # Check if the object to log is None (None values are only logged if the artifact type is Result):
-            if obj is None and artifact_type != ArtifactType.RESULT.value:
+            if obj is None and (
+                artifact_type != ArtifactType.RESULT.value
+                or self._context.results.get(str(key))
+            ):
                 continue
             # Log:
             self._log_output(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1775,10 +1775,7 @@ class ContextHandler:
                 if len(instructions) > 2:
                     logging_kwargs = instructions[2]
             # Check if the object to log is None (None values are only logged if the artifact type is Result):
-            if obj is None and (
-                artifact_type != ArtifactType.RESULT.value
-                or self._context.results.get(str(key)) not in [None, "None"]
-            ):
+            if obj is None and artifact_type != ArtifactType.RESULT.value:
                 continue
             # Log:
             self._log_output(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1775,10 +1775,9 @@ class ContextHandler:
                 if len(instructions) > 2:
                     logging_kwargs = instructions[2]
             # Check if the object to log is None (None values are only logged if the artifact type is Result):
-            if (
-                obj is None
-                and artifact_type != ArtifactType.RESULT.value
-                and not self._context.results.get(str(key))
+            if obj is None and (
+                artifact_type != ArtifactType.RESULT.value
+                or self._context.results.get(str(key)) not in [None, "None"]
             ):
                 continue
             # Log:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1775,9 +1775,10 @@ class ContextHandler:
                 if len(instructions) > 2:
                     logging_kwargs = instructions[2]
             # Check if the object to log is None (None values are only logged if the artifact type is Result):
-            if obj is None and (
-                artifact_type != ArtifactType.RESULT.value
-                or self._context.results.get(str(key))
+            if (
+                obj is None
+                and artifact_type != ArtifactType.RESULT.value
+                and not self._context.results.get(str(key))
             ):
                 continue
             # Log:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -952,6 +952,8 @@ class BaseRuntime(ModelObj):
                 updates["status.error"] = str(err)
 
         elif not was_none and last_state != "completed":
+            logger.debug("updating run state to completed", kind=kind)
+
             # mpi workers should not set the run as completed, only the launcher
             if kind != "mpijob":
                 updates = {

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -857,7 +857,7 @@ class BaseRuntime(ModelObj):
     def _pre_run(self, runspec: RunObject, execution):
         pass
 
-    def _post_run(self, results, execution):
+    def _post_run(self, result, execution):
         pass
 
     def _run(self, runobj: RunObject, execution) -> dict:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -940,8 +940,10 @@ class BaseRuntime(ModelObj):
         last_state = get_in(resp, "status.state", "")
         kind = get_in(resp, "metadata.labels.kind", "")
         if last_state == "error" or err:
-            updates = {"status.last_update": now_date().isoformat()}
-            updates["status.state"] = "error"
+            updates = {
+                "status.last_update": now_date().isoformat(),
+                "status.state": "error",
+            }
             update_in(resp, "status.state", "error")
             if err:
                 update_in(resp, "status.error", str(err))
@@ -952,9 +954,13 @@ class BaseRuntime(ModelObj):
         elif not was_none and last_state != "completed":
             # mpi workers should not set the run as completed, only the launcher
             if kind != "mpijob":
-                updates = {"status.last_update": now_date().isoformat()}
-                updates["status.state"] = "completed"
+                updates = {
+                    "status.last_update": now_date().isoformat(),
+                    "status.state": "completed",
+                }
                 update_in(resp, "status.state", "completed")
+            else:
+                logger.debug("mpijob worker, not setting run as completed")
 
         if self._get_db() and updates:
             project = get_in(resp, "metadata.project")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -915,6 +915,8 @@ class BaseRuntime(ModelObj):
         err=None,
     ) -> dict:
         """update the task state in the DB"""
+        print("where am i?")
+        logger.info("Is this working?")
         was_none = False
         if resp is None and task:
             was_none = True
@@ -936,6 +938,8 @@ class BaseRuntime(ModelObj):
         updates = None
         last_state = get_in(resp, "status.state", "")
         kind = get_in(resp, "metadata.labels.kind", "")
+        logger.info(f"last state {last_state}")
+        logger.info(f"kind {kind}")
         if last_state == "error" or err:
             updates = {
                 "status.last_update": now_date().isoformat(),
@@ -949,7 +953,7 @@ class BaseRuntime(ModelObj):
                 updates["status.error"] = str(err)
 
         elif not was_none and last_state != "completed":
-            logger.debug(
+            logger.info(
                 "Updating run state to completed", kind=kind, last_state=last_state
             )
 
@@ -963,7 +967,7 @@ class BaseRuntime(ModelObj):
                 }
                 update_in(resp, "status.state", "completed")
             else:
-                logger.debug("MpiJob worker, not setting run as completed")
+                logger.info("MpiJob worker, not setting run as completed")
 
         if self._get_db() and updates:
             project = get_in(resp, "metadata.project")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -915,8 +915,6 @@ class BaseRuntime(ModelObj):
         err=None,
     ) -> dict:
         """update the task state in the DB"""
-        print("where am i?")
-        logger.info("Is this working?")
         was_none = False
         if resp is None and task:
             was_none = True
@@ -938,8 +936,6 @@ class BaseRuntime(ModelObj):
         updates = None
         last_state = get_in(resp, "status.state", "")
         kind = get_in(resp, "metadata.labels.kind", "")
-        logger.info(f"last state {last_state}")
-        logger.info(f"kind {kind}")
         if last_state == "error" or err:
             updates = {
                 "status.last_update": now_date().isoformat(),
@@ -953,21 +949,18 @@ class BaseRuntime(ModelObj):
                 updates["status.error"] = str(err)
 
         elif not was_none and last_state != "completed":
-            logger.info(
-                "Updating run state to completed", kind=kind, last_state=last_state
-            )
 
-            # mpi workers should not set the run as completed, only the launcher
-            # TODO: add a 'workers' section in run objects state and here each worker will update its state while
+            # TODO: add a 'workers' section in run objects state, each worker will update its state while
             #  the run state will be resolved by the server.
             if kind != "mpijob":
+                logger.debug(
+                    "Updating run state to completed", kind=kind, last_state=last_state
+                )
                 updates = {
                     "status.last_update": now_date().isoformat(),
                     "status.state": "completed",
                 }
                 update_in(resp, "status.state", "completed")
-            else:
-                logger.info("MpiJob worker, not setting run as completed")
 
         if self._get_db() and updates:
             project = get_in(resp, "metadata.project")

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -949,10 +949,12 @@ class BaseRuntime(ModelObj):
                 updates["status.error"] = str(err)
 
         elif not was_none and last_state != "completed":
-            logger.info("updating run state to completed", kind=kind)
+            logger.debug(
+                "Updating run state to completed", kind=kind, last_state=last_state
+            )
 
             # mpi workers should not set the run as completed, only the launcher
-            # TODO: create a 'workers' section in run objects state and here each worker will update its state while
+            # TODO: add a 'workers' section in run objects state and here each worker will update its state while
             #  the run state will be resolved by the server.
             if kind != "mpijob":
                 updates = {
@@ -961,7 +963,7 @@ class BaseRuntime(ModelObj):
                 }
                 update_in(resp, "status.state", "completed")
             else:
-                logger.info("mpijob worker, not setting run as completed")
+                logger.debug("MpiJob worker, not setting run as completed")
 
         if self._get_db() and updates:
             project = get_in(resp, "metadata.project")

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -454,7 +454,7 @@ def exec_from_params(handler, runobj: RunObject, context: MLClientCtx, cwd=None)
     context.set_logger_stream(sys.stdout)
     if val:
         context.log_result("return", val)
-    context.commit()
+    context.commit(completed=False)
     logger.set_logger_level(old_level)
     return stdout.buf.getvalue(), err
 

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -279,7 +279,7 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
 
             igz_spark_pre_hook()
 
-    def _post_run(self, result, execution: MLClientCtx):
+    def _post_run(self, results, execution: MLClientCtx):
         if execution._old_workdir:
             os.chdir(execution._old_workdir)
 

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -441,7 +441,7 @@ def exec_from_params(handler, runobj: RunObject, context: MLClientCtx, cwd=None)
             if cwd:
                 os.chdir(cwd)
             val = handler(**kwargs)
-            context.set_state("completed", commit=False)
+            # context.set_state("completed", commit=False)
         except Exception as exc:
             err = str(exc)
             logger.error(traceback.format_exc())

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -441,7 +441,6 @@ def exec_from_params(handler, runobj: RunObject, context: MLClientCtx, cwd=None)
             if cwd:
                 os.chdir(cwd)
             val = handler(**kwargs)
-            # context.set_state("completed", commit=False)
         except Exception as exc:
             err = str(exc)
             logger.error(traceback.format_exc())

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -279,7 +279,7 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
 
             igz_spark_pre_hook()
 
-    def _post_run(self, results, execution: MLClientCtx):
+    def _post_run(self, result, execution: MLClientCtx):
         if execution._old_workdir:
             os.chdir(execution._old_workdir)
 

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -201,10 +201,13 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         return None
 
     def _post_run(self, result, execution: MLClientCtx):
+        time.sleep(5)
+        logger.info("MpiJob post run", result=result, execution=execution.to_dict())
         # we get the run object from the DB since it might have been updated multiple times by mpi workers
         # and we want to ensure we have the latest version of it
         resp = self._get_db_run(result)
-        execution.from_dict(resp, update_db=False)
+        logger.info("MpiJob post run", resp=resp.to_dict())
+        result["status"] = resp["status"]
 
     def _submit_mpijob(self, job, namespace=None):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -421,7 +421,8 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         """
         state, _ = run.logs(watch=True, db=self._get_db())
         resp = self._get_db_run(run)
-        if resp.status.state != state:
+        last_state = get_in(resp, "status.state", "")
+        if last_state != state:
             updates = {
                 "status.last_update": now_date().isoformat(),
                 "status.state": "completed",

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -412,7 +412,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
 
     def _watch_logs(self, run):
         """
-        With mpijobs we update the run state by monitoring the run (monitor_runs)
+        With mpijobs we update the run state by monitoring the run (mlrun/api/main.py:_monitor_runs)
         If the client is watching the logs, we may get a faster response from the API since the endpoint
         checks the Launcher status if the run object is not in terminal state.
         If we got a terminal state it means that either the monitoring updated the run object in the DB or
@@ -431,4 +431,13 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
             project = get_in(resp, "metadata.project")
             uid = get_in(resp, "metadata.uid")
             iter = get_in(resp, "metadata.iteration", 0)
+
+            logger.debug(
+                "Updating mpijob run state to completed",
+                state=state,
+                last_state=last_state,
+                project=project,
+                uid=uid,
+                run_name=run.metadata.name,
+            )
             self._get_db().update_run(updates, uid, project, iter=iter)

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -204,7 +204,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         # we get the run object from the DB since it might have been updated multiple times by mpi workers
         # and we want to ensure we have the latest version of it
         resp = self._get_db_run(result)
-        execution.from_dict(resp)
+        execution.from_dict(resp, update_db=False)
 
     def _submit_mpijob(self, job, namespace=None):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -422,6 +422,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
         state, _ = run.logs(watch=True, db=self._get_db())
         resp = self._get_db_run(run)
         last_state = get_in(resp, "status.state", "")
+        logger.info("I'm here")
         if last_state != state:
             updates = {
                 "status.last_update": now_date().isoformat(),
@@ -432,7 +433,7 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
             uid = get_in(resp, "metadata.uid")
             iter = get_in(resp, "metadata.iteration", 0)
 
-            logger.debug(
+            logger.info(
                 "Updating mpijob run state to completed",
                 state=state,
                 last_state=last_state,

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -200,6 +200,12 @@ class AbstractMPIJobRuntime(KubejobRuntime, abc.ABC):
 
         return None
 
+    def _post_run(self, result, execution: MLClientCtx):
+        # we get the run object from the DB since it might have been updated multiple times by mpi workers
+        # and we want to ensure we have the latest version of it
+        resp = self._get_db_run(result)
+        execution.from_dict(resp)
+
     def _submit_mpijob(self, job, namespace=None):
         mpi_group, mpi_version, mpi_plural = self._get_crd_info()
 

--- a/mlrun/runtimes/mpijob/abstract.py
+++ b/mlrun/runtimes/mpijob/abstract.py
@@ -24,7 +24,7 @@ from mlrun.model import RunObject
 from mlrun.runtimes.kubejob import KubejobRuntime
 from mlrun.runtimes.pod import KubeResourceSpec
 from mlrun.runtimes.utils import RunError
-from mlrun.utils import get_in, logger, now_date, update_in
+from mlrun.utils import get_in, logger
 
 
 class MPIResourceSpec(KubeResourceSpec):


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3119
With `mpijobs` we update the run state by monitoring the run (mlrun/api/main.py:_monitor_runs)
If the client is watching the logs, we may get a faster response from the API since the endpoint
checks the Launcher status if the run object is not in terminal state.
**Next phase**:
Add a `workers` section in the run object status that will track the state of each worker separately.