### PR TITLE
[Datastore] Fix google cloud import error 

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -63,11 +63,11 @@ def extra_requirements() -> typing.Dict[str, typing.List[str]]:
             "google-cloud-storage~=1.20",
             # because of storey which isn't compatible with google-cloud-bigquery >3.2, conflicting grpcio
             # google-cloud-bigquery 3.3.0 has grpcio >= 1.47.0, < 2.0dev while storey 1.2.2 has grpcio<1.42 and >1.34.0
-            "google-cloud-bigquery[pandas]~=3.2",
+            "google-cloud-bigquery[pandas]>=3.2,<3.5",
             "google-cloud~=0.34",
         ],
         "google-cloud-storage": ["gcsfs~=2021.8.1"],
-        "google-cloud-bigquery": ["google-cloud-bigquery[pandas]~=3.2"],
+        "google-cloud-bigquery": ["google-cloud-bigquery[pandas]>=3.2,<3.5"],
         "kafka": ["kafka-python~=2.0"],
         "redis": ["redis~=4.3"],
     }

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -24,7 +24,9 @@ gcsfs~=2021.8.1
 # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
 # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
 plotly~=5.4, <5.12.0
-google-cloud-bigquery[pandas]~=3.2
+# TODO: For google-cloud-bigquer>=3.5, we need to depend on google-cloud-bigquery[pandas, bqstorage] and
+# resolve conflicts related to grpcio and google-auth versions
+google-cloud-bigquery[pandas]>=3.2,<3.5
 kafka-python~=2.0
 redis~=4.3
 graphviz~=0.20.0

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -24,8 +24,10 @@ gcsfs~=2021.8.1
 # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
 # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
 plotly~=5.4, <5.12.0
-# TODO: For google-cloud-bigquer>=3.5, we need to depend on google-cloud-bigquery[pandas, bqstorage] and
-# resolve conflicts related to grpcio and google-auth versions
+# TODO: For google-cloud-bigquery>=3.5, we need to depend on google-cloud-bigquery[pandas, bqstorage] and
+# resolve conflicts related to grpcio and google-auth versions. Furthermore, to support python 11,
+# we'll need to upgrade to google-cloud-bigquery>=3.4.2, which requires grpcio>=1.49.1, which is incompatible with
+# the grpcio version required by frames (because it upgrades protobuf from 3.x to 4.x, breaking binary compatibility)
 google-cloud-bigquery[pandas]>=3.2,<3.5
 kafka-python~=2.0
 redis~=4.3

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -133,6 +133,7 @@ def test_requirement_specifiers_convention():
         "importlib_metadata": {">=3.6"},
         "gitpython": {"~=3.1, >= 3.1.30"},
         "pyopenssl": {">=23"},
+        "google-cloud-bigquery": {">=3.2,<3.5"},
         # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
         # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
         "plotly": {"~=5.4, <5.12.0"},


### PR DESCRIPTION
by introducing an upper limit for google-cloud-bigquery (see TODO for details).

[ML-3478](https://jira.iguazeng.com/browse/ML-3478)