### PR TITLE
[Tests] Replace `sklearn_classifier` with `auto_trainer` in tests and examples

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -87,8 +87,12 @@ def run_function(
 
     example (use with function object)::
 
+        LABELS = "is_error"
+        MODEL_CLASS = "sklearn.ensemble.RandomForestClassifier"
+        DATA_PATH = "v3io:///bigdata/bla.parquet"
         function = mlrun.import_function("hub://auto_trainer")
-        run1 = run_function(function, params={"label_columns": LABELS}, inputs={"dataset": DATA_URI})
+        run1 = run_function(function, params={"label_columns": LABELS, "model_class": MODEL_CLASS},
+                                      inputs={"dataset": DATA_PATH})
 
     example (use with project)::
 
@@ -99,14 +103,16 @@ def run_function(
 
         # run functions (refer to them by name)
         run1 = run_function("myfunc", params={"x": 7})
-        run2 = run_function("train", params={"label_columns": LABELS}, inputs={"dataset": run1.outputs["data"]})
+        run2 = run_function("train", params={"label_columns": LABELS, "model_class": MODEL_CLASS},
+                                     inputs={"dataset": run1.outputs["data"]})
 
     example (use in pipeline)::
 
         @dsl.pipeline(name="test pipeline", description="test")
         def my_pipe(url=""):
             run1 = run_function("loaddata", params={"url": url})
-            run2 = run_function("train", params={"label_columns": LABELS}, inputs={"dataset": run1.outputs["data"]})
+            run2 = run_function("train", params={"label_columns": LABELS, "model_class": MODEL_CLASS},
+                                         inputs={"dataset": run1.outputs["data"]})
 
         project.run(workflow_handler=my_pipe, arguments={"param1": 7})
 

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -89,7 +89,7 @@ def run_function(
 
         LABELS = "is_error"
         MODEL_CLASS = "sklearn.ensemble.RandomForestClassifier"
-        DATA_PATH = "v3io:///bigdata/bla.parquet"
+        DATA_PATH = "s3://bigdata/data.parquet"
         function = mlrun.import_function("hub://auto_trainer")
         run1 = run_function(function, params={"label_columns": LABELS, "model_class": MODEL_CLASS},
                                       inputs={"dataset": DATA_PATH})

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -87,26 +87,26 @@ def run_function(
 
     example (use with function object)::
 
-        function = mlrun.import_function("hub://sklearn_classifier")
-        run1 = run_function(function, params={"data": url})
+        function = mlrun.import_function("hub://auto_trainer")
+        run1 = run_function(function, params={"label_columns": LABELS}, inputs={"dataset": DATA_URI})
 
     example (use with project)::
 
         # create a project with two functions (local and from marketplace)
         project = mlrun.new_project(project_name, "./proj)
         project.set_function("mycode.py", "myfunc", image="mlrun/mlrun")
-        project.set_function("hub://sklearn_classifier", "train")
+        project.set_function("hub://auto_trainer", "train")
 
         # run functions (refer to them by name)
         run1 = run_function("myfunc", params={"x": 7})
-        run2 = run_function("train", params={"data": run1.outputs["data"]})
+        run2 = run_function("train", params={"label_columns": LABELS}, inputs={"dataset": run1.outputs["data"]})
 
     example (use in pipeline)::
 
         @dsl.pipeline(name="test pipeline", description="test")
         def my_pipe(url=""):
             run1 = run_function("loaddata", params={"url": url})
-            run2 = run_function("train", params={"data": run1.outputs["data"]})
+            run2 = run_function("train", params={"label_columns": LABELS}, inputs={"dataset": run1.outputs["data"]})
 
         project.run(workflow_handler=my_pipe, arguments={"param1": 7})
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -108,7 +108,7 @@ def new_project(
         # create a project with local and marketplace functions, a workflow, and an artifact
         project = mlrun.new_project("myproj", "./", init_git=True, description="my new project")
         project.set_function('prep_data.py', 'prep-data', image='mlrun/mlrun', handler='prep_data')
-        project.set_function('hub://sklearn_classifier', 'train')
+        project.set_function('hub://auto_trainer', 'train')
         project.set_artifact('data', Artifact(target_path=data_url))
         project.set_workflow('main', "./myflow.py")
         project.save()
@@ -1551,7 +1551,7 @@ class MlrunProject(ModelObj):
 
             object (s3://, v3io://, ..)
             MLRun DB e.g. db://project/func:ver
-            functions hub/market: e.g. hub://sklearn_classifier:master
+            functions hub/market: e.g. hub://auto_trainer:master
 
         examples::
 
@@ -2195,11 +2195,12 @@ class MlrunProject(ModelObj):
             # create a project with two functions (local and from marketplace)
             project = mlrun.new_project(project_name, "./proj")
             project.set_function("mycode.py", "myfunc", image="mlrun/mlrun")
-            project.set_function("hub://sklearn_classifier", "train")
+            project.set_function("hub://auto_trainer", "train")
 
             # run functions (refer to them by name)
             run1 = project.run_function("myfunc", params={"x": 7})
-            run2 = project.run_function("train", params={"data": run1.outputs["data"]})
+            run2 = project.run_function("train", params={"label_columns": LABELS},
+                                                 inputs={"dataset":run1.outputs["data"]})
 
         :param function:        name of the function (in the project) or function object
         :param handler:         name of the function handler
@@ -2722,7 +2723,7 @@ class MlrunProjectLegacy(ModelObj):
 
             object (s3://, v3io://, ..)
             MLRun DB e.g. db://project/func:ver
-            functions hub/market: e.g. hub://sklearn_classifier:master
+            functions hub/market: e.g. hub://auto_trainer:master
 
         examples::
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -443,7 +443,7 @@ def import_function(url="", secrets=None, db="", project=None, new_name=None):
 
     examples::
 
-        function = mlrun.import_function("hub://sklearn_classifier")
+        function = mlrun.import_function("hub://auto_trainer")
         function = mlrun.import_function("./func.yaml")
         function = mlrun.import_function("https://raw.githubusercontent.com/org/repo/func.yaml")
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -55,7 +55,7 @@ def test_sync_functions():
     assert fn.metadata.name == "describe", "func did not return"
 
     # test that functions can be fetched from the DB (w/o set_function)
-    mlrun.import_function("hub://sklearn_classifier", new_name="train").save()
+    mlrun.import_function("hub://auto_trainer", new_name="train").save()
     fn = project.get_function("train")
     assert fn.metadata.name == "train", "train func did not return"
 

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -29,7 +29,7 @@ class TestSKLearn(TestDemo):
 
     def create_demo_project(self) -> mlrun.projects.MlrunProject:
         self._logger.debug("Creating sklearn project")
-        demo_project = mlrun.new_project(
+        demo_project = mlrun.get_or_create_project(
             self.project_name, str(self.assets_path), init_git=True
         )
 
@@ -52,8 +52,7 @@ class TestSKLearn(TestDemo):
         self._logger.debug("Setting project functions")
         demo_project.set_function(iris_generator_function)
         demo_project.set_function("hub://describe", "describe")
-        demo_project.set_function("hub://sklearn_classifier", "train")
-        demo_project.set_function("hub://test_classifier", "test")
+        demo_project.set_function("hub://auto_trainer", "auto_trainer")
         demo_project.set_function("hub://model_server", "serving")
         demo_project.set_function("hub://model_server_tester", "live_tester")
 

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -316,17 +316,16 @@ class TestModelMonitoringAPI(TestMLRunSystem):
             "sklearn_AdaBoostClassifier": "sklearn.ensemble.AdaBoostClassifier",
         }
 
-        # import the training function from the marketplace (hub://)
-        train = mlrun.import_function("hub://sklearn_classifier")
+        # Import the auto trainer function from the marketplace (hub://)
+        train = mlrun.import_function("hub://auto_trainer")
 
         for name, pkg in model_names.items():
 
-            # run the function and specify input dataset path and some parameters (algorithm and label column name)
+            # Run the function and specify input dataset path and some parameters (algorithm and label column name)
             train_run = train.run(
                 name=name,
                 inputs={"dataset": path},
-                params={"model_pkg_class": pkg, "label_column": label_column},
-                artifact_path=f"v3io:///projects/{name}/artifacts",
+                params={"model_class": pkg, "label_columns": label_column},
             )
 
             # Add the model to the serving function's routing spec

--- a/tests/system/projects/assets/kflow.py
+++ b/tests/system/projects/assets/kflow.py
@@ -41,6 +41,7 @@ def kfpipeline(model_class=default_pkg_class, build=0):
     )
 
     # train the model using a library (hub://) function and the generated data
+    # no need to define handler in this step because the train function is the default handler
     train = funcs["auto_trainer"].as_step(
         name="train",
         inputs={"dataset": prep_data.outputs["cleaned_data"]},

--- a/tests/system/projects/assets/kflow.py
+++ b/tests/system/projects/assets/kflow.py
@@ -23,7 +23,7 @@ default_pkg_class = "sklearn.linear_model.LogisticRegression"
 
 
 @dsl.pipeline(name="Demo training pipeline", description="Shows how to use mlrun.")
-def kfpipeline(model_pkg_class=default_pkg_class, build=0):
+def kfpipeline(model_class=default_pkg_class, build=0):
 
     # if build=True, build the function image before the run
     with dsl.Condition(build == 1) as build_cond:
@@ -41,22 +41,22 @@ def kfpipeline(model_pkg_class=default_pkg_class, build=0):
     )
 
     # train the model using a library (hub://) function and the generated data
-    train = funcs["train"].as_step(
+    train = funcs["auto_trainer"].as_step(
         name="train",
         inputs={"dataset": prep_data.outputs["cleaned_data"]},
         params={
-            "model_pkg_class": model_pkg_class,
-            "label_column": project.get_param("label", "label"),
+            "model_class": model_class,
+            "label_columns": project.get_param("label", "label"),
         },
         outputs=["model", "test_set"],
     )
 
     # test the model using a library (hub://) function and the generated model
-    funcs["test"].as_step(
+    funcs["auto_trainer"].as_step(
         name="test",
-        params={"label_column": "label"},
+        handler="evaluate",
+        params={"label_columns": "label", "model": train.outputs["model"]},
         inputs={
-            "models_path": train.outputs["model"],
-            "test_set": train.outputs["test_set"],
+            "dataset": train.outputs["test_set"],
         },
     )

--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -52,11 +52,11 @@ def newpipe():
 
     # train with hyper-paremeters
     train = run_function(
-        "train",
+        "auto_trainer",
         name="train",
-        params={"sample": -1, "label_column": LABELS, "test_size": 0.10},
+        params={"label_columns": LABELS, "train_test_split_size": 0.10},
         hyperparams={
-            "model_pkg_class": [
+            "model_class": [
                 "sklearn.ensemble.RandomForestClassifier",
                 "sklearn.linear_model.LogisticRegression",
                 "sklearn.ensemble.AdaBoostClassifier",
@@ -70,12 +70,12 @@ def newpipe():
 
     # test and visualize our model
     run_function(
-        "test",
+        "auto_trainer",
         name="test",
-        params={"label_column": LABELS},
+        handler="evaluate",
+        params={"label_columns": LABELS, "model": train.outputs["model"]},
         inputs={
-            "models_path": train.outputs["model"],
-            "test_set": train.outputs["test_set"],
+            "dataset": train.outputs["test_set"],
         },
     )
 


### PR DESCRIPTION
`sklearn_classifier` from the functions marketplace is no longer supported and might not be working following the release of `scikit-learn` v1.2. In this PR, we update the system tests to use the `auto_trainer` function (also from the functions marketplace - https://github.com/mlrun/functions/blob/master/auto_trainer/auto_trainer.py) instead of the `sklearn_classifier`.