### PR TITLE
[API] Add collect logs method on startup of API

### DIFF
--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -540,7 +540,7 @@ func (s *Server) streamPodLogs(ctx context.Context,
 
 // resolvePodLogFilePath returns the path to the pod log file
 func (s *Server) resolvePodLogFilePath(projectName, runUID, podName string) string {
-	return path.Join(s.baseDir, "logs", projectName, fmt.Sprintf("%s_%s", runUID, podName))
+	return path.Join(s.baseDir, projectName, fmt.Sprintf("%s_%s", runUID, podName))
 }
 
 // hasLogs returns true if the stream has logs, or false if the stream is empty or context is dead

--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -42,7 +42,7 @@ func NewFileStore(logger logger.Logger, baseDirPath string, stateFileUpdateInter
 		state: &statestore.State{
 			InProgress: &sync.Map{},
 		},
-		logger:                  logger.GetChild("filestatestore"),
+		logger: logger.GetChild("filestatestore"),
 		// setting _metadata with "_" as a sub directory, so it won't conflict with projects directories
 		stateFilePath:           path.Join(baseDirPath, "_metadata", "state.json"),
 		stateFileUpdateInterval: stateFileUpdateInterval,

--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -43,7 +43,8 @@ func NewFileStore(logger logger.Logger, baseDirPath string, stateFileUpdateInter
 			InProgress: &sync.Map{},
 		},
 		logger:                  logger.GetChild("filestatestore"),
-		stateFilePath:           path.Join(baseDirPath, "metadata", "state.json"),
+		// setting _metadata with "_" as a sub directory, so it won't conflict with projects directories
+		stateFilePath:           path.Join(baseDirPath, "_metadata", "state.json"),
 		stateFileUpdateInterval: stateFileUpdateInterval,
 		lock:                    &sync.Mutex{},
 	}

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -63,8 +63,10 @@ class DBInterface(ABC):
         self,
         session,
         project: str = None,
-        requested_logs: bool = None,
+        requested_logs_modes: List[bool] = None,
         only_uids: bool = False,
+        last_update_time_from: datetime.datetime = None,
+        states: List[str] = None,
     ):
         pass
 

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -64,8 +64,10 @@ class FileDB(DBInterface):
         self,
         session,
         project: str = None,
-        requested_logs: bool = None,
+        requested_logs_modes: List[bool] = None,
         only_uids: bool = False,
+        last_update_time_from: datetime.datetime = None,
+        states: List[str] = None,
     ):
         raise NotImplementedError()
 

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -22,6 +22,7 @@ import uuid
 
 import fastapi
 import fastapi.concurrency
+import sqlalchemy.orm
 import uvicorn
 import uvicorn.protocols.utils
 from fastapi.exception_handlers import http_exception_handler
@@ -281,8 +282,8 @@ async def _verify_log_collection_started_on_startup(
         states=mlrun.runtimes.constants.RunStates.non_terminal_states(),
     )
     logger.debug(
-        "Getting all runs which are in terminal state from the ",
-        hours=config.log_collector.log_buffer_start_collection_in_hours,
+        "Getting all runs which are might have reached terminal state while the API was down",
+        api_downtime_grace_period=config.log_collector.api_downtime_grace_period,
     )
     runs.extend(
         await fastapi.concurrency.run_in_threadpool(
@@ -302,6 +303,43 @@ async def _verify_log_collection_started_on_startup(
             "Found runs which require logs collection",
             runs_uids=runs,
         )
+        await _start_log_and_update_runs(start_logs_limit, db_session, runs)
+
+
+async def _initiate_logs_collection(start_logs_limit: asyncio.Semaphore):
+    """
+    This function is responsible for initiating the logs collection process. It will get a list of all runs which are
+    in a state which requires logs collection and will initiate the logs collection process for each of them.
+    :param start_logs_limit: a semaphore which limits the number of concurrent logs collection processes
+    """
+    db_session = await fastapi.concurrency.run_in_threadpool(create_session)
+    try:
+        # list all the runs in the system which we didn't request logs collection for yet
+        runs = await fastapi.concurrency.run_in_threadpool(
+            get_db().list_distinct_runs_uids,
+            db_session,
+            requested_logs_modes=[False],
+            only_uids=False,
+        )
+        if runs:
+            logger.debug(
+                "Found runs which require logs collection",
+                runs_uids=runs,
+            )
+            await _start_log_and_update_runs(start_logs_limit, db_session, runs)
+
+    finally:
+        await fastapi.concurrency.run_in_threadpool(close_session, db_session)
+
+
+async def _start_log_and_update_runs(
+    start_logs_limit: asyncio.Semaphore,
+    db_session: sqlalchemy.orm.Session,
+    runs: list,
+):
+    if not runs:
+        return
+
     # each result contains either run_uid or None
     # if it's None it means something went wrong and we should skip it
     # if it's run_uid it means we requested logs collection for it and we should update it's requested_logs field
@@ -327,52 +365,6 @@ async def _verify_log_collection_started_on_startup(
             db_session,
             uids=runs_to_update_requested_logs,
         )
-
-
-async def _initiate_logs_collection(start_logs_limit: asyncio.Semaphore):
-    """
-    This function is responsible for initiating the logs collection process. It will get a list of all runs which are
-    in a state which requires logs collection and will initiate the logs collection process for each of them.
-    :param start_logs_limit: a semaphore which limits the number of concurrent logs collection processes
-    """
-    db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-    try:
-        # list all the runs in the system which we didn't request logs collection for yet
-        runs = await fastapi.concurrency.run_in_threadpool(
-            get_db().list_distinct_runs_uids,
-            db_session,
-            requested_logs_modes=[False],
-            only_uids=False,
-        )
-        if runs:
-            logger.debug(
-                "Found runs which require logs collection",
-                runs_uids=runs,
-            )
-        # each result contains either run_uid or None
-        # if it's None it means something went wrong and we should skip it
-        # if it's run_uid it means we requested logs collection for it and we should update it's requested_logs field
-        results = await asyncio.gather(
-            *[
-                _start_log_for_run(run, start_logs_limit, raise_on_error=False)
-                for run in runs
-            ]
-        )
-        runs_to_update_requested_logs = [result for result in results if result]
-        if len(runs_to_update_requested_logs) > 0:
-            logger.debug(
-                "Updating runs to indicate that we requested logs collection for them",
-                runs_uids=runs_to_update_requested_logs,
-            )
-            # update the runs to indicate that we have requested log collection for them
-            await fastapi.concurrency.run_in_threadpool(
-                get_db().update_runs_requested_logs,
-                db_session,
-                uids=runs_to_update_requested_logs,
-            )
-
-    finally:
-        await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
 
 async def _start_log_for_run(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -482,10 +482,10 @@ default_config = {
         "verbose": True,
         # the number of workers which will be used to trigger the start log collection
         "concurrent_start_logs_workers": 15,
-        # the time in hours in which to start log collection for runs when initialization API
+        # the time in hours in which to start log collection from.
         # after upgrade we might have runs which completed in the mean time or still in non-terminal state and
         # we want to collect their logs in the new log collection method (sidecar)
-        "log_buffer_start_collection_in_hours": 6,
+        "api_downtime_grace_period": 6,
         "get_logs": {
             # the number of retries to get logs from the log collector
             "max_retries": 3,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -482,6 +482,10 @@ default_config = {
         "verbose": True,
         # the number of workers which will be used to trigger the start log collection
         "concurrent_start_logs_workers": 15,
+        # the time in hours in which to start log collection for runs when initialization API
+        # after upgrade we might have runs which completed in the mean time or still in non-terminal state and
+        # we want to collect their logs in the new log collection method (sidecar)
+        "log_buffer_start_collection_in_hours": 6,
         "get_logs": {
             # the number of retries to get logs from the log collector
             "max_retries": 3,

--- a/tests/api/db/test_runs.py
+++ b/tests/api/db/test_runs.py
@@ -86,23 +86,23 @@ def test_list_distinct_runs_uids(db: DBInterface, db_session: Session):
     assert only_uids[0] == uid
 
     only_uids_requested_true = db.list_distinct_runs_uids(
-        db_session, project=project_name, only_uids=True, requested_logs=True
+        db_session, project=project_name, only_uids=True, requested_logs_modes=[True]
     )
     assert len(only_uids_requested_true) == 0
 
     only_uids_requested_false = db.list_distinct_runs_uids(
-        db_session, project=project_name, only_uids=True, requested_logs=False
+        db_session, project=project_name, only_uids=True, requested_logs_modes=[False]
     )
     assert len(only_uids_requested_false) == 1
     assert type(only_uids[0]) == str
 
     distinct_runs_requested_true = db.list_distinct_runs_uids(
-        db_session, project=project_name, requested_logs=True
+        db_session, project=project_name, requested_logs_modes=[True]
     )
     assert len(distinct_runs_requested_true) == 0
 
     distinct_runs_requested_false = db.list_distinct_runs_uids(
-        db_session, project=project_name, requested_logs=False
+        db_session, project=project_name, requested_logs_modes=[False]
     )
     assert len(distinct_runs_requested_false) == 1
     assert type(distinct_runs[0]) == dict

--- a/tests/api/test_collect_runs_logs.py
+++ b/tests/api/test_collect_runs_logs.py
@@ -14,6 +14,7 @@
 import asyncio
 import unittest.mock
 
+import deepdiff
 import fastapi.testclient
 import pytest
 import sqlalchemy.orm.session
@@ -147,10 +148,16 @@ class TestCollectRunSLogs:
             == 1
         )
         assert (
-            mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs.call_args[
-                1
-            ]["uids"]
-            == run_uids
+            deepdiff.DeepDiff(
+                mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs.call_args[
+                    1
+                ][
+                    "uids"
+                ],
+                run_uids,
+                ignore_order=True,
+            )
+            == {}
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This addition is for cases when the API was upgrade from legacy mode to sidecar mode. 
Which in this case we have two kind of scenarios we want to make sure we catch:
- Run is still running from previous log collection method, so we would like to start collecting logs for that run with the new method.
- Run changed it state while API was down and requires logs to be picked up.

Log collector service :
- Removed from directory generation to addition of `/logs` in the path as it already being passed in the helm chart
- Renamed the `metadata` generated directory to `_metadata` so it won't conflict with user project names 