### PR TITLE
[Chief] Follow up fix for session escaping

### DIFF
--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -232,7 +232,9 @@ class Client(
             elif cookie_name == "session" and mlrun.mlconf.is_running_on_iguazio():
 
                 # unquote first, to avoid double quoting ourselves, in case the cookie is already quoted
-                unquoted_session = urllib.parse.unquote(request_kwargs["cookies"][cookie_name])
+                unquoted_session = urllib.parse.unquote(
+                    request_kwargs["cookies"][cookie_name]
+                )
                 request_kwargs["cookies"][cookie_name] = urllib.parse.quote(
                     unquoted_session
                 )

--- a/mlrun/api/utils/clients/chief.py
+++ b/mlrun/api/utils/clients/chief.py
@@ -230,8 +230,11 @@ class Client(
             # we will url-encode them (aka quote), so the value would be safe against such escaping.
             # e.g.: instead of having "x":"y" being escaped to "\"x\":\"y\"", it will be escaped to "%22x%22:%22y%22"
             elif cookie_name == "session" and mlrun.mlconf.is_running_on_iguazio():
+
+                # unquote first, to avoid double quoting ourselves, in case the cookie is already quoted
+                unquoted_session = urllib.parse.unquote(request_kwargs["cookies"][cookie_name])
                 request_kwargs["cookies"][cookie_name] = urllib.parse.quote(
-                    request_kwargs["cookies"][cookie_name]
+                    unquoted_session
                 )
 
         request_kwargs.update(**kwargs)

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -457,7 +457,9 @@ class Client(
                 response_body = response.json()
             except Exception:
                 response_body = {}
-            self._handle_error_response(method, path, response, response_body, error_message, kwargs)
+            self._handle_error_response(
+                method, path, response, response_body, error_message, kwargs
+            )
         return response
 
     def _generate_auth_info_from_session_verification_response(
@@ -690,7 +692,9 @@ class Client(
                 if isinstance(dict_[key], enum.Enum):
                     dict_[key] = dict_[key].value
 
-    def _handle_error_response(self, method, path, response, response_body, error_message, kwargs):
+    def _handle_error_response(
+        self, method, path, response, response_body, error_message, kwargs
+    ):
         log_kwargs = copy.deepcopy(kwargs)
         log_kwargs.update({"method": method, "path": path})
         try:
@@ -699,8 +703,10 @@ class Client(
         except Exception:
             pass
         else:
-            error_message = f"{error_message}: {str(errors)}"
-            log_kwargs.update({"ctx": ctx, "errors": errors})
+            if errors:
+                error_message = f"{error_message}: {str(errors)}"
+            if errors or ctx:
+                log_kwargs.update({"ctx": ctx, "errors": errors})
 
         logger.warning("Request to iguazio failed", **log_kwargs)
         mlrun.errors.raise_for_status(response, error_message)

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -453,7 +453,11 @@ class Client(
         self._prepare_request_kwargs(session, path, kwargs=kwargs)
         response = self._session.request(method, url, verify=False, **kwargs)
         if not response.ok:
-            self._handle_error_response(method, path, response, error_message, kwargs)
+            try:
+                response_body = response.json()
+            except Exception:
+                response_body = {}
+            self._handle_error_response(method, path, response, response_body, error_message, kwargs)
         return response
 
     def _generate_auth_info_from_session_verification_response(
@@ -686,19 +690,18 @@ class Client(
                 if isinstance(dict_[key], enum.Enum):
                     dict_[key] = dict_[key].value
 
-    def _handle_error_response(self, method, path, response, error_message, kwargs):
+    def _handle_error_response(self, method, path, response, response_body, error_message, kwargs):
         log_kwargs = copy.deepcopy(kwargs)
         log_kwargs.update({"method": method, "path": path})
-        if response.content:
-            try:
-                data = response.json()
-                ctx = data.get("meta", {}).get("ctx")
-                errors = data.get("errors", [])
-            except Exception:
-                pass
-            else:
-                error_message = f"{error_message}: {str(errors)}"
-                log_kwargs.update({"ctx": ctx, "errors": errors})
+        try:
+            ctx = response_body.get("meta", {}).get("ctx")
+            errors = response_body.get("errors", [])
+        except Exception:
+            pass
+        else:
+            error_message = f"{error_message}: {str(errors)}"
+            log_kwargs.update({"ctx": ctx, "errors": errors})
+
         logger.warning("Request to iguazio failed", **log_kwargs)
         mlrun.errors.raise_for_status(response, error_message)
 
@@ -787,8 +790,12 @@ class AsyncClient(Client):
                 method, url, verify_ssl=False, **kwargs
             )
             if not response.ok:
+                try:
+                    response_body = await response.json()
+                except Exception:
+                    response_body = {}
                 self._handle_error_response(
-                    method, path, response, error_message, kwargs
+                    method, path, response, response_body, error_message, kwargs
                 )
             yield response
         finally:

--- a/tests/api/utils/clients/test_chief.py
+++ b/tests/api/utils/clients/test_chief.py
@@ -300,8 +300,7 @@ async def test_do_not_escape_cookie(
 
     app = aiohttp.web.Application()
     app.router.add_post("/api/v1/operations/migrations", handler)
-    server = TestServer(app, skip_url_asserts=True)
-    async with TestClient(server) as client:
+    async with TestClient(TestServer(app)) as client:
         chief_client._api_url = ""
         await chief_client._ensure_session()
         chief_client._session._client = client

--- a/tests/api/utils/clients/test_chief.py
+++ b/tests/api/utils/clients/test_chief.py
@@ -20,10 +20,10 @@ import unittest.mock
 import aiohttp
 import aiohttp.web
 import fastapi.encoders
-from aiohttp.test_utils import TestClient, TestServer
-import starlette.datastructures
 import pytest
+import starlette.datastructures
 from aiohttp import ClientConnectorError
+from aiohttp.test_utils import TestClient, TestServer
 
 import mlrun.api.schemas
 import mlrun.api.utils.clients.chief
@@ -270,26 +270,27 @@ def _generate_background_task(
 
 
 @pytest.mark.parametrize(
-    "session_cookie, expected_cookie_header", [
+    "session_cookie, expected_cookie_header",
+    [
         # no escape is needed, sanity
         ("j", "j"),
-
         # escape is needed
-        ("j:{\"", "j%3A%7B%22"),
-
+        ('j:{"', "j%3A%7B%22"),
         # do not double escape
         ("j%3A%7B%22", "j%3A%7B%22"),
-    ]
+    ],
 )
 @pytest.mark.asyncio
-async def test_do_not_escape_cookie(chief_client, session_cookie, expected_cookie_header):
+async def test_do_not_escape_cookie(
+    chief_client, session_cookie, expected_cookie_header
+):
     async def handler(request):
-        assert request.headers["cookie"] == f'session={expected_cookie_header}', (
-            "Cookie header escaping is malfunctioning"
-        )
-        assert request.cookies["session"] == expected_cookie_header, (
-            "Cookie session escaping is malfunctioning"
-        )
+        assert (
+            request.headers["cookie"] == f"session={expected_cookie_header}"
+        ), "Cookie header escaping is malfunctioning"
+        assert (
+            request.cookies["session"] == expected_cookie_header
+        ), "Cookie session escaping is malfunctioning"
         return aiohttp.web.Response(status=200)
 
     mock_request = fastapi.Request({"type": "http"})
@@ -298,7 +299,7 @@ async def test_do_not_escape_cookie(chief_client, session_cookie, expected_cooki
     mock_request._query_params = starlette.datastructures.QueryParams()
 
     app = aiohttp.web.Application()
-    app.router.add_post('/api/v1/operations/migrations', handler)
+    app.router.add_post("/api/v1/operations/migrations", handler)
     server = TestServer(app, skip_url_asserts=True)
     async with TestClient(server) as client:
         chief_client._api_url = ""


### PR DESCRIPTION
Following up https://github.com/mlrun/mlrun/pull/2942 - I have missed the case where the cookie might be already quoted. for such cases, make sure to unquote first (so content would be raw) and then quote. Added UT as well

In addition, fixed the `on request error` flow where it didnt "await" on request body correctly.