### PR TITLE
[Tests] Send system test session reports

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -317,17 +317,18 @@ def get_or_create_project(
                          git://github.com/mlrun/demo-xgb-project.git
                          http://mysite/archived-project.zip
     :param secrets:      key:secret dict or SecretsStore used to download sources
-    :param init_git:     if True, will git init the context dir
+    :param init_git:     if True, will excute `git init` on the context dir
     :param subpath:      project subpath (within the archive/context)
     :param clone:        if True, always clone (delete any existing content)
-    :param user_project: add the current user name to the project name (for db:// prefixes)
+    :param user_project: add the current username to the project name (for db:// prefixes)
     :param from_template:     path to project YAML file that will be used as from_template (for new projects)
     :param save:         whether to save the created project in the DB
     :returns: project object
     """
     context = context or "./"
     try:
-        # load project from the DB
+        # load project from the DB.
+        # use `name` as `url` as we load the project from the DB
         project = load_project(
             context,
             name,

--- a/tests/system/api/test_secrets.py
+++ b/tests/system/api/test_secrets.py
@@ -24,6 +24,18 @@ from tests.system.base import TestMLRunSystem
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
+class TestStam(TestMLRunSystem):
+    def test_nothing(self):
+        pass
+
+    def test_fail_nothing(self):
+        raise Exception("test_fail_nothing")
+
+    def _skip_set_environment(self):
+        return True
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
 class TestKubernetesProjectSecrets(TestMLRunSystem):
     project_name = "db-system-test-project"
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -93,7 +93,7 @@ def post_report_session_finish_to_slack(
         except Exception:
             test_session_info += f"\nVersion: unknown"
 
-    test_session_info += f"\n{','.join(session.config.option.file_or_dir)}"
+    test_session_info += f"\nPath: {','.join(session.config.option.file_or_dir)}"
     text = f"*{text}*\n{test_session_info}"
 
     data = {"text": text, "attachments": []}


### PR DESCRIPTION
Other than sending the snippet of each failing report, send a session report including each passed/failing report and its relation to mlrun's component. e.g.:

<img width="496" alt="Screen Shot 2023-01-01 at 17 21 02" src="https://user-images.githubusercontent.com/6547459/210175863-dff10388-3130-4485-b729-b82fa13885b4.png">
