### PR TITLE
[Runtimes] Fix reaching `run.logs` when running on server side 

### DIFF
--- a/mlrun/feature_store/ingestion.py
+++ b/mlrun/feature_store/ingestion.py
@@ -279,7 +279,9 @@ def run_ingestion_job(name, featureset, run_config, schedule=None, spark_service
     featureset.save()
 
     # when running in server side we want to set the function db connection to the actual DB and not to use the httpdb
-    function.set_db_connection(featureset._get_run_db())
+    function.set_db_connection(
+        featureset._get_run_db(), is_api=mlrun.config.is_running_as_api()
+    )
 
     # when running on server side there are multiple enrichments and validations to be applied on a function,
     # auth_info is an attribute which is been added only on server side.

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1079,6 +1079,7 @@ class RunObject(RunTemplate):
             state, new_offset = db.watch_log(
                 self.metadata.uid, self.metadata.project, watch=watch, offset=offset
             )
+        # not expected to reach this else, as FileDB is not supported any more and because we don't watch logs on API
         else:
             state, text = db.get_log(
                 self.metadata.uid, self.metadata.project, offset=offset

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -510,7 +510,12 @@ class BaseRuntime(ModelObj):
             # single run
             try:
                 resp = self._run(run, execution)
-                if watch and mlrun.runtimes.RuntimeKinds.is_watchable(self.kind):
+                if (
+                    watch
+                    and mlrun.runtimes.RuntimeKinds.is_watchable(self.kind)
+                    # API shouldn't watch logs, its the client job to query the run logs
+                    and not mlrun.config.is_running_as_api()
+                ):
                     state, _ = run.logs(True, self._get_db())
                     if state not in ["succeeded", "completed"]:
                         logger.warning(f"run ended with state {state}")

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -15,6 +15,7 @@
 import base64
 import json
 import os
+import unittest.mock
 
 import deepdiff
 import pytest
@@ -83,6 +84,16 @@ class TestKubejobRuntime(TestRuntimeBase):
             expected_hyper_params=hyper_params,
             expected_secrets=secret_source,
         )
+
+    def test_run_with_watch_on_server_side(self, db: Session, client: TestClient):
+        runtime = self._generate_runtime()
+        with unittest.mock.patch.object(
+            mlrun.model.RunObject,
+            "logs",
+            side_effect=mlrun.errors.MLRunFatalFailureError("should not reach here"),
+        ) as logs_mock:
+            self._execute_run(runtime, watch=True)
+            assert logs_mock.call_count == 0
 
     def test_run_with_resource_limits_and_requests(
         self, db: Session, client: TestClient


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3525

- Added the `is_running_as_api` as part of the flow of running a function so we won't reach the "DB" side `logs` method.
- Noticed a warning in the API logs when ingesting through an endpoint that should be only raised on client side, fixed by passing `is_api` when `set_db_connection` in the ingestion flow.
```
> 2023-03-05 08:43:38,117 [warning] warning!, Api url not set, trying to exec remote runtime locally
```