### PR TITLE
[Opa] Use async http client

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ flake8~=5.0
 pytest-asyncio~=0.15.0
 pytest-alembic~=0.4.0
 pytest-httpserver~=1.0
+aioresponses~=0.7
 requests-mock~=1.8
 httpx~=0.22.0
 # needed for system tests

--- a/mlrun/api/api/endpoints/artifacts.py
+++ b/mlrun/api/api/endpoints/artifacts.py
@@ -128,7 +128,7 @@ async def get_artifact(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    data = run_in_threadpool(
+    data = await run_in_threadpool(
         mlrun.api.crud.Artifacts().get_artifact,
         db_session,
         key,

--- a/mlrun/api/api/endpoints/auth.py
+++ b/mlrun/api/api/endpoints/auth.py
@@ -22,13 +22,13 @@ router = fastapi.APIRouter()
 
 
 @router.post("/authorization/verifications")
-def verify_authorization(
+async def verify_authorization(
     authorization_verification_input: mlrun.api.schemas.AuthorizationVerificationInput,
     auth_info: mlrun.api.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_permissions(
         authorization_verification_input.resource,
         authorization_verification_input.action,
         auth_info,

--- a/mlrun/api/api/endpoints/background_tasks.py
+++ b/mlrun/api/api/endpoints/background_tasks.py
@@ -50,7 +50,7 @@ async def get_project_background_task(
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    return run_in_threadpool(
+    return await run_in_threadpool(
         mlrun.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task,
         db_session,
         name=name,
@@ -90,11 +90,11 @@ async def get_internal_background_task(
             internal_background_task=name,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return run_in_threadpool(
+        return await run_in_threadpool(
             chief_client.get_internal_background_task, name=name, request=request
         )
 
-    return run_in_threadpool(
+    return await run_in_threadpool(
         mlrun.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task,
         name=name,
     )

--- a/mlrun/api/api/endpoints/client_spec.py
+++ b/mlrun/api/api/endpoints/client_spec.py
@@ -25,4 +25,6 @@ router = APIRouter()
     response_model=mlrun.api.schemas.ClientSpec,
 )
 def get_client_spec():
+
+    # TODO: cache me
     return mlrun.api.crud.ClientSpec().get_client_spec()

--- a/mlrun/api/api/endpoints/clusterization_spec.py
+++ b/mlrun/api/api/endpoints/clusterization_spec.py
@@ -34,4 +34,5 @@ def clusterization_spec():
         chief_client = mlrun.api.utils.clients.chief.Client()
         return chief_client.get_clusterization_spec()
 
+    # TODO: cache me
     return mlrun.api.crud.ClusterizationSpec().get_clusterization_spec()

--- a/mlrun/api/api/endpoints/feature_store.py
+++ b/mlrun/api/api/endpoints/feature_store.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 from http import HTTPStatus
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Header, Query, Response
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import mlrun.api.crud
@@ -36,31 +38,36 @@ router = APIRouter()
 
 
 @router.post("/projects/{project}/feature-sets", response_model=schemas.FeatureSet)
-def create_feature_set(
+async def create_feature_set(
     project: str,
     feature_set: schemas.FeatureSet,
     versioned: bool = True,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-        db_session, project, auth_info=auth_info
+    await run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         project,
         feature_set.metadata.name,
         mlrun.api.schemas.AuthorizationAction.create,
         auth_info,
     )
-    feature_set_uid = mlrun.api.crud.FeatureStore().create_feature_set(
+    feature_set_uid = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().create_feature_set,
         db_session,
         project,
         feature_set,
         versioned,
     )
 
-    return mlrun.api.crud.FeatureStore().get_feature_set(
+    return await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_set,
         db_session,
         project,
         feature_set.metadata.name,
@@ -73,7 +80,7 @@ def create_feature_set(
     "/projects/{project}/feature-sets/{name}/references/{reference}",
     response_model=schemas.FeatureSet,
 )
-def store_feature_set(
+async def store_feature_set(
     project: str,
     name: str,
     reference: str,
@@ -82,10 +89,13 @@ def store_feature_set(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-        db_session, project, auth_info=auth_info
+    await run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         project,
         name,
@@ -93,7 +103,8 @@ def store_feature_set(
         auth_info,
     )
     tag, uid = parse_reference(reference)
-    uid = mlrun.api.crud.FeatureStore().store_feature_set(
+    uid = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().store_feature_set,
         db_session,
         project,
         name,
@@ -102,7 +113,8 @@ def store_feature_set(
         uid,
         versioned,
     )
-    return mlrun.api.crud.FeatureStore().get_feature_set(
+    return await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_set,
         db_session,
         project,
         feature_set.metadata.name,
@@ -112,7 +124,7 @@ def store_feature_set(
 
 
 @router.patch("/projects/{project}/feature-sets/{name}/references/{reference}")
-def patch_feature_set(
+async def patch_feature_set(
     project: str,
     name: str,
     feature_set_update: dict,
@@ -123,7 +135,7 @@ def patch_feature_set(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         project,
         name,
@@ -131,7 +143,8 @@ def patch_feature_set(
         auth_info,
     )
     tag, uid = parse_reference(reference)
-    mlrun.api.crud.FeatureStore().patch_feature_set(
+    await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().patch_feature_set,
         db_session,
         project,
         name,
@@ -147,7 +160,7 @@ def patch_feature_set(
     "/projects/{project}/feature-sets/{name}/references/{reference}",
     response_model=schemas.FeatureSet,
 )
-def get_feature_set(
+async def get_feature_set(
     project: str,
     name: str,
     reference: str,
@@ -155,10 +168,15 @@ def get_feature_set(
     db_session: Session = Depends(deps.get_db_session),
 ):
     tag, uid = parse_reference(reference)
-    feature_set = mlrun.api.crud.FeatureStore().get_feature_set(
-        db_session, project, name, tag, uid
+    feature_set = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_set,
+        db_session,
+        project,
+        name,
+        tag,
+        uid,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         project,
         name,
@@ -170,14 +188,14 @@ def get_feature_set(
 
 @router.delete("/projects/{project}/feature-sets/{name}")
 @router.delete("/projects/{project}/feature-sets/{name}/references/{reference}")
-def delete_feature_set(
+async def delete_feature_set(
     project: str,
     name: str,
     reference: str = None,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         project,
         name,
@@ -187,8 +205,13 @@ def delete_feature_set(
     tag = uid = None
     if reference:
         tag, uid = parse_reference(reference)
-    mlrun.api.crud.FeatureStore().delete_feature_set(
-        db_session, project, name, tag, uid
+    await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().delete_feature_set,
+        db_session,
+        project,
+        name,
+        tag,
+        uid,
     )
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
@@ -196,7 +219,7 @@ def delete_feature_set(
 @router.get(
     "/projects/{project}/feature-sets", response_model=schemas.FeatureSetsOutput
 )
-def list_feature_sets(
+async def list_feature_sets(
     project: str,
     name: str = None,
     state: str = None,
@@ -215,12 +238,13 @@ def list_feature_sets(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    feature_sets = mlrun.api.crud.FeatureStore().list_feature_sets(
+    feature_sets = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().list_feature_sets,
         db_session,
         project,
         name,
@@ -234,7 +258,7 @@ def list_feature_sets(
         partition_sort_by,
         partition_order,
     )
-    feature_sets = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    feature_sets = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         feature_sets.feature_sets,
         lambda feature_set: (
@@ -250,7 +274,7 @@ def list_feature_sets(
     "/projects/{project}/feature-sets/{name}/tags",
     response_model=schemas.FeatureSetsTagsOutput,
 )
-def list_feature_sets_tags(
+async def list_feature_sets_tags(
     project: str,
     name: str,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
@@ -260,17 +284,18 @@ def list_feature_sets_tags(
         raise mlrun.errors.MLRunInvalidArgumentError(
             "Listing a specific feature set tags is not supported, set name to *"
         )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    tag_tuples = mlrun.api.crud.FeatureStore().list_feature_sets_tags(
+    tag_tuples = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().list_feature_sets_tags,
         db_session,
         project,
     )
     feature_set_name_to_tag = {tag_tuple[1]: tag_tuple[2] for tag_tuple in tag_tuples}
-    allowed_feature_set_names = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    allowed_feature_set_names = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         list(feature_set_name_to_tag.keys()),
         lambda feature_set_name: (
@@ -317,7 +342,7 @@ def _has_v3io_path(data_source, data_targets, feature_set):
     response_model=schemas.FeatureSetIngestOutput,
     status_code=HTTPStatus.ACCEPTED.value,
 )
-def ingest_feature_set(
+async def ingest_feature_set(
     project: str,
     name: str,
     reference: str,
@@ -332,14 +357,14 @@ def ingest_feature_set(
     This endpoint is being called only through the UI, this is mainly for enrichment of the feature set
     that already being happen on client side
     """
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         project,
         name,
         mlrun.api.schemas.AuthorizationAction.update,
         auth_info,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,
         project,
         "",
@@ -350,7 +375,7 @@ def ingest_feature_set(
     if ingest_parameters.source:
         data_source = DataSource.from_dict(ingest_parameters.source.dict())
     if data_source.schedule:
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.schedule,
             project,
             "",
@@ -358,13 +383,18 @@ def ingest_feature_set(
             auth_info,
         )
     tag, uid = parse_reference(reference)
-    feature_set_record = mlrun.api.crud.FeatureStore().get_feature_set(
-        db_session, project, name, tag, uid
+    feature_set_record = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_set,
+        db_session,
+        project,
+        name,
+        tag,
+        uid,
     )
     feature_set = mlrun.feature_store.FeatureSet.from_dict(feature_set_record.dict())
     if feature_set.spec.function and feature_set.spec.function.function_object:
         function = feature_set.spec.function.function_object
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.function,
             function.metadata.project,
             function.metadata.name,
@@ -374,7 +404,7 @@ def ingest_feature_set(
     # Need to override the default rundb since we're in the server.
     # this is done so further down the flow when running the function created for ingestion we won't access the httpdb
     # but rather "understand" that we are running on server side and call the DB.
-    feature_set._override_run_db(db_session)
+    await run_in_threadpool(feature_set._override_run_db, db_session)
 
     if ingest_parameters.targets:
         data_targets = [
@@ -404,7 +434,8 @@ def ingest_feature_set(
 
     infer_options = ingest_parameters.infer_options or InferOptions.default()
 
-    run_params = ingest(
+    run_params = await run_in_threadpool(
+        ingest,
         feature_set,
         data_source,
         data_targets,
@@ -420,7 +451,7 @@ def ingest_feature_set(
 
 
 @router.get("/projects/{project}/features", response_model=schemas.FeaturesOutput)
-def list_features(
+async def list_features(
     project: str,
     name: str = None,
     tag: str = None,
@@ -429,15 +460,21 @@ def list_features(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    features = mlrun.api.crud.FeatureStore().list_features(
-        db_session, project, name, tag, entities, labels
+    features = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().list_features,
+        db_session,
+        project,
+        name,
+        tag,
+        entities,
+        labels,
     )
-    features = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    features = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature,
         features.features,
         lambda feature_list_output: (
@@ -450,7 +487,7 @@ def list_features(
 
 
 @router.get("/projects/{project}/entities", response_model=schemas.EntitiesOutput)
-def list_entities(
+async def list_entities(
     project: str,
     name: str = None,
     tag: str = None,
@@ -458,15 +495,20 @@ def list_entities(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    entities = mlrun.api.crud.FeatureStore().list_entities(
-        db_session, project, name, tag, labels
+    entities = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().list_entities,
+        db_session,
+        project,
+        name,
+        tag,
+        labels,
     )
-    entities = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    entities = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.entity,
         entities.entities,
         lambda entity_list_output: (
@@ -481,34 +523,39 @@ def list_entities(
 @router.post(
     "/projects/{project}/feature-vectors", response_model=schemas.FeatureVector
 )
-def create_feature_vector(
+async def create_feature_vector(
     project: str,
     feature_vector: schemas.FeatureVector,
     versioned: bool = True,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-        db_session, project, auth_info=auth_info
+    await run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         project,
         feature_vector.metadata.name,
         mlrun.api.schemas.AuthorizationAction.create,
         auth_info,
     )
-    _verify_feature_vector_features_permissions(
+    await _verify_feature_vector_features_permissions(
         auth_info, project, feature_vector.dict()
     )
-    feature_vector_uid = mlrun.api.crud.FeatureStore().create_feature_vector(
+    feature_vector_uid = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().create_feature_vector,
         db_session,
         project,
         feature_vector,
         versioned,
     )
 
-    return mlrun.api.crud.FeatureStore().get_feature_vector(
+    return await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_vector,
         db_session,
         project,
         feature_vector.metadata.name,
@@ -521,7 +568,7 @@ def create_feature_vector(
     "/projects/{project}/feature-vectors/{name}/references/{reference}",
     response_model=schemas.FeatureVector,
 )
-def get_feature_vector(
+async def get_feature_vector(
     project: str,
     name: str,
     reference: str,
@@ -529,17 +576,22 @@ def get_feature_vector(
     db_session: Session = Depends(deps.get_db_session),
 ):
     tag, uid = parse_reference(reference)
-    feature_vector = mlrun.api.crud.FeatureStore().get_feature_vector(
-        db_session, project, name, tag, uid
+    feature_vector = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_vector,
+        db_session,
+        project,
+        name,
+        tag,
+        uid,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         project,
         name,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    _verify_feature_vector_features_permissions(
+    await _verify_feature_vector_features_permissions(
         auth_info, project, feature_vector.dict()
     )
     return feature_vector
@@ -548,7 +600,7 @@ def get_feature_vector(
 @router.get(
     "/projects/{project}/feature-vectors", response_model=schemas.FeatureVectorsOutput
 )
-def list_feature_vectors(
+async def list_feature_vectors(
     project: str,
     name: str = None,
     state: str = None,
@@ -565,12 +617,13 @@ def list_feature_vectors(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    feature_vectors = mlrun.api.crud.FeatureStore().list_feature_vectors(
+    feature_vectors = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().list_feature_vectors,
         db_session,
         project,
         name,
@@ -582,7 +635,7 @@ def list_feature_vectors(
         partition_sort_by,
         partition_order,
     )
-    feature_vectors = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    feature_vectors = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         feature_vectors.feature_vectors,
         lambda feature_vector: (
@@ -591,10 +644,12 @@ def list_feature_vectors(
         ),
         auth_info,
     )
-    for feature_vector in feature_vectors:
-        _verify_feature_vector_features_permissions(
-            auth_info, project, feature_vector.dict()
-        )
+    await asyncio.gather(
+        *[
+            _verify_feature_vector_features_permissions(auth_info, project, fv.dict())
+            for fv in feature_vectors
+        ]
+    )
     return mlrun.api.schemas.FeatureVectorsOutput(feature_vectors=feature_vectors)
 
 
@@ -602,7 +657,7 @@ def list_feature_vectors(
     "/projects/{project}/feature-vectors/{name}/tags",
     response_model=schemas.FeatureVectorsTagsOutput,
 )
-def list_feature_vectors_tags(
+async def list_feature_vectors_tags(
     project: str,
     name: str,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
@@ -612,19 +667,20 @@ def list_feature_vectors_tags(
         raise mlrun.errors.MLRunInvalidArgumentError(
             "Listing a specific feature vector tags is not supported, set name to *"
         )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    tag_tuples = mlrun.api.crud.FeatureStore().list_feature_vectors_tags(
+    tag_tuples = await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().list_feature_vectors_tags,
         db_session,
         project,
     )
     feature_vector_name_to_tag = {
         tag_tuple[1]: tag_tuple[2] for tag_tuple in tag_tuples
     }
-    allowed_feature_vector_names = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    allowed_feature_vector_names = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         list(feature_vector_name_to_tag.keys()),
         lambda feature_vector_name: (
@@ -645,7 +701,7 @@ def list_feature_vectors_tags(
     "/projects/{project}/feature-vectors/{name}/references/{reference}",
     response_model=schemas.FeatureVector,
 )
-def store_feature_vector(
+async def store_feature_vector(
     project: str,
     name: str,
     reference: str,
@@ -654,21 +710,25 @@ def store_feature_vector(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-        db_session, project, auth_info=auth_info
+    await run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         project,
         name,
         mlrun.api.schemas.AuthorizationAction.update,
         auth_info,
     )
-    _verify_feature_vector_features_permissions(
+    await _verify_feature_vector_features_permissions(
         auth_info, project, feature_vector.dict()
     )
     tag, uid = parse_reference(reference)
-    uid = mlrun.api.crud.FeatureStore().store_feature_vector(
+    uid = run_in_threadpool(
+        mlrun.api.crud.FeatureStore().store_feature_vector,
         db_session,
         project,
         name,
@@ -678,13 +738,18 @@ def store_feature_vector(
         versioned,
     )
 
-    return mlrun.api.crud.FeatureStore().get_feature_vector(
-        db_session, project, name, tag, uid
+    return run_in_threadpool(
+        mlrun.api.crud.FeatureStore().get_feature_vector,
+        db_session,
+        project,
+        name,
+        tag,
+        uid,
     )
 
 
 @router.patch("/projects/{project}/feature-vectors/{name}/references/{reference}")
-def patch_feature_vector(
+async def patch_feature_vector(
     project: str,
     name: str,
     feature_vector_patch: dict,
@@ -695,18 +760,19 @@ def patch_feature_vector(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         project,
         name,
         mlrun.api.schemas.AuthorizationAction.update,
         auth_info,
     )
-    _verify_feature_vector_features_permissions(
+    await _verify_feature_vector_features_permissions(
         auth_info, project, feature_vector_patch
     )
     tag, uid = parse_reference(reference)
-    mlrun.api.crud.FeatureStore().patch_feature_vector(
+    await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().patch_feature_vector,
         db_session,
         project,
         name,
@@ -720,14 +786,14 @@ def patch_feature_vector(
 
 @router.delete("/projects/{project}/feature-vectors/{name}")
 @router.delete("/projects/{project}/feature-vectors/{name}/references/{reference}")
-def delete_feature_vector(
+async def delete_feature_vector(
     project: str,
     name: str,
     reference: str = None,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
         project,
         name,
@@ -737,13 +803,18 @@ def delete_feature_vector(
     tag = uid = None
     if reference:
         tag, uid = parse_reference(reference)
-    mlrun.api.crud.FeatureStore().delete_feature_vector(
-        db_session, project, name, tag, uid
+    await run_in_threadpool(
+        mlrun.api.crud.FeatureStore().delete_feature_vector,
+        db_session,
+        project,
+        name,
+        tag,
+        uid,
     )
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
-def _verify_feature_vector_features_permissions(
+async def _verify_feature_vector_features_permissions(
     auth_info: mlrun.api.schemas.AuthInfo, project: str, feature_vector: dict
 ):
     features = []
@@ -762,7 +833,7 @@ def _verify_feature_vector_features_permissions(
     for _project, names in feature_set_project_to_name_set_map.items():
         for name in names:
             feature_set_project_name_tuples.append((_project, name))
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resources_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resources_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
         feature_set_project_name_tuples,
         lambda feature_set_project_name_tuple: (

--- a/mlrun/api/api/endpoints/feature_store.py
+++ b/mlrun/api/api/endpoints/feature_store.py
@@ -295,14 +295,17 @@ async def list_feature_sets_tags(
         project,
     )
     feature_set_name_to_tag = {tag_tuple[1]: tag_tuple[2] for tag_tuple in tag_tuples}
-    allowed_feature_set_names = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
-        list(feature_set_name_to_tag.keys()),
-        lambda feature_set_name: (
-            project,
-            feature_set_name,
-        ),
-        auth_info,
+    auth_verifier = mlrun.api.utils.auth.verifier.AuthVerifier()
+    allowed_feature_set_names = (
+        await auth_verifier.filter_project_resources_by_permissions(
+            mlrun.api.schemas.AuthorizationResourceTypes.feature_set,
+            list(feature_set_name_to_tag.keys()),
+            lambda feature_set_name: (
+                project,
+                feature_set_name,
+            ),
+            auth_info,
+        )
     )
     tags = {
         tag_tuple[2]
@@ -680,14 +683,17 @@ async def list_feature_vectors_tags(
     feature_vector_name_to_tag = {
         tag_tuple[1]: tag_tuple[2] for tag_tuple in tag_tuples
     }
-    allowed_feature_vector_names = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
-        list(feature_vector_name_to_tag.keys()),
-        lambda feature_vector_name: (
-            project,
-            feature_vector_name,
-        ),
-        auth_info,
+    auth_verifier = mlrun.api.utils.auth.verifier.AuthVerifier()
+    allowed_feature_vector_names = (
+        await auth_verifier.filter_project_resources_by_permissions(
+            mlrun.api.schemas.AuthorizationResourceTypes.feature_vector,
+            list(feature_vector_name_to_tag.keys()),
+            lambda feature_vector_name: (
+                project,
+                feature_vector_name,
+            ),
+            auth_info,
+        )
     )
     tags = {
         tag_tuple[2]

--- a/mlrun/api/api/endpoints/feature_store.py
+++ b/mlrun/api/api/endpoints/feature_store.py
@@ -727,7 +727,7 @@ async def store_feature_vector(
         auth_info, project, feature_vector.dict()
     )
     tag, uid = parse_reference(reference)
-    uid = run_in_threadpool(
+    uid = await run_in_threadpool(
         mlrun.api.crud.FeatureStore().store_feature_vector,
         db_session,
         project,
@@ -738,7 +738,7 @@ async def store_feature_vector(
         versioned,
     )
 
-    return run_in_threadpool(
+    return await run_in_threadpool(
         mlrun.api.crud.FeatureStore().get_feature_vector,
         db_session,
         project,

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -16,6 +16,7 @@ import mimetypes
 from http import HTTPStatus
 
 import fastapi
+from fastapi.concurrency import run_in_threadpool
 
 import mlrun.api.api.deps
 import mlrun.api.crud.secrets
@@ -44,7 +45,7 @@ def get_files(
 
 
 @router.get("/projects/{project}/files")
-def get_files_with_project_secrets(
+async def get_files_with_project_secrets(
     project: str,
     schema: str = "",
     objpath: str = fastapi.Query("", alias="path"),
@@ -56,7 +57,7 @@ def get_files_with_project_secrets(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
@@ -82,7 +83,7 @@ def get_filestat(
 
 
 @router.get("/projects/{project}/filestat")
-def get_filestat_with_project_secrets(
+async def get_filestat_with_project_secrets(
     project: str,
     schema: str = "",
     path: str = "",
@@ -92,7 +93,7 @@ def get_filestat_with_project_secrets(
     user: str = "",
     use_secrets: bool = fastapi.Query(True, alias="use-secrets"),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
@@ -100,9 +101,11 @@ def get_filestat_with_project_secrets(
 
     secrets = {}
     if use_secrets:
-        secrets = _verify_and_get_project_secrets(project, auth_info)
+        secrets = await _verify_and_get_project_secrets(project, auth_info)
 
-    return _get_filestat(schema, path, user, auth_info, secrets=secrets)
+    return await run_in_threadpool(
+        _get_filestat, schema, path, user, auth_info, secrets=secrets
+    )
 
 
 def _get_files(
@@ -190,15 +193,16 @@ def _get_filestat(
     }
 
 
-def _verify_and_get_project_secrets(project, auth_info):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+async def _verify_and_get_project_secrets(project, auth_info):
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.secret,
         project,
         mlrun.api.schemas.SecretProviderName.kubernetes,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    secrets_data = mlrun.api.crud.Secrets().list_project_secrets(
+    secrets_data = await run_in_threadpool(
+        mlrun.api.crud.Secrets().list_project_secrets,
         project,
         mlrun.api.schemas.SecretProviderName.kubernetes,
         allow_secrets_from_k8s=True,

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -65,9 +65,11 @@ async def get_files_with_project_secrets(
 
     secrets = {}
     if use_secrets:
-        secrets = _verify_and_get_project_secrets(project, auth_info)
+        secrets = await _verify_and_get_project_secrets(project, auth_info)
 
-    return _get_files(schema, objpath, user, size, offset, auth_info, secrets=secrets)
+    return await run_in_threadpool(
+        _get_files, schema, objpath, user, size, offset, auth_info, secrets=secrets
+    )
 
 
 @router.get("/filestat")

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -112,7 +112,7 @@ async def get_function(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    func = run_in_threadpool(
+    func = await run_in_threadpool(
         mlrun.api.crud.Functions().get_function,
         db_session,
         name,

--- a/mlrun/api/api/endpoints/grafana_proxy.py
+++ b/mlrun/api/api/endpoints/grafana_proxy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Set, Union
@@ -79,6 +80,8 @@ async def grafana_proxy_model_endpoints_query(
     # checks again.
     target_endpoint = query_parameters["target_endpoint"]
     function = NAME_TO_QUERY_FUNCTION_DICTIONARY[target_endpoint]
+    if asyncio.iscoroutinefunction(function):
+        return await function(body, query_parameters, auth_info)
     result = await run_in_threadpool(function, body, query_parameters, auth_info)
     return result
 
@@ -106,6 +109,8 @@ async def grafana_proxy_model_endpoints_search(
     # checks again.
     target_endpoint = query_parameters["target_endpoint"]
     function = NAME_TO_SEARCH_FUNCTION_DICTIONARY[target_endpoint]
+    if asyncio.iscoroutinefunction(function):
+        return await function(db_session, auth_info)
     result = await run_in_threadpool(function, db_session, auth_info)
     return result
 
@@ -119,7 +124,7 @@ def grafana_list_projects(
     return projects_output.projects
 
 
-def grafana_list_endpoints(
+async def grafana_list_endpoints(
     body: Dict[str, Any],
     query_parameters: Dict[str, str],
     auth_info: mlrun.api.schemas.AuthInfo,
@@ -141,12 +146,13 @@ def grafana_list_endpoints(
     end = body.get("rangeRaw", {}).get("end", "now")
 
     if project:
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
             project,
             mlrun.api.schemas.AuthorizationAction.read,
             auth_info,
         )
-    endpoint_list = mlrun.api.crud.ModelEndpoints().list_model_endpoints(
+    endpoint_list = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().list_model_endpoints,
         auth_info=auth_info,
         project=project,
         model=model,
@@ -156,7 +162,7 @@ def grafana_list_endpoints(
         start=start,
         end=end,
     )
-    allowed_endpoints = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    allowed_endpoints = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
         endpoint_list.endpoints,
         lambda _endpoint: (
@@ -214,14 +220,14 @@ def grafana_list_endpoints(
     return [table]
 
 
-def grafana_individual_feature_analysis(
+async def grafana_individual_feature_analysis(
     body: Dict[str, Any],
     query_parameters: Dict[str, str],
     auth_info: mlrun.api.schemas.AuthInfo,
 ):
     endpoint_id = query_parameters.get("endpoint_id")
     project = query_parameters.get("project")
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
         project,
         endpoint_id,
@@ -229,7 +235,8 @@ def grafana_individual_feature_analysis(
         auth_info,
     )
 
-    endpoint = mlrun.api.crud.ModelEndpoints().get_model_endpoint(
+    endpoint = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
         auth_info=auth_info,
         project=project,
         endpoint_id=endpoint_id,
@@ -276,21 +283,22 @@ def grafana_individual_feature_analysis(
     return [table]
 
 
-def grafana_overall_feature_analysis(
+async def grafana_overall_feature_analysis(
     body: Dict[str, Any],
     query_parameters: Dict[str, str],
     auth_info: mlrun.api.schemas.AuthInfo,
 ):
     endpoint_id = query_parameters.get("endpoint_id")
     project = query_parameters.get("project")
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
         project,
         endpoint_id,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    endpoint = mlrun.api.crud.ModelEndpoints().get_model_endpoint(
+    endpoint = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
         auth_info=auth_info,
         project=project,
         endpoint_id=endpoint_id,
@@ -321,7 +329,7 @@ def grafana_overall_feature_analysis(
     return [table]
 
 
-def grafana_incoming_features(
+async def grafana_incoming_features(
     body: Dict[str, Any],
     query_parameters: Dict[str, str],
     auth_info: mlrun.api.schemas.AuthInfo,
@@ -331,7 +339,7 @@ def grafana_incoming_features(
     start = body.get("rangeRaw", {}).get("from", "now-1h")
     end = body.get("rangeRaw", {}).get("to", "now")
 
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
         project,
         endpoint_id,
@@ -339,8 +347,11 @@ def grafana_incoming_features(
         auth_info,
     )
 
-    endpoint = mlrun.api.crud.ModelEndpoints().get_model_endpoint(
-        auth_info=auth_info, project=project, endpoint_id=endpoint_id
+    endpoint = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
+        auth_info=auth_info,
+        project=project,
+        endpoint_id=endpoint_id,
     )
 
     time_series = []
@@ -365,7 +376,8 @@ def grafana_incoming_features(
         container=container,
     )
 
-    data: pd.DataFrame = client.read(
+    data: pd.DataFrame = await run_in_threadpool(
+        client.read,
         backend="tsdb",
         table=path,
         columns=feature_names,

--- a/mlrun/api/api/endpoints/marketplace.py
+++ b/mlrun/api/api/endpoints/marketplace.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query, Response
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import mlrun
@@ -40,78 +41,82 @@ router = APIRouter()
     status_code=HTTPStatus.CREATED.value,
     response_model=IndexedMarketplaceSource,
 )
-def create_source(
+async def create_source(
     source: IndexedMarketplaceSource,
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.create,
         auth_info,
     )
 
-    get_db().create_marketplace_source(db_session, source)
+    await run_in_threadpool(get_db().create_marketplace_source, db_session, source)
     # Handle credentials if they exist
-    mlrun.api.crud.Marketplace().add_source(source.source)
-    return get_db().get_marketplace_source(db_session, source.source.metadata.name)
+    await run_in_threadpool(mlrun.api.crud.Marketplace().add_source, source.source)
+    return await run_in_threadpool(
+        get_db().get_marketplace_source, db_session, source.source.metadata.name
+    )
 
 
 @router.get(
     path="/marketplace/sources",
     response_model=List[IndexedMarketplaceSource],
 )
-def list_sources(
+async def list_sources(
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.read,
         auth_info,
     )
 
-    return get_db().list_marketplace_sources(db_session)
+    return await run_in_threadpool(get_db().list_marketplace_sources, db_session)
 
 
 @router.delete(
     path="/marketplace/sources/{source_name}",
     status_code=HTTPStatus.NO_CONTENT.value,
 )
-def delete_source(
+async def delete_source(
     source_name: str,
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.delete,
         auth_info,
     )
 
-    get_db().delete_marketplace_source(db_session, source_name)
-    mlrun.api.crud.Marketplace().remove_source(source_name)
+    await run_in_threadpool(get_db().delete_marketplace_source, db_session, source_name)
+    await run_in_threadpool(mlrun.api.crud.Marketplace().remove_source, source_name)
 
 
 @router.get(
     path="/marketplace/sources/{source_name}",
     response_model=IndexedMarketplaceSource,
 )
-def get_source(
+async def get_source(
     source_name: str,
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    marketplace_source = get_db().get_marketplace_source(db_session, source_name)
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    marketplace_source = await run_in_threadpool(
+        get_db().get_marketplace_source, db_session, source_name
+    )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.read,
         auth_info,
@@ -123,7 +128,7 @@ def get_source(
 @router.put(
     path="/marketplace/sources/{source_name}", response_model=IndexedMarketplaceSource
 )
-def store_source(
+async def store_source(
     source_name: str,
     source: IndexedMarketplaceSource,
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
@@ -131,24 +136,28 @@ def store_source(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.store,
         auth_info,
     )
 
-    get_db().store_marketplace_source(db_session, source_name, source)
+    await run_in_threadpool(
+        get_db().store_marketplace_source, db_session, source_name, source
+    )
     # Handle credentials if they exist
-    mlrun.api.crud.Marketplace().add_source(source.source)
+    await run_in_threadpool(mlrun.api.crud.Marketplace().add_source, source.source)
 
-    return get_db().get_marketplace_source(db_session, source_name)
+    return await run_in_threadpool(
+        get_db().get_marketplace_source, db_session, source_name
+    )
 
 
 @router.get(
     path="/marketplace/sources/{source_name}/items",
     response_model=MarketplaceCatalog,
 )
-def get_catalog(
+async def get_catalog(
     source_name: str,
     channel: Optional[str] = Query(None),
     version: Optional[str] = Query(None),
@@ -159,15 +168,22 @@ def get_catalog(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    ordered_source = get_db().get_marketplace_source(db_session, source_name)
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    ordered_source = await run_in_threadpool(
+        get_db().get_marketplace_source, db_session, source_name
+    )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.read,
         auth_info,
     )
 
-    return mlrun.api.crud.Marketplace().get_source_catalog(
-        ordered_source.source, channel, version, tag, force_refresh
+    return await run_in_threadpool(
+        mlrun.api.crud.Marketplace().get_source_catalog,
+        ordered_source.source,
+        channel,
+        version,
+        tag,
+        force_refresh,
     )
 
 
@@ -175,7 +191,7 @@ def get_catalog(
     "/marketplace/sources/{source_name}/items/{item_name}",
     response_model=MarketplaceItem,
 )
-def get_item(
+async def get_item(
     source_name: str,
     item_name: str,
     channel: Optional[str] = Query("development"),
@@ -187,22 +203,30 @@ def get_item(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    ordered_source = get_db().get_marketplace_source(db_session, source_name)
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    ordered_source = await run_in_threadpool(
+        get_db().get_marketplace_source, db_session, source_name
+    )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.read,
         auth_info,
     )
 
-    return mlrun.api.crud.Marketplace().get_item(
-        ordered_source.source, item_name, channel, version, tag, force_refresh
+    return await run_in_threadpool(
+        mlrun.api.crud.Marketplace().get_item,
+        ordered_source.source,
+        item_name,
+        channel,
+        version,
+        tag,
+        force_refresh,
     )
 
 
 @router.get(
     "/marketplace/sources/{source_name}/item-object",
 )
-def get_object(
+async def get_object(
     source_name: str,
     url: str,
     db_session: Session = Depends(mlrun.api.api.deps.get_db_session),
@@ -210,11 +234,15 @@ def get_object(
         mlrun.api.api.deps.authenticate_request
     ),
 ):
-    ordered_source = get_db().get_marketplace_source(db_session, source_name)
-    object_data = mlrun.api.crud.Marketplace().get_item_object_using_source_credentials(
-        ordered_source.source, url
+    ordered_source = await run_in_threadpool(
+        get_db().get_marketplace_source, db_session, source_name
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
+    object_data = await run_in_threadpool(
+        mlrun.api.crud.Marketplace().get_item_object_using_source_credentials,
+        ordered_source.source,
+        url,
+    )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.marketplace_source,
         AuthorizationAction.read,
         auth_info,

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -47,8 +47,7 @@ async def store_run(
         project,
         auth_info=auth_info,
     )
-    await run_in_threadpool(
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,
         project,
         uid,
@@ -82,8 +81,7 @@ async def update_run(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    await run_in_threadpool(
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,
         project,
         uid,
@@ -108,15 +106,17 @@ async def update_run(
 
 
 @router.get("/run/{project}/{uid}")
-def get_run(
+async def get_run(
     project: str,
     uid: str,
     iter: int = 0,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    data = mlrun.api.crud.Runs().get_run(db_session, uid, iter, project)
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    data = await run_in_threadpool(
+        mlrun.api.crud.Runs().get_run, db_session, uid, iter, project
+    )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,
         project,
         uid,
@@ -129,21 +129,22 @@ def get_run(
 
 
 @router.delete("/run/{project}/{uid}")
-def delete_run(
+async def delete_run(
     project: str,
     uid: str,
     iter: int = 0,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,
         project,
         uid,
         mlrun.api.schemas.AuthorizationAction.delete,
         auth_info,
     )
-    mlrun.api.crud.Runs().delete_run(
+    await run_in_threadpool(
+        mlrun.api.crud.Runs().delete_run,
         db_session,
         uid,
         iter,
@@ -153,7 +154,7 @@ def delete_run(
 
 
 @router.get("/runs")
-def list_runs(
+async def list_runs(
     project: str = None,
     name: str = None,
     uid: List[str] = Query([]),
@@ -181,12 +182,13 @@ def list_runs(
     db_session: Session = Depends(deps.get_db_session),
 ):
     if project != "*":
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
             project,
             mlrun.api.schemas.AuthorizationAction.read,
             auth_info,
         )
-    runs = mlrun.api.crud.Runs().list_runs(
+    runs = await run_in_threadpool(
+        mlrun.api.crud.Runs().list_runs,
         db_session,
         name,
         uid,
@@ -206,7 +208,7 @@ def list_runs(
         partition_order,
         max_partitions,
     )
-    filtered_runs = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    filtered_runs = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.run,
         runs,
         lambda run: (
@@ -221,7 +223,7 @@ def list_runs(
 
 
 @router.delete("/runs")
-def delete_runs(
+async def delete_runs(
     project: str = None,
     name: str = None,
     labels: List[str] = Query([], alias="label"),
@@ -234,7 +236,7 @@ def delete_runs(
         # Currently we don't differentiate between runs permissions inside a project.
         # Meaning there is no reason at the moment to query the permission for each run under the project
         # TODO check for every run when we will manage permission per run inside a project
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.run,
             project or mlrun.mlconf.default_project,
             "",
@@ -247,7 +249,8 @@ def delete_runs(
             start_time_from = datetime.datetime.now(
                 datetime.timezone.utc
             ) - datetime.timedelta(days=days_ago)
-        runs = mlrun.api.crud.Runs().list_runs(
+        runs = await run_in_threadpool(
+            mlrun.api.crud.Runs().list_runs,
             db_session,
             name,
             project=project,
@@ -262,7 +265,7 @@ def delete_runs(
         for run_project in projects:
             # currently we fail if the user doesn't has permissions to delete runs to one of the projects in the system
             # TODO Delete only runs from projects that user has permissions to
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+            await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
                 mlrun.api.schemas.AuthorizationResourceTypes.run,
                 run_project,
                 "",
@@ -270,7 +273,8 @@ def delete_runs(
                 auth_info,
             )
 
-    mlrun.api.crud.Runs().delete_runs(
+    await run_in_threadpool(
+        mlrun.api.crud.Runs().delete_runs,
         db_session,
         name,
         project,

--- a/mlrun/api/api/endpoints/schedules.py
+++ b/mlrun/api/api/endpoints/schedules.py
@@ -14,8 +14,9 @@
 #
 from http import HTTPStatus
 
-import fastapi.concurrency
+import fastapi
 from fastapi import APIRouter, Depends, Response
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import mlrun.api.api.utils
@@ -31,17 +32,20 @@ router = APIRouter()
 
 
 @router.post("/projects/{project}/schedules")
-def create_schedule(
+async def create_schedule(
     project: str,
     schedule: schemas.ScheduleInput,
     request: fastapi.Request,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.singletons.project_member.get_project_member().ensure_project(
-        db_session, project, auth_info=auth_info
+    await run_in_threadpool(
+        mlrun.api.utils.singletons.project_member.get_project_member().ensure_project,
+        db_session,
+        project,
+        auth_info=auth_info,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         project,
         schedule.name,
@@ -59,13 +63,17 @@ def create_schedule(
             schedule=schedule.dict(),
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.create_schedule(
-            project=project, request=request, json=schedule.dict()
+        return await run_in_threadpool(
+            chief_client.create_schedule,
+            project=project,
+            request=request,
+            json=schedule.dict(),
         )
 
     if schedule.credentials.access_key:
         auth_info.access_key = schedule.credentials.access_key
-    get_scheduler().create_schedule(
+    await run_in_threadpool(
+        get_scheduler().create_schedule,
         db_session,
         auth_info,
         project,
@@ -80,7 +88,7 @@ def create_schedule(
 
 
 @router.put("/projects/{project}/schedules/{name}")
-def update_schedule(
+async def update_schedule(
     project: str,
     name: str,
     schedule: schemas.ScheduleUpdate,
@@ -88,7 +96,7 @@ def update_schedule(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         project,
         name,
@@ -107,13 +115,18 @@ def update_schedule(
             schedule=schedule.dict(),
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.update_schedule(
-            project=project, name=name, request=request, json=schedule.dict()
+        return await run_in_threadpool(
+            chief_client.update_schedule,
+            project=project,
+            name=name,
+            request=request,
+            json=schedule.dict(),
         )
 
     if schedule.credentials.access_key:
         auth_info.access_key = schedule.credentials.access_key
-    get_scheduler().update_schedule(
+    await run_in_threadpool(
+        get_scheduler().update_schedule,
         db_session,
         auth_info,
         project,
@@ -126,7 +139,7 @@ def update_schedule(
 
 
 @router.get("/projects/{project}/schedules", response_model=schemas.SchedulesOutput)
-def list_schedules(
+async def list_schedules(
     project: str,
     name: str = None,
     labels: str = None,
@@ -136,15 +149,22 @@ def list_schedules(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project,
         mlrun.api.schemas.AuthorizationAction.read,
         auth_info,
     )
-    schedules = get_scheduler().list_schedules(
-        db_session, project, name, kind, labels, include_last_run, include_credentials
+    schedules = await run_in_threadpool(
+        get_scheduler().list_schedules,
+        db_session,
+        project,
+        name,
+        kind,
+        labels,
+        include_last_run,
+        include_credentials,
     )
-    filtered_schedules = mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+    filtered_schedules = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         schedules.schedules,
         lambda schedule: (
@@ -160,7 +180,7 @@ def list_schedules(
 @router.get(
     "/projects/{project}/schedules/{name}", response_model=schemas.ScheduleOutput
 )
-def get_schedule(
+async def get_schedule(
     project: str,
     name: str,
     include_last_run: bool = False,
@@ -168,10 +188,15 @@ def get_schedule(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    schedule = get_scheduler().get_schedule(
-        db_session, project, name, include_last_run, include_credentials
+    schedule = await run_in_threadpool(
+        get_scheduler().get_schedule,
+        db_session,
+        project,
+        name,
+        include_last_run,
+        include_credentials,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         project,
         name,
@@ -189,8 +214,7 @@ async def invoke_schedule(
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    await fastapi.concurrency.run_in_threadpool(
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         project,
         name,
@@ -208,7 +232,9 @@ async def invoke_schedule(
             name=name,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.invoke_schedule(project=project, name=name, request=request)
+        return await run_in_threadpool(
+            chief_client.invoke_schedule, project=project, name=name, request=request
+        )
 
     return await get_scheduler().invoke_schedule(db_session, auth_info, project, name)
 
@@ -216,14 +242,14 @@ async def invoke_schedule(
 @router.delete(
     "/projects/{project}/schedules/{name}", status_code=HTTPStatus.NO_CONTENT.value
 )
-def delete_schedule(
+async def delete_schedule(
     project: str,
     name: str,
     request: fastapi.Request,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         project,
         name,
@@ -241,24 +267,27 @@ def delete_schedule(
             name=name,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.delete_schedule(project=project, name=name, request=request)
+        return await run_in_threadpool(
+            chief_client.delete_schedule, project=project, name=name, request=request
+        )
 
-    get_scheduler().delete_schedule(db_session, project, name)
+    await run_in_threadpool(get_scheduler().delete_schedule, db_session, project, name)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
 @router.delete("/projects/{project}/schedules", status_code=HTTPStatus.NO_CONTENT.value)
-def delete_schedules(
+async def delete_schedules(
     project: str,
     request: fastapi.Request,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    schedules = get_scheduler().list_schedules(
+    schedules = await run_in_threadpool(
+        get_scheduler().list_schedules,
         db_session,
         project,
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resources_permissions(
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resources_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.schedule,
         schedules.schedules,
         lambda schedule: (schedule.project, schedule.name),
@@ -275,7 +304,9 @@ def delete_schedules(
             project=project,
         )
         chief_client = mlrun.api.utils.clients.chief.Client()
-        return chief_client.delete_schedules(project=project, request=request)
+        return await run_in_threadpool(
+            chief_client.delete_schedules, project=project, request=request
+        )
 
-    get_scheduler().delete_schedules(db_session, project)
+    await run_in_threadpool(get_scheduler().delete_schedules, db_session, project)
     return Response(status_code=HTTPStatus.NO_CONTENT.value)

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -66,8 +66,7 @@ async def submit_job(
             _,
             _,
         ) = mlrun.utils.helpers.parse_versioned_object_uri(function_url)
-        await fastapi.concurrency.run_in_threadpool(
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.function,
             function_project,
             function_name,
@@ -96,7 +95,9 @@ async def submit_job(
                 task=task,
             )
             chief_client = mlrun.api.utils.clients.chief.Client()
-            return chief_client.submit_job(request=request, json=data)
+            return await fastapi.concurrency.run_in_threadpool(
+                chief_client.submit_job, request=request, json=data
+            )
 
     else:
         await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
@@ -123,6 +124,5 @@ async def submit_job(
         data["task"]["metadata"].setdefault("labels", {}).update(
             {"mlrun/client_version": client_version}
         )
-    logger.info("Submit run", data=data)
-    response = await mlrun.api.api.utils.submit_run(db_session, auth_info, data)
-    return response
+    logger.info("Submitting run", data=data)
+    return await mlrun.api.api.utils.submit_run(db_session, auth_info, data)

--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -75,8 +75,7 @@ async def submit_job(
             auth_info,
         )
     if data.get("schedule"):
-        await fastapi.concurrency.run_in_threadpool(
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.schedule,
             data["task"]["metadata"]["project"],
             data["task"]["metadata"]["name"],
@@ -100,8 +99,7 @@ async def submit_job(
             return chief_client.submit_job(request=request, json=data)
 
     else:
-        await fastapi.concurrency.run_in_threadpool(
-            mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.api.schemas.AuthorizationResourceTypes.run,
             data["task"]["metadata"]["project"],
             "",

--- a/mlrun/api/api/endpoints/tags.py
+++ b/mlrun/api/api/endpoints/tags.py
@@ -47,11 +47,10 @@ async def overwrite_object_tags_with_tag(
     )
 
     # check permission per object type
-    await fastapi.concurrency.run_in_threadpool(
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         getattr(mlrun.api.schemas.AuthorizationResourceTypes, tag_objects.kind),
         project,
-        resource_name=None,
+        resource_name="",
         # not actually overwriting objects, just overwriting the objects tags
         action=mlrun.api.schemas.AuthorizationAction.update,
         auth_info=auth_info,
@@ -86,11 +85,10 @@ async def append_tag_to_objects(
         auth_info=auth_info,
     )
 
-    await fastapi.concurrency.run_in_threadpool(
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         getattr(mlrun.api.schemas.AuthorizationResourceTypes, tag_objects.kind),
         project,
-        resource_name=None,
+        resource_name="",
         action=mlrun.api.schemas.AuthorizationAction.update,
         auth_info=auth_info,
     )
@@ -126,11 +124,10 @@ async def delete_tag_from_objects(
         auth_info=auth_info,
     )
 
-    await fastapi.concurrency.run_in_threadpool(
-        mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions,
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         getattr(mlrun.api.schemas.AuthorizationResourceTypes, tag_objects.kind),
         project,
-        resource_name=None,
+        resource_name="",
         # not actually deleting objects, just deleting the objects tags
         action=mlrun.api.schemas.AuthorizationAction.update,
         auth_info=auth_info,

--- a/mlrun/api/utils/auth/providers/base.py
+++ b/mlrun/api/utils/auth/providers/base.py
@@ -20,7 +20,7 @@ import mlrun.api.schemas
 
 class Provider(abc.ABC):
     @abc.abstractmethod
-    def query_permissions(
+    async def query_permissions(
         self,
         resource: str,
         action: mlrun.api.schemas.AuthorizationAction,
@@ -30,7 +30,7 @@ class Provider(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def filter_by_permissions(
+    async def filter_by_permissions(
         self,
         resources: typing.List,
         opa_resource_extractor: typing.Callable,

--- a/mlrun/api/utils/auth/providers/nop.py
+++ b/mlrun/api/utils/auth/providers/nop.py
@@ -23,7 +23,7 @@ class Provider(
     mlrun.api.utils.auth.providers.base.Provider,
     metaclass=mlrun.utils.singleton.AbstractSingleton,
 ):
-    def query_permissions(
+    async def query_permissions(
         self,
         resource: str,
         action: mlrun.api.schemas.AuthorizationAction,
@@ -32,7 +32,7 @@ class Provider(
     ) -> bool:
         return True
 
-    def filter_by_permissions(
+    async def filter_by_permissions(
         self,
         resources: typing.List,
         opa_resource_extractor: typing.Callable,

--- a/mlrun/api/utils/auth/providers/opa.py
+++ b/mlrun/api/utils/auth/providers/opa.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import asyncio
 import copy
 import datetime
 import typing
@@ -33,7 +35,9 @@ class Provider(
 ):
     def __init__(self) -> None:
         super().__init__()
-        self._session = mlrun.utils.HTTPSessionWithRetry(verbose=True)
+        self._session = mlrun.utils.AsyncClientWithRetry(
+            logger=logger,
+        )
         self._api_url = mlrun.mlconf.httpdb.authorization.opa.address
         self._permission_query_path = (
             mlrun.mlconf.httpdb.authorization.opa.permission_query_path
@@ -60,27 +64,31 @@ class Provider(
             str, typing.Dict[str, datetime]
         ] = {}
 
-    def query_permissions(
+    async def query_permissions(
         self,
         resource: str,
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
     ) -> bool:
+
         # store is not really a verb in our OPA manifest, we map it to 2 query permissions requests (create & update)
         if action == mlrun.api.schemas.AuthorizationAction.store:
-            create_allowed = self.query_permissions(
-                resource,
-                mlrun.api.schemas.AuthorizationAction.create,
-                auth_info,
-                raise_on_forbidden,
+            results = await asyncio.gather(
+                self.query_permissions(
+                    resource,
+                    mlrun.api.schemas.AuthorizationAction.create,
+                    auth_info,
+                    raise_on_forbidden,
+                ),
+                self.query_permissions(
+                    resource,
+                    mlrun.api.schemas.AuthorizationAction.update,
+                    auth_info,
+                    raise_on_forbidden,
+                ),
             )
-            update_allowed = self.query_permissions(
-                resource,
-                mlrun.api.schemas.AuthorizationAction.update,
-                auth_info,
-                raise_on_forbidden,
-            )
+            create_allowed, update_allowed = results
             return create_allowed and update_allowed
         if self._is_request_from_leader(auth_info.projects_role):
             return True
@@ -89,10 +97,10 @@ class Provider(
         body = self._generate_permission_request_body(resource, action, auth_info)
         if self._log_level > 5:
             logger.debug("Sending request to OPA", body=body)
-        response = self._send_request_to_api(
+        response = await self._send_request_to_api(
             "POST", self._permission_query_path, json=body
         )
-        response_body = response.json()
+        response_body = await response.json()
         if self._log_level > 5:
             logger.debug("Received response from OPA", body=response_body)
         allowed = response_body["result"]
@@ -102,7 +110,7 @@ class Provider(
             )
         return allowed
 
-    def filter_by_permissions(
+    async def filter_by_permissions(
         self,
         resources: typing.List,
         opa_resource_extractor: typing.Callable,
@@ -128,10 +136,10 @@ class Provider(
         body = self._generate_filter_request_body(opa_resources, action, auth_info)
         if self._log_level > 5:
             logger.debug("Sending filter request to OPA", body=body)
-        response = self._send_request_to_api(
+        response = await self._send_request_to_api(
             "POST", self._permission_filter_path, json=body
         )
-        response_body = response.json()
+        response_body = await response.json()
         if self._log_level > 5:
             logger.debug("Received filter response from OPA", body=response_body)
         allowed_opa_resources = response_body["result"]
@@ -198,24 +206,27 @@ class Provider(
             return True
         return False
 
-    def _send_request_to_api(self, method, path, **kwargs):
+    async def _send_request_to_api(self, method, path, **kwargs):
         url = f"{self._api_url}{path}"
         if kwargs.get("timeout") is None:
             kwargs["timeout"] = self._request_timeout
-        response = self._session.request(method, url, verify=False, **kwargs)
-        if not response.ok:
-            log_kwargs = copy.deepcopy(kwargs)
-            log_kwargs.update({"method": method, "path": path})
-            if response.content:
-                try:
-                    data = response.json()
-                except Exception:
-                    pass
-                else:
-                    log_kwargs.update({"data": data})
-            logger.warning("Request to opa failed", **log_kwargs)
-            mlrun.errors.raise_for_status(response)
-        return response
+
+        async with self._session.request(
+            method, url, verify_ssl=False, **kwargs
+        ) as response:
+            if not response.ok:
+                log_kwargs = copy.deepcopy(kwargs)
+                log_kwargs.update({"method": method, "path": path})
+                if response.content:
+                    try:
+                        data = await response.json()
+                    except Exception:
+                        pass
+                    else:
+                        log_kwargs.update({"data": data})
+                logger.warning("Request to opa failed", **log_kwargs)
+                mlrun.errors.raise_for_status(response)
+            return response
 
     @staticmethod
     def _generate_permission_request_body(
@@ -226,7 +237,7 @@ class Provider(
         body = {
             "input": {
                 "resource": resource,
-                "action": action,
+                "action": str(action),
                 "ids": auth_info.get_member_ids(),
             },
         }
@@ -241,7 +252,7 @@ class Provider(
         body = {
             "input": {
                 "resources": resources,
-                "action": action,
+                "action": str(action),
                 "ids": auth_info.get_member_ids(),
             },
         }

--- a/mlrun/api/utils/auth/verifier.py
+++ b/mlrun/api/utils/auth/verifier.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import base64
 import typing
 
@@ -45,7 +46,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         project_and_resource_name_extractor: typing.Callable,
         auth_info: mlrun.api.schemas.AuthInfo,
         action: mlrun.api.schemas.AuthorizationAction = mlrun.api.schemas.AuthorizationAction.read,
-    ) -> typing.List:
+    ) -> typing.Coroutine[typing.Any, typing.Any, typing.List]:
         def _generate_opa_resource(resource):
             project_name, resource_name = project_and_resource_name_extractor(resource)
             return self._generate_resource_string_from_project_resource(
@@ -61,7 +62,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         project_names: typing.List[str],
         auth_info: mlrun.api.schemas.AuthInfo,
         action: mlrun.api.schemas.AuthorizationAction = mlrun.api.schemas.AuthorizationAction.read,
-    ) -> typing.List:
+    ) -> typing.Coroutine[typing.Any, typing.Any, typing.List]:
         return self.filter_by_permissions(
             project_names,
             self._generate_resource_string_from_project_name,
@@ -101,7 +102,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ) -> bool:
+    ) -> typing.Coroutine[typing.Any, typing.Any, bool]:
         return self.query_permissions(
             self._generate_resource_string_from_project_resource(
                 resource_type, project_name, resource_name
@@ -117,7 +118,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ) -> bool:
+    ) -> typing.Coroutine[typing.Any, typing.Any, bool]:
         return self.query_permissions(
             self._generate_resource_string_from_project_name(project_name),
             action,
@@ -131,7 +132,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ) -> bool:
+    ) -> typing.Coroutine[typing.Any, typing.Any, bool]:
         return self.query_resource_permissions(
             resource_type,
             "",
@@ -147,7 +148,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ) -> bool:
+    ) -> typing.Coroutine[typing.Any, typing.Any, bool]:
         return self.query_permissions(
             resource_type.to_resource_string("", resource_name),
             action=action,
@@ -161,12 +162,9 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ) -> bool:
+    ) -> typing.Coroutine[typing.Any, typing.Any, bool]:
         return self._auth_provider.query_permissions(
-            resource,
-            action,
-            auth_info,
-            raise_on_forbidden,
+            resource, action, auth_info, raise_on_forbidden
         )
 
     def filter_by_permissions(
@@ -175,7 +173,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         opa_resource_extractor: typing.Callable,
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
-    ) -> typing.List:
+    ) -> typing.Coroutine[typing.Any, typing.Any, typing.List]:
         return self._auth_provider.filter_by_permissions(
             resources,
             opa_resource_extractor,

--- a/mlrun/api/utils/auth/verifier.py
+++ b/mlrun/api/utils/auth/verifier.py
@@ -162,14 +162,14 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             raise_on_forbidden=raise_on_forbidden,
         )
 
-    def query_permissions(
+    async def query_permissions(
         self,
         resource: str,
         action: mlrun.api.schemas.AuthorizationAction,
         auth_info: mlrun.api.schemas.AuthInfo,
         raise_on_forbidden: bool = True,
-    ) -> typing.Coroutine[typing.Any, typing.Any, bool]:
-        return self._auth_provider.query_permissions(
+    ) -> bool:
+        return await self._auth_provider.query_permissions(
             resource, action, auth_info, raise_on_forbidden
         )
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -301,7 +301,7 @@ default_config = {
         },
         "scheduling": {
             # the minimum interval that will be allowed between two scheduled jobs - e.g. a job wouldn't be
-            # allowed to be scheduled to run more then 2 times in X. Can't be less then 1 minute, "0" to disable
+            # allowed to be scheduled to run more than 2 times in X. Can't be less than 1 minute, "0" to disable
             "min_allowed_interval": "10 minutes",
             "default_concurrency_limit": 1,
             # Firing our jobs include things like creating pods which might not be instant, therefore in the case of

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -98,7 +98,7 @@ def raise_for_status(
             error_message = f"{error_message}: {message}"
         status_code = (
             response.status_code
-            if isinstance(response, requests.Response)
+            if hasattr(response, "status_code")
             else response.status
         )
         try:

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -15,6 +15,7 @@
 import typing
 from http import HTTPStatus
 
+import aiohttp
 import requests
 
 
@@ -37,8 +38,10 @@ class MLRunHTTPError(MLRunBaseError, requests.HTTPError):
     def __init__(
         self,
         *args,
-        response: requests.Response = None,
-        status_code: int = None,
+        response: typing.Optional[
+            typing.Union[requests.Response, aiohttp.ClientResponse]
+        ] = None,
+        status_code: typing.Optional[int] = None,
         **kwargs,
     ):
 
@@ -48,6 +51,15 @@ class MLRunHTTPError(MLRunBaseError, requests.HTTPError):
             response = requests.Response()
         if status_code:
             response.status_code = status_code
+
+        if isinstance(response, aiohttp.ClientResponse):
+            if "request" not in kwargs:
+                kwargs["request"] = response.request_info
+
+            # consolidate the response object to be a requests.Response object-like
+            setattr(
+                response, "status_code", status_code if status_code else response.status
+            )
 
         requests.HTTPError.__init__(self, *args, response=response, **kwargs)
 
@@ -67,21 +79,30 @@ class MLRunHTTPStatusError(MLRunHTTPError):
         )
 
 
-def raise_for_status(response: requests.Response, message: str = None):
+def raise_for_status(
+    response: typing.Union[
+        requests.Response,
+        aiohttp.ClientResponse,
+    ],
+    message: str = None,
+):
     """
     Raise a specific MLRunSDK error depending on the given response status code.
     If no specific error exists, raises an MLRunHTTPError
     """
     try:
         response.raise_for_status()
-    except requests.HTTPError as exc:
+    except (requests.HTTPError, aiohttp.ClientResponseError) as exc:
         error_message = err_to_str(exc)
         if message:
             error_message = f"{error_message}: {message}"
+        status_code = (
+            response.status_code
+            if isinstance(response, requests.Response)
+            else response.status
+        )
         try:
-            raise STATUS_ERRORS[response.status_code](
-                error_message, response=response
-            ) from exc
+            raise STATUS_ERRORS[status_code](error_message, response=response) from exc
         except KeyError:
             raise MLRunHTTPError(error_message, response=response) from exc
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1737,7 +1737,10 @@ class ContextHandler:
         for key in kwargs.keys():
             if isinstance(kwargs[key], mlrun.DataItem) and expected_arguments_types[
                 key
-            ] not in [inspect._empty, mlrun.DataItem]:
+            ] not in [
+                inspect._empty,
+                mlrun.DataItem,
+            ]:
                 kwargs[key] = self._parse_input(
                     data_item=kwargs[key], expected_type=expected_arguments_types[key]
                 )

--- a/mlrun/utils/__init__.py
+++ b/mlrun/utils/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .async_http import AsyncClientWithRetry  # noqa
 from .azure_vault import AzureVaultStore  # noqa
 from .clones import get_git_username_password_from_token  # noqa
 from .helpers import *  # noqa

--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -173,7 +173,7 @@ class _CustomRequestContext(_RequestContext):
                         return response
                 else:
                     self._logger.debug(
-                        f"Request failed on retryable http code, retrying",
+                        "Request failed on retryable http code, retrying",
                         retry_wait_secs=retry_wait,
                         method=params.method,
                         url=params.url,
@@ -185,7 +185,7 @@ class _CustomRequestContext(_RequestContext):
             except Exception as exc:
                 if not self._retry_options.retry_on_exception:
                     self._logger.warning(
-                        f"Request failed, retry on exception is disabled",
+                        "Request failed, retry on exception is disabled",
                         method=params.method,
                         url=params.url,
                         exc=err_to_str(exc),
@@ -214,7 +214,7 @@ class _CustomRequestContext(_RequestContext):
                     attempt=current_attempt, response=None
                 )
                 self._logger.debug(
-                    f"Request failed on retryable exception, retrying",
+                    "Request failed on retryable exception, retrying",
                     retry_wait_secs=retry_wait,
                     method=params.method,
                     url=params.url,
@@ -242,7 +242,7 @@ class _CustomRequestContext(_RequestContext):
                     return result
             except Exception as exc:
                 self._logger.warning(
-                    f"Request failed on evaluating response",
+                    "Request failed on evaluating response",
                     retry_wait_secs=retry_wait_secs,
                     method=params.method,
                     url=params.url,

--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -1,0 +1,264 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import asyncio
+import http
+import typing
+from typing import List, Optional
+
+import aiohttp
+import aiohttp.http_exceptions
+from aiohttp_retry import ExponentialRetry, RequestParams, RetryClient, RetryOptionsBase
+from aiohttp_retry.client import _RequestContext
+
+from ..config import config
+from ..errors import err_to_str
+from .helpers import logger as mlrun_logger
+
+
+class AsyncClientWithRetry(RetryClient):
+    """
+    Extends by adding retry logic on both error statuses and certain exceptions.
+    """
+
+    def __init__(
+        self,
+        max_retries=config.http_retry_defaults.max_retries,
+        retry_backoff_factor=config.http_retry_defaults.backoff_factor,
+        retry_on_exception=True,
+        retry_on_status=True,
+        blacklisted_methods=None,
+        logger=None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            *args,
+            retry_options=ExponentialRetryOverride(
+                retry_on_exception=retry_on_exception,
+                # do not retry on PUT / PATCH as they might have side effects (not truly idempotent)
+                blacklisted_methods=blacklisted_methods or ["POST", "PUT", "PATCH"],
+                attempts=max_retries,
+                statuses={
+                    http.HTTPStatus.BAD_GATEWAY.value,
+                    http.HTTPStatus.SERVICE_UNAVAILABLE.value,
+                    http.HTTPStatus.GATEWAY_TIMEOUT.value,
+                    http.HTTPStatus.TOO_MANY_REQUESTS,
+                },
+                # a callback that will run on response to decide if retry is needed
+                factor=retry_backoff_factor,
+            ),
+            logger=logger or mlrun_logger,
+            raise_for_status=retry_on_status,
+            **kwargs,
+        )
+
+    def _make_requests(
+        self,
+        params_list: List[RequestParams],
+        retry_options: Optional[RetryOptionsBase] = None,
+        raise_for_status: Optional[bool] = None,
+    ) -> "_CustomRequestContext":
+        if retry_options is None:
+            retry_options = self._retry_options
+        if raise_for_status is None:
+            raise_for_status = self._raise_for_status
+        return _CustomRequestContext(
+            request_func=self._client.request,
+            params_list=params_list,
+            logger=self._logger,
+            retry_options=retry_options,
+            raise_for_status=raise_for_status,
+        )
+
+
+class ExponentialRetryOverride(ExponentialRetry):
+    # make sure to only add exceptions that are raised early in the request. For example, ConnectionError can be raised
+    # during the handling of a request, and therefore should not be retried, as the request might not be idempotent.
+    HTTP_RETRYABLE_EXCEPTION = [
+        # "Connection reset by peer" is raised when the server closes the connection prematurely during TCP handshake.
+        ConnectionResetError,
+        # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
+        ConnectionRefusedError,
+        ConnectionAbortedError,
+        # aiohttp exceptions that can be raised during connection establishment
+        aiohttp.ClientConnectionError,
+        aiohttp.ServerDisconnectedError,
+    ]
+
+    def __init__(self, retry_on_exception, blacklisted_methods, *args, **kwargs):
+
+        # whether to retry on exceptions
+        self.retry_on_exception = retry_on_exception
+
+        # methods that should not be retried
+        self.blacklisted_methods = blacklisted_methods
+
+        # default exceptions that should be retried on (when retry_on_exception is True)
+        if "exceptions" not in kwargs:
+            kwargs["exceptions"] = self.HTTP_RETRYABLE_EXCEPTION
+        super().__init__(*args, **kwargs)
+
+
+class _CustomRequestContext(_RequestContext):
+    """
+    Extends by adding retry logic on both error statuses and certain exceptions.
+    """
+
+    async def _do_request(self) -> aiohttp.ClientResponse:
+        current_attempt = 0
+        while True:
+            current_attempt += 1
+            response = None
+            params = None
+            try:
+                try:
+                    params = self._params_list[current_attempt - 1]
+                except IndexError:
+                    params = self._params_list[-1]
+
+                response: typing.Optional[
+                    aiohttp.ClientResponse
+                ] = await self._request_func(
+                    params.method,
+                    params.url,
+                    headers=params.headers,
+                    trace_request_ctx={
+                        "current_attempt": current_attempt,
+                        **(params.trace_request_ctx or {}),
+                    },
+                    **(params.kwargs or {}),
+                )
+                retry_wait = self._retry_options.get_timeout(
+                    attempt=current_attempt, response=response
+                )
+
+                # if the response is not retryable, return it.
+                # this is done to prevent the retry logic from running on non-idempotent methods such as POST.
+                if not self._is_method_retryable(params.method):
+                    self._response = response
+                    return response
+
+                # check if status code is retryable (given by the retry options) or last attempt
+                if (
+                    self._is_status_code_ok(response.status)
+                    or current_attempt == self._retry_options.attempts
+                ):
+                    if self._raise_for_status:
+                        response.raise_for_status()
+
+                    # allow user to provide a callback to decide if retry is needed
+                    is_response_correct = await self._check_response_callback(
+                        params, current_attempt, retry_wait, response
+                    )
+
+                    # response is correct or last attempt, return it
+                    if (
+                        is_response_correct
+                        or current_attempt == self._retry_options.attempts
+                    ):
+                        self._response = response
+                        return response
+                else:
+                    self._logger.debug(
+                        f"Request failed on retryable http code, retrying",
+                        retry_wait_secs=retry_wait,
+                        method=params.method,
+                        url=params.url,
+                        current_attempt=current_attempt,
+                        max_attemps=self._retry_options.attempts,
+                        status_code=response.status,
+                    )
+
+            except Exception as exc:
+                if not self._retry_options.retry_on_exception:
+                    self._logger.warning(
+                        f"Request failed, retry on exception is disabled",
+                        method=params.method,
+                        url=params.url,
+                        exc=err_to_str(exc),
+                    )
+                    raise exc
+
+                # exhaust all attempts, stop here, return the last response
+                if current_attempt >= self._retry_options.attempts:
+                    if response:
+                        self._response = response
+                        return response
+                    raise exc
+
+                # by type
+                self.verify_exception_type(exc)
+
+                # if the response is not retryable, return now.
+                # this is done to prevent the retry logic from running on non-idempotent methods such as POST.
+                if not self._is_method_retryable(params.method):
+                    if response:
+                        self._response = response
+                        return response
+                    raise exc
+
+                retry_wait = self._retry_options.get_timeout(
+                    attempt=current_attempt, response=None
+                )
+                self._logger.debug(
+                    f"Request failed on retryable exception, retrying",
+                    retry_wait_secs=retry_wait,
+                    method=params.method,
+                    url=params.url,
+                    current_attempt=current_attempt,
+                    max_attemps=self._retry_options.attempts,
+                    exc=err_to_str(exc),
+                )
+
+            await asyncio.sleep(retry_wait)
+
+    def _is_method_retryable(self, method: str):
+        return method not in self._retry_options.blacklisted_methods
+
+    async def _check_response_callback(
+        self, params, retry_count, retry_wait_secs, response
+    ):
+        if self._retry_options.evaluate_response_callback is not None:
+            try:
+                result = self._retry_options.evaluate_response_callback(response)
+                if asyncio.iscoroutinefunction(
+                    self._retry_options.evaluate_response_callback
+                ):
+                    return await result
+                else:
+                    return result
+            except Exception as exc:
+                self._logger.warning(
+                    f"Request failed on evaluating response",
+                    retry_wait_secs=retry_wait_secs,
+                    method=params.method,
+                    url=params.url,
+                    retry_count=retry_count,
+                    max_attemps=self._retry_options.attempts,
+                    status_code=response.status,
+                    exc=err_to_str(exc),
+                )
+                return False
+        return True
+
+    def verify_exception_type(self, exc):
+        for exc_type in self._retry_options.exceptions:
+            if isinstance(exc, exc_type):
+                return
+            if isinstance(exc, aiohttp.ClientConnectorError):
+                if isinstance(exc.os_error, exc_type):
+                    return
+        raise exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ urllib3>=1.25.4, <1.27
 chardet>=3.0.2, <4.0
 GitPython~=3.0
 aiohttp~=3.8
+aiohttp-retry~=2.8
 # 8.1.0+ breaks dask/distributed versions older than 2022.04.0, see here - https://github.com/dask/distributed/pull/6018
 click~=8.0.0
 # when installing google-cloud-storage which required >=3.20.1, <5 it was upgrading the protobuf version to the latest

--- a/tests/api/api/feature_store/test_feature_vectors.py
+++ b/tests/api/api/feature_store/test_feature_vectors.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 from uuid import uuid4
 
 import deepdiff
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -462,7 +463,8 @@ def test_feature_vector_list_partition_by(db: Session, client: TestClient) -> No
     )
 
 
-def test_verify_feature_vector_features_permissions(
+@pytest.mark.asyncio
+async def test_verify_feature_vector_features_permissions(
     db: Session, client: TestClient
 ) -> None:
     project = "some-project"
@@ -503,9 +505,9 @@ def test_verify_feature_vector_features_permissions(
         )
 
     mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resources_permissions = (
-        unittest.mock.Mock(side_effect=_verify_queried_resources)
+        unittest.mock.AsyncMock(side_effect=_verify_queried_resources)
     )
-    mlrun.api.api.endpoints.feature_store._verify_feature_vector_features_permissions(
+    await mlrun.api.api.endpoints.feature_store._verify_feature_vector_features_permissions(
         mlrun.api.schemas.AuthInfo(),
         project,
         {"spec": {"features": features, "label_feature": label_feature}},

--- a/tests/api/api/test_auth.py
+++ b/tests/api/api/test_auth.py
@@ -28,7 +28,7 @@ def test_verify_authorization(
         resource="/some-resource", action=mlrun.api.schemas.AuthorizationAction.create
     )
 
-    def _mock_successful_query_permissions(resource, action, *args):
+    async def _mock_successful_query_permissions(resource, action, *args):
         assert authorization_verification_input.resource == resource
         assert authorization_verification_input.action == action
 

--- a/tests/api/api/test_background_tasks.py
+++ b/tests/api/api/test_background_tasks.py
@@ -214,7 +214,7 @@ def test_get_background_task_auth_skip(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ):
     mlrun.api.utils.auth.verifier.AuthVerifier().query_resource_permissions = (
-        unittest.mock.Mock()
+        unittest.mock.AsyncMock()
     )
     mlrun.mlconf.igz_version = "3.2.0-b26.20210904121245"
     response = client.post("/test/internal-background-tasks")

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -125,7 +125,7 @@ def test_get_pipeline_no_project_opa_validation(
         return_value=project
     )
     mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions = (
-        unittest.mock.Mock()
+        unittest.mock.AsyncMock()
     )
     api_run_detail = _generate_get_run_mock()
     _mock_get_run(kfp_client_mock, api_run_detail)

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -155,7 +155,7 @@ def test_get_non_existing_project(
     """
     project = "does-not-exist"
     mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions = (
-        unittest.mock.Mock(side_effect=mlrun.errors.MLRunUnauthorizedError("bla"))
+        unittest.mock.AsyncMock(side_effect=mlrun.errors.MLRunUnauthorizedError("bla"))
     )
     response = client.get(f"projects/{project}")
     assert response.status_code == HTTPStatus.NOT_FOUND.value

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -385,7 +385,7 @@ def test_list_runs_single_and_multiple_uids(db: Session, client: TestClient):
 
 def test_delete_runs_with_permissions(db: Session, client: TestClient):
     mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions = (
-        unittest.mock.Mock()
+        unittest.mock.AsyncMock()
     )
 
     # delete runs from specific project

--- a/tests/api/api/test_runtime_resources.py
+++ b/tests/api/api/test_runtime_resources.py
@@ -78,7 +78,7 @@ def test_list_runtimes_resources_group_by_job(
         return_value=grouped_by_project_runtime_resources_output
     )
     # allow all
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         side_effect=lambda _, resources, *args, **kwargs: resources
     )
     response = client.get(
@@ -132,7 +132,7 @@ def test_list_runtimes_resources_no_group_by(
         return_value=grouped_by_project_runtime_resources_output
     )
     # allow all
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         side_effect=lambda _, resources, *args, **kwargs: resources
     )
     response = client.get(
@@ -191,7 +191,7 @@ def test_list_runtime_resources_no_resources(
         return_value={}
     )
 
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         return_value=[]
     )
     response = client.get(
@@ -259,7 +259,7 @@ def test_list_runtime_resources_filter_by_kind(
             grouped_by_project_runtime_resources_output,
         )
     )
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         side_effect=lambda _, resources, *args, **kwargs: resources
     )
     response = client.get(
@@ -321,7 +321,7 @@ def test_delete_runtime_resources_nothing_allowed(
         return_value=grouped_by_project_runtime_resources_output
     )
 
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         return_value=[]
     )
     _assert_forbidden_responses_in_delete_endpoints(client)
@@ -335,7 +335,7 @@ def test_delete_runtime_resources_no_resources(
     )
 
     # allow all
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         side_effect=lambda _, resources, *args, **kwargs: resources
     )
     _assert_empty_responses_in_delete_endpoints(client)
@@ -360,7 +360,7 @@ def test_delete_runtime_resources_opa_filtering(
     )
 
     allowed_projects = [project_1, project_2]
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         return_value=allowed_projects
     )
     _mock_runtime_handlers_delete_resources(
@@ -395,7 +395,7 @@ def test_delete_runtime_resources_with_legacy_builder_pod_opa_filtering(
     )
 
     allowed_projects = []
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         return_value=allowed_projects
     )
     # no projects are allowed, but there is a non project runtime resource (the legacy builder pod)
@@ -442,7 +442,7 @@ def test_delete_runtime_resources_with_kind(
     )
 
     allowed_projects = [project_1, project_3]
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         return_value=allowed_projects
     )
     _mock_runtime_handlers_delete_resources([kind], allowed_projects)
@@ -498,7 +498,7 @@ def test_delete_runtime_resources_with_object_id(
     )
 
     # allow all
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         side_effect=lambda _, resources, *args, **kwargs: resources
     )
     _mock_runtime_handlers_delete_resources([kind], [project_1])
@@ -746,7 +746,7 @@ def _mock_opa_filter_and_assert_list_response(
     grouped_by_project_runtime_resources_output: mlrun.api.schemas.GroupedByProjectRuntimeResourcesOutput,
     opa_filter_response,
 ):
-    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.Mock(
+    mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions = unittest.mock.AsyncMock(
         return_value=opa_filter_response
     )
     response = client.get(

--- a/tests/api/utils/auth/providers/test_opa.py
+++ b/tests/api/utils/auth/providers/test_opa.py
@@ -58,15 +58,13 @@ async def opa_provider(
     mlrun.mlconf.httpdb.authorization.mode = "opa"
     provider = mlrun.api.utils.auth.providers.opa.Provider()
 
-    # closing the provider's session to avoid "unclosed session" warning on below reinit
-    await provider._session.close()
-
     # force running init again so the configured api url will be used
     provider.__init__()
     yield provider
 
     # explicitly closing the provider's session to avoid "unclosed session" warning between tests
-    await provider._session.close()
+    if provider._session:
+        await provider._session.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -130,6 +130,8 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.13, <3.20"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
+        # used in tests
+        "aioresponses": {"~=0.7"},
     }
 
     for (

--- a/tests/utils/test_async_http.py
+++ b/tests/utils/test_async_http.py
@@ -1,0 +1,217 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import http.server
+import threading
+from unittest import mock
+
+import pytest
+from aiohttp import (
+    ClientConnectorError,
+    ClientResponse,
+    ClientResponseError,
+    ServerDisconnectedError,
+)
+
+from mlrun.errors import MLRunHTTPError
+from mlrun.errors import raise_for_status as mlrun_raise_for_status
+from mlrun.utils.async_http import AsyncClientWithRetry
+from mlrun.utils.logger import create_logger
+
+
+@pytest.fixture
+async def async_client():
+    async with AsyncClientWithRetry() as client:
+        client._client.request = mock.AsyncMock()
+        return client
+
+
+@pytest.fixture
+def httpd_on_demand():
+    httpd_on_demand = HTTPDaemonOnDemand()
+    yield httpd_on_demand
+    httpd_on_demand.close()
+
+
+@pytest.mark.asyncio
+async def test_retry_exceptions(httpd_on_demand: "HTTPDaemonOnDemand"):
+    retry_counter = 0
+
+    def wrap_real_request(client_):
+        def handle_request(*args, **kwargs):
+            nonlocal retry_counter
+            retry_counter += 1
+            return real_handle_request(*args, **kwargs)
+
+        real_handle_request = client_._client.request
+        client_._client.request = handle_request
+
+    async with AsyncClientWithRetry(
+        read_timeout=10,
+        conn_timeout=10,
+    ) as client:
+        wrap_real_request(client)
+
+        # Case - Server was not started, expect it to refuse our connection
+        with pytest.raises(ClientConnectorError) as exc:
+            await client.get(f"http://localhost:{httpd_on_demand.port}")
+        assert retry_counter == 3, "should have retried 3 times"
+        assert exc.value.os_error.errno == 61, "expected connection refused"
+
+        # starting the server
+        httpd_on_demand.start()
+
+        # Case - Server is started, but it's not responding, or closing the connection prematurely
+        # reset counter
+        retry_counter = 0
+        with pytest.raises(ServerDisconnectedError) as exc:
+            await client.get(
+                f"http://localhost:{httpd_on_demand.port}",
+                headers={
+                    "x-action": "close",
+                },
+            )
+        assert retry_counter == 3, "should have retried 3 times"
+        assert exc.value.message == "Server disconnected"
+
+        # Case - Server is started, but it's not responding, or closing the connection prematurely
+        # Do not retry because method is blacklisted
+        # reset counter
+        retry_counter = 0
+        client.retry_options.blacklisted_methods = ["POST"]
+        with pytest.raises(ServerDisconnectedError) as exc:
+            await client.post(
+                f"http://localhost:{httpd_on_demand.port}",
+                headers={
+                    "x-action": "close",
+                },
+            )
+        assert (
+            retry_counter == 1
+        ), "should have retried 1 time, POST is a blacklisted method"
+        assert exc.value.message == "Server disconnected"
+
+
+@pytest.mark.parametrize(
+    "method, status_codes",
+    [
+        ("GET", [http.HTTPStatus.OK]),
+        ("GET", [http.HTTPStatus.SERVICE_UNAVAILABLE, http.HTTPStatus.OK]),
+        (
+            "GET",
+            [
+                http.HTTPStatus.SERVICE_UNAVAILABLE,
+                http.HTTPStatus.SERVICE_UNAVAILABLE,
+                http.HTTPStatus.OK,
+            ],
+        ),
+        (
+            "GET",
+            [
+                http.HTTPStatus.SERVICE_UNAVAILABLE,
+                http.HTTPStatus.SERVICE_UNAVAILABLE,
+                http.HTTPStatus.SERVICE_UNAVAILABLE,
+            ],
+        ),
+        ("POST", [http.HTTPStatus.OK]),
+        # we don't retry on POST.
+        # on top of that, we return the response even if it's an error, so asynchttp client don't raise an exception.
+        ("POST", [http.HTTPStatus.SERVICE_UNAVAILABLE]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_retry_method_status_codes(async_client, method, status_codes):
+    def dummy_raise_for_status():
+        status_code = status_codes[async_client._client.request.call_count - 1]
+        if status_code >= http.HTTPStatus.BAD_REQUEST:
+            raise ClientResponseError(
+                mock.MagicMock(),
+                mock.MagicMock(),
+                # return the last status code from the retry list
+                status=status_codes[async_client._client.request.call_count - 1],
+            )
+
+    async_client._client.request.side_effect = [
+        mock.AsyncMock(
+            spec=ClientResponse,
+            status=status_code,
+            raise_for_status=dummy_raise_for_status,
+        )
+        for status_code in status_codes
+    ]
+    response = await async_client.request(method, "http://nothinghere")
+    assert response.status == status_codes[-1], "response status is not as expected"
+
+    # ensure we called the request the correct number of times
+    assert async_client._client.request.call_count == len(
+        status_codes
+    ), "Wrong number of retries"
+
+
+class HTTPDaemonOnDemand:
+    def __init__(self):
+        self._logger = create_logger("DEBUG", name="async-http-logger")
+        self._port = 30666
+        self._httpd = None
+        self._httpd_thread = None
+        self._started = False
+        self._closed = False
+
+    @property
+    def httpd(self):
+        return self._httpd
+
+    @property
+    def port(self):
+        return self._port
+
+    def start(self):
+        self._logger.debug("Starting HTTP daemon")
+        self._httpd = http.server.HTTPServer(
+            ("localhost", self._port), HTTPDaemonOnDemandRequestHandler
+        )
+        self._httpd_thread = threading.Thread(target=self.run_server)
+        self._httpd_thread.start()
+        self._started = True
+
+    def run_server(self):
+        self._logger.debug("Running HTTP daemon")
+        self._httpd.serve_forever()
+
+    def close(self):
+        if self._closed:
+            return
+        self._logger.debug("Closing HTTP daemon")
+        self._httpd.shutdown()
+        self._logger.debug("HTTP daemon closed, joining thread")
+        self._httpd_thread.join()
+        self._closed = True
+
+
+class HTTPDaemonOnDemandRequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self._default_handler()
+
+    def do_POST(self):
+        self._default_handler()
+
+    def _default_handler(self):
+        action = self.headers.get("x-action", "")
+        status_code = int(self.headers.get("x-status-code", http.HTTPStatus.OK))
+        if action == "close":
+            self.request.close()
+        else:
+            self.send_response(status_code)
+            self.end_headers()


### PR DESCRIPTION
In this big yet lovely PR I have introduced

1. Retryable Asynchronous HTTP client
2. OPA to use it
3. Almost all API endpoints turned to be async-based while its sync code still runs in threadpools


Onwards we go, make authentication http client to be async as well, chief <> worker communication, api file operations with aiofiles and so on