### PR TITLE
[CI] Skip numpy vulnerabilities test when running under python 3.7

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -15,6 +15,7 @@
 import json
 import re
 import subprocess
+import sys
 
 import click
 
@@ -200,6 +201,16 @@ class PackageTester:
                     },
                 ],
             }
+
+            python_3_7 = sys.version_info[0] == 3 and sys.version_info[1] == 7
+            if python_3_7:
+                ignored_vulnerabilities["numpy"] = [
+                    {
+                        "pattern": r"^Numpy 1.22.2  includes a fix for CVE-2021-41495:(.*)",
+                        "reason": "Numpy support for 3.7 has stopped post 1.21.x",
+                    }
+                ]
+
             filtered_vulnerabilities = []
             for vulnerability in vulnerabilities:
                 if vulnerability[0] in ignored_vulnerabilities:


### PR DESCRIPTION
Security fixes are not applied to <= python 3.7 anymore