### PR TITLE
[Project] Fix `sync_functions` to sync the function names from the `project.spec._function_definitions` map

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1766,11 +1766,11 @@ class MlrunProject(ModelObj):
             if not f:
                 raise ValueError(f"function named {name} not found")
             if hasattr(f, "to_dict"):
-                name, func = _init_function_from_obj(f, self)
+                name, func = _init_function_from_obj(f, self, name)
             else:
                 if not isinstance(f, dict):
                     raise ValueError("function must be an object or dict")
-                name, func = _init_function_from_dict(f, self)
+                name, func = _init_function_from_dict(f, self, name)
             func.spec.build.code_origin = origin
             funcs[name] = func
             if save:
@@ -2781,8 +2781,8 @@ class MlrunProjectLegacy(ModelObj):
             fp.write(self.to_yaml())
 
 
-def _init_function_from_dict(f, project):
-    name = f.get("name", "")
+def _init_function_from_dict(f, project, name=None):
+    name = name or f.get("name", "")
     url = f.get("url", "")
     kind = f.get("kind", "")
     image = f.get("image", None)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -60,6 +60,24 @@ def test_sync_functions():
     assert fn.metadata.name == "train", "train func did not return"
 
 
+def test_sync_functions_with_names_different_than_default():
+    project_name = "project-name"
+    project = mlrun.new_project(project_name, save=False)
+
+    describe_func = mlrun.import_function("hub://describe")
+    # set a different name than the default
+    project.set_function(describe_func, "new_describe_func")
+
+    project_function_object = project.spec._function_objects
+    project_function_definition = project.spec._function_definitions
+
+    # sync functions - expected to sync the function objects from the definitions
+    project.sync_functions()
+
+    assert project.spec._function_objects == project_function_object
+    assert project.spec._function_definitions == project_function_definition
+
+
 def test_create_project_from_file_with_legacy_structure():
     project_name = "project-name"
     description = "project description"


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-3150