### PR TITLE
[Runtimes] Add an API to control image pull configuration

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -999,6 +999,25 @@ class KubeResource(BaseRuntime):
     def gpus(self, gpus, gpu_type="nvidia.com/gpu"):
         update_in(self.spec.resources, ["limits", gpu_type], gpus)
 
+    def with_image_pull_configuration(
+        self, image_pull_policy: str = None, image_pull_secret_name: str = None
+    ):
+        """
+        Configure the image pull parameters for the runtime.
+
+        :param image_pull_policy: The policy to use when pulling. One of `IfNotPresent`, `Always` or `Never`
+        :param image_pull_secret_name: Name of a k8s secret containing image repository's authentication credentials
+        """
+        if image_pull_policy:
+            allowed_policies = ["Always", "IfNotPresent", "Never"]
+            if image_pull_policy not in allowed_policies:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Image pull policy must be one of {allowed_policies}, got {image_pull_policy}"
+                )
+            self.spec.image_pull_policy = image_pull_policy
+        if image_pull_secret_name:
+            self.spec.image_pull_secret = image_pull_secret_name
+
     def with_limits(
         self,
         mem: str = None,

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1009,8 +1009,7 @@ class KubeResource(BaseRuntime):
         :param image_pull_secret_name: Name of a k8s secret containing image repository's authentication credentials
         """
         if image_pull_policy is not None:
-            # An empty string can be used to reset to default configuration
-            allowed_policies = ["Always", "IfNotPresent", "Never", ""]
+            allowed_policies = ["Always", "IfNotPresent", "Never"]
             if image_pull_policy not in allowed_policies:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"Image pull policy must be one of {allowed_policies}, got {image_pull_policy}"

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -999,7 +999,7 @@ class KubeResource(BaseRuntime):
     def gpus(self, gpus, gpu_type="nvidia.com/gpu"):
         update_in(self.spec.resources, ["limits", gpu_type], gpus)
 
-    def with_image_pull_configuration(
+    def set_image_pull_configuration(
         self, image_pull_policy: str = None, image_pull_secret_name: str = None
     ):
         """
@@ -1008,14 +1008,15 @@ class KubeResource(BaseRuntime):
         :param image_pull_policy: The policy to use when pulling. One of `IfNotPresent`, `Always` or `Never`
         :param image_pull_secret_name: Name of a k8s secret containing image repository's authentication credentials
         """
-        if image_pull_policy:
-            allowed_policies = ["Always", "IfNotPresent", "Never"]
+        if image_pull_policy is not None:
+            # An empty string can be used to reset to default configuration
+            allowed_policies = ["Always", "IfNotPresent", "Never", ""]
             if image_pull_policy not in allowed_policies:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"Image pull policy must be one of {allowed_policies}, got {image_pull_policy}"
                 )
             self.spec.image_pull_policy = image_pull_policy
-        if image_pull_secret_name:
+        if image_pull_secret_name is not None:
             self.spec.image_pull_secret = image_pull_secret_name
 
     def with_limits(

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -482,6 +482,16 @@ def my_func(context):
         self.execute_function(runtime, runspec=task)
         self._assert_pod_creation_config(expected_labels=labels)
 
+    def test_with_image_pull_configuration(self, db: Session, client: TestClient):
+        runtime = self._generate_runtime()
+        policy = "IfNotPresent"
+        secret = "some_secret"
+        runtime.with_image_pull_configuration(image_pull_policy=policy, image_pull_secret_name=secret)
+        assert runtime.spec.image_pull_policy == policy and runtime.spec.image_pull_secret == secret
+
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="Image pull policy must be one of"):
+            runtime.with_image_pull_configuration(image_pull_policy="invalidPolicy")
+
     def test_with_requirements(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
         runtime.with_requirements(self.requirements_file)

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -486,11 +486,19 @@ def my_func(context):
         runtime = self._generate_runtime()
         policy = "IfNotPresent"
         secret = "some_secret"
-        runtime.with_image_pull_configuration(image_pull_policy=policy, image_pull_secret_name=secret)
-        assert runtime.spec.image_pull_policy == policy and runtime.spec.image_pull_secret == secret
+        runtime.set_image_pull_configuration(
+            image_pull_policy=policy, image_pull_secret_name=secret
+        )
+        assert (
+            runtime.spec.image_pull_policy == policy
+            and runtime.spec.image_pull_secret == secret
+        )
 
-        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="Image pull policy must be one of"):
-            runtime.with_image_pull_configuration(image_pull_policy="invalidPolicy")
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="Image pull policy must be one of",
+        ):
+            runtime.set_image_pull_configuration(image_pull_policy="invalidPolicy")
 
     def test_with_requirements(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()


### PR DESCRIPTION
Added an sdk - `set_image_pull_configuration` to modify `func.spec.image_pull_secret` and `func.spec.image_pull_policy`, instead of directly accessing these values through the spec.

[ML-3204](https://jira.iguazeng.com/browse/ML-3204)