### PR TITLE
[Spark] Fix spark job pods not being found

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -199,9 +199,9 @@ async def _verify_log_collection_started_on_startup(
     start_logs_limit: asyncio.Semaphore,
 ):
     """
-    Verifies that log collection was started on startup for all runs which might started before the API initialization
-    or after upgrade.
-    In that case we want to make sure that all runs which are in non terminal state will have their logs collected
+    Verifies that log collection was started on startup for all runs which might have started before the API
+    initialization or after upgrade.
+    In that case we want to make sure that all runs which are in non-terminal state will have their logs collected
     with the new log collection method and runs which might have reached terminal state while the API was down will
     have their logs collected as well.
     :param start_logs_limit: Semaphore which limits the number of concurrent log collection tasks
@@ -353,8 +353,7 @@ async def _start_log_for_run(
             logger.warning(
                 "Failed to start logs for run",
                 run_uid=run_uid,
-                exc=exc,
-                traceback=traceback.format_exc(),
+                exc=mlrun.errors.err_to_str(exc),
             )
             return None
 

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -76,11 +76,6 @@ class LogCollectorClient(
         if not response.success:
             msg = f"Failed to start logs for run {run_uid}"
             if raise_on_error:
-                logger.info(
-                    "Failed to start logs",
-                    error_message=response.errorMessage,
-                    error_code=response.errorCode,
-                )
                 if response.errorCode == LogCollectorErrorCode.ErrCodeNotFound.value:
                     raise mlrun.errors.MLRunNotFoundError(
                         f"{msg},error= {response.errorMessage}"

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -53,7 +53,7 @@ class LogCollectorClient(
         run_uid: str,
         selector: str,
         project: str = "",
-        verbose: bool = True,
+        verbose: bool = False,
         raise_on_error: bool = True,
     ) -> (bool, str):
         """
@@ -75,9 +75,12 @@ class LogCollectorClient(
         response = await self._call("StartLog", request)
         if not response.success:
             msg = f"Failed to start logs for run {run_uid}"
-            if verbose:
-                logger.warning(msg, error=response.errorMessage)
             if raise_on_error:
+                logger.info(
+                    "Failed to start logs",
+                    error_message=response.errorMessage,
+                    error_code=response.errorCode,
+                )
                 if response.errorCode == LogCollectorErrorCode.ErrCodeNotFound.value:
                     raise mlrun.errors.MLRunNotFoundError(
                         f"{msg},error= {response.errorMessage}"
@@ -85,6 +88,8 @@ class LogCollectorClient(
                 raise mlrun.errors.MLRunInternalServerError(
                     f"{msg},error= {response.errorMessage}"
                 )
+            if verbose:
+                logger.warning(msg, error=response.errorMessage)
         return response.success, response.errorMessage
 
     async def get_logs(

--- a/mlrun/runtimes/sparkjob/abstract.py
+++ b/mlrun/runtimes/sparkjob/abstract.py
@@ -42,7 +42,7 @@ from ...utils import (
     verify_field_regex,
     verify_list_and_update_in,
 )
-from ..base import RunError
+from ..base import RunError, RuntimeClassMode
 from ..kubejob import KubejobRuntime
 from ..pod import KubeResourceSpec
 from ..utils import get_item_name
@@ -831,7 +831,7 @@ with ctx:
 class SparkRuntimeHandler(BaseRuntimeHandler):
     kind = "spark"
     class_modes = {
-        "run": "spark",
+        RuntimeClassMode.run: "spark",
     }
 
     def _resolve_crd_object_status_info(


### PR DESCRIPTION
Spark job pods were missing the `RuntimeClassMode` class mode label and thus weren't found by the log collector.

Also skip logging failure to start logs if `raise_on_error == True`, to remove log duplication.

Fixes https://jira.iguazeng.com/browse/ML-3360 