### PR TITLE
[Requirements] Bump nuclio-jupyter to 0.9.8

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,7 +6,7 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.20.0
 python-dotenv~=0.17.0
-nuclio-jupyter[jupyter-server]~=0.9.7
+nuclio-jupyter[jupyter-server]~=0.9.8
 nbclassic>=0.2.8
 # added to tackle security vulnerabilities
 notebook~=6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ protobuf>=3.13, <3.20
 kfp~=1.8.0, <1.8.14
 nest-asyncio~=1.0
 ipython~=7.0
-nuclio-jupyter~=0.9.7
+nuclio-jupyter~=0.9.8
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
 # limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us


### PR DESCRIPTION
Added a fix for: [ML-3224](https://jira.iguazeng.com/browse/ML-3224)