### PR TITLE
[Nuclio] Fix pulling interval and reduce the amount of storing to the database

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -533,26 +533,35 @@ def _handle_nuclio_deploy_status(
     # the built and pushed image name used to run the nuclio function container
     container_image = status.get("containerImage", "")
 
-    update_in(fn, "status.nuclio_name", nuclio_name)
-    update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)
-    update_in(fn, "status.external_invocation_urls", external_invocation_urls)
-    update_in(fn, "status.state", state)
-    update_in(fn, "status.address", address)
-    update_in(fn, "status.container_image", container_image)
+    # we don't want to store the function on all requests to get the deploy status, therefore we verify
+    # that changes were actually made and if that's the case then we store the function
+    if _is_nuclio_deploy_status_changed(
+        previous_status=fn.get("status", {}),
+        new_status=status,
+        new_state=state,
+        new_nuclio_name=nuclio_name,
+    ):
+        update_in(fn, "status.nuclio_name", nuclio_name)
+        update_in(fn, "status.internal_invocation_urls", internal_invocation_urls)
+        update_in(fn, "status.external_invocation_urls", external_invocation_urls)
+        update_in(fn, "status.state", state)
+        update_in(fn, "status.address", address)
+        update_in(fn, "status.container_image", container_image)
 
-    versioned = False
-    if state == "ready":
-        # Versioned means the version will be saved in the DB forever, we don't want to spam
-        # the DB with intermediate or unusable versions, only successfully deployed versions
-        versioned = True
-    mlrun.api.crud.Functions().store_function(
-        db_session,
-        fn,
-        name,
-        project,
-        tag,
-        versioned=versioned,
-    )
+        versioned = False
+        if state == "ready":
+            # Versioned means the version will be saved in the DB forever, we don't want to spam
+            # the DB with intermediate or unusable versions, only successfully deployed versions
+            versioned = True
+        mlrun.api.crud.Functions().store_function(
+            db_session,
+            fn,
+            name,
+            project,
+            tag,
+            versioned=versioned,
+        )
+
     return Response(
         content=text,
         media_type="text/plain",
@@ -885,3 +894,26 @@ def _process_model_monitoring_secret(db_session, project_name: str, secret_key: 
         Secrets().delete_project_secret(project_name, provider, secret_key)
 
     return secret_value
+
+
+def _is_nuclio_deploy_status_changed(
+    previous_status: dict, new_status: dict, new_state: str, new_nuclio_name: str = None
+) -> bool:
+    # get relevant fields from the new status
+    new_container_image = new_status.get("containerImage", "")
+    new_internal_invocation_urls = new_status.get("internalInvocationUrls", [])
+    new_external_invocation_urls = new_status.get("externalInvocationUrls", [])
+    address = new_external_invocation_urls[0] if new_external_invocation_urls else ""
+
+    # Determine if any of the relevant fields have changed
+    has_changed = (
+        previous_status.get("functionName", "") != new_nuclio_name
+        or previous_status.get("state") != new_state
+        or previous_status.get("containerImage", "") != new_container_image
+        or previous_status.get("internalInvocationUrls", [])
+        != new_internal_invocation_urls
+        or previous_status.get("externalInvocationUrls", [])
+        != new_external_invocation_urls
+        or previous_status.get("address", "") != address
+    )
+    return has_changed

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -907,12 +907,12 @@ def _is_nuclio_deploy_status_changed(
 
     # Determine if any of the relevant fields have changed
     has_changed = (
-        previous_status.get("functionName", "") != new_nuclio_name
+        previous_status.get("nuclio_name", "") != new_nuclio_name
         or previous_status.get("state") != new_state
-        or previous_status.get("containerImage", "") != new_container_image
-        or previous_status.get("internalInvocationUrls", [])
+        or previous_status.get("container_image", "") != new_container_image
+        or previous_status.get("internal_invocation_urls", [])
         != new_internal_invocation_urls
-        or previous_status.get("externalInvocationUrls", [])
+        or previous_status.get("external_invocation_urls", [])
         != new_external_invocation_urls
         or previous_status.get("address", "") != address
     )

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -288,6 +288,12 @@ default_config = {
                     "pull_state_interval": 5,  # seconds
                 },
             },
+            "nuclio": {
+                # setting interval to a higher interval than regular jobs / build, because pulling the retrieved logs
+                # from nuclio for the deploy status doesn't include the actual live "builder" container logs, but
+                # rather a high level status
+                "pull_deploy_status_default_interval": 10  # seconds
+            },
             # this is the default interval period for pulling logs, if not specified different timeout interval
             "pull_logs_default_interval": 3,  # seconds
             "pull_logs_backoff_no_logs_default_interval": 10,  # seconds

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -626,7 +626,9 @@ class RemoteRuntime(KubeResource):
         state = ""
         last_log_timestamp = 1
         while state not in ["ready", "error", "unhealthy"]:
-            sleep(1)
+            sleep(
+                int(mlrun.mlconf.httpdb.logs.nuclio.pull_deploy_status_default_interval)
+            )
             try:
                 text, last_log_timestamp = db.get_builder_status(
                     self, last_log_timestamp=last_log_timestamp, verbose=verbose


### PR DESCRIPTION
- Changed the pulling interval of the nuclio deploy status to default of 10s, this is because the logs that are being returned to the user are not live logs from the builder container but rather a high level status of the builder status ( averages to 5 lines log output if no errors occurs )   .
- When querying the deploy status we were storing the function on each request, this becomes more and more consuming when the build function process take long time (as bigger the image the longer time it will take), I were able to count 250 store function actions for a single deploy function that took 4min to finish deploying. Therefore I added a validation that checks whether something has changed before storing it to the database.

Both these changes together are expected to reduce the load on the API and the database by a lot. 