### PR TITLE
[Run] Ignore `typing` module for input parsing

### DIFF
--- a/docs/concepts/decorators-and-auto-logging.md
+++ b/docs/concepts/decorators-and-auto-logging.md
@@ -87,6 +87,8 @@ def train_and_predict(train_data: pd.DataFrame,
 ...
 ```
 
+**Notice**: `typing` hints like `Optional`, `Union` and `List` are currently not supported but will be in the future. 
+
 > **Note:** If the inputs does not have a type input, the decorator assumes the parameter type in {py:class}`mlrun.datastore.DataItem`. If you specify `inputs=False`, all the run inputs are assumed to be of type `mlrun.datastore.DataItem`. You also have the option to specify a dictionary where each key is the name of the input and the value is the type.
 
 ## Logging return values as artifacts
@@ -122,5 +124,5 @@ If you use only the name without the type, the following mapping is used:
 | bokeh.plotting.Figure    | Plot          |
 
 
-Another option is to specify a tuple in the form of `(name, artifact_type)` or `(name, artifact_type, arguments)`. Refer to the {py:func}`mlrun.handler` for more details.
+Refer to the {py:func}`mlrun.handler` for more details.
 

--- a/docs/concepts/decorators-and-auto-logging.md
+++ b/docs/concepts/decorators-and-auto-logging.md
@@ -87,7 +87,8 @@ def train_and_predict(train_data: pd.DataFrame,
 ...
 ```
 
-**Notice**: `typing` hints like `Optional`, `Union` and `List` are currently not supported but will be in the future. 
+**Notice**: Type hints from the `typing` module (e.g. `typing.Optional`, `typing.Union`, `typing.List` etc.) are 
+currently not supported but will be in the future.
 
 > **Note:** If the inputs does not have a type input, the decorator assumes the parameter type in {py:class}`mlrun.datastore.DataItem`. If you specify `inputs=False`, all the run inputs are assumed to be of type `mlrun.datastore.DataItem`. You also have the option to specify a dictionary where each key is the name of the input and the value is the type.
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1276,7 +1276,7 @@ def _parse_type_hint(type_hint: Union[Type, str]) -> Type:
 
     * Python builtin type - one of ``tuple``, ``list``, ``set``, ``dict`` and ``bytearray``.
     * Full module import path. An alias is not allowed (if ``import pandas as pd`` is used, the type hint cannot be
-      ``pd.DataFrame``).
+      ``pd.DataFrame`` but ``pandas.DataFrame``).
 
     The type class on its own (like `DataFrame`) cannot be used as the scope of the decorator is not the same as the
     handler itself, hence modules and objects that were imported in the handler's scope are not available. This is the
@@ -1463,7 +1463,9 @@ def handler(
                    * Dict[str, Union[Type, str]] - A dictionary with argument name as key and the expected type to parse
                      the `mlrun.DataItem` to. The expected type can be a string as well, idicating the full module path.
 
-                   **Notice**: `typing` hints like `Optional`, `Union` and `List` are currently not supported.
+                   **Notice**: Type hints from the `typing` module (e.g. `typing.Optional`, `typing.Union`,
+                   `typing.List` etc.) are currently not supported but will be in the future.
+
                    Default: True.
 
     Example::

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -1274,9 +1274,9 @@ def _parse_type_hint(type_hint: Union[Type, str]) -> Type:
     """
     Parse a given type hint from string to its actual hinted type class object. The string must be one of the following:
 
-    * Python builtin type - one of `tuple`, `list`, `set`, `dict` and `bytearray`.
-    * Full module import path. An alias (if import pandas as pd is used, the type hint cannot be `pd.DataFrame`) is
-      not allowed.
+    * Python builtin type - one of ``tuple``, ``list``, ``set``, ``dict`` and ``bytearray``.
+    * Full module import path. An alias is not allowed (if ``import pandas as pd`` is used, the type hint cannot be
+      ``pd.DataFrame``).
 
     The type class on its own (like `DataFrame`) cannot be used as the scope of the decorator is not the same as the
     handler itself, hence modules and objects that were imported in the handler's scope are not available. This is the
@@ -1294,6 +1294,11 @@ def _parse_type_hint(type_hint: Union[Type, str]) -> Type:
     """
     if not isinstance(type_hint, str):
         return type_hint
+
+    # TODO: Remove once Packager is implemented (it will support typing hints)
+    # If a typing hint is provided, we return a dummy Union type so the parser will skip the data item:
+    if type_hint.startswith("typing."):
+        return Union[int, str]
 
     # Validate the type hint is a valid module path:
     if not bool(
@@ -1458,6 +1463,7 @@ def handler(
                    * Dict[str, Union[Type, str]] - A dictionary with argument name as key and the expected type to parse
                      the `mlrun.DataItem` to. The expected type can be a string as well, idicating the full module path.
 
+                   **Notice**: `typing` hints like `Optional`, `Union` and `List` are currently not supported.
                    Default: True.
 
     Example::

--- a/mlrun/runtimes/package/context_handler.py
+++ b/mlrun/runtimes/package/context_handler.py
@@ -655,6 +655,8 @@ class ContextHandler:
 
         :raises MLRunRuntimeError: If an error was raised during the parsing function.
         """
+        if str(type_hint).startswith("typing."):
+            return data_item
         try:
             return self._INPUTS_PARSING_MAP.get(
                 type_hint, self._INPUTS_PARSING_MAP[object]


### PR DESCRIPTION
`typing` type hints like `Union`, `List` and `Optional` will be ignored (so the object's type will remain a `mlrun.DataItem`) when the auto-parse of the `mlrun.handler` will get them. Once the `mlrun.package` module is implemented, `typing` will be supported.