### PR TITLE
[CI] Fix CI not creating env vars correctly

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -118,14 +118,14 @@ jobs:
     - name: Extract git branch
       id: git_info
       run: |
-        echo "branch=$(echo ${GITHUB_REF#refs/heads/})"
+        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
     - name: Extract git hash from action mlrun version
       # by default when running as part of the CI this param doesn't get enriched meaning it will be empty.
       # we want the mlrun_hash to be set from the $GITHUB_SHA when running in CI
       if: ${{ github.event.inputs.test_code_from_action != 'false' }}
       id: git_action_info
       run: |
-        echo "mlrun_hash=$(git rev-parse --short=8 $GITHUB_SHA)"
+        echo "mlrun_hash=$(git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_OUTPUT
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
@@ -136,7 +136,7 @@ jobs:
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
-          rm -rf mlrun-ui)"
+          rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info
       run: |
@@ -146,42 +146,42 @@ jobs:
           cd mlrun-upstream && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
-          rm -rf mlrun-upstream)"
+          rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
         echo "ui_hash=$( \
           cd /tmp && \
           git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
-          rm -rf mlrun-ui)"
-        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)"
+          rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
+        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
     - name: Set computed versions params
       id: computed_params
       run: |
         action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
         export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
-        echo "mlrun_hash=$(echo $mlrun_hash)"
+        echo "mlrun_hash=$(echo $mlrun_hash)" >> $GITHUB_OUTPUT
         action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
         upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
         export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
-        echo "ui_hash=$(echo $ui_hash)"
-        echo "mlrun_version=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}+$mlrun_hash)"
-        echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)"
-        echo "mlrun_ui_version=${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$ui_hash"
+        echo "ui_hash=$(echo $ui_hash)" >> $GITHUB_OUTPUT
+        echo "mlrun_version=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}+$mlrun_hash)" >> $GITHUB_OUTPUT
+        echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)" >> $GITHUB_OUTPUT
+        echo "mlrun_ui_version=${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$ui_hash" >> $GITHUB_OUTPUT
         echo "mlrun_docker_repo=$( \
           input_docker_repo=${{ github.event.inputs.docker_repo }} && \
-          echo ${input_docker_repo:-mlrun})"
+          echo ${input_docker_repo:-mlrun})" >> $GITHUB_OUTPUT
         echo "mlrun_docker_registry=$( \
           input_docker_registry=${{ github.event.inputs.docker_registry }} && \
-          echo ${input_docker_registry:-ghcr.io/})"
+          echo ${input_docker_registry:-ghcr.io/})" >> $GITHUB_OUTPUT
         echo "mlrun_system_tests_clean_resources=$( \
           input_system_tests_clean_resources=${{ github.event.inputs.clean_resources_in_teardown }} && \
-          echo ${input_system_tests_clean_resources:-true})"
+          echo ${input_system_tests_clean_resources:-true})" >> $GITHUB_OUTPUT
         echo "iguazio_version=$( \
           override_iguazio_version=${{ github.event.inputs.override_iguazio_version }} && \
           iguazio_system_version=`echo "3.4.2-b149.20220705184806"` && \
-          resolved_iguazio_version=${override_iguazio_version:-$iguazio_system_version} && echo $resolved_iguazio_version)"
+          resolved_iguazio_version=${override_iguazio_version:-$iguazio_system_version} && echo $resolved_iguazio_version)" >> $GITHUB_OUTPUT
     - name: Prepare System Test env.yaml and MLRun installation from current branch
       timeout-minutes: 50
       run: |

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -87,12 +87,12 @@ jobs:
     - name: Extract git branch
       id: git_info
       run: |
-        echo "branch=$(echo ${GITHUB_REF#refs/heads/})"
+        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.test_code_from_action == 'true' }}
       id: git_action_info
       run: |
-        echo "mlrun_hash=$(git rev-parse --short=8 $GITHUB_SHA)"
+        echo "mlrun_hash=$(git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_OUTPUT
     - name: Extract UI git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
@@ -103,7 +103,7 @@ jobs:
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
-          rm -rf mlrun-ui)"
+          rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info
       run: |
@@ -113,38 +113,38 @@ jobs:
           cd mlrun-upstream && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
-          rm -rf mlrun-upstream)"
+          rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
         echo "ui_hash=$( \
           cd /tmp && \
           git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
-          rm -rf mlrun-ui)"
-        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)"
+          rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
+        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
     - name: Set computed versions params
       id: computed_params
       run: |
         action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
         export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
-        echo "mlrun_hash=$(echo $mlrun_hash)"
+        echo "mlrun_hash=$(echo $mlrun_hash)" >> $GITHUB_OUTPUT
         action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
         upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
         export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
-        echo "ui_hash=$(echo $ui_hash)"
-        echo "mlrun_version=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}+$mlrun_hash)"
-        echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)"
-        echo "mlrun_ui_version=${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$ui_hash"
+        echo "ui_hash=$(echo $ui_hash)" >> $GITHUB_OUTPUT
+        echo "mlrun_version=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}+$mlrun_hash)" >> $GITHUB_OUTPUT
+        echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)" >> $GITHUB_OUTPUT
+        echo "mlrun_ui_version=${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$ui_hash" >> $GITHUB_OUTPUT
         echo "mlrun_docker_repo=$( \
           input_docker_repo=${{ github.event.inputs.docker_repo }} && \
-          echo ${input_docker_repo:-mlrun})"
+          echo ${input_docker_repo:-mlrun})" >> $GITHUB_OUTPUT
         echo "mlrun_docker_registry=$( \
           input_docker_registry=${{ github.event.inputs.docker_registry }} && \
-          echo ${input_docker_registry:-ghcr.io/})"
+          echo ${input_docker_registry:-ghcr.io/})" >> $GITHUB_OUTPUT
         echo "mlrun_system_tests_clean_resources=$( \
           input_system_tests_clean_resources=${{ github.event.inputs.clean_resources_in_teardown }} && \
-          echo ${input_system_tests_clean_resources:-true})"
+          echo ${input_system_tests_clean_resources:-true})" >> $GITHUB_OUTPUT
 
     - uses: azure/setup-helm@v3
       with:


### PR DESCRIPTION
Following up https://github.com/mlrun/mlrun/pull/2952
Fix did not include the piping to the github output envvar, thus, envvars were empty.
