### PR TITLE
[API] Enrich kfp images based on the client versions

### DIFF
--- a/mlrun/api/api/endpoints/client_spec.py
+++ b/mlrun/api/api/endpoints/client_spec.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from fastapi import APIRouter
+import typing
+
+from fastapi import APIRouter, Header
 
 import mlrun.api.crud
 import mlrun.api.schemas
@@ -24,7 +26,14 @@ router = APIRouter()
     "/client-spec",
     response_model=mlrun.api.schemas.ClientSpec,
 )
-def get_client_spec():
-
-    # TODO: cache me
-    return mlrun.api.crud.ClientSpec().get_client_spec()
+def get_client_spec(
+    client_version: typing.Optional[str] = Header(
+        None, alias=mlrun.api.schemas.HeaderNames.client_version
+    ),
+    client_python_version: typing.Optional[str] = Header(
+        None, alias=mlrun.api.schemas.HeaderNames.python_version
+    ),
+):
+    return mlrun.api.crud.ClientSpec().get_client_spec(
+        client_version=client_version, client_python_version=client_python_version
+    )

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -118,9 +118,13 @@ class ClientSpec(
         :param client_python_version: the client python version
         :return: enriched image url
         """
-        return mlrun.utils.helpers.enrich_image_url(
-            image, client_version, client_python_version
-        )
+        try:
+            return mlrun.utils.helpers.enrich_image_url(
+                image, client_version, client_python_version
+            )
+        # if for some reason the user provided un-parsable versions, fall back to resolve version only by server
+        except ValueError:
+            return mlrun.utils.helpers.enrich_image_url(image)
 
     @staticmethod
     def _get_config_value_if_not_default(config_key):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -58,7 +58,6 @@ default_config = {
     "remote_host": "",
     "api_base_version": "v1",
     "version": "",  # will be set to current version
-    "api_version": "",
     "images_tag": "",  # tag to use with mlrun images e.g. mlrun/mlrun (defaults to version)
     "images_registry": "",  # registry to use with mlrun images e.g. quay.io/ (defaults to empty, for dockerhub)
     # comma separated list of images that are in the specified images_registry, and therefore will be enriched with this

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -37,6 +37,7 @@ from .utils import (
     is_legacy_artifact,
     logger,
     run_keys,
+    version,
 )
 
 # default KFP artifacts and output (ui metadata, metrics etc.)
@@ -438,6 +439,10 @@ def mlrun_op(
             image = f"{registry}/{image[1:]}"
         else:
             raise ValueError("local image registry env not found")
+
+    image = mlrun.utils.enrich_image_url(
+        image, mlrun.get_version(), str(version.Version().get_python_version())
+    )
 
     cop = dsl.ContainerOp(
         name=name,

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -202,3 +202,16 @@ def test_client_spec_response_based_on_client_version(
         response_body = response.json()
         assert response_body["kfp_image"] == "mlrun/mlrun:1.3.0-rc20"
         assert response_body["dask_kfp_image"] == "mlrun/ml-base:1.3.0-rc20"
+
+        # verify that we are falling back to resolve only by server
+        response = client.get(
+            "client-spec",
+            headers={
+                mlrun.api.schemas.HeaderNames.client_version: "test-integration",
+                mlrun.api.schemas.HeaderNames.python_version: "3.9.13",
+            },
+        )
+        assert response.status_code == http.HTTPStatus.OK.value
+        response_body = response.json()
+        assert response_body["kfp_image"] == "mlrun/mlrun:1.3.0-rc23"
+        assert response_body["dask_kfp_image"] == "mlrun/ml-base:1.3.0-rc23"

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -140,7 +140,7 @@ class TestMLRunIntegration:
             args=["run-api"],
             env=self._extend_current_env(
                 {
-                    "MLRUN_VERSION": "test-integration",
+                    "MLRUN_VERSION": "0.0.0+unstable",
                     "MLRUN_HTTPDB__DSN": self.db_dsn,
                     # integration tests run in docker, and do no support sidecars for log collection
                     "MLRUN__LOG_COLLECTOR__MODE": "legacy",


### PR DESCRIPTION
### Added functionality on server side which returns the client spec based on the clients versions.

KFP workflows are being built on client side and therefore we need to provide the client with the right image to run the kfp step with. 
When running an MLRun step inside a KFP workflow two pods are being created, the first is the KFP step which  is responsible for spawning the actual mlrun job (on another pod) now because we have the whole image enrichments stuff we need to replicate the client environment into the KFP step environment(same mlrun version and python version) so that the pod which is being spawned from the KFP step will be enriched with the right image version.