### PR TITLE
[System Tests] Fix Schedule Workflow Test

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -687,14 +687,6 @@ class TestProject(TestMLRunSystem):
             schedule.scheduled_object["schedule"] == schedules[1]
         ), "Failed to override existing workflow"
 
-        # submit schedule when one exists without override - fail:
-        with pytest.raises(mlrun.errors.MLRunConflictError):
-            project.run(
-                workflow_name,
-                schedule=schedules[1],
-                dirty=True,
-            )
-
         # overwriting schedule from cli:
         args = [
             project_dir,


### PR DESCRIPTION
The test runs a workflow 3 times. The first time it gets created, the second time we expect override (previously by using an `override` flag, but now the override behavior is the default), and on the third there was an expectation for a conflict when not using the flag. However this isn't the case anymore, so no need to run 3 times.