### PR TITLE
[Nuclio] Set default workers to 0 to allow backend enrichments

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -427,7 +427,7 @@ class RemoteRuntime(KubeResource):
         if worker_timeout:
             gateway_timeout = gateway_timeout or (worker_timeout + 60)
         if workers is None:
-            workers = 8
+            workers = 0
         if gateway_timeout:
             if worker_timeout and worker_timeout >= gateway_timeout:
                 raise ValueError(


### PR DESCRIPTION
To avoid opinionated client, default to 0