### PR TITLE
[CI] Enable verbose logging for enterprise system test preparation

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -403,6 +403,7 @@ class SystemTestPreparer:
         self._run_command(
             f"./{provctl_path}",
             args=[
+                "--verbose",
                 f"--logger-file-path={provctl_create_patch_log}",
                 "create-patch",
                 "appservice",
@@ -430,6 +431,7 @@ class SystemTestPreparer:
         self._run_command(
             f"./{provctl_path}",
             args=[
+                "--verbose",
                 f"--logger-file-path={provctl_patch_mlrun_log}",
                 "--app-cluster-password",
                 self._app_cluster_ssh_password,


### PR DESCRIPTION
In case of preparation errors, show debug logs