### PR TITLE
[FeatureStore] Fix pandas-engine passthrough-fset handling and deduplicte to prevent frames from out-of-order writes to online target

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1130,8 +1130,9 @@ class NoSqlBaseTarget(BaseStoreTarget):
             df = self.prepare_spark_df(df)
             df.write.mode("overwrite").save(**options)
         else:
-            # To prevent modification of the original dataframe
-            df = df.copy(deep=False)
+            # To prevent modification of the original dataframe and make sure
+            # that the last event of a key is the one being persisted
+            df = df.groupby(df.index).last()
             access_key = self._secrets.get(
                 "V3IO_ACCESS_KEY", os.getenv("V3IO_ACCESS_KEY")
             )

--- a/mlrun/feature_store/ingestion.py
+++ b/mlrun/feature_store/ingestion.py
@@ -92,6 +92,8 @@ def init_featureset_graph(
     data_result = None
     total_rows = 0
     targets = [get_target_driver(target, featureset) for target in targets]
+    if featureset.spec.passthrough:
+        targets = [target for target in targets if not target.is_offline]
     for chunk in chunks:
         event = MockEvent(body=chunk)
         if featureset.spec.entities[0] and isinstance(event.body, pd.DataFrame):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -914,7 +914,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         expected = source.to_dataframe().set_index("patient_id")
 
-        if engine != "pandas":  # pandas engine does not support preview
+        if engine != "pandas":  # pandas engine does not support preview (ML-2694)
             preview_pd = fstore.preview(
                 measurements_set,
                 source=source,
@@ -940,8 +940,6 @@ class TestFeatureStore(TestMLRunSystem):
         assert_frame_equal(expected, get_offline_pd, check_like=True, check_dtype=False)
 
         # assert get_online correctness
-        if engine == "pandas":
-            return  # TBD ML-3251 - investigate pandas get_online response
         with fstore.get_online_feature_service(vector) as svc:
             resp = svc.get([{"patient_id": "305-90-1613"}])
             assert resp == [

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -895,11 +895,16 @@ class TestFeatureStore(TestMLRunSystem):
         orig_columns.remove("patient_id")
         assert result_columns.sort() == orig_columns.sort()
 
-    def test_passthrough_feature_set(self):
+    @pytest.mark.parametrize("engine", ["storey", "pandas"])
+    def test_passthrough_feature_set(self, engine):
         name = f"measurements_set_{uuid.uuid4()}"
         key = "patient_id"
         measurements_set = fstore.FeatureSet(
-            name, entities=[Entity(key)], timestamp_key="timestamp", passthrough=True
+            name,
+            entities=[Entity(key)],
+            timestamp_key="timestamp",
+            passthrough=True,
+            engine=engine,
         )
         source = CSVSource(
             "mycsv",
@@ -907,12 +912,16 @@ class TestFeatureStore(TestMLRunSystem):
             time_field="timestamp",
         )
 
-        preview_pd = fstore.preview(
-            measurements_set,
-            source=source,
-        )
-        # preview does not do set_index on the entity
-        preview_pd.set_index("patient_id", inplace=True)
+        expected = source.to_dataframe().set_index("patient_id")
+
+        if engine != "pandas":  # pandas engine does not support preview
+            preview_pd = fstore.preview(
+                measurements_set,
+                source=source,
+            )
+            # preview does not do set_index on the entity
+            preview_pd.set_index("patient_id", inplace=True)
+            assert_frame_equal(expected, preview_pd, check_like=True, check_dtype=False)
 
         fstore.ingest(measurements_set, source)
 
@@ -928,12 +937,11 @@ class TestFeatureStore(TestMLRunSystem):
         get_offline_pd = resp.to_dataframe()
         get_offline_pd["timestamp"] = pd.to_datetime(get_offline_pd["timestamp"])
 
-        expected = source.to_dataframe().set_index("patient_id")
-
         assert_frame_equal(expected, get_offline_pd, check_like=True, check_dtype=False)
-        assert_frame_equal(expected, preview_pd, check_like=True, check_dtype=False)
 
         # assert get_online correctness
+        if engine == "pandas":
+            return  # TBD ML-3251 - investigate pandas get_online response
         with fstore.get_online_feature_service(vector) as svc:
             resp = svc.get([{"patient_id": "305-90-1613"}])
             assert resp == [


### PR DESCRIPTION
Also fix [ML-3251](https://jira.iguazeng.com/browse/ML-3251) by deduplicating each chunk before sending to frames.