### PR TITLE
[Scheduler] Update next run time after skipping run [1.2.x]

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1116,6 +1116,7 @@ class SQLDB(DBInterface):
             cron_trigger=cron_trigger,
             labels=labels,
             concurrency_limit=concurrency_limit,
+            next_run_time=next_run_time,
         )
         self._upsert(session, [schedule])
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -741,6 +741,8 @@ class Scheduler:
             if job:
                 schedule.next_run_time = job.next_run_time
             else:
+
+                # if the job does not exist, there is no next run time (the job has finished)
                 schedule.next_run_time = None
 
         if include_last_run:

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -740,6 +740,8 @@ class Scheduler:
             job = self._scheduler.get_job(job_id)
             if job:
                 schedule.next_run_time = job.next_run_time
+            else:
+                schedule.next_run_time = None
 
         if include_last_run:
             self._enrich_schedule_with_last_run(db_session, schedule)

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -850,8 +850,9 @@ class Scheduler:
             labels=f"{schemas.constants.LabelNames.schedule_name}={schedule_name}",
         )
         if len(active_runs) >= schedule_concurrency_limit:
+            message = "Schedule exceeded concurrency limit, skipping this run"
             logger.warn(
-                "Schedule exceeded concurrency limit, skipping this run",
+                message,
                 project=project_name,
                 schedule_name=schedule_name,
                 schedule_concurrency_limit=schedule_concurrency_limit,
@@ -860,7 +861,8 @@ class Scheduler:
             scheduler.update_schedule_next_run_time(
                 db_session, schedule_name, project_name
             )
-            return
+            close_session(db_session)
+            raise mlrun.errors.MLRunConflictError(message)
 
         # if credentials are needed but missing (will happen for schedules on upgrade from scheduler that didn't store
         # credentials to one that does store) enrich them

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -604,8 +604,8 @@ class Scheduler:
         )
 
         # we use max_instances as well as our logic in the run wrapper for concurrent jobs
-        # in order to allow concurrency for triggering the jobs (max_instances), and concurrency
-        # of the jobs themselves (our logic in the run wrapper).
+        # in order to allow concurrency for triggering the jobs from the scheduler (max_instances), and concurrency
+        # of the jobs themselves (our logic in the run wrapper may be invoked manually).
         return self._scheduler.add_job(
             function,
             self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -850,9 +850,8 @@ class Scheduler:
             labels=f"{schemas.constants.LabelNames.schedule_name}={schedule_name}",
         )
         if len(active_runs) >= schedule_concurrency_limit:
-            message = "Schedule exceeded concurrency limit, skipping this run"
             logger.warn(
-                message,
+                "Schedule exceeded concurrency limit, skipping this run",
                 project=project_name,
                 schedule_name=schedule_name,
                 schedule_concurrency_limit=schedule_concurrency_limit,
@@ -862,7 +861,7 @@ class Scheduler:
                 db_session, schedule_name, project_name
             )
             close_session(db_session)
-            raise mlrun.errors.MLRunConflictError(message)
+            return
 
         # if credentials are needed but missing (will happen for schedules on upgrade from scheduler that didn't store
         # credentials to one that does store) enrich them

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -143,7 +143,7 @@ class Scheduler:
             concurrency_limit,
             labels,
         )
-        self._create_schedule_in_scheduler(
+        job = self._create_schedule_in_scheduler(
             project,
             name,
             kind,
@@ -152,16 +152,23 @@ class Scheduler:
             concurrency_limit,
             auth_info,
         )
-        job_id = self._resolve_job_id(project, name)
-        job = self._scheduler.get_job(job_id)
-        if job and job.next_run_time:
+        self.update_schedule_next_run_time(db_session, name, project, job)
+
+    def update_schedule_next_run_time(
+        self, db_session, schedule_name, project_name, job=None
+    ):
+        if not job:
+            job_id = self._resolve_job_id(project_name, schedule_name)
+            job = self._scheduler.get_job(job_id)
+
+        if job:
             logger.info(
-                "updating schedule with next_run_time",
+                "Updating schedule with next_run_time",
                 job=job,
                 next_run_time=job.next_run_time,
             )
             get_db().update_schedule(
-                db_session, project, name, next_run_time=job.next_run_time
+                db_session, project_name, schedule_name, next_run_time=job.next_run_time
             )
 
     @mlrun.api.utils.helpers.ensure_running_on_chief
@@ -212,7 +219,7 @@ class Scheduler:
             db_session, db_schedule
         )
 
-        self._update_schedule_in_scheduler(
+        job = self._update_schedule_in_scheduler(
             project,
             name,
             updated_schedule.kind,
@@ -221,13 +228,7 @@ class Scheduler:
             updated_schedule.concurrency_limit,
             auth_info,
         )
-        if updated_schedule.next_run_time:
-            get_db().update_schedule(
-                db_session,
-                project,
-                name,
-                next_run_time=updated_schedule.next_run_time,
-            )
+        self.update_schedule_next_run_time(db_session, name, project, job)
 
     def list_schedules(
         self,
@@ -605,7 +606,7 @@ class Scheduler:
         # we use max_instances as well as our logic in the run wrapper for concurrent jobs
         # in order to allow concurrency for triggering the jobs (max_instances), and concurrency
         # of the jobs themselves (our logic in the run wrapper).
-        self._scheduler.add_job(
+        return self._scheduler.add_job(
             function,
             self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
                 cron_trigger
@@ -636,7 +637,7 @@ class Scheduler:
         )
         now = datetime.now(self._scheduler.timezone)
         next_run_time = trigger.get_next_fire_time(None, now)
-        self._scheduler.modify_job(
+        return self._scheduler.modify_job(
             job_id,
             func=function,
             args=args,
@@ -729,8 +730,8 @@ class Scheduler:
         }
         schedule = schemas.ScheduleOutput(**schedule_dict)
 
-        # schedules are running only on chief Therefore we querying next_run_time from the scheduler only when
-        # running on chief
+        # Schedules are running only on chief. Therefore, we query next_run_time from the scheduler only when
+        # running on chief.
         if (
             mlrun.mlconf.httpdb.clusterization.role
             == mlrun.api.schemas.ClusterizationRole.chief
@@ -855,6 +856,9 @@ class Scheduler:
                 schedule_name=schedule_name,
                 schedule_concurrency_limit=schedule_concurrency_limit,
                 active_runs=len(active_runs),
+            )
+            scheduler.update_schedule_next_run_time(
+                db_session, schedule_name, project_name
             )
             return
 

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1256,12 +1256,10 @@ async def test_schedule_job_next_run_time(
         concurrency_limit=1,
     )
 
-    response_1 = await scheduler.invoke_schedule(
+    await scheduler.invoke_schedule(
         db, mlrun.api.schemas.AuthInfo(), project_name, schedule_name
     )
 
-    # TODO: check why this returns a response (should be None)
-    print(response_1)
     # invocation should have failed due to concurrency limit
     # assert next run time was updated
     schedule = scheduler.get_schedule(

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1210,7 +1210,7 @@ async def test_schedule_job_concurrency_limit(
         concurrency_limit=concurrency_limit,
     )
 
-    random_sleep_time = random.randint(1, 4)
+    random_sleep_time = random.randint(1, 5)
     await asyncio.sleep(random_sleep_time)
     schedule = scheduler.get_schedule(
         db,


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3075
We are skipping runs when the concurrency limit is exceeded.
In such cases, we also need to update the next run time in the db. Otherwise, we get a "next run time" that has already passed.