### PR TITLE
[Log Collector] Separate GetLogs and StartLog buffer size

### DIFF
--- a/go/cmd/logcollector/main.go
+++ b/go/cmd/logcollector/main.go
@@ -40,8 +40,8 @@ func StartServer() error {
 	monitoringInterval := flag.String("monitoring-interval", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__MONITORING_INTERVAL", "10s"), "Periodic interval for monitoring the goroutines collecting logs (default 10s)")
 	logCollectionBufferPoolSize := flag.Int("log-collection-buffer-pool-size", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_POOL_SIZE", 512), "Number of buffers in the buffer pool for collecting logs (default: 512 buffers)")
 	getLogsBufferPoolSize := flag.Int("get-logs-buffer-pool-size", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_POOL_SIZE", 512), "Number of buffers in the buffer pool for getting logs (default: 512 buffers)")
-	logCollectionBufferSizeBytes := flag.Int("buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_SIZE_BYTES", common.DefaultLogCollectionBufferSize), "Size of buffers in the log collection buffer pool, in bytes (default: 10MB)")
-	getLogsBufferSizeBytes := flag.Int("buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_SIZE_BYTES", common.DefaultGetLogsBufferSize), "Size of buffers in the buffer pool for getting logs, in bytes (default: 3.75MB)")
+	logCollectionBufferSizeBytes := flag.Int("log-collection-buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_SIZE_BYTES", common.DefaultLogCollectionBufferSize), "Size of buffers in the log collection buffer pool, in bytes (default: 10MB)")
+	getLogsBufferSizeBytes := flag.Int("get-logs-buffer-buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_SIZE_BYTES", common.DefaultGetLogsBufferSize), "Size of buffers in the buffer pool for getting logs, in bytes (default: 3.75MB)")
 	clusterizationRole := flag.String("clusterization-role", common.GetEnvOrDefaultString("MLRUN_HTTPDB__CLUSTERIZATION__ROLE", "chief"), "The role of the log collector in the cluster (chief, worker)")
 
 	// if namespace is not passed, it will be taken from env

--- a/go/cmd/logcollector/main.go
+++ b/go/cmd/logcollector/main.go
@@ -40,7 +40,8 @@ func StartServer() error {
 	monitoringInterval := flag.String("monitoring-interval", common.GetEnvOrDefaultString("MLRUN_LOG_COLLECTOR__MONITORING_INTERVAL", "10s"), "Periodic interval for monitoring the goroutines collecting logs (default 10s)")
 	logCollectionBufferPoolSize := flag.Int("log-collection-buffer-pool-size", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_POOL_SIZE", 512), "Number of buffers in the buffer pool for collecting logs (default: 512 buffers)")
 	getLogsBufferPoolSize := flag.Int("get-logs-buffer-pool-size", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_POOL_SIZE", 512), "Number of buffers in the buffer pool for getting logs (default: 512 buffers)")
-	bufferSizeBytes := flag.Int("buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__BUFFER_SIZE_BYTES", 10*1024*1024), "Size of buffers in the buffer pool, in bytes (default: 10MB)")
+	logCollectionBufferSizeBytes := flag.Int("buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_SIZE_BYTES", common.DefaultLogCollectionBufferSize), "Size of buffers in the log collection buffer pool, in bytes (default: 10MB)")
+	getLogsBufferSizeBytes := flag.Int("buffer-size-bytes", common.GetEnvOrDefaultInt("MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_SIZE_BYTES", common.DefaultGetLogsBufferSize), "Size of buffers in the buffer pool for getting logs, in bytes (default: 3.75MB)")
 	clusterizationRole := flag.String("clusterization-role", common.GetEnvOrDefaultString("MLRUN_HTTPDB__CLUSTERIZATION__ROLE", "chief"), "The role of the log collector in the cluster (chief, worker)")
 
 	// if namespace is not passed, it will be taken from env
@@ -74,7 +75,8 @@ func StartServer() error {
 		kubeClientSet,
 		*logCollectionBufferPoolSize,
 		*getLogsBufferPoolSize,
-		*bufferSizeBytes)
+		*logCollectionBufferSizeBytes,
+		*getLogsBufferSizeBytes)
 	if err != nil {
 		return errors.Wrap(err, "Failed to create log collector server")
 	}

--- a/go/pkg/common/consts.go
+++ b/go/pkg/common/consts.go
@@ -19,3 +19,14 @@ const (
 	ErrCodeNotFound int32 = iota
 	ErrCodeInternal
 )
+
+// Buffer sizes
+
+const (
+	// DefaultLogCollectionBufferSize is the default buffer size for collecting logs from pods
+	DefaultLogCollectionBufferSize int = 10 * 1024 * 1024 // 10MB
+
+	// DefaultGetLogsBufferSize is the default buffer size for reading logs
+	// gRPC has a limit of 4MB, so we set it to 3.75MB in case of overhead
+	DefaultGetLogsBufferSize int = 3.75 * 1024 * 1024 // 3.75MB
+)

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -81,6 +81,7 @@ func (suite *LogCollectorTestSuite) SetupSuite() {
 		&suite.kubeClientSet,
 		bufferPoolSize,
 		bufferPoolSize,
+		bufferSizeBytes,
 		bufferSizeBytes)
 	suite.Require().NoError(err, "Failed to create log collector server")
 
@@ -236,7 +237,7 @@ func (suite *LogCollectorTestSuite) TestStreamPodLogs() {
 	suite.Require().Equal("fake logs", string(logFileContent))
 }
 
-func (suite *LogCollectorTestSuite) TestGetLogSuccessful() {
+func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 
 	runUID := uuid.New().String()
 	podName := "my-pod"

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -44,17 +44,18 @@ import (
 
 type Server struct {
 	*framework.AbstractMlrunGRPCServer
-	namespace               string
-	baseDir                 string
-	kubeClientSet           kubernetes.Interface
-	stateStore              statestore.StateStore
-	inMemoryState           statestore.StateStore
-	logCollectionBufferPool *bpool.BytePool
-	getLogsBufferPool       *bpool.BytePool
-	readLogWaitTime         time.Duration
-	monitoringInterval      time.Duration
-	bufferSizeBytes         int
-	isChief                 bool
+	namespace                    string
+	baseDir                      string
+	kubeClientSet                kubernetes.Interface
+	stateStore                   statestore.StateStore
+	inMemoryState                statestore.StateStore
+	logCollectionBufferPool      *bpool.BytePool
+	getLogsBufferPool            *bpool.BytePool
+	logCollectionBufferSizeBytes int
+	getLogsBufferSizeBytes       int
+	readLogWaitTime              time.Duration
+	monitoringInterval           time.Duration
+	isChief                      bool
 }
 
 // NewLogCollectorServer creates a new log collector server
@@ -68,7 +69,8 @@ func NewLogCollectorServer(logger logger.Logger,
 	kubeClientSet kubernetes.Interface,
 	logCollectionBufferPoolSize,
 	getLogsBufferPoolSize,
-	bufferSizeBytes int) (*Server, error) {
+	logCollectionBufferSizeBytes,
+	getLogsBufferSizeBytes int) (*Server, error) {
 	abstractServer, err := framework.NewAbstractMlrunGRPCServer(logger, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create abstract server")
@@ -110,23 +112,29 @@ func NewLogCollectorServer(logger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to ensure base dir exists")
 	}
 
+	// ensure log collection buffer size is not bigger than the default, because of the gRPC message size limit
+	if getLogsBufferSizeBytes > common.DefaultGetLogsBufferSize {
+		getLogsBufferSizeBytes = common.DefaultGetLogsBufferSize
+	}
+
 	// create a byte buffer pool - a pool of size `bufferPoolSize`, where each buffer is of size `bufferSizeBytes`
-	logCollectionBufferPool := bpool.NewBytePool(logCollectionBufferPoolSize, bufferSizeBytes)
-	getLogsBufferPool := bpool.NewBytePool(getLogsBufferPoolSize, bufferSizeBytes)
+	logCollectionBufferPool := bpool.NewBytePool(logCollectionBufferPoolSize, logCollectionBufferSizeBytes)
+	getLogsBufferPool := bpool.NewBytePool(getLogsBufferPoolSize, getLogsBufferSizeBytes)
 
 	return &Server{
-		AbstractMlrunGRPCServer: abstractServer,
-		namespace:               namespace,
-		baseDir:                 baseDir,
-		stateStore:              stateStore,
-		inMemoryState:           inMemoryState,
-		kubeClientSet:           kubeClientSet,
-		readLogWaitTime:         readLogTimeoutDuration,
-		monitoringInterval:      monitoringIntervalDuration,
-		logCollectionBufferPool: logCollectionBufferPool,
-		getLogsBufferPool:       getLogsBufferPool,
-		bufferSizeBytes:         bufferSizeBytes,
-		isChief:                 clusterizationRole == "chief",
+		AbstractMlrunGRPCServer:      abstractServer,
+		namespace:                    namespace,
+		baseDir:                      baseDir,
+		stateStore:                   stateStore,
+		inMemoryState:                inMemoryState,
+		kubeClientSet:                kubeClientSet,
+		readLogWaitTime:              readLogTimeoutDuration,
+		monitoringInterval:           monitoringIntervalDuration,
+		logCollectionBufferPool:      logCollectionBufferPool,
+		getLogsBufferPool:            getLogsBufferPool,
+		logCollectionBufferSizeBytes: logCollectionBufferSizeBytes,
+		getLogsBufferSizeBytes:       getLogsBufferSizeBytes,
+		isChief:                      clusterizationRole == "chief",
 	}, nil
 }
 
@@ -662,7 +670,7 @@ func (s *Server) validateOffsetAndSize(offset, size, fileSize int64) (int64, int
 
 	// if size is negative, zero, or bigger than fileSize, read the whole file or the allowed size
 	if size <= 0 || size > fileSize {
-		size = int64(math.Min(float64(fileSize), float64(s.bufferSizeBytes)))
+		size = int64(math.Min(float64(fileSize), float64(s.getLogsBufferSizeBytes)))
 	}
 
 	// if size is bigger than what's left to read, only read the rest of the file
@@ -764,7 +772,7 @@ func (s *Server) isLogCollectionRunning(ctx context.Context, runUID string) bool
 // getChunkSuze returns the minimum between the request size, buffer size and the remaining size to read
 func (s *Server) getChunkSize(requestSize, endSize, currentOffset int64) int64 {
 
-	chunkSize := int64(s.bufferSizeBytes)
+	chunkSize := int64(s.getLogsBufferSizeBytes)
 
 	// if the request size is smaller than the buffer size, use the request size
 	if requestSize > 0 && requestSize < chunkSize {

--- a/go/pkg/services/logcollector/test/logcollector_test.go
+++ b/go/pkg/services/logcollector/test/logcollector_test.go
@@ -92,9 +92,10 @@ func (suite *LogCollectorTestSuite) SetupSuite() {
 		"30s",   /* monitoringInterval */
 		"chief", /* clusterizationRole */
 		suite.kubeClientSet,
-		30, /* logCollectionBufferPoolSize */
-		30, /* getLogsBufferSizeBytes */
-		suite.bufferSizeBytes)
+		30,                    /* logCollectionBufferPoolSize */
+		30,                    /* getLogsBufferSizeBytes */
+		suite.bufferSizeBytes, /* logCollectionBufferSizeBytes */
+		suite.bufferSizeBytes) /* getLogsBufferSizeBytes */
 	suite.Require().NoError(err, "Failed to create log collector server")
 
 	// start log collector server in a goroutine, so it won't block the test


### PR DESCRIPTION
gRPC response message is limited by 4MB, thus each message in the `GetLogs` stream response needs to be less than or equal to that.

To not limit the buffer size reading logs from pod according to the same limit, we allow different buffer size for each pool.

The default buffer size are:
- `StartLog` - 10MB
- `GetLogs` - 3.75MB (to allow some overhead)