### PR TITLE
[Iguazio] Add async client

### DIFF
--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -26,15 +26,19 @@ import mlrun.api.utils.clients.iguazio
 
 
 def get_db_session() -> typing.Generator[Session, None, None]:
+    db_session = None
     try:
         db_session = mlrun.api.db.session.create_session()
         yield db_session
     finally:
-        mlrun.api.db.session.close_session(db_session)
+        if db_session:
+            mlrun.api.db.session.close_session(db_session)
 
 
-def authenticate_request(request: Request) -> mlrun.api.schemas.AuthInfo:
-    return mlrun.api.utils.auth.verifier.AuthVerifier().authenticate_request(request)
+async def authenticate_request(request: Request) -> mlrun.api.schemas.AuthInfo:
+    return await mlrun.api.utils.auth.verifier.AuthVerifier().authenticate_request(
+        request
+    )
 
 
 def verify_api_state(request: Request):

--- a/mlrun/api/api/endpoints/grafana_proxy.py
+++ b/mlrun/api/api/endpoints/grafana_proxy.py
@@ -20,8 +20,8 @@ from typing import Any, Dict, List, Optional, Set, Union
 import numpy as np
 import pandas as pd
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
-from starlette.concurrency import run_in_threadpool
 
 import mlrun.api.crud
 import mlrun.api.schemas

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -337,6 +337,9 @@ class Client(
 
     @property
     def is_sync(self):
+        """
+        False because client is synchronous
+        """
         return True
 
     def _find_latest_updated_at(
@@ -712,9 +715,21 @@ class AsyncClient(Client):
 
     @property
     def is_sync(self):
+        """
+        False because client is asynchronous
+        """
         return False
 
     def __getattribute__(self, name):
+        """
+        This method is called when trying to access an attribute of the class.
+        We override it to make sure that all *public* methods that are not async will be run in a thread pool.
+          by convention/norm - public methods are methods that don't start with an underscore.
+          If the method name starts with an underscore - it's a private method that was called from a public method,
+          which means that it's already running in a thread pool or runs asynchronously.
+        If the method is async, we don't do anything and let the async machinery handle it.
+
+        """
         attr = super().__getattribute__(name)
         if name.startswith("_") or not callable(attr):
             return attr

--- a/tests/api/api/test_frontend_spec.py
+++ b/tests/api/api/test_frontend_spec.py
@@ -109,8 +109,8 @@ def test_get_frontend_spec_jobs_dashboard_url_resolution(
 
     # no grafana (None returned) so no url
     mlrun.mlconf.httpdb.authentication.mode = "iguazio"
-    mlrun.api.utils.clients.iguazio.Client().verify_request_session = (
-        unittest.mock.Mock(
+    mlrun.api.utils.clients.iguazio.AsyncClient().verify_request_session = (
+        unittest.mock.AsyncMock(
             return_value=(
                 mlrun.api.schemas.AuthInfo(
                     username=None,

--- a/tests/api/api/test_grafana_proxy.py
+++ b/tests/api/api/test_grafana_proxy.py
@@ -57,8 +57,8 @@ def test_grafana_proxy_model_endpoints_check_connection(
     db: Session, client: TestClient
 ):
     mlrun.mlconf.httpdb.authentication.mode = "iguazio"
-    mlrun.api.utils.clients.iguazio.Client().verify_request_session = (
-        unittest.mock.Mock(
+    mlrun.api.utils.clients.iguazio.AsyncClient().verify_request_session = (
+        unittest.mock.AsyncMock(
             return_value=(
                 mlrun.api.schemas.AuthInfo(
                     username=None,

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -94,7 +94,7 @@ def pod_create_mock():
         mlrun.api.utils.auth.verifier.AuthVerifier().authenticate_request
     )
     mlrun.api.utils.auth.verifier.AuthVerifier().authenticate_request = (
-        unittest.mock.Mock(return_value=auth_info_mock)
+        unittest.mock.AsyncMock(return_value=auth_info_mock)
     )
 
     yield get_k8s().create_pod

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -336,12 +336,14 @@ def test_submit_job_with_hyper_params_file(
         function, project_name, with_output_path=False
     )
 
+    async def auth_info_mock(*args, **kwargs):
+        return mlrun.api.schemas.AuthInfo(username="user", data_session=access_key)
+
     # Create test-specific mocks
-    auth_info = mlrun.api.schemas.AuthInfo(username="user", data_session=access_key)
     monkeypatch.setattr(
         mlrun.api.utils.auth.verifier.AuthVerifier(),
         "authenticate_request",
-        lambda *args, **kwargs: auth_info,
+        auth_info_mock,
     )
     project_secrets = {"SECRET1": "VALUE1"}
     k8s_secrets_mock.store_project_secrets(project_name, project_secrets)

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import datetime
 import functools
 import http
@@ -23,11 +24,20 @@ import fastapi
 import pytest
 import requests_mock as requests_mock_package
 import starlette.datastructures
+from aioresponses import CallbackResult
+from aioresponses import aioresponses as aioresponses_
+from requests.cookies import cookiejar_from_dict
 
 import mlrun.api.schemas
 import mlrun.api.utils.clients.iguazio
 import mlrun.config
 import mlrun.errors
+
+
+@pytest.fixture
+def aioresponses():
+    with aioresponses_() as aior:
+        yield aior
 
 
 @pytest.fixture()
@@ -40,19 +50,66 @@ async def api_url() -> str:
 @pytest.fixture()
 async def iguazio_client(
     api_url: str,
+    request,
 ) -> mlrun.api.utils.clients.iguazio.Client:
-    client = mlrun.api.utils.clients.iguazio.Client()
+
+    if request.param == "async":
+        client = mlrun.api.utils.clients.iguazio.AsyncClient()
+    else:
+        client = mlrun.api.utils.clients.iguazio.Client()
+
     # force running init again so the configured api url will be used
     client.__init__()
     client._wait_for_job_completion_retry_interval = 0
     client._wait_for_project_terminal_state_retry_interval = 0
+
+    # inject the request param into client, so we can use it in tests
+    setattr(client, "mode", request.param)
     return client
 
 
-def test_verify_request_session_success(
+def patch_restful_request(
+    is_client_sync: bool,
+    requests_mock: requests_mock_package.Mocker,
+    aioresponses: aioresponses_,
+    method: str,
+    url: str,
+    callback: typing.Optional[typing.Callable] = None,
+    status_code: typing.Optional[int] = None,
+):
+    """
+    Consolidating the requests_mock / aioresponses library to mock a RESTful request.
+    """
+    kwargs = {}
+    if is_client_sync:
+        if callback:
+            kwargs["json"] = callback
+        if status_code:
+            kwargs["status_code"] = status_code
+        requests_mock.request(
+            method,
+            url,
+            **kwargs,
+        )
+    else:
+        if callback:
+            kwargs["callback"] = callback
+        if status_code:
+            kwargs["status"] = status_code
+        aioresponses.add(
+            url,
+            method,
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_verify_request_session_success(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
+    aioresponses: aioresponses,
 ):
     mock_request_headers = starlette.datastructures.Headers(
         {"cookie": "session=some-session-cookie"}
@@ -62,17 +119,23 @@ def test_verify_request_session_success(
 
     mock_response_headers = _generate_session_verification_response_headers()
 
-    def _verify_session_mock(request, context):
+    def _verify_session_mock(*args, **kwargs):
+        response = {}
+        if iguazio_client.is_sync:
+            request, context = args
+            request_headers = request.headers
+            context.headers = mock_response_headers
+        else:
+            request_headers = kwargs["headers"]
         for header_key, header_value in mock_request_headers.items():
-            assert request.headers[header_key] == header_value
-        context.headers = mock_response_headers
-        return {}
+            assert request_headers[header_key] == header_value
+        if iguazio_client.is_sync:
+            return response
+        else:
+            return CallbackResult(headers=mock_response_headers)
 
-    def _verify_session_with_body_mock(request, context):
-        for header_key, header_value in mock_request_headers.items():
-            assert request.headers[header_key] == header_value
-        context.headers = mock_response_headers
-        return {
+    def _verify_session_with_body_mock(*args, **kwargs):
+        response = {
             "data": {
                 "attributes": {
                     "username": "some-user",
@@ -84,12 +147,26 @@ def test_verify_request_session_success(
                                 "some-group-id-1,some-group-id-2",
                             ],
                             "mode": "normal",
-                        }
+                        },
                     },
-                }
-            }
+                },
+            },
         }
+        if iguazio_client.is_sync:
+            request, context = args
+            request_headers = request.headers
+            context.headers = mock_response_headers
+        else:
+            request_headers = kwargs["headers"]
+        for header_key, header_value in mock_request_headers.items():
+            assert request_headers[header_key] == header_value
 
+        if iguazio_client.is_sync:
+            return response
+        else:
+            return CallbackResult(payload=response, headers=mock_response_headers)
+
+    url = f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}"
     for test_case in [
         {
             "response_json": _verify_session_mock,
@@ -98,56 +175,90 @@ def test_verify_request_session_success(
             "response_json": _verify_session_with_body_mock,
         },
     ]:
-        requests_mock.post(
-            f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}",
-            json=test_case["response_json"],
+        patch_restful_request(
+            iguazio_client.is_sync,
+            requests_mock,
+            aioresponses,
+            method="POST",
+            url=url,
+            callback=test_case["response_json"],
         )
-        auth_info = iguazio_client.verify_request_session(mock_request)
+
+        auth_info = await maybe_coroutine(
+            iguazio_client.verify_request_session(mock_request)
+        )
         _assert_auth_info_from_session_verification_mock_response_headers(
             auth_info, mock_response_headers
         )
 
 
-def test_verify_request_session_failure(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_verify_request_session_failure(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
+    aioresponses: aioresponses,
 ):
     mock_request = fastapi.Request({"type": "http"})
     mock_request._headers = starlette.datastructures.Headers()
-
-    requests_mock.post(
-        f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}",
+    url = f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}"
+    patch_restful_request(
+        iguazio_client.is_sync,
+        requests_mock,
+        aioresponses,
+        method="POST",
+        url=url,
         status_code=http.HTTPStatus.UNAUTHORIZED.value,
     )
-    with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
-        iguazio_client.verify_request_session(mock_request)
+    with pytest.raises(mlrun.errors.MLRunUnauthorizedError) as exc:
+        await maybe_coroutine(iguazio_client.verify_request_session(mock_request))
+        assert exc.value.status_code == http.HTTPStatus.UNAUTHORIZED.value
 
 
-def test_verify_session_success(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_verify_session_success(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
+    aioresponses: aioresponses,
 ):
     session = "some-session"
     mock_response_headers = _generate_session_verification_response_headers()
 
-    def _verify_session_mock(request, context):
-        _verify_request_cookie(request.headers, session)
-        context.headers = mock_response_headers
-        return {}
+    def _verify_session_mock(*args, **kwargs):
+        if iguazio_client.is_sync:
+            request, context = args
+            _verify_request_cookie(request.headers, session)
+            context.headers = mock_response_headers
+        else:
+            _verify_request_cookie(kwargs, session)
 
-    requests_mock.post(
-        f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}",
-        json=_verify_session_mock,
+        return (
+            {}
+            if iguazio_client.is_sync
+            else CallbackResult(headers=mock_response_headers)
+        )
+
+    url = f"{api_url}/api/{mlrun.mlconf.httpdb.authentication.iguazio.session_verification_endpoint}"
+    patch_restful_request(
+        iguazio_client.is_sync,
+        requests_mock,
+        aioresponses,
+        method="POST",
+        url=url,
+        callback=_verify_session_mock,
     )
-    auth_info = iguazio_client.verify_session(session)
+    auth_info = await maybe_coroutine(iguazio_client.verify_session(session))
     _assert_auth_info_from_session_verification_mock_response_headers(
         auth_info, mock_response_headers
     )
 
 
-def test_get_grafana_service_url_success(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_get_grafana_service_url_success(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -167,11 +278,15 @@ def test_get_grafana_service_url_success(
     }
     response_body = _generate_app_services_manifests_body([grafana_service])
     requests_mock.get(f"{api_url}/api/app_services_manifests", json=response_body)
-    grafana_url = iguazio_client.try_get_grafana_service_url("session-cookie")
+    grafana_url = await maybe_coroutine(
+        iguazio_client.try_get_grafana_service_url("session-cookie")
+    )
     assert grafana_url == expected_grafana_url
 
 
-def test_get_grafana_service_url_ignoring_disabled_service(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_get_grafana_service_url_ignoring_disabled_service(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -179,22 +294,30 @@ def test_get_grafana_service_url_ignoring_disabled_service(
     grafana_service = {"spec": {"kind": "grafana"}, "status": {"state": "disabled"}}
     response_body = _generate_app_services_manifests_body([grafana_service])
     requests_mock.get(f"{api_url}/api/app_services_manifests", json=response_body)
-    grafana_url = iguazio_client.try_get_grafana_service_url("session-cookie")
+    grafana_url = await maybe_coroutine(
+        iguazio_client.try_get_grafana_service_url("session-cookie")
+    )
     assert grafana_url is None
 
 
-def test_get_grafana_service_url_no_grafana_exists(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_get_grafana_service_url_no_grafana_exists(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
 ):
     response_body = _generate_app_services_manifests_body([])
     requests_mock.get(f"{api_url}/api/app_services_manifests", json=response_body)
-    grafana_url = iguazio_client.try_get_grafana_service_url("session-cookie")
+    grafana_url = await maybe_coroutine(
+        iguazio_client.try_get_grafana_service_url("session-cookie")
+    )
     assert grafana_url is None
 
 
-def test_get_grafana_service_url_no_urls(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_get_grafana_service_url_no_urls(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -205,11 +328,15 @@ def test_get_grafana_service_url_no_urls(
     }
     response_body = _generate_app_services_manifests_body([grafana_service])
     requests_mock.get(f"{api_url}/api/app_services_manifests", json=response_body)
-    grafana_url = iguazio_client.try_get_grafana_service_url("session-cookie")
+    grafana_url = await maybe_coroutine(
+        iguazio_client.try_get_grafana_service_url("session-cookie")
+    )
     assert grafana_url is None
 
 
-def test_get_or_create_access_key_success(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_get_or_create_access_key_success(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -246,7 +373,9 @@ def test_get_or_create_access_key_success(
             _get_or_create_access_key_mock, http.HTTPStatus.CREATED.value
         ),
     )
-    returned_access_key = iguazio_client.get_or_create_access_key(session, planes)
+    returned_access_key = await maybe_coroutine(
+        iguazio_client.get_or_create_access_key(session, planes)
+    )
     assert access_key_id == returned_access_key
 
     # mock get
@@ -256,11 +385,15 @@ def test_get_or_create_access_key_success(
             _get_or_create_access_key_mock, http.HTTPStatus.OK.value
         ),
     )
-    returned_access_key = iguazio_client.get_or_create_access_key(session, planes)
+    returned_access_key = await maybe_coroutine(
+        iguazio_client.get_or_create_access_key(session, planes)
+    )
     assert access_key_id == returned_access_key
 
 
-def test_get_project_owner(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_get_project_owner(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -288,15 +421,19 @@ def test_get_project_owner(
         f"{api_url}/api/projects/__name__/{project.metadata.name}",
         json=verify_get,
     )
-    project_owner = iguazio_client.get_project_owner(
-        session,
-        project.metadata.name,
+    project_owner = await maybe_coroutine(
+        iguazio_client.get_project_owner(
+            session,
+            project.metadata.name,
+        )
     )
     assert project_owner.username == owner_username
     assert project_owner.access_key == owner_access_key
 
 
-def test_list_project_with_updated_after(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_list_project_with_updated_after(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -326,13 +463,17 @@ def test_list_project_with_updated_after(
         f"{api_url}/api/projects",
         json=verify_list,
     )
-    iguazio_client.list_projects(
-        session,
-        updated_after,
+    await maybe_coroutine(
+        iguazio_client.list_projects(
+            session,
+            updated_after,
+        )
     )
 
 
-def test_list_project(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_list_project(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -370,7 +511,9 @@ def test_list_project(
         ]
     }
     requests_mock.get(f"{api_url}/api/projects", json=response_body)
-    projects, latest_updated_at = iguazio_client.list_projects(None)
+    projects, latest_updated_at = await maybe_coroutine(
+        iguazio_client.list_projects(None)
+    )
     for index, project in enumerate(projects):
         assert project.metadata.name == mock_projects[index]["name"]
         assert project.spec.description == mock_projects[index].get("description")
@@ -397,16 +540,20 @@ def test_list_project(
     )
 
 
-def test_create_project(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_create_project(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
 ):
     project = _generate_project()
-    _create_project_and_assert(api_url, iguazio_client, requests_mock, project)
+    await _create_project_and_assert(api_url, iguazio_client, requests_mock, project)
 
 
-def test_create_project_failures(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_create_project_failures(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -436,9 +583,11 @@ def test_create_project_failures(
     with pytest.raises(
         mlrun.errors.MLRunBadRequestError, match=rf"(.*){error_message}(.*)"
     ):
-        iguazio_client.create_project(
-            session,
-            project,
+        await maybe_coroutine(
+            iguazio_client.create_project(
+                session,
+                project,
+            )
         )
 
     # mock job failure - with nice error message in result
@@ -466,9 +615,11 @@ def test_create_project_failures(
     with pytest.raises(
         mlrun.errors.MLRunBadRequestError, match=rf"(.*){error_message}(.*)"
     ):
-        iguazio_client.create_project(
-            session,
-            project,
+        await maybe_coroutine(
+            iguazio_client.create_project(
+                session,
+                project,
+            )
         )
 
     # mock job failure - without nice error message (shouldn't happen, but let's test)
@@ -481,13 +632,17 @@ def test_create_project_failures(
     )
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError):
-        iguazio_client.create_project(
-            session,
-            project,
+        await maybe_coroutine(
+            iguazio_client.create_project(
+                session,
+                project,
+            )
         )
 
 
-def test_create_project_minimal_project(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_create_project_minimal_project(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -497,10 +652,12 @@ def test_create_project_minimal_project(
             name="some-name",
         ),
     )
-    _create_project_and_assert(api_url, iguazio_client, requests_mock, project)
+    await _create_project_and_assert(api_url, iguazio_client, requests_mock, project)
 
 
-def test_create_project_without_wait(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_create_project_without_wait(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -515,13 +672,15 @@ def test_create_project_without_wait(
             _verify_creation, iguazio_client, project, session, job_id
         ),
     )
-    is_running_in_background = iguazio_client.create_project(
-        session, project, wait_for_completion=False
+    is_running_in_background = await maybe_coroutine(
+        iguazio_client.create_project(session, project, wait_for_completion=False)
     )
     assert is_running_in_background is True
 
 
-def test_update_project(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_update_project(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -539,14 +698,18 @@ def test_update_project(
         f"{api_url}/api/projects/__name__/{project.metadata.name}",
         json=verify_store_update,
     )
-    iguazio_client.update_project(
-        session,
-        project.metadata.name,
-        project,
+    await maybe_coroutine(
+        iguazio_client.update_project(
+            session,
+            project.metadata.name,
+            project,
+        )
     )
 
 
-def test_update_project_remove_labels_and_annotations(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_update_project_remove_labels_and_annotations(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -582,19 +745,25 @@ def test_update_project_remove_labels_and_annotations(
         json=verify_no_labels_and_annotations_in_request,
     )
 
-    iguazio_client.update_project(
-        session,
-        project.metadata.name,
-        project,
+    await maybe_coroutine(
+        iguazio_client.update_project(
+            session,
+            project.metadata.name,
+            project,
+        )
     )
-    iguazio_client.update_project(
-        session,
-        project_without_labels.metadata.name,
-        project_without_labels,
+    await maybe_coroutine(
+        iguazio_client.update_project(
+            session,
+            project_without_labels.metadata.name,
+            project_without_labels,
+        )
     )
 
 
-def test_delete_project(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_delete_project(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -610,7 +779,9 @@ def test_delete_project(
     mocker, num_of_calls_until_completion = _mock_job_progress(
         api_url, requests_mock, session, job_id
     )
-    is_running_in_background = iguazio_client.delete_project(session, project_name)
+    is_running_in_background = await maybe_coroutine(
+        iguazio_client.delete_project(session, project_name)
+    )
     assert is_running_in_background is False
     assert mocker.call_count == num_of_calls_until_completion
 
@@ -618,7 +789,7 @@ def test_delete_project(
     requests_mock.delete(
         f"{api_url}/api/projects", status_code=http.HTTPStatus.NOT_FOUND.value
     )
-    iguazio_client.delete_project(session, project_name)
+    await maybe_coroutine(iguazio_client.delete_project(session, project_name))
 
     # TODO: not sure really needed
     # assert correctly propagating 412 errors (will be returned when project has resources)
@@ -626,10 +797,12 @@ def test_delete_project(
         f"{api_url}/api/projects", status_code=http.HTTPStatus.PRECONDITION_FAILED.value
     )
     with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
-        iguazio_client.delete_project(session, project_name)
+        await maybe_coroutine(iguazio_client.delete_project(session, project_name))
 
 
-def test_delete_project_without_wait(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_delete_project_without_wait(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -642,18 +815,22 @@ def test_delete_project_without_wait(
         f"{api_url}/api/projects",
         json=functools.partial(_verify_deletion, project_name, session, job_id),
     )
-    is_running_in_background = iguazio_client.delete_project(
-        session, project_name, wait_for_completion=False
+    is_running_in_background = await maybe_coroutine(
+        iguazio_client.delete_project(session, project_name, wait_for_completion=False)
     )
     assert is_running_in_background is True
 
 
-def test_format_as_leader_project(
+@pytest.mark.parametrize("iguazio_client", ("async", "sync"), indirect=True)
+@pytest.mark.asyncio
+async def test_format_as_leader_project(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
 ):
     project = _generate_project()
-    iguazio_project = iguazio_client.format_as_leader_project(project)
+    iguazio_project = await maybe_coroutine(
+        iguazio_client.format_as_leader_project(project)
+    )
     assert (
         deepdiff.DeepDiff(
             _build_project_response(iguazio_client, project),
@@ -713,7 +890,7 @@ def _assert_auth_info(
     assert auth_info.data_session == data_session
 
 
-def _create_project_and_assert(
+async def _create_project_and_assert(
     api_url: str,
     iguazio_client: mlrun.api.utils.clients.iguazio.Client,
     requests_mock: requests_mock_package.Mocker,
@@ -735,9 +912,11 @@ def _create_project_and_assert(
         f"{api_url}/api/projects/__name__/{project.metadata.name}",
         json={"data": _build_project_response(iguazio_client, project)},
     )
-    is_running_in_background = iguazio_client.create_project(
-        session,
-        project,
+    is_running_in_background = await maybe_coroutine(
+        iguazio_client.create_project(
+            session,
+            project,
+        )
     )
     assert is_running_in_background is False
     assert mocker.call_count == num_of_calls_until_completion
@@ -766,7 +945,24 @@ def _verify_creation(iguazio_client, project, session, job_id, request, context)
 
 
 def _verify_request_cookie(headers: dict, session: str):
-    assert headers["Cookie"] == f'session=j:{{"sid": "{session}"}}'
+    expected_session_value = f'session=j:{{"sid": "{session}"}}'
+    if "Cookie" in headers:
+        assert headers["Cookie"] == expected_session_value
+    elif "cookies" in headers:
+
+        # in async client we get the `cookies` key while it contains the cookies in form of a dict
+        # use requests to construct it back to a string as expected above
+        cookie = "; ".join(
+            list(
+                map(
+                    lambda x: f"{x[0]}={x[1]}",
+                    cookiejar_from_dict(headers["cookies"]).items(),
+                )
+            )
+        )
+        assert cookie == expected_session_value
+    else:
+        raise AssertionError("No cookie found in headers")
 
 
 def _verify_project_request_headers(headers: dict, session: str):
@@ -943,3 +1139,9 @@ def _assert_project_creation(
 
 def _generate_app_services_manifests_body(app_services):
     return {"data": [{"attributes": {"app_services": app_services}}]}
+
+
+async def maybe_coroutine(o):
+    if asyncio.iscoroutine(o):
+        return await o
+    return o


### PR DESCRIPTION
Introducing iguazio async  http client. currently, it inherits the sync client, which means, all *public* methods the sync client will be run under async http client inside an awaitable thread. coroutine functions that async expose will be run natively on the event loop.
In this PR, I have added support for both `verify_request_session` and `verify_session` which effectively make sure the session verification dependency for our api endpoints would be 100% asynchronous.

The changes I've made to the `test_iguazio.py` are such that
- I test all functions for both async and sync iguazio http clients. 
- for `verify_request_session` and `verify_session` I do check for aiohttp response + request response
- I tried to consolidate as much as possible between two requests/aioresponses mockers