### PR TITLE
[Log Collector] Fix lock race conditions and state overwrites

### DIFF
--- a/go/pkg/common/utils.go
+++ b/go/pkg/common/utils.go
@@ -119,10 +119,6 @@ func WriteToFile(filePath string,
 	openFlags := os.O_CREATE | os.O_RDWR
 	if append {
 		openFlags |= os.O_APPEND
-	} else {
-
-		// if we're not appending, we want to truncate the file
-		openFlags |= os.O_TRUNC
 	}
 
 	if err := EnsureFileExists(filePath); err != nil {

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -420,28 +420,28 @@ func (suite *LogCollectorTestSuite) TestStopLog() {
 	for i := 0; i < projectNum; i++ {
 		projectName := fmt.Sprintf("project-%d", i)
 
-		// add log item to the server's state
+		// add log item to the server's states, so no error will be returned
 		for j := 0; j < logItemsNum; j++ {
 			runUID := uuid.New().String()
 			projectToRuns[projectName] = append(projectToRuns[projectName], runUID)
 			selector := fmt.Sprintf("run=%s", runUID)
 
-			// Add state to the log collector's persistent state store
-			err = suite.LogCollectorServer.stateStore.AddLogItem(suite.ctx, runUID, selector, projectName)
-			suite.Require().NoError(err, "Failed to add log item to state store")
+			// Add state to the log collector's state manifest
+			err = suite.LogCollectorServer.stateManifest.AddLogItem(suite.ctx, runUID, selector, projectName)
+			suite.Require().NoError(err, "Failed to add log item to the state manifest")
 
-			// Add state to the log collector's in-memory state
-			err = suite.LogCollectorServer.inMemoryState.AddLogItem(suite.ctx, runUID, selector, projectName)
-			suite.Require().NoError(err, "Failed to add log item to in-memory state")
+			// Add state to the log collector's current state
+			err = suite.LogCollectorServer.currentState.AddLogItem(suite.ctx, runUID, selector, projectName)
+			suite.Require().NoError(err, "Failed to add log item to the current state")
 		}
 	}
 
 	// write state
-	err = suite.LogCollectorServer.stateStore.WriteState(suite.LogCollectorServer.stateStore.GetState())
+	err = suite.LogCollectorServer.stateManifest.WriteState(suite.LogCollectorServer.stateManifest.GetState())
 	suite.Require().NoError(err, "Failed to write state")
 
 	// verify all items are in progress
-	logItemsInProgress, err := suite.LogCollectorServer.stateStore.GetItemsInProgress()
+	logItemsInProgress, err := suite.LogCollectorServer.stateManifest.GetItemsInProgress()
 	suite.Require().NoError(err, "Failed to get items in progress")
 
 	suite.Require().Equal(projectNum, common.SyncMapLength(logItemsInProgress), "Expected items to be in progress")
@@ -465,11 +465,11 @@ func (suite *LogCollectorTestSuite) TestStopLog() {
 	}
 
 	// write state again
-	err = suite.LogCollectorServer.stateStore.WriteState(suite.LogCollectorServer.stateStore.GetState())
+	err = suite.LogCollectorServer.stateManifest.WriteState(suite.LogCollectorServer.stateManifest.GetState())
 	suite.Require().NoError(err, "Failed to write state")
 
 	// verify no items in progress
-	logItemsInProgress, err = suite.LogCollectorServer.stateStore.GetItemsInProgress()
+	logItemsInProgress, err = suite.LogCollectorServer.stateManifest.GetItemsInProgress()
 	suite.Require().NoError(err, "Failed to get items in progress")
 
 	suite.Require().Equal(0,

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -159,7 +159,6 @@ func (s *Server) OnBeforeStart(ctx context.Context) error {
 	// initialize the state store (load state from file, start state file update loop)
 	// if the server is not the chief, do not monitor anything
 	if s.isChief {
-		s.Logger.DebugWithCtx(ctx, "Initializing state store")
 		if err := s.stateManifest.Initialize(ctx); err != nil {
 			return errors.Wrap(err, "Failed to initialize state store")
 		}
@@ -765,7 +764,6 @@ func (s *Server) monitorLogCollection(ctx context.Context) {
 	// If an item is written in the state store but not in the in memory state - call StartLog for it,
 	// as the state store is the source of truth
 	for range monitoringTicker.C {
-		s.Logger.DebugWithCtx(ctx, "Monitoring log streaming goroutines")
 
 		// if there are already log items in progress, call StartLog for each of them
 		projectRunUIDsInProgress, err := s.stateManifest.GetItemsInProgress()
@@ -881,7 +879,6 @@ func (s *Server) getLogItemsToStart(ctx context.Context, projectRunUIDsInProgres
 
 			// check if the log streaming is already running for this runUID
 			if logCollectionStarted := s.isLogCollectionRunning(ctx, logItem.RunUID, logItem.Project); !logCollectionStarted {
-				s.Logger.DebugWithCtx(ctx, "Log collection is not running for log item", "runUID", logItem.RunUID)
 
 				// if not, add it to the list of log items to start
 				logItemsToStart = append(logItemsToStart, logItem)
@@ -891,8 +888,6 @@ func (s *Server) getLogItemsToStart(ctx context.Context, projectRunUIDsInProgres
 		})
 		return true
 	})
-
-	s.Logger.DebugWithCtx(ctx, "Found log items to start", "logItemsToStart", logItemsToStart)
 
 	return logItemsToStart
 }

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/nuclio/errors"
 	"github.com/nuclio/logger"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -44,18 +45,25 @@ import (
 
 type Server struct {
 	*framework.AbstractMlrunGRPCServer
-	namespace                    string
-	baseDir                      string
-	kubeClientSet                kubernetes.Interface
-	stateStore                   statestore.StateStore
-	inMemoryState                statestore.StateStore
+	namespace     string
+	baseDir       string
+	kubeClientSet kubernetes.Interface
+	isChief       bool
+
+	// the state manifest determines which runs' logs should being collected, and is persisted to a file
+	stateManifest statestore.StateStore
+	// the current state has the actual runs that are currently being collected, and is not persisted
+	currentState statestore.StateStore
+
+	// buffer pools
 	logCollectionBufferPool      bufferpool.Pool
 	getLogsBufferPool            bufferpool.Pool
 	logCollectionBufferSizeBytes int
 	getLogsBufferSizeBytes       int
-	readLogWaitTime              time.Duration
-	monitoringInterval           time.Duration
-	isChief                      bool
+
+	// interval durations
+	readLogWaitTime    time.Duration
+	monitoringInterval time.Duration
 }
 
 // NewLogCollectorServer creates a new log collector server
@@ -90,7 +98,7 @@ func NewLogCollectorServer(logger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to parse monitoring interval duration")
 	}
 
-	stateStore, err := factory.CreateStateStore(
+	fileStateStore, err := factory.CreateStateStore(
 		statestore.KindFile,
 		&statestore.Config{
 			Logger:                  logger,
@@ -102,7 +110,7 @@ func NewLogCollectorServer(logger logger.Logger,
 		return nil, errors.Wrap(err, "Failed to create state store")
 	}
 
-	inMemoryState, err := factory.CreateStateStore(statestore.KindInMemory, &statestore.Config{
+	inMemoryStateStore, err := factory.CreateStateStore(statestore.KindInMemory, &statestore.Config{
 		Logger: logger,
 	})
 	if err != nil {
@@ -131,8 +139,8 @@ func NewLogCollectorServer(logger logger.Logger,
 		AbstractMlrunGRPCServer:      abstractServer,
 		namespace:                    namespace,
 		baseDir:                      baseDir,
-		stateStore:                   stateStore,
-		inMemoryState:                inMemoryState,
+		stateManifest:                fileStateStore,
+		currentState:                 inMemoryStateStore,
 		kubeClientSet:                kubeClientSet,
 		readLogWaitTime:              readLogTimeoutDuration,
 		monitoringInterval:           monitoringIntervalDuration,
@@ -151,7 +159,8 @@ func (s *Server) OnBeforeStart(ctx context.Context) error {
 	// initialize the state store (load state from file, start state file update loop)
 	// if the server is not the chief, do not monitor anything
 	if s.isChief {
-		if err := s.stateStore.Initialize(ctx); err != nil {
+		s.Logger.DebugWithCtx(ctx, "Initializing state store")
+		if err := s.stateManifest.Initialize(ctx); err != nil {
 			return errors.Wrap(err, "Failed to initialize state store")
 		}
 
@@ -234,7 +243,7 @@ func (s *Server) StartLog(ctx context.Context, request *protologcollector.StartL
 	pod := pods.Items[0]
 
 	// write log item in progress to state store
-	if err := s.stateStore.AddLogItem(ctx, request.RunUID, request.Selector, request.ProjectName); err != nil {
+	if err := s.stateManifest.AddLogItem(ctx, request.RunUID, request.Selector, request.ProjectName); err != nil {
 		err := errors.Wrapf(err, "Failed to add run id %s to state file", request.RunUID)
 		return &protologcollector.BaseResponse{
 			Success:      false,
@@ -254,8 +263,8 @@ func (s *Server) StartLog(ctx context.Context, request *protologcollector.StartL
 	// wait for the streaming goroutine to start
 	<-startedStreamingGoroutine
 
-	// add log item to in-memory state, so we can monitor it
-	if err := s.inMemoryState.AddLogItem(ctx, request.RunUID, request.Selector, request.ProjectName); err != nil {
+	// add log item to current state, so we can monitor it
+	if err := s.currentState.AddLogItem(ctx, request.RunUID, request.Selector, request.ProjectName); err != nil {
 		err := errors.Wrapf(err, "Failed to add run id %s to in memory state", request.RunUID)
 		return &protologcollector.BaseResponse{
 			Success:      false,
@@ -416,9 +425,9 @@ func (s *Server) StopLog(ctx context.Context, request *protologcollector.StopLog
 	// if no run uids were provided, remove the entire project from the state
 	if len(request.RunUIDs) == 0 {
 
-		// remove entire project from persistent state
-		if err := s.stateStore.RemoveProject(request.Project); err != nil {
-			message := fmt.Sprintf("Failed to remove project %s from persistent state", request.Project)
+		// remove entire project from state manifest
+		if err := s.stateManifest.RemoveProject(request.Project); err != nil {
+			message := fmt.Sprintf("Failed to remove project %s from state manifest", request.Project)
 			return &protologcollector.BaseResponse{
 				Success:      false,
 				ErrorCode:    0,
@@ -426,8 +435,8 @@ func (s *Server) StopLog(ctx context.Context, request *protologcollector.StopLog
 			}, errors.Wrap(err, message)
 		}
 
-		// remove entire project from in-memory state
-		if err := s.inMemoryState.RemoveProject(request.Project); err != nil {
+		// remove entire project from current state
+		if err := s.currentState.RemoveProject(request.Project); err != nil {
 			message := fmt.Sprintf("Failed to remove project %s from in memory state", request.Project)
 			return &protologcollector.BaseResponse{
 				Success:      false,
@@ -442,9 +451,9 @@ func (s *Server) StopLog(ctx context.Context, request *protologcollector.StopLog
 	// remove each run uid from the state
 	for _, runUID := range request.RunUIDs {
 
-		// remove item from persistent state
-		if err := s.stateStore.RemoveLogItem(runUID, request.Project); err != nil {
-			message := fmt.Sprintf("Failed to remove item from persistent state for run id %s", runUID)
+		// remove item from state manifest
+		if err := s.stateManifest.RemoveLogItem(runUID, request.Project); err != nil {
+			message := fmt.Sprintf("Failed to remove item from state manifest for run id %s", runUID)
 			return &protologcollector.BaseResponse{
 				Success:      false,
 				ErrorCode:    0,
@@ -452,8 +461,8 @@ func (s *Server) StopLog(ctx context.Context, request *protologcollector.StopLog
 			}, errors.Wrap(err, message)
 		}
 
-		// remove item from in-memory state
-		if err := s.inMemoryState.RemoveLogItem(runUID, request.Project); err != nil {
+		// remove item from current state
+		if err := s.currentState.RemoveLogItem(runUID, request.Project); err != nil {
 			message := fmt.Sprintf("Failed to remove item from in memory state for run id %s", runUID)
 			return &protologcollector.BaseResponse{
 				Success:      false,
@@ -474,15 +483,15 @@ func (s *Server) startLogStreaming(ctx context.Context,
 	startedStreamingGoroutine chan bool,
 	cancelCtxFunc context.CancelFunc) {
 
-	// in case of a panic, remove this goroutine from the in-memory state, so the
+	// in case of a panic, remove this goroutine from the current state, so the
 	// monitoring loop will start logging again for this runUID.
 	defer func() {
 
 		// cancel all other goroutines spawned from this one
 		defer cancelCtxFunc()
 
-		// remove this goroutine from in-memory state
-		if err := s.inMemoryState.RemoveLogItem(runUID, projectName); err != nil {
+		// remove this goroutine from in-current state
+		if err := s.currentState.RemoveLogItem(runUID, projectName); err != nil {
 			s.Logger.WarnWithCtx(ctx, "Failed to remove item from in memory state")
 		}
 
@@ -573,7 +582,7 @@ func (s *Server) startLogStreaming(ctx context.Context,
 		"podName", podName)
 
 	// remove run from state file
-	if err := s.stateStore.RemoveLogItem(runUID, projectName); err != nil {
+	if err := s.stateManifest.RemoveLogItem(runUID, projectName); err != nil {
 		s.Logger.WarnWithCtx(ctx, "Failed to remove log item from state file")
 	}
 
@@ -752,33 +761,46 @@ func (s *Server) monitorLogCollection(ctx context.Context) {
 	// count the errors so we won't spam the logs
 	errCount := 0
 
-	// Check the items in the inMemoryState against the items in the state store.
+	// Check the items in the currentState against the items in the state store.
 	// If an item is written in the state store but not in the in memory state - call StartLog for it,
 	// as the state store is the source of truth
 	for range monitoringTicker.C {
+		s.Logger.DebugWithCtx(ctx, "Monitoring log streaming goroutines")
 
 		// if there are already log items in progress, call StartLog for each of them
-		projectRunUIDsInProgress, err := s.stateStore.GetItemsInProgress()
+		projectRunUIDsInProgress, err := s.stateManifest.GetItemsInProgress()
 		if err == nil {
 
 			logItemsToStart := s.getLogItemsToStart(ctx, projectRunUIDsInProgress)
 
-			for _, logItem := range logItemsToStart {
-				s.Logger.DebugWithCtx(ctx, "Starting log collection for log item", "runUID", logItem.RunUID)
-				if _, err := s.StartLog(ctx, &protologcollector.StartLogRequest{
-					RunUID:      logItem.RunUID,
-					Selector:    logItem.LabelSelector,
-					ProjectName: logItem.Project,
-				}); err != nil {
+			errGroup, _ := errgroup.WithContext(ctx)
 
-					// we don't fail here, as there might be other items to start log for, just log it
-					s.Logger.WarnWithCtx(ctx,
-						"Failed to start log collection for log item",
-						"runUID", logItem.RunUID,
-						"project", logItem.Project,
-						"err", common.GetErrorStack(err, 10),
-					)
-				}
+			for _, logItem := range logItemsToStart {
+				logItem := logItem
+				errGroup.Go(func() error {
+					s.Logger.DebugWithCtx(ctx, "Starting log collection for log item", "runUID", logItem.RunUID)
+					if _, err := s.StartLog(ctx, &protologcollector.StartLogRequest{
+						RunUID:      logItem.RunUID,
+						Selector:    logItem.LabelSelector,
+						ProjectName: logItem.Project,
+					}); err != nil {
+
+						s.Logger.WarnWithCtx(ctx,
+							"Failed to start log collection for log item",
+							"runUID", logItem.RunUID,
+							"project", logItem.Project,
+							"err", common.GetErrorStack(err, 10),
+						)
+						return errors.Wrapf(err, "Failed to start log collection for log item %s", logItem.RunUID)
+					}
+					return nil
+				})
+			}
+
+			if err := errGroup.Wait(); err != nil {
+
+				// we don't fail here, there will be a retry in the next iteration
+				s.Logger.WarnWithCtx(ctx, "Failed to start log collection for some log items", "err", err.Error())
 			}
 		} else {
 
@@ -796,10 +818,10 @@ func (s *Server) monitorLogCollection(ctx context.Context) {
 
 // isLogCollectionRunning checks if log collection is running for a given runUID
 func (s *Server) isLogCollectionRunning(ctx context.Context, runUID, project string) bool {
-	inMemoryInProgress, err := s.inMemoryState.GetItemsInProgress()
+	inMemoryInProgress, err := s.currentState.GetItemsInProgress()
 	if err != nil {
 
-		// this is just for sanity, as inMemoryState won't return an error
+		// this is just for sanity, as currentState won't return an error
 		s.Logger.WarnWithCtx(ctx,
 			"Failed to get in progress items from in memory state",
 			"err", err.Error())
@@ -859,6 +881,7 @@ func (s *Server) getLogItemsToStart(ctx context.Context, projectRunUIDsInProgres
 
 			// check if the log streaming is already running for this runUID
 			if logCollectionStarted := s.isLogCollectionRunning(ctx, logItem.RunUID, logItem.Project); !logCollectionStarted {
+				s.Logger.DebugWithCtx(ctx, "Log collection is not running for log item", "runUID", logItem.RunUID)
 
 				// if not, add it to the list of log items to start
 				logItemsToStart = append(logItemsToStart, logItem)
@@ -868,6 +891,9 @@ func (s *Server) getLogItemsToStart(ctx context.Context, projectRunUIDsInProgres
 		})
 		return true
 	})
+
+	s.Logger.DebugWithCtx(ctx, "Found log items to start", "logItemsToStart", logItemsToStart)
+
 	return logItemsToStart
 }
 

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -50,7 +50,7 @@ type Server struct {
 	kubeClientSet kubernetes.Interface
 	isChief       bool
 
-	// the state manifest determines which runs' logs should being collected, and is persisted to a file
+	// the state manifest determines which runs' logs should be collected, and is persisted to a file
 	stateManifest statestore.StateStore
 	// the current state has the actual runs that are currently being collected, and is not persisted
 	currentState statestore.StateStore
@@ -156,9 +156,10 @@ func NewLogCollectorServer(logger logger.Logger,
 func (s *Server) OnBeforeStart(ctx context.Context) error {
 	s.Logger.DebugCtx(ctx, "Initializing Server")
 
-	// initialize the state store (load state from file, start state file update loop)
 	// if the server is not the chief, do not monitor anything
 	if s.isChief {
+
+		// initialize the state manifest (load state from file, start state file update loop)
 		if err := s.stateManifest.Initialize(ctx); err != nil {
 			return errors.Wrap(err, "Failed to initialize state store")
 		}

--- a/go/pkg/services/logcollector/statestore/abstract/client.go
+++ b/go/pkg/services/logcollector/statestore/abstract/client.go
@@ -123,6 +123,11 @@ func (s *Store) WriteState(state *statestore.State) error {
 	return nil
 }
 
+// GetItemsInProgress returns the in progress log items
+func (s *Store) GetItemsInProgress() (*sync.Map, error) {
+	return s.State.InProgress, nil
+}
+
 // GetState returns the state store state
 func (s *Store) GetState() *statestore.State {
 	return s.State

--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -86,9 +86,7 @@ func (s *Store) WriteState(state *statestore.State) error {
 // GetState returns the state store state
 func (s *Store) GetState() *statestore.State {
 	s.stateLock.Lock()
-	defer func() {
-		s.stateLock.Unlock()
-	}()
+	defer s.stateLock.Unlock()
 	return s.State
 }
 
@@ -132,9 +130,7 @@ func (s *Store) writeStateToFile(state *statestore.State) error {
 
 	// get lock, unlock later
 	s.fileLock.Lock()
-	defer func() {
-		s.fileLock.Unlock()
-	}()
+	defer s.fileLock.Unlock()
 
 	// write to file
 	return common.WriteToFile(s.stateFilePath, encodedState, false)

--- a/go/pkg/services/logcollector/statestore/file/client.go
+++ b/go/pkg/services/logcollector/statestore/file/client.go
@@ -54,8 +54,6 @@ func NewFileStore(logger logger.Logger, baseDirPath string, stateFileUpdateInter
 func (s *Store) Initialize(ctx context.Context) error {
 	var err error
 
-	s.Logger.DebugWithCtx(ctx, "Initialize - file state store", "stateFilePath", s.stateFilePath)
-
 	// load state from file before starting the update loop, as thr file is our source of truth
 	s.fileLock.Lock()
 	s.State, err = s.readStateFile()
@@ -75,7 +73,7 @@ func (s *Store) Initialize(ctx context.Context) error {
 	// spawn a goroutine that will update the state file periodically
 	go s.stateFileUpdateLoop(ctx)
 
-	s.Logger.DebugWithCtx(ctx, "Initialize - file state store - DONE")
+	s.Logger.DebugWithCtx(ctx, "Successfully initialized file state store")
 
 	return nil
 }
@@ -87,10 +85,8 @@ func (s *Store) WriteState(state *statestore.State) error {
 
 // GetState returns the state store state
 func (s *Store) GetState() *statestore.State {
-	s.Logger.DebugWithCtx(context.Background(), "GetState - acquiring stateLock")
 	s.stateLock.Lock()
 	defer func() {
-		s.Logger.DebugWithCtx(context.Background(), "GetState - releasing stateLock")
 		s.stateLock.Unlock()
 	}()
 	return s.State
@@ -135,14 +131,10 @@ func (s *Store) writeStateToFile(state *statestore.State) error {
 	}
 
 	// get lock, unlock later
-	s.Logger.DebugWithCtx(context.Background(), "writeStateToFile - acquiring fileLock")
 	s.fileLock.Lock()
 	defer func() {
-		s.Logger.DebugWithCtx(context.Background(), "writeStateToFile - releasing fileLock")
 		s.fileLock.Unlock()
 	}()
-
-	s.Logger.DebugWithCtx(context.Background(), "writeStateToFile - blablabla")
 
 	// write to file
 	return common.WriteToFile(s.stateFilePath, encodedState, false)

--- a/go/pkg/services/logcollector/statestore/inmemory/client.go
+++ b/go/pkg/services/logcollector/statestore/inmemory/client.go
@@ -16,7 +16,6 @@ package inmemory
 
 import (
 	"context"
-	"sync"
 
 	"github.com/mlrun/mlrun/pkg/services/logcollector/statestore"
 	"github.com/mlrun/mlrun/pkg/services/logcollector/statestore/abstract"
@@ -43,9 +42,4 @@ func (s *Store) Initialize(ctx context.Context) error {
 // WriteState writes the state to persistent storage
 func (s *Store) WriteState(state *statestore.State) error {
 	return nil
-}
-
-// GetItemsInProgress returns the in progress log items
-func (s *Store) GetItemsInProgress() (*sync.Map, error) {
-	return s.State.InProgress, nil
 }

--- a/go/pkg/services/logcollector/test/logcollector_test.go
+++ b/go/pkg/services/logcollector/test/logcollector_test.go
@@ -19,6 +19,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -146,9 +147,18 @@ func (suite *LogCollectorTestSuite) TestLogCollector() {
 		Selector:    "app=test",
 		ProjectName: projectName,
 	})
-
 	suite.Require().NoError(err, "Failed to start log collection")
 	suite.Require().True(startLogResponse.Success, "Failed to start log collection")
+
+	// read state file
+	stateFilePath := path.Join(suite.baseDir, "_metadata", "state.json")
+	stateFile, err := os.Open(stateFilePath)
+	suite.Require().NoError(err, "Failed to open state file")
+
+	// read state file and make sure it is not empty
+	stateFileBytes, err := io.ReadAll(stateFile)
+	suite.Require().NoError(err, "Failed to read state file")
+	suite.Require().NotEmpty(stateFileBytes, "State file is empty")
 
 	// wait for logs to be collected
 	suite.logger.InfoWith("Waiting for logs to be collected")


### PR DESCRIPTION
This PR introduces several fixes to the log collector server:

- The 2 state stores that the sever has were renamed for better readability and usability:
  - `stateManifest` - this is the persisted state and it is the source of truth. It depicts which runs should be log collected, and is periodically written to a file for persisting the state in case of pod restarts.
  - `currentState` - this state holds the runs that currently have running goroutines collecting logs. It is used for monitoring by going through the runs in the state manifest and verifying they are present in the current state.
- The file state store client has 2 mutex locks - one for the state itself, and one for reading/writing the persisted file. 
There were some race conditions between those two locks that have sometime caused a deadlock, making the log collector server stuck. These race condition have now been fixed.
- The file state store implemented `GetItemsInProgress` by reading from the file. 
The state manifest was written to the file in a periodic background task.
This caused some runs to be discarded form the state manifest, in the case that the state was overwritten with the old state before the new state manifest was written to the file.
Hence, now the monitoring is using the state manifest map and only reading from the file during initialization.
- In the monitoring goroutine, start logs for runs in parallel for faster handling.

Fixes https://jira.iguazeng.com/browse/ML-3460 