### PR TITLE
[Datastore] Fix BaseStoreTarget from_spec() to set target secrets and credentials_prefix

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -582,6 +582,11 @@ class BaseStoreTarget(DataTargetBase):
         if hasattr(spec, "columns"):
             driver.columns = spec.columns
 
+        if hasattr(spec, "_credentials_prefix"):
+            driver._credentials_prefix = spec._credentials_prefix
+        if hasattr(spec, "_secrets"):
+            driver._secrets = spec._secrets
+
         driver.partitioned = spec.partitioned
 
         driver.key_bucketing_number = spec.key_bucketing_number


### PR DESCRIPTION
[ML-3321](https://jira.iguazeng.com/browse/ML-3321)
When target driver is created from a target object, copy the credentials prefix and the secrets to the driver