### PR TITLE
[Requirements] Add graphivz to `mlrun[complete]`

### DIFF
--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -27,3 +27,4 @@ plotly~=5.4, <5.12.0
 google-cloud-bigquery[pandas]~=3.2
 kafka-python~=2.0
 redis~=4.3
+graphviz~=0.20.0

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,8 @@ extras_require = {
     # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
     # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
     "plotly": ["plotly~=5.4, <5.12.0"],
+    # used to generate visualization nuclio/serving graph steps
+    "graphviz":["graphviz~=0.20.0"],
     # google-cloud is mainly used for QA, that is why we are not including it in complete
     "google-cloud": [
         # because of kfp 1.8.13 requiring google-cloud-storage<2.0.0, >=1.20.0

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ extras_require = {
     # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
     "plotly": ["plotly~=5.4, <5.12.0"],
     # used to generate visualization nuclio/serving graph steps
-    "graphviz":["graphviz~=0.20.0"],
+    "graphviz": ["graphviz~=0.20.0"],
     # google-cloud is mainly used for QA, that is why we are not including it in complete
     "google-cloud": [
         # because of kfp 1.8.13 requiring google-cloud-storage<2.0.0, >=1.20.0


### PR DESCRIPTION
until now `graphivz` wasn't a requirement of MLRun but rather an extra requirement which was installed as part of some of our images such as `jupyter` / `ml-base` / `dev-requirements`. as part of supporting both python 3.9 and 3.7 in 1.3.0 it means that users might use their old jupyter and install new conda env with python 3.9, but in that environment we wouldn't have `graphivz` pre-baked so we add `grpahivz` as part of our `[complete]` install which means the `align_mlrun` will install it.

https://jira.iguazeng.com/browse/ML-3239