### PR TITLE
[Nuclio] Populate errors to clients

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -1234,6 +1234,9 @@ def deploy_nuclio_function(
             )
 
             try:
+
+                # the error might not be jsonable, so we'll try to parse it
+                # and extract the error message
                 json_err = exc.err.response.json()
                 if "error" in json_err:
                     err_message += f" {json_err['error']}"
@@ -1242,8 +1245,11 @@ def deploy_nuclio_function(
                         "Failed to deploy nuclio function",
                         nuclio_stacktrace=json_err["errorStackTrace"],
                     )
-            except Exception:
-                pass
+            except Exception as parse_exc:
+                logger.warning(
+                    "Failed to parse nuclio deploy error",
+                    parse_exc=err_to_str(parse_exc),
+                )
 
             mlrun.errors.raise_for_status(
                 exc.err.response,

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -569,7 +569,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_build_base_image=expected_build_base_image,
         )
 
-    def test_deploy_build_base_image(
+    def test_deploy_populate_nuclio_errors(
         self, db: Session, k8s_secrets_mock: K8sSecretsMock
     ):
         function = self._generate_runtime(self.runtime_kind)


### PR DESCRIPTION
When nuclio return with meaningful error string, use it

in addition, reduce spammy log when nuclio version is not set

[ML-3446](https://jira.iguazeng.com/browse/ML-3446)