### PR TITLE
[Log Collector] Change state file key delimiter

### DIFF
--- a/go/pkg/services/logcollector/statestore/types.go
+++ b/go/pkg/services/logcollector/statestore/types.go
@@ -114,5 +114,5 @@ type StateStore interface {
 }
 
 func GenerateKey(runUID, project string) string {
-	return fmt.Sprintf("%s-%s", runUID, project)
+	return fmt.Sprintf("%s/%s", runUID, project)
 }


### PR DESCRIPTION
Change the state file key delimiter to `/`, resolving key as `<runUID>/<project>`.
This change is done because `-` is permitted in runUIDs and project names.