### PR TITLE
[API] Add middlewares to ensure ui reset cache upon mlrun upgrades

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,11 @@ jobs:
     - name: Run Dockerized tests
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
 
+      # REMOVE BEFORE MERGE
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ failure() }}
+
   integration-tests:
     name: Run Dockerized Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,11 +94,6 @@ jobs:
     - name: Run Dockerized tests
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
 
-      # REMOVE BEFORE MERGE
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ failure() }}
-
   integration-tests:
     name: Run Dockerized Integration Tests
     runs-on: ubuntu-latest

--- a/mlrun/api/middlewares.py
+++ b/mlrun/api/middlewares.py
@@ -105,8 +105,12 @@ async def ui_clear_cache(request: fastapi.Request, call_next):
     response: fastapi.Response = await call_next(request)
     development_version = config.version.startswith("0.0.0")
 
-    # do not ask ui to reload cache on development versions as it will make each request to reload ui and clear cache
-    if not development_version and not ui_version or ui_version != config.version:
+    # ask ui to reload cache if
+    #  - ui sent a version
+    #  - backend is not a development version
+    #  - ui version is different from backend version
+    # otherwise, do not ask ui to reload its cache as it will make each request to reload ui and clear cache
+    if ui_version and not development_version and ui_version != config.version:
 
         # clear site cache
         response.headers["Clear-Site-Data"] = '"cache"'

--- a/mlrun/api/middlewares.py
+++ b/mlrun/api/middlewares.py
@@ -1,0 +1,114 @@
+import time
+import traceback
+import uuid
+
+import fastapi
+import uvicorn.protocols.utils
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from mlrun.config import config
+from mlrun.utils import logger
+
+
+def init_middlewares(app: fastapi.FastAPI):
+    for func in [
+        log_request_response,
+        ui_clear_cache,
+        ensure_be_version,
+    ]:
+        app.add_middleware(BaseHTTPMiddleware, dispatch=func)
+
+
+async def log_request_response(request: fastapi.Request, call_next):
+    """
+    This middleware logs request and response including its start / end time and duration
+    """
+    request_id = str(uuid.uuid4())
+    silent_logging_paths = [
+        "healthz",
+    ]
+    path_with_query_string = uvicorn.protocols.utils.get_path_with_query_string(
+        request.scope
+    )
+    start_time = time.perf_counter_ns()
+    if not any(
+        silent_logging_path in path_with_query_string
+        for silent_logging_path in silent_logging_paths
+    ):
+        logger.debug(
+            "Received request",
+            headers=request.headers,
+            method=request.method,
+            client_address=_resolve_client_address(request.scope),
+            http_version=request.scope["http_version"],
+            request_id=request_id,
+            uri=path_with_query_string,
+        )
+    try:
+        response = await call_next(request)
+    except Exception as exc:
+        logger.warning(
+            "Request handling failed. Sending response",
+            # User middleware (like this one) runs after the exception handling middleware, the only thing running after
+            # it is starletter's ServerErrorMiddleware which is responsible for catching any un-handled exception
+            # and transforming it to 500 response. therefore we can statically assign status code to 500
+            status_code=500,
+            request_id=request_id,
+            uri=path_with_query_string,
+            method=request.method,
+            exc=exc,
+            traceback=traceback.format_exc(),
+        )
+        raise
+    else:
+        # convert from nanoseconds to milliseconds
+        elapsed_time_in_ms = (time.perf_counter_ns() - start_time) / 1000 / 1000
+        if not any(
+            silent_logging_path in path_with_query_string
+            for silent_logging_path in silent_logging_paths
+        ):
+            logger.debug(
+                "Sending response",
+                status_code=response.status_code,
+                request_id=request_id,
+                elapsed_time_in_ms=elapsed_time_in_ms,
+                uri=path_with_query_string,
+                method=request.method,
+                headers=response.headers,
+            )
+        return response
+
+
+async def ui_clear_cache(request: fastapi.Request, call_next):
+    """
+    This middleware tells ui when to clear its cache based on backend version changes.
+    """
+    ui_version = request.headers.get("X-MLRun-UI-Version", "")
+    response: fastapi.Response = await call_next(request)
+    development_version = config.version.startswith("0.0.0")
+
+    # do not ask ui to reload cache on development versions as it will make each request to reload ui and clear cache
+    if not development_version and not ui_version or ui_version != config.version:
+
+        # clear site cache
+        response.headers["Clear-Site-Data"] = '"cache"'
+
+        # tell ui to reload
+        response.headers["X-MLRun-UI-Clear-Cache"] = "true"
+    return response
+
+
+async def ensure_be_version(request: fastapi.Request, call_next):
+    """
+    This middleware ensures response header includes backend version
+    """
+    response: fastapi.Response = await call_next(request)
+    response.headers["X-MLRun-BE-Version"] = config.version
+    return response
+
+
+def _resolve_client_address(scope):
+    # uvicorn expects this to be a tuple while starlette test client sets it to be a list
+    if isinstance(scope.get("client"), list):
+        scope["client"] = tuple(scope.get("client"))
+    return uvicorn.protocols.utils.get_client_addr(scope)

--- a/mlrun/api/middlewares.py
+++ b/mlrun/api/middlewares.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import time
 import traceback
 import uuid

--- a/mlrun/api/middlewares.py
+++ b/mlrun/api/middlewares.py
@@ -21,6 +21,7 @@ import fastapi
 import uvicorn.protocols.utils
 from starlette.middleware.base import BaseHTTPMiddleware
 
+import mlrun.api.schemas.constants
 from mlrun.config import config
 from mlrun.utils import logger
 
@@ -98,7 +99,9 @@ async def ui_clear_cache(request: fastapi.Request, call_next):
     """
     This middleware tells ui when to clear its cache based on backend version changes.
     """
-    ui_version = request.headers.get("X-MLRun-UI-Version", "")
+    ui_version = request.headers.get(
+        mlrun.api.schemas.constants.HeaderNames.ui_version, ""
+    )
     response: fastapi.Response = await call_next(request)
     development_version = config.version.startswith("0.0.0")
 
@@ -109,7 +112,9 @@ async def ui_clear_cache(request: fastapi.Request, call_next):
         response.headers["Clear-Site-Data"] = '"cache"'
 
         # tell ui to reload
-        response.headers["X-MLRun-UI-Clear-Cache"] = "true"
+        response.headers[
+            mlrun.api.schemas.constants.HeaderNames.ui_clear_cache
+        ] = "true"
     return response
 
 
@@ -118,7 +123,9 @@ async def ensure_be_version(request: fastapi.Request, call_next):
     This middleware ensures response header includes backend version
     """
     response: fastapi.Response = await call_next(request)
-    response.headers["X-MLRun-BE-Version"] = config.version
+    response.headers[
+        mlrun.api.schemas.constants.HeaderNames.backend_version
+    ] = config.version
     return response
 
 

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -92,6 +92,9 @@ class HeaderNames:
     pipeline_arguments = f"{headers_prefix}pipeline-arguments"
     client_version = f"{headers_prefix}client-version"
     python_version = f"{headers_prefix}client-python-version"
+    backend_version = f"{headers_prefix}be-version"
+    ui_version = f"{headers_prefix}ui-version"
+    ui_clear_cache = f"{headers_prefix}ui-clear-cache"
 
 
 class FeatureStorePartitionByField(mlrun.api.utils.helpers.StrEnum):

--- a/tests/api/api/framework/__init__.py
+++ b/tests/api/api/framework/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/api/api/framework/test_middlewares.py
+++ b/tests/api/api/framework/test_middlewares.py
@@ -49,7 +49,7 @@ def test_ui_clear_cache_middleware(
         mlrun.utils.version.Version, "get", return_value={"version": backend_version}
     ):
         response = client.get(
-            f"client-spec",
+            "client-spec",
             headers={
                 mlrun.api.schemas.constants.HeaderNames.ui_version: ui_version,
             },

--- a/tests/api/api/framework/test_middlewares.py
+++ b/tests/api/api/framework/test_middlewares.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import unittest.mock
 
 import fastapi.testclient

--- a/tests/api/api/framework/test_middlewares.py
+++ b/tests/api/api/framework/test_middlewares.py
@@ -1,0 +1,67 @@
+import unittest.mock
+
+import fastapi.testclient
+import pytest
+import sqlalchemy.orm
+
+import mlrun.api.schemas.constants
+import mlrun.utils.version
+
+
+@pytest.mark.parametrize(
+    "ui_version,backend_version,clear_cache",
+    [
+        # ui version was not sent, no need to clear cache
+        ("", "0.0.1", False),
+        # matching version, no need to clear cache
+        ("1.0.0", "1.0.0", False),
+        # development version, no need to clear cache
+        ("0.0.1", "0.0.0", False),
+        # non-matching version, need to clear cache
+        ("0.0.1", "0.0.2", True),
+        ("0.0.0", "0.0.1", True),
+        ("0.0.2", "0.0.1", True),
+    ],
+)
+def test_ui_clear_cache_middleware(
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    ui_version: str,
+    backend_version: str,
+    clear_cache: bool,
+) -> None:
+    with unittest.mock.patch.object(
+        mlrun.utils.version.Version, "get", return_value={"version": backend_version}
+    ):
+        response = client.get(
+            f"client-spec",
+            headers={
+                mlrun.api.schemas.constants.HeaderNames.ui_version: ui_version,
+            },
+        )
+
+    if clear_cache:
+        assert response.headers["Clear-Site-Data"] == '"cache"'
+        assert (
+            response.headers[mlrun.api.schemas.constants.HeaderNames.ui_clear_cache]
+            == "true"
+        )
+    else:
+        assert "Clear-Site-Data" not in response.headers
+        assert (
+            mlrun.api.schemas.constants.HeaderNames.ui_clear_cache
+            not in response.headers
+        )
+
+
+def test_ensure_be_version_middleware(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    with unittest.mock.patch.object(
+        mlrun.utils.version.Version, "get", return_value={"version": "dummy-version"}
+    ) as mock_version_get:
+        response = client.get("client-spec")
+        assert (
+            response.headers[mlrun.api.schemas.constants.HeaderNames.backend_version]
+            == mock_version_get.return_value["version"]
+        )

--- a/tests/api/test_logging_middleware.py
+++ b/tests/api/test_logging_middleware.py
@@ -105,13 +105,24 @@ middleware_modes = [
 # must add it here since we're adding routes
 @pytest.fixture(params=middleware_modes)
 def client(request) -> typing.Generator:
-    if request.param == "without_middleware":
-        # HACKY
-        app.user_middleware = []
-        app.middleware_stack = app.build_middleware_stack()
-    app.include_router(test_router, prefix="/test")
-    with TestClient(app) as c:
-        yield c
+
+    # save a copy of the middlewares. we would want to restore them once we're done with the test
+    user_middleware = app.user_middleware.copy()
+    try:
+        if request.param == "without_middleware":
+
+            # this overrides the webapp middlewares by removing the logging middleware
+            app.user_middleware = []
+            app.middleware_stack = app.build_middleware_stack()
+        app.include_router(test_router, prefix="/test")
+        with TestClient(app) as c:
+            yield c
+    finally:
+
+        # restore back the middlewares
+        if request.param == "without_middleware":
+            app.user_middleware = user_middleware
+            app.middleware_stack = app.build_middleware_stack()
 
 
 def test_logging_middleware(db: Session, client: TestClient) -> None:


### PR DESCRIPTION
To allow mlrun ui reload its cache post upgrade, it is required to indicate whether a clear cache is required.
the mechanism suggested is that each response will hold mlrun backend version. it is up to the client (ui) to send its cached / current `X-MLRun-UI-Version` header which its value is the ui version. The API will match both versions (backend running version and ui version, and if versions are not matched, the ui will be asked to reload its cache)