### PR TITLE
[Tests] Test test_get_offline_features_with_spark_engine: add temp debug logs

### DIFF
--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -48,10 +48,9 @@ from tests.system.feature_store.data_sample import stocks
 from tests.system.feature_store.expected_stats import expected_stats
 
 
-def print_full_df(df: pd.DataFrame, df_name, passthrough) -> None:
-    with pd.option_context('display.max_rows', None, 'display.max_columns',
-                           None):
-        print(f'{df_name}-passthrough_{str(passthrough)}:')
+def print_full_df(df: pd.DataFrame, df_name: str, passthrough: str) -> None:
+    with pd.option_context("display.max_rows", None, "display.max_columns", None):
+        print(f"{df_name}-passthrough_{passthrough}:")
         print(df)
 
 
@@ -828,7 +827,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_spark_engines(
-            self, should_succeed, is_parquet, is_partitioned, target_path
+        self, should_succeed, is_parquet, is_partitioned, target_path
     ):
         fset = FeatureSet("fsname", entities=[Entity("ticker")], engine="spark")
 
@@ -977,9 +976,9 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         source_df = source.to_dataframe()
         expected_df = source_df[source_df["bad"] == 7][["bad", "department"]]
         expected_df.reset_index(drop=True, inplace=True)
-        print_full_df(df=resp_df, df_name='resp_df', passthrough=passthrough)
-        print_full_df(df=target_df, df_name='target_df', passthrough=passthrough)
-        print_full_df(df=expected_df, df_name='expected_df', passthrough=passthrough)
+        print_full_df(df=resp_df, df_name="resp_df", passthrough=passthrough)
+        print_full_df(df=target_df, df_name="target_df", passthrough=passthrough)
+        print_full_df(df=expected_df, df_name="expected_df", passthrough=passthrough)
         assert resp_df.equals(target_df)
         assert resp_df[["bad", "department"]].equals(expected_df)
 

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -48,6 +48,13 @@ from tests.system.feature_store.data_sample import stocks
 from tests.system.feature_store.expected_stats import expected_stats
 
 
+def print_full_df(df: pd.DataFrame, df_name, passthrough) -> None:
+    with pd.option_context('display.max_rows', None, 'display.max_columns',
+                           None):
+        print(f'{df_name}-passthrough_{str(passthrough)}:')
+        print(df)
+
+
 def read_and_assert(csv_path_spark, csv_path_storey):
     read_back_df_spark = None
     file_system = fsspec.filesystem("v3io")
@@ -821,7 +828,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_spark_engines(
-        self, should_succeed, is_parquet, is_partitioned, target_path
+            self, should_succeed, is_parquet, is_partitioned, target_path
     ):
         fset = FeatureSet("fsname", entities=[Entity("ticker")], engine="spark")
 
@@ -970,6 +977,9 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         source_df = source.to_dataframe()
         expected_df = source_df[source_df["bad"] == 7][["bad", "department"]]
         expected_df.reset_index(drop=True, inplace=True)
+        print_full_df(df=resp_df, df_name='resp_df', passthrough=passthrough)
+        print_full_df(df=target_df, df_name='target_df', passthrough=passthrough)
+        print_full_df(df=expected_df, df_name='expected_df', passthrough=passthrough)
         assert resp_df.equals(target_df)
         assert resp_df[["bad", "department"]].equals(expected_df)
 


### PR DESCRIPTION
The test test_spark_engine.py::TestFeatureStoreSparkEngine::test_get_offline_features_with_spark_engine[True] is failing only in GitHub workflows(not on local machine).

Added print statements for debugging.