### PR TITLE
[Datastore] Fix depractations removal - delete all references to `after_state` parameter

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -378,7 +378,6 @@ class BaseStoreTarget(DataTargetBase):
         key_bucketing_number: Optional[int] = None,
         partition_cols: Optional[List[str]] = None,
         time_partitioning_granularity: Optional[str] = None,
-        after_state=None,
         max_events: Optional[int] = None,
         flush_after_seconds: Optional[int] = None,
         storage_options: Dict[str, str] = None,
@@ -1448,7 +1447,6 @@ class SQLTarget(BaseStoreTarget):
         key_bucketing_number: Optional[int] = None,
         partition_cols: Optional[List[str]] = None,
         time_partitioning_granularity: Optional[str] = None,
-        after_state=None,
         max_events: Optional[int] = None,
         flush_after_seconds: Optional[int] = None,
         storage_options: Dict[str, str] = None,
@@ -1478,7 +1476,6 @@ class SQLTarget(BaseStoreTarget):
         :param key_bucketing_number:
         :param partition_cols:
         :param time_partitioning_granularity:
-        :param after_state:
         :param max_events:
         :param flush_after_seconds:
         :param storage_options:
@@ -1539,7 +1536,6 @@ class SQLTarget(BaseStoreTarget):
             max_events=max_events,
             flush_after_seconds=flush_after_seconds,
             storage_options=storage_options,
-            after_state=after_state,
             schema=schema,
         )
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -16,7 +16,6 @@ import inspect
 import pathlib
 import re
 import time
-import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime
@@ -1203,12 +1202,9 @@ class DataTargetBase(ModelObj):
         "schema",
     ]
 
-    # TODO - remove once "after_state" is fully deprecated
     @classmethod
     def from_dict(cls, struct=None, fields=None):
-        return super().from_dict(
-            struct, fields=fields, deprecated_fields={"after_state": "after_step"}
-        )
+        return super().from_dict(struct, fields=fields)
 
     def get_path(self):
         if self.path:
@@ -1230,19 +1226,9 @@ class DataTargetBase(ModelObj):
         time_partitioning_granularity: Optional[str] = None,
         max_events: Optional[int] = None,
         flush_after_seconds: Optional[int] = None,
-        after_state=None,
         storage_options: Dict[str, str] = None,
         schema: Dict[str, Any] = None,
     ):
-        if after_state:
-            warnings.warn(
-                "The 'after_state' parameter is deprecated in 1.3.0 and will be removed in 1.5.0. "
-                "Use 'after_step' instead",
-                # TODO: remove in 1.5.0
-                FutureWarning,
-            )
-            after_step = after_step or after_state
-
         self.name = name
         self.kind: str = kind
         self.path = path

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1621,7 +1621,7 @@ class TestFeatureStore(TestMLRunSystem):
         non_default_target_name = "side-target"
         quotes_set.set_targets(
             targets=[
-                CSVTarget(name=non_default_target_name, after_state=side_step_name)
+                CSVTarget(name=non_default_target_name, after_step=side_step_name)
             ],
             default_final_step="FeaturesetValidator",
         )


### PR DESCRIPTION
Fixes `TestFeatureStore::test_split_graph`, which was broken when the fallback on the deprecated parameter was removed in #3075.