### PR TITLE
[Requirements] Freeze pyarrow version 10.0 to keep ParquetDataset v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,8 @@ numpy>=1.16.5, <1.23.0
 pandas~=1.2, <1.5.0
 # used as a the engine for parquet files by pandas
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)
-pyarrow>=10,<12
+# < 11 since starting from 11 ParquetDataset is deprecated and ParquetDatasetV2 is used instead
+pyarrow>=10,<11
 pyyaml~=5.1
 requests~=2.22
 # in sqlalchemy>=2.0 there is breaking changes (such as in Table class autoload argument is removed)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -125,7 +125,7 @@ def test_requirement_specifiers_convention():
         "alembic": {"~=1.4,<1.6.0"},
         "boto3": {"~=1.9, <1.17.107"},
         "dask-ml": {"~=1.4,<1.9.0"},
-        "pyarrow": {">=10,<12"},
+        "pyarrow": {">=10,<11"},
         "nbclassic": {">=0.2.8"},
         "protobuf": {">=3.13, <3.20"},
         "pandas": {"~=1.2, <1.5.0"},


### PR DESCRIPTION
Resolve regression tests failure