### PR TITLE
[Log Collector] Add project name to state log items

### DIFF
--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -70,10 +70,11 @@ func (s *Store) Initialize(ctx context.Context) error {
 }
 
 // AddLogItem adds a log item to the state store
-func (s *Store) AddLogItem(ctx context.Context, runUID, selector string) error {
+func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string) error {
 	logItem := statestore.LogItem{
 		RunUID:        runUID,
 		LabelSelector: selector,
+		Project:       project,
 	}
 
 	if existingItem, exists := s.state.InProgress.Load(runUID); exists {

--- a/go/pkg/services/logcollector/statestore/file/file_test.go
+++ b/go/pkg/services/logcollector/statestore/file/file_test.go
@@ -107,8 +107,9 @@ func (suite *FileStateStoreTestSuite) TestReadWriteStateFile() {
 func (suite *FileStateStoreTestSuite) TestAddRemoveItemFromInProgress() {
 	runId := "some-run-id"
 	labelSelector := "app=test"
+	project := "some-project"
 
-	err := suite.stateStore.AddLogItem(suite.ctx, runId, labelSelector)
+	err := suite.stateStore.AddLogItem(suite.ctx, runId, labelSelector, project)
 	suite.Require().NoError(err, "Failed to add item to in progress")
 
 	// write state to file

--- a/go/pkg/services/logcollector/statestore/inmemory/client.go
+++ b/go/pkg/services/logcollector/statestore/inmemory/client.go
@@ -37,10 +37,11 @@ func (s *Store) Initialize(ctx context.Context) error {
 }
 
 // AddLogItem adds a log item to the state store
-func (s *Store) AddLogItem(ctx context.Context, runId, selector string) error {
+func (s *Store) AddLogItem(ctx context.Context, runId, selector, project string) error {
 	logItem := statestore.LogItem{
 		RunUID:        runId,
 		LabelSelector: selector,
+		Project:       project,
 	}
 	s.inProgress.Store(runId, logItem)
 	return nil

--- a/go/pkg/services/logcollector/statestore/types.go
+++ b/go/pkg/services/logcollector/statestore/types.go
@@ -34,6 +34,7 @@ const (
 type LogItem struct {
 	RunUID        string `json:"runId"`
 	LabelSelector string `json:"labelSelector"`
+	Project       string `json:"project"`
 }
 
 // MarshalledState is a helper struct for marshalling the state
@@ -96,7 +97,7 @@ type StateStore interface {
 	Initialize(ctx context.Context) error
 
 	// AddLogItem adds a log item to the state store
-	AddLogItem(ctx context.Context, runId, selector string) error
+	AddLogItem(ctx context.Context, runId, selector, project string) error
 
 	// RemoveLogItem removes a log item from the state store
 	RemoveLogItem(runId string) error

--- a/go/pkg/services/logcollector/test/logcollector_test.go
+++ b/go/pkg/services/logcollector/test/logcollector_test.go
@@ -179,7 +179,7 @@ func (suite *LogCollectorTestSuite) TestLogCollector() {
 		if len(logs) >= expectedLogLines {
 			break
 		}
-		if time.Since(startedGettingLogsTime) > 2*time.Minute {
+		if time.Since(startedGettingLogsTime) > 3*time.Minute {
 			suite.Require().Fail("Timed out waiting to get all logs")
 		}
 


### PR DESCRIPTION
The log collector is monitoring runs that are being log-collected, and calls `StartLog` by itself for runs that stopped collecting due to an error or something else.
For restarting the log collection, it needs to get the project name from the persistent state file.