### PR TITLE
[Model Monitoring] Log an error for out-of-order event request in the monitoring stream function

### DIFF
--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -747,8 +747,8 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
         ):
 
             logger.error(
-                f"current event request time {timestamp} has to be later than the last request "
-                f"{self.last_request[endpoint_id]}. Otherwise, it will not be written into the TSDB."
+                f"current event request time {timestamp} is earlier than the last request time "
+                f"{self.last_request[endpoint_id]} - write to TSDB will be rejected"
             )
 
     def is_list_of_numerics(

--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -746,9 +746,9 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
             and self.last_request[endpoint_id] > timestamp
         ):
 
-            raise mlrun.errors.MLRunPreconditionFailedError(
+            logger.error(
                 f"current event request time {timestamp} has to be later than the last request "
-                f"{self.last_request[endpoint_id]}"
+                f"{self.last_request[endpoint_id]}. Otherwise, it will not be written into the TSDB."
             )
 
     def is_list_of_numerics(


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/3157, instead of raising an error, the model monitoring stream function will log an error about the out of order issue. In that way, the events with the out of order issue will be processed through the rest of the monitoring stream graph (although these event won't be written into the TSDB). 