### PR TITLE
[Execution] Update run params, inputs and outputs

### DIFF
--- a/docs/feature-store/basic-demo.ipynb
+++ b/docs/feature-store/basic-demo.ipynb
@@ -32,7 +32,7 @@
     "Setting up the environment and project:"
    ]
   },
- {
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -977,6 +977,8 @@ class MLClientCtx(object):
             "metadata.labels": self._labels,
             "metadata.annotations": self._annotations,
             "spec.parameters": self._parameters,
+            "spec.outputs": self._outputs,
+            "spec.inputs": {k: v.artifact_url for k, v in self._inputs.items()},
             "status.results": self._results,
             "status.start_time": to_date_str(self._start_time),
             "status.last_update": to_date_str(self._last_update),

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -976,6 +976,7 @@ class MLClientCtx(object):
         struct = {
             "metadata.labels": self._labels,
             "metadata.annotations": self._annotations,
+            "spec.parameters": self._parameters,
             "status.results": self._results,
             "status.start_time": to_date_str(self._start_time),
             "status.last_update": to_date_str(self._last_update),


### PR DESCRIPTION
raised by system test: `tests.system.examples.basics.test_db.TestDB.test_db_commands`
Added execution parameters that can be updated during the run to the list of updates.
We then use that list to update the run in the db (reminder we use update and not store since update does not override with `None` values)