### PR TITLE
[LogCollector] Enhance finding log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ tests/system/env.yml
 docs/CONTRIBUTING.md
 mlrun/api/proto/*pb2*.py
 docs/tutorial/colab/01-mlrun-basics-colab.ipynb
+
+# used for local development.
+# e.g., when developing for mlrun api, you may use this env to preset envvars.
+# then, when running the api, just feed it with "MLRUN_DEFAULT_ENV_FILE=<absolute-path-to-this-file>"
+hack/mlrun.env

--- a/go/pkg/common/utils.go
+++ b/go/pkg/common/utils.go
@@ -28,6 +28,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var TimedOutErrorMessage = "Timed out waiting until successful"
+var ErrRetryUntilSuccessfulTimeout = errors.New(TimedOutErrorMessage)
+
 // GetEnvOrDefaultString returns the string value of the environment variable with the given key, or the given default
 // value if the environment variable is not set
 func GetEnvOrDefaultString(key string, defaultValue string) string {
@@ -197,7 +200,6 @@ func RetryUntilSuccessfulWithResult(duration time.Duration,
 		shouldRetry  bool
 	)
 
-	timedOutErrorMessage := "Timed out waiting until successful"
 	deadline := time.Now().Add(duration)
 
 	// while we haven't passed the deadline
@@ -214,12 +216,12 @@ func RetryUntilSuccessfulWithResult(duration time.Duration,
 	if lastErr != nil {
 
 		// wrap last error
-		return result, errors.Wrapf(lastErr, timedOutErrorMessage)
+		return result, errors.Wrapf(lastErr, TimedOutErrorMessage)
 	}
 
 	// duration expired, but last callback failed
 	if shouldRetry {
-		return result, errors.New(timedOutErrorMessage)
+		return result, ErrRetryUntilSuccessfulTimeout
 	}
 
 	// duration expired, but last callback succeeded

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -247,6 +247,8 @@ func (suite *LogCollectorTestSuite) TestStartLogBestEffort() {
 		Selector:    "app=some-app",
 		BestEffort:  true,
 	}
+	suite.LogCollectorServer.startLogsFindingPodsTimeout = 50 * time.Millisecond
+	suite.LogCollectorServer.startLogsFindingPodsInterval = 20 * time.Millisecond
 	response, err := suite.LogCollectorServer.StartLog(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to start log")
 	suite.Require().True(response.Success, "Failed to start log")

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -387,7 +387,7 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 
 	// wait for goroutines to finish
 	suite.Require().NoError(errGroup.Wait(), "Failed to wait for goroutines to finish")
-	suite.Require().Equal(totalWritten, totalRead, "Expected total written to be equal to offset")
+	suite.Require().Equal(totalWritten, totalRead, "Expected total written to be equal to total read")
 }
 
 func (suite *LogCollectorTestSuite) TestHasLogs() {

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -324,26 +324,20 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 
 	errGroup, ctx := errgroup.WithContext(suite.ctx)
 
-	startedWriting := make(chan bool)
+	startReading := make(chan bool)
+	var totalWritten = 0
+	var totalRead = 0
 
 	// write to file
 	errGroup.Go(func() error {
-		signaled := false
 		for i := 0; i < 100; i++ {
-			if i > 5 && !signaled {
-				startedWriting <- true
-				signaled = true
-			}
-
-			// sleep for a bit to let the other goroutine read from the file
-			if i%10 == 0 {
-				time.Sleep(1 * time.Second)
+			if i == 10 {
+				startReading <- true
 			}
 			message := fmt.Sprintf(messageTemplate, i)
-			suite.logger.DebugWith("Writing to file", "message", message)
-
 			err := common.WriteToFile(filePath, []byte(message), true)
 			suite.Require().NoError(err, "Failed to write to file")
+			totalWritten += len(message)
 		}
 		return nil
 	})
@@ -351,35 +345,49 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 	// read from file
 	errGroup.Go(func() error {
 
-		// let some logs be written
-		<-startedWriting
-		time.Sleep(500 * time.Millisecond)
+		// wait before writing to file
+		<-startReading
+		var offset int
 
-		offset := 0
-		for j := 0; j < 100; j++ {
-
-			// sleep for a bit to let the other goroutine write to the file
-			if j%10 == 0 {
-				time.Sleep(1 * time.Second)
-			}
-
+		var j int
+		for {
 			message := fmt.Sprintf(messageTemplate, j)
 			size := int64(len(message))
-			logs, err := suite.LogCollectorServer.readLogsFromFile(ctx, "1", filePath, int64(offset), size)
-			suite.Require().NoError(err, "Failed to read logs from file")
+			suite.logger.DebugWith("Reading logs from file",
+				"offset", offset,
+				"size", size)
+			logs, err := suite.LogCollectorServer.readLogsFromFile(ctx,
+				"1",
+				filePath,
+				int64(offset),
+				size)
+			if err != nil {
+				return err
+			}
+
+			offset += len(message)
+			totalRead += len(logs)
+
+			if j == 100 {
+				return nil
+			}
+			if logs == nil {
+				time.Sleep(10 * time.Millisecond)
+				suite.logger.DebugWith("Got nil logs, retrying",
+					"totalWritten", totalWritten,
+					"offset", offset)
+				continue
+			}
 
 			// verify logs
-			suite.logger.DebugWith("Read from file", "offset", offset, "logs", string(logs))
 			suite.Require().Equal(message, string(logs))
-			offset += len(message)
+			j++
 		}
-
-		return nil
 	})
 
 	// wait for goroutines to finish
-	err = errGroup.Wait()
-	suite.Require().NoError(err, "Failed to wait for goroutines to finish")
+	suite.Require().NoError(errGroup.Wait(), "Failed to wait for goroutines to finish")
+	suite.Require().Equal(totalWritten, totalRead, "Expected total written to be equal to offset")
 }
 
 func (suite *LogCollectorTestSuite) TestHasLogs() {

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -378,10 +378,10 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 					"offset", offset)
 				continue
 			}
+			j++
 
 			// verify logs
 			suite.Require().Equal(message, string(logs))
-			j++
 		}
 	})
 

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path"
@@ -40,6 +41,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -64,6 +66,9 @@ type Server struct {
 	// interval durations
 	readLogWaitTime    time.Duration
 	monitoringInterval time.Duration
+
+	logFilesCache    *cache.Expiring
+	logFilesCacheTTL time.Duration
 }
 
 // NewLogCollectorServer creates a new log collector server
@@ -135,6 +140,8 @@ func NewLogCollectorServer(logger logger.Logger,
 	logCollectionBufferPool := bufferpool.NewSizedBytePool(logCollectionBufferPoolSize, logCollectionBufferSizeBytes)
 	getLogsBufferPool := bufferpool.NewSizedBytePool(getLogsBufferPoolSize, getLogsBufferSizeBytes)
 
+	logFilesCache := cache.NewExpiring()
+
 	return &Server{
 		AbstractMlrunGRPCServer:      abstractServer,
 		namespace:                    namespace,
@@ -149,6 +156,15 @@ func NewLogCollectorServer(logger logger.Logger,
 		logCollectionBufferSizeBytes: logCollectionBufferSizeBytes,
 		getLogsBufferSizeBytes:       getLogsBufferSizeBytes,
 		isChief:                      isChief,
+		logFilesCache:                logFilesCache,
+
+		// we delete log files only when deleting the project
+		// that means, if project is gone, log files are gone too
+		// hasLogFiles is called during get_logs on project runs
+		// so if no project, no runs, no get_logs, and this one is pretty much safe to cache
+		// that being said, limit to 5 minutes (hard coded for now)
+		// this cache is done to reduce IOs
+		logFilesCacheTTL: 5 * time.Minute,
 	}, nil
 }
 
@@ -214,24 +230,41 @@ func (s *Server) StartLog(ctx context.Context, request *protologcollector.StartL
 		})
 
 		// if no pods were found, retry
-		if err != nil || pods == nil || len(pods.Items) == 0 {
+		if err != nil {
 			return true, errors.Wrap(err, "Failed to list pods")
+		} else if pods == nil || len(pods.Items) == 0 {
+			return true, errors.Errorf("No pods found for run uid '%s'", request.RunUID)
 		}
 
 		// if pods were found, stop retrying
 		return false, nil
 	}); err != nil {
-		s.Logger.ErrorWithCtx(ctx,
-			"Failed to get pod using label selector",
-			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
-			"runUID", request.RunUID,
-			"selector", request.Selector)
-		err := errors.Wrapf(err, "Failed to list pods for run id %s", request.RunUID)
 
 		// if request is best-effort, return success so run will be marked as "requested logs" in the DB
 		if request.BestEffort {
+			s.Logger.WarnWithCtx(ctx,
+				"Failed to get pod using label selector, but request is best effort, returning success",
+				"err", errors.RootCause(err).Error(),
+				"runUID", request.RunUID,
+				"projectName", request.ProjectName,
+				"selector", request.Selector)
 			return s.successfulBaseResponse(), nil
 		}
+
+		var lastErr = err
+
+		// this is simply a timeout err, we want the root cause
+		if errors.Is(err, common.ErrRetryUntilSuccessfulTimeout) {
+			lastErr = errors.RootCause(lastErr)
+		}
+		s.Logger.ErrorWithCtx(ctx,
+			"Failed to get pod using label selector",
+			"err", common.GetErrorStack(lastErr, common.DefaultErrorStackDepth),
+			"runUID", request.RunUID,
+			"projectName", request.ProjectName,
+			"selector", request.Selector)
+
+		err := errors.Wrapf(lastErr, "Failed to find run '%s' pods", request.RunUID)
 		return &protologcollector.BaseResponse{
 			Success:      false,
 			ErrorCode:    common.ErrCodeNotFound,
@@ -290,16 +323,7 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 		"size", request.Size,
 		"offset", request.Offset)
 
-	// get log file path
-	filePath, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName)
-	if err != nil {
-		s.Logger.ErrorWithCtx(ctx,
-			"Failed to get log file path",
-			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
-			"runUID", request.RunUID)
-		return errors.Wrapf(err, "Failed to get log file path for run id %s", request.RunUID)
-	}
-
+	// if size is 0, return empty logs
 	if request.Size == 0 {
 		if err := responseStream.Send(&protologcollector.GetLogsResponse{
 			Success: true,
@@ -308,6 +332,16 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 			return errors.Wrapf(err, "Failed to send empty logs to stream for run id %s", request.RunUID)
 		}
 		return nil
+	}
+
+	// get log file path
+	filePath, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName)
+	if err != nil {
+		s.Logger.ErrorWithCtx(ctx,
+			"Failed to get log file path",
+			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
+			"runUID", request.RunUID)
+		return errors.Wrapf(err, "Failed to get log file path for run id %s", request.RunUID)
 	}
 
 	// open log file and calc its size
@@ -379,11 +413,6 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 // HasLogs returns true if the log file exists for a given run id
 func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogsRequest) (*protologcollector.HasLogsResponse, error) {
 
-	s.Logger.DebugWithCtx(ctx,
-		"Received has logs request",
-		"runUID", request.RunUID,
-		"projectName", request.ProjectName)
-
 	// get log file path
 	if _, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName); err != nil {
 		if strings.Contains(errors.RootCause(err).Error(), "not found") {
@@ -405,11 +434,14 @@ func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogs
 			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
 			"runUID", request.RunUID,
 			"projectName", request.ProjectName)
+
+		// do not return the 'err' itself, so that mlrun api would catch the response
+		// and will resolve the response on its own.
 		return &protologcollector.HasLogsResponse{
 			Success:      false,
 			ErrorCode:    common.ErrCodeInternal,
 			ErrorMessage: common.GetErrorStack(err, common.DefaultErrorStackDepth),
-		}, err
+		}, nil
 	}
 
 	return &protologcollector.HasLogsResponse{
@@ -737,30 +769,45 @@ func (s *Server) resolvePodLogFilePath(projectName, runUID, podName string) stri
 // getLogFilePath returns the path to the run's latest log file
 func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string) (string, error) {
 
+	// first try load from cache
+	if filePath, found := s.logFilesCache.Get(s.getLogFilCacheKey(runUID, projectName)); found {
+		return filePath.(string), nil
+	}
+
 	logFilePath := ""
 	var latestModTime time.Time
 
 	if err := common.RetryUntilSuccessful(5*time.Second, 1*time.Second, func() (bool, error) {
 
-		// list all files in base directory
-		if err := filepath.Walk(s.baseDir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return errors.Wrapf(err, "Failed to walk path %s", path)
-			}
-
-			// if file name starts with run id, it's a log file
-			if strings.HasPrefix(info.Name(), runUID) && strings.Contains(path, projectName) {
-
-				// if it's the first file, set it as the log file path
-				// otherwise, check if it's the latest modified file
-				if logFilePath == "" || info.ModTime().After(latestModTime) {
-					logFilePath = path
-					latestModTime = info.ModTime()
+		// list all files in project directory
+		if err := filepath.WalkDir(filepath.Join(s.baseDir, projectName),
+			func(path string, dirEntry fs.DirEntry, err error) error {
+				if err != nil {
+					return errors.Wrapf(err, "Failed to walk path %s", path)
 				}
-			}
 
-			return nil
-		}); err != nil {
+				// skip directories
+				if dirEntry.IsDir() {
+					return nil
+				}
+
+				// if file name starts with run id, it's a log file
+				if strings.HasPrefix(dirEntry.Name(), runUID) {
+					info, err := dirEntry.Info()
+					if err != nil {
+						return errors.Wrapf(err, "Failed to get file info for %s", path)
+					}
+
+					// if it's the first file, set it as the log file path
+					// otherwise, check if it's the latest modified file
+					if logFilePath == "" || info.ModTime().After(latestModTime) {
+						logFilePath = path
+						latestModTime = info.ModTime()
+					}
+				}
+
+				return nil
+			}); err != nil {
 			return false, errors.Wrap(err, "Failed to list files in base directory")
 		}
 
@@ -775,6 +822,8 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 		return "", errors.Wrap(err, "Failed to get log file path")
 	}
 
+	// store in cache
+	s.logFilesCache.Set(s.getLogFilCacheKey(runUID, projectName), logFilePath, s.logFilesCacheTTL)
 	return logFilePath, nil
 }
 
@@ -1033,4 +1082,8 @@ func (s *Server) deleteProjectLogs(project string) error {
 	}
 
 	return nil
+}
+
+func (s *Server) getLogFilCacheKey(runUID, project string) string {
+	return fmt.Sprintf("%s/%s", runUID, project)
 }

--- a/go/pkg/services/logcollector/test/logcollector_test.go
+++ b/go/pkg/services/logcollector/test/logcollector_test.go
@@ -215,7 +215,6 @@ func (suite *LogCollectorTestSuite) TestStartLogFailureOnLabelSelector() {
 
 	suite.Require().False(startLogResponse.Success)
 	suite.Require().Error(err)
-	suite.Require().Contains(err.Error(), "Failed to list pods")
 }
 
 func (suite *LogCollectorTestSuite) startLogCollectorServer(listenPort int) {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -44,7 +44,7 @@ env_prefix = "MLRUN_"
 env_file_key = f"{env_prefix}CONFIG_FILE"
 _load_lock = Lock()
 _none_type = type(None)
-default_env_file = "~/.mlrun.env"
+default_env_file = os.getenv("MLRUN_DEFAULT_ENV_FILE", "~/.mlrun.conf")
 
 default_config = {
     "namespace": "",  # default kubernetes namespace
@@ -490,7 +490,7 @@ default_config = {
         # the number of workers which will be used to trigger the start log collection
         "concurrent_start_logs_workers": 15,
         # the time in hours in which to start log collection from.
-        # after upgrade we might have runs which completed in the mean time or still in non-terminal state and
+        # after upgrade, we might have runs which completed in the mean time or still in non-terminal state and
         # we want to collect their logs in the new log collection method (sidecar)
         # default is 4 hours = 4*60*60 = 14400 seconds
         "api_downtime_grace_period": 14400,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -44,7 +44,7 @@ env_prefix = "MLRUN_"
 env_file_key = f"{env_prefix}CONFIG_FILE"
 _load_lock = Lock()
 _none_type = type(None)
-default_env_file = os.getenv("MLRUN_DEFAULT_ENV_FILE", "~/.mlrun.conf")
+default_env_file = os.getenv("MLRUN_DEFAULT_ENV_FILE", "~/.mlrun.env")
 
 default_config = {
     "namespace": "",  # default kubernetes namespace


### PR DESCRIPTION
Few changes were introduced in this PR

1. If `HasLogs` failed, return internal error so MLRun API would resolve the error itself and return appropriate error to user
2. Optimized finding log file by caching found log file and using `WalkDir` (introduced on go.16)
3. Reduced spammy logs

https://jira.iguazeng.com/browse/ML-3488