### PR TITLE
[Schedule] Allow submit jobs to create or update schedules idempotently

### DIFF
--- a/mlrun/api/api/endpoints/submit.py
+++ b/mlrun/api/api/endpoints/submit.py
@@ -132,5 +132,4 @@ async def submit_job(
         data["task"]["metadata"].setdefault("labels", {}).update(
             {"mlrun/client_python_version": client_python_version}
         )
-    logger.info("Submitting run", data=data)
     return await mlrun.api.api.utils.submit_run(db_session, auth_info, data)

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -738,8 +738,8 @@ def submit_run_sync(
                 "schedule": schedule,
                 "project": task["metadata"]["project"],
                 "name": task["metadata"]["name"],
-                # indicate whether it was created or updated
-                "action": "created" if created else "updated",
+                # indicate whether it was created or modified
+                "action": "created" if created else "modified",
             }
         else:
             # When processing a hyper-param run, secrets may be needed to access the parameters file (which is accessed

--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -71,6 +71,12 @@ class ScheduleCronTrigger(BaseModel):
             timezone=timezone,
         )
 
+    def to_crontab(self) -> str:
+        """
+        Convert the trigger to a crontab expression.
+        """
+        return f"{self.minute} {self.hour} {self.day} {self.month} {self.day_of_week}"
+
 
 class ScheduleKinds(mlrun.api.utils.helpers.StrEnum):
     job = "job"

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -57,8 +57,8 @@ class Scheduler:
         self._scheduler = AsyncIOScheduler(gconfig=scheduler_config, prefix=None)
         # this should be something that does not make any sense to be inside project name or job name
         self._job_id_separator = "-_-"
-        # we don't allow to schedule a job to run more then one time per X
-        # NOTE this cannot be less then one minute - see _validate_cron_trigger
+        # we don't allow to schedule a job to run more than one time per X
+        # NOTE this cannot be less than one minute - see _validate_cron_trigger
         self._min_allowed_interval = config.httpdb.scheduling.min_allowed_interval
         self._secrets_provider = schemas.SecretProviderName.kubernetes
 
@@ -550,9 +550,8 @@ class Scheduler:
         now: datetime = None,
     ):
         """
-        Enforce no more then one job per min_allowed_interval
+        Enforce no more than one job per min_allowed_interval
         """
-        logger.debug("Validating cron trigger")
         apscheduler_cron_trigger = (
             self.transform_schemas_cron_trigger_to_apscheduler_cron_trigger(
                 cron_trigger
@@ -561,7 +560,7 @@ class Scheduler:
         now = now or datetime.now(apscheduler_cron_trigger.timezone)
         second_next_run_time = now
 
-        # doing 60 checks to allow one minute precision, if the _min_allowed_interval is less then one minute validation
+        # doing 60 checks to allow one minute precision, if the _min_allowed_interval is less than one minute validation
         # won't fail in certain scenarios that it should. See test_validate_cron_trigger_multi_checks for detailed
         # explanation
         for index in range(60):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -802,7 +802,8 @@ class BaseRuntime(ModelObj):
         try:
             resp = db.submit_job(run, schedule=schedule)
             if schedule:
-                logger.info("successfully scheduled", **resp)
+                action = resp.pop("action", "created")
+                logger.info(f"task schedule {action}", **resp)
                 return
 
         except (requests.HTTPError, Exception) as err:

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -72,12 +72,12 @@ def test_submit_run_sync(db: Session, client: TestClient):
     )
     assert response_data["data"]["action"] == "created"
 
-    # submit again, make sure it was updated
+    # submit again, make sure it was modified
     submit_job_body["schedule"] = "0 1 * * *"  # change schedule
     _, _, _, response_data = mlrun.api.api.utils.submit_run_sync(
         db, auth_info, submit_job_body
     )
-    assert response_data["data"]["action"] == "updated"
+    assert response_data["data"]["action"] == "modified"
 
     updated_schedule = get_scheduler().get_schedule(
         db, project, submit_job_body["task"]["metadata"]["name"]

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -38,6 +38,7 @@ from mlrun.api.api.utils import (
     _mask_v3io_volume_credentials,
     ensure_function_has_auth_set,
     ensure_function_security_context,
+    get_scheduler,
 )
 from mlrun.api.schemas import SecurityContextEnrichmentModes
 from mlrun.utils import logger
@@ -72,10 +73,18 @@ def test_submit_run_sync(db: Session, client: TestClient):
     assert response_data["data"]["action"] == "created"
 
     # submit again, make sure it was updated
+    submit_job_body["schedule"] = "0 1 * * *"  # change schedule
     _, _, _, response_data = mlrun.api.api.utils.submit_run_sync(
         db, auth_info, submit_job_body
     )
     assert response_data["data"]["action"] == "updated"
+
+    updated_schedule = get_scheduler().get_schedule(
+        db, project, submit_job_body["task"]["metadata"]["name"]
+    )
+    assert (
+        updated_schedule.cron_trigger.to_crontab() == "0 1 * * *"
+    ), "schedule was not updated"
 
 
 def test_generate_function_and_task_from_submit_run_body_body_override_values(


### PR DESCRIPTION
We don't check if a schedule already exists when creating a new schedule (idempotency), thus, API fails because DB already have a schedule record.
To allow users to update function's schedule more easily, such as below, it is required to perform create_or_update kind of flow.
```py
func.run(schedule="0 * * * *")
...
func.run(schedule="0 12 * * *")
```

https://jira.iguazeng.com/browse/ML-3542