### PR TITLE
[Function] Fix build status doesn't return the created image after reaching `ready` state 

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -433,6 +433,8 @@ def _handle_job_deploy_status(
     terminal_states = ["failed", "error", "ready"]
     log_file = log_path(project, f"build_{name}__{tag or 'latest'}")
     if state in terminal_states and log_file.exists():
+
+        image = get_in(fn, "status.image", "") or image
         with log_file.open("rb") as fp:
             fp.seek(offset)
             out = fp.read()
@@ -472,6 +474,7 @@ def _handle_job_deploy_status(
     update_in(fn, "status.state", state)
     if state == mlrun.api.schemas.FunctionState.ready:
         update_in(fn, "spec.image", image)
+        update_in(fn, "status.image", image)
 
     versioned = False
     if state == mlrun.api.schemas.FunctionState.ready:

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -474,9 +474,7 @@ def _handle_job_deploy_status(
         logger.error(f"build {state}, watch the build pod logs: {pod}")
         state = mlrun.api.schemas.FunctionState.error
 
-    if (
-        logs and state != "pending"
-    ) or state in terminal_states:
+    if (logs and state != "pending") or state in terminal_states:
         resp = get_k8s().logs(pod)
         if state in terminal_states:
             log_file.parent.mkdir(parents=True, exist_ok=True)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -418,10 +418,11 @@ def _handle_job_deploy_status(
     out = b""
     if not pod:
         if state == mlrun.api.schemas.FunctionState.ready:
-            # when function has been built we set the created image in to the `spec.image` for reference see at the end
-            # of the function where we resolve if we in status ready and then set the spec.build.image to spec.image
+            # when the function has been built we set the created image into the `spec.image` for reference see at the
+            # end of the function where we resolve if the status is ready and then set the spec.build.image to
+            # spec.image
             # TODO: spec shouldn't hold backend enriched attributes, but rather in the status block
-            #   therefore need to change to set it to a new attribute in status.image which will ease on our resolution
+            #   therefore need set it as a new attribute in status.image which will ease our resolution
             #   of whether it is a user defined image or MLRun enriched one.
             image = image or get_in(fn, "spec.image")
         return Response(
@@ -440,10 +441,11 @@ def _handle_job_deploy_status(
     if state in terminal_states and log_file.exists():
 
         if state == mlrun.api.schemas.FunctionState.ready:
-            # when function has been built we set the created image in to the `spec.image` for reference see at the end
-            # of the function where we resolve if we in status ready and then set the spec.build.image to spec.image
+            # when the function has been built we set the created image into the `spec.image` for reference see at the
+            # end of the function where we resolve if the status is ready and then set the spec.build.image to
+            # spec.image
             # TODO: spec shouldn't hold backend enriched attributes, but rather in the status block
-            #   therefore need to change to set it to a new attribute in status.image which will ease on our resolution
+            #   therefore need set it as a new attribute in status.image which will ease our resolution
             #   of whether it is a user defined image or MLRun enriched one.
             image = image or get_in(fn, "spec.image")
 
@@ -473,7 +475,7 @@ def _handle_job_deploy_status(
         state = mlrun.api.schemas.FunctionState.error
 
     if (
-        logs and state != mlrun.api.schemas.FunctionState.pending
+        logs and state != "pending"
     ) or state in terminal_states:
         resp = get_k8s().logs(pod)
         if state in terminal_states:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -107,9 +107,10 @@ class RuntimeClassMode(enum.Enum):
 
 
 class FunctionStatus(ModelObj):
-    def __init__(self, state=None, build_pod=None):
+    def __init__(self, state=None, build_pod=None, image:str=None):
         self.state = state
         self.build_pod = build_pod
+        self.image = image
 
 
 class FunctionSpec(ModelObj):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -107,10 +107,9 @@ class RuntimeClassMode(enum.Enum):
 
 
 class FunctionStatus(ModelObj):
-    def __init__(self, state=None, build_pod=None, image:str=None):
+    def __init__(self, state=None, build_pod=None):
         self.state = state
         self.build_pod = build_pod
-        self.image = image
 
 
 class FunctionSpec(ModelObj):

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -280,7 +280,7 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
             requirements=["pandaasdasds"],
         )
         project.save()
-        with pytest.raises(Exception):
+        with pytest.raises(mlrun.errors.MLRunRuntimeError):
             project.run_function("myjob", auto_build=True)
 
         project = mlrun.get_or_create_project("run-with-source-and-auto-build")

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -236,6 +236,47 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         assert run.state() == "completed"
         assert run.output("tag")
 
+    def test_set_source_with_auto_build_function(self):
+        project = mlrun.get_or_create_project("run-with-source-and-auto-build")
+        # using project.name because this is a user project meaning the project name get concatenated with the user name
+        self.custom_project_names_to_delete.append(project.name)
+        project.set_source(f"{git_uri}#main", False)
+        project.set_function(
+            name="myjob",
+            handler="rootfn.job_handler",
+            image=base_image,
+            kind="job",
+            with_repo=True,
+            requirements=["pandas"]
+        )
+        print(project.spec._function_objects['myjob'].to_dict())
+        print(project.spec._function_definitions)
+        project.save()
+        project.run_function("myjob", auto_build=True)
+        print(project.spec._function_objects['myjob'].to_dict())
+        print(project.spec._function_definitions)
+        project = mlrun.get_or_create_project("run-with-source-and-auto-build")
+        print(project.spec._function_objects)
+        print(project.spec._function_definitions)
+        project.set_source(f"{git_uri}#main", False)
+        print(project.spec._function_objects['myjob'].to_dict())
+        print(project.spec._function_definitions)
+        project.set_function(
+            name="myjob",
+            handler="rootfn.job_handler",
+            image=base_image,
+            kind="job",
+            with_repo=True,
+            requirements=["pandas"]
+        )
+        print(project.spec._function_objects['myjob'].to_dict())
+        print(project.spec._function_definitions)
+        project.sync_functions()
+        project.save()
+        project.run_function("myjob", auto_build=True)
+        print(project.spec._function_objects['myjob'].to_dict())
+        print(project.spec._function_definitions)
+
     def test_nuclio_project(self):
         project = mlrun.new_project("git-proj-nuc", user_project=True)
         # using project.name because this is a user project meaning the project name get concatenated with the user name

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -236,7 +236,7 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         assert run.state() == "completed"
         assert run.output("tag")
 
-    def test_set_source_with_auto_build_function(self):
+    def test_run_function_with_auto_build_and_source_is_idempotent(self):
         project = mlrun.get_or_create_project("run-with-source-and-auto-build")
         # using project.name because this is a user project meaning the project name get concatenated with the user name
         self.custom_project_names_to_delete.append(project.name)
@@ -247,35 +247,23 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
             image=base_image,
             kind="job",
             with_repo=True,
-            requirements=["pandas"]
+            requirements=["pandas"],
         )
-        print(project.spec._function_objects['myjob'].to_dict())
-        print(project.spec._function_definitions)
         project.save()
         project.run_function("myjob", auto_build=True)
-        print(project.spec._function_objects['myjob'].to_dict())
-        print(project.spec._function_definitions)
+
         project = mlrun.get_or_create_project("run-with-source-and-auto-build")
-        print(project.spec._function_objects)
-        print(project.spec._function_definitions)
         project.set_source(f"{git_uri}#main", False)
-        print(project.spec._function_objects['myjob'].to_dict())
-        print(project.spec._function_definitions)
         project.set_function(
             name="myjob",
             handler="rootfn.job_handler",
             image=base_image,
             kind="job",
             with_repo=True,
-            requirements=["pandas"]
+            requirements=["pandas"],
         )
-        print(project.spec._function_objects['myjob'].to_dict())
-        print(project.spec._function_definitions)
-        project.sync_functions()
         project.save()
         project.run_function("myjob", auto_build=True)
-        print(project.spec._function_objects['myjob'].to_dict())
-        print(project.spec._function_definitions)
 
     def test_nuclio_project(self):
         project = mlrun.new_project("git-proj-nuc", user_project=True)


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3540

Aligning how we were returning the created image by the build flow, after build finished we are setting the `spec.build.image` to the `spec.image` and cleaning the `spec.build.image`, but we had a bug that in one of the flows when function was already ready we were returning the `spec.build.image` instead of the `spec.image` 