### PR TITLE
[Projects] Support `GITHUB_TOKEN` when searching for git token in `clone_git`

### DIFF
--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -127,7 +127,7 @@ def clone_git(url, context, secrets=None, clone=True):
         or get_secret("git_password")
         or ""
     )
-    token = get_secret("GIT_TOKEN")
+    token = get_secret("GITHUB_TOKEN") or get_secret("GIT_TOKEN")
     if token:
         username, password = get_git_username_password_from_token(token)
 


### PR DESCRIPTION
Cloning a git branch only supported `GIT_TOKEN` as source for git token, unlike the git notifications code that also supported the `GITHUB_TOKEN` parameter.
Added support for `GITHUB_TOKEN` to align our usage across the codebase.