### PR TITLE
[Model Monitoring] Fix stream processing by removing unpacked labels before updating the KV table

### DIFF
--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -423,8 +423,8 @@ class ProcessBeforeKV(mlrun.feature_store.steps.MapClass):
         }
         # Unpack labels dictionary
         e = {
-            **e,
             **e.pop(EventFieldType.UNPACKED_LABELS, {}),
+            **e,
         }
         # Write labels to kv as json string to be presentable later
         e[EventFieldType.LABELS] = json.dumps(e[EventFieldType.LABELS])

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -420,6 +420,8 @@ class TestModelMonitoringAPI(TestMLRunSystem):
         endpoints_list = mlrun.get_run_db().list_model_endpoints(self.project_name)
 
         for endpoint in endpoints_list.endpoints:
+            # Validate that the model endpoint record has been updated through the stream process
+            assert endpoint.status.first_request != endpoint.status.last_request
             data = client.read(
                 backend="tsdb",
                 table=tsdb_path,


### PR DESCRIPTION
As part of the `model-monitoring-stream` flow, we update the model endpoint record in the KV table with the related fields (e.g. the time of the last request, the number of errors, etc.). Before the update process, the `model-mointoring-stream` is unpacking the labels from the event dictionary into a separated keys and afterwards remove the `unpacked_labels` key from the event dictionary. 
In this PR we fix a bug that was related to the removal of the `unpacked_labels` key at the end of the process which has started due to the new required syntax of Python `3.9` (https://github.com/mlrun/mlrun/pull/2563). 

Note that is is also a fix for [ML-3190](https://jira.iguazeng.com/browse/ML-3190). 