### PR TITLE
[SDK] Fix calls to `new_pipe_meta` not passing `ops`

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -40,7 +40,7 @@ from ..utils import (
     datetime_to_iso,
     dict_to_json,
     logger,
-    new_pipe_meta,
+    new_pipe_metadata,
     normalize_name,
     version,
 )
@@ -1432,8 +1432,10 @@ class HTTPRunDB(RunDBInterface):
             pipe_file = pipeline
         else:
             pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
-            conf = new_pipe_meta(
-                artifact_path=artifact_path, args=ops, cleanup_ttl=cleanup_ttl or ttl
+            conf = new_pipe_metadata(
+                artifact_path=artifact_path,
+                cleanup_ttl=cleanup_ttl or ttl,
+                op_transformers=ops,
             )
             kfp.compiler.Compiler().compile(
                 pipeline, pipe_file, type_check=False, pipeline_conf=conf

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -30,7 +30,12 @@ import mlrun
 import mlrun.api.schemas
 import mlrun.utils.notifications
 from mlrun.errors import err_to_str
-from mlrun.utils import get_ui_url, logger, new_pipe_meta, parse_versioned_object_uri
+from mlrun.utils import (
+    get_ui_url,
+    logger,
+    new_pipe_metadata,
+    parse_versioned_object_uri,
+)
 
 from ..config import config
 from ..run import run_pipeline, wait_for_pipeline_completion
@@ -546,7 +551,7 @@ class _KFPRunner(_PipelineRunner):
         )
         artifact_path = artifact_path or project.spec.artifact_path
 
-        conf = new_pipe_meta(
+        conf = new_pipe_metadata(
             artifact_path=artifact_path,
             cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl,
         )

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -70,7 +70,7 @@ from .utils import (
     extend_hub_uri_if_needed,
     get_in,
     logger,
-    new_pipe_meta,
+    new_pipe_metadata,
     parse_versioned_object_uri,
     retry_until_successful,
     run_keys,
@@ -1001,7 +1001,9 @@ def run_pipeline(
                 experiment.id, run, pipeline, params=arguments
             )
         else:
-            conf = new_pipe_meta(artifact_path=artifact_path, args=ops, cleanup_ttl=ttl)
+            conf = new_pipe_metadata(
+                artifact_path=artifact_path, cleanup_ttl=ttl, op_transformers=ops
+            )
             run_result = client.create_run_from_pipeline_func(
                 pipeline,
                 arguments,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -32,6 +32,7 @@ import pandas
 import semver
 import yaml
 from dateutil import parser
+from deprecated import deprecated
 from pandas._libs.tslibs.timestamps import Timedelta, Timestamp
 from yaml.representer import RepresenterError
 
@@ -633,7 +634,11 @@ def gen_html_table(header, rows=None):
     return style + '<table class="tg">\n' + out + "</table>\n\n"
 
 
-def new_pipe_meta(artifact_path=None, ttl=None, *args, **kwargs):
+def new_pipe_metadata(
+    artifact_path: str = None,
+    cleanup_ttl: int = None,
+    op_transformers: typing.List[typing.Callable] = None,
+):
     from kfp.dsl import PipelineConf
 
     def _set_artifact_path(task):
@@ -645,26 +650,28 @@ def new_pipe_meta(artifact_path=None, ttl=None, *args, **kwargs):
         return task
 
     conf = PipelineConf()
+    cleanup_ttl = cleanup_ttl or int(config.kfp_ttl)
 
-    if ttl:
-        warnings.warn(
-            "'ttl' is deprecated, use 'cleanup_ttl' instead (in kwargs)",
-            "This will be removed in 1.5.0",
-            # TODO: Remove this in 1.5.0
-            FutureWarning,
-        )
-
-    # Putting the cleanup_ttl in the kwargs of the method, as we cannot deprecate the ttl argument
-    # while it's a positional argument
-    cleanup_ttl = kwargs.get("cleanup_ttl", None) or ttl or int(config.kfp_ttl)
     if cleanup_ttl:
         conf.set_ttl_seconds_after_finished(cleanup_ttl)
     if artifact_path:
         conf.add_op_transformer(_set_artifact_path)
-    for op in args:
-        if op:
-            conf.add_op_transformer(op)
+    if op_transformers:
+        for op_transformer in op_transformers:
+            conf.add_op_transformer(op_transformer)
     return conf
+
+
+# TODO: remove in 1.5.0
+@deprecated(
+    version="1.3.0",
+    reason="'new_pipe_meta' will be removed in 1.5.0",
+    category=FutureWarning,
+)
+def new_pipe_meta(artifact_path=None, ttl=None, *args):
+    return new_pipe_metadata(
+        artifact_path=artifact_path, cleanup_ttl=ttl, op_transformers=args
+    )
 
 
 def _convert_python_package_version_to_image_tag(version: typing.Optional[str]):


### PR DESCRIPTION
The previous function signature was problematic as it included kwargs before positional `*args`. Deprecated the whole function and created a new one with only kwargs.