### PR TITLE
[Errors] Fix `err_to_str` without error description

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -129,10 +129,7 @@ def err_to_str(err):
     error_strings = []
     while err and err not in errors:
         errors.append(err)
-        err_msg = str(err)
-        if not err_msg:
-            err_msg = err.__class__.__name__
-        error_strings.append(err_msg)
+        error_strings.append(repr(err))
         err = err.__cause__
 
     return ", caused by: ".join(error_strings)

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -129,7 +129,10 @@ def err_to_str(err):
     error_strings = []
     while err and err not in errors:
         errors.append(err)
-        error_strings.append(str(err))
+        err_msg = str(err)
+        if not err_msg:
+            err_msg = err.__class__.__name__
+        error_strings.append(err_msg)
         err = err.__cause__
 
     return ", caused by: ".join(error_strings)

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -129,7 +129,10 @@ def err_to_str(err):
     error_strings = []
     while err and err not in errors:
         errors.append(err)
-        error_strings.append(repr(err))
+        err_msg = str(err)
+        if not err_msg:
+            err_msg = repr(err)
+        error_strings.append(err_msg)
         err = err.__cause__
 
     return ", caused by: ".join(error_strings)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -36,6 +36,13 @@ def test_error_single():
         assert err_to_str(ex) == "a"
 
 
+def test_error_with_no_description():
+    try:
+        raise AttributeError
+    except Exception as ex:
+        assert err_to_str(ex) == "AttributeError"
+
+
 def test_error_chain_n2():
     try:
         raise Exception("b") from Exception("a")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -33,21 +33,21 @@ def test_error_single():
     try:
         raise Exception("a")
     except Exception as ex:
-        assert err_to_str(ex) == "a"
+        assert err_to_str(ex) == "Exception('a')"
 
 
 def test_error_with_no_description():
     try:
         raise AttributeError
     except Exception as ex:
-        assert err_to_str(ex) == "AttributeError"
+        assert err_to_str(ex) == "AttributeError()"
 
 
 def test_error_chain_n2():
     try:
         raise Exception("b") from Exception("a")
     except Exception as ex:
-        assert err_to_str(ex) == "b, caused by: a"
+        assert err_to_str(ex) == "Exception('b'), caused by: Exception('a')"
 
 
 def test_error_chain_n3():
@@ -57,7 +57,10 @@ def test_error_chain_n3():
         b.__cause__ = a
         raise Exception("c") from b
     except Exception as ex:
-        assert err_to_str(ex) == "c, caused by: b, caused by: a"
+        assert (
+            err_to_str(ex)
+            == "Exception('c'), caused by: Exception('b'), caused by: Exception('a')"
+        )
 
 
 def test_error_circular_chain():
@@ -65,7 +68,7 @@ def test_error_circular_chain():
     b = Exception("b")
     a.__cause__ = b
     b.__cause__ = a
-    assert err_to_str(b) == "b, caused by: a"
+    assert err_to_str(b) == "Exception('b'), caused by: Exception('a')"
 
 
 def test_raise_for_aiohttp_client_response_status():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -33,7 +33,7 @@ def test_error_single():
     try:
         raise Exception("a")
     except Exception as ex:
-        assert err_to_str(ex) == "Exception('a')"
+        assert err_to_str(ex) == "a"
 
 
 def test_error_with_no_description():
@@ -47,7 +47,7 @@ def test_error_chain_n2():
     try:
         raise Exception("b") from Exception("a")
     except Exception as ex:
-        assert err_to_str(ex) == "Exception('b'), caused by: Exception('a')"
+        assert err_to_str(ex) == "b, caused by: a"
 
 
 def test_error_chain_n3():
@@ -57,10 +57,7 @@ def test_error_chain_n3():
         b.__cause__ = a
         raise Exception("c") from b
     except Exception as ex:
-        assert (
-            err_to_str(ex)
-            == "Exception('c'), caused by: Exception('b'), caused by: Exception('a')"
-        )
+        assert err_to_str(ex) == "c, caused by: b, caused by: a"
 
 
 def test_error_circular_chain():
@@ -68,7 +65,7 @@ def test_error_circular_chain():
     b = Exception("b")
     a.__cause__ = b
     b.__cause__ = a
-    assert err_to_str(b) == "Exception('b'), caused by: Exception('a')"
+    assert err_to_str(b) == "b, caused by: a"
 
 
 def test_raise_for_aiohttp_client_response_status():


### PR DESCRIPTION
related to https://jira.iguazeng.com/browse/ML-3599
use the error clase name as an error message when a description is not provided