### PR TITLE
[Tags] Allow artifact tags to contain underscore 

### DIFF
--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -73,6 +73,6 @@ project_name = dns_1123_label
 
 # Special characters are not permitted in tag names because they can be included in the url and cause problems.
 # We only accept letters, capital letters, numbers, dots, and hyphens, with a k8s character limit.
-tag_name = k8s_character_limit + [r"^(([A-Za-z0-9][-A-Za-z0-9.]*)?[A-Za-z0-9])?$"]
+tag_name = label_value
 
 secret_key = k8s_secret_and_config_map_key

--- a/tests/api/api/test_tags.py
+++ b/tests/api/api/test_tags.py
@@ -249,7 +249,7 @@ class TestArtifactTags:
         """
 
         self._create_project(client)
-        valid_tag_name = "valid-tag"
+        valid_tag_name = "valid_tag"
         invalid_tag_name = "tag$%^#"
         artifact1_labels = {"artifact_name": "artifact1"}
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -223,10 +223,6 @@ def test_get_regex_list_as_string(regex_list, value, expected_str, expected):
     "tag_name,expected",
     [
         (
-            "tag_name",
-            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
-        ),
-        (
             "tag_with_char!@#",
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
@@ -245,6 +241,7 @@ def test_get_regex_list_as_string(regex_list, value, expected_str, expected):
         ("tagname2.0", does_not_raise()),
         ("tag-name", does_not_raise()),
         ("tag-NAME", does_not_raise()),
+        ("tag_name", does_not_raise()),
     ],
 )
 def test_validate_tag_name(tag_name, expected):


### PR DESCRIPTION
fix for: https://jira.iguazeng.com/browse/ML-2829

We discovered that underscore is permitted in k8, so we'd like to support it as well. Reverting the changes that prevent it in the SDK.