### PR TITLE
[Scheduler] Fix transient unit test failures take 2

### DIFF
--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -53,8 +53,6 @@ async def scheduler(db: Session) -> typing.Generator:
     yield scheduler
     logger.info("Stopping scheduler")
     await scheduler.stop()
-    logger.debug("Deleting default project resources")
-    get_db().delete_project_related_resources(db, config.default_project)
 
 
 call_counter: int = 0

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1313,9 +1313,14 @@ async def test_schedule_job_next_run_time(
         concurrency_limit=1,
     )
 
-    await asyncio.sleep(1)
-    runs = get_db().list_runs(db, project=project_name)
-    assert len(runs) == 1
+    while datetime.now() < now_plus_4_seconds:
+        runs = get_db().list_runs(db, project=project_name)
+        if len(runs) == 1:
+            break
+
+        await asyncio.sleep(0.5)
+    else:
+        assert False, "No runs were created"
 
     # invoke schedule should fail due to concurrency limit
     # the next run time should be updated to the next second after the invocation failure

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -53,6 +53,8 @@ async def scheduler(db: Session) -> typing.Generator:
     yield scheduler
     logger.info("Stopping scheduler")
     await scheduler.stop()
+    logger.debug("Deleting default project resources")
+    get_db().delete_project_related_resources(db, config.default_project)
 
 
 call_counter: int = 0


### PR DESCRIPTION
wait until the run is created instead of checking once