### PR TITLE
[Model Monitoring] Fix monitoring stream redeployment exception

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -17,7 +17,6 @@
 import os
 import typing
 
-import nuclio.utils
 import sqlalchemy.orm
 
 import mlrun.api.api.endpoints.functions
@@ -589,14 +588,17 @@ class ModelEndpoints:
         try:
             # validate that the model monitoring stream has not yet been deployed
             mlrun.runtimes.function.get_nuclio_deploy_status(
-                name="model-monitoring-stream", project=project, tag=""
+                name="model-monitoring-stream",
+                project=project,
+                tag="",
+                auth_info=auth_info,
             )
             logger.info(
                 "Detected model monitoring stream processing function already deployed",
                 project=project,
             )
             return
-        except nuclio.utils.DeployError:
+        except mlrun.errors.MLRunNotFoundError:
             logger.info(
                 "Deploying model monitoring stream processing function", project=project
             )


### PR DESCRIPTION
Before deploying the `model-monitoring-stream` nuclio function, we need to validate that this function is yet to be deployed to avoid redeployment. Therefore, this function should be deployed only when we get exception from type `mlrun.errors.MLRunNotFoundError` (and not  `nuclio.utils.DeployError` as it was until this PR).

Please note that if the user has changed his mlrun version and want to redeploy the `model-monitoring-stream` function on existing project with existing `model-monitoring-stream` function, he has to delete this function manually before trying to redeploy it again. 