### PR TITLE
[Scheduler] Fix transient test failure take 3

### DIFF
--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1285,9 +1285,11 @@ async def test_schedule_job_next_run_time(
     While the 1st run is still running, manually invoke the schedule (should fail due to concurrency limit)
     and check that the next run time is updated.
     """
-    now_plus_4_seconds = datetime.now() + timedelta(seconds=4)
+    now = datetime.now(timezone.utc)
+    now_plus_1_seconds = now + timedelta(seconds=1)
+    now_plus_5_seconds = now + timedelta(seconds=5)
     cron_trigger = schemas.ScheduleCronTrigger(
-        second="*/1", end_date=now_plus_4_seconds
+        second="*/1", start_date=now_plus_1_seconds, end_date=now_plus_5_seconds
     )
     schedule_name = "schedule-name"
     project_name = config.default_project
@@ -1311,7 +1313,7 @@ async def test_schedule_job_next_run_time(
         concurrency_limit=1,
     )
 
-    while datetime.now() < now_plus_4_seconds:
+    while datetime.now(timezone.utc) < now_plus_5_seconds:
         runs = get_db().list_runs(db, project=project_name)
         if len(runs) == 1:
             break


### PR DESCRIPTION
The failure we saw is that the schedule end date was at second 56.996
The 1st run should have started at 53.0 but it took more than 0.004 seconds to create the schedule :( so the run started at the next second (54) and CI is slow :( the function took more than 2 seconds to complete and the 2 run that should have started at 56 was skipped and the schedule ends before second 57.
So if we start the schedule with +1 second start time, it should not skip the 1st second.