### PR TITLE
[Nuclio] Fix image pull secret enrichment

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -231,7 +231,7 @@ def build_function(
     image=None,
     base_image=None,
     commands: list = None,
-    secret_name="",
+    secret_name=None,
     requirements: Union[str, List[str]] = None,
     mlrun_version_specifier=None,
     builder_env: dict = None,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2189,7 +2189,7 @@ class MlrunProject(ModelObj):
         image=None,
         base_image=None,
         commands: list = None,
-        secret_name="",
+        secret_name=None,
         requirements: typing.Union[str, typing.List[str]] = None,
         mlrun_version_specifier=None,
         builder_env: dict = None,

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -145,7 +145,7 @@ class KubejobRuntime(KubeResource):
             self.with_commands(commands, overwrite=False, verify_base_image=False)
         if extra:
             self.spec.build.extra = extra
-        if secret:
+        if secret is not None:
             self.spec.build.secret = secret
         if source:
             self.spec.build.source = source

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1175,10 +1175,17 @@ class TestNuclioRuntime(TestRuntimeBase):
                 "my-other-builder-secret",
                 "my-default-image-pull-secret",
                 "my-default-builder-secret",
-                "my-other-builder-secret",
+                None,
             ),
             (
                 "",
+                "",
+                "my-default-image-pull-secret",
+                "my-default-builder-secret",
+                None,
+            ),
+            (
+                "my-default-image-pull-secret",
                 "",
                 "my-default-image-pull-secret",
                 "my-default-builder-secret",


### PR DESCRIPTION
Until today we would pass the build secret name to nuclio image pull secret and we would ignore the functions' image pull secret.
Added logic to resolve the secret to set with giving precedence to image pull secret.
Nuclio will use the 1 secret for both the build pod and the deployment.
**NOTE**: With ECR we must differentiate between the secrets. To resolve that nuclio must have the registry provider secret set and it will be used regardless of the secret we provide.