### PR TITLE
[API] Support to request list of uids through `list-runs` endpoint

### DIFF
--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -156,7 +156,7 @@ def delete_run(
 def list_runs(
     project: str = None,
     name: str = None,
-    uid: str = None,
+    uid: List[str] = Query([]),
     labels: List[str] = Query([], alias="label"),
     state: str = None,
     last: int = 0,

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -14,7 +14,7 @@
 import datetime
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mlrun.api import schemas
 
@@ -67,7 +67,7 @@ class DBInterface(ABC):
         self,
         session,
         name="",
-        uid=None,
+        uid: Union[str, List[str]] = None,
         project="",
         labels=None,
         states=None,

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -67,7 +67,7 @@ class DBInterface(ABC):
         self,
         session,
         name="",
-        uid: Union[str, List[str]] = None,
+        uid: Optional[Union[str, List[str]]] = None,
         project="",
         labels=None,
         states=None,

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mlrun.api import schemas
 from mlrun.api.db.base import DBError, DBInterface
@@ -67,7 +67,7 @@ class FileDB(DBInterface):
         self,
         session,
         name="",
-        uid=None,
+        uid: Union[str, List[str]] = None,
         project="",
         labels=None,
         states=None,

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -67,7 +67,7 @@ class FileDB(DBInterface):
         self,
         session,
         name="",
-        uid: Union[str, List[str]] = None,
+        uid: Optional[Union[str, List[str]]] = None,
         project="",
         labels=None,
         states=None,

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -238,7 +238,7 @@ class SQLDB(DBInterface):
         self,
         session,
         name=None,
-        uid: typing.Union[str, List[str]] = None,
+        uid: typing.Optional[typing.Union[str, List[str]]] = None,
         project=None,
         labels=None,
         states=None,
@@ -2735,8 +2735,7 @@ class SQLDB(DBInterface):
         query = self._query(session, Run, project=project)
         if uid:
             # uid may be either a single uid (string) or a list of uids
-            if isinstance(uid, str):
-                uid = [uid]
+            uid = mlrun.utils.helpers.as_list(uid)
             query = query.filter(Run.uid.in_(uid))
         return self._add_labels_filter(session, query, Run, labels)
 

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -238,7 +238,7 @@ class SQLDB(DBInterface):
         self,
         session,
         name=None,
-        uid=None,
+        uid: typing.Union[str, List[str]] = None,
         project=None,
         labels=None,
         states=None,
@@ -2732,7 +2732,12 @@ class SQLDB(DBInterface):
         labels = label_set(labels)
         if project == "*":
             project = None
-        query = self._query(session, Run, uid=uid, project=project)
+        query = self._query(session, Run, project=project)
+        if uid:
+            # uid may be either a single uid (string) or a list of uids
+            if isinstance(uid, str):
+                uid = [uid]
+            query = query.filter(Run.uid.in_(uid))
         return self._add_labels_filter(session, query, Run, labels)
 
     def _latest_uid_filter(self, session, query):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -60,7 +60,7 @@ class RunDBInterface(ABC):
     def list_runs(
         self,
         name="",
-        uid: Union[str, List[str]] = None,
+        uid: Optional[Union[str, List[str]]] = None,
         project="",
         labels=None,
         state="",

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -60,7 +60,7 @@ class RunDBInterface(ABC):
     def list_runs(
         self,
         name="",
-        uid=None,
+        uid: Union[str, List[str]] = None,
         project="",
         labels=None,
         state="",

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -14,7 +14,6 @@
 
 import json
 import pathlib
-from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from os import listdir, makedirs, path, remove, scandir
 from typing import List, Optional, Union

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -133,7 +133,7 @@ class FileRunDB(RunDBInterface):
     def list_runs(
         self,
         name="",
-        uid=None,
+        uid: Union[str, List[str]] = None,
         project="",
         labels=None,
         state="",
@@ -154,6 +154,11 @@ class FileRunDB(RunDBInterface):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Runs partitioning not supported"
             )
+        if uid and isinstance(uid, list):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Runs list with multiple uids not supported"
+            )
+
         labels = [] if labels is None else labels
         filepath = self._filepath(run_logs, project)
         results = RunList()

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -14,6 +14,7 @@
 
 import json
 import pathlib
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from os import listdir, makedirs, path, remove, scandir
 from typing import List, Optional, Union
@@ -133,7 +134,7 @@ class FileRunDB(RunDBInterface):
     def list_runs(
         self,
         name="",
-        uid: Union[str, List[str]] = None,
+        uid: Optional[Union[str, List[str]]] = None,
         project="",
         labels=None,
         state="",
@@ -154,7 +155,7 @@ class FileRunDB(RunDBInterface):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Runs partitioning not supported"
             )
-        if uid and isinstance(uid, list):
+        if uid and isinstance(uid, Iterable):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Runs list with multiple uids not supported"
             )

--- a/mlrun/db/filedb.py
+++ b/mlrun/db/filedb.py
@@ -155,7 +155,7 @@ class FileRunDB(RunDBInterface):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Runs partitioning not supported"
             )
-        if uid and isinstance(uid, Iterable):
+        if uid and isinstance(uid, list):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Runs list with multiple uids not supported"
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -530,7 +530,7 @@ class HTTPRunDB(RunDBInterface):
     def list_runs(
         self,
         name=None,
-        uid=None,
+        uid: Union[str, List[str]] = None,
         project=None,
         labels=None,
         state=None,
@@ -556,7 +556,7 @@ class HTTPRunDB(RunDBInterface):
 
 
         :param name: Name of the run to retrieve.
-        :param uid: Unique ID of the run.
+        :param uid: Unique ID of the run, or a list of run UIDs.
         :param project: Project that the runs belongs to.
         :param labels: List runs that have a specific label assigned. Currently only a single label filter can be
             applied, otherwise result will be empty.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -530,7 +530,7 @@ class HTTPRunDB(RunDBInterface):
     def list_runs(
         self,
         name=None,
-        uid: Union[str, List[str]] = None,
+        uid: Optional[Union[str, List[str]]] = None,
         project=None,
         labels=None,
         state=None,

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -113,7 +113,7 @@ class SQLDB(RunDBInterface):
     def list_runs(
         self,
         name=None,
-        uid=None,
+        uid: Union[str, List[str]] = None,
         project=None,
         labels=None,
         state=None,

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -113,7 +113,7 @@ class SQLDB(RunDBInterface):
     def list_runs(
         self,
         name=None,
-        uid: Union[str, List[str]] = None,
+        uid: Optional[Union[str, List[str]]] = None,
         project=None,
         labels=None,
         state=None,

--- a/tests/integration/sdk_api/httpdb/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/test_runs.py
@@ -45,11 +45,12 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         # Create runs
         projects = ["run-project-1", "run-project-2", "run-project-3"]
         run_names = ["run-name-1", "run-name-2", "run-name-3"]
+        suffixes = ["first", "second", "third"]
         for project in projects:
             project_obj = mlrun.new_project(project)
             project_obj.save()
             for name in run_names:
-                for suffix in ["first", "second", "third"]:
+                for suffix in suffixes:
                     uid = f"{name}-uid-{suffix}"
                     for iteration in range(3):
                         run = {
@@ -150,6 +151,26 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             excinfo.value.response.status_code
             == http.HTTPStatus.UNPROCESSABLE_ENTITY.value
         )
+
+        # expecting 3 since we're getting back all iterations for that uid
+        _list_and_assert_objects(
+            3,
+            project=projects[0],
+            uid=f"{run_names[0]}-uid-{suffixes[0]}",
+            iter=True,
+        )
+
+        uid_list = [f"{run_names[0]}-uid-{suffix}" for suffix in suffixes]
+        runs = _list_and_assert_objects(
+            len(uid_list),
+            project=projects[0],
+            uid=uid_list,
+            iter=False,
+        )
+        uid_list = set(uid_list)
+        for run in runs:
+            assert run["metadata"]["uid"] in uid_list
+            uid_list.remove(run["metadata"]["uid"])
 
 
 def _list_and_assert_objects(expected_number_of_runs: int, **kwargs):

--- a/tests/integration/sdk_api/httpdb/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/test_runs.py
@@ -72,7 +72,7 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         # basic list, specific project, only iteration 0, so 3 names * 3 uids = 9
         runs = _list_and_assert_objects(9, project=projects[0], iter=False)
 
-        # partioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
+        # partitioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
         runs = _list_and_assert_objects(
             3,
             project=projects[0],
@@ -84,7 +84,7 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         for run in runs:
             assert "first" in run["metadata"]["uid"]
 
-        # partioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
+        # partitioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
         runs = _list_and_assert_objects(
             3,
             project=projects[0],
@@ -96,7 +96,7 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         for run in runs:
             assert "third" in run["metadata"]["uid"]
 
-        # partioned list, specific project, 5 row per partition, so 3 names * 5 row = 15
+        # partitioned list, specific project, 5 row per partition, so 3 names * 5 row = 15
         runs = _list_and_assert_objects(
             15,
             project=projects[0],


### PR DESCRIPTION
Change the `list-runs` API to support querying a list of uids, rather than a single one.
This is for the UI purposes, to be able to query with a single API call the list of all runs that construct a pipeline. Support added to the REST API and to the sdk (`httpdb` etc.).
The REST API is automatically backwards-compatible, since a list is constructed of multiple parameters of the same name, hence a single name keeps being supported and interpreted as a list of length 1.
For example, the "old format":
`GET .../runs?project=<proj>&uid=<uid1>`
is still supported, along with the multi-uid variant:
`GET .../runs?project=<proj>&uid=<uid1>&uid=<uid2>&uid=<uid3>...`

The sdk was modified to support a union of either a `str` or a `List[str]`.
This implements [ML-3153](https://jira.iguazeng.com/browse/ML-3153)