### PR TITLE
[Project] Fix working dir consistency behavior of project functions

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2816,7 +2816,6 @@ def _init_function_from_dict(f, project):
             name, image=image, kind=kind or "job", handler=handler, tag=tag
         )
 
-        # TODO: add helper to determine if url ends with yaml,yml and reuse from import artifact as weell
     elif url.endswith(".yaml") or url.startswith("db://") or url.startswith("hub://"):
         if tag:
             raise ValueError(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1495,6 +1495,7 @@ class MlrunProject(ModelObj):
             artifact.metadata.tag = tag or artifact.metadata.tag
             return artifact
 
+        # Obtaining the item's absolute path from the project context, in case the user provided a relative path
         item_path, _ = _get_item_absolute_path(item_path, self)
         dataitem = mlrun.get_dataitem(item_path)
 
@@ -2951,10 +2952,12 @@ def _is_imported_artifact(artifact):
 
 
 def _get_item_absolute_path(url, project):
+    in_context = False
     if url and "://" not in url:
         if project.spec.context and not url.startswith("/"):
+            in_context = True
             url = path.join(project.spec.get_code_path(), url)
-            return url, True
+            return url, in_context
         if not path.isfile(url):
             raise OSError(f"{url} not found")
-    return url, False
+    return url, in_context

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -466,3 +466,19 @@ def test_inline_body():
     )
     assert artifact.spec.get_body() == "123"
     assert artifact.metadata.key == "y"
+
+
+def test_import_artifact_using_relative_path():
+    project = mlrun.new_project("inline", context=str(assets_path()), save=False)
+
+    # log an artifact and save the content/body in the object (inline)
+    artifact = project.log_artifact(
+        "x", body="123", is_inline=True, artifact_path=str(assets_path())
+    )
+    assert artifact.spec.get_body() == "123"
+    artifact.export(f"{str(assets_path())}/x.yaml")
+
+    # importing the artifact using a relative path
+    artifact = project.import_artifact(f"x.yaml", "y")
+    assert artifact.spec.get_body() == "123"
+    assert artifact.metadata.key == "y"

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -479,6 +479,6 @@ def test_import_artifact_using_relative_path():
     artifact.export(f"{str(assets_path())}/x.yaml")
 
     # importing the artifact using a relative path
-    artifact = project.import_artifact(f"x.yaml", "y")
+    artifact = project.import_artifact("x.yaml", "y")
     assert artifact.spec.get_body() == "123"
     assert artifact.metadata.key == "y"

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -466,19 +466,3 @@ def test_inline_body():
     )
     assert artifact.spec.get_body() == "123"
     assert artifact.metadata.key == "y"
-
-
-def test_import_artifact_using_relative_path():
-    project = mlrun.new_project("inline", context=str(assets_path()), save=False)
-
-    # log an artifact and save the content/body in the object (inline)
-    artifact = project.log_artifact(
-        "x", body="123", is_inline=True, artifact_path=str(assets_path())
-    )
-    assert artifact.spec.get_body() == "123"
-    artifact.export(f"{str(assets_path())}/x.yaml")
-
-    # importing the artifact using a relative path
-    artifact = project.import_artifact("x.yaml", "y")
-    assert artifact.spec.get_body() == "123"
-    assert artifact.metadata.key == "y"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -39,6 +39,10 @@ def context():
         shutil.rmtree(context)
 
 
+def assets_path():
+    return pathlib.Path(__file__).absolute().parent / "assets"
+
+
 def test_sync_functions():
     project_name = "project-name"
     project = mlrun.new_project(project_name, save=False)
@@ -468,6 +472,21 @@ def test_set_func_with_tag():
     )
     func = project.get_function("desc2")
     assert func.metadata.tag is None
+
+
+def test_set_function_with_relative_path(context):
+    project = mlrun.new_project("inline", context=str(assets_path()), save=False)
+
+    project.set_function(
+        "handler.py",
+        "desc1",
+        image="mlrun/mlrun",
+    )
+
+    func = project.get_function("desc1")
+    assert func is not None and func.spec.build.origin_filename.startswith(
+        str(assets_path())
+    )
 
 
 def test_function_run_cli():

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+import unittest.mock
 import zipfile
 from contextlib import nullcontext as does_not_raise
 
@@ -487,6 +488,52 @@ def test_set_function_with_relative_path(context):
     assert func is not None and func.spec.build.origin_filename.startswith(
         str(assets_path())
     )
+
+
+def test_import_artifact_using_relative_path():
+    project = mlrun.new_project("inline", context=str(assets_path()), save=False)
+
+    # log an artifact and save the content/body in the object (inline)
+    artifact = project.log_artifact(
+        "x", body="123", is_inline=True, artifact_path=str(assets_path())
+    )
+    assert artifact.spec.get_body() == "123"
+    artifact.export(f"{str(assets_path())}/artifact.yaml")
+
+    # importing the artifact using a relative path
+    artifact = project.import_artifact("artifact.yaml", "y")
+    assert artifact.spec.get_body() == "123"
+    assert artifact.metadata.key == "y"
+
+
+@pytest.mark.parametrize(
+    "relative_artifact_path,project_context,expected_path,expected_in_context",
+    [
+        (
+            "artifact.yml",
+            "/project/context/assets",
+            "/project/context/assets/artifact.yml",
+            True,
+        ),
+        (
+            "../../artifact.yml",
+            "/project/assets/project/context",
+            "/project/assets/artifact.yml",
+            True,
+        ),
+        ("../artifact.json", "/project/context", "/project/artifact.json", True),
+        ("v3io://artifact.zip", "/project/context", "v3io://artifact.zip", False),
+        ("/artifact.json", "/project/context", "/artifact.json", False),
+    ],
+)
+def test_get_item_absolute_path(
+    relative_artifact_path, project_context, expected_path, expected_in_context
+):
+    with unittest.mock.patch("os.path.isfile", return_value=True):
+        project = mlrun.new_project("inline", save=False)
+        project.spec.context = project_context
+        result, in_context = project.get_item_absolute_path(relative_artifact_path)
+        assert result == expected_path and in_context == expected_in_context
 
 
 def test_function_run_cli():


### PR DESCRIPTION
a fix for: https://jira.iguazeng.com/browse/ML-3070

project.import_artifact now searches in context path instead of current directory