### PR TITLE
[API] Remove stream_request from api call

### DIFF
--- a/go/pkg/common/k8s/k8s.go
+++ b/go/pkg/common/k8s/k8s.go
@@ -14,7 +14,7 @@ func ResolveRunningNamespace(namespaceArgument string) string {
 	}
 
 	// if the namespace exists in env, use that
-	if namespaceEnv := os.Getenv("MLRUN_LOG_COLLECTOR__NAMESPACE"); namespaceEnv != "" {
+	if namespaceEnv := os.Getenv("MLRUN_NAMESPACE"); namespaceEnv != "" {
 		return namespaceEnv
 	}
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -137,8 +137,6 @@ class HTTPRunDB(RunDBInterface):
         headers=None,
         timeout=45,
         version=None,
-        stream: bool = False,
-        to_stdout: bool = False,
     ):
         """Perform a direct REST API call on the :py:mod:`mlrun` API server.
 
@@ -210,10 +208,6 @@ class HTTPRunDB(RunDBInterface):
             )
 
         try:
-            if stream:
-                return self.session.stream_request(
-                    method, url, to_stdout=to_stdout, timeout=timeout, **kw
-                )
             response = self.session.request(
                 method, url, timeout=timeout, verify=False, **kw
             )

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -134,25 +134,6 @@ class HTTPSessionWithRetry(requests.Session):
                 retry_count += 1
                 time.sleep(self.retry_backoff_factor)
 
-    def stream_request(self, method: str, url: str, to_stdout: bool = True, **kwargs):
-        """
-        Stream a request to stdout or return the
-        :param method: HTTP method
-        :param url: URL to request
-        :param to_stdout: If True, stream to stdout. If False, return the response.
-        :param kwargs: Additional arguments to pass to requests
-        :return: response body if to_stdout is False, else empty string
-        """
-        response_body = ""
-        with super().request(method, url, stream=True, **kwargs) as resp:
-            for line in resp.iter_lines():
-                if line:
-                    if to_stdout:
-                        print(line.decode())
-                    else:
-                        response_body += line.decode()
-        return response_body
-
     @staticmethod
     def _get_retry_methods(retry_on_post=False):
         return (


### PR DESCRIPTION
`stream_request` is unused by anyone, so it can be removed from `api_call`.

Also, align sidecar's namespace env var with the api's env var.