### PR TITLE
[Base] Sanitize inline comments when using `with_requirements` 

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1407,6 +1407,11 @@ class BaseRuntime(ModelObj):
             if not requirement or requirement.startswith("#"):
                 continue
 
+            # ignore inline comments as well
+            inline_comment = requirement.split(" #")
+            if len(inline_comment) > 1:
+                requirement = inline_comment[0].strip()
+
             # -r / --requirement are flags and should not be escaped
             # we allow such flags (could be passed within the requirements.txt file) and do not
             # try to open the file and include its content since it might be a remote file

--- a/tests/api/runtimes/assets/requirements.txt
+++ b/tests/api/runtimes/assets/requirements.txt
@@ -1,2 +1,4 @@
+# comment
 faker
 python-dotenv
+chardet>=3.0.2, <4.0 # inline comment

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -554,7 +554,9 @@ def my_func(context):
     def test_with_requirements(self, db: Session, client: TestClient):
         runtime = self._generate_runtime()
         runtime.with_requirements(self.requirements_file)
-        expected_commands = ["python -m pip install faker python-dotenv"]
+        expected_commands = [
+            "python -m pip install faker python-dotenv 'chardet>=3.0.2, <4.0'"
+        ]
         assert (
             deepdiff.DeepDiff(
                 expected_commands,

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -99,6 +99,10 @@ class TestAutoMount:
                 ["something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something"],
                 "'something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something'",
             ),
+            # handle comments
+            (["# dont care", "faker"], "faker"),
+            (["faker # inline dontcare"], "faker"),
+            (["faker #inline dontcare2"], "faker"),
         ],
     )
     def test_encode_requirements(self, requirements, encoded_requirements):

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -299,6 +299,9 @@ def _load_requirements(path):
                 continue
             line = line.strip()
 
+            if len(line.split(" #")) > 1:
+                line = line.split(" #")[0]
+
             # e.g.: git+https://github.com/nuclio/nuclio-jupyter.git@some-branch#egg=nuclio-jupyter
             if "#egg=" in line:
                 _, package = line.split("#egg=")


### PR DESCRIPTION
Following up with https://github.com/mlrun/mlrun/pull/3237#issuecomment-1461696497 to handle inline comments

For the record, handling inline comments is just a cosmetic, because doing `pip install 'requests # just a comment'` is legit.