### PR TITLE
[Project] Delete project from DB when not found in iguazio

### DIFF
--- a/mlrun/api/utils/projects/remotes/leader.py
+++ b/mlrun/api/utils/projects/remotes/leader.py
@@ -16,6 +16,8 @@ import abc
 import datetime
 import typing
 
+import sqlalchemy.orm
+
 import mlrun.api.schemas
 
 
@@ -42,6 +44,7 @@ class Member(abc.ABC):
     def delete_project(
         self,
         session: str,
+        db_session: sqlalchemy.orm.Session,
         name: str,
         deletion_strategy: mlrun.api.schemas.DeletionStrategy = mlrun.api.schemas.DeletionStrategy.default(),
         wait_for_completion: bool = True,


### PR DESCRIPTION
There was a bug in mlrun system test where a project was deleted in iguazio but it was not deleted in mlrun.
When I tried to delete it again from the UI, nothing happened because mlrun got 404 from iguazio.
We should make sure that the project is deleted in mlrun db if it was already deleted in iguazio.
This doesn't fix the original bug (why the project wasn't deleted in mlrun in the 1st place?) but it is a necessary mitigation. 