### PR TITLE
[Dask] Resolve object id label as the function name

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -345,9 +345,10 @@ async def _start_log_for_run(
             runtime_handler = await fastapi.concurrency.run_in_threadpool(
                 get_runtime_handler, run_kind
             )
+            object_id = runtime_handler.resolve_object_id(run)
             label_selector = runtime_handler.resolve_label_selector(
                 project=project_name,
-                object_id=run_uid,
+                object_id=object_id,
                 class_mode=RuntimeClassMode.run,
             )
             success, _ = await logs_collector_client.start_logs(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1898,6 +1898,18 @@ class BaseRuntimeHandler(ABC):
 
         return label_selector
 
+    @staticmethod
+    def resolve_object_id(
+        run: dict,
+    ) -> typing.Optional[str]:
+        """
+        Get the object id from the run object
+        Override this if the object id is not the run uid
+        :param run: run object
+        :return: object id
+        """
+        return run.get("metadata", {}).get("uid", None)
+
     def _wait_for_pods_deletion(
         self,
         namespace: str,

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -15,6 +15,7 @@ import datetime
 import inspect
 import socket
 import time
+import typing
 from os import environ
 from typing import Dict, List, Optional, Union
 
@@ -704,6 +705,27 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
     @staticmethod
     def _get_object_label_selector(object_id: str) -> str:
         return f"mlrun/function={object_id}"
+
+    @staticmethod
+    def resolve_object_id(
+        run: dict,
+    ) -> typing.Optional[str]:
+        """
+        Resolves the object ID from the run object.
+        In dask runtime, the object ID is the function name.
+        :param run: run object
+        :return: function name
+        """
+
+        function = run.get("spec", {}).get("function", None)
+        if function:
+
+            # a dask run's function field is in the format <project-name>/<function-name>@<run-uid>
+            # we only want the function name
+            project_and_function = function.split("@")[0]
+            return project_and_function.split("/")[-1]
+
+        return None
 
     def _enrich_list_resources_response(
         self,

--- a/tests/api/test_collect_runs_logs.py
+++ b/tests/api/test_collect_runs_logs.py
@@ -232,6 +232,31 @@ class TestCollectRunSLogs:
         assert log_collector._call.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_start_log_for_run_success_dask_kind(
+        self, db: sqlalchemy.orm.session.Session, client: fastapi.testclient.TestClient
+    ):
+        log_collector = mlrun.api.utils.clients.log_collector.LogCollectorClient()
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=BaseLogCollectorResponse(True, "")
+        )
+        project_name = "some-project"
+        uid = "my-uid"
+        function_name = "some-function"
+        function = f"{project_name}/{function_name}@{uid}"
+
+        _, _, uid, _, run = _create_new_run(
+            db, "some-project", kind="dask", function=function
+        )
+        run_uid = await mlrun.api.main._start_log_for_run(
+            run, self.start_log_limit, raise_on_error=False
+        )
+        assert run_uid == uid
+        assert log_collector._call.call_count == 1
+        start_log_request = log_collector._call.call_args[0][1]
+        assert f"mlrun/function={function_name}" in start_log_request.selector
+        print(start_log_request)
+
+    @pytest.mark.asyncio
     async def test_start_log_for_run_failure(
         self, db: sqlalchemy.orm.session.Session, client: fastapi.testclient.TestClient
     ):
@@ -378,6 +403,7 @@ def _create_new_run(
     uid="run-uid",
     iteration=0,
     kind="",
+    function="",
     state=mlrun.runtimes.constants.RunStates.created,
     store: bool = True,
 ):
@@ -392,6 +418,8 @@ def _create_new_run(
         },
         "status": {"state": state},
     }
+    if function:
+        run["spec"] = {"function": function}
     if store:
         mlrun.api.crud.Runs().store_run(
             db_session, run, uid, iter=iteration, project=project


### PR DESCRIPTION
In dask, the pods have a function name label, instead of `run_id`.
When resolving the run's label selector for starting log collection, the `object_id` value should be the function name for dask runtime, and run id for all other runtimes.

In this PR I added the `resolve_object_id` method for the runtime handlers, returning function name for dask, and `run_id` for all other runtimes.

Fixes https://jira.iguazeng.com/browse/ML-3484