### PR TITLE
[Runtimes] Add ability to mount (and auto-mount) a secret as environment variables using `envFrom` 

### DIFF
--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -121,6 +121,24 @@ def mount_secret(secret_name, mount_path, volume_name="secret", items=None):
     return _mount_secret
 
 
+def mount_env_from_secret(secret_name, prefix=None):
+    """
+    Modifier function to mount kubernetes secret as environment variables. Uses k8s env_from
+    to apply all contents of the secret as env. variables.
+
+    :param secret_name:         k8s secret name
+    :param prefix:              Prefix to append to env. variable names when mounting to the pod
+    """
+
+    def _mount_env_from_secret(task):
+        from kubernetes import client as k8s_client
+
+        env_from = k8s_client.V1EnvFromSource(secret_ref=secret_name, prefix=prefix)
+        task.container.add_env_from(env_from)
+
+    return _mount_env_from_secret
+
+
 def mount_configmap(configmap_name, mount_path, volume_name="configmap", items=None):
     """Modifier function to mount kubernetes configmap as files(s)
 

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -133,7 +133,7 @@ def mount_env_from_secret(secret_name, prefix=None):
 
     if secret_name.startswith("mlrun-"):
         raise mlrun.errors.MLRunInvalidArgumentError(
-            "secret must not be an MLRun internal secret"
+            "env_from secret must not be an MLRun internal secret"
         )
 
     def _mount_env_from_secret(task):

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -133,7 +133,9 @@ def mount_env_from_secret(secret_name, prefix=None):
     def _mount_env_from_secret(task):
         from kubernetes import client as k8s_client
 
-        env_from = k8s_client.V1EnvFromSource(secret_ref=secret_name, prefix=prefix)
+        env_from = k8s_client.V1EnvFromSource(
+            secret_ref=k8s_client.V1SecretEnvSource(name=secret_name), prefix=prefix
+        )
         task.container.add_env_from(env_from)
 
     return _mount_env_from_secret

--- a/mlrun/platforms/other.py
+++ b/mlrun/platforms/other.py
@@ -124,11 +124,17 @@ def mount_secret(secret_name, mount_path, volume_name="secret", items=None):
 def mount_env_from_secret(secret_name, prefix=None):
     """
     Modifier function to mount kubernetes secret as environment variables. Uses k8s env_from
-    to apply all contents of the secret as env. variables.
+    to apply all contents of the secret as env. variables. To mount secret keys as files, use the `mount_secret`
+    modifier instead.
 
     :param secret_name:         k8s secret name
-    :param prefix:              Prefix to append to env. variable names when mounting to the pod
+    :param prefix:              Prefix to append to env. variable names when mounting
     """
+
+    if secret_name.startswith("mlrun-"):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "secret must not be an MLRun internal secret"
+        )
 
     def _mount_env_from_secret(task):
         from kubernetes import client as k8s_client

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -388,6 +388,7 @@ def func_to_pod(image, runtime, extra_env, command, args, workdir):
         name="base",
         image=image,
         env=extra_env + runtime.spec.env,
+        env_from=runtime.spec.env_from,
         command=[command],
         args=args,
         working_dir=workdir,

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -353,6 +353,9 @@ class KubejobRuntime(KubeResource):
                 # relative path mapped to real path in the job pod
                 workdir = os.path.join("/mlrun", workdir)
 
+        # make sure internal mlrun project secrets were not accessed through env_from
+        self._filter_env_from_entries_before_running()
+
         pod_spec = func_to_pod(
             self.full_image_path(
                 client_version=runobj.metadata.labels.get("mlrun/client_version")

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -91,6 +91,7 @@ class KubeResourceSpec(FunctionSpec):
         "volumes",
         "volume_mounts",
         "env",
+        "env_from",
         "resources",
         "replicas",
         "image_pull_policy",
@@ -133,6 +134,7 @@ class KubeResourceSpec(FunctionSpec):
         tolerations=None,
         preemption_mode=None,
         security_context=None,
+        env_from=None,
     ):
         super().__init__(
             command=command,
@@ -152,6 +154,7 @@ class KubeResourceSpec(FunctionSpec):
         self.volumes = volumes or []
         self.volume_mounts = volume_mounts or []
         self.env = env or []
+        self.env_from = env_from or []
         self._resources = self.enrich_resources_with_default_pod_resources(
             "resources", resources
         )
@@ -807,6 +810,7 @@ class AutoMountType(str, Enum):
     pvc = "pvc"
     s3 = "s3"
     env = "env"
+    env_from_secret = "env_from_secret"
 
     @classmethod
     def _missing_(cls, value):
@@ -831,6 +835,7 @@ class AutoMountType(str, Enum):
             mlrun.auto_mount.__name__,
             mlrun.platforms.mount_s3.__name__,
             mlrun.platforms.set_env_variables.__name__,
+            mlrun.platforms.other.mount_env_from_secret.__name__,
         ]
 
     @classmethod
@@ -865,6 +870,7 @@ class AutoMountType(str, Enum):
             AutoMountType.auto: self._get_auto_modifier(),
             AutoMountType.s3: mlrun.platforms.mount_s3,
             AutoMountType.env: mlrun.platforms.set_env_variables,
+            AutoMountType.env_from_secret: mlrun.platforms.other.mount_env_from_secret,
         }[self]
 
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1171,6 +1171,18 @@ class KubeResource(BaseRuntime):
             new_meta.generate_name = norm_name
         return new_meta
 
+    def _filter_env_from_entries_before_running(self):
+        filtered_env_from = []
+        for env_from in self.spec.env_from:
+            if env_from["secretRef"]["name"].startswith("mlrun-"):
+                logger.warning(
+                    "env_from attempted with an internal mlrun secret",
+                    name=env_from["secretRef"]["name"],
+                )
+            else:
+                filtered_env_from.append(env_from)
+        self.spec.env_from = filtered_env_from
+
     def _add_secrets_to_spec_before_running(self, runobj=None, project=None):
         if self._secrets:
             if self._secrets.has_vault_source():

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -421,14 +421,8 @@ def apply_kfp(modify, cop, runtime):
         cop.container.env.clear()
 
     if cop.container.env_from:
-        runtime.spec.env_from = [
-            {
-                "secret_ref": env_from.secret_ref
-                if hasattr(env_from, "secret_ref")
-                else env_from["secret_ref"]
-            }
-            for env_from in cop.container.env_from
-        ]
+        for env_from in cop.container.env_from:
+            runtime.spec.env_from.append(api.sanitize_for_serialization(env_from))
         cop.container.env_from.clear()
 
     if cop.volumes and cop.container.volume_mounts:

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -421,8 +421,14 @@ def apply_kfp(modify, cop, runtime):
         cop.container.env.clear()
 
     if cop.container.env_from:
-        for env_from in cop.container.env_from:
-            runtime.spec.env_from.append(api.sanitize_for_serialization(env_from))
+        runtime.spec.env_from = [
+            {
+                "secret_ref": env_from.secret_ref
+                if hasattr(env_from, "secret_ref")
+                else env_from["secret_ref"]
+            }
+            for env_from in cop.container.env_from
+        ]
         cop.container.env_from.clear()
 
     if cop.volumes and cop.container.volume_mounts:

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -420,6 +420,11 @@ def apply_kfp(modify, cop, runtime):
                 env_names.append(name)
         cop.container.env.clear()
 
+    if cop.container.env_from:
+        for env_from in cop.container.env_from:
+            runtime.spec.env_from.append(api.sanitize_for_serialization(env_from))
+        cop.container.env_from.clear()
+
     if cop.volumes and cop.container.volume_mounts:
         vols = api.sanitize_for_serialization(cop.volumes)
         mounts = api.sanitize_for_serialization(cop.container.volume_mounts)

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -310,7 +310,7 @@ class RunDBMock:
 
     def assert_env_from_secret_configured(self, secret_name):
         env_from_list = self._function["spec"]["env_from"]
-        secret_names = [env_from["secretRef"] for env_from in env_from_list]
+        secret_names = [env_from["secret_ref"] for env_from in env_from_list]
         assert secret_name in secret_names
 
     def assert_v3io_mount_or_creds_configured(

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -308,6 +308,11 @@ class RunDBMock:
         assert len(volumes) == 0
         assert len(volume_mounts) == 0
 
+    def assert_env_from_secret_configured(self, secret_name):
+        env_from_list = self._function["spec"]["env_from"]
+        secret_names = [env_from["secretRef"] for env_from in env_from_list]
+        assert secret_name in secret_names
+
     def assert_v3io_mount_or_creds_configured(
         self, v3io_user, v3io_access_key, cred_only=False
     ):

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -310,7 +310,7 @@ class RunDBMock:
 
     def assert_env_from_secret_configured(self, secret_name):
         env_from_list = self._function["spec"]["env_from"]
-        secret_names = [env_from["secret_ref"] for env_from in env_from_list]
+        secret_names = [env_from["secretRef"]["name"] for env_from in env_from_list]
         assert secret_name in secret_names
 
     def assert_v3io_mount_or_creds_configured(

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -223,3 +223,13 @@ class TestAutoMount:
         rundb_mock.reset()
         self._execute_run(runtime)
         rundb_mock.assert_env_variables(expected_env)
+
+    def test_auto_mount_env_from_secret(self, rundb_mock):
+        secret_name = "my_secret_1"
+
+        mlconf.storage.auto_mount_type = "env_from_secret"
+        mlconf.storage.auto_mount_params = f"secret_name={secret_name}"
+
+        runtime = self._generate_runtime()
+        self._execute_run(runtime)
+        rundb_mock.assert_env_from_secret_configured(secret_name)

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -208,3 +208,19 @@ def test_volume_mounts_addition():
         sanitized_dict_volume_mount,
     ]
     assert len(function.spec.volume_mounts) == 1
+
+
+def test_filtering_env_from_entries():
+    function = mlrun.new_function(kind=mlrun.runtimes.RuntimeKinds.job)
+    function.apply(
+        mlrun.platforms.other.mount_env_from_secret(secret_name="mlrun-internal-secret")
+    )
+    function.apply(
+        mlrun.platforms.other.mount_env_from_secret(secret_name="a-valid-secret")
+    )
+    assert len(function.spec.env_from) == 2
+
+    function._filter_env_from_entries_before_running()
+
+    assert len(function.spec.env_from) == 1
+    assert function.spec.env_from[0]["secretRef"]["name"] == "a-valid-secret"


### PR DESCRIPTION
* Created the `mount_env_from_secret` modifier that accepts a secret name and uses `envFrom` to mount keys defined in the secret as env variables
* Added a new auto-mount type - `env_from_secret` which uses this modifier
* The secret name cannot start with `mlrun-` to prevent users from mapping project-secrets and internal MLRun secrets to their jobs. This is enforced both in the modifier and on server-side, before calling `func_to_pod` (since otherwise the user can manually add env-from to the runtime itself, bypassing the modifier)
* The intended use-case is for auto-mounting Azure credentials, while not exposing them as cleartext in the MLRun service pod spec
