### PR TITLE
[Runtimes] Add global secret option - secret whose keys will be attached to all functions

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -398,7 +398,7 @@ default_config = {
             "project_secret_name": "mlrun-project-secrets-{project}",
             "auth_secret_name": "mlrun-auth-secrets.{hashed_access_key}",
             "env_variable_prefix": "MLRUN_K8S_SECRET__",
-            "global_secret_name": None,
+            "global_function_env_secret_name": None,
         },
     },
     "feature_store": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -398,6 +398,7 @@ default_config = {
             "project_secret_name": "mlrun-project-secrets-{project}",
             "auth_secret_name": "mlrun-auth-secrets.{hashed_access_key}",
             "env_variable_prefix": "MLRUN_K8S_SECRET__",
+            "global_secret_name": None,
         },
     },
     "feature_store": {

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -543,6 +543,9 @@ class K8sHelper:
 
     def _get_project_secrets_raw_data(self, project, namespace=""):
         secret_name = self.get_project_secret_name(project)
+        return self._get_secret_raw_data(secret_name, namespace)
+
+    def _get_secret_raw_data(self, secret_name, namespace=""):
         namespace = self.resolve_namespace(namespace)
 
         try:
@@ -565,8 +568,15 @@ class K8sHelper:
         return secret_keys
 
     def get_project_secret_data(self, project, secret_keys=None, namespace=""):
-        results = {}
         secrets_data = self._get_project_secrets_raw_data(project, namespace)
+        return self._decode_secret_data(secrets_data, secret_keys)
+
+    def get_secret_data(self, secret_name, namespace=""):
+        secrets_data = self._get_secret_raw_data(secret_name, namespace)
+        return self._decode_secret_data(secrets_data)
+
+    def _decode_secret_data(self, secrets_data, secret_keys=None):
+        results = {}
         if not secrets_data:
             return results
 
@@ -577,7 +587,6 @@ class K8sHelper:
             encoded_value = secrets_data.get(key)
             if encoded_value:
                 results[key] = base64.b64decode(secrets_data[key]).decode("utf-8")
-
         return results
 
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -509,7 +509,7 @@ class RemoteRuntime(KubeResource):
         # For nuclio functions, we just add the project secrets as env variables. Since there's no MLRun code
         # to decode the secrets and special env variable names in the function, we just use the same env variable as
         # the key name (encode_key_names=False)
-        self._add_project_k8s_secrets_to_spec(
+        self._add_k8s_secrets_to_spec(
             None, project=self.metadata.project, encode_key_names=False
         )
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1210,7 +1210,9 @@ class KubeResource(BaseRuntime):
     ):
         # Check if we need to add the keys of a global secret. Global secrets are intentionally added before
         # project secrets, to allow project secret keys to override them
-        global_secret_name = mlconf.secret_stores.kubernetes.global_secret_name
+        global_secret_name = (
+            mlconf.secret_stores.kubernetes.global_function_env_secret_name
+        )
         if mlrun.config.is_running_as_api() and global_secret_name:
             global_secrets = self._get_k8s().get_secret_data(global_secret_name)
             for key, value in global_secrets.items():

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -561,11 +561,11 @@ class ServingRuntime(RemoteRuntime):
                 self._add_azure_vault_params_to_spec(
                     self._secrets.get_azure_vault_k8s_secret()
                 )
-            self._add_project_k8s_secrets_to_spec(
+            self._add_k8s_secrets_to_spec(
                 self._secrets.get_k8s_secrets(), project=self.metadata.project
             )
         else:
-            self._add_project_k8s_secrets_to_spec(None, project=self.metadata.project)
+            self._add_k8s_secrets_to_spec(None, project=self.metadata.project)
 
     def deploy(
         self,

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -382,12 +382,14 @@ class TestKubejobRuntime(TestRuntimeBase):
         k8s_secrets_mock.store_project_secrets(self.project, project_secrets)
         k8s_secrets_mock.store_secret(global_secret_name, global_secrets)
 
-        mlconf.secret_stores.kubernetes.global_secret_name = global_secret_name
+        mlconf.secret_stores.kubernetes.global_function_env_secret_name = (
+            global_secret_name
+        )
         runtime = self._generate_runtime()
 
         self.execute_function(runtime)
 
-        mlconf.secret_stores.kubernetes.global_secret_name = None
+        mlconf.secret_stores.kubernetes.global_function_env_secret_name = None
 
         expected_env_from_secrets = (
             k8s_secrets_mock.get_expected_env_variables_from_secrets(

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -363,6 +363,42 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_env_from_secrets=expected_env_from_secrets,
         )
 
+    def test_run_with_global_secrets(
+        self, db: Session, k8s_secrets_mock: K8sSecretsMock
+    ):
+        project_secret_keys = ["secret1", "secret2", "secret3", "mlrun.internal_secret"]
+        project_secrets = {key: "some-secret-value" for key in project_secret_keys}
+        # secret1 is included both in the global secrets and the project secrets, it should have the value from the
+        # project-secret (this is the logic in get_expected_env_variables_from_secrets)
+        global_secret_keys = [
+            "global_secret1",
+            "global_secret2",
+            "mlrun.global_secret3",
+            "secret1",
+        ]
+        global_secrets = {key: "some-global-secret-value" for key in global_secret_keys}
+        global_secret_name = "global-secret-1"
+
+        k8s_secrets_mock.store_project_secrets(self.project, project_secrets)
+        k8s_secrets_mock.store_secret(global_secret_name, global_secrets)
+
+        mlconf.secret_stores.kubernetes.global_secret_name = global_secret_name
+        runtime = self._generate_runtime()
+
+        self.execute_function(runtime)
+
+        mlconf.secret_stores.kubernetes.global_secret_name = None
+
+        expected_env_from_secrets = (
+            k8s_secrets_mock.get_expected_env_variables_from_secrets(
+                self.project, include_internal=False, global_secret=global_secret_name
+            )
+        )
+
+        self._assert_pod_creation_config(
+            expected_env_from_secrets=expected_env_from_secrets,
+        )
+
     def test_run_with_vault_secrets(self, db: Session, client: TestClient):
         self._mock_vault_functionality()
         runtime = self._generate_runtime()


### PR DESCRIPTION
Adding a global secret capability that is equivalent to project-secrets, but with global scope. The secret name is configured in the MLRun config under `secret_stores.kubernetes.global_function_env_secret_name`, and if it exists, any job that is executed will get all the keys in that secret attached as env variables.
Project secrets will override the global secret, meaning that if the same key is defined in the global secret and in a project secret, the value will be taken from the project secret.
MLRun does not provide a facility for the user to set or manage the global secret content -  this needs to be done externally through `kubectl` or similar. All MLRun does is mounting the secret keys to jobs. MLRun also does not perform any check on the secret name - it is expected that the admin that configures MLRun has taken caution to only expose intended data.

The intended usage for this is situations such as deploying CE on Azure, where we want to use an Azure blob storage container as artifact store, and need the Azure connection string to automatically be available to all jobs - auto-mount does not give a solution there since it exposes the connection string in the MLRun pod spec, so it can be now achieved by creating a secret at deployment time with the connection string, and setting a global secret pointing at it.