### PR TITLE
[Log Collector] Truncate file if not appending to it

### DIFF
--- a/go/pkg/common/utils.go
+++ b/go/pkg/common/utils.go
@@ -119,6 +119,10 @@ func WriteToFile(filePath string,
 	openFlags := os.O_CREATE | os.O_RDWR
 	if append {
 		openFlags |= os.O_APPEND
+	} else {
+
+		// if we're not appending, we want to truncate the file
+		openFlags |= os.O_TRUNC
 	}
 
 	if err := EnsureFileExists(filePath); err != nil {


### PR DESCRIPTION
When not appending to a file, truncate it by adding the os flag.