### PR TITLE
[Nuclio] Deprecate nuclio dashboard url

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 import json
 import pathlib
+import warnings
 import socket
 import traceback
 from ast import literal_eval
@@ -593,7 +594,7 @@ def build(
     default="",
     help="path/url of function yaml or function " "yaml or db://<project>/<name>[:tag]",
 )
-@click.option("--dashboard", "-d", default="", help="nuclio dashboard url")
+@click.option("--dashboard", "-d", default="", help="Deprecated. Keep empty to allow auto-detect by MLRun API")
 @click.option("--project", "-p", default="", help="project name")
 @click.option("--model", "-m", multiple=True, help="model name and path (name=path)")
 @click.option("--kind", "-k", default=None, help="runtime sub kind")
@@ -672,6 +673,14 @@ def deploy(
         for k, v in list2dict(env).items():
             function.set_env(k, v)
     function.verbose = verbose
+
+    if dashboard:
+        warnings.warn(
+            "'--dashboard' is deprecated in 1.3.0, and will be removed in 1.5.0, "
+            "Keep '--dashboard' value empty to allow auto-detection by MLRun API.",
+            # TODO: Remove in 1.5.0
+            FutureWarning,
+        )
 
     try:
         addr = function.deploy(dashboard=dashboard, project=project, tag=tag)

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 import json
 import pathlib
-import warnings
 import socket
 import traceback
+import warnings
 from ast import literal_eval
 from base64 import b64decode, b64encode
 from os import environ, path, remove
@@ -594,7 +594,12 @@ def build(
     default="",
     help="path/url of function yaml or function " "yaml or db://<project>/<name>[:tag]",
 )
-@click.option("--dashboard", "-d", default="", help="Deprecated. Keep empty to allow auto-detect by MLRun API")
+@click.option(
+    "--dashboard",
+    "-d",
+    default="",
+    help="Deprecated. Keep empty to allow auto-detect by MLRun API",
+)
 @click.option("--project", "-p", default="", help="project name")
 @click.option("--model", "-m", multiple=True, help="model name and path (name=path)")
 @click.option("--kind", "-k", default=None, help="runtime sub kind")

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -327,7 +327,7 @@ def deploy_function(
     """deploy real-time (nuclio based) functions
 
     :param function:   name of the function (in the project) or function object
-    :param dashboard:  url of the remote Nuclio dashboard (when not local)
+    :param dashboard:  DEPRECATED. Keep empty to allow auto-detection by MLRun API.
     :param models:     list of model items
     :param env:        dict of extra environment variables
     :param tag:        extra version tag

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2240,7 +2240,7 @@ class MlrunProject(ModelObj):
         """deploy real-time (nuclio based) functions
 
         :param function:    name of the function (in the project) or function object
-        :param dashboard:   url of the remote Nuclio dashboard (when not local)
+        :param dashboard:   DEPRECATED. Keep empty to allow auto-detection by MLRun API.
         :param models:      list of model items
         :param env:         dict of extra environment variables
         :param tag:         extra version tag

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -584,7 +584,7 @@ class ServingRuntime(RemoteRuntime):
     ):
         """deploy model serving function to a local/remote cluster
 
-        :param dashboard: remote nuclio dashboard url (blank for local or auto detection)
+        :param dashboard: DEPRECATED. Keep empty to allow auto-detection by MLRun API
         :param project:   optional, override function specified project name
         :param tag:       specify unique function tag (a different function service is created for every tag)
         :param verbose:   verbose logging


### PR DESCRIPTION
It is has been deprecated internally for a while, expose deprecation warning.