### PR TITLE
[Feature-store] Fix issues with storing to DB objects with non-JSON-serializable fields (in `ingest` REST API)

### DIFF
--- a/mlrun/api/db/sqldb/models/models_mysql.py
+++ b/mlrun/api/db/sqldb/models/models_mysql.py
@@ -407,7 +407,8 @@ with warnings.catch_warnings():
 
         @full_object.setter
         def full_object(self, value):
-            self._full_object = json.dumps(value)
+            # TODO - convert to pickle, to avoid issues with non-json serializable fields such as datetime
+            self._full_object = json.dumps(value, default=str)
 
     class FeatureVector(Base, BaseModel):
         __tablename__ = "feature_vectors"
@@ -447,7 +448,8 @@ with warnings.catch_warnings():
 
         @full_object.setter
         def full_object(self, value):
-            self._full_object = json.dumps(value)
+            # TODO - convert to pickle, to avoid issues with non-json serializable fields such as datetime
+            self._full_object = json.dumps(value, default=str)
 
     class MarketplaceSource(Base, BaseModel):
         __tablename__ = "marketplace_sources"
@@ -477,7 +479,8 @@ with warnings.catch_warnings():
 
         @full_object.setter
         def full_object(self, value):
-            self._full_object = json.dumps(value)
+            # TODO - convert to pickle, to avoid issues with non-json serializable fields such as datetime
+            self._full_object = json.dumps(value, default=str)
 
     class DataVersion(Base, BaseModel):
         __tablename__ = "data_versions"

--- a/mlrun/api/db/sqldb/models/models_sqlite.py
+++ b/mlrun/api/db/sqldb/models/models_sqlite.py
@@ -388,7 +388,7 @@ with warnings.catch_warnings():
 
         @full_object.setter
         def full_object(self, value):
-            self._full_object = json.dumps(value)
+            self._full_object = json.dumps(value, default=str)
 
     class FeatureVector(Base, BaseModel):
         __tablename__ = "feature_vectors"
@@ -421,7 +421,7 @@ with warnings.catch_warnings():
 
         @full_object.setter
         def full_object(self, value):
-            self._full_object = json.dumps(value)
+            self._full_object = json.dumps(value, default=str)
 
     class MarketplaceSource(Base, BaseModel):
         __tablename__ = "marketplace_sources"
@@ -445,7 +445,7 @@ with warnings.catch_warnings():
 
         @full_object.setter
         def full_object(self, value):
-            self._full_object = json.dumps(value)
+            self._full_object = json.dumps(value, default=str)
 
     class DataVersion(Base, BaseModel):
         __tablename__ = "data_versions"

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -788,7 +788,11 @@ def fill_object_hash(object_dict, uid_property_name, tag=""):
     object_dict["status"] = None
     object_dict["metadata"]["updated"] = None
     object_created_timestamp = object_dict["metadata"].pop("created", None)
-    data = json.dumps(object_dict, sort_keys=True).encode()
+    # Note the usage of default=str here, which means everything not JSON serializable (for example datetime) will be
+    # converted to string when dumping to JSON. This is not safe for de-serializing (since it won't know we
+    # originated from a datetime, for example), but since this is a one-way dump only for hash calculation,
+    # it's valid here.
+    data = json.dumps(object_dict, sort_keys=True, default=str).encode()
     h = hashlib.sha1()
     h.update(data)
     uid = h.hexdigest()

--- a/tests/api/db/test_feature_sets.py
+++ b/tests/api/db/test_feature_sets.py
@@ -16,6 +16,8 @@ import deepdiff
 import pytest
 from sqlalchemy.orm import Session
 
+import mlrun.feature_store as fstore
+import mlrun.utils.helpers
 from mlrun import errors
 from mlrun.api import schemas
 from mlrun.api.db.base import DBInterface
@@ -32,6 +34,17 @@ def _create_feature_set(name):
                 {"name": "bid", "value_type": "float"},
                 {"name": "ask", "value_type": "time"},
             ],
+            "source": {
+                "attributes": {},
+                "end_time": "2016-05-26T11:09:00.000Z",
+                "key_field": "",
+                "kind": "parquet",
+                "parse_dates": "",
+                "path": "v3io:///projects/a1.parquet",
+                "schedule": "",
+                "start_time": "2016-05-24T22:00:00.000Z",
+                "time_field": "time",
+            },
         },
         "status": {
             "state": "created",
@@ -67,6 +80,23 @@ def test_create_feature_set(db: DBInterface, db_session: Session):
 
     features_res = db.list_features(db_session, project, "time")
     assert len(features_res.features) == 1
+
+
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
+def test_handle_feature_set_with_datetime_fields(db: DBInterface, db_session: Session):
+    # Simulate a situation where a feature-set client-side object is created with datetime fields, and then stored to
+    # DB. This may happen in API calls which utilize client-side objects (such as ingest). See ML-3552.
+    name = "dummy"
+    feature_set = _create_feature_set(name)
+
+    # This object will have datetime in the spec.source object fields
+    fs_object = fstore.FeatureSet.from_dict(feature_set)
+    # Convert it to DB schema object (will still have datetime fields)
+    fs_server_object = schemas.FeatureSet(**fs_object.to_dict())
+    mlrun.utils.helpers.fill_object_hash(fs_server_object.dict(), "uid")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When using the `ingest` REST API, code would attempt to store to DB objects generated from client-side objects (`FeatureSet` in this case). If the object had fields of type `datetime`, then DB code would explode when trying to convert the object to JSON for `uid` calculation and storing in DB table. This only happens when client-side objects are directly used, since otherwise the objects are already serialized to string when creating payload for the REST API calls, so the DB code doesn't usually get `datetime` objects.
I've fixed this in a general way, rather than just fixing the `fset.spec.source` fields - ensuring that any non-serializable objects are converted to string as part of the JSON `dumps` call. There's still a TODO which is to change the serializing of objects for DB table storage to use pickle instead of JSON which is more flexible and allows storing more objects, but this requires data migration so not doing now (added a TODO).
Fixes [ML-3552](https://jira.iguazeng.com/browse/ML-3552)