### PR TITLE
[Runtimes] Creating an external get_url function

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -856,14 +856,9 @@ class RemoteRuntime(KubeResource):
         self._mock_server = None
 
         if "://" not in path:
-            if not self.status.address:
-                state, _, _ = self._get_state(dashboard, auth_info=auth_info)
-                if state != "ready" or not self.status.address:
-                    raise ValueError(
-                        "no function address or not ready, first run .deploy()"
-                    )
-
-            path = self._resolve_invocation_url(path, force_external_address)
+            self.get_url(
+                path, auth_info=auth_info, force_external_address=force_external_address
+            )
 
         if headers is None:
             headers = {}
@@ -1089,6 +1084,29 @@ class RemoteRuntime(KubeResource):
                 "Mock (simulation) is currently not supported for Nuclio, Turn off the mock (mock=False) "
                 "and make sure Nuclio is installed for real deployment to Nuclio"
             )
+
+    def get_url(
+        self,
+        path: str = "",
+        force_external_address: bool = False,
+        auth_info: AuthInfo = None,
+    ):
+        """
+        This method returns function's url.
+        :param path:                     request sub path (e.g. /images)
+        :param force_external_address:   use the external ingress URL
+        :param auth_info:                service AuthInfo
+
+        :return: returns function's url
+        """
+        if not self.status.address:
+            state, _, _ = self._get_state(auth_info=auth_info)
+            if state != "ready" or not self.status.address:
+                raise ValueError(
+                    "no function address or not ready, first run .deploy()"
+                )
+
+        return self._resolve_invocation_url(path, force_external_address)
 
 
 def parse_logs(logs):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1026,8 +1026,8 @@ class RemoteRuntime(KubeResource):
 
     def _resolve_invocation_url(self, path, force_external_address):
 
-        if path.startswith("/"):
-            path = path[1:]
+        if not path.startswith("/") and path != "":
+            path = f"/{path}"
 
         # internal / external invocation urls is a nuclio >= 1.6.x feature
         # try to infer the invocation url from the internal and if not exists, use external.
@@ -1039,12 +1039,12 @@ class RemoteRuntime(KubeResource):
                 silent=True, log=False
             ).is_running_inside_kubernetes_cluster()
         ):
-            return f"http://{self.status.internal_invocation_urls[0]}/{path}"
+            return f"http://{self.status.internal_invocation_urls[0]}{path}"
 
         if self.status.external_invocation_urls:
-            return f"http://{self.status.external_invocation_urls[0]}/{path}"
+            return f"http://{self.status.external_invocation_urls[0]}{path}"
         else:
-            return f"http://{self.status.address}/{path}"
+            return f"http://{self.status.address}{path}"
 
     def _update_credentials_from_remote_build(self, remote_data):
         self.metadata.credentials = remote_data.get("metadata", {}).get(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -856,7 +856,7 @@ class RemoteRuntime(KubeResource):
         self._mock_server = None
 
         if "://" not in path:
-            self.get_url(
+            path = self.get_url(
                 path, auth_info=auth_info, force_external_address=force_external_address
             )
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1091,9 +1091,9 @@ class RemoteRuntime(KubeResource):
             )
 
     def get_url(
-            self,
-            force_external_address: bool = False,
-            auth_info: AuthInfo = None,
+        self,
+        force_external_address: bool = False,
+        auth_info: AuthInfo = None,
     ):
         """
         This method returns function's url.
@@ -1111,6 +1111,7 @@ class RemoteRuntime(KubeResource):
                 )
 
         return self._resolve_invocation_url("", force_external_address)
+
 
 def parse_logs(logs):
     logs = json.loads(logs)

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -55,7 +55,10 @@ class TestNuclioRuntime(tests.system.base.TestMLRunSystem):
         graph.error_handler("catcher")
 
         self._logger.debug("Deploying nuclio function")
-        function.deploy()
+        deployment = function.deploy()
+
+        assert deployment == function.get_url()  # check function url
+
 
     # Nuclio sometimes passes b'' instead of None due to dirty memory
     def test_workaround_for_nuclio_bug(self):

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -59,7 +59,6 @@ class TestNuclioRuntime(tests.system.base.TestMLRunSystem):
 
         assert deployment == function.get_url()  # check function url
 
-
     # Nuclio sometimes passes b'' instead of None due to dirty memory
     def test_workaround_for_nuclio_bug(self):
         code_path = str(self.assets_path / "nuclio_function_to_print_type.py")


### PR DESCRIPTION
Create ability for getting url of RemoteRuntime function after deploy.

Note : dashboard is deprecated because security issues   