### PR TITLE
[Feature Store] Validator for features only & Init `RegexValidator` class `from_dict` 

### DIFF
--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -788,7 +788,7 @@ class FeatureSet(ModelObj):
             self._spec.features.update(item, key)
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "FeatureSet can't have entity and " f"feature with the same name."
+                "FeatureSet can't have entity and feature with the same name."
             )
 
     def plot(self, filename=None, format=None, with_targets=False, **kw):

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -784,7 +784,12 @@ class FeatureSet(ModelObj):
         return self._spec.features[name]
 
     def __setitem__(self, key, item):
-        self._spec.features.update(item, key)
+        if key not in self._spec.entities.keys():
+            self._spec.features.update(item, key)
+        else:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"FeatureSet can't have entity and " f"feature with the same name."
+            )
 
     def plot(self, filename=None, format=None, with_targets=False, **kw):
         """generate graphviz plot"""

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -788,7 +788,8 @@ class FeatureSet(ModelObj):
             self._spec.features.update(item, key)
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "FeatureSet can't have entity and feature with the same name."
+                "A `FeatureSet` cannot have an entity and a feature with the same name. "
+                f"The feature that was given to add '{key}' has the same name of the `FeatureSet`'s entity."
             )
 
     def plot(self, filename=None, format=None, with_targets=False, **kw):

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -788,7 +788,7 @@ class FeatureSet(ModelObj):
             self._spec.features.update(item, key)
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"FeatureSet can't have entity and " f"feature with the same name."
+                "FeatureSet can't have entity and " f"feature with the same name."
             )
 
     def plot(self, filename=None, format=None, with_targets=False, **kw):

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -438,7 +438,7 @@ class RegexValidator(Validator):
         new_obj = super(RegexValidator, cls).from_dict(
             struct=struct, fields=fields, deprecated_fields=deprecated_fields
         )
-        if hasattr(new_obj, "regex"):
+        if hasattr(new_obj, "regex") and new_obj.regex is not None:
             new_obj.regex_compile = re.compile(new_obj.regex)
         else:
             raise MLRunRuntimeError(

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -108,14 +108,6 @@ class Feature(ModelObj):
         self.aggregate = aggregate
         self.origin = None  # used to link the feature to the feature set origin (inside vector.status)
         self._validator = validator
-        # bypass DB bug - self.value_type have to be set when saving fs
-        if not self.value_type:
-            if isinstance(self._validator, MinMaxValidator):
-                self.value_type = "int"
-            elif isinstance(self._validator, MinMaxLenValidator):
-                self.value_type = "list"
-            else:  # including regex validator
-                self.value_type = "str"
 
     @property
     def validator(self):

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -418,17 +418,13 @@ class RegexValidator(Validator):
         """
         super().__init__(check_type, severity)
         self.regex = regex
-        self.regex_compile = None
 
     def check(self, value):
-        self.regex_compile = (
-            self.regex_compile if self.regex_compile else re.compile(self.regex)
-        )
         ok, args = super().check(value)
         if ok:
             try:
                 if self.regex is not None:
-                    if not re.fullmatch(self.regex_compile, value):
+                    if not re.fullmatch(self.regex, value):
                         return (
                             False,
                             {

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -414,18 +414,17 @@ class RegexValidator(Validator):
 
     def check(self, value):
         ok, args = super().check(value)
-        if ok:
+        if ok and self.regex_compile:
             try:
-                if self.regex is not None:
-                    if not re.fullmatch(self.regex_compile, value):
-                        return (
-                            False,
-                            {
-                                "message": "Value is not valid with regular expression",
-                                "regexp": self.regex,
-                                "value": _limited_string(str(value)),
-                            },
-                        )
+                if not re.fullmatch(self.regex_compile, value):
+                    return (
+                        False,
+                        {
+                            "message": "Value is not valid with regular expression",
+                            "regexp": self.regex,
+                            "value": _limited_string(str(value)),
+                        },
+                    )
             except Exception as err:
                 return (
                     False,
@@ -438,8 +437,8 @@ class RegexValidator(Validator):
         new_obj = super(RegexValidator, cls).from_dict(
             struct=struct, fields=fields, deprecated_fields=deprecated_fields
         )
-        if hasattr(new_obj, "regex") and new_obj.regex is not None:
-            new_obj.regex_compile = re.compile(new_obj.regex)
+        if hasattr(new_obj, "regex"):
+            new_obj.regex_compile = re.compile(new_obj.regex) if new_obj.regex else None
         else:
             raise MLRunRuntimeError(
                 f"Object with type {type(new_obj)} "

--- a/mlrun/features.py
+++ b/mlrun/features.py
@@ -414,17 +414,18 @@ class RegexValidator(Validator):
 
     def check(self, value):
         ok, args = super().check(value)
-        if ok and self.regex_compile:
+        if ok:
             try:
-                if not re.fullmatch(self.regex_compile, value):
-                    return (
-                        False,
-                        {
-                            "message": "Value is not valid with regular expression",
-                            "regexp": self.regex,
-                            "value": _limited_string(str(value)),
-                        },
-                    )
+                if self.regex is not None:
+                    if not re.fullmatch(self.regex_compile, value):
+                        return (
+                            False,
+                            {
+                                "message": "Value is not valid with regular expression",
+                                "regexp": self.regex,
+                                "value": _limited_string(str(value)),
+                            },
+                        )
             except Exception as err:
                 return (
                     False,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -57,7 +57,7 @@ from mlrun.feature_store import Entity, FeatureSet
 from mlrun.feature_store.feature_set import aggregates_step
 from mlrun.feature_store.feature_vector import FixedWindowType
 from mlrun.feature_store.steps import FeaturesetValidator, OneHotEncoder
-from mlrun.features import RegexValidator
+from mlrun.features import MinMaxValidator, RegexValidator
 from mlrun.model import DataTarget
 from tests.system.base import TestMLRunSystem
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -3435,6 +3435,12 @@ class TestFeatureStore(TestMLRunSystem):
             feature_set["key1"] = fstore.Feature(
                 validator=RegexValidator(regex=".[A-Za-z]", severity="info")
             )
+            try:
+                feature_set["key"] = fstore.Feature(
+                    validator=RegexValidator(regex=".[A-Za-z]", severity="info")
+                )
+            except mlrun.errors.MLRunInvalidArgumentError:
+                pass  # test equal name for entity and feature
             feature_set.graph.to(
                 FeaturesetValidator(),
                 name="validator",

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -57,7 +57,7 @@ from mlrun.feature_store import Entity, FeatureSet
 from mlrun.feature_store.feature_set import aggregates_step
 from mlrun.feature_store.feature_vector import FixedWindowType
 from mlrun.feature_store.steps import FeaturesetValidator, OneHotEncoder
-from mlrun.features import MinMaxValidator
+from mlrun.features import RegexValidator
 from mlrun.model import DataTarget
 from tests.system.base import TestMLRunSystem
 
@@ -3423,7 +3423,7 @@ class TestFeatureStore(TestMLRunSystem):
         df = pd.DataFrame(
             {
                 "key": [1, 2, 3, 4, 5, 6, 7],
-                "key1": [1, 2, 3, 4, 5, 6, 7],
+                "key1": ["1", "2", "3", "4", "5", "6", "7"],
                 "key2": ["C", "F", "I", "W", "X", "J", "K"],
             }
         )
@@ -3433,7 +3433,7 @@ class TestFeatureStore(TestMLRunSystem):
                 "myfset", entities=[fstore.Entity("key")], engine=engine
             )
             feature_set["key1"] = fstore.Feature(
-                validator=MinMaxValidator(max=5, min=1, severity="info")
+                validator=RegexValidator(regex=".[A-Za-z]", severity="info")
             )
             feature_set.graph.to(
                 FeaturesetValidator(),

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -3429,7 +3429,7 @@ class TestFeatureStore(TestMLRunSystem):
         )
 
         feature_set = fstore.FeatureSet(
-            "myfset_232", entities=[fstore.Entity("key")], engine=engine
+            "myfset", entities=[fstore.Entity("key")], engine=engine
         )
         feature_set["key1"] = fstore.Feature(
             validator=RegexValidator(regex=".[A-Za-z]", severity="info"),


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3282

This pr handling 2 bugs : 
1. Setting feature of feature set with the same name of is entity - raise an error.
2. When Init `RegexValidator` class `from_dict`  so `re.compile` raised an error - using `self.regex` directly.