### PR TITLE
[K8s] Failed to read secret exception

### DIFF
--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -114,11 +114,15 @@ class Secrets(
                 f"Provider requested is not supported. provider = {secrets.provider}"
             )
 
-    def read_auth_secret(self, secret_name) -> mlrun.api.schemas.AuthSecretData:
+    def read_auth_secret(
+        self, secret_name, raise_on_not_found=False
+    ) -> mlrun.api.schemas.AuthSecretData:
         (
             username,
             access_key,
-        ) = mlrun.api.utils.singletons.k8s.get_k8s().read_auth_secret(secret_name)
+        ) = mlrun.api.utils.singletons.k8s.get_k8s().read_auth_secret(
+            secret_name, raise_on_not_found=raise_on_not_found
+        )
         return mlrun.api.schemas.AuthSecretData(
             provider=mlrun.api.schemas.SecretProviderName.kubernetes,
             username=username,

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -357,7 +357,9 @@ class Scheduler:
                 secret_name = auth_info.access_key.lstrip(
                     mlrun.model.Credentials.secret_reference_prefix
                 )
-                secret = mlrun.api.crud.Secrets().read_auth_secret(secret_name)
+                secret = mlrun.api.crud.Secrets().read_auth_secret(
+                    secret_name, raise_on_not_found=True
+                )
                 auth_info.access_key = secret.access_key
                 auth_info.username = secret.username
 
@@ -664,7 +666,9 @@ class Scheduler:
                         db_schedule
                     )
                     if secret_name:
-                        secret = mlrun.api.crud.Secrets().read_auth_secret(secret_name)
+                        secret = mlrun.api.crud.Secrets().read_auth_secret(
+                            secret_name, raise_on_not_found=True
+                        )
                         username = secret.username
                         access_key = secret.access_key
                     else:

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -443,6 +443,8 @@ class K8sHelper:
                     f"Secret not found: {secret_name}"
                 ) from exc
 
+            return None, None
+
         def _get_secret_value(key):
             if secret_data.get(key):
                 return base64.b64decode(secret_data[key]).decode("utf-8")

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -440,7 +440,7 @@ class K8sHelper:
                 raise exc
             elif raise_on_not_found:
                 raise mlrun.errors.MLRunNotFoundError(
-                    f"Secret not found: {secret_name}"
+                    f"Secret '{secret_name}' was not found in namespace '{namespace}'"
                 ) from exc
 
             return None, None

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -142,6 +142,11 @@ class K8sSecretsMock:
     def read_auth_secret(self, secret_name, namespace="", raise_on_not_found=False):
         secret = self.auth_secrets_map.get(secret_name)
         if not secret:
+            if raise_on_not_found:
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Secret not found: {secret_name}"
+                )
+
             return None, None
         username = secret[
             mlrun.api.schemas.AuthSecretData.get_field_secret_key("username")

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -139,7 +139,7 @@ class K8sSecretsMock:
     def delete_auth_secret(self, secret_ref: str, namespace=""):
         del self.auth_secrets_map[secret_ref]
 
-    def read_auth_secret(self, secret_name, namespace=""):
+    def read_auth_secret(self, secret_name, namespace="", raise_on_not_found=False):
         secret = self.auth_secrets_map.get(secret_name)
         if not secret:
             return None, None

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -144,7 +144,7 @@ class K8sSecretsMock:
         if not secret:
             if raise_on_not_found:
                 raise mlrun.errors.MLRunNotFoundError(
-                    f"Secret not found: {secret_name}"
+                    f"Secret '{secret_name}' was not found in auth secrets map"
                 )
 
             return None, None


### PR DESCRIPTION
Since `read_auth_secret` is expected to return a tuple it would raise an exception when unpacking `None` as it's not iterable.
Instead of getting `cannot unpack non-iterable NoneType object` exception, raise a proper one.