### PR TITLE
[Requirements] Freeze `plotly` version

### DIFF
--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -6,7 +6,7 @@ lz4~=3.0
 vaex~=4.0
 yellowbrick~=1.1
 lifelines~=0.25.0
-plotly~=5.4
+plotly~=5.4, <=5.11.0
 pyod~=0.8.1
 pytest~=6.0
 scikit-multiflow~=0.5.3

--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -6,7 +6,7 @@ lz4~=3.0
 vaex~=4.0
 yellowbrick~=1.1
 lifelines~=0.25.0
-plotly~=5.4, <=5.11.0
+plotly~=5.4, <5.12.0
 pyod~=0.8.1
 pytest~=6.0
 scikit-multiflow~=0.5.3

--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -6,6 +6,8 @@ lz4~=3.0
 vaex~=4.0
 yellowbrick~=1.1
 lifelines~=0.25.0
+# plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
+# so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
 plotly~=5.4, <5.12.0
 pyod~=0.8.1
 pytest~=6.0

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -21,6 +21,8 @@ azure-identity~=1.5
 azure-keyvault-secrets~=4.2
 bokeh~=2.4, >=2.4.2
 gcsfs~=2021.8.1
+# plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
+# so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
 plotly~=5.4, <5.12.0
 google-cloud-bigquery[pandas]~=3.2
 kafka-python~=2.0

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -21,7 +21,7 @@ azure-identity~=1.5
 azure-keyvault-secrets~=4.2
 bokeh~=2.4, >=2.4.2
 gcsfs~=2021.8.1
-plotly~=5.4, <=5.11.0
+plotly~=5.4, <5.12.0
 google-cloud-bigquery[pandas]~=3.2
 kafka-python~=2.0
 redis~=4.3

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -21,7 +21,7 @@ azure-identity~=1.5
 azure-keyvault-secrets~=4.2
 bokeh~=2.4, >=2.4.2
 gcsfs~=2021.8.1
-plotly~=5.4
+plotly~=5.4, <=5.11.0
 google-cloud-bigquery[pandas]~=3.2
 kafka-python~=2.0
 redis~=4.3

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ extras_require = {
         # >=2.4.2 to force having a security fix done in 2.4.2
         "bokeh~=2.4, >=2.4.2",
     ],
-    "plotly": ["plotly~=5.4, <=5.11.0"],
+    "plotly": ["plotly~=5.4, <5.12.0"],
     # google-cloud is mainly used for QA, that is why we are not including it in complete
     "google-cloud": [
         # because of kfp 1.8.13 requiring google-cloud-storage<2.0.0, >=1.20.0

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ extras_require = {
         # >=2.4.2 to force having a security fix done in 2.4.2
         "bokeh~=2.4, >=2.4.2",
     ],
-    "plotly": ["plotly~=5.4"],
+    "plotly": ["plotly~=5.4, <=5.11.0"],
     # google-cloud is mainly used for QA, that is why we are not including it in complete
     "google-cloud": [
         # because of kfp 1.8.13 requiring google-cloud-storage<2.0.0, >=1.20.0

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,8 @@ extras_require = {
         # >=2.4.2 to force having a security fix done in 2.4.2
         "bokeh~=2.4, >=2.4.2",
     ],
+    # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
+    # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
     "plotly": ["plotly~=5.4, <5.12.0"],
     # google-cloud is mainly used for QA, that is why we are not including it in complete
     "google-cloud": [

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -130,6 +130,8 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.13, <3.20"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
+        # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
+        # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
         "plotly": {"~=5.4, <5.12.0"},
         # used in tests
         "aioresponses": {"~=0.7"},

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -130,6 +130,7 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.13, <3.20"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
+        "plotly": {"~=5.4, <5.12.0"},
         # used in tests
         "aioresponses": {"~=0.7"},
     }


### PR DESCRIPTION
Due to changes in `plotly==5.12.0` that uses 'latin-1' encoding, we freeze temporarily `plotly`.
This issue affects logging `plotly` artifacts, as you can see here [ML-3255](https://jira.iguazeng.com/browse/ML-3255).
