### PR TITLE
[Requirements] Move pyopenssl requirement to azure extra

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -46,8 +46,13 @@ def extra_requirements() -> typing.Dict[str, typing.List[str]]:
             "azure-core~=1.24",
             "azure-storage-blob~=12.13",
             "adlfs~=2021.8.1",
+            "pyopenssl>=23",
         ],
-        "azure-key-vault": ["azure-identity~=1.5", "azure-keyvault-secrets~=4.2"],
+        "azure-key-vault": [
+            "azure-identity~=1.5",
+            "azure-keyvault-secrets~=4.2",
+            "pyopenssl>=23",
+        ],
         "bokeh": [
             # >=2.4.2 to force having a security fix done in 2.4.2
             "bokeh~=2.4, >=2.4.2",

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -19,6 +19,9 @@ azure-storage-blob~=12.13
 adlfs~=2021.8.1
 azure-identity~=1.5
 azure-keyvault-secrets~=4.2
+# cryptography>=39, which is required by azure, needs this, or else we get
+# AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms' (ML-3471)
+pyopenssl>=23
 bokeh~=2.4, >=2.4.2
 gcsfs~=2021.8.1
 # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,3 @@ python-dotenv~=0.17.0
 # older version of setuptools contains vulnerabilities, see `GHSA-r9hx-vwmv-q579`, so we limit to 65.5 and above
 setuptools~=65.5
 deprecated~=1.2
-# cryptography>=39 needs this, or else we get
-# AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms' (ML-3471)
-pyopenssl>=23


### PR DESCRIPTION
Since it's only needed by azure libraries.