### PR TITLE
[Serving] Fix serving log prints

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -312,12 +312,12 @@ def v2_serving_init(context, namespace=None):
         server.verbose = True
     if hasattr(context, "trigger"):
         server.http_trigger = getattr(context.trigger, "kind", "http") == "http"
-    context.logger.info(
+    context.logger.info_with(
         "Setting current function",
         current_functiton=os.environ.get("SERVING_CURRENT_FUNCTION", ""),
     )
     server.set_current_function(os.environ.get("SERVING_CURRENT_FUNCTION", ""))
-    context.logger.info(
+    context.logger.info_with(
         "Initializing states", namespace=namespace or get_caller_globals()
     )
     server.init_states(context, namespace or get_caller_globals())
@@ -326,7 +326,7 @@ def v2_serving_init(context, namespace=None):
     # set the handler hook to point to our handler
     setattr(context, "mlrun_handler", serving_handler)
     setattr(context, "_server", server)
-    context.logger.info("Serving was initialized", verbose=server.verbose)
+    context.logger.info_with("Serving was initialized", verbose=server.verbose)
     if server.verbose:
         context.logger.info(server.to_yaml())
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -828,7 +828,7 @@ class FlowStep(BaseStep):
 
         for step in self._steps.values():
             step.set_parent(self)
-            context.logger.info("Initializing step", step=step.name)
+            context.logger.info_with("Initializing step", step=step.name)
             step.init_object(context, namespace, mode, reset=reset)
         self._set_error_handler()
         self._post_init(mode)

--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -61,6 +61,16 @@ class Logger(object):
         self._bound_variables = {}
         self._handlers = {}
 
+        for log_level_func in [
+            self.exception,
+            self.error,
+            self.warn,
+            self.warning,
+            self.info,
+            self.debug,
+        ]:
+            setattr(self, f"{log_level_func.__name__}_with", log_level_func)
+
     def set_handler(
         self, handler_name: str, file: IO[str], formatter: logging.Formatter
     ):

--- a/tests/utils/logger/test_logger.py
+++ b/tests/utils/logger/test_logger.py
@@ -71,9 +71,10 @@ def test_with_kwargs(make_stream_logger):
     assert "special_kwarg_value" in stream.getvalue()
 
 
-def test_levels(make_stream_logger, logger_level):
+@pytest.mark.parametrize("level_with", [True, False])
+def test_levels(make_stream_logger, logger_level, level_with):
     stream, test_logger = make_stream_logger
-    getattr(test_logger, logger_level)(
+    getattr(test_logger, f"{logger_level}_with" if level_with else logger_level)(
         "Message %s", "somearg", somekwarg="somekwarg-value"
     )
     assert "Message somearg" in stream.getvalue()


### PR DESCRIPTION
following and my misleading comment about `log_with` https://github.com/mlrun/mlrun/pull/3244 - the reason for ci to pass while real function fails is that ci uses mock server (that relay on mlrun logger) while real deployments uses nuclio logger which expects `log_with`. In this PR I've added an alias on mlrun logger to behave like nuclio one. so in that case