### PR TITLE
[Feature Store] Fix unsafe access to `output_path`

### DIFF
--- a/mlrun/feature_store/retrieval/job.py
+++ b/mlrun/feature_store/retrieval/job.py
@@ -75,7 +75,7 @@ def run_merge_job(
             "engine_args": engine_args,
         },
         inputs={"entity_rows": entity_rows},
-        out_path=function.spec.output_path,
+        out_path=getattr(function.spec, "output_path", None),
     )
     task.spec.secret_sources = run_config.secret_sources
     task.set_label("job-type", "feature-merge").set_label("feature-vector", vector.uri)


### PR DESCRIPTION
This attribute is not present for every function.