### PR TITLE
[Model Monitoring] Adjust Grafana dashboards to use V3IO datasource instead of MLRun API

### DIFF
--- a/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-details.json
+++ b/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-details.json
@@ -1,0 +1,773 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 8,
+  "iteration": 1627466479152,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Performance",
+      "type": "link",
+      "url": "/d/9CazA-UGz/model-monitoring-performance"
+    },
+    {
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Overview",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/g0M4uh0Mz"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "iguazio",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "text": "",
+              "to": "",
+              "type": 1
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "First Request"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Request"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint ID"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Model"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Function URI"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Model Class"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Predictions/s (5 minute avg)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Average Latency (1 hour)"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "unit",
+                "value": "µs"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "name"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "hide": false,
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfilter=endpoint_id==\"$MODEL\";\nfields=endpoint_id,model,function_uri,model_class,predictions_per_second,latency_avg_1h,first_request,last_request;",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "endpoint_id": "Endpoint ID",
+              "first_request": "First Request",
+              "function": "Function",
+              "function_uri": "Function URI",
+              "last_request": "Last Request",
+              "latency_avg_1h": "Average Latency (1 hour)",
+              "latency_avg_1s": "Average Latency",
+              "latency_avg_5m": "Average Latency (1 hour)",
+              "model": "Model",
+              "model_class": "Model Class",
+              "predictions_per_second": "Predictions/s (5 minute avg)",
+              "predictions_per_second_count_1s": "Predictions/sec",
+              "tag": "Tag"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": "model-monitoring",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "text": "",
+              "to": "",
+              "type": 1
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "tvd_sum"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TVD (sum)"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "tvd_mean"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TVD (mean)"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hellinger_sum"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hellinger (sum)"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hellinger_mean"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hellinger (mean)"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kld_sum"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KLD (sum)"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kld_mean"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KLD (mean)"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 21,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "name"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "hide": false,
+          "rawQuery": true,
+          "refId": "A",
+          "target": "target_endpoint=overall_feature_analysis;endpoint_id=$MODEL;project=$PROJECT",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Overall Drift Analysis",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "endpoint_id": "Endpoint ID",
+              "first_request": "First Request",
+              "function": "Function",
+              "last_request": "Last Request",
+              "latency_avg_1s": "Average Latency",
+              "model": "Model",
+              "model_class": "Model Class",
+              "predictions_per_second_count_1s": "Predictions/sec",
+              "tag": "Tag"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": "model-monitoring",
+      "description": "Feature analysis of the latest batch",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "text": "",
+              "to": "",
+              "type": 1
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Feature"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Actual Min"
+            },
+            "properties": []
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expected Min"
+            },
+            "properties": [
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expected Mean"
+            },
+            "properties": [
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Expected Max"
+            },
+            "properties": [
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "tvd"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "TVD"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hellinger"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Hellinger"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kld"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "KLD"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 14,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Feature"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "target_endpoint=individual_feature_analysis;endpoint_id=$MODEL;project=$PROJECT",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Features Analysis",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "count": true,
+              "idx": true,
+              "model": true
+            },
+            "indexByName": {
+              "actual_max": 3,
+              "actual_mean": 2,
+              "actual_min": 1,
+              "expected_max": 4,
+              "expected_mean": 5,
+              "expected_min": 6,
+              "feature_name": 0
+            },
+            "renameByName": {
+              "actual_max": "Actual Max",
+              "actual_mean": "Actual Mean",
+              "actual_min": "Actual Min",
+              "expected_max": "Expected Min",
+              "expected_mean": "Expected Mean",
+              "expected_min": "Expected Max",
+              "feature_name": "Feature"
+            }
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODEL'  AND record_type=='endpoint_features';",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Incoming Features",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "model-monitoring",
+        "definition": "target_endpoint=list_projects",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Project",
+        "multi": false,
+        "name": "PROJECT",
+        "options": [],
+        "query": "target_endpoint=list_projects",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "iguazio",
+        "definition": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Model",
+        "multi": false,
+        "name": "MODEL",
+        "options": [],
+        "query": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Model Monitoring - Details",
+  "uid": "AohIXhAMk",
+  "version": 3
+}

--- a/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-overview.json
@@ -1,0 +1,927 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 7,
+  "iteration": 1627466285618,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "title": "Model Monitoring - Performance",
+      "type": "link",
+      "url": "/d/9CazA-UGz/model-monitoring-performance"
+    },
+        {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Details",
+      "type": "link",
+      "url": "d/AohIXhAMk/model-monitoring-details"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Endpoints",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "count"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 6,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "hide": false,
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=predictions_per_second;",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Predictions/s (5 Minute Average)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 12,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=latency_avg_1h;",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Latency (Last Hour)",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "mean"
+            ]
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=error_count;",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Errors",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "model-monitoring",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "filterable": true
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "text": "",
+              "to": "",
+              "type": 1
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Function"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Model"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Model Class"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "First Request"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              },
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last Request"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "unit",
+                "value": "dateTimeFromNow"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accuracy"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error Count"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Drift Status"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "center"
+              },
+              {
+                "id": "noValue",
+                "value": "N/A"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "from": "",
+                    "id": 0,
+                    "text": "0",
+                    "to": "",
+                    "type": 1,
+                    "value": "NO_DRIFT"
+                  },
+                  {
+                    "from": "",
+                    "id": 1,
+                    "text": "1",
+                    "to": "",
+                    "type": 1,
+                    "value": "POSSIBLE_DRIFT"
+                  },
+                  {
+                    "from": "",
+                    "id": 2,
+                    "text": "2",
+                    "to": "",
+                    "type": 1,
+                    "value": "DRIFT_DETECTED"
+                  },
+                  {
+                    "from": "",
+                    "id": 3,
+                    "text": "-1",
+                    "to": "",
+                    "type": 1,
+                    "value": "N\\A"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "rgba(255, 255, 255, 0)",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1
+                    },
+                    {
+                      "color": "red",
+                      "value": 2
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint ID"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "",
+                    "url": "/d/AohIXhAMk/model-monitoring-details?orgId=1&refresh=1m&var-PROJECT=$PROJECT&var-MODEL=﻿${__value.text}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 22,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Name"
+          }
+        ]
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "hide": false,
+          "rawQuery": true,
+          "refId": "A",
+          "target": "project=$PROJECT;target_endpoint=list_endpoints",
+          "type": "table"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Models",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "model_hash": false
+            },
+            "indexByName": {
+              "accuracy": 8,
+              "drift_status": 9,
+              "endpoint_function": 1,
+              "endpoint_id": 0,
+              "endpoint_model": 2,
+              "endpoint_model_class": 3,
+              "endpoint_tag": 4,
+              "error_count": 7,
+              "first_request": 5,
+              "last_request": 6
+            },
+            "renameByName": {
+              "accuracy": "Accuracy",
+              "drift_status": "Drift Status",
+              "endpoint_function": "Function",
+              "endpoint_id": "Endpoint ID",
+              "endpoint_model": "Model",
+              "endpoint_model_class": "Model Class",
+              "endpoint_tag": "Tag",
+              "error_count": "Error Count",
+              "first_request": "First Request",
+              "function": "Function",
+              "last_request": "Last Request",
+              "latency_avg_1s": "Average Latency",
+              "model": "Model",
+              "model_class": "Class",
+              "predictions_per_second_count_1s": "Predictions/1s",
+              "tag": "Tag"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolatePlasma",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 18,
+      "legend": {
+        "show": false
+      },
+      "pluginVersion": "7.2.0",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;",
+          "type": "timeserie"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Predictions/s (5 Minute Average)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "transparent": true,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolatePlasma",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "timeseries",
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "µs"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 19,
+      "legend": {
+        "show": false
+      },
+      "pluginVersion": "7.2.0",
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;",
+          "type": "timeserie"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Latency (1 Hour)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "transparent": true,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "short",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "refId": "A",
+          "target": "select metric",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "model-monitoring",
+        "definition": "target_endpoint=list_projects",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Project",
+        "multi": false,
+        "name": "PROJECT",
+        "options": [],
+        "query": "target_endpoint=list_projects",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Model Monitoring - Overview",
+  "uid": "g0M4uh0Mz",
+  "version": 2
+}

--- a/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-performance.json
+++ b/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-performance.json
@@ -1,0 +1,593 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 9,
+  "iteration": 1627466092078,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "title": "Model Monitoring - Overview",
+      "type": "link",
+      "url": "d/g0M4uh0Mz/model-monitoring-overview"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Details",
+      "type": "link",
+      "url": "d/AohIXhAMk/model-monitoring-details"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODEL'  AND record_type=='drift_measures';",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Drift Measures",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_5m,latency_avg_1h;\nfilter=endpoint_id=='$MODEL';",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;\nfilter=endpoint_id=='$MODEL';",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Predictions/s (5 minute average)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_count_5m,predictions_count_1h;\nfilter=endpoint_id=='$MODEL';",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Predictions Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "iguazio",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 250,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb; container=users; table=pipelines/$PROJECT/model-endpoints/events; filter=endpoint_id=='$MODEL'  AND record_type=='custom_metrics';",
+          "type": "timeserie"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Custom Metrics",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "model-monitoring",
+        "definition": "target_endpoint=list_projects",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Project",
+        "multi": false,
+        "name": "PROJECT",
+        "options": [],
+        "query": "target_endpoint=list_projects",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "iguazio",
+        "definition": "backend=kv;container=users;table=pipelines/$PROJECT/model-endpoints/endpoints;fields=endpoint_id;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Model",
+        "multi": false,
+        "name": "MODEL",
+        "options": [],
+        "query": "backend=kv;container=users;table=pipelines/$PROJECT/model-endpoints/endpoints;fields=endpoint_id;",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Model Monitoring - Performance",
+  "uid": "9CazA-UGz",
+  "version": 2
+}

--- a/docs/monitoring/dashboards/model-monitoring-details.json
+++ b/docs/monitoring/dashboards/model-monitoring-details.json
@@ -3,63 +3,66 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
-  "iteration": 1627466479152,
+  "id": 18,
   "links": [
     {
       "icon": "external link",
       "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "targetBlank": true,
       "title": "Model Monitoring - Performance",
       "type": "link",
       "url": "/d/9CazA-UGz/model-monitoring-performance"
     },
     {
-      "icon": "dashboard",
-      "includeVars": false,
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "targetBlank": true,
       "title": "Model Monitoring - Overview",
-      "tooltip": "",
       "type": "link",
-      "url": "/d/g0M4uh0Mz"
+      "url": "d/g0M4uh0Mz/model-monitoring-overview"
     }
   ],
+  "liveNow": false,
   "panels": [
     {
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {
-            "align": null,
+            "align": "auto",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "text": "",
-              "to": "",
-              "type": 1
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -191,8 +194,15 @@
         "x": 0,
         "y": 0
       },
-      "id": 12,
+      "id": 22,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": [
           {
@@ -201,19 +211,20 @@
           }
         ]
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfilter=endpoint_id==\"$MODEL\";\nfields=endpoint_id,model,function_uri,model_class,predictions_per_second,latency_avg_1h,first_request,last_request;",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfilter=endpoint_id==\"$MODELENDPOINT\";\nfields=endpoint_id,model,function_uri,model_class,predictions_per_second,latency_avg_1h,first_request,last_request;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "",
       "transformations": [
         {
           "id": "organize",
@@ -242,24 +253,20 @@
       "type": "table"
     },
     {
-      "datasource": "model-monitoring",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {
-            "align": null,
+            "align": "auto",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "text": "",
-              "to": "",
-              "type": 1
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -370,6 +377,22 @@
                 "value": "center"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "drift_measures"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": false
+              },
+              {
+                "id": "mappings",
+                "value": []
+              }
+            ]
           }
         ]
       },
@@ -379,8 +402,15 @@
         "x": 0,
         "y": 3
       },
-      "id": 21,
+      "id": 25,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": [
           {
@@ -389,35 +419,42 @@
           }
         ]
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "target_endpoint=overall_feature_analysis;endpoint_id=$MODEL;project=$PROJECT",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfilter=endpoint_id==\"$MODELENDPOINT\";\nfields=drift_measures;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Overall Drift Analysis",
       "transformations": [
         {
-          "id": "organize",
+          "id": "extractFields",
           "options": {
-            "excludeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "endpoint_id": "Endpoint ID",
-              "first_request": "First Request",
-              "function": "Function",
-              "last_request": "Last Request",
-              "latency_avg_1s": "Average Latency",
-              "model": "Model",
-              "model_class": "Model Class",
-              "predictions_per_second_count_1s": "Predictions/sec",
-              "tag": "Tag"
+            "format": "json",
+            "replace": false,
+            "source": "drift_measures"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "tvd_sum",
+                "tvd_mean",
+                "hellinger_sum",
+                "hellinger_mean",
+                "kld_sum",
+                "kld_mean"
+              ]
             }
           }
         }
@@ -426,24 +463,20 @@
       "type": "table"
     },
     {
-      "datasource": "model-monitoring",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "description": "Feature analysis of the latest batch",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "align": "center",
             "displayMode": "auto",
-            "filterable": false
+            "filterable": false,
+            "inspect": false
           },
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "text": "",
-              "to": "",
-              "type": 1
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -459,20 +492,6 @@
           }
         },
         "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Feature"
-            },
-            "properties": []
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Actual Min"
-            },
-            "properties": []
-          },
           {
             "matcher": {
               "id": "byName",
@@ -553,55 +572,332 @@
         "x": 0,
         "y": 6
       },
-      "id": 14,
+      "id": 29,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": [
           {
-            "desc": false,
-            "displayName": "Feature"
+            "desc": true,
+            "displayName": "Field"
           }
         ]
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
-          "target": "target_endpoint=individual_feature_analysis;endpoint_id=$MODEL;project=$PROJECT",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfilter=endpoint_id==\"$MODELENDPOINT\";\nfields= current_stats;",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
+          "hide": false,
+          "refId": "B",
+          "target": "backend=kv; container=users; table=pipelines/$PROJECT/model-endpoints/endpoints; filter=endpoint_id==\"$MODELENDPOINT\"; fields= feature_stats;",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
+          "hide": false,
+          "refId": "C",
+          "target": "backend=kv; container=users; table=pipelines/$PROJECT/model-endpoints/endpoints; filter=endpoint_id==\"$MODELENDPOINT\"; fields= drift_measures;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Features Analysis",
       "transformations": [
         {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "replace": false,
+            "source": "current_stats"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "source": "feature_stats"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "replace": false,
+            "source": "drift_measures"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "labelsToFields": false,
+            "mode": "seriesToRows",
+            "reducers": [
+              "allValues"
+            ]
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "feature_stats"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "current_stats"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "timestamp"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "drift_measures"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "kld_sum"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "kld_mean"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "tvd_mean"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "tvd_sum"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "hellinger_sum"
+                  }
+                },
+                "fieldName": "Field"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "hellinger_mean"
+                  }
+                },
+                "fieldName": "Field"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "replace": false,
+            "source": "All values"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Field",
+                "0",
+                "1",
+                "2"
+              ]
+            }
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "replace": false,
+            "source": "0"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "1"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "2"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Field",
+                "mean 1",
+                "min 1",
+                "max 1",
+                "mean 2",
+                "min 2",
+                "tvd",
+                "hellinger",
+                "kld",
+                "max 2"
+              ]
+            }
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mean 1",
+            "renamePattern": "Actual Mean"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "min 1",
+            "renamePattern": "Actual Min"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "max 1",
+            "renamePattern": "Actual Max"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mean 2",
+            "renamePattern": "Expected Mean"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "min 2",
+            "renamePattern": "Expected Min"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "max 2",
+            "renamePattern": "Expected Max"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "tvd",
+            "renamePattern": "TVD"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "hellinger",
+            "renamePattern": "Hellinger"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "kld",
+            "renamePattern": "KLD"
+          }
+        },
+        {
           "id": "organize",
           "options": {
-            "excludeByName": {
-              "count": true,
-              "idx": true,
-              "model": true
-            },
+            "excludeByName": {},
             "indexByName": {
-              "actual_max": 3,
-              "actual_mean": 2,
-              "actual_min": 1,
-              "expected_max": 4,
-              "expected_mean": 5,
-              "expected_min": 6,
-              "feature_name": 0
+              "Actual Max": 6,
+              "Actual Mean": 2,
+              "Actual Min": 4,
+              "Expected Max": 5,
+              "Expected Mean": 1,
+              "Expected Min": 3,
+              "Field": 0,
+              "Hellinger": 8,
+              "KLD": 9,
+              "TVD": 7
             },
-            "renameByName": {
-              "actual_max": "Actual Max",
-              "actual_mean": "Actual Mean",
-              "actual_min": "Actual Min",
-              "expected_max": "Expected Min",
-              "expected_mean": "Expected Mean",
-              "expected_min": "Expected Max",
-              "feature_name": "Feature"
-            }
+            "renameByName": {}
           }
         }
       ],
@@ -613,12 +909,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "iguazio",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
       },
       "fill": 1,
       "fillGradient": 1,
@@ -649,7 +942,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -659,16 +952,18 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODEL'  AND record_type=='endpoint_features';",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODELENDPOINT'  AND record_type=='endpoint_features';",
           "type": "timeserie"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Incoming Features",
       "tooltip": {
         "shared": true,
@@ -679,46 +974,39 @@
       "transparent": true,
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 26,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": "model-monitoring",
+        "datasource": {
+          "type": "grafana-simple-json-datasource",
+          "uid": "PEC14ECF472278438"
+        },
         "definition": "target_endpoint=list_projects",
         "hide": 0,
         "includeAll": false,
@@ -727,26 +1015,27 @@
         "name": "PROJECT",
         "options": [],
         "query": "target_endpoint=list_projects",
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {},
-        "datasource": "iguazio",
+        "datasource": {
+          "type": "grafana-simple-json-datasource",
+          "uid": "PiBy-ta4z"
+        },
         "definition": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
         "hide": 0,
         "includeAll": false,
-        "label": "Model",
+        "label": "Model Endpoint",
         "multi": false,
-        "name": "MODEL",
+        "name": "MODELENDPOINT",
         "options": [],
         "query": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
         "refresh": 1,
@@ -754,7 +1043,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -769,5 +1057,6 @@
   "timezone": "",
   "title": "Model Monitoring - Details",
   "uid": "AohIXhAMk",
-  "version": 3
+  "version": 2,
+  "weekStart": ""
 }

--- a/docs/monitoring/dashboards/model-monitoring-details.json
+++ b/docs/monitoring/dashboards/model-monitoring-details.json
@@ -49,10 +49,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -214,10 +211,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "hide": false,
           "rawQuery": true,
           "refId": "A",
@@ -253,10 +247,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -422,10 +413,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "hide": false,
           "rawQuery": true,
           "refId": "A",
@@ -463,10 +451,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "description": "Feature analysis of the latest batch",
       "fieldConfig": {
         "defaults": {
@@ -592,30 +577,21 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfilter=endpoint_id==\"$MODELENDPOINT\";\nfields= current_stats;",
           "type": "table"
         },
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "hide": false,
           "refId": "B",
           "target": "backend=kv; container=users; table=pipelines/$PROJECT/model-endpoints/endpoints; filter=endpoint_id==\"$MODELENDPOINT\"; fields= feature_stats;",
           "type": "table"
         },
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "hide": false,
           "refId": "C",
           "target": "backend=kv; container=users; table=pipelines/$PROJECT/model-endpoints/endpoints; filter=endpoint_id==\"$MODELENDPOINT\"; fields= drift_measures;",
@@ -909,10 +885,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fill": 1,
       "fillGradient": 1,
       "gridPos": {
@@ -952,10 +925,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODELENDPOINT'  AND record_type=='endpoint_features';",
@@ -1003,10 +973,7 @@
     "list": [
       {
         "current": {},
-        "datasource": {
-          "type": "grafana-simple-json-datasource",
-          "uid": "PEC14ECF472278438"
-        },
+        "datasource": "model-monitoring",
         "definition": "target_endpoint=list_projects",
         "hide": 0,
         "includeAll": false,
@@ -1026,10 +993,7 @@
       },
       {
         "current": {},
-        "datasource": {
-          "type": "grafana-simple-json-datasource",
-          "uid": "PiBy-ta4z"
-        },
+        "datasource": "iguazio",
         "definition": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
         "hide": 0,
         "includeAll": false,

--- a/docs/monitoring/dashboards/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/model-monitoring-overview.json
@@ -3,20 +3,28 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
-  "iteration": 1627466285618,
+  "id": 13,
   "links": [
     {
       "icon": "external link",
@@ -28,20 +36,25 @@
       "url": "/d/9CazA-UGz/model-monitoring-performance"
     },
     {
-      "icon": "info",
+      "icon": "external link",
+      "includeVars": true,
       "keepTime": true,
       "tags": [],
-      "title": "Model Alerts",
+      "targetBlank": false,
+      "title": "Model Monitoring - Details",
       "type": "link",
-      "url": "/d/q6GvXh0Gz/model-alerts"
+      "url": "d/AohIXhAMk/model-monitoring-details"
     }
   ],
+  "liveNow": false,
   "panels": [
     {
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -80,17 +93,19 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Endpoints",
       "transformations": [
         {
@@ -106,10 +121,12 @@
       "type": "stat"
     },
     {
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -148,9 +165,13 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "hide": false,
           "rawQuery": true,
           "refId": "A",
@@ -158,17 +179,17 @@
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Predictions/s (5 Minute Average)",
       "transparent": true,
       "type": "stat"
     },
     {
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -204,17 +225,19 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=latency_avg_1h;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Average Latency (Last Hour)",
       "transformations": [
         {
@@ -230,10 +253,12 @@
       "type": "stat"
     },
     {
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "mappings": [],
           "noValue": "0",
           "thresholds": {
@@ -273,40 +298,38 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=error_count;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Errors",
       "transparent": true,
       "type": "stat"
     },
     {
-      "datasource": "model-monitoring",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "align": "center",
             "displayMode": "auto",
-            "filterable": true
+            "filterable": true,
+            "inspect": false
           },
-          "mappings": [
-            {
-              "from": "",
-              "id": 0,
-              "text": "",
-              "to": "",
-              "type": 1
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -325,7 +348,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Function"
+              "options": "function_uri"
             },
             "properties": [
               {
@@ -452,36 +475,28 @@
                 "id": "mappings",
                 "value": [
                   {
-                    "from": "",
-                    "id": 0,
-                    "text": "0",
-                    "to": "",
-                    "type": 1,
-                    "value": "NO_DRIFT"
-                  },
-                  {
-                    "from": "",
-                    "id": 1,
-                    "text": "1",
-                    "to": "",
-                    "type": 1,
-                    "value": "POSSIBLE_DRIFT"
-                  },
-                  {
-                    "from": "",
-                    "id": 2,
-                    "text": "2",
-                    "to": "",
-                    "type": 1,
-                    "value": "DRIFT_DETECTED"
-                  },
-                  {
-                    "from": "",
-                    "id": 3,
-                    "text": "-1",
-                    "to": "",
-                    "type": 1,
-                    "value": "N\\A"
+                    "options": {
+                      "DRIFT_DETECTED": {
+                        "color": "red",
+                        "index": 3,
+                        "text": "2"
+                      },
+                      "NO_DRIFT": {
+                        "color": "green",
+                        "index": 2,
+                        "text": "0"
+                      },
+                      "N\\A": {
+                        "index": 1,
+                        "text": "-1"
+                      },
+                      "POSSIBLE_DRIFT": {
+                        "color": "yellow",
+                        "index": 0,
+                        "text": "1"
+                      }
+                    },
+                    "type": "value"
                   }
                 ]
               },
@@ -543,6 +558,13 @@
       },
       "id": 22,
       "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
         "showHeader": true,
         "sortBy": [
           {
@@ -551,18 +573,20 @@
           }
         ]
       },
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "project=$PROJECT;target_endpoint=list_endpoints",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id,model,function_uri,model_class,first_request,last_request,error_count,drift_status;",
           "type": "table"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Models",
       "transformations": [
         {
@@ -572,16 +596,13 @@
               "model_hash": false
             },
             "indexByName": {
-              "accuracy": 8,
-              "drift_status": 9,
-              "endpoint_function": 1,
               "endpoint_id": 0,
-              "endpoint_model": 2,
-              "endpoint_model_class": 3,
-              "endpoint_tag": 4,
-              "error_count": 7,
-              "first_request": 5,
-              "last_request": 6
+              "error_count": 6,
+              "first_request": 4,
+              "function_uri": 1,
+              "last_request": 5,
+              "model": 2,
+              "model_class": 3
             },
             "renameByName": {
               "accuracy": "Accuracy",
@@ -594,6 +615,7 @@
               "error_count": "Error Count",
               "first_request": "First Request",
               "function": "Function",
+              "function_uri": "Function",
               "last_request": "Last Request",
               "latency_avg_1s": "Average Latency",
               "model": "Model",
@@ -607,10 +629,7 @@
       "type": "table"
     },
     {
-      "cards": {
-        "cardPadding": null,
-        "cardRound": null
-      },
+      "cards": {},
       "color": {
         "cardColor": "#b4ff00",
         "colorScale": "sqrt",
@@ -619,23 +638,21 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
           }
         },
         "overrides": []
@@ -653,18 +670,57 @@
       "legend": {
         "show": false
       },
-      "pluginVersion": "7.2.0",
+      "options": {
+        "calculate": true,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Plasma",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.2.2",
       "reverseYBuckets": false,
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
           "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;",
           "type": "timeserie"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Predictions/s (5 Minute Average)",
       "tooltip": {
         "show": true,
@@ -675,26 +731,15 @@
       "xAxis": {
         "show": true
       },
-      "xBucketNumber": null,
-      "xBucketSize": null,
       "yAxis": {
-        "decimals": null,
         "format": "short",
         "logBase": 1,
-        "max": null,
-        "min": null,
-        "show": true,
-        "splitFactor": null
+        "show": true
       },
-      "yBucketBound": "auto",
-      "yBucketNumber": null,
-      "yBucketSize": null
+      "yBucketBound": "auto"
     },
     {
-      "cards": {
-        "cardPadding": null,
-        "cardRound": null
-      },
+      "cards": {},
       "color": {
         "cardColor": "#b4ff00",
         "colorScale": "sqrt",
@@ -703,39 +748,24 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": "iguazio",
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
+      },
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byType",
-              "options": "number"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "µs"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 6,
@@ -750,18 +780,57 @@
       "legend": {
         "show": false
       },
-      "pluginVersion": "7.2.0",
+      "options": {
+        "calculate": true,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#b4ff00",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Plasma",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.2.2",
       "reverseYBuckets": false,
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "rawQuery": true,
           "refId": "A",
           "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;",
           "type": "timeserie"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Average Latency (1 Hour)",
       "tooltip": {
         "show": true,
@@ -772,32 +841,21 @@
       "xAxis": {
         "show": true
       },
-      "xBucketNumber": null,
-      "xBucketSize": null,
       "yAxis": {
-        "decimals": null,
         "format": "short",
         "logBase": 1,
-        "max": null,
-        "min": null,
-        "show": true,
-        "splitFactor": null
+        "show": true
       },
-      "yBucketBound": "auto",
-      "yBucketNumber": null,
-      "yBucketSize": null
+      "yBucketBound": "auto"
     },
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "iguazio",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "grafana-simple-json-datasource",
+        "uid": "PiBy-ta4z"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -825,7 +883,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.2.0",
+      "pluginVersion": "9.2.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -835,15 +893,17 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "grafana-simple-json-datasource",
+            "uid": "PiBy-ta4z"
+          },
           "refId": "A",
           "target": "select metric",
           "type": "timeserie"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Errors",
       "tooltip": {
         "shared": true,
@@ -853,46 +913,39 @@
       "transparent": true,
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {},
-        "datasource": "model-monitoring",
+        "datasource": {
+          "type": "grafana-simple-json-datasource",
+          "uid": "PEC14ECF472278438"
+        },
         "definition": "target_endpoint=list_projects",
         "hide": 0,
         "includeAll": false,
@@ -906,7 +959,6 @@
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -921,5 +973,6 @@
   "timezone": "",
   "title": "Model Monitoring - Overview",
   "uid": "g0M4uh0Mz",
-  "version": 2
+  "version": 9,
+  "weekStart": ""
 }

--- a/docs/monitoring/dashboards/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/model-monitoring-overview.json
@@ -291,7 +291,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "sum"
           ],
           "fields": "",
           "values": false

--- a/docs/monitoring/dashboards/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/model-monitoring-overview.json
@@ -49,10 +49,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -96,10 +93,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource": "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=endpoint_id;",
@@ -121,10 +115,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -168,10 +159,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource":  "iguazio",
           "hide": false,
           "rawQuery": true,
           "refId": "A",
@@ -184,10 +172,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+    "datasource": "iguazio",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -228,10 +213,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource":  "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=latency_avg_1h;",
@@ -253,10 +235,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -301,10 +280,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource":  "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=error_count;",
@@ -316,10 +292,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -576,10 +549,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource":  "iguazio",
           "hide": false,
           "rawQuery": true,
           "refId": "A",
@@ -638,10 +608,7 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -711,10 +678,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource":  "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;",
@@ -748,10 +712,7 @@
         "mode": "spectrum"
       },
       "dataFormat": "timeseries",
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -821,10 +782,7 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+"datasource":  "iguazio",
           "rawQuery": true,
           "refId": "A",
           "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;",
@@ -853,10 +811,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -893,10 +848,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+        "datasource": "iguazio",
           "refId": "A",
           "target": "select metric",
           "type": "timeserie"
@@ -942,10 +894,7 @@
     "list": [
       {
         "current": {},
-        "datasource": {
-          "type": "grafana-simple-json-datasource",
-          "uid": "PEC14ECF472278438"
-        },
+        "datasource": "model-monitoring",
         "definition": "target_endpoint=list_projects",
         "hide": 0,
         "includeAll": false,

--- a/docs/monitoring/dashboards/model-monitoring-performance.json
+++ b/docs/monitoring/dashboards/model-monitoring-performance.json
@@ -21,7 +21,7 @@
     {
       "asDropdown": true,
       "icon": "external link",
-      "includeVars": false,
+      "includeVars": true,
       "keepTime": true,
       "tags": [],
       "title": "Model Monitoring - Overview",
@@ -34,7 +34,7 @@
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Model Monitoring Details",
+      "title": "Model Monitoring - Details",
       "type": "link",
       "url": "d/AohIXhAMk/model-monitoring-details"
     }
@@ -93,7 +93,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODEL'  AND record_type=='drift_measures';",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfilter=endpoint_id=='$MODELENDPOINT'  AND record_type=='drift_measures';",
           "type": "timeserie"
         }
       ],
@@ -190,7 +190,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_5m,latency_avg_1h;\nfilter=endpoint_id=='$MODEL';",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_5m,latency_avg_1h;\nfilter=endpoint_id=='$MODELENDPOINT';",
           "type": "timeserie"
         }
       ],
@@ -286,7 +286,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;\nfilter=endpoint_id=='$MODEL';",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;\nfilter=endpoint_id=='$MODELENDPOINT';",
           "type": "timeserie"
         }
       ],
@@ -382,7 +382,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_count_5m,predictions_count_1h;\nfilter=endpoint_id=='$MODEL';",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_count_5m,predictions_count_1h;\nfilter=endpoint_id=='$MODELENDPOINT';",
           "type": "timeserie"
         }
       ],
@@ -481,7 +481,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb; container=users; table=pipelines/$PROJECT/model-endpoints/events; filter=endpoint_id=='$MODEL'  AND record_type=='custom_metrics';",
+          "target": "backend=tsdb; container=users; table=pipelines/$PROJECT/model-endpoints/events; filter=endpoint_id=='$MODELENDPOINT'  AND record_type=='custom_metrics';",
           "type": "timeserie"
         }
       ],
@@ -564,9 +564,9 @@
         "definition": "backend=kv;container=users;table=pipelines/$PROJECT/model-endpoints/endpoints;fields=endpoint_id;",
         "hide": 0,
         "includeAll": false,
-        "label": "Model",
+        "label": "Model Endpoint",
         "multi": false,
-        "name": "MODEL",
+        "name": "MODELENDPOINT",
         "options": [],
         "query": "backend=kv;container=users;table=pipelines/$PROJECT/model-endpoints/endpoints;fields=endpoint_id;",
         "refresh": 0,

--- a/mlrun/api/api/endpoints/grafana_proxy.py
+++ b/mlrun/api/api/endpoints/grafana_proxy.py
@@ -13,33 +13,20 @@
 # limitations under the License.
 #
 import asyncio
-import json
+import warnings
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import List, Union
 
-import numpy as np
-import pandas as pd
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import mlrun.api.crud
+import mlrun.api.crud.model_monitoring.grafana
 import mlrun.api.schemas
 import mlrun.api.utils.auth.verifier
 from mlrun.api.api import deps
-from mlrun.api.schemas import (
-    GrafanaColumn,
-    GrafanaDataPoint,
-    GrafanaNumberColumn,
-    GrafanaTable,
-    GrafanaTimeSeriesTarget,
-    ProjectsFormat,
-)
-from mlrun.api.utils.singletons.project_member import get_project_member
-from mlrun.errors import MLRunBadRequestError
-from mlrun.utils import config, logger
-from mlrun.utils.model_monitoring import parse_model_endpoint_store_prefix
-from mlrun.utils.v3io_clients import get_frames_client
+from mlrun.api.schemas import GrafanaTable, GrafanaTimeSeriesTarget
 
 router = APIRouter()
 
@@ -56,34 +43,10 @@ def grafana_proxy_model_endpoints_check_connection(
     return Response(status_code=HTTPStatus.OK.value)
 
 
-@router.post(
-    "/grafana-proxy/model-endpoints/query",
-    response_model=List[Union[GrafanaTable, GrafanaTimeSeriesTarget]],
-)
-async def grafana_proxy_model_endpoints_query(
-    request: Request,
-    auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
-) -> List[Union[GrafanaTable, GrafanaTimeSeriesTarget]]:
-    """
-    Query route for model-endpoints grafana proxy API, used for creating an interface between grafana queries and
-    model-endpoints logic.
-
-    This implementation requires passing target_endpoint query parameter in order to dispatch different
-    model-endpoint monitoring functions.
-    """
-    body = await request.json()
-    query_parameters = _parse_query_parameters(body)
-    _validate_query_parameters(query_parameters, SUPPORTED_QUERY_FUNCTIONS)
-    query_parameters = _drop_grafana_escape_chars(query_parameters)
-
-    # At this point everything is validated and we can access everything that is needed without performing all previous
-    # checks again.
-    target_endpoint = query_parameters["target_endpoint"]
-    function = NAME_TO_QUERY_FUNCTION_DICTIONARY[target_endpoint]
-    if asyncio.iscoroutinefunction(function):
-        return await function(body, query_parameters, auth_info)
-    result = await run_in_threadpool(function, body, query_parameters, auth_info)
-    return result
+NAME_TO_SEARCH_FUNCTION_DICTIONARY = {
+    "list_projects": mlrun.api.crud.model_monitoring.grafana.grafana_list_projects,
+}
+SUPPORTED_SEARCH_FUNCTIONS = set(NAME_TO_SEARCH_FUNCTION_DICTIONARY)
 
 
 @router.post("/grafana-proxy/model-endpoints/search", response_model=List[str])
@@ -101,9 +64,13 @@ async def grafana_proxy_model_endpoints_search(
     """
     mlrun.api.crud.ModelEndpoints().get_access_key(auth_info)
     body = await request.json()
-    query_parameters = _parse_search_parameters(body)
+    query_parameters = mlrun.api.crud.model_monitoring.grafana.parse_search_parameters(
+        body
+    )
 
-    _validate_query_parameters(query_parameters, SUPPORTED_SEARCH_FUNCTIONS)
+    mlrun.api.crud.model_monitoring.grafana.validate_query_parameters(
+        query_parameters, SUPPORTED_SEARCH_FUNCTIONS
+    )
 
     # At this point everything is validated and we can access everything that is needed without performing all previous
     # checks again.
@@ -115,394 +82,56 @@ async def grafana_proxy_model_endpoints_search(
     return result
 
 
-def grafana_list_projects(
-    db_session: Session, auth_info: mlrun.api.schemas.AuthInfo
-) -> List[str]:
-    projects_output = get_project_member().list_projects(
-        db_session, format_=ProjectsFormat.name_only, leader_session=auth_info.session
-    )
-    return projects_output.projects
-
-
-async def grafana_list_endpoints(
-    body: Dict[str, Any],
-    query_parameters: Dict[str, str],
-    auth_info: mlrun.api.schemas.AuthInfo,
-) -> List[GrafanaTable]:
-    project = query_parameters.get("project")
-
-    # Filters
-    model = query_parameters.get("model", None)
-    function = query_parameters.get("function", None)
-    labels = query_parameters.get("labels", "")
-    labels = labels.split(",") if labels else []
-
-    # Metrics to include
-    metrics = query_parameters.get("metrics", "")
-    metrics = metrics.split(",") if metrics else []
-
-    # Time range for metrics
-    start = body.get("rangeRaw", {}).get("start", "now-1h")
-    end = body.get("rangeRaw", {}).get("end", "now")
-
-    if project:
-        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
-            project,
-            mlrun.api.schemas.AuthorizationAction.read,
-            auth_info,
-        )
-    endpoint_list = await run_in_threadpool(
-        mlrun.api.crud.ModelEndpoints().list_model_endpoints,
-        auth_info=auth_info,
-        project=project,
-        model=model,
-        function=function,
-        labels=labels,
-        metrics=metrics,
-        start=start,
-        end=end,
-    )
-    allowed_endpoints = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
-        endpoint_list.endpoints,
-        lambda _endpoint: (
-            _endpoint.metadata.project,
-            _endpoint.metadata.uid,
-        ),
-        auth_info,
-    )
-    endpoint_list.endpoints = allowed_endpoints
-
-    columns = [
-        GrafanaColumn(text="endpoint_id", type="string"),
-        GrafanaColumn(text="endpoint_function", type="string"),
-        GrafanaColumn(text="endpoint_model", type="string"),
-        GrafanaColumn(text="endpoint_model_class", type="string"),
-        GrafanaColumn(text="first_request", type="time"),
-        GrafanaColumn(text="last_request", type="time"),
-        GrafanaColumn(text="accuracy", type="number"),
-        GrafanaColumn(text="error_count", type="number"),
-        GrafanaColumn(text="drift_status", type="number"),
-    ]
-
-    metric_columns = []
-
-    found_metrics = set()
-    for endpoint in endpoint_list.endpoints:
-        if endpoint.status.metrics is not None:
-            for key in endpoint.status.metrics.keys():
-                if key not in found_metrics:
-                    found_metrics.add(key)
-                    metric_columns.append(GrafanaColumn(text=key, type="number"))
-
-    columns = columns + metric_columns
-    table = GrafanaTable(columns=columns)
-
-    for endpoint in endpoint_list.endpoints:
-        row = [
-            endpoint.metadata.uid,
-            endpoint.spec.function_uri,
-            endpoint.spec.model,
-            endpoint.spec.model_class,
-            endpoint.status.first_request,
-            endpoint.status.last_request,
-            endpoint.status.accuracy,
-            endpoint.status.error_count,
-            endpoint.status.drift_status,
-        ]
-
-        if endpoint.status.metrics is not None and metric_columns:
-            for metric_column in metric_columns:
-                row.append(endpoint.status.metrics[metric_column.text])
-
-        table.add_row(*row)
-
-    return [table]
-
-
-async def grafana_individual_feature_analysis(
-    body: Dict[str, Any],
-    query_parameters: Dict[str, str],
-    auth_info: mlrun.api.schemas.AuthInfo,
-):
-    endpoint_id = query_parameters.get("endpoint_id")
-    project = query_parameters.get("project")
-    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
-        project,
-        endpoint_id,
-        mlrun.api.schemas.AuthorizationAction.read,
-        auth_info,
-    )
-
-    endpoint = await run_in_threadpool(
-        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
-        project=project,
-        endpoint_id=endpoint_id,
-        feature_analysis=True,
-    )
-
-    # Load JSON data from KV, make sure not to fail if a field is missing
-    feature_stats = endpoint.status.feature_stats or {}
-    current_stats = endpoint.status.current_stats or {}
-    drift_measures = endpoint.status.drift_measures or {}
-
-    table = GrafanaTable(
-        columns=[
-            GrafanaColumn(text="feature_name", type="string"),
-            GrafanaColumn(text="actual_min", type="number"),
-            GrafanaColumn(text="actual_mean", type="number"),
-            GrafanaColumn(text="actual_max", type="number"),
-            GrafanaColumn(text="expected_min", type="number"),
-            GrafanaColumn(text="expected_mean", type="number"),
-            GrafanaColumn(text="expected_max", type="number"),
-            GrafanaColumn(text="tvd", type="number"),
-            GrafanaColumn(text="hellinger", type="number"),
-            GrafanaColumn(text="kld", type="number"),
-        ]
-    )
-
-    for feature, base_stat in feature_stats.items():
-        current_stat = current_stats.get(feature, {})
-        drift_measure = drift_measures.get(feature, {})
-
-        table.add_row(
-            feature,
-            current_stat.get("min"),
-            current_stat.get("mean"),
-            current_stat.get("max"),
-            base_stat.get("min"),
-            base_stat.get("mean"),
-            base_stat.get("max"),
-            drift_measure.get("tvd"),
-            drift_measure.get("hellinger"),
-            drift_measure.get("kld"),
-        )
-
-    return [table]
-
-
-async def grafana_overall_feature_analysis(
-    body: Dict[str, Any],
-    query_parameters: Dict[str, str],
-    auth_info: mlrun.api.schemas.AuthInfo,
-):
-    endpoint_id = query_parameters.get("endpoint_id")
-    project = query_parameters.get("project")
-    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
-        project,
-        endpoint_id,
-        mlrun.api.schemas.AuthorizationAction.read,
-        auth_info,
-    )
-    endpoint = await run_in_threadpool(
-        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
-        project=project,
-        endpoint_id=endpoint_id,
-        feature_analysis=True,
-    )
-
-    table = GrafanaTable(
-        columns=[
-            GrafanaNumberColumn(text="tvd_sum"),
-            GrafanaNumberColumn(text="tvd_mean"),
-            GrafanaNumberColumn(text="hellinger_sum"),
-            GrafanaNumberColumn(text="hellinger_mean"),
-            GrafanaNumberColumn(text="kld_sum"),
-            GrafanaNumberColumn(text="kld_mean"),
-        ]
-    )
-
-    if endpoint.status.drift_measures:
-        table.add_row(
-            endpoint.status.drift_measures.get("tvd_sum"),
-            endpoint.status.drift_measures.get("tvd_mean"),
-            endpoint.status.drift_measures.get("hellinger_sum"),
-            endpoint.status.drift_measures.get("hellinger_mean"),
-            endpoint.status.drift_measures.get("kld_sum"),
-            endpoint.status.drift_measures.get("kld_mean"),
-        )
-
-    return [table]
-
-
-async def grafana_incoming_features(
-    body: Dict[str, Any],
-    query_parameters: Dict[str, str],
-    auth_info: mlrun.api.schemas.AuthInfo,
-):
-    endpoint_id = query_parameters.get("endpoint_id")
-    project = query_parameters.get("project")
-    start = body.get("rangeRaw", {}).get("from", "now-1h")
-    end = body.get("rangeRaw", {}).get("to", "now")
-
-    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
-        project,
-        endpoint_id,
-        mlrun.api.schemas.AuthorizationAction.read,
-        auth_info,
-    )
-
-    endpoint = await run_in_threadpool(
-        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
-        project=project,
-        endpoint_id=endpoint_id,
-    )
-
-    time_series = []
-
-    feature_names = endpoint.spec.feature_names
-
-    if not feature_names:
-        logger.warn(
-            "'feature_names' is either missing or not initialized in endpoint record",
-            endpoint_id=endpoint.metadata.uid,
-        )
-        return time_series
-
-    path = config.model_endpoint_monitoring.store_prefixes.default.format(
-        project=project, kind=mlrun.api.schemas.ModelMonitoringStoreKinds.EVENTS
-    )
-    _, container, path = parse_model_endpoint_store_prefix(path)
-
-    client = get_frames_client(
-        token=auth_info.data_session,
-        address=config.v3io_framesd,
-        container=container,
-    )
-
-    data: pd.DataFrame = await run_in_threadpool(
-        client.read,
-        backend="tsdb",
-        table=path,
-        columns=feature_names,
-        filter=f"endpoint_id=='{endpoint_id}'",
-        start=start,
-        end=end,
-    )
-
-    data.drop(["endpoint_id"], axis=1, inplace=True, errors="ignore")
-    data.index = data.index.astype(np.int64) // 10**6
-
-    for feature, indexed_values in data.to_dict().items():
-        target = GrafanaTimeSeriesTarget(target=feature)
-        for index, value in indexed_values.items():
-            data_point = GrafanaDataPoint(value=float(value), timestamp=index)
-            target.add_data_point(data_point)
-        time_series.append(target)
-
-    return time_series
-
-
-def _parse_query_parameters(request_body: Dict[str, Any]) -> Dict[str, str]:
-    """
-    This function searches for the target field in Grafana's SimpleJson json. Once located, the target string is
-    parsed by splitting on semi-colons (;). Each part in the resulting list is then split by an equal sign (=) to be
-    read as key-value pairs.
-    """
-
-    # Try to get the target
-    targets = request_body.get("targets", [])
-
-    if len(targets) > 1:
-        logger.warn(
-            f"The 'targets' list contains more then one element ({len(targets)}), all targets except the first one are "
-            f"ignored."
-        )
-
-    target_obj = targets[0] if targets else {}
-    target_query = target_obj.get("target") if target_obj else ""
-
-    if not target_query:
-        raise MLRunBadRequestError(f"Target missing in request body:\n {request_body}")
-
-    parameters = _parse_parameters(target_query)
-
-    return parameters
-
-
-def _parse_search_parameters(request_body: Dict[str, Any]) -> Dict[str, str]:
-    """
-    This function searches for the target field in Grafana's SimpleJson json. Once located, the target string is
-    parsed by splitting on semi-colons (;). Each part in the resulting list is then split by an equal sign (=) to be
-    read as key-value pairs.
-    """
-
-    # Try to get the target
-    target = request_body.get("target")
-
-    if not target:
-        raise MLRunBadRequestError(f"Target missing in request body:\n {request_body}")
-
-    parameters = _parse_parameters(target)
-
-    return parameters
-
-
-def _parse_parameters(target_query):
-    parameters = {}
-    for query in filter(lambda q: q, target_query.split(";")):
-        query_parts = query.split("=")
-        if len(query_parts) < 2:
-            raise MLRunBadRequestError(
-                f"Query must contain both query key and query value. Expected query_key=query_value, found {query} "
-                f"instead."
-            )
-        parameters[query_parts[0]] = query_parts[1]
-    return parameters
-
-
-def _drop_grafana_escape_chars(query_parameters: Dict[str, str]):
-    query_parameters = dict(query_parameters)
-    endpoint_id = query_parameters.get("endpoint_id")
-    if endpoint_id is not None:
-        query_parameters["endpoint_id"] = endpoint_id.replace("\\", "")
-    return query_parameters
-
-
-def _validate_query_parameters(
-    query_parameters: Dict[str, str], supported_endpoints: Optional[Set[str]] = None
-):
-    """Validates the parameters sent via Grafana's SimpleJson query"""
-    if "target_endpoint" not in query_parameters:
-        raise MLRunBadRequestError(
-            f"Expected 'target_endpoint' field in query, found {query_parameters} instead"
-        )
-
-    if (
-        supported_endpoints is not None
-        and query_parameters["target_endpoint"] not in supported_endpoints
-    ):
-        raise MLRunBadRequestError(
-            f"{query_parameters['target_endpoint']} unsupported in query parameters: {query_parameters}. "
-            f"Currently supports: {','.join(supported_endpoints)}"
-        )
-
-
-def _json_loads_or_default(string: Optional[str], default: Any):
-    if string is None:
-        return default
-    obj = json.loads(string)
-    if not obj:
-        return default
-    return obj
-
-
+#
 NAME_TO_QUERY_FUNCTION_DICTIONARY = {
-    "list_endpoints": grafana_list_endpoints,
-    "individual_feature_analysis": grafana_individual_feature_analysis,
-    "overall_feature_analysis": grafana_overall_feature_analysis,
-    "incoming_features": grafana_incoming_features,
-}
-
-NAME_TO_SEARCH_FUNCTION_DICTIONARY = {
-    "list_projects": grafana_list_projects,
+    "list_endpoints": mlrun.api.crud.model_monitoring.grafana.grafana_list_endpoints,
+    "individual_feature_analysis": mlrun.api.crud.model_monitoring.grafana.grafana_individual_feature_analysis,
+    "overall_feature_analysis": mlrun.api.crud.model_monitoring.grafana.grafana_overall_feature_analysis,
+    "incoming_features": mlrun.api.crud.model_monitoring.grafana.grafana_incoming_features,
 }
 
 SUPPORTED_QUERY_FUNCTIONS = set(NAME_TO_QUERY_FUNCTION_DICTIONARY.keys())
-SUPPORTED_SEARCH_FUNCTIONS = set(NAME_TO_SEARCH_FUNCTION_DICTIONARY)
+
+
+@router.post(
+    "/grafana-proxy/model-endpoints/query",
+    response_model=List[Union[GrafanaTable, GrafanaTimeSeriesTarget]],
+)
+async def grafana_proxy_model_endpoints_query(
+    request: Request,
+    auth_info: mlrun.api.schemas.AuthInfo = Depends(deps.authenticate_request),
+) -> List[Union[GrafanaTable, GrafanaTimeSeriesTarget]]:
+    """
+    Query route for model-endpoints grafana proxy API, used for creating an interface between grafana queries and
+    model-endpoints logic.
+
+    This implementation requires passing target_endpoint query parameter in order to dispatch different
+    model-endpoint monitoring functions.
+    """
+    warnings.warn(
+        "This api is deprecated in 1.3.0 and will be removed in 1.5.0. "
+        "Please update grafana model monitoring dashboards that use a different data source",
+        # TODO: remove in 1.5.0
+        FutureWarning,
+    )
+    body = await request.json()
+    query_parameters = mlrun.api.crud.model_monitoring.grafana.parse_query_parameters(
+        body
+    )
+    mlrun.api.crud.model_monitoring.grafana.validate_query_parameters(
+        query_parameters, SUPPORTED_QUERY_FUNCTIONS
+    )
+    query_parameters = (
+        mlrun.api.crud.model_monitoring.grafana.drop_grafana_escape_chars(
+            query_parameters
+        )
+    )
+
+    # At this point everything is validated and we can access everything that is needed without performing all previous
+    # checks again.
+    target_endpoint = query_parameters["target_endpoint"]
+    function = NAME_TO_QUERY_FUNCTION_DICTIONARY[target_endpoint]
+    if asyncio.iscoroutinefunction(function):
+        return await function(body, query_parameters, auth_info)
+    result = await run_in_threadpool(function, body, query_parameters, auth_info)
+    return result

--- a/mlrun/api/crud/model_monitoring/grafana.py
+++ b/mlrun/api/crud/model_monitoring/grafana.py
@@ -1,0 +1,419 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Any, Dict, List, Optional, Set
+
+import numpy as np
+import pandas as pd
+from fastapi.concurrency import run_in_threadpool
+from sqlalchemy.orm import Session
+
+import mlrun.api.crud
+import mlrun.api.schemas
+import mlrun.api.utils.auth.verifier
+import mlrun.model_monitoring
+from mlrun.api.schemas import (
+    GrafanaColumn,
+    GrafanaDataPoint,
+    GrafanaNumberColumn,
+    GrafanaTable,
+    GrafanaTimeSeriesTarget,
+    ProjectsFormat,
+)
+from mlrun.api.utils.singletons.project_member import get_project_member
+from mlrun.errors import MLRunBadRequestError
+from mlrun.utils import config, logger
+from mlrun.utils.model_monitoring import parse_model_endpoint_store_prefix
+from mlrun.utils.v3io_clients import get_frames_client
+
+
+def grafana_list_projects(
+    db_session: Session, auth_info: mlrun.api.schemas.AuthInfo
+) -> List[str]:
+    """
+    List available project names. Will be used as a filter in each grafana dashboard.
+    :param db_session:        A session that manages the current dialog with the database.
+    :param auth_info:         The auth info of the request.
+
+    :return: List of available project names.
+    """
+    projects_output = get_project_member().list_projects(
+        db_session, format_=ProjectsFormat.name_only, leader_session=auth_info.session
+    )
+    return projects_output.projects
+
+
+# TODO: remove in 1.5.0 the following functions: grafana_list_endpoints, grafana_individual_feature_analysis,
+#  grafana_overall_feature_analysis, grafana_income_features, parse_query_parameters, drop_grafana_escape_chars,
+
+
+async def grafana_list_endpoints(
+    body: Dict[str, Any],
+    query_parameters: Dict[str, str],
+    auth_info: mlrun.api.schemas.AuthInfo,
+) -> List[GrafanaTable]:
+    project = query_parameters.get("project")
+
+    # Filters
+    model = query_parameters.get("model", None)
+    function = query_parameters.get("function", None)
+    labels = query_parameters.get("labels", "")
+    labels = labels.split(",") if labels else []
+
+    # Metrics to include
+    metrics = query_parameters.get("metrics", "")
+    metrics = metrics.split(",") if metrics else []
+
+    # Time range for metrics
+    start = body.get("rangeRaw", {}).get("start", "now-1h")
+    end = body.get("rangeRaw", {}).get("end", "now")
+
+    if project:
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+            project,
+            mlrun.api.schemas.AuthorizationAction.read,
+            auth_info,
+        )
+    endpoint_list = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().list_model_endpoints,
+        auth_info=auth_info,
+        project=project,
+        model=model,
+        function=function,
+        labels=labels,
+        metrics=metrics,
+        start=start,
+        end=end,
+    )
+    allowed_endpoints = await mlrun.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
+        endpoint_list.endpoints,
+        lambda _endpoint: (
+            _endpoint.metadata.project,
+            _endpoint.metadata.uid,
+        ),
+        auth_info,
+    )
+    endpoint_list.endpoints = allowed_endpoints
+
+    columns = [
+        GrafanaColumn(text="endpoint_id", type="string"),
+        GrafanaColumn(text="endpoint_function", type="string"),
+        GrafanaColumn(text="endpoint_model", type="string"),
+        GrafanaColumn(text="endpoint_model_class", type="string"),
+        GrafanaColumn(text="first_request", type="time"),
+        GrafanaColumn(text="last_request", type="time"),
+        GrafanaColumn(text="accuracy", type="number"),
+        GrafanaColumn(text="error_count", type="number"),
+        GrafanaColumn(text="drift_status", type="number"),
+    ]
+
+    metric_columns = []
+
+    found_metrics = set()
+    for endpoint in endpoint_list.endpoints:
+        if endpoint.status.metrics is not None:
+            for key in endpoint.status.metrics.keys():
+                if key not in found_metrics:
+                    found_metrics.add(key)
+                    metric_columns.append(GrafanaColumn(text=key, type="number"))
+
+    columns = columns + metric_columns
+    table = GrafanaTable(columns=columns)
+
+    for endpoint in endpoint_list.endpoints:
+        row = [
+            endpoint.metadata.uid,
+            endpoint.spec.function_uri,
+            endpoint.spec.model,
+            endpoint.spec.model_class,
+            endpoint.status.first_request,
+            endpoint.status.last_request,
+            endpoint.status.accuracy,
+            endpoint.status.error_count,
+            endpoint.status.drift_status,
+        ]
+
+        if endpoint.status.metrics is not None and metric_columns:
+            for metric_column in metric_columns:
+                row.append(endpoint.status.metrics[metric_column.text])
+
+        table.add_row(*row)
+
+    return [table]
+
+
+async def grafana_individual_feature_analysis(
+    body: Dict[str, Any],
+    query_parameters: Dict[str, str],
+    auth_info: mlrun.api.schemas.AuthInfo,
+):
+    endpoint_id = query_parameters.get("endpoint_id")
+    project = query_parameters.get("project")
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
+        project,
+        endpoint_id,
+        mlrun.api.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+
+    endpoint = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
+        auth_info=auth_info,
+        project=project,
+        endpoint_id=endpoint_id,
+        feature_analysis=True,
+    )
+
+    # Load JSON data from KV, make sure not to fail if a field is missing
+    feature_stats = endpoint.status.feature_stats or {}
+    current_stats = endpoint.status.current_stats or {}
+    drift_measures = endpoint.status.drift_measures or {}
+
+    table = GrafanaTable(
+        columns=[
+            GrafanaColumn(text="feature_name", type="string"),
+            GrafanaColumn(text="actual_min", type="number"),
+            GrafanaColumn(text="actual_mean", type="number"),
+            GrafanaColumn(text="actual_max", type="number"),
+            GrafanaColumn(text="expected_min", type="number"),
+            GrafanaColumn(text="expected_mean", type="number"),
+            GrafanaColumn(text="expected_max", type="number"),
+            GrafanaColumn(text="tvd", type="number"),
+            GrafanaColumn(text="hellinger", type="number"),
+            GrafanaColumn(text="kld", type="number"),
+        ]
+    )
+
+    for feature, base_stat in feature_stats.items():
+        current_stat = current_stats.get(feature, {})
+        drift_measure = drift_measures.get(feature, {})
+
+        table.add_row(
+            feature,
+            current_stat.get("min"),
+            current_stat.get("mean"),
+            current_stat.get("max"),
+            base_stat.get("min"),
+            base_stat.get("mean"),
+            base_stat.get("max"),
+            drift_measure.get("tvd"),
+            drift_measure.get("hellinger"),
+            drift_measure.get("kld"),
+        )
+
+    return [table]
+
+
+async def grafana_overall_feature_analysis(
+    body: Dict[str, Any],
+    query_parameters: Dict[str, str],
+    auth_info: mlrun.api.schemas.AuthInfo,
+):
+    endpoint_id = query_parameters.get("endpoint_id")
+    project = query_parameters.get("project")
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
+        project,
+        endpoint_id,
+        mlrun.api.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+    endpoint = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
+        auth_info=auth_info,
+        project=project,
+        endpoint_id=endpoint_id,
+        feature_analysis=True,
+    )
+
+    table = GrafanaTable(
+        columns=[
+            GrafanaNumberColumn(text="tvd_sum"),
+            GrafanaNumberColumn(text="tvd_mean"),
+            GrafanaNumberColumn(text="hellinger_sum"),
+            GrafanaNumberColumn(text="hellinger_mean"),
+            GrafanaNumberColumn(text="kld_sum"),
+            GrafanaNumberColumn(text="kld_mean"),
+        ]
+    )
+
+    if endpoint.status.drift_measures:
+        table.add_row(
+            endpoint.status.drift_measures.get("tvd_sum"),
+            endpoint.status.drift_measures.get("tvd_mean"),
+            endpoint.status.drift_measures.get("hellinger_sum"),
+            endpoint.status.drift_measures.get("hellinger_mean"),
+            endpoint.status.drift_measures.get("kld_sum"),
+            endpoint.status.drift_measures.get("kld_mean"),
+        )
+
+    return [table]
+
+
+async def grafana_incoming_features(
+    body: Dict[str, Any],
+    query_parameters: Dict[str, str],
+    auth_info: mlrun.api.schemas.AuthInfo,
+):
+    endpoint_id = query_parameters.get("endpoint_id")
+    project = query_parameters.get("project")
+    start = body.get("rangeRaw", {}).get("from", "now-1h")
+    end = body.get("rangeRaw", {}).get("to", "now")
+
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.api.schemas.AuthorizationResourceTypes.model_endpoint,
+        project,
+        endpoint_id,
+        mlrun.api.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+
+    endpoint = await run_in_threadpool(
+        mlrun.api.crud.ModelEndpoints().get_model_endpoint,
+        auth_info=auth_info,
+        project=project,
+        endpoint_id=endpoint_id,
+    )
+
+    time_series = []
+
+    feature_names = endpoint.spec.feature_names
+
+    if not feature_names:
+        logger.warn(
+            "'feature_names' is either missing or not initialized in endpoint record",
+            endpoint_id=endpoint.metadata.uid,
+        )
+        return time_series
+
+    path = config.model_endpoint_monitoring.store_prefixes.default.format(
+        project=project, kind=mlrun.api.schemas.ModelMonitoringStoreKinds.EVENTS
+    )
+    _, container, path = parse_model_endpoint_store_prefix(path)
+
+    client = get_frames_client(
+        token=auth_info.data_session,
+        address=config.v3io_framesd,
+        container=container,
+    )
+
+    data: pd.DataFrame = await run_in_threadpool(
+        client.read,
+        backend="tsdb",
+        table=path,
+        columns=feature_names,
+        filter=f"endpoint_id=='{endpoint_id}'",
+        start=start,
+        end=end,
+    )
+
+    data.drop(["endpoint_id"], axis=1, inplace=True, errors="ignore")
+    data.index = data.index.astype(np.int64) // 10**6
+
+    for feature, indexed_values in data.to_dict().items():
+        target = GrafanaTimeSeriesTarget(target=feature)
+        for index, value in indexed_values.items():
+            data_point = GrafanaDataPoint(value=float(value), timestamp=index)
+            target.add_data_point(data_point)
+        time_series.append(target)
+
+    return time_series
+
+
+def parse_query_parameters(request_body: Dict[str, Any]) -> Dict[str, str]:
+    """
+    This function searches for the target field in Grafana's SimpleJson json. Once located, the target string is
+    parsed by splitting on semi-colons (;). Each part in the resulting list is then split by an equal sign (=) to be
+    read as key-value pairs.
+    """
+
+    # Try to get the target
+    targets = request_body.get("targets", [])
+
+    if len(targets) > 1:
+        logger.warn(
+            f"The 'targets' list contains more then one element ({len(targets)}), all targets except the first one are "
+            f"ignored."
+        )
+
+    target_obj = targets[0] if targets else {}
+    target_query = target_obj.get("target") if target_obj else ""
+
+    if not target_query:
+        raise MLRunBadRequestError(f"Target missing in request body:\n {request_body}")
+
+    parameters = _parse_parameters(target_query)
+
+    return parameters
+
+
+def parse_search_parameters(request_body: Dict[str, Any]) -> Dict[str, str]:
+    """
+    This function searches for the target field in Grafana's SimpleJson json. Once located, the target string is
+    parsed by splitting on semi-colons (;). Each part in the resulting list is then split by an equal sign (=) to be
+    read as key-value pairs.
+    """
+
+    # Try to get the target
+    target = request_body.get("target")
+
+    if not target:
+        raise MLRunBadRequestError(f"Target missing in request body:\n {request_body}")
+
+    parameters = _parse_parameters(target)
+
+    return parameters
+
+
+def _parse_parameters(target_query):
+    parameters = {}
+    for query in filter(lambda q: q, target_query.split(";")):
+        query_parts = query.split("=")
+        if len(query_parts) < 2:
+            raise MLRunBadRequestError(
+                f"Query must contain both query key and query value. Expected query_key=query_value, found {query} "
+                f"instead."
+            )
+        parameters[query_parts[0]] = query_parts[1]
+    return parameters
+
+
+def drop_grafana_escape_chars(query_parameters: Dict[str, str]):
+    query_parameters = dict(query_parameters)
+    endpoint_id = query_parameters.get("endpoint_id")
+    if endpoint_id is not None:
+        query_parameters["endpoint_id"] = endpoint_id.replace("\\", "")
+    return query_parameters
+
+
+def validate_query_parameters(
+    query_parameters: Dict[str, str], supported_endpoints: Optional[Set[str]] = None
+):
+    """Validates the parameters sent via Grafana's SimpleJson query"""
+    if "target_endpoint" not in query_parameters:
+        raise MLRunBadRequestError(
+            f"Expected 'target_endpoint' field in query, found {query_parameters} instead"
+        )
+
+    if (
+        supported_endpoints is not None
+        and query_parameters["target_endpoint"] not in supported_endpoints
+    ):
+        raise MLRunBadRequestError(
+            f"{query_parameters['target_endpoint']} unsupported in query parameters: {query_parameters}. "
+            f"Currently supports: {','.join(supported_endpoints)}"
+        )

--- a/mlrun/api/crud/model_monitoring/model_endpoint_store.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoint_store.py
@@ -591,6 +591,7 @@ class _ModelEndpointKVStore(_ModelEndpointStore):
         label_names = endpoint.spec.label_names or []
         feature_stats = endpoint.status.feature_stats or {}
         current_stats = endpoint.status.current_stats or {}
+        drift_measures = endpoint.status.drift_measures or {}
         children = endpoint.status.children or []
         endpoint_type = endpoint.status.endpoint_type or None
         children_uids = endpoint.status.children_uids or []
@@ -609,6 +610,8 @@ class _ModelEndpointKVStore(_ModelEndpointStore):
             "active": endpoint.spec.active or "",
             "monitoring_feature_set_uri": endpoint.status.monitoring_feature_set_uri
             or "",
+            "drift_status": endpoint.status.drift_status or "",
+            "drift_measures": json.dumps(drift_measures),
             "monitoring_mode": endpoint.spec.monitoring_mode or "",
             "state": endpoint.status.state or "",
             "feature_stats": json.dumps(feature_stats),

--- a/tests/api/api/test_grafana_proxy.py
+++ b/tests/api/api/test_grafana_proxy.py
@@ -31,9 +31,9 @@ import mlrun
 import mlrun.api.crud
 import mlrun.api.schemas
 import mlrun.api.utils.clients.iguazio
-from mlrun.api.api.endpoints.grafana_proxy import (
-    _parse_query_parameters,
-    _validate_query_parameters,
+from mlrun.api.crud.model_monitoring.grafana import (
+    parse_query_parameters,
+    validate_query_parameters,
 )
 from mlrun.config import config
 from mlrun.errors import MLRunBadRequestError
@@ -82,6 +82,7 @@ def test_grafana_proxy_model_endpoints_check_connection(
     reason=_build_skip_message(),
 )
 def test_grafana_list_endpoints(db: Session, client: TestClient):
+
     endpoints_in = [_mock_random_endpoint("active") for _ in range(5)]
 
     # Initialize endpoint store target object
@@ -302,30 +303,30 @@ def test_grafana_overall_feature_analysis(db: Session, client: TestClient):
 def test_parse_query_parameters_failure():
     # No 'targets' in body
     with pytest.raises(MLRunBadRequestError):
-        _parse_query_parameters({})
+        parse_query_parameters({})
 
     # No 'target' list in 'targets' dictionary
     with pytest.raises(MLRunBadRequestError):
-        _parse_query_parameters({"targets": []})
+        parse_query_parameters({"targets": []})
 
     # Target query not separated by equals ('=') char
     with pytest.raises(MLRunBadRequestError):
-        _parse_query_parameters({"targets": [{"target": "test"}]})
+        parse_query_parameters({"targets": [{"target": "test"}]})
 
 
 def test_parse_query_parameters_success():
     # Target query separated by equals ('=') char
-    params = _parse_query_parameters({"targets": [{"target": "test=some_test"}]})
+    params = parse_query_parameters({"targets": [{"target": "test=some_test"}]})
     assert params["test"] == "some_test"
 
     # Target query separated by equals ('=') char (multiple queries)
-    params = _parse_query_parameters(
+    params = parse_query_parameters(
         {"targets": [{"target": "test=some_test;another_test=some_other_test"}]}
     )
     assert params["test"] == "some_test"
     assert params["another_test"] == "some_other_test"
 
-    params = _parse_query_parameters(
+    params = parse_query_parameters(
         {"targets": [{"target": "test=some_test;another_test=some_other_test;"}]}
     )
     assert params["test"] == "some_test"
@@ -335,19 +336,17 @@ def test_parse_query_parameters_success():
 def test_validate_query_parameters_failure():
     # No 'target_endpoint' in query parameters
     with pytest.raises(MLRunBadRequestError):
-        _validate_query_parameters({})
+        validate_query_parameters({})
 
     # target_endpoint unsupported
     with pytest.raises(MLRunBadRequestError):
-        _validate_query_parameters(
+        validate_query_parameters(
             {"target_endpoint": "unsupported_endpoint"}, {"supported_endpoint"}
         )
 
 
 def test_validate_query_parameters_success():
-    _validate_query_parameters(
-        {"target_endpoint": "list_endpoints"}, {"list_endpoints"}
-    )
+    validate_query_parameters({"target_endpoint": "list_endpoints"}, {"list_endpoints"})
 
 
 def _get_access_key() -> Optional[str]:


### PR DESCRIPTION
At the moment there are several Grafana charts and KPIs that are based on MLRun API datasource (e.g. `drift_status`). In order to reduce the amount of calls to MLRun API from Grafana, in this PR we adjust these charts and KPIs to use the data store target directly. That means adjust the model monitoring dashboards to use only `V3IO Framesd` datasource. 

Please note that we are still using MLRun API service for listing and selecting the projects in the user's cluster but apart of that, all of the other charts and KPIs are based on the `V3IO Framsed`.

A ticket for this improvement https://jira.iguazeng.com/browse/ML-3605.
This PR also includes fixes for open issues in Grafana:
* [IG-21324](https://jira.iguazeng.com/browse/IG-21324)
* [IG-2991](https://jira.iguazeng.com/browse/ML-2991)
* [IG-20227](https://jira.iguazeng.com/browse/IG-20227)

It is also important for the support of model monitoring features in the CE ([ML-3553](https://jira.iguazeng.com/browse/ML-3553)) that are expected to be released in `1.3.1`.

UPDATE
- Deprecation warning has been added to the deprecated API (`/grafana-proxy/model-endpoints/query`)
- Grafana CRUD operations were moved from `mlrun.api.api.endpoints.grafana_proxy.py` into a new file `mlrun.api.crud.model_monitoring.grafana.py`
- The new dashboards are based on Grafana `9.2.2` which available in iguazio `3.5.3`. However, we also keep the dashboards for previous iguazio versions (`<3.5.3`) in which he Grafana version is `<7.2.0`.  