### PR TITLE
[Scheduler] Fix missing job in scheduler error message

### DIFF
--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -671,7 +671,7 @@ class Scheduler:
             )
         except JobLookupError as exc:
             raise mlrun.errors.MLRunNotFoundError(
-                f"Schedule job with id {job_id} not found in scheduler. Reload is required."
+                f"Schedule job with id {job_id} not found in scheduler. Reload schedules is required."
             ) from exc
 
     def _reload_schedules(self, db_session: Session):

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1186,7 +1186,7 @@ async def test_update_schedule_failure_not_found_in_scheduler(
         )
     job_id = scheduler._resolve_job_id(project_name, schedule_name)
     assert (
-        f"Schedule job with id {job_id} not found in scheduler. Reload is required."
+        f"Schedule job with id {job_id} not found in scheduler. Reload schedules is required."
         in str(excinfo.value)
     )
 

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1166,8 +1166,6 @@ async def test_update_schedule_failure_not_found_in_scheduler(
     scheduled_object = _create_mlrun_function_and_matching_scheduled_object(
         db, project_name
     )
-    runs = get_db().list_runs(db, project=project_name)
-    assert len(runs) == 0
 
     # create the schedule only in the db
     inactive_cron_trigger = schemas.ScheduleCronTrigger(year="1999")

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1145,7 +1145,9 @@ async def test_update_schedule(
 
 
 @pytest.mark.asyncio
-async def test_update_schedule_failure_not_found_in_db(db: Session, scheduler: Scheduler):
+async def test_update_schedule_failure_not_found_in_db(
+    db: Session, scheduler: Scheduler
+):
     schedule_name = "schedule-name"
     project = config.default_project
     with pytest.raises(mlrun.errors.MLRunNotFoundError) as excinfo:
@@ -1156,7 +1158,9 @@ async def test_update_schedule_failure_not_found_in_db(db: Session, scheduler: S
 
 
 @pytest.mark.asyncio
-async def test_update_schedule_failure_not_found_in_scheduler(db: Session, scheduler: Scheduler):
+async def test_update_schedule_failure_not_found_in_scheduler(
+    db: Session, scheduler: Scheduler
+):
     schedule_name = "schedule-name"
     project_name = config.default_project
     scheduled_object = _create_mlrun_function_and_matching_scheduled_object(
@@ -1182,7 +1186,10 @@ async def test_update_schedule_failure_not_found_in_scheduler(db: Session, sched
             db, mlrun.api.schemas.AuthInfo(), project_name, schedule_name
         )
     job_id = scheduler._resolve_job_id(project_name, schedule_name)
-    assert f"Schedule job with id {job_id} not found in scheduler. Reload is required." in str(excinfo.value)
+    assert (
+        f"Schedule job with id {job_id} not found in scheduler. Reload is required."
+        in str(excinfo.value)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1179,6 +1179,7 @@ async def test_update_schedule_failure_not_found_in_scheduler(
         1,
     )
 
+    # update schedule should fail since the schedule job was not created in the scheduler
     with pytest.raises(mlrun.errors.MLRunNotFoundError) as excinfo:
         scheduler.update_schedule(
             db, mlrun.api.schemas.AuthInfo(), project_name, schedule_name


### PR DESCRIPTION
Raise more informative error when trying to update a schedule that doesn't exist in the `APScheduler` memory