### PR TITLE
[Log Collector] Add project name to state store key

### DIFF
--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -77,20 +77,22 @@ func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string
 		Project:       project,
 	}
 
-	if existingItem, exists := s.state.InProgress.Load(runUID); exists {
+	key := statestore.GenerateKey(runUID, project)
+	if existingItem, exists := s.state.InProgress.Load(key); exists {
 		s.logger.DebugWithCtx(ctx,
 			"Item already exists in state file. Overwriting label selector",
 			"runUID", runUID,
 			"existingItem", existingItem)
 	}
 
-	s.state.InProgress.Store(logItem.RunUID, logItem)
+	s.state.InProgress.Store(key, logItem)
 	return nil
 }
 
 // RemoveLogItem removes a log item from the state store
-func (s *Store) RemoveLogItem(runUID string) error {
-	s.state.InProgress.Delete(runUID)
+func (s *Store) RemoveLogItem(runUID, project string) error {
+	key := statestore.GenerateKey(runUID, project)
+	s.state.InProgress.Delete(key)
 	return nil
 }
 

--- a/go/pkg/services/logcollector/statestore/file/file_test.go
+++ b/go/pkg/services/logcollector/statestore/file/file_test.go
@@ -108,6 +108,7 @@ func (suite *FileStateStoreTestSuite) TestAddRemoveItemFromInProgress() {
 	runId := "some-run-id"
 	labelSelector := "app=test"
 	project := "some-project"
+	key := statestore.GenerateKey(runId, project)
 
 	err := suite.stateStore.AddLogItem(suite.ctx, runId, labelSelector, project)
 	suite.Require().NoError(err, "Failed to add item to in progress")
@@ -122,13 +123,13 @@ func (suite *FileStateStoreTestSuite) TestAddRemoveItemFromInProgress() {
 
 	// verify item is in progress
 	suite.Require().Equal(1, common.SyncMapLength(itemsInProgress))
-	storedItem, ok := itemsInProgress.Load(runId)
+	storedItem, ok := itemsInProgress.Load(key)
 	suite.Require().True(ok)
 	suite.Require().Equal(runId, storedItem.(statestore.LogItem).RunUID)
 	suite.Require().Equal(labelSelector, storedItem.(statestore.LogItem).LabelSelector)
 
 	// remove item from in progress
-	err = suite.stateStore.RemoveLogItem(runId)
+	err = suite.stateStore.RemoveLogItem(runId, project)
 	suite.Require().NoError(err, "Failed to remove item from in progress")
 
 	// write state to file again

--- a/go/pkg/services/logcollector/statestore/inmemory/client.go
+++ b/go/pkg/services/logcollector/statestore/inmemory/client.go
@@ -37,19 +37,21 @@ func (s *Store) Initialize(ctx context.Context) error {
 }
 
 // AddLogItem adds a log item to the state store
-func (s *Store) AddLogItem(ctx context.Context, runId, selector, project string) error {
+func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string) error {
 	logItem := statestore.LogItem{
-		RunUID:        runId,
+		RunUID:        runUID,
 		LabelSelector: selector,
 		Project:       project,
 	}
-	s.inProgress.Store(runId, logItem)
+	key := statestore.GenerateKey(runUID, project)
+	s.inProgress.Store(key, logItem)
 	return nil
 }
 
 // RemoveLogItem removes a log item from the state store
-func (s *Store) RemoveLogItem(runId string) error {
-	s.inProgress.Delete(runId)
+func (s *Store) RemoveLogItem(runUID, project string) error {
+	key := statestore.GenerateKey(runUID, project)
+	s.inProgress.Delete(key)
 	return nil
 }
 

--- a/go/pkg/services/logcollector/statestore/types.go
+++ b/go/pkg/services/logcollector/statestore/types.go
@@ -17,6 +17,7 @@ package statestore
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -32,7 +33,7 @@ const (
 )
 
 type LogItem struct {
-	RunUID        string `json:"runId"`
+	RunUID        string `json:"runUID"`
 	LabelSelector string `json:"labelSelector"`
 	Project       string `json:"project"`
 }
@@ -97,10 +98,10 @@ type StateStore interface {
 	Initialize(ctx context.Context) error
 
 	// AddLogItem adds a log item to the state store
-	AddLogItem(ctx context.Context, runId, selector, project string) error
+	AddLogItem(ctx context.Context, runUID, selector, project string) error
 
 	// RemoveLogItem removes a log item from the state store
-	RemoveLogItem(runId string) error
+	RemoveLogItem(runUID, project string) error
 
 	// WriteState writes the state to persistent storage
 	WriteState(state *State) error
@@ -110,4 +111,8 @@ type StateStore interface {
 
 	// GetState returns the state store state
 	GetState() *State
+}
+
+func GenerateKey(runUID, project string) string {
+	return fmt.Sprintf("%s-%s", runUID, project)
 }


### PR DESCRIPTION
Run UIDs are unique for runs **in the same project**.
This means that the run UID itself is not unique enough for saving log items in the LC's state store.

In this PR the key for the log items in the state for is changed to `<runUID>-<projectName>`.