### PR TITLE
[Schedule] Remove workflow schedule override flags

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1040,16 +1040,6 @@ def logs(uid, project, offset, db, watch):
     "https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron."
     "For using the pre-defined workflow's schedule, set --schedule 'true'",
 )
-# TODO: Remove in 1.6.0 --overwrite-schedule and -os, keep --override-workflow and -ow
-@click.option(
-    "--override-workflow",
-    "--overwrite-schedule",
-    "-ow",
-    "-os",
-    "override_workflow",
-    is_flag=True,
-    help="Override a schedule when submitting a new one with the same name.",
-)
 @click.option(
     "--save-secrets",
     is_flag=True,
@@ -1080,7 +1070,6 @@ def project(
     timeout,
     ensure_project,
     schedule,
-    override_workflow,
     save_secrets,
     save,
 ):
@@ -1170,7 +1159,6 @@ def project(
                 local=local,
                 schedule=schedule,
                 timeout=timeout,
-                override=override_workflow,
             )
 
         except Exception as exc:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1864,8 +1864,6 @@ class MlrunProject(ModelObj):
         local: bool = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger, bool] = None,
         timeout: int = None,
-        overwrite: bool = False,
-        override: bool = False,
         source: str = None,
         cleanup_ttl: int = None,
     ) -> _PipelineRunStatus:
@@ -1897,8 +1895,6 @@ class MlrunProject(ModelObj):
                           https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
                           for using the pre-defined workflow's schedule, set `schedule=True`
         :param timeout:   timeout in seconds to wait for pipeline completion (watch will be activated)
-        :param overwrite: replacing the schedule of the same workflow (under the same name) if exists with the new one
-        :param override:  replacing the schedule of the same workflow (under the same name) if exists with the new one
         :param source:    remote source to use instead of the actual `project.spec.source` (used when engine is remote).
                           for other engines the source is to validate that the code is up-to-date
         :param cleanup_ttl:
@@ -1952,21 +1948,11 @@ class MlrunProject(ModelObj):
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name
         artifact_path = artifact_path or self._enrich_artifact_path_with_workflow_uid()
 
-        if schedule:
-            if override or overwrite:
-                if overwrite:
-                    logger.warn(
-                        "Please use override (SDK) or --override-workflow (CLI) "
-                        "instead of overwrite (SDK) or --overwrite-schedule (CLI)"
-                        "This will be removed in 1.6.0",
-                        # TODO: Remove in 1.6.0
-                    )
-                workflow_spec.override = True
-            # Schedule = True -> use workflow_spec.schedule
-            if not isinstance(schedule, bool):
-                workflow_spec.schedule = schedule
-        else:
+        if not schedule:
             workflow_spec.schedule = None
+        elif not isinstance(schedule, bool):
+            # Schedule = True -> use workflow_spec.schedule
+            workflow_spec.schedule = schedule
 
         inner_engine = None
         if engine and engine.startswith("remote"):


### PR DESCRIPTION
Since https://github.com/mlrun/mlrun/pull/3254 , all schedule storing is idempotent - there are no more conflicting schedules, and the store function modifies the existing schedule if it exists (This logic is handled in `function.run`.
Therefore, there is no more need for the override flags in `project.run` (which ultimately calls `function.run`).
The flags were introduced in an 1.3.0 RC, so no need for deprecation.

See the "task schedule modified" log below
<img width="1178" alt="Screen Shot 2023-03-13 at 16 20 50" src="https://user-images.githubusercontent.com/12761913/224729336-07ea4e7d-050f-44da-a613-bd34a7460fe0.png">
