### PR TITLE
[Docs] Spark engine support for steps: MapValues, Imputer, OneHotEncoder, DropFeatures; DateExtractor (partial) 

### DIFF
--- a/docs/serving/available-steps.md
+++ b/docs/serving/available-steps.md
@@ -1,7 +1,7 @@
 (available-steps)=
 # Built-in steps
 
-MlRun provides you with many built-in steps that you can use when building your graph. 
+MlRun provides you with many built-in steps that you can use when building your graph. All steps are supported by the storey engine. Support by any other engines is included in the step description, as relevant.
 
 Click on the step names in the following sections to see the full usage.
 
@@ -38,11 +38,12 @@ Click on the step names in the following sections to see the full usage.
 | Class name            | Description                           |  
 |----------------------------|--------------------------------------------------------------|   
 | [storey.AggregateByKey](https://storey.readthedocs.io/en/latest/api.html#storey.aggregations.AggregateByKey) | Aggregates the data into the table object provided for later persistence, and outputs an event enriched with the requested aggregation features. |
-| [DateExtractor](../api/mlrun.feature_store.html#mlrun.feature_store.steps.DateExtractor)  | Extract a date-time component. |
-| [mlrun.feature_store.Imputer](../api/mlrun.feature_store.html#mlrun.feature_store.steps.Imputer) | Replace None values with default values.   |
-| [mlrun.feature_store.MapValues](../api/mlrun.feature_store.html#mlrun.feature_store.steps.MapValues) | Map column values to new values.   |
-| [mlrun.feature_store.OneHotEncoder](../api/mlrun.feature_store.html#mlrun.feature_store.steps.OneHotEncoder) | Create new binary fields, one per category (one hot encoded).  | 
-| [mlrun.feature_store.SetEventMetadata](../api/mlrun.feature_store.html#mlrun.feature_store.steps.SetEventMetadata) | Set the event metadata (id, key, timestamp) from the event body. |
+| [mlrun.feature_store.DateExtractor](../api/mlrun.feature_store.html#mlrun.feature_store.steps.DateExtractor)  | Extract a date-time component. Supported also by Pandas and Spark engines. Spark supports extracting only the time parts from the date data.|
+| [mlrun.feature_store.DropFeatures](../api/mlrun.feature_store.html#mlrun.feature_store.steps.DropFeatures) | Drop features from feature list. Supported also by the Pandas and Spark engines. |
+| [mlrun.feature_store.Imputer](../api/mlrun.feature_store.html#mlrun.feature_store.steps.Imputer) | Replace None values with default values. Supported also by the Pandas and Spark engines. |
+| [mlrun.feature_store.MapValues](../api/mlrun.feature_store.html#mlrun.feature_store.steps.MapValues) | Map column values to new values. Supported also by the Pandas and Spark engines. |
+| [mlrun.feature_store.OneHotEncoder](../api/mlrun.feature_store.html#mlrun.feature_store.steps.OneHotEncoder) | Create new binary fields, one per category (one hot encoded). Supported also by the Pandas and Spark engines. | 
+| [mlrun.feature_store.SetEventMetadata](../api/mlrun.feature_store.html#mlrun.feature_store.steps.SetEventMetadata) | Set the event metadata (id, key, timestamp) from the event body. Supported also by the Pandas and Spark engines.|
 
 
 ## External IO and data enrichment
@@ -62,8 +63,8 @@ Click on the step names in the following sections to see the full usage.
 |--------------------------------------------------|---------------------------------|
 | [mlrun.datastore.BigQuerySource](../api/mlrun.datastore.html#mlrun.datastore.BigQuerySource) | Reads Google BigQuery query results as input source for a flow.  |
 | [mlrun.datastore.CSVSource](https://storey.readthedocs.io/en/latest/api.html#storey.sources.CSVSource) | Reads a CSV file as input source for a flow.   |
-| [DataframeSource](https://storey.readthedocs.io/en/latest/api.html#storey.sources.DataframeSource) | Reads data frame as input source for a flow. | 
-| [mlrun.datastore.HttpSource](../api/mlrun.datastore.html#mlrun.datastore.HttpSource) |             |
+| [storey.sources.DataframeSource](https://storey.readthedocs.io/en/latest/api.html#storey.sources.DataframeSource) | Reads data frame as input source for a flow. | 
+| [mlrun.datastore.HttpSource](../api/mlrun.datastore.html#mlrun.datastore.HttpSource) | Sets the HTTP-endpoint source for the flow. |
 | [mlrun.datastore.KafkaSource](../api/mlrun.datastore.html#mlrun.datastore.KafkaSource) | Sets the kafka source for the flow. |
 | [mlrun.datastore.ParquetSource](https://storey.readthedocs.io/en/latest/api.html#storey.sources.ParquetSource) | Reads the Parquet file/dir as the input source for a flow.  |
 | [mlrun.datastore.StreamSource](../api/mlrun.datastore.html#mlrun.datastore.StreamSource) | Sets the stream source for the flow. If the stream doesn’t exist it creates it.  | 
@@ -101,5 +102,5 @@ Click on the step names in the following sections to see the full usage.
 ## Other
 | Class name                                       | Description                                   |   
 |--------------------------------------------------|-----------------------------------------------------------|
-| [mlrun.feature_store.FeaturesetValidator](../api/mlrun.feature_store.html#mlrun.feature_store.steps.FeaturesetValidator) | Validate feature values according to the feature set validation policy. | 
+| [mlrun.feature_store.FeaturesetValidator](../api/mlrun.feature_store.html#mlrun.feature_store.steps.FeaturesetValidator) | Validate feature values according to the feature set validation policy. Supported also by the Pandas and Spark engines. | 
 | ReduceToDataFrame | Builds a pandas DataFrame from events and returns that DataFrame on flow termination. |

--- a/docs/serving/available-steps.md
+++ b/docs/serving/available-steps.md
@@ -102,5 +102,5 @@ Click on the step names in the following sections to see the full usage.
 ## Other
 | Class name                                       | Description                                   |   
 |--------------------------------------------------|-----------------------------------------------------------|
-| [mlrun.feature_store.FeaturesetValidator](../api/mlrun.feature_store.html#mlrun.feature_store.steps.FeaturesetValidator) | Validate feature values according to the feature set validation policy. Supported also by the Pandas and Spark engines. | 
+| [mlrun.feature_store.FeaturesetValidator](../api/mlrun.feature_store.html#mlrun.feature_store.steps.FeaturesetValidator) | Validate feature values according to the feature set validation policy. Supported also by the Pandas engines. | 
 | ReduceToDataFrame | Builds a pandas DataFrame from events and returns that DataFrame on flow termination. |

--- a/docs/serving/available-steps.md
+++ b/docs/serving/available-steps.md
@@ -43,7 +43,7 @@ Click on the step names in the following sections to see the full usage.
 | [mlrun.feature_store.Imputer](../api/mlrun.feature_store.html#mlrun.feature_store.steps.Imputer) | Replace None values with default values. Supported also by the Pandas and Spark engines. |
 | [mlrun.feature_store.MapValues](../api/mlrun.feature_store.html#mlrun.feature_store.steps.MapValues) | Map column values to new values. Supported also by the Pandas and Spark engines. |
 | [mlrun.feature_store.OneHotEncoder](../api/mlrun.feature_store.html#mlrun.feature_store.steps.OneHotEncoder) | Create new binary fields, one per category (one hot encoded). Supported also by the Pandas and Spark engines. | 
-| [mlrun.feature_store.SetEventMetadata](../api/mlrun.feature_store.html#mlrun.feature_store.steps.SetEventMetadata) | Set the event metadata (id, key, timestamp) from the event body. Supported also by the Pandas and Spark engines.|
+| [mlrun.feature_store.SetEventMetadata](../api/mlrun.feature_store.html#mlrun.feature_store.steps.SetEventMetadata) | Set the event metadata (id, key, timestamp) from the event body. |
 
 
 ## External IO and data enrichment


### PR DESCRIPTION
ML-2709. For discussion, see https://github.com/mlrun/mlrun/pull/2991