### PR TITLE
[Spark] Skip test when no redis server is set

### DIFF
--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -298,6 +298,10 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             read_back_df_storey.sort_index(axis=1)
         )
 
+    @pytest.mark.skipif(
+        not mlrun.mlconf.redis.url,
+        reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",
+    )
     def test_ingest_to_redis(self):
         key = "patient_id"
         name = "measurements_spark"


### PR DESCRIPTION
handle system-test failure:
```
FAILED tests/system/feature_store/test_***_engine.py::TestFeatureStoreSparkEngine::test_ingest_to_redis
```