### PR TITLE
[FileDB] Add warning message when initializing FileRunDB

### DIFF
--- a/mlrun/db/__init__.py
+++ b/mlrun/db/__init__.py
@@ -69,7 +69,7 @@ def get_run_db(url="", secrets=None, force_reconnect=False):
     kwargs = {}
     if "://" not in url or scheme in ["file", "s3", "v3io", "v3ios"]:
         logger.warning(
-            "Could not detect path to API server, Using Deprecated client interface."
+            "Could not detect path to API server, Using Deprecated client interface"
         )
         logger.warning(
             "Please make sure your env variable MLRUN_DB_PATH is configured correctly to point to the API server!"

--- a/mlrun/db/__init__.py
+++ b/mlrun/db/__init__.py
@@ -69,7 +69,7 @@ def get_run_db(url="", secrets=None, force_reconnect=False):
     kwargs = {}
     if "://" not in url or scheme in ["file", "s3", "v3io", "v3ios"]:
         logger.warning(
-            "Could not detect path to API server, Using Deprecated client interface to communicate with the MLRun API"
+            "Could not detect path to API server, Using Deprecated client interface."
         )
         logger.warning(
             "Please make sure your env variable MLRUN_DB_PATH is configured correctly to point to the API server!"

--- a/mlrun/db/__init__.py
+++ b/mlrun/db/__init__.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 from ..config import config
 from ..platforms import add_or_refresh_credentials
+from ..utils import logger
 from .base import RunDBError, RunDBInterface  # noqa
 from .filedb import FileRunDB
 from .sqldb import SQLDB
@@ -67,6 +68,12 @@ def get_run_db(url="", secrets=None, force_reconnect=False):
     scheme = parsed_url.scheme.lower()
     kwargs = {}
     if "://" not in url or scheme in ["file", "s3", "v3io", "v3ios"]:
+        logger.warning(
+            "Could not detect path to API server, Using Deprecated client interface to communicate with the MLRun API"
+        )
+        logger.warning(
+            "Please make sure your env variable MLRUN_DB_PATH is configured correctly to point to the API server!"
+        )
         cls = FileRunDB
     elif scheme in ("http", "https"):
         # import here to avoid circular imports


### PR DESCRIPTION
```
import mlrun
> 2023-01-01 15:35:14,645 [warning] Could not detect path to API server, Using Deprecated client interface
> 2023-01-01 15:35:14,645 [warning] Please make sure your env variable MLRUN_DB_PATH is configured correctly to point to the API server!
```