### PR TITLE
[Runtimes] Escape and encode requirements correctly

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1472,6 +1472,7 @@ class MlrunProject(ModelObj):
             proj.set_function('http://.../mynb.ipynb', 'train')
             proj.set_function('./func.yaml')
             proj.set_function('hub://get_toy_data', 'getdata')
+            proj.set_function('my.py', requirements=["requests"])
 
         :param func:      function object or spec/code url, None refers to current Notebook
         :param name:      name of the function (under the project)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1472,7 +1472,14 @@ class MlrunProject(ModelObj):
             proj.set_function('http://.../mynb.ipynb', 'train')
             proj.set_function('./func.yaml')
             proj.set_function('hub://get_toy_data', 'getdata')
-            proj.set_function('my.py', requirements=["requests"])
+
+            # set function requirements
+
+            # by providing a list of packages
+            proj.set_function('my.py', requirements=["requests", "pandas"])
+
+            # by providing a path to a pip requirements file
+            proj.set_function('my.py', requirements="requirements.txt")
 
         :param func:      function object or spec/code url, None refers to current Notebook
         :param name:      name of the function (under the project)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1216,11 +1216,9 @@ class BaseRuntime(ModelObj):
         :param verify_base_image:  verify that the base image is configured
         :return: function object
         """
-        if isinstance(requirements, str):
-            with open(requirements, "r") as fp:
-                requirements = fp.read().splitlines()
+        encoded_requirements = self._encode_requirements(requirements)
         commands = self.spec.build.commands or [] if not overwrite else []
-        new_command = "python -m pip install " + " ".join(requirements)
+        new_command = f"python -m pip install {encoded_requirements}"
         # make sure we dont append the same line twice
         if new_command not in commands:
             commands.append(new_command)
@@ -1393,6 +1391,32 @@ class BaseRuntime(ModelObj):
                         if "default" in p:
                             line += f", default={p['default']}"
                         print("    " + line)
+
+    def _encode_requirements(self, requirements_to_encode):
+
+        # if a string, read the file then encode
+        if isinstance(requirements_to_encode, str):
+            with open(requirements_to_encode, "r") as fp:
+                requirements_to_encode = fp.read().splitlines()
+
+        requirements = []
+        for requirement in requirements_to_encode:
+            requirement = requirement.strip()
+            escaped = False
+
+            # -r / --requirement are flags and should not be escaped
+            for req_flag in ["-r", "--requirement"]:
+                if requirement.startswith(req_flag):
+                    requirements.append(
+                        f"{req_flag} '{requirement[len(req_flag):].strip()}'"
+                    )
+                    escaped = True
+                    break
+
+            if not escaped:
+                requirements.append(f"'{requirement}'")
+
+        return " ".join(requirements)
 
 
 def is_local(url):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -14,6 +14,7 @@
 import enum
 import getpass
 import http
+import shlex
 import traceback
 import typing
 import uuid
@@ -1402,19 +1403,17 @@ class BaseRuntime(ModelObj):
         requirements = []
         for requirement in requirements_to_encode:
             requirement = requirement.strip()
-            escaped = False
 
             # -r / --requirement are flags and should not be escaped
             for req_flag in ["-r", "--requirement"]:
                 if requirement.startswith(req_flag):
-                    requirements.append(
-                        f"{req_flag} '{requirement[len(req_flag):].strip()}'"
-                    )
-                    escaped = True
+                    requirement = requirement[len(req_flag) :].strip()
+                    requirements.append(req_flag)
                     break
 
-            if not escaped:
-                requirements.append(f"'{requirement}'")
+            # wrap in single quote to ensure that the requirement is treated as a single string
+            # quote the requirement to avoid issues with special characters, double quotes, etc.
+            requirements.append(shlex.quote(requirement))
 
         return " ".join(requirements)
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -383,7 +383,9 @@ def _assert_project_function_objects(project, expected_function_objects):
 
 
 def test_set_func_requirements():
-    project = mlrun.projects.MlrunProject("newproj", default_requirements=["pandas>1, <3"])
+    project = mlrun.projects.MlrunProject(
+        "newproj", default_requirements=["pandas>1, <3"]
+    )
     project.set_function("hub://describe", "desc1", requirements=["x"])
     assert project.get_function("desc1", enrich=True).spec.build.commands == [
         "python -m pip install x",

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -383,18 +383,18 @@ def _assert_project_function_objects(project, expected_function_objects):
 
 
 def test_set_func_requirements():
-    project = mlrun.projects.MlrunProject("newproj", default_requirements=["pandas"])
+    project = mlrun.projects.MlrunProject("newproj", default_requirements=["pandas>1, <3"])
     project.set_function("hub://describe", "desc1", requirements=["x"])
     assert project.get_function("desc1", enrich=True).spec.build.commands == [
         "python -m pip install x",
-        "python -m pip install pandas",
+        "python -m pip install 'pandas>1, <3'",
     ]
 
     fn = mlrun.import_function("hub://describe")
     project.set_function(fn, "desc2", requirements=["y"])
     assert project.get_function("desc2", enrich=True).spec.build.commands == [
         "python -m pip install y",
-        "python -m pip install pandas",
+        "python -m pip install 'pandas>1, <3'",
     ]
 
 

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -15,6 +15,8 @@
 import base64
 import json
 import os
+import shutil
+import tempfile
 
 import pytest
 
@@ -35,11 +37,15 @@ class TestAutoMount:
         self.name = "test-function"
         self.image_name = "mlrun/mlrun:latest"
         self.artifact_path = "/tmp"
+        self._temp_dir = tempfile.mkdtemp()
 
         os.environ["V3IO_ACCESS_KEY"] = self.v3io_access_key = "1111-2222-3333-4444"
         os.environ["V3IO_USERNAME"] = self.v3io_user = "test-user"
 
-    def _generate_runtime(self, disable_auto_mount=False):
+    def teardown_method(self, test_method):
+        shutil.rmtree(self._temp_dir, ignore_errors=True)
+
+    def _generate_runtime(self, disable_auto_mount=False) -> KubejobRuntime:
         runtime = KubejobRuntime()
         runtime.spec.image = self.image_name
         runtime.spec.disable_auto_mount = disable_auto_mount
@@ -71,6 +77,44 @@ class TestAutoMount:
         runtime = self._generate_runtime(disable_auto_mount=True)
         self._execute_run(runtime)
         rundb_mock.assert_no_mount_or_creds_configured()
+
+    @pytest.mark.parametrize(
+        "requirements,encoded_requirements",
+        [
+            # strip spaces
+            (["pandas==1.0.0", "numpy==1.0.0 "], "'pandas==1.0.0' 'numpy==1.0.0'"),
+            # handle flags
+            (["-r somewhere/requirements.txt"], "-r 'somewhere/requirements.txt'"),
+            # handle flags and specific
+            # handle escaping within specific
+            (
+                ["-r somewhere/requirements.txt", "pandas>=1.0.0, <2"],
+                "-r 'somewhere/requirements.txt' 'pandas>=1.0.0, <2'",
+            ),
+            # handle from git
+            (
+                ["something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something"],
+                "'something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something'",
+            ),
+        ],
+    )
+    def test_encode_requirements(self, requirements, encoded_requirements):
+        for requirements_as_file in [True, False]:
+            if requirements_as_file:
+
+                # create a temporary file with the requirements
+                with tempfile.NamedTemporaryFile(
+                    delete=False, dir=self._temp_dir
+                ) as temp_file:
+                    with open(temp_file.name, "w") as f:
+                        for requirement in requirements:
+                            f.write(requirement + "\n")
+                    requirements = temp_file.name
+
+            encoded = self._generate_runtime()._encode_requirements(requirements)
+            assert (
+                encoded_requirements == encoded
+            ), f"Failed to encode {requirements} as file {requirements_as_file}"
 
     def test_fill_credentials(self, rundb_mock):
         """

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -82,14 +82,17 @@ class TestAutoMount:
         "requirements,encoded_requirements",
         [
             # strip spaces
-            (["pandas==1.0.0", "numpy==1.0.0 "], "'pandas==1.0.0' 'numpy==1.0.0'"),
+            (["pandas==1.0.0", "numpy==1.0.0 "], "pandas==1.0.0 numpy==1.0.0"),
+            # handle ranges
+            (["pandas>=1.0.0, <2"], "'pandas>=1.0.0, <2'"),
+            (["pandas>=1.0.0,<2"], "'pandas>=1.0.0,<2'"),
             # handle flags
-            (["-r somewhere/requirements.txt"], "-r 'somewhere/requirements.txt'"),
+            (["-r somewhere/requirements.txt"], "-r somewhere/requirements.txt"),
             # handle flags and specific
             # handle escaping within specific
             (
                 ["-r somewhere/requirements.txt", "pandas>=1.0.0, <2"],
-                "-r 'somewhere/requirements.txt' 'pandas>=1.0.0, <2'",
+                "-r somewhere/requirements.txt 'pandas>=1.0.0, <2'",
             ),
             # handle from git
             (
@@ -113,7 +116,7 @@ class TestAutoMount:
 
             encoded = self._generate_runtime()._encode_requirements(requirements)
             assert (
-                encoded_requirements == encoded
+                encoded == encoded_requirements
             ), f"Failed to encode {requirements} as file {requirements_as_file}"
 
     def test_fill_credentials(self, rundb_mock):


### PR DESCRIPTION
before, if user would pass 'requests>=5, <4' then the space between `5` to `<` would not be escaped correctly when the command was executed.
This PR escapes the pip command more correctly and handle flags accordingly

https://jira.iguazeng.com/browse/ML-3518