### PR TITLE
[Requirements] Freeze the version from `~=1.0` to `~=1.0.0` [1.2.x]

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ nuclio-sdk~=0.3.0
 isort~=5.7
 avro~=1.11
 # needed for mlutils tests
-scikit-learn~=1.0
+scikit-learn~=1.0.0
 # needed for frameworks tests
 lightgbm~=3.0
 xgboost~=1.1

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=1.0
+scikit-learn~=1.0.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib~=3.0
 scipy~=1.0
-scikit-learn~=1.0
+scikit-learn~=1.0.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7

--- a/dockerfiles/test-system/requirements.txt
+++ b/dockerfiles/test-system/requirements.txt
@@ -1,4 +1,4 @@
 pytest~=5.4
 matplotlib~=3.0
 graphviz~=0.16.0
-scikit-learn~=1.0
+scikit-learn~=1.0.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -130,6 +130,7 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.20.2, <4"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
+        "scikit-learn": {"~=1.0.0"},
     }
 
     for (


### PR DESCRIPTION
Jupyter's image python version is 3.8 where the MLRun images are running python version 3.7. When installing `scikit-learn~=1.0`, due to the python differences, on the Jupyter SciKit-Learn version 1.2 is installed and on the MLRun images version 1.0.2 is installed. This change break the demos and tutorials as in version 1.2 some stuff got deprecated and changed. 

So, I froze the version to install 1.0.2 always regardless of python version and its only in `1.2.x` because in MLRun 1.3 we will have python 3.9 on everything :)