### PR TITLE
[Chief] Fix double quoting cookies

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -131,6 +131,7 @@ async def log_request_response(request: fastapi.Request, call_next):
     ):
         logger.debug(
             "Received request",
+            headers=request.headers,
             method=request.method,
             client_address=get_client_address(request.scope),
             http_version=request.scope["http_version"],
@@ -143,7 +144,7 @@ async def log_request_response(request: fastapi.Request, call_next):
         logger.warning(
             "Request handling failed. Sending response",
             # User middleware (like this one) runs after the exception handling middleware, the only thing running after
-            # it is Starletter's ServerErrorMiddleware which is responsible for catching any un-handled exception
+            # it is starletter's ServerErrorMiddleware which is responsible for catching any un-handled exception
             # and transforming it to 500 response. therefore we can statically assign status code to 500
             status_code=500,
             request_id=request_id,
@@ -154,7 +155,7 @@ async def log_request_response(request: fastapi.Request, call_next):
         )
         raise
     else:
-        # convert from nano seconds to milliseconds
+        # convert from nanoseconds to milliseconds
         elapsed_time_in_ms = (time.perf_counter_ns() - start_time) / 1000 / 1000
         if not any(
             silent_logging_path in path_with_query_string
@@ -167,6 +168,7 @@ async def log_request_response(request: fastapi.Request, call_next):
                 elapsed_time=elapsed_time_in_ms,
                 uri=path_with_query_string,
                 method=request.method,
+                headers=response.headers,
             )
         return response
 

--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -126,7 +126,7 @@ class _CustomRequestContext(_RequestContext):
         while True:
             current_attempt += 1
             response = None
-            params = None
+            params: typing.Optional[RequestParams] = None
             try:
                 try:
                     params = self._params_list[current_attempt - 1]


### PR DESCRIPTION
It is observed that when requests are being proxied from worker to chief, aiohttp quote the cookies (https://github.com/aio-libs/aiohttp/issues/2571) in a way that iguazio be cannot understand the value of the cookie. since the cookie includes special characters (such as double quotes), the actual request that goes to the chief includes malformed value.
to avoid such scenario, the client will first quote (url quoting) the content and by that, will protect the value from being escaped by quotes (e.g.: `"` -> `"\""`).

In addition, added few information when request / failure is being log as a result of debugging this issue.

Internal - https://jira.iguazeng.com/browse/ML-3252
