### PR TITLE
[SDK] Pass Cleanup TTL to Kubeflow Workflow Runner

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1412,7 +1412,8 @@ class HTTPRunDB(RunDBInterface):
         :param namespace: Kubernetes namespace to execute the pipeline in.
         :param artifact_path: A path to artifacts used by this pipeline.
         :param ops: Transformers to apply on all ops in the pipeline.
-        :param ttl: Set the TTL for the pipeline after its completion.
+        :param ttl: pipeline cleanup ttl in secs (time to wait workflow after completion, at which point the workflow
+                    and all its resources are deleted)
         """
 
         if isinstance(pipeline, str):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1400,7 +1400,9 @@ class HTTPRunDB(RunDBInterface):
         namespace=None,
         artifact_path=None,
         ops=None,
+        # TODO: deprecated, remove in 1.6.0
         ttl=None,
+        cleanup_ttl=None,
     ):
         """Submit a KFP pipeline for execution.
 
@@ -1413,14 +1415,16 @@ class HTTPRunDB(RunDBInterface):
         :param artifact_path: A path to artifacts used by this pipeline.
         :param ops: Transformers to apply on all ops in the pipeline.
         :param ttl: pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the workflow
-                    and all its resources are deleted)
+                    and all its resources are deleted) (deprecated, use cleanup_ttl instead)
+        :param cleanup_ttl: pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                            workflow and all its resources are deleted)
         """
 
         if isinstance(pipeline, str):
             pipe_file = pipeline
         else:
             pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
-            conf = new_pipe_meta(artifact_path, ttl, ops)
+            conf = new_pipe_meta(artifact_path, cleanup_ttl or ttl, ops)
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1422,17 +1422,17 @@ class HTTPRunDB(RunDBInterface):
 
         if ttl:
             warnings.warn(
-                "ttl is deprecated, please use cleanup_ttl instead",
+                "'ttl' is deprecated, use 'cleanup_ttl' instead",
                 "This will be removed in 1.5.0",
                 # TODO: Remove this in 1.5.0
-                PendingDeprecationWarning,
+                FutureWarning,
             )
 
         if isinstance(pipeline, str):
             pipe_file = pipeline
         else:
             pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
-            conf = new_pipe_meta(artifact_path, cleanup_ttl or ttl, ops)
+            conf = new_pipe_meta(artifact_path, None, ops, cleanup_ttl=cleanup_ttl or ttl)
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1400,7 +1400,7 @@ class HTTPRunDB(RunDBInterface):
         namespace=None,
         artifact_path=None,
         ops=None,
-        # TODO: deprecated, remove in 1.6.0
+        # TODO: deprecated, remove in 1.5.0
         ttl=None,
         cleanup_ttl=None,
     ):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1432,7 +1432,9 @@ class HTTPRunDB(RunDBInterface):
             pipe_file = pipeline
         else:
             pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
-            conf = new_pipe_meta(artifact_path, None, ops, cleanup_ttl=cleanup_ttl or ttl)
+            conf = new_pipe_meta(
+                artifact_path, None, ops, cleanup_ttl=cleanup_ttl or ttl
+            )
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1420,6 +1420,14 @@ class HTTPRunDB(RunDBInterface):
                             workflow and all its resources are deleted)
         """
 
+        if ttl:
+            warnings.warn(
+                "ttl is deprecated, please use cleanup_ttl instead",
+                "This will be removed in 1.5.0",
+                # TODO: Remove this in 1.5.0
+                PendingDeprecationWarning,
+            )
+
         if isinstance(pipeline, str):
             pipe_file = pipeline
         else:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1412,7 +1412,7 @@ class HTTPRunDB(RunDBInterface):
         :param namespace: Kubernetes namespace to execute the pipeline in.
         :param artifact_path: A path to artifacts used by this pipeline.
         :param ops: Transformers to apply on all ops in the pipeline.
-        :param ttl: pipeline cleanup ttl in secs (time to wait workflow after completion, at which point the workflow
+        :param ttl: pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the workflow
                     and all its resources are deleted)
         """
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1433,7 +1433,7 @@ class HTTPRunDB(RunDBInterface):
         else:
             pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
             conf = new_pipe_meta(
-                artifact_path, None, ops, cleanup_ttl=cleanup_ttl or ttl
+                artifact_path=artifact_path, args=ops, cleanup_ttl=cleanup_ttl or ttl
             )
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -71,10 +71,12 @@ class WorkflowSpec(mlrun.model.ModelObj):
         args=None,
         name=None,
         handler=None,
+        # TODO: deprecated, remove in 1.6.0
         ttl=None,
         args_schema: dict = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger] = None,
         override: bool = None,
+        cleanup_ttl: int = None,
     ):
         self.engine = engine
         self.code = code
@@ -82,7 +84,8 @@ class WorkflowSpec(mlrun.model.ModelObj):
         self.args = args
         self.name = name
         self.handler = handler
-        self.ttl = ttl
+        self.ttl = cleanup_ttl or ttl
+        self.cleanup_ttl = cleanup_ttl or ttl
         self.args_schema = args_schema
         self.run_local = False
         self._tmp_path = None
@@ -535,7 +538,7 @@ class _KFPRunner(_PipelineRunner):
         )
         artifact_path = artifact_path or project.spec.artifact_path
 
-        conf = new_pipe_meta(artifact_path, ttl=workflow_spec.ttl)
+        conf = new_pipe_meta(artifact_path, cleanup_ttl=workflow_spec.cleanup_ttl)
         compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
         workflow_spec.clear_tmp()
         pipeline_context.clear()
@@ -567,7 +570,7 @@ class _KFPRunner(_PipelineRunner):
             experiment=name or workflow_spec.name,
             namespace=namespace,
             artifact_path=artifact_path,
-            ttl=workflow_spec.ttl,
+            cleanup_ttl=workflow_spec.cleanup_ttl,
         )
         project.notifiers.push_pipeline_start_message(
             project.metadata.name,
@@ -771,7 +774,7 @@ class _RemoteRunner(_PipelineRunner):
                     "artifact_path": artifact_path,
                     "workflow_handler": workflow_handler or workflow_spec.handler,
                     "namespace": namespace,
-                    "ttl": workflow_spec.ttl,
+                    "ttl": workflow_spec.cleanup_ttl,
                     "engine": workflow_spec.engine,
                     "local": workflow_spec.run_local,
                     "schedule": workflow_spec.schedule,
@@ -970,10 +973,12 @@ def load_and_run(
     namespace: str = None,
     sync: bool = False,
     dirty: bool = False,
+    # TODO: deprecated, remove in 1.6.0
     ttl: int = None,
     engine: str = None,
     local: bool = None,
     schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger] = None,
+    cleanup_ttl: int = None,
 ):
     """
     Auxiliary function that the RemoteRunner run once or run every schedule.
@@ -996,11 +1001,14 @@ def load_and_run(
     :param namespace:           kubernetes namespace if other than default
     :param sync:                force functions sync before run
     :param dirty:               allow running the workflow when the git repo is dirty
-    :param ttl:                 pipeline ttl in secs (after that the pods will be removed)
+    :param ttl:                 pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                                workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
     :param engine:              workflow engine running the workflow.
                                 supported values are 'kfp' (default) or 'local'
     :param local:               run local pipeline with local functions (set local=True in function.run())
     :param schedule:            ScheduleCronTrigger class instance or a standard crontab expression string
+    :param cleanup_ttl:         pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                                workflow and all its resources are deleted)
     """
     try:
         project = mlrun.load_project(
@@ -1049,7 +1057,7 @@ def load_and_run(
         sync=sync,
         watch=False,  # Required for fetching the workflow_id
         dirty=dirty,
-        ttl=ttl,
+        cleanup_ttl=cleanup_ttl or ttl,
         engine=engine,
         local=local,
     )

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -538,7 +538,9 @@ class _KFPRunner(_PipelineRunner):
         )
         artifact_path = artifact_path or project.spec.artifact_path
 
-        conf = new_pipe_meta(artifact_path, cleanup_ttl=workflow_spec.cleanup_ttl)
+        conf = new_pipe_meta(
+            artifact_path, cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl
+        )
         compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
         workflow_spec.clear_tmp()
         pipeline_context.clear()
@@ -570,7 +572,7 @@ class _KFPRunner(_PipelineRunner):
             experiment=name or workflow_spec.name,
             namespace=namespace,
             artifact_path=artifact_path,
-            cleanup_ttl=workflow_spec.cleanup_ttl,
+            cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl,
         )
         project.notifiers.push_pipeline_start_message(
             project.metadata.name,
@@ -774,7 +776,7 @@ class _RemoteRunner(_PipelineRunner):
                     "artifact_path": artifact_path,
                     "workflow_handler": workflow_handler or workflow_spec.handler,
                     "namespace": namespace,
-                    "ttl": workflow_spec.cleanup_ttl,
+                    "ttl": workflow_spec.cleanup_ttl or workflow_spec.ttl,
                     "engine": workflow_spec.engine,
                     "local": workflow_spec.run_local,
                     "schedule": workflow_spec.schedule,

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -71,7 +71,7 @@ class WorkflowSpec(mlrun.model.ModelObj):
         args=None,
         name=None,
         handler=None,
-        # TODO: deprecated, remove in 1.6.0
+        # TODO: deprecated, remove in 1.5.0
         ttl=None,
         args_schema: dict = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger] = None,
@@ -975,7 +975,7 @@ def load_and_run(
     namespace: str = None,
     sync: bool = False,
     dirty: bool = False,
-    # TODO: deprecated, remove in 1.6.0
+    # TODO: deprecated, remove in 1.5.0
     ttl: int = None,
     engine: str = None,
     local: bool = None,

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -80,10 +80,10 @@ class WorkflowSpec(mlrun.model.ModelObj):
     ):
         if ttl:
             warnings.warn(
-                "ttl is deprecated, please use cleanup_ttl instead",
+                "'ttl' is deprecated, use 'cleanup_ttl' instead",
                 "This will be removed in 1.5.0",
                 # TODO: Remove this in 1.5.0
-                PendingDeprecationWarning,
+                FutureWarning,
             )
 
         self.engine = engine
@@ -1022,10 +1022,10 @@ def load_and_run(
     """
     if ttl:
         warnings.warn(
-            "ttl is deprecated, please use cleanup_ttl instead",
+            "'ttl' is deprecated, use 'cleanup_ttl' instead",
             "This will be removed in 1.5.0",
             # TODO: Remove this in 1.5.0
-            PendingDeprecationWarning,
+            FutureWarning,
         )
 
     try:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -78,6 +78,14 @@ class WorkflowSpec(mlrun.model.ModelObj):
         override: bool = None,
         cleanup_ttl: int = None,
     ):
+        if ttl:
+            warnings.warn(
+                "ttl is deprecated, please use cleanup_ttl instead",
+                "This will be removed in 1.5.0",
+                # TODO: Remove this in 1.5.0
+                PendingDeprecationWarning,
+            )
+
         self.engine = engine
         self.code = code
         self.path = path
@@ -1012,6 +1020,14 @@ def load_and_run(
     :param cleanup_ttl:         pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
                                 workflow and all its resources are deleted)
     """
+    if ttl:
+        warnings.warn(
+            "ttl is deprecated, please use cleanup_ttl instead",
+            "This will be removed in 1.5.0",
+            # TODO: Remove this in 1.5.0
+            PendingDeprecationWarning,
+        )
+
     try:
         project = mlrun.load_project(
             context=f"./{project_name}",

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -547,7 +547,8 @@ class _KFPRunner(_PipelineRunner):
         artifact_path = artifact_path or project.spec.artifact_path
 
         conf = new_pipe_meta(
-            artifact_path, cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl
+            artifact_path=artifact_path,
+            cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl,
         )
         compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
         workflow_spec.clear_tmp()

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1870,7 +1870,7 @@ class MlrunProject(ModelObj):
         sync: bool = False,
         watch: bool = False,
         dirty: bool = False,
-        # TODO: deprecated, remove in 1.6.0
+        # TODO: deprecated, remove in 1.5.0
         ttl: int = None,
         engine: str = None,
         local: bool = None,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1919,6 +1919,14 @@ class MlrunProject(ModelObj):
         :returns: run id
         """
 
+        if ttl:
+            warnings.warn(
+                "ttl is deprecated, please use cleanup_ttl instead",
+                "This will be removed in 1.5.0",
+                # TODO: Remove this in 1.5.0
+                PendingDeprecationWarning,
+            )
+
         arguments = arguments or {}
         need_repo = self.spec._need_repo()
         if self.spec.repo and self.spec.repo.is_dirty():

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1895,7 +1895,8 @@ class MlrunProject(ModelObj):
         :param sync:      force functions sync before run
         :param watch:     wait for pipeline completion
         :param dirty:     allow running the workflow when the git repo is dirty
-        :param ttl:       pipeline ttl in secs (after that the pods will be removed)
+        :param ttl:       pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                          workflow and all its resources are deleted)
         :param engine:    workflow engine running the workflow.
                           supported values are 'kfp' (default), 'local' or 'remote'.
                           for setting engine for remote running use 'remote:local' or 'remote:kfp'.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1921,10 +1921,10 @@ class MlrunProject(ModelObj):
 
         if ttl:
             warnings.warn(
-                "ttl is deprecated, please use cleanup_ttl instead",
+                "'ttl' is deprecated, use 'cleanup_ttl' instead",
                 "This will be removed in 1.5.0",
                 # TODO: Remove this in 1.5.0
-                PendingDeprecationWarning,
+                FutureWarning,
             )
 
         arguments = arguments or {}

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1870,6 +1870,7 @@ class MlrunProject(ModelObj):
         sync: bool = False,
         watch: bool = False,
         dirty: bool = False,
+        # TODO: deprecated, remove in 1.6.0
         ttl: int = None,
         engine: str = None,
         local: bool = None,
@@ -1878,6 +1879,7 @@ class MlrunProject(ModelObj):
         overwrite: bool = False,
         override: bool = False,
         source: str = None,
+        cleanup_ttl: int = None,
     ) -> _PipelineRunStatus:
         """run a workflow using kubeflow pipelines
 
@@ -1896,7 +1898,7 @@ class MlrunProject(ModelObj):
         :param watch:     wait for pipeline completion
         :param dirty:     allow running the workflow when the git repo is dirty
         :param ttl:       pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
-                          workflow and all its resources are deleted)
+                          workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
         :param engine:    workflow engine running the workflow.
                           supported values are 'kfp' (default), 'local' or 'remote'.
                           for setting engine for remote running use 'remote:local' or 'remote:kfp'.
@@ -1911,6 +1913,9 @@ class MlrunProject(ModelObj):
         :param override:  replacing the schedule of the same workflow (under the same name) if exists with the new one
         :param source:    remote source to use instead of the actual `project.spec.source` (used when engine is remote).
                           for other engines the source is to validate that the code is up-to-date
+        :param cleanup_ttl:
+                          pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                          workflow and all its resources are deleted)
         :returns: run id
         """
 
@@ -1943,7 +1948,7 @@ class MlrunProject(ModelObj):
         else:
             workflow_spec = self.spec._workflows[name].copy()
             workflow_spec.merge_args(arguments)
-            workflow_spec.ttl = ttl or workflow_spec.ttl
+            workflow_spec.cleanup_ttl = cleanup_ttl or ttl or workflow_spec.ttl
         workflow_spec.run_local = local
 
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1948,7 +1948,9 @@ class MlrunProject(ModelObj):
         else:
             workflow_spec = self.spec._workflows[name].copy()
             workflow_spec.merge_args(arguments)
-            workflow_spec.cleanup_ttl = cleanup_ttl or ttl or workflow_spec.ttl
+            workflow_spec.cleanup_ttl = (
+                cleanup_ttl or ttl or workflow_spec.cleanup_ttl or workflow_spec.ttl
+            )
         workflow_spec.run_local = local
 
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -940,7 +940,8 @@ def run_pipeline(
     :param url:        optional, url to mlrun API service
     :param artifact_path:  target location/url for mlrun artifacts
     :param ops:        additional operators (.apply() to all pipeline functions)
-    :param ttl:        pipeline ttl in secs (after that the pods will be removed)
+    :param ttl:        pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                       workflow and all its resources are deleted)
     :param remote:     read kfp data from mlrun service (default=True)
 
     :returns: kubeflow pipeline id
@@ -975,6 +976,7 @@ def run_pipeline(
             namespace=namespace,
             ops=ops,
             artifact_path=artifact_path,
+            ttl=ttl,
         )
 
     else:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -22,6 +22,7 @@ import socket
 import tempfile
 import time
 import uuid
+import warnings
 from base64 import b64decode
 from collections import OrderedDict
 from copy import deepcopy
@@ -951,6 +952,14 @@ def run_pipeline(
 
     :returns: kubeflow pipeline id
     """
+
+    if ttl:
+        warnings.warn(
+            "ttl is deprecated, please use cleanup_ttl instead",
+            "This will be removed in 1.5.0",
+            # TODO: Remove this in 1.5.0
+            PendingDeprecationWarning,
+        )
 
     artifact_path = artifact_path or mlconf.artifact_path
     project = project or mlconf.default_project

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1001,7 +1001,7 @@ def run_pipeline(
                 experiment.id, run, pipeline, params=arguments
             )
         else:
-            conf = new_pipe_meta(artifact_path, None, ops, cleanup_ttl=ttl)
+            conf = new_pipe_meta(artifact_path=artifact_path, args=ops, cleanup_ttl=ttl)
             run_result = client.create_run_from_pipeline_func(
                 pipeline,
                 arguments,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -924,7 +924,7 @@ def run_pipeline(
     artifact_path=None,
     ops=None,
     url=None,
-    # TODO: deprecated, remove in 1.6.0
+    # TODO: deprecated, remove in 1.5.0
     ttl=None,
     remote: bool = True,
     cleanup_ttl=None,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -955,10 +955,10 @@ def run_pipeline(
 
     if ttl:
         warnings.warn(
-            "ttl is deprecated, please use cleanup_ttl instead",
+            "'ttl' is deprecated, use 'cleanup_ttl' instead",
             "This will be removed in 1.5.0",
             # TODO: Remove this in 1.5.0
-            PendingDeprecationWarning,
+            FutureWarning,
         )
 
     artifact_path = artifact_path or mlconf.artifact_path
@@ -1001,7 +1001,7 @@ def run_pipeline(
                 experiment.id, run, pipeline, params=arguments
             )
         else:
-            conf = new_pipe_meta(artifact_path, ttl, ops)
+            conf = new_pipe_meta(artifact_path, None, ops, cleanup_ttl=ttl)
             run_result = client.create_run_from_pipeline_func(
                 pipeline,
                 arguments,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -924,8 +924,10 @@ def run_pipeline(
     artifact_path=None,
     ops=None,
     url=None,
+    # TODO: deprecated, remove in 1.6.0
     ttl=None,
     remote: bool = True,
+    cleanup_ttl=None,
 ):
     """remote KubeFlow pipeline execution
 
@@ -941,8 +943,11 @@ def run_pipeline(
     :param artifact_path:  target location/url for mlrun artifacts
     :param ops:        additional operators (.apply() to all pipeline functions)
     :param ttl:        pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
-                       workflow and all its resources are deleted)
+                       workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
     :param remote:     read kfp data from mlrun service (default=True)
+    :param cleanup_ttl:
+                       pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                       workflow and all its resources are deleted)
 
     :returns: kubeflow pipeline id
     """
@@ -976,7 +981,7 @@ def run_pipeline(
             namespace=namespace,
             ops=ops,
             artifact_path=artifact_path,
-            ttl=ttl,
+            cleanup_ttl=cleanup_ttl or ttl,
         )
 
     else:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -615,7 +615,7 @@ def gen_html_table(header, rows=None):
     return style + '<table class="tg">\n' + out + "</table>\n\n"
 
 
-def new_pipe_meta(artifact_path=None, ttl=None, *args):
+def new_pipe_meta(artifact_path=None, cleanup_ttl=None, *args):
     from kfp.dsl import PipelineConf
 
     def _set_artifact_path(task):
@@ -627,9 +627,9 @@ def new_pipe_meta(artifact_path=None, ttl=None, *args):
         return task
 
     conf = PipelineConf()
-    ttl = ttl or int(config.kfp_ttl)
-    if ttl:
-        conf.set_ttl_seconds_after_finished(ttl)
+    cleanup_ttl = cleanup_ttl or int(config.kfp_ttl)
+    if cleanup_ttl:
+        conf.set_ttl_seconds_after_finished(cleanup_ttl)
     if artifact_path:
         conf.add_op_transformer(_set_artifact_path)
     for op in args:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -615,7 +615,7 @@ def gen_html_table(header, rows=None):
     return style + '<table class="tg">\n' + out + "</table>\n\n"
 
 
-def new_pipe_meta(artifact_path=None, cleanup_ttl=None, *args):
+def new_pipe_meta(artifact_path=None, ttl=None, *args, **kwargs):
     from kfp.dsl import PipelineConf
 
     def _set_artifact_path(task):
@@ -627,7 +627,18 @@ def new_pipe_meta(artifact_path=None, cleanup_ttl=None, *args):
         return task
 
     conf = PipelineConf()
-    cleanup_ttl = cleanup_ttl or int(config.kfp_ttl)
+
+    if ttl:
+        warnings.warn(
+            "'ttl' is deprecated, use 'cleanup_ttl' instead (in kwargs)",
+            "This will be removed in 1.5.0",
+            # TODO: Remove this in 1.5.0
+            FutureWarning,
+        )
+
+    # Putting the cleanup_ttl in the kwargs of the method, as we cannot deprecate the ttl argument
+    # while it's a positional argument
+    cleanup_ttl = kwargs.get("cleanup_ttl", None) or ttl or int(config.kfp_ttl)
     if cleanup_ttl:
         conf.set_ttl_seconds_after_finished(cleanup_ttl)
     if artifact_path:


### PR DESCRIPTION
Fix for - https://jira.iguazeng.com/browse/ML-3161

TTL wasn't passed from `project.run` to the KFP workflow runner. Added it to the params being passed, and gave the parameter a more indicative description.