### PR TITLE
[API] Ensure DB Backup Dir Exists Before Migrations In CE

### DIFF
--- a/mlrun/api/utils/db/backup.py
+++ b/mlrun/api/utils/db/backup.py
@@ -37,6 +37,10 @@ class DBBackupUtil(object):
 
     def backup_database(self, backup_file_name: str = None) -> None:
         backup_file_name = backup_file_name or self._generate_backup_file_name()
+
+        # ensure the backup directory exists
+        self._get_db_dir_path().mkdir(parents=True, exist_ok=True)
+
         if ":memory:" in mlconf.httpdb.dsn:
             return
         elif "mysql" in mlconf.httpdb.dsn:


### PR DESCRIPTION
Fix for https://jira.iguazeng.com/browse/ML-3348 

Currently running migrations in CE fails with
```
> 2023-02-02 15:03:43,597 [info] Checking if migration is needed: {'is_migration_from_scratch': False, 'is_schema_migration_needed': True, 'is_data_migration_needed': False, 'is_database_migration_needed': False, 'is_backup_needed': True, 'is_migration_needed': True}
> 2023-02-02 15:03:43,597 [info] DB Backup is needed, backing up...
> 2023-02-02 15:03:43,606 [error] Failed running shell command: {'command': 'mysqldump --single-transaction --routines --triggers --max_allowed_packet=64000000 -h mlrun-db -P 3306 -u root mlrun > /mlrun/db/mysql/db_backup_202302021503.db', 'stdout': b'', 'stderr': b'/bin/sh: 1: cannot create /mlrun/db/mysql/db_backup_202302021503.db: Directory nonexistent\n', 'exit_status': 2}
> 2023-02-02 15:03:43,607 [warning] Failed during background task execution: _perform_migration, exc: Traceback (most recent call last):
 File "/mlrun/mlrun/api/utils/background_tasks.py", line 154, in background_task_wrapper
 await function(*args, **kwargs)
 File "/mlrun/mlrun/api/api/endpoints/operations.py", line 101, in _perform_migration
 await run_in_threadpool(
 File "/usr/local/lib/python3.9/site-packages/starlette/concurrency.py", line 41, in run_in_threadpool
 return await anyio.to_thread.run_sync(func, *args)
 File "/usr/local/lib/python3.9/site-packages/anyio/to_thread.py", line 31, in run_sync
 return await get_asynclib().run_sync_in_worker_thread(
 File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
 return await future
 File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 867, in run
 result = context.run(func, *args)
 File "/mlrun/mlrun/api/initial_data.py", line 73, in init_data
 db_backup.backup_database()
 File "/mlrun/mlrun/api/utils/db/backup.py", line 43, in backup_database
 self._backup_database_mysql(backup_file_name)
 File "/mlrun/mlrun/api/utils/db/backup.py", line 98, in _backup_database_mysql
 self._run_shell_command(
 File "/mlrun/mlrun/api/utils/db/backup.py", line 216, in _run_shell_command
 raise RuntimeError(
RuntimeError: Got non-zero return code (2) on running shell command: mysqldump --single-transaction --routines --triggers --max_allowed_packet=64000000 -h mlrun-db -P 3306 -u root mlrun > /mlrun/db/mysql/db_backup_202302021503.db
```

Ensure the dir exists before trying to back up the DB.