### PR TITLE
[Requirements] Bump GitPython to 3.1.30

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 urllib3>=1.25.4, <1.27
 # >=3.0.2 from requests 2.25.1 <4.0 from aiohttp 3.7.3, requests is <5, so without the upbound there's a conflict
 chardet>=3.0.2, <4.0
-GitPython~=3.0
+GitPython~=3.1, >= 3.1.30
 aiohttp~=3.8
 aiohttp-retry~=2.8
 # 8.1.0+ breaks dask/distributed versions older than 2022.04.0, see here - https://github.com/dask/distributed/pull/6018

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -131,6 +131,7 @@ def test_requirement_specifiers_convention():
         "protobuf": {">=3.13, <3.20"},
         "pandas": {"~=1.2, <1.5.0"},
         "importlib_metadata": {">=3.6"},
+        "gitpython": {"~=3.1, >= 3.1.30"},
         # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
         # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
         "plotly": {"~=5.4, <5.12.0"},


### PR DESCRIPTION
major vulnerability found - https://security.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-3113858