### PR TITLE
[Pipelines] Handle case when running `run_pipeline` directly with `run_function`

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -55,6 +55,7 @@ from .projects import (
 )
 from .projects.project import _add_username_to_project_name_if_needed
 from .run import (
+    _run_pipeline,
     code_to_function,
     function_to_module,
     get_dataitem,

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -49,11 +49,6 @@ def _get_engine_and_function(function, project=None):
     if not pipeline_context.workflow:
         return "local", function
 
-    # in case running a pipeline straight from `run_pipeline` this isn't encouraged and should be run
-    # from the `project.run()` which handles the right assignment of the pipeline_context
-    if pipeline_context.workflow is True:
-        return "kfp", function
-
     return pipeline_context.workflow.engine, function
 
 

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -49,6 +49,11 @@ def _get_engine_and_function(function, project=None):
     if not pipeline_context.workflow:
         return "local", function
 
+    # in case running a pipeline straight from `run_pipeline` this isn't encouraged and should be run
+    # from the `project.run()` which handles the right assignment of the pipeline_context
+    if pipeline_context.workflow is True:
+        return "kfp", function
+
     return pipeline_context.workflow.engine, function
 
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -38,7 +38,7 @@ from mlrun.utils import (
 )
 
 from ..config import config
-from ..run import run_pipeline, wait_for_pipeline_completion
+from ..run import _run_pipeline, wait_for_pipeline_completion
 from ..runtimes.pod import AutoMountType
 
 
@@ -579,7 +579,7 @@ class _KFPRunner(_PipelineRunner):
             project.set_source(source=source)
 
         namespace = namespace or config.namespace
-        id = run_pipeline(
+        id = _run_pipeline(
             workflow_handler,
             project=project.metadata.name,
             arguments=workflow_spec.args,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -45,7 +45,6 @@ from .datastore import store_manager
 from .db import get_or_set_dburl, get_run_db
 from .execution import MLClientCtx
 from .model import BaseMetadata, RunObject, RunTemplate
-from .projects.pipelines import pipeline_context
 from .runtimes import (
     DaskCluster,
     HandlerRuntime,
@@ -988,6 +987,7 @@ def run_pipeline(
     arguments = arguments or {}
 
     if remote or url:
+        from .projects.pipelines import pipeline_context
         # if pipeline_context.workflow isn't set it means the `run_pipeline` method was called directly
         # so to make sure the pipeline and functions inside are being run in the KFP pipeline we set the the workflow
         # to True

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -33,6 +33,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 import nuclio
 import yaml
+from deprecated import deprecated
 from kfp import Client
 
 import mlrun.api.schemas
@@ -927,6 +928,11 @@ def code_to_function(
     return r
 
 
+@deprecated(
+    version="1.3.0",
+    reason="'run_pipeline' will be removed in 1.5.0, use 'project.run' instead",
+    category=FutureWarning,
+)
 def run_pipeline(
     pipeline,
     arguments=None,
@@ -942,7 +948,8 @@ def run_pipeline(
     remote: bool = True,
     cleanup_ttl=None,
 ):
-    """remote KubeFlow pipeline execution
+    """
+    remote KubeFlow pipeline execution
 
     Submit a workflow task to KFP via mlrun API service
 
@@ -957,14 +964,13 @@ def run_pipeline(
     :param ops:        additional operators (.apply() to all pipeline functions)
     :param ttl:        pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
                        workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
-    :param remote:     read kfp data from mlrun service (default=True)
+    :param remote:     read kfp data from mlrun service (default=True) should not use False!
     :param cleanup_ttl:
                        pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
                        workflow and all its resources are deleted)
 
     :returns: kubeflow pipeline id
     """
-
     if ttl:
         warnings.warn(
             "'ttl' is deprecated, use 'cleanup_ttl' instead. "
@@ -987,36 +993,34 @@ def run_pipeline(
     arguments = arguments or {}
 
     if remote or url:
-        from .projects.pipelines import pipeline_context
+        from .projects.pipelines import WorkflowSpec, pipeline_context
 
         # if pipeline_context.workflow isn't set it means the `run_pipeline` method was called directly
         # so to make sure the pipeline and functions inside are being run in the KFP pipeline we set the the workflow
         # to True
         if not pipeline_context.workflow:
-            pipeline_context.workflow = True
+            workflow_spec = WorkflowSpec(engine="kfp")
+            pipeline_context.set(pipeline_context.project, workflow=workflow_spec)
 
-        mldb = mlrun.db.get_run_db(url)
-        if mldb.kind != "http":
-            raise ValueError(
-                "run pipeline require access to remote api-service"
-                ", please set the dbpath url"
-            )
-        id = mldb.submit_pipeline(
-            project,
-            pipeline,
-            arguments,
+        pipeline_run_id = _run_pipeline(
+            pipeline=pipeline,
+            arguments=arguments,
+            project=project,
             experiment=experiment,
             run=run,
             namespace=namespace,
-            ops=ops,
             artifact_path=artifact_path,
+            ops=ops,
+            url=url,
             cleanup_ttl=cleanup_ttl or ttl,
         )
+
         # workflow is True only when executing `run_pipeline` directly, therefore we want to cleanup the context after
         # execution
-        if pipeline_context.workflow is True:
-            pipeline_context.workflow = None
+        if pipeline_context.workflow:
+            pipeline_context.clear()
 
+    # this shouldn't be used, keeping for backwards compatibility until the entire method is deprecated
     else:
         client = Client(namespace=namespace)
         if isinstance(pipeline, str):
@@ -1036,9 +1040,63 @@ def run_pipeline(
                 pipeline_conf=conf,
             )
 
-        id = run_result.run_id
-    logger.info(f"Pipeline run id={id}, check UI for progress")
-    return id
+        pipeline_run_id = run_result.run_id
+        logger.info(f"Pipeline run id={id}, check UI for progress")
+
+    return pipeline_run_id
+
+
+def _run_pipeline(
+    pipeline,
+    arguments=None,
+    project=None,
+    experiment=None,
+    run=None,
+    namespace=None,
+    artifact_path=None,
+    ops=None,
+    url=None,
+    cleanup_ttl=None,
+):
+    """remote KubeFlow pipeline execution
+
+    Submit a workflow task to KFP via mlrun API service
+
+    :param pipeline:   KFP pipeline function or path to .yaml/.zip pipeline file
+    :param arguments:  pipeline arguments
+    :param project:    name of project
+    :param experiment: experiment name
+    :param run:        optional, run name
+    :param namespace:  Kubernetes namespace (if not using default)
+    :param url:        optional, url to mlrun API service
+    :param artifact_path:  target location/url for mlrun artifacts
+    :param ops:        additional operators (.apply() to all pipeline functions)
+    :param cleanup_ttl:
+                       pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                       workflow and all its resources are deleted)
+
+    :returns: kubeflow pipeline id
+    """
+    mldb = mlrun.db.get_run_db(url)
+    if mldb.kind != "http":
+        raise ValueError(
+            "run pipeline require access to remote api-service"
+            ", please set the dbpath url"
+        )
+
+    pipeline_run_id = mldb.submit_pipeline(
+        project,
+        pipeline,
+        arguments,
+        experiment=experiment,
+        run=run,
+        namespace=namespace,
+        ops=ops,
+        artifact_path=artifact_path,
+        cleanup_ttl=cleanup_ttl,
+    )
+    logger.info(f"Pipeline run id={pipeline_run_id}, check UI for progress")
+    return pipeline_run_id
 
 
 def wait_for_pipeline_completion(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -988,6 +988,7 @@ def run_pipeline(
 
     if remote or url:
         from .projects.pipelines import pipeline_context
+
         # if pipeline_context.workflow isn't set it means the `run_pipeline` method was called directly
         # so to make sure the pipeline and functions inside are being run in the KFP pipeline we set the the workflow
         # to True

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -995,12 +995,14 @@ def run_pipeline(
     if remote or url:
         from .projects.pipelines import WorkflowSpec, pipeline_context
 
+        clear_pipeline_context = False
         # if pipeline_context.workflow isn't set it means the `run_pipeline` method was called directly
-        # so to make sure the pipeline and functions inside are being run in the KFP pipeline we set the the workflow
-        # to True
+        # so to make sure the pipeline and functions inside are being run in the KFP pipeline we set the pipeline
+        # context with KFP engine
         if not pipeline_context.workflow:
             workflow_spec = WorkflowSpec(engine="kfp")
             pipeline_context.set(pipeline_context.project, workflow=workflow_spec)
+            clear_pipeline_context = True
 
         pipeline_run_id = _run_pipeline(
             pipeline=pipeline,
@@ -1015,9 +1017,7 @@ def run_pipeline(
             cleanup_ttl=cleanup_ttl or ttl,
         )
 
-        # workflow is True only when executing `run_pipeline` directly, therefore we want to cleanup the context after
-        # execution
-        if pipeline_context.workflow:
+        if clear_pipeline_context:
             pipeline_context.clear()
 
     # this shouldn't be used, keeping for backwards compatibility until the entire method is deprecated

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -964,7 +964,8 @@ def run_pipeline(
     :param ops:        additional operators (.apply() to all pipeline functions)
     :param ttl:        pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
                        workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
-    :param remote:     read kfp data from mlrun service (default=True) should not use False!
+    :param remote:     read kfp data from mlrun service (default=True). Run pipeline from local kfp data (remote=False)
+      is deprecated. Should not be used
     :param cleanup_ttl:
                        pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
                        workflow and all its resources are deleted)

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -21,10 +21,10 @@ import pytest
 
 import mlrun.utils
 from mlrun import (
+    _run_pipeline,
     code_to_function,
     mount_v3io,
     new_task,
-    run_pipeline,
     wait_for_pipeline_completion,
 )
 from mlrun.run import RunStatuses
@@ -90,7 +90,7 @@ class TestDask(TestMLRunSystem):
         kfp.compiler.Compiler().compile(dask_pipe, "daskpipe.yaml", type_check=False)
         arguments = {"x": 4, "y": -5}
         artifact_path = "/User/test"
-        workflow_run_id = run_pipeline(
+        workflow_run_id = _run_pipeline(
             dask_pipe,
             arguments,
             artifact_path=artifact_path,

--- a/tests/system/examples/jobs/test_jobs.py
+++ b/tests/system/examples/jobs/test_jobs.py
@@ -18,7 +18,12 @@ import kfp.compiler
 import kfp.dsl
 import pytest
 
-from mlrun import code_to_function, new_task, run_pipeline, wait_for_pipeline_completion
+from mlrun import (
+    _run_pipeline,
+    code_to_function,
+    new_task,
+    wait_for_pipeline_completion,
+)
 from mlrun.platforms.other import mount_v3io
 from tests.system.base import TestMLRunSystem
 
@@ -81,7 +86,7 @@ class TestJobs(TestMLRunSystem):
         kfp.compiler.Compiler().compile(job_pipeline, "jobpipe.yaml")
         artifact_path = "v3io:///users/admin/kfp/{{workflow.uid}}/"
         arguments = {"p1": 8}
-        workflow_run_id = run_pipeline(
+        workflow_run_id = _run_pipeline(
             job_pipeline, arguments, experiment="my-job", artifact_path=artifact_path
         )
 

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -81,7 +81,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         function = mlrun.get_run_db().get_function(
             function_name, project=self.project_name, tag="latest", hash_key=hash_key
         )
-        assert not function["metadata"]["credentials"]["access_key"]
+        assert not function["metadata"].get("credentials", {}).get("access_key", None)
 
     def test_store_function_after_run_local_verify_credentials_are_masked(self):
         code_path = str(self.assets_path / "kubejob_function.py")

--- a/tests/system/test_kfp.py
+++ b/tests/system/test_kfp.py
@@ -47,7 +47,7 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         out = mlconf.artifact_path or os.path.abspath("./data")
         artifact_path = os.path.join(out, "{{run.uid}}")
         arguments = {"p1": 8}
-        run_id = mlrun.run_pipeline(
+        run_id = mlrun._run_pipeline(
             job_pipeline,
             arguments,
             experiment="my-job",
@@ -101,7 +101,7 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         def job_pipeline():
             my_func.as_step(handler="handler", auto_build=True)
 
-        run_id = mlrun.run_pipeline(
+        run_id = mlrun._run_pipeline(
             job_pipeline,
             experiment="my-job",
             project=self.project_name,


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-3437

Issue appears when having a pipeline with `run_function` method, as the `run_function` depends on the pipeline context being set prior to running it (which happens when using `project.run()`), while running `run_pipeline` directly doesn't enriches the `pipeline_context` which caused the flow to try submit the pipeline as KFP but the functions inside thought that it has to run locally.


Found out `run_pipeline` should not be used directly - therefore added deprecation warning, left the relevant stuff in the `run_pipeline` and added new `_run_pipeline` which will handle only work on the API which already relies on initialized `pipeline_context` . moved the `pipeline.run()` to use the lightweight `_run_pipeline`. 