### PR TITLE
[Projects] Add project default image

### DIFF
--- a/docs/projects/run-build-deploy.md
+++ b/docs/projects/run-build-deploy.md
@@ -6,6 +6,7 @@
 - [run_function](#run)
 - [build_function](#build)
 - [deploy_function](#deploy)
+- [Project default image](#default_image)
 
 <a id="overview"></a>
 ## Overview
@@ -132,3 +133,34 @@ Example of using `deploy_function` inside a pipeline, after the `train` step, to
 ```{admonition} Note
 If you want to create a simulated (mock) function instead of a real Kubernetes service, set the `mock` flag is set to `True`. See [deploy_function api](https://docs.mlrun.org/en/latest/api/mlrun.projects.html#mlrun.projects.MlrunProject.deploy_function).
 ```
+
+<a id="default_image"></a>
+## Project default image
+
+You can set a default image for the project. This image will be used for deploying and running any function that does
+not have an explicit image assigned, and replaces MLRun's default image of `mlrun/mlrun`. To set the default image use 
+the {py:meth}`~mlrun.projects.MlrunProject.set_default_image` method with the name of the default image to use.
+
+The default image is applied to the functions in the process of enriching the function prior to running or 
+deploying. Functions will therefore use the default image set in the project at the time of their execution, not the
+image that was set when the function was added to the project.
+
+For example:
+
+    project = mlrun.new_project(project_name, "./proj")
+    # use v1 of a pre-built image as default
+    project.set_default_image("myrepo/my-prebuilt-image:v1")
+    # set function without an image, will use the project's default image
+    project.set_function("mycode.py", "prep")
+
+    # function will run with the "myrepo/my-prebuilt-image:v1" image
+    run1 = project.run_function("prep", params={"x": 7}, inputs={'data': data_url})
+
+    ...
+
+    # replace the default image with a newer v2
+    project.set_default_image("myrepo/my-prebuilt-image:v2")
+    # function will now run using the v2 version of the image 
+    run2 = project.run_function("prep", params={"x": 7}, inputs={'data': data_url})
+
+

--- a/docs/projects/run-build-deploy.md
+++ b/docs/projects/run-build-deploy.md
@@ -6,7 +6,7 @@
 - [run_function](#run)
 - [build_function](#build)
 - [deploy_function](#deploy)
-- [Project default image](#default_image)
+- [Default image](#default_image)
 
 <a id="overview"></a>
 ## Overview
@@ -135,11 +135,11 @@ If you want to create a simulated (mock) function instead of a real Kubernetes s
 ```
 
 <a id="default_image"></a>
-## Project default image
+## Default image
 
 You can set a default image for the project. This image will be used for deploying and running any function that does
 not have an explicit image assigned, and replaces MLRun's default image of `mlrun/mlrun`. To set the default image use 
-the {py:meth}`~mlrun.projects.MlrunProject.set_default_image` method with the name of the default image to use.
+the {py:meth}`~mlrun.projects.MlrunProject.set_default_image` method with the name of the image.
 
 The default image is applied to the functions in the process of enriching the function prior to running or 
 deploying. Functions will therefore use the default image set in the project at the time of their execution, not the

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -370,6 +370,10 @@ def enrich_function_object(
     f = function.copy() if copy_function else function
     f.metadata.project = project.metadata.name
     setattr(f, "_enriched", True)
+
+    # set project default image if defined and function does not have an image specified
+    f.spec.image = f.spec.image or project.default_image
+
     src = f.spec.build.source
     if src and src in [".", "./"]:
         if not project.spec.source and not project.spec.mountdir:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -372,7 +372,9 @@ def enrich_function_object(
     setattr(f, "_enriched", True)
 
     # set project default image if defined and function does not have an image specified
-    f.spec.image = f.spec.image or project.default_image
+    if project.spec.default_image and not f.spec.image:
+        setattr(f, "_enriched_image", True)
+        f.spec.image = project.spec.default_image
 
     src = f.spec.build.source
     if src and src in [".", "./"]:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -373,7 +373,7 @@ def enrich_function_object(
 
     # set project default image if defined and function does not have an image specified
     if project.spec.default_image and not f.spec.image:
-        setattr(f, "_enriched_image", True)
+        f._enriched_image = True
         f.spec.image = project.spec.default_image
 
     src = f.spec.build.source

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -773,9 +773,7 @@ class ProjectSpec(ModelObj):
             return
         for key in self._function_objects:
             function = self._function_objects[key]
-            if hasattr(function, "_enriched_image") and getattr(
-                function, "_enriched_image", False
-            ):
+            if function._enriched_image:
                 function.spec.image = new_image
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1013,6 +1013,14 @@ class MlrunProject(ModelObj):
         return self.spec.default_image
 
     def set_default_image(self, default_image: str):
+        """
+        Set the default image to be used for running runtimes (functions) in this project. This image will be used
+        if an image was not provided for a runtime. In case the default image is replaced, functions already
+        registered with the project that used the previous default image will have their image replaced on
+        next execution.
+
+        :param default_image: Default image to use
+        """
         current_default_image = self.spec.default_image
         if current_default_image:
             self.spec._replace_default_image_in_enriched_functions(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1557,7 +1557,6 @@ class MlrunProject(ModelObj):
             # in hub or db functions name defaults to the function name
             if not name and not (func.startswith("db://") or func.startswith("hub://")):
                 raise ValueError("function name must be specified")
-            image = image or self.default_image
             function_dict = {
                 "url": func,
                 "name": name,
@@ -2773,7 +2772,7 @@ def _init_function_from_dict(f, project, name=None):
             name, filename=url, image=image, kind=kind, handler=handler, tag=tag
         )
     elif url.endswith(".py"):
-        if not image and kind != "local":
+        if not image and not project.default_image and kind != "local":
             raise ValueError(
                 "image must be provided with py code files which do not "
                 "run on 'local' engine kind"

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -767,16 +767,16 @@ class ProjectSpec(ModelObj):
 
     def _replace_default_image_in_enriched_functions(self, previous_image, new_image):
         """
-        Set a new project-default-image in functions that were already enriched. This is done on functions that didn't
-        have an image prior to this change or used the previous default image.
+        Set a new project-default-image in functions that were already enriched.
         """
         if previous_image == new_image:
             return
         for key in self._function_objects:
             function = self._function_objects[key]
-            if hasattr(function, "_enriched") and getattr(function, "_enriched", False):
-                if not function.spec.image or function.spec.image == previous_image:
-                    function.spec.image = new_image
+            if hasattr(function, "_enriched_image") and getattr(
+                function, "_enriched_image", False
+            ):
+                function.spec.image = new_image
 
 
 class ProjectStatus(ModelObj):
@@ -1012,8 +1012,7 @@ class MlrunProject(ModelObj):
     def default_image(self) -> str:
         return self.spec.default_image
 
-    @default_image.setter
-    def default_image(self, default_image: str):
+    def set_default_image(self, default_image: str):
         current_default_image = self.spec.default_image
         if current_default_image:
             self.spec._replace_default_image_in_enriched_functions(
@@ -1657,7 +1656,10 @@ class MlrunProject(ModelObj):
             function = get_db_function(self, key)
             self.spec._function_objects[key] = function
         if enrich:
-            return enrich_function_object(self, function, copy_function=copy_function)
+            function = enrich_function_object(
+                self, function, copy_function=copy_function
+            )
+            self.spec._function_objects[key] = function
         return function
 
     def get_function_objects(self) -> typing.Dict[str, mlrun.runtimes.BaseRuntime]:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -549,6 +549,7 @@ class ProjectSpec(ModelObj):
         owner=None,
         disable_auto_mount=None,
         workdir=None,
+        default_image=None,
     ):
         self.repo = None
 
@@ -580,6 +581,7 @@ class ProjectSpec(ModelObj):
         self._function_definitions = {}
         self.functions = functions or []
         self.disable_auto_mount = disable_auto_mount
+        self.default_image = default_image
 
     @property
     def source(self) -> str:
@@ -858,46 +860,18 @@ class MlrunProject(ModelObj):
 
     @property
     def artifact_path(self) -> str:
-        """This is a property of the spec, look there for documentation
-        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
-        warnings.warn(
-            "This is a property of the spec, use project.spec.artifact_path instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         return self.spec.artifact_path
 
     @artifact_path.setter
     def artifact_path(self, artifact_path):
-        warnings.warn(
-            "This is a property of the spec, use project.spec.artifact_path instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         self.spec.artifact_path = artifact_path
 
     @property
     def source(self) -> str:
-        """This is a property of the spec, look there for documentation
-        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
-        warnings.warn(
-            "This is a property of the spec, use project.spec.source instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         return self.spec.source
 
     @source.setter
     def source(self, source):
-        warnings.warn(
-            "This is a property of the spec, use project.spec.source instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         self.spec.source = source
 
     def set_source(self, source, pull_at_runtime=False, workdir=None):
@@ -941,90 +915,40 @@ class MlrunProject(ModelObj):
 
     @property
     def context(self) -> str:
-        """This is a property of the spec, look there for documentation
-        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
-        warnings.warn(
-            "This is a property of the spec, use project.spec.context instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         return self.spec.context
 
     @context.setter
     def context(self, context):
-        warnings.warn(
-            "This is a property of the spec, use project.spec.context instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         self.spec.context = context
 
     @property
     def mountdir(self) -> str:
-        """This is a property of the spec, look there for documentation
-        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
-        warnings.warn(
-            "This is a property of the spec, use project.spec.mountdir instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         return self.spec.mountdir
 
     @mountdir.setter
     def mountdir(self, mountdir):
-        warnings.warn(
-            "This is a property of the spec, use project.spec.mountdir instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         self.spec.mountdir = mountdir
 
     @property
     def params(self) -> str:
-        """This is a property of the spec, look there for documentation
-        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
-        warnings.warn(
-            "This is a property of the spec, use project.spec.params instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         return self.spec.params
 
     @params.setter
     def params(self, params):
         warnings.warn(
-            "This is a property of the spec, use project.spec.params instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            "This is a property of the spec, use project.spec.params instead. "
+            "This is deprecated in 1.3.0, and will be removed in 1.5.0",
+            # TODO: In 1.3.0 do changes in examples & demos In 1.5.0 remove
+            FutureWarning,
         )
         self.spec.params = params
 
     @property
     def description(self) -> str:
-        """This is a property of the spec, look there for documentation
-        leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
-        warnings.warn(
-            "This is a property of the spec, use project.spec.description instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         return self.spec.description
 
     @description.setter
     def description(self, description):
-        warnings.warn(
-            "This is a property of the spec, use project.spec.description instead"
-            "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
-            # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
-        )
         self.spec.description = description
 
     @property
@@ -1054,22 +978,30 @@ class MlrunProject(ModelObj):
         """This is a property of the spec, look there for documentation
         leaving here for backwards compatibility with users code that used MlrunProjectLegacy"""
         warnings.warn(
-            "This is a property of the spec, use project.spec.workflows instead"
+            "This is a property of the spec, use project.spec.workflows instead. "
             "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
             # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            FutureWarning,
         )
         return self.spec.workflows
 
     @workflows.setter
     def workflows(self, workflows):
         warnings.warn(
-            "This is a property of the spec, use project.spec.workflows instead"
+            "This is a property of the spec, use project.spec.workflows instead. "
             "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
             # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            FutureWarning,
         )
         self.spec.workflows = workflows
+
+    @property
+    def default_image(self) -> str:
+        return self.spec.default_image
+
+    @default_image.setter
+    def default_image(self, default_image: str):
+        self.spec.default_image = default_image
 
     def set_workflow(
         self,
@@ -1132,7 +1064,7 @@ class MlrunProject(ModelObj):
             "This is a property of the spec, use project.spec.artifacts instead"
             "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
             # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            FutureWarning,
         )
         return self.spec.artifacts
 
@@ -1142,7 +1074,7 @@ class MlrunProject(ModelObj):
             "This is a property of the spec, use project.spec.artifacts instead"
             "This will be deprecated in 0.7.0, and will be removed in 0.9.0",
             # TODO: In 0.7.0 do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            FutureWarning,
         )
         self.spec.artifacts = artifacts
 
@@ -1625,6 +1557,7 @@ class MlrunProject(ModelObj):
             # in hub or db functions name defaults to the function name
             if not name and not (func.startswith("db://") or func.startswith("hub://")):
                 raise ValueError("function name must be specified")
+            image = image or self.default_image
             function_dict = {
                 "url": func,
                 "name": name,
@@ -1673,9 +1606,10 @@ class MlrunProject(ModelObj):
         :returns: function object
         """
         warnings.warn(
-            "This will be deprecated in future releases, use  get_function() instead",
-            # TODO: do changes in examples & demos In 0.9.0 remove
-            PendingDeprecationWarning,
+            "This will be deprecated in future releases, use  get_function() instead. "
+            "This is deprecated in 1.3.0, and will be removed in 1.5.0",
+            # TODO: do changes in examples & demos In 1.5.0 remove
+            FutureWarning,
         )
         return self.get_function(key, sync)
 
@@ -1904,34 +1838,6 @@ class MlrunProject(ModelObj):
             self.metadata.name, provider=provider, secrets=env_vars
         )
 
-    def create_vault_secrets(self, secrets):
-        warnings.warn(
-            "This method is obsolete, use project.set_secrets() instead"
-            "This will be deprecated and removed in 1.0.0",
-            # TODO: In 1.0 remove
-            PendingDeprecationWarning,
-        )
-        run_db = mlrun.db.get_run_db(secrets=self._secrets)
-        run_db.create_project_secrets(
-            self.metadata.name, mlrun.api.schemas.SecretProviderName.vault, secrets
-        )
-
-    def get_vault_secrets(self, secrets=None, local=False):
-        if local:
-            logger.warning(
-                "get_vault_secrets executed locally. This is not recommended and may become deprecated soon"
-            )
-            return self._secrets.vault.get_secrets(secrets, project=self.metadata.name)
-
-        run_db = mlrun.db.get_run_db(secrets=self._secrets)
-        project_secrets = run_db.list_project_secrets(
-            self.metadata.name,
-            self._secrets.vault.token,
-            mlrun.api.schemas.SecretProviderName.vault,
-            secrets,
-        )
-        return project_secrets.secrets
-
     def get_param(self, key: str, default=None):
         """get project param by key"""
         if self.spec.params:
@@ -2124,9 +2030,9 @@ class MlrunProject(ModelObj):
         notifiers: CustomNotificationPusher = None,
     ):
         warnings.warn(
-            "This will be deprecated in 1.4.0, and will be removed in 1.6.0. "
+            "This is deprecated in 1.3.0, and will be removed in 1.5.0. "
             "Use `timeout` parameter in `project.run()` method instead",
-            PendingDeprecationWarning,
+            FutureWarning,
         )
         return run._engine.get_run_status(
             project=self,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -168,6 +168,7 @@ class BaseRuntime(ModelObj):
         self.status = None
         self._is_api_server = False
         self.verbose = False
+        self._enriched_image = False
 
     def set_db_connection(self, conn, is_api=False):
         if not self._db_conn:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -725,6 +725,14 @@ def test_function_receives_project_default_image():
     enriched_function = proj1.get_function("func3", enrich=True)
     assert enriched_function.spec.image == "some/other_image"
 
+    # Enrich the function in-place. Validate that changing the default image affects this function
+    # proj1.get_function("func", enrich=True, copy_function=False)
+    new_default_image = "mynewrepo/mynewimage1"
+    proj1.default_image = new_default_image
+
+    enriched_function = proj1.get_function("func")
+    assert enriched_function.spec.image == new_default_image
+
 
 def test_project_exports_default_image():
     project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -687,6 +687,37 @@ def test_function_receives_project_artifact_path(rundb_mock):
     assert run5.spec.output_path == mlrun.mlconf.artifact_path
 
 
+def test_function_receives_project_default_image():
+    func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
+    mlrun.mlconf.artifact_path = "/tmp"
+    proj1 = mlrun.new_project("proj1", save=False)
+    default_image = "myrepo/myimage1"
+
+    # Without a project default image, set_function for remote kind must get an image
+    with pytest.raises(ValueError, match="image must be provided"):
+        proj1.set_function(func=func_path, name="func", kind="job", handler="myhandler")
+
+    proj1.default_image = default_image
+
+    func1 = mlrun.code_to_function(
+        "func", kind="job", handler="myhandler", filename=func_path
+    )
+    proj1.set_function(func1, name="func")
+
+    # Function is kept without the image, only when enriching the default image is added
+    enriched_function = proj1.get_function("func", enrich=False)
+    assert enriched_function.spec.image == ""
+
+    enriched_function = proj1.get_function("func", enrich=True)
+    assert enriched_function.spec.image == default_image
+
+    # If function already had an image, the default image should not override
+    func1.spec.image = "some/other_image"
+    proj1.set_function(func1, name="func2")
+    enriched_function = proj1.get_function("func2", enrich=True)
+    assert enriched_function.spec.image == "some/other_image"
+
+
 def test_run_function_passes_project_artifact_path(rundb_mock):
     func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
     mlrun.mlconf.artifact_path = "/tmp"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -697,7 +697,7 @@ def test_function_receives_project_default_image():
     with pytest.raises(ValueError, match="image must be provided"):
         proj1.set_function(func=func_path, name="func", kind="job", handler="myhandler")
 
-    proj1.default_image = default_image
+    proj1.set_default_image(default_image)
     proj1.set_function(func=func_path, name="func", kind="job", handler="myhandler")
 
     # Functions should remain without the default image in the project cache (i.e. without enrichment). Only with
@@ -728,7 +728,7 @@ def test_function_receives_project_default_image():
     # Enrich the function in-place. Validate that changing the default image affects this function
     proj1.get_function("func", enrich=True, copy_function=False)
     new_default_image = "mynewrepo/mynewimage1"
-    proj1.default_image = new_default_image
+    proj1.set_default_image(new_default_image)
 
     enriched_function = proj1.get_function("func")
     assert enriched_function.spec.image == new_default_image
@@ -738,7 +738,7 @@ def test_project_exports_default_image():
     project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"
     default_image = "myrepo/myimage1"
     project = mlrun.new_project("proj1", save=False)
-    project.default_image = default_image
+    project.set_default_image(default_image)
 
     project.export(str(project_file_path))
     imported_project = mlrun.load_project("./", str(project_file_path), save=False)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -718,6 +718,17 @@ def test_function_receives_project_default_image():
     assert enriched_function.spec.image == "some/other_image"
 
 
+def test_project_exports_default_image():
+    project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"
+    default_image = "myrepo/myimage1"
+    project = mlrun.new_project("proj1", save=False)
+    project.default_image = default_image
+
+    project.export(str(project_file_path))
+    imported_project = mlrun.load_project("./", str(project_file_path), save=False)
+    assert imported_project.default_image == default_image
+
+
 def test_run_function_passes_project_artifact_path(rundb_mock):
     func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
     mlrun.mlconf.artifact_path = "/tmp"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -726,7 +726,7 @@ def test_function_receives_project_default_image():
     assert enriched_function.spec.image == "some/other_image"
 
     # Enrich the function in-place. Validate that changing the default image affects this function
-    # proj1.get_function("func", enrich=True, copy_function=False)
+    proj1.get_function("func", enrich=True, copy_function=False)
     new_default_image = "mynewrepo/mynewimage1"
     proj1.default_image = new_default_image
 

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -598,7 +598,7 @@ class TestProject(TestMLRunSystem):
         assert run_result.output("score")
 
         # Use project default image to run function, don't specify image when calling set_function
-        project.default_image = fn.spec.image
+        project.set_default_image(fn.spec.image)
         project.set_function(
             "./sentiment.py",
             "scores4",

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -597,6 +597,20 @@ class TestProject(TestMLRunSystem):
         assert fn.spec.image, "image path got cleared"
         assert run_result.output("score")
 
+        # Use project default image to run function, don't specify image when calling set_function
+        project.default_image = fn.spec.image
+        project.set_function(
+            "./sentiment.py",
+            "scores4",
+            kind="job",
+            handler="handler",
+        )
+        enriched_fn = project.get_function("scores4", enrich=True)
+        assert enriched_fn.spec.image == fn.spec.image
+        project.run_function("scores4", params={"text": "good evening"})
+        assert fn.status.state == "ready"
+        assert run_result.output("score")
+
     def test_set_secrets(self):
         name = "set-secrets"
         self.custom_project_names_to_delete.append(name)


### PR DESCRIPTION
Add a `default_image` property to project spec, that will set the `image` property for project functions, if not explicitly specified in the function itself.
The `default_image` is applied:
* When enriching the function, as part of function retrieval from the project. This is used in the various image-related project APIs, such as `project.run_function` etc.
* When setting a new `default_image` for a project which already had one, the default image will be replaced in all already-enriched functions held by the project that had no image (after the enrichment) or used the previous `default_image`.

Also did some deprecation warning fixes per the guidelines in https://jira.iguazeng.com/browse/ML-3104