### PR TITLE
[Log Collector] Add HasLogs endpoint + additional fixes

### DIFF
--- a/go/cmd/logcollector/main.go
+++ b/go/cmd/logcollector/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/mlrun/mlrun/pkg/common"
 	"github.com/mlrun/mlrun/pkg/common/k8s"

--- a/go/cmd/logcollector/main.go
+++ b/go/cmd/logcollector/main.go
@@ -33,7 +33,7 @@ func StartServer() error {
 	listenPort := flag.Int("listen-port", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LISTEN_PORT", 8080), "GRPC listen port")
 	logLevel := flag.String("log-level", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__LOG_LEVEL", "debug"), "Log level (debug, info, warn, error, fatal, panic)")
 	logFormatter := flag.String("log-formatter", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__LOG_FORMATTER", "text"), "Log formatter (text, json)")
-	baseDir := flag.String("base-dir", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__BASE_DIR", "/var/mlrun/log-collector/pod-logs"), "The directory to store the logs in")
+	baseDir := flag.String("base-dir", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__BASE_DIR", "/var/mlrun/log-collector/logs"), "The directory to store the logs in")
 	kubeconfigPath := flag.String("kubeconfig-path", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__KUBECONFIG_PATH", ""), "Path to kubeconfig file")
 	stateFileUpdateInterval := flag.String("state-file-update-interval", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__STATE_FILE_UPDATE_INTERVAL", "10s"), "Periodic interval for updating the state file (default 10s)")
 	readLogWaitTime := flag.String("read-log-wait-time", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__READ_LOG_WAIT_TIME", "3s"), "Wait time until trying to get more logs from the pod (default 3s)")
@@ -41,6 +41,7 @@ func StartServer() error {
 	logCollectionBufferPoolSize := flag.Int("log-collection-buffer-pool-size", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_POOL_SIZE", 512), "Number of buffers in the buffer pool for collecting logs (default: 512 buffers)")
 	getLogsBufferPoolSize := flag.Int("get-logs-buffer-pool-size", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_POOL_SIZE", 512), "Number of buffers in the buffer pool for getting logs (default: 512 buffers)")
 	bufferSizeBytes := flag.Int("buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__BUFFER_SIZE_BYTES", 10*1024*1024), "Size of buffers in the buffer pool, in bytes (default: 10MB)")
+	clusterizationRole := flag.String("clusterization-role", common.GetEnvOrDefaultString("MLRUN_HTTPDB__CLUSTERIZATION__ROLE", "chief"), "The role of the log collector in the cluster (chief, worker)")
 
 	// if namespace is not passed, it will be taken from env
 	namespace := flag.String("namespace", "", "The namespace to collect logs from")
@@ -69,6 +70,7 @@ func StartServer() error {
 		*stateFileUpdateInterval,
 		*readLogWaitTime,
 		*monitoringInterval,
+		*clusterizationRole,
 		kubeClientSet,
 		*logCollectionBufferPoolSize,
 		*getLogsBufferPoolSize,
@@ -87,7 +89,7 @@ func getNamespace(namespaceArgument string) string {
 	}
 
 	// if the namespace exists in env, use that
-	if namespaceEnv := os.Getenv("MLRUN_LOG_COLLECTOR__NAMESPACE"); namespaceEnv != "" {
+	if namespaceEnv := os.Getenv("MLRUN_NAMESPACE"); namespaceEnv != "" {
 		return namespaceEnv
 	}
 

--- a/go/pkg/common/consts.go
+++ b/go/pkg/common/consts.go
@@ -1,0 +1,20 @@
+// Copyright 2018 Iguazio
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+const (
+	ErrCodeNotFound int32 = iota
+	ErrCodeInternal
+)

--- a/go/pkg/common/consts.go
+++ b/go/pkg/common/consts.go
@@ -14,6 +14,7 @@
 
 package common
 
+// error codes
 const (
 	ErrCodeNotFound int32 = iota
 	ErrCodeInternal

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -343,12 +343,9 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 // HasLogs returns true if the log file exists for a given run id
 func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogsRequest) (*protologcollector.HasLogsResponse, error) {
 
-	s.Logger.DebugWithCtx(ctx, "Received Has Logs request", "runUID", request.RunUID)
-
 	// get log file path
-	_, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName)
-	if err != nil {
-		if strings.Contains(common.GetErrorStack(err, 10), "not found") {
+	if _, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName); err != nil {
+		if strings.Contains(errors.RootCause(err).Error(), "not found") {
 			return &protologcollector.HasLogsResponse{
 				Success: true,
 				HasLogs: false,

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -54,6 +54,7 @@ type Server struct {
 	readLogWaitTime         time.Duration
 	monitoringInterval      time.Duration
 	bufferSizeBytes         int
+	isChief                 bool
 }
 
 // NewLogCollectorServer creates a new log collector server
@@ -62,7 +63,8 @@ func NewLogCollectorServer(logger logger.Logger,
 	baseDir,
 	stateFileUpdateInterval,
 	readLogWaitTime,
-	monitoringInterval string,
+	monitoringInterval,
+	clusterizationRole string,
 	kubeClientSet kubernetes.Interface,
 	logCollectionBufferPoolSize,
 	getLogsBufferPoolSize,
@@ -124,6 +126,7 @@ func NewLogCollectorServer(logger logger.Logger,
 		logCollectionBufferPool: logCollectionBufferPool,
 		getLogsBufferPool:       getLogsBufferPool,
 		bufferSizeBytes:         bufferSizeBytes,
+		isChief:                 clusterizationRole == "chief",
 	}, nil
 }
 
@@ -132,10 +135,13 @@ func (s *Server) OnBeforeStart(ctx context.Context) error {
 	s.Logger.DebugCtx(ctx, "Initializing Server")
 
 	// initialize the state store (load state from file, start state file update loop)
-	s.stateStore.Initialize(ctx)
+	// if the server is not the chief, do not monitor anything
+	if s.isChief {
+		s.stateStore.Initialize(ctx)
 
-	// start logging monitor
-	go s.monitorLogCollection(ctx)
+		// start logging monitor
+		go s.monitorLogCollection(ctx)
+	}
 
 	return nil
 }
@@ -188,8 +194,9 @@ func (s *Server) StartLog(ctx context.Context, request *protologcollector.StartL
 			"selector", request.Selector)
 		err := errors.Wrapf(err, "Failed to list pods for run id %s", request.RunUID)
 		return &protologcollector.StartLogResponse{
-			Success: false,
-			Error:   err.Error(),
+			Success:      false,
+			ErrorCode:    common.ErrCodeNotFound,
+			ErrorMessage: err.Error(),
 		}, err
 	}
 
@@ -200,8 +207,9 @@ func (s *Server) StartLog(ctx context.Context, request *protologcollector.StartL
 	if err := s.stateStore.AddLogItem(ctx, request.RunUID, request.Selector); err != nil {
 		err := errors.Wrapf(err, "Failed to add run id %s to state file", request.RunUID)
 		return &protologcollector.StartLogResponse{
-			Success: false,
-			Error:   err.Error(),
+			Success:      false,
+			ErrorCode:    common.ErrCodeInternal,
+			ErrorMessage: common.GetErrorStack(err, 10),
 		}, err
 	}
 
@@ -220,8 +228,9 @@ func (s *Server) StartLog(ctx context.Context, request *protologcollector.StartL
 	if err := s.inMemoryState.AddLogItem(ctx, request.RunUID, request.Selector); err != nil {
 		err := errors.Wrapf(err, "Failed to add run id %s to in memory state", request.RunUID)
 		return &protologcollector.StartLogResponse{
-			Success: false,
-			Error:   err.Error(),
+			Success:      false,
+			ErrorCode:    common.ErrCodeInternal,
+			ErrorMessage: common.GetErrorStack(err, 10),
 		}, err
 	}
 
@@ -324,6 +333,33 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 	return nil
 }
 
+// HasLogs returns true if the log file exists for a given run id
+func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogsRequest) (*protologcollector.HasLogsResponse, error) {
+
+	s.Logger.DebugWithCtx(ctx, "Received Has Logs request", "runUID", request.RunUID)
+
+	// get log file path
+	_, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName)
+	if err != nil {
+		if strings.Contains(common.GetErrorStack(err, 10), "not found") {
+			return &protologcollector.HasLogsResponse{
+				Success: true,
+				HasLogs: false,
+			}, nil
+		}
+		return &protologcollector.HasLogsResponse{
+			Success:      false,
+			ErrorCode:    common.ErrCodeInternal,
+			ErrorMessage: common.GetErrorStack(err, 10),
+		}, err
+	}
+
+	return &protologcollector.HasLogsResponse{
+		Success: true,
+		HasLogs: true,
+	}, nil
+}
+
 // startLogStreaming streams logs from a pod and writes them into a file
 func (s *Server) startLogStreaming(ctx context.Context,
 	runUID,
@@ -381,7 +417,7 @@ func (s *Server) startLogStreaming(ctx context.Context,
 	)
 
 	// stream logs - retry if failed
-	err := common.RetryUntilSuccessful(5*time.Second, 1*time.Second, func() (bool, error) {
+	err := common.RetryUntilSuccessful(15*time.Second, 3*time.Second, func() (bool, error) {
 		stream, streamErr = restClientRequest.Stream(ctx)
 		if streamErr != nil {
 			s.Logger.WarnWithCtx(ctx,
@@ -500,7 +536,7 @@ func (s *Server) streamPodLogs(ctx context.Context,
 
 // resolvePodLogFilePath returns the path to the pod log file
 func (s *Server) resolvePodLogFilePath(projectName, runUID, podName string) string {
-	return path.Join(s.baseDir, "logs", projectName, fmt.Sprintf("%s_%s.log", runUID, podName))
+	return path.Join(s.baseDir, "logs", projectName, fmt.Sprintf("%s_%s", runUID, podName))
 }
 
 // hasLogs returns true if the stream has logs, or false if the stream is empty or context is dead
@@ -563,15 +599,7 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 		}
 
 		if logFilePath == "" {
-
-			// if log collection for this runUID has already started, sleep and retry,
-			// as the log file might not have been created yet
-			if s.isLogCollectionRunning(ctx, runUID) {
-				return true, nil
-			}
-
-			// otherwise fail
-			return false, errors.Errorf("Failed to find log file for run id %s", runUID)
+			return false, errors.Errorf("Log file not found for run %s", runUID)
 		}
 
 		// found log file

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -622,13 +622,6 @@ func (s *Server) readLogsFromFile(ctx context.Context,
 	offset,
 	size int64) ([]byte, error) {
 
-	s.Logger.DebugWithCtx(ctx,
-		"Reading logs from file",
-		"runUID", runUID,
-		"filePath", filePath,
-		"offset", offset,
-		"size", size)
-
 	fileSize, err := common.GetFileSize(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to get file size for run id %s", runUID)

--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -43,7 +43,7 @@ func NewFileStore(logger logger.Logger, baseDirPath string, stateFileUpdateInter
 			InProgress: &sync.Map{},
 		},
 		logger:                  logger.GetChild("filestatestore"),
-		stateFilePath:           path.Join(baseDirPath, "state.json"),
+		stateFilePath:           path.Join(baseDirPath, "metadata", "state.json"),
 		stateFileUpdateInterval: stateFileUpdateInterval,
 		lock:                    &sync.Mutex{},
 	}

--- a/go/pkg/services/logcollector/test/logcollector_test.go
+++ b/go/pkg/services/logcollector/test/logcollector_test.go
@@ -87,9 +87,10 @@ func (suite *LogCollectorTestSuite) SetupSuite() {
 	suite.LogCollectorServer, err = logcollector.NewLogCollectorServer(suite.logger,
 		suite.namespace,
 		suite.baseDir,
-		"5s",  /* stateFileUpdateIntervalStr */
-		"3s",  /* readLogWaitTime */
-		"30s", /* monitoringInterval */
+		"5s",    /* stateFileUpdateIntervalStr */
+		"3s",    /* readLogWaitTime */
+		"30s",   /* monitoringInterval */
+		"chief", /* clusterizationRole */
 		suite.kubeClientSet,
 		30, /* logCollectionBufferPoolSize */
 		30, /* getLogsBufferSizeBytes */
@@ -110,8 +111,12 @@ func (suite *LogCollectorTestSuite) SetupTest() {
 
 func (suite *LogCollectorTestSuite) TearDownSuite() {
 
+	// delete namespace
+	err := suite.kubeClientSet.CoreV1().Namespaces().Delete(context.Background(), suite.namespace, metav1.DeleteOptions{})
+	suite.Require().NoError(err, "Failed to delete namespace")
+
 	// delete base dir and created files
-	err := os.RemoveAll(suite.baseDir)
+	err = os.RemoveAll(suite.baseDir)
 	suite.Require().NoError(err, "Failed to delete base dir")
 	suite.logger.InfoWith("Tear down complete", "testName", suite.T().Name())
 }

--- a/go/proto/log_collector.proto
+++ b/go/proto/log_collector.proto
@@ -23,6 +23,7 @@ import "google/protobuf/empty.proto";
 service LogCollector {
   rpc StartLog(StartLogRequest) returns (StartLogResponse) {}
   rpc GetLogs(GetLogsRequest) returns (stream GetLogsResponse) {}
+  rpc HasLogs(HasLogsRequest) returns (HasLogsResponse) {}
 }
 
 message StartLogRequest {
@@ -33,7 +34,8 @@ message StartLogRequest {
 
 message StartLogResponse {
   bool success = 1;
-  string error = 2;
+  int32 errorCode = 2;
+  string errorMessage = 3;
 }
 
 message GetLogsRequest {
@@ -45,6 +47,19 @@ message GetLogsRequest {
 
 message GetLogsResponse {
   bool success = 1;
-  string error = 2;
-  bytes logs = 3;
+  bytes logs = 2;
+  int32 errorCode = 3;
+  string errorMessage = 4;
+}
+
+message HasLogsRequest {
+  string runUID = 1;
+  string projectName = 2;
+}
+
+message HasLogsResponse {
+  bool success = 1;
+  bool hasLogs = 2;
+  int32 errorCode = 3;
+  string errorMessage = 4;
 }

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import enum
 import http
 import typing
 
@@ -20,6 +21,11 @@ import mlrun.errors
 import mlrun.utils.singleton
 from mlrun.config import config
 from mlrun.utils import logger
+
+
+class LogCollectorErrorCode(enum.Enum):
+    ErrCodeNotFound = 0
+    ErrCodeInternal = 1
 
 
 class LogCollectorClient(
@@ -69,12 +75,16 @@ class LogCollectorClient(
         response = await self._call("StartLog", request)
         if not response.success:
             msg = f"Failed to start logs for run {run_uid}"
-            if raise_on_error:
-                raise mlrun.errors.MLRunInternalServerError(
-                    f"{msg},error= {response.errorMessage}"
-                )
             if verbose:
                 logger.warning(msg, error=response.error)
+            if raise_on_error:
+                if response.error_code == LogCollectorErrorCode.ErrCodeNotFound.value:
+                    raise mlrun.errors.MLRunNotFoundError(
+                        f"{msg},error= {response.error_message}"
+                    )
+                raise mlrun.errors.MLRunInternalServerError(
+                    f"{msg},error= {response.error_message}"
+                )
         return response.success, response.error
 
     async def get_logs(
@@ -97,14 +107,22 @@ class LogCollectorClient(
         :return: The logs bytes
         """
 
-        # make sure this run has logs to collect
+        # check if this run has logs to collect
         try:
             has_logs = await self.has_logs(run_uid, project, verbose, raise_on_error)
-        except mlrun.errors.MLRunInternalServerError:
-            return
+            if not has_logs:
 
-        if not has_logs:
-            return
+                # run has no logs - return empty logs and exit so caller won't wait for logs or retry
+                yield b""
+                return
+        except mlrun.errors.MLRunInternalServerError as exc:
+            logger.warning(
+                "Failed to check if run has logs to collect", run_uid=run_uid
+            )
+            if raise_on_error:
+                raise mlrun.errors.MLRunInternalServerError(
+                    f"Failed to check if run has logs to collect for {run_uid}. exception= {exc}"
+                )
 
         request = self._log_collector_pb2.GetLogsRequest(
             runUID=run_uid,
@@ -112,9 +130,6 @@ class LogCollectorClient(
             offset=offset,
             size=size,
         )
-
-        # TODO: make a request to ensure file exists, return 404 if not
-        # otherwise, the first requests will return 500
 
         # retry calling the server, it can fail in case the log-collector hasn't started collecting logs for this yet
         # TODO: add async retry function
@@ -127,10 +142,10 @@ class LogCollectorClient(
                         msg = f"Failed to get logs for run {run_uid}"
                         if raise_on_error:
                             raise mlrun.errors.MLRunInternalServerError(
-                                f"{msg},error= {chunk.error}"
+                                f"{msg},error= {chunk.error_message}"
                             )
                         if verbose:
-                            logger.warning(msg, error=chunk.error)
+                            logger.warning(msg, error=chunk.error_message)
                     yield chunk.logs
                 return
             except Exception as exc:
@@ -170,9 +185,9 @@ class LogCollectorClient(
         if not response.success:
             msg = f"Failed to check if run has logs to collect for {run_uid}"
             if verbose:
-                logger.warning(msg, error=response.errorMessage)
+                logger.warning(msg, error=response.error_message)
             if raise_on_error:
                 raise mlrun.errors.MLRunInternalServerError(
-                    f"{msg},error= {response.errorMessage}"
+                    f"{msg},error= {response.error_message}"
                 )
-        return response.hasLogs
+        return response.has_logs

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -76,16 +76,16 @@ class LogCollectorClient(
         if not response.success:
             msg = f"Failed to start logs for run {run_uid}"
             if verbose:
-                logger.warning(msg, error=response.error)
+                logger.warning(msg, error=response.errorMessage)
             if raise_on_error:
-                if response.error_code == LogCollectorErrorCode.ErrCodeNotFound.value:
+                if response.errorCode == LogCollectorErrorCode.ErrCodeNotFound.value:
                     raise mlrun.errors.MLRunNotFoundError(
-                        f"{msg},error= {response.error_message}"
+                        f"{msg},error= {response.errorMessage}"
                     )
                 raise mlrun.errors.MLRunInternalServerError(
-                    f"{msg},error= {response.error_message}"
+                    f"{msg},error= {response.errorMessage}"
                 )
-        return response.success, response.error
+        return response.success, response.errorMessage
 
     async def get_logs(
         self,
@@ -140,12 +140,12 @@ class LogCollectorClient(
                 async for chunk in response_stream:
                     if not chunk.success:
                         msg = f"Failed to get logs for run {run_uid}"
+                        if verbose:
+                            logger.warning(msg, error=chunk.errorMessage)
                         if raise_on_error:
                             raise mlrun.errors.MLRunInternalServerError(
-                                f"{msg},error= {chunk.error_message}"
+                                f"{msg},error= {chunk.errorMessage}"
                             )
-                        if verbose:
-                            logger.warning(msg, error=chunk.error_message)
                     yield chunk.logs
                 return
             except Exception as exc:
@@ -185,9 +185,9 @@ class LogCollectorClient(
         if not response.success:
             msg = f"Failed to check if run has logs to collect for {run_uid}"
             if verbose:
-                logger.warning(msg, error=response.error_message)
+                logger.warning(msg, error=response.errorMessage)
             if raise_on_error:
                 raise mlrun.errors.MLRunInternalServerError(
-                    f"{msg},error= {response.error_message}"
+                    f"{msg},error= {response.errorMessage}"
                 )
-        return response.has_logs
+        return response.hasLogs

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -476,7 +476,7 @@ default_config = {
         # note that this mode also effects the log querying method as well, meaning if the mode is "best-effort"
         # the log query will try to use the sidecar first and if it's not available it will use the legacy method
         # TODO: once this is changed to "sidecar" by default, also change in common_fixtures.py
-        "mode": "legacy",
+        "mode": "sidecar",
         # interval for collecting and sending runs which require their logs to be collected
         "periodic_start_log_interval": 10,
         "verbose": True,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -476,7 +476,7 @@ default_config = {
         # note that this mode also effects the log querying method as well, meaning if the mode is "best-effort"
         # the log query will try to use the sidecar first and if it's not available it will use the legacy method
         # TODO: once this is changed to "sidecar" by default, also change in common_fixtures.py
-        "mode": "sidecar",
+        "mode": "legacy",
         # interval for collecting and sending runs which require their logs to be collected
         "periodic_start_log_interval": 10,
         "verbose": True,

--- a/tests/api/utils/clients/test_log_collector.py
+++ b/tests/api/utils/clients/test_log_collector.py
@@ -27,15 +27,19 @@ import mlrun.api.utils.clients.log_collector
 class StartLogResponse:
     def __init__(self, success, error):
         self.success = success
-        self.error_message = error
-        self.error_code = mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
+        self.errorMessage = error
+        self.errorCode = (
+            mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
+        )
 
 
 class GetLogsResponse:
     def __init__(self, success, error, logs, total_calls):
         self.success = success
-        self.error_message = error
-        self.error_code = mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
+        self.errorMessage = error
+        self.errorCode = (
+            mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
+        )
         self.logs = logs
         self.total_calls = total_calls
         self.current_calls = 0
@@ -54,9 +58,11 @@ class GetLogsResponse:
 class HasLogsResponse:
     def __init__(self, success, error, has_logs):
         self.success = success
-        self.error_message = error
-        self.error_code = mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
-        self.has_logs = has_logs
+        self.errorMessage = error
+        self.errorCode = (
+            mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
+        )
+        self.hasLogs = has_logs
 
 
 mlrun.mlconf.log_collector.address = "http://localhost:8080"

--- a/tests/api/utils/clients/test_log_collector.py
+++ b/tests/api/utils/clients/test_log_collector.py
@@ -27,13 +27,15 @@ import mlrun.api.utils.clients.log_collector
 class StartLogResponse:
     def __init__(self, success, error):
         self.success = success
-        self.error = error
+        self.error_message = error
+        self.error_code = mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
 
 
 class GetLogsResponse:
     def __init__(self, success, error, logs, total_calls):
         self.success = success
-        self.error = error
+        self.error_message = error
+        self.error_code = mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
         self.logs = logs
         self.total_calls = total_calls
         self.current_calls = 0
@@ -47,6 +49,14 @@ class GetLogsResponse:
             self.current_calls += 1
             return self
         raise StopAsyncIteration
+
+
+class HasLogsResponse:
+    def __init__(self, success, error, has_logs):
+        self.success = success
+        self.error_message = error
+        self.error_code = mlrun.api.utils.clients.log_collector.LogCollectorErrorCode.ErrCodeInternal
+        self.has_logs = has_logs
 
 
 mlrun.mlconf.log_collector.address = "http://localhost:8080"
@@ -100,6 +110,10 @@ class TestLogCollector:
 
         log_byte_string = b"some log"
 
+        # mock responses for HasLogs and GetLogs
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=HasLogsResponse(True, "", True)
+        )
         log_collector._call_stream = unittest.mock.MagicMock(
             return_value=GetLogsResponse(True, "", log_byte_string, 1)
         )
@@ -117,6 +131,11 @@ class TestLogCollector:
                 run_uid=run_uid, project=project_name
             ):
                 assert log == b""  # should not get here
+
+        # mock HasLogs response to return False
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=HasLogsResponse(True, "", False)
+        )
 
         log_stream = log_collector.get_logs(
             run_uid=run_uid, project=project_name, raise_on_error=False

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -139,7 +139,13 @@ class TestMLRunIntegration:
             "MLRUN_SKIP_COMPILE_SCHEMAS=true make",
             args=["run-api"],
             env=self._extend_current_env(
-                {"MLRUN_VERSION": "test-integration", "MLRUN_HTTPDB__DSN": self.db_dsn}
+                {
+                    "MLRUN_VERSION": "test-integration",
+                    "MLRUN_HTTPDB__DSN": self.db_dsn,
+
+                    # integration tests run in docker, and do no support sidecars for log collection
+                    "MLRUN__LOG_COLLECTOR__MODE": "legacy",
+                }
             ),
             cwd=TestMLRunIntegration.root_path,
         )

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -142,7 +142,6 @@ class TestMLRunIntegration:
                 {
                     "MLRUN_VERSION": "test-integration",
                     "MLRUN_HTTPDB__DSN": self.db_dsn,
-
                     # integration tests run in docker, and do no support sidecars for log collection
                     "MLRUN__LOG_COLLECTOR__MODE": "legacy",
                 }


### PR DESCRIPTION
In this PR there are several additions and fixes wrt the log collector gRPC service:

- Add `HasLogs` endpoint in the log collector server, for the api to call before calling `get_logs`. This enables the api to gracefully return empty logs to the client if the run has no logs to retrieve, instead of exploding.
- Align env vars according to https://github.com/v3io/helm-charts/pull/913.
- Limit the log collector to monitor goroutines, update the state file and call `StartLogs` for runs in progress only if it is in the chief pod (according the the env var `MLRUN_HTTPDB__CLUSTERIZATION__ROLE`.
- Support error codes in the grpc responses. Currently supports `NotFound` and `InternalError`.
- Fix log files and state file paths.
- Log stack trace in case of unexpected internal errors.