### PR TITLE
[Projects] Remove owner name when loading project from remote

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -284,13 +284,15 @@ def load_project(
 
     if not project:
         project = _load_project_dir(context, name, subpath)
-        # Remove original owner name for avoiding possible conflicts
-        project.spec.owner = None
+
     if not project.metadata.name:
         raise ValueError("project name must be specified")
-    if not from_db or (url and url.startswith("git://")):
+    if not from_db:
         project.spec.source = url or project.spec.source
         project.spec.origin_url = url or project.spec.origin_url
+        # Remove original owner name for avoiding possible conflicts when loading project from remote
+        project.spec.owner = None
+
     project.spec.repo = repo
     if repo:
         try:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -786,3 +786,17 @@ def test_load_project_with_git_enrichment(
     assert (
         project.spec.source == "git://github.com/mlrun/project-demo.git#refs/heads/main"
     )
+
+
+def test_remove_owner_name_in_load_project_from_yaml():
+    # Create project and generate owner name
+    project_name = "project-name"
+    project = mlrun.new_project(project_name, save=False)
+    project.spec.owner = "some_owner"
+
+    # Load the project from yaml and validate that the owner name was removed
+    project_file_path = pathlib.Path(tests.conftest.results) / "project.yaml"
+    project.export(str(project_file_path))
+    imported_project = mlrun.load_project("./", str(project_file_path), save=False)
+    assert project.spec.owner == "some_owner"
+    assert imported_project.spec.owner is None


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/3163, when the user loads a project from remote (e.g. git source, yaml, etc.), we remove the owner name from `project.spec.owner` to avoid possible conflicts. 
A related tickets: https://jira.iguazeng.com/browse/ML-3571, https://jira.iguazeng.com/browse/IG-21676 