### PR TITLE
[DB] Fix version compatibility validation

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2601,7 +2601,7 @@ class HTTPRunDB(RunDBInterface):
                 parsed_client_version=parsed_client_version,
             )
             return False
-        if parsed_server_version.minor <= parsed_client_version.minor + 2:
+        if parsed_server_version.minor != parsed_client_version.minor:
             logger.info(
                 "Server and client versions are not the same but compatible",
                 parsed_server_version=parsed_server_version,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2586,9 +2586,23 @@ class HTTPRunDB(RunDBInterface):
                 parsed_client_version=parsed_client_version,
             )
             return False
-        if parsed_server_version.minor != parsed_client_version.minor:
+        if parsed_server_version.minor > parsed_client_version.minor + 2:
             logger.info(
-                "Server and client versions are not the same",
+                "Backwards compatibility does not apply to server and client versions",
+                parsed_server_version=parsed_server_version,
+                parsed_client_version=parsed_client_version,
+            )
+            return False
+        if parsed_client_version.minor > parsed_server_version.minor:
+            logger.warning(
+                "Client version can't be higher than server version",
+                parsed_server_version=parsed_server_version,
+                parsed_client_version=parsed_client_version,
+            )
+            return False
+        if parsed_server_version.minor <= parsed_client_version.minor + 2:
+            logger.info(
+                "Server and client versions are not the same but compatible",
                 parsed_server_version=parsed_server_version,
                 parsed_client_version=parsed_client_version,
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2588,8 +2588,7 @@ class HTTPRunDB(RunDBInterface):
             return False
         if parsed_server_version.minor > parsed_client_version.minor + 2:
             logger.info(
-                "Backwards compatibility might not apply between the server and client version,"
-                " refer to our docs for a full compatibility list",
+                "Backwards compatibility might not apply between the server and client version",
                 parsed_server_version=parsed_server_version,
                 parsed_client_version=parsed_client_version,
             )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2588,14 +2588,16 @@ class HTTPRunDB(RunDBInterface):
             return False
         if parsed_server_version.minor > parsed_client_version.minor + 2:
             logger.info(
-                "Backwards compatibility does not apply to server and client versions",
+                "Backwards compatibility might not apply between the server and client version,"
+                " refer to our docs for a full compatibility list",
                 parsed_server_version=parsed_server_version,
                 parsed_client_version=parsed_client_version,
             )
             return False
         if parsed_client_version.minor > parsed_server_version.minor:
             logger.warning(
-                "Client version can't be higher than server version",
+                "Client version with higher version than server version isn't supported,"
+                " align your client to the server version",
                 parsed_server_version=parsed_server_version,
                 parsed_client_version=parsed_client_version,
             )

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -340,21 +340,28 @@ def test_list_functions(create_server):
 @pytest.mark.parametrize(
     "server_version,client_version,compatible",
     [
+        # Unstable client or server, not parsing, and assuming compatibility
         ("unstable", "unstable", True),
         ("0.5.3", "unstable", True),
         ("unstable", "0.6.1", True),
+        # Server and client versions are not the same but compatible
         ("0.5.3", "0.5.1", True),
         ("0.6.0-rc1", "0.6.1", True),
         ("0.6.0-rc1", "0.5.4", True),
         ("0.6.3", "0.4.8", True),
         ("1.3.0", "1.1.0", True),
+        # Majors on the server and client versions are not the same
         ("1.0.0", "0.5.0", False),
         ("0.5.0", "1.0.0", False),
-        ("1.3.0", "1.0.0", False),
-        ("1.3.0", "1.9.0", False),
-        ("1.3.0", "1.4.0", False),
         ("2.0.0", "1.3.0", False),
         ("2.0.0", "1.9.0", False),
+        # Server version much higher than client
+        ("1.3.0", "1.0.0", False),
+        ("1.9.0", "1.3.0", False),
+        # Client version higher than server, not supported
+        ("1.3.0", "1.9.0", False),
+        ("1.3.0", "1.4.0", False),
+        # Server or client version is unstable, assuming compatibility
         ("0.7.1", "0.0.0+unstable", True),
         ("0.0.0+unstable", "0.7.1", True),
     ],

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -337,36 +337,32 @@ def test_list_functions(create_server):
     assert len(functions) == count, "bad list"
 
 
-def test_version_compatibility_validation():
-    cases = [
-        {
-            "server_version": "unstable",
-            "client_version": "unstable",
-            "compatible": True,
-        },
-        {"server_version": "0.5.3", "client_version": "unstable", "compatible": True},
-        {"server_version": "unstable", "client_version": "0.6.1", "compatible": True},
-        {"server_version": "0.5.3", "client_version": "0.5.1", "compatible": True},
-        {"server_version": "0.6.0-rc1", "client_version": "0.6.1", "compatible": True},
-        {"server_version": "0.6.0-rc1", "client_version": "0.5.4", "compatible": True},
-        {"server_version": "0.6.3", "client_version": "0.4.8", "compatible": True},
-        {"server_version": "1.0.0", "client_version": "0.5.0", "compatible": False},
-        {"server_version": "0.5.0", "client_version": "1.0.0", "compatible": False},
-        {
-            "server_version": "0.7.1",
-            "client_version": "0.0.0+unstable",
-            "compatible": True,
-        },
-        {
-            "server_version": "0.0.0+unstable",
-            "client_version": "0.7.1",
-            "compatible": True,
-        },
-    ]
-    for case in cases:
-        assert case["compatible"] == HTTPRunDB._validate_version_compatibility(
-            case["server_version"], case["client_version"]
-        )
+@pytest.mark.parametrize(
+    "server_version,client_version,compatible",
+    [
+        ("unstable", "unstable", True),
+        ("0.5.3", "unstable", True),
+        ("unstable", "0.6.1", True),
+        ("0.5.3", "0.5.1", True),
+        ("0.6.0-rc1", "0.6.1", True),
+        ("0.6.0-rc1", "0.5.4", True),
+        ("0.6.3", "0.4.8", True),
+        ("1.3.0", "1.1.0", True),
+        ("1.0.0", "0.5.0", False),
+        ("0.5.0", "1.0.0", False),
+        ("1.3.0", "1.0.0", False),
+        ("1.3.0", "1.9.0", False),
+        ("1.3.0", "1.4.0", False),
+        ("2.0.0", "1.3.0", False),
+        ("2.0.0", "1.9.0", False),
+        ("0.7.1", "0.0.0+unstable", True),
+        ("0.0.0+unstable", "0.7.1", True),
+    ],
+)
+def test_version_compatibility_validation(server_version, client_version, compatible):
+    assert compatible == HTTPRunDB._validate_version_compatibility(
+        server_version, client_version
+    )
 
 
 def _create_feature_set(name):


### PR DESCRIPTION
a fix for [ML-2515](https://jira.iguazeng.com/browse/ML-2515)

Validation checks the following:

- if server major != client major raise a warning states the versions are incompatible 
- If the server minor version is greater than the client minor version+2, raise a warning that this violates our backwards compatibility policy.
- If the client minor version is greater than the server minor version, raise a warning stating that the client version cannot be greater than the server version
- If the client is within our compatible range (2 versions back), log a message stating that the server and client versions are not identical but are compatible

