### PR TITLE
[DB] Add `hash_key` filter to `list_functions`

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -158,10 +158,10 @@ async def list_functions(
     project: str = None,
     name: str = None,
     tag: str = None,
-    hash_key: str = None,
     labels: List[str] = Query([], alias="label"),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
+    hash_key: str = None,
 ):
     if project is None:
         project = config.default_project

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -159,9 +159,9 @@ async def list_functions(
     name: str = None,
     tag: str = None,
     labels: List[str] = Query([], alias="label"),
+    hash_key: str = None,
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
-    hash_key: str = None,
 ):
     if project is None:
         project = config.default_project
@@ -172,12 +172,12 @@ async def list_functions(
     )
     functions = await run_in_threadpool(
         mlrun.api.crud.Functions().list_functions,
-        db_session,
-        project,
-        name,
-        tag,
-        hash_key,
-        labels,
+        db_session=db_session,
+        project=project,
+        name=name,
+        tag=tag,
+        labels=labels,
+        hash_key=hash_key,
     )
     functions = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.api.schemas.AuthorizationResourceTypes.function,

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -158,6 +158,7 @@ async def list_functions(
     project: str = None,
     name: str = None,
     tag: str = None,
+    hash_key: str = None,
     labels: List[str] = Query([], alias="label"),
     auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
@@ -175,6 +176,7 @@ async def list_functions(
         project,
         name,
         tag,
+        hash_key,
         labels,
     )
     functions = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(

--- a/mlrun/api/crud/functions.py
+++ b/mlrun/api/crud/functions.py
@@ -76,6 +76,7 @@ class Functions(
         project: str = mlrun.mlconf.default_project,
         name: str = "",
         tag: str = "",
+        hash_key: str = "",
         labels: typing.List[str] = None,
     ) -> typing.List:
         project = project or mlrun.mlconf.default_project
@@ -86,5 +87,6 @@ class Functions(
             name,
             project,
             tag,
+            hash_key,
             labels,
         )

--- a/mlrun/api/crud/functions.py
+++ b/mlrun/api/crud/functions.py
@@ -83,10 +83,10 @@ class Functions(
         if labels is None:
             labels = []
         return mlrun.api.utils.singletons.db.get_db().list_functions(
-            db_session,
-            name,
-            project,
-            tag,
-            hash_key,
-            labels,
+            session=db_session,
+            name=name,
+            project=project,
+            tag=tag,
+            labels=labels,
+            hash_key=hash_key,
         )

--- a/mlrun/api/crud/functions.py
+++ b/mlrun/api/crud/functions.py
@@ -76,8 +76,8 @@ class Functions(
         project: str = mlrun.mlconf.default_project,
         name: str = "",
         tag: str = "",
-        hash_key: str = "",
         labels: typing.List[str] = None,
+        hash_key: str = "",
     ) -> typing.List:
         project = project or mlrun.mlconf.default_project
         if labels is None:

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -216,7 +216,13 @@ class DBInterface(ABC):
 
     @abstractmethod
     def list_functions(
-        self, session, name=None, project="", tag="", labels=None, hash_key=None
+        self,
+        session,
+        name: str = None,
+        project: str = None,
+        tag: str = None,
+        labels: List[str] = None,
+        hash_key: str = None,
     ):
         pass
 

--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -215,7 +215,9 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def list_functions(self, session, name=None, project="", tag="", labels=None):
+    def list_functions(
+        self, session, name=None, project="", tag="", labels=None, hash_key=None
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/api/db/filedb/db.py
+++ b/mlrun/api/db/filedb/db.py
@@ -228,7 +228,9 @@ class FileDB(DBInterface):
     def delete_function(self, session, project: str, name: str):
         raise NotImplementedError()
 
-    def list_functions(self, session, name=None, project="", tag="", labels=None):
+    def list_functions(
+        self, session, name=None, project="", tag="", labels=None, hash_key=None
+    ):
         return self._transform_run_db_error(
             self.db.list_functions, name, project, tag, labels
         )

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1034,7 +1034,7 @@ class SQLDB(DBInterface):
         tag: str = None,
         labels: List[str] = None,
         hash_key: str = None,
-    ) -> typing.Union[FunctionList, list[dict]]:
+    ) -> typing.Union[FunctionList, List[dict]]:
         project = project or config.default_project
         uids = None
         if tag:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1027,8 +1027,14 @@ class SQLDB(DBInterface):
                 self._delete(session, labeled_class, project=project)
 
     def list_functions(
-        self, session, name=None, project=None, tag=None, labels=None, hash_key=None
-    ):
+        self,
+        session: Session,
+        name: str = None,
+        project: str = None,
+        tag: str = None,
+        labels: List[str] = None,
+        hash_key: str = None,
+    ) -> typing.Union[FunctionList, list[dict]]:
         project = project or config.default_project
         uids = None
         if tag:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1021,19 +1021,14 @@ class SQLDB(DBInterface):
         for tagged_class in _tagged:
             self._delete(session, tagged_class, project=project)
 
-    def _delete_resources_labels(self, session: Session, project: str):
-        for labeled_class in _labeled:
-            if hasattr(labeled_class, "project"):
-                self._delete(session, labeled_class, project=project)
-
     def list_functions(
         self,
         session: Session,
         name: str = None,
         project: str = None,
         tag: str = None,
-        labels: List[str] = None,
         hash_key: str = None,
+        labels: List[str] = None,
     ) -> typing.Union[FunctionList, List[dict]]:
         project = project or config.default_project
         uids = None
@@ -1072,6 +1067,11 @@ class SQLDB(DBInterface):
                 function_dict["metadata"]["tag"] = tag
                 functions.append(function_dict)
         return functions
+
+    def _delete_resources_labels(self, session: Session, project: str):
+        for labeled_class in _labeled:
+            if hasattr(labeled_class, "project"):
+                self._delete(session, labeled_class, project=project)
 
     def _delete_function_tags(self, session, project, function_name, commit=True):
         query = session.query(Function.Tag).filter(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1026,11 +1026,17 @@ class SQLDB(DBInterface):
             if hasattr(labeled_class, "project"):
                 self._delete(session, labeled_class, project=project)
 
-    def list_functions(self, session, name=None, project=None, tag=None, labels=None):
+    def list_functions(
+        self, session, name=None, project=None, tag=None, labels=None, hash_key=None
+    ):
         project = project or config.default_project
         uids = None
         if tag:
             uids = self._resolve_class_tag_uids(session, Function, project, tag, name)
+            if hash_key:
+                uids = [uid for uid in uids if uid == hash_key] or None
+        if not tag and hash_key:
+            uids = [hash_key]
         functions = FunctionList()
         for function in self._find_functions(session, name, project, uids, labels):
             function_dict = function.struct

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1027,8 +1027,8 @@ class SQLDB(DBInterface):
         name: str = None,
         project: str = None,
         tag: str = None,
-        hash_key: str = None,
         labels: List[str] = None,
+        hash_key: str = None,
     ) -> typing.Union[FunctionList, List[dict]]:
         project = project or config.default_project
         uids = None

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -299,11 +299,11 @@ class SQLDB(RunDBInterface):
 
         return self._transform_db_error(
             mlrun.api.crud.Functions().list_functions,
-            self.session,
-            project,
-            name,
-            tag,
-            labels,
+            db_session=self.session,
+            project=project,
+            name=name,
+            tag=tag,
+            labels=labels,
         )
 
     def list_artifact_tags(

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -84,28 +84,33 @@ async def test_list_functions_with_hash_key_versioned(
 ):
     await tests.api.api.utils.create_project_async(async_client, PROJECT)
 
+    function_tag = "function-tag"
+    function_project = "project-name"
+    function_name = "function-name"
+
     function = {
         "kind": "job",
         "metadata": {
-            "name": "function-name",
-            "project": "project-name",
-            "tag": "some-tag",
+            "name": function_name,
+            "project": function_project,
+            "tag": function_tag,
         },
         "spec": {"image": "mlrun/mlrun"},
     }
 
+    another_tag = "another-tag"
     function2 = {
         "kind": "job",
         "metadata": {
-            "name": "function-name",
-            "project": "project-name",
-            "tag": "some-tag2",
+            "name": function_name,
+            "project": function_project,
+            "tag": "another-tag",
         },
     }
 
     post_function1_response = await async_client.post(
-        f"func/{function['metadata']['project']}/"
-        f"{function['metadata']['name']}?tag={function['metadata']['tag']}&versioned={True}",
+        f"func/{function_project}/"
+        f"{function_name}?tag={function_tag}&versioned={True}",
         json=function,
     )
 
@@ -114,14 +119,14 @@ async def test_list_functions_with_hash_key_versioned(
 
     # Store another function with the same project and name but different tag and hash key
     post_function2_response = await async_client.post(
-        f"func/{function2['metadata']['project']}/"
-        f"{function2['metadata']['name']}?tag={function2['metadata']['tag']}&versioned={True}",
+        f"func/{function_project}/"
+        f"{function_name}?tag={another_tag}&versioned={True}",
         json=function2,
     )
     assert post_function2_response.status_code == HTTPStatus.OK.value
 
     list_functions_by_hash_key_response = await async_client.get(
-        f"funcs?project={function['metadata']['project']}&name={function['metadata']['name']}&hash_key={hash_key}"
+        f"funcs?project={function_project}&name={function_name}&hash_key={hash_key}"
     )
 
     list_functions_results = list_functions_by_hash_key_response.json()["funcs"]

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -79,6 +79,57 @@ def test_build_status_pod_not_found(
 
 
 @pytest.mark.asyncio
+async def test_list_functions_with_hash_key_versioned(
+    db: sqlalchemy.orm.Session, async_client: httpx.AsyncClient
+):
+    await tests.api.api.utils.create_project_async(async_client, PROJECT)
+
+    function = {
+        "kind": "job",
+        "metadata": {
+            "name": "function-name",
+            "project": "project-name",
+            "tag": "some-tag",
+        },
+        "spec": {"image": "mlrun/mlrun"},
+    }
+
+    function2 = {
+        "kind": "job",
+        "metadata": {
+            "name": "function-name",
+            "project": "project-name",
+            "tag": "some-tag2",
+        },
+    }
+
+    post_function1_response = await async_client.post(
+        f"func/{function['metadata']['project']}/"
+        f"{function['metadata']['name']}?tag={function['metadata']['tag']}&versioned={True}",
+        json=function,
+    )
+
+    assert post_function1_response.status_code == HTTPStatus.OK.value
+    hash_key = post_function1_response.json()["hash_key"]
+
+    # Store another function with the same project and name but different tag and hash key
+    post_function2_response = await async_client.post(
+        f"func/{function2['metadata']['project']}/"
+        f"{function2['metadata']['name']}?tag={function2['metadata']['tag']}&versioned={True}",
+        json=function2,
+    )
+    assert post_function2_response.status_code == HTTPStatus.OK.value
+
+    list_functions_by_hash_key_response = await async_client.get(
+        f"funcs?project={function['metadata']['project']}&name={function['metadata']['name']}&hash_key={hash_key}"
+    )
+
+    list_functions_results = list_functions_by_hash_key_response.json()["funcs"]
+    assert len(list_functions_results) == 1
+    assert list_functions_results[0]["metadata"]["hash"] == hash_key
+
+
+@pytest.mark.asyncio
 async def test_multiple_store_function_race_condition(
     db: sqlalchemy.orm.Session, async_client: httpx.AsyncClient
 ):

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -25,16 +25,17 @@ from tests.api.db.conftest import dbs
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_store_function_default_to_latest(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla"}
-    function_name_1 = "function_name_1"
-    function_hash_key = db.store_function(db_session, function_1, function_name_1)
+    function_1 = _generate_function()
+    function_hash_key = db.store_function(
+        db_session, function_1.to_dict(), function_1.metadata.name
+    )
     assert function_hash_key is not None
-    function_queried_without_tag = db.get_function(db_session, function_name_1)
+    function_queried_without_tag = db.get_function(db_session, function_1.metadata.name)
     function_queried_without_tag_hash = function_queried_without_tag["metadata"]["hash"]
     assert function_hash_key == function_queried_without_tag_hash
     assert function_queried_without_tag["metadata"]["tag"] == "latest"
     function_queried_with_tag = db.get_function(
-        db_session, function_name_1, tag="latest"
+        db_session, function_1.metadata.name, tag="latest"
     )
     function_queried_without_tag_hash = function_queried_with_tag["metadata"]["hash"]
     assert function_queried_with_tag is not None
@@ -46,18 +47,19 @@ def test_store_function_default_to_latest(db: DBInterface, db_session: Session):
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_store_function_versioned(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla"}
-    function_name_1 = "function_name_1"
+    function_1 = _generate_function()
     function_hash_key = db.store_function(
-        db_session, function_1, function_name_1, versioned=True
+        db_session, function_1.to_dict(), function_1.metadata.name, versioned=True
     )
-    function_queried_without_hash_key = db.get_function(db_session, function_name_1)
+    function_queried_without_hash_key = db.get_function(
+        db_session, function_1.metadata.name
+    )
     assert function_queried_without_hash_key is not None
     assert function_queried_without_hash_key["metadata"]["tag"] == "latest"
 
     # Verifying versioned function is queryable by hash_key
     function_queried_with_hash_key = db.get_function(
-        db_session, function_name_1, hash_key=function_hash_key
+        db_session, function_1.metadata.name, hash_key=function_hash_key
     )
     function_queried_with_hash_key_hash = function_queried_with_hash_key["metadata"][
         "hash"
@@ -66,10 +68,9 @@ def test_store_function_versioned(db: DBInterface, db_session: Session):
     assert function_queried_with_hash_key["metadata"]["tag"] == ""
     assert function_queried_with_hash_key_hash == function_hash_key
 
-    function_2 = {"bla": "blabla", "bla2": "blabla2"}
-    function_name_1 = "function_name_1"
-    db.store_function(db_session, function_2, function_name_1, versioned=True)
-    functions = db.list_functions(db_session, function_name_1)
+    function_2 = {"test": "new_version"}
+    db.store_function(db_session, function_2, function_1.metadata.name, versioned=True)
+    functions = db.list_functions(db_session, function_1.metadata.name)
 
     # Verifying both versions of the functions were saved
     assert len(functions) == 2
@@ -87,22 +88,23 @@ def test_store_function_versioned(db: DBInterface, db_session: Session):
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_store_function_not_versioned(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla"}
-    function_name_1 = "function_name_1"
+    function_1 = _generate_function()
     function_hash_key = db.store_function(
-        db_session, function_1, function_name_1, versioned=False
+        db_session, function_1.to_dict(), function_1.metadata.name, versioned=False
     )
-    function_result_1 = db.get_function(db_session, function_name_1)
+    function_result_1 = db.get_function(db_session, function_1.metadata.name)
     assert function_result_1 is not None
     assert function_result_1["metadata"]["tag"] == "latest"
 
     # not versioned so not queryable by hash key
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        db.get_function(db_session, function_name_1, hash_key=function_hash_key)
+        db.get_function(
+            db_session, function_1.metadata.name, hash_key=function_hash_key
+        )
 
-    function_2 = {"bla": "blabla", "bla2": "blabla2"}
-    db.store_function(db_session, function_2, function_name_1, versioned=False)
-    functions = db.list_functions(db_session, function_name_1)
+    function_2 = {"test": "new_version"}
+    db.store_function(db_session, function_2, function_1.metadata.name, versioned=False)
+    functions = db.list_functions(db_session, function_1.metadata.name)
 
     # Verifying only the latest version was saved
     assert len(functions) == 1
@@ -112,17 +114,18 @@ def test_store_function_not_versioned(db: DBInterface, db_session: Session):
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_get_function_by_hash_key(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla", "status": {"bla": "blabla"}}
-    function_name_1 = "function_name_1"
+    function_1 = _generate_function()
     function_hash_key = db.store_function(
-        db_session, function_1, function_name_1, versioned=True
+        db_session, function_1.to_dict(), function_1.metadata.name, versioned=True
     )
-    function_queried_without_hash_key = db.get_function(db_session, function_name_1)
+    function_queried_without_hash_key = db.get_function(
+        db_session, function_1.metadata.name
+    )
     assert function_queried_without_hash_key is not None
 
     # Verifying function is queryable by hash_key
     function_queried_with_hash_key = db.get_function(
-        db_session, function_name_1, hash_key=function_hash_key
+        db_session, function_1.metadata.name, hash_key=function_hash_key
     )
     assert function_queried_with_hash_key is not None
 
@@ -135,13 +138,12 @@ def test_get_function_by_hash_key(db: DBInterface, db_session: Session):
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_get_function_by_tag(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla", "status": {"bla": "blabla"}}
-    function_name_1 = "function_name_1"
+    function_1 = _generate_function()
     function_hash_key = db.store_function(
-        db_session, function_1, function_name_1, versioned=True
+        db_session, function_1.to_dict(), function_1.metadata.name, versioned=True
     )
     function_queried_by_hash_key = db.get_function(
-        db_session, function_name_1, hash_key=function_hash_key
+        db_session, function_1.metadata.name, hash_key=function_hash_key
     )
     function_not_queried_by_tag_hash = function_queried_by_hash_key["metadata"]["hash"]
     assert function_hash_key == function_not_queried_by_tag_hash
@@ -151,15 +153,18 @@ def test_get_function_by_tag(db: DBInterface, db_session: Session):
     "db,db_session", [(db, db) for db in dbs], indirect=["db", "db_session"]
 )
 def test_get_function_not_found(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla", "status": {"bla": "blabla"}}
-    function_name_1 = "function_name_1"
-    db.store_function(db_session, function_1, function_name_1, versioned=True)
+    function_1 = _generate_function()
+    db.store_function(
+        db_session, function_1.to_dict(), function_1.metadata.name, versioned=True
+    )
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        db.get_function(db_session, function_name_1, tag="inexistent_tag")
+        db.get_function(db_session, function_1.metadata.name, tag="inexistent_tag")
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        db.get_function(db_session, function_name_1, hash_key="inexistent_hash_key")
+        db.get_function(
+            db_session, function_1.metadata.name, hash_key="inexistent_hash_key"
+        )
 
 
 @pytest.mark.parametrize(
@@ -227,15 +232,24 @@ def test_list_functions_with_non_existent_tag(db: DBInterface, db_session: Sessi
 def test_list_functions_filtering_unversioned_untagged(
     db: DBInterface, db_session: Session
 ):
-    function_1 = {"bla": "blabla"}
-    function_2 = {"bla": "blablablabla"}
-    function_name_1 = "function_name_1"
+    function_1 = _generate_function()
+    function_2 = _generate_function()
     tag = "some_tag"
-    db.store_function(db_session, function_1, function_name_1, versioned=False, tag=tag)
-    tagged_function_hash_key = db.store_function(
-        db_session, function_2, function_name_1, versioned=True, tag=tag
+    db.store_function(
+        db_session,
+        function_1.to_dict(),
+        function_1.metadata.name,
+        versioned=False,
+        tag=tag,
     )
-    functions = db.list_functions(db_session, function_name_1)
+    tagged_function_hash_key = db.store_function(
+        db_session,
+        function_2.to_dict(),
+        function_2.metadata.name,
+        versioned=True,
+        tag=tag,
+    )
+    functions = db.list_functions(db_session, function_1.metadata.name)
 
     # First we stored to the tag without versioning (unversioned instance) then we stored to the tag with version
     # so the unversioned instance remained untagged, verifying we're not getting it
@@ -302,6 +316,7 @@ def test_delete_function(db: DBInterface, db_session: Session):
     assert number_of_labels == 0
 
 
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
 @pytest.mark.parametrize(
     "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
 )
@@ -309,17 +324,20 @@ def test_delete_function(db: DBInterface, db_session: Session):
 def test_list_functions_multiple_tags(
     db: DBInterface, db_session: Session, use_hash_key: bool
 ):
-    function_1 = {"bla": "blabla", "status": {"bla": "blabla"}}
-    function_name_1 = "function_name_1"
+    function_1 = _generate_function()
 
     tags = ["some_tag", "some_tag2", "some_tag3"]
     for tag in tags:
         function_hash_key = db.store_function(
-            db_session, function_1, function_name_1, tag=tag, versioned=True
+            db_session,
+            function_1.to_dict(),
+            function_1.metadata.name,
+            tag=tag,
+            versioned=True,
         )
     functions = db.list_functions(
         db_session,
-        function_name_1,
+        function_1.metadata.name,
         hash_key=function_hash_key if use_hash_key else None,
     )
     assert len(functions) == len(tags)
@@ -331,30 +349,48 @@ def test_list_functions_multiple_tags(
     assert len(tags) == 0
 
 
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
 @pytest.mark.parametrize(
     "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
 )
 def test_list_function_with_tag_and_uid(db: DBInterface, db_session: Session):
-    function_1 = {"bla": "blabla", "status": {"bla": "blabla"}}
-    function_2 = {"blabla": "bla", "status": {"blabla": "bla"}}
-
-    function_name_1 = "function_name_1"
-    function_name_2 = "function_name_2"
     tag_name = "some_tag"
+    function_1 = _generate_function(tag=tag_name)
+    function_2 = _generate_function(function_name="function_name_2", tag=tag_name)
 
     function_1_hash_key = db.store_function(
-        db_session, function_1, function_name_1, tag=tag_name, versioned=True
+        db_session,
+        function_1.to_dict(),
+        function_1.metadata.name,
+        tag=tag_name,
+        versioned=True,
     )
 
     # Storing another function with the same tag,
     # to ensure that filtering by tag and hash key works, and that not both are returned
     db.store_function(
-        db_session, function_2, function_name_2, tag=tag_name, versioned=True
+        db_session,
+        function_2.to_dict(),
+        function_2.metadata.name,
+        tag=tag_name,
+        versioned=True,
     )
 
     functions = db.list_functions(
-        db_session, function_name_1, tag=tag_name, hash_key=function_1_hash_key
+        db_session, function_1.metadata.name, tag=tag_name, hash_key=function_1_hash_key
     )
     assert (
         len(functions) == 1 and functions[0]["metadata"]["hash"] == function_1_hash_key
+    )
+
+
+def _generate_function(
+    function_name: str = "function_name_1",
+    project: str = "project_name",
+    tag: str = "latest",
+):
+    return mlrun.new_function(
+        name=function_name,
+        project=project,
+        tag=tag,
     )


### PR DESCRIPTION
a fix for: https://jira.iguazeng.com/browse/ML-2534

Adding a hash_key filter parameter to `list_functions` so that the UI can query the API for the function tag using the function uri.