### PR TITLE
[Feature Store] Fix `Imputer`'s `None` types check

### DIFF
--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -272,12 +272,12 @@ class Imputer(StepToDict, MLRunStep):
         :param kwargs:        optional kwargs (for storey)
         """
         super().__init__(**kwargs)
-        self.mapping = mapping
+        self.mapping = mapping or {}
         self.method = method
         self.default_value = default_value
 
     def _impute(self, feature: str, value):
-        if value is None:
+        if pd.isna(value):
             return self.mapping.get(feature, self.default_value)
         return value
 

--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -276,7 +276,7 @@ class Imputer(StepToDict, MLRunStep):
         self.method = method
         self.default_value = default_value
 
-    def _impute(self, feature: str, value):
+    def _impute(self, feature: str, value: Any):
         if pd.isna(value):
             return self.mapping.get(feature, self.default_value)
         return value

--- a/tests/feature-store/test_steps.py
+++ b/tests/feature-store/test_steps.py
@@ -647,7 +647,6 @@ def test_imputer_default_value(rundb_mock, engine):
         source=data_with_nones,
         targets=[ParquetTarget(path=f"{output_path.name}/temp.parquet")],
     )
-    print(imputed_df)
 
     # Checking that the ingested dataframe is none-free:
     assert not imputed_df.isnull().values.any()

--- a/tests/feature-store/test_steps.py
+++ b/tests/feature-store/test_steps.py
@@ -617,7 +617,8 @@ def test_pandas_step_drop_feature(rundb_mock, entities, set_index_before):
     )
 
 
-def test_imputer_default_value(rundb_mock):
+@pytest.mark.parametrize("engine", ["storey", "pandas"])
+def test_imputer_default_value(rundb_mock, engine):
     data_with_nones = pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
@@ -630,6 +631,7 @@ def test_imputer_default_value(rundb_mock):
         "fs-default-value",
         entities=["id"],
         description="feature set with nones",
+        engine=engine,
     )
     feature_set.graph.to(Imputer(default_value=1))
 


### PR DESCRIPTION
Up to now, the `Imputer` did not replace none types such as `np.nan`, `pd.NA`, `pd.NaT` with the default value, only simple `None` was take into consideration.
[ML-3258](https://jira.iguazeng.com/browse/ML-3258)