### PR TITLE
[Projects] Stop logs for runs when deleting project

### DIFF
--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -194,8 +194,7 @@ async def delete_project(
         chief_client = mlrun.api.utils.clients.chief.Client()
         return await chief_client.delete_project(name=name, request=request)
 
-    is_running_in_background = await run_in_threadpool(
-        get_project_member().delete_project,
+    is_running_in_background = await get_project_member().delete_project(
         db_session,
         name,
         deletion_strategy,

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -88,8 +88,10 @@ class Projects(
                 session, name
             ):
                 return
-            mlrun.api.utils.singletons.db.get_db().verify_project_has_no_related_resources(
-                session, name
+            await fastapi.concurrency.run_in_threadpool(
+                mlrun.api.utils.singletons.db.get_db().verify_project_has_no_related_resources,
+                session,
+                name,
             )
             self._verify_project_has_no_external_resources(name)
             if deletion_strategy == mlrun.api.schemas.DeletionStrategy.check:

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -325,7 +325,10 @@ class Projects(
                 project_to_running_pipelines_count[pipeline["project"]] += 1
         return project_to_running_pipelines_count
 
-    async def _stop_logs_for_project(self, session, name) -> None:
+    @staticmethod
+    async def _stop_logs_for_project(session, name) -> None:
+
+        logger.debug("Stopping logs for project's runs", project=name)
 
         # get all project runs' uids
         run_uids = mlrun.api.utils.singletons.db.get_db().list_distinct_runs_uids(
@@ -342,7 +345,8 @@ class Projects(
             )
         except Exception as exc:
             logger.warning(
-                "Failed stopping logs for runs. Ignoring",
+                "Failed stopping logs for project's runs. Ignoring",
                 exc=mlrun.errors.err_to_str(exc),
+                project=name,
                 project_to_run_uids=project_to_run_uids,
             )

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -151,7 +151,7 @@ async def move_api_to_online():
     # In general it makes more sense to initialize the project member before the scheduler but in 1.1.0 in follower
     # we've added the full sync on the project member initialization (see code there for details) which might delete
     # projects which requires the scheduler to be set
-    initialize_project_member()
+    await initialize_project_member()
 
     # maintenance periodic functions should only run on the chief instance
     if config.httpdb.clusterization.role == mlrun.api.schemas.ClusterizationRole.chief:

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -193,36 +193,20 @@ class LogCollectorClient(
 
     async def stop_logs(
         self,
-        project_to_run_uids_dict: dict,
+        project_to_run_uids_dict: typing.Dict[str, typing.List[str]],
         verbose: bool = False,
+        raise_on_error: bool = True,
     ) -> None:
         """
-        Stop logs streaming from the log collector service
-        :param project_to_run_uids_dict: a dict of run uids per project to stop logs for
-        :param verbose: Whether to log errors
-        :param raise_on_error: Whether to raise an exception on error
-        :return: None
+        PLACEHOLDER UNTIL PR #3082 IS MERGED
         """
         # convert the dict to a map with protobuf StringArray
         request_dict = {}
         for project, runs in project_to_run_uids_dict.items():
-            request_dict[project] = self._log_collector_pb2.StringArray(
-                values=project_to_run_uids_dict[project]
-            )
+            request_dict[project] = self._log_collector_pb2.StringArray(values=runs)
 
         request = self._log_collector_pb2.StopLogRequest(
             projectToRunUIDs=request_dict,
         )
 
-        try:
-            # StopLogs has no return value, so we don't need to check the response
-            await self._call("StopLog", request)
-
-        except Exception as exc:
-            # gRPC is thread safe, but an exception can be raised when running in threadpool
-            # we catch and log/ignore it until fixed, see https://github.com/grpc/grpc/issues/25364
-            if verbose:
-                logger.warning(
-                    "Failed to stop logs",
-                    exc=mlrun.errors.err_to_str(exc),
-                )
+        await self._call("StopLog", request)

--- a/mlrun/api/utils/projects/member.py
+++ b/mlrun/api/utils/projects/member.py
@@ -84,7 +84,7 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_project(
+    async def delete_project(
         self,
         db_session: sqlalchemy.orm.Session,
         name: str,

--- a/mlrun/api/utils/projects/remotes/follower.py
+++ b/mlrun/api/utils/projects/remotes/follower.py
@@ -47,7 +47,7 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_project(
+    async def delete_project(
         self,
         session: sqlalchemy.orm.Session,
         name: str,

--- a/mlrun/api/utils/projects/remotes/leader.py
+++ b/mlrun/api/utils/projects/remotes/leader.py
@@ -39,7 +39,7 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_project(
+    async def delete_project(
         self,
         session: str,
         name: str,

--- a/mlrun/api/utils/projects/remotes/nop_follower.py
+++ b/mlrun/api/utils/projects/remotes/nop_follower.py
@@ -56,7 +56,7 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
         mergedeep.merge(existing_project_dict, project, strategy=strategy)
         self._projects[name] = mlrun.api.schemas.Project(**existing_project_dict)
 
-    def delete_project(
+    async def delete_project(
         self,
         session: sqlalchemy.orm.Session,
         name: str,

--- a/mlrun/api/utils/projects/remotes/nop_leader.py
+++ b/mlrun/api/utils/projects/remotes/nop_leader.py
@@ -64,14 +64,14 @@ class Member(mlrun.api.utils.projects.remotes.leader.Member):
                 project.spec.desired_state
             )
 
-    def delete_project(
+    async def delete_project(
         self,
         session: str,
         name: str,
         deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
         wait_for_completion: bool = True,
     ) -> bool:
-        return mlrun.api.utils.singletons.project_member.get_project_member().delete_project(
+        return await mlrun.api.utils.singletons.project_member.get_project_member().delete_project(
             self.db_session, name, deletion_strategy, self._project_role
         )
 

--- a/mlrun/api/utils/singletons/project_member.py
+++ b/mlrun/api/utils/singletons/project_member.py
@@ -21,14 +21,14 @@ import mlrun.config
 project_member: mlrun.api.utils.projects.member.Member = None
 
 
-def initialize_project_member():
+async def initialize_project_member():
     global project_member
     if mlrun.config.config.httpdb.projects.leader in ["mlrun", "nop-self-leader"]:
         project_member = mlrun.api.utils.projects.leader.Member()
-        project_member.initialize()
+        await project_member.initialize()
     else:
         project_member = mlrun.api.utils.projects.follower.Member()
-        project_member.initialize()
+        await project_member.initialize()
 
 
 def get_project_member() -> mlrun.api.utils.projects.member.Member:

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -61,16 +61,16 @@ ORIGINAL_VERSIONED_API_PREFIX = mlrun.api.main.BASE_VERSIONED_API_PREFIX
 
 
 @pytest.fixture(params=["leader", "follower"])
-def project_member_mode(request, db: Session) -> str:
+async def project_member_mode(request, db: Session) -> str:
     if request.param == "follower":
         mlrun.config.config.httpdb.projects.leader = "nop"
-        mlrun.api.utils.singletons.project_member.initialize_project_member()
+        await mlrun.api.utils.singletons.project_member.initialize_project_member()
         mlrun.api.utils.singletons.project_member.get_project_member()._leader_client.db_session = (
             db
         )
     elif request.param == "leader":
         mlrun.config.config.httpdb.projects.leader = "mlrun"
-        mlrun.api.utils.singletons.project_member.initialize_project_member()
+        await mlrun.api.utils.singletons.project_member.initialize_project_member()
     else:
         raise NotImplementedError(
             f"Provided project member mode is not supported. mode={request.param}"
@@ -161,6 +161,7 @@ def test_get_non_existing_project(
     assert response.status_code == HTTPStatus.NOT_FOUND.value
 
 
+@pytest.mark.asyncio
 def test_delete_project_with_resources(
     db: Session,
     client: TestClient,
@@ -262,6 +263,7 @@ def test_delete_project_with_resources(
     assert response.status_code == HTTPStatus.NO_CONTENT.value
 
 
+@pytest.mark.asyncio
 def test_list_and_get_project_summaries(
     db: Session, client: TestClient, project_member_mode: str
 ) -> None:
@@ -392,6 +394,7 @@ def test_list_and_get_project_summaries(
     )
 
 
+@pytest.mark.asyncio
 def test_list_project_summaries_different_installation_modes(
     db: Session, client: TestClient, project_member_mode: str
 ) -> None:
@@ -498,6 +501,7 @@ def test_list_project_summaries_different_installation_modes(
     )
 
 
+@pytest.mark.asyncio
 def test_delete_project_deletion_strategy_check(
     db: Session,
     client: TestClient,
@@ -546,6 +550,7 @@ def test_delete_project_deletion_strategy_check(
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
 
 
+@pytest.mark.asyncio
 def test_delete_project_not_deleting_versioned_objects_multiple_times(
     db: Session,
     client: TestClient,
@@ -626,6 +631,7 @@ def test_delete_project_not_deleting_versioned_objects_multiple_times(
     )
 
 
+@pytest.mark.asyncio
 def test_delete_project_deletion_strategy_check_external_resource(
     db: Session,
     client: TestClient,
@@ -666,6 +672,7 @@ def test_delete_project_deletion_strategy_check_external_resource(
     assert response
 
 
+@pytest.mark.asyncio
 # leader format is only relevant to follower mode
 @pytest.mark.parametrize("project_member_mode", ["follower"], indirect=True)
 def test_list_projects_leader_format(
@@ -705,6 +712,7 @@ def test_list_projects_leader_format(
     )
 
 
+@pytest.mark.asyncio
 def test_projects_crud(
     db: Session,
     client: TestClient,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -37,7 +37,7 @@ from mlrun.utils import logger
 
 
 @pytest.fixture()
-def db() -> Generator:
+async def db() -> Generator:
     """
     This fixture initialize the db singleton (so it will be accessible using mlrun.api.singletons.get_db()
     and generates a db session that can be used by the test
@@ -56,7 +56,7 @@ def db() -> Generator:
     # forcing from scratch because we created an empty file for the db
     init_data(from_scratch=True)
     initialize_db()
-    initialize_project_member()
+    await initialize_project_member()
 
     # we're also running client code in tests so set dbpath as well
     # note that setting this attribute triggers connection to the run db therefore must happen after the initialization

--- a/tests/api/db/conftest.py
+++ b/tests/api/db/conftest.py
@@ -33,7 +33,7 @@ dbs = [
 
 
 @pytest.fixture(params=dbs)
-def db(request) -> Generator:
+async def db(request) -> Generator:
     if request.param == "sqldb":
         dsn = "sqlite:///:memory:?check_same_thread=false"
         config.httpdb.dsn = dsn
@@ -46,7 +46,7 @@ def db(request) -> Generator:
             db = SQLDB(dsn)
             db.initialize(db_session)
             initialize_db(db)
-            initialize_project_member()
+            await initialize_project_member()
             yield db
         finally:
             close_session(db_session)

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -110,7 +110,7 @@ def aioresponses_mock():
 
 
 @pytest.fixture
-def db():
+async def db():
     global session_maker
     dsn = "sqlite:///:memory:?check_same_thread=false"
     db_session = None
@@ -126,7 +126,7 @@ def db():
         if db_session is not None:
             db_session.close()
     mlrun.api.utils.singletons.db.initialize_db(db)
-    mlrun.api.utils.singletons.project_member.initialize_project_member()
+    await mlrun.api.utils.singletons.project_member.initialize_project_member()
     return db
 
 


### PR DESCRIPTION
A followup PR to #3082.

When deleting a project, call `stop_logs` for all of the project's runs before they and their resources(pods) are deleted.
This is done so the log collector won't get stuck trying to collect logs for non-existing runs.

Since the log collector client is async, this required moving all of the `delete_project` functions from sync to async.