### PR TITLE
[Models] Install tensorflow instead of intel-tensorflow

### DIFF
--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -31,8 +31,7 @@ RUN python -m pip install torch==1.13.0+cpu torchvision==0.14.0+cpu \
 
 ARG TENSORFLOW_VERSION=2.9.0
 
-# intel-tensorflow is a slimmer, CPU optimizied distribution of tensorflow by intel
-RUN python -m pip install -U intel-tensorflow~=${TENSORFLOW_VERSION} mxnet
+RUN python -m pip install -U tensorflow~=${TENSORFLOW_VERSION} mxnet
 
 ARG HOROVOD_VERSION=0.25.0
 RUN HOROVOD_WITH_MPI=1 HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1  \


### PR DESCRIPTION
note this tensorflow installation shows warnings of missing GPU / cuda which should be ignored
~~~
2023-03-15 09:05:15.351346: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
2023-03-15 09:05:15.351388: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
2023-03-15 09:05:17.849317: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory
2023-03-15 09:05:17.849370: W tensorflow/stream_executor/cuda/cuda_driver.cc:269] failed call to cuInit: UNKNOWN ERROR (303)
2023-03-15 09:05:17.849398: I tensorflow/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (training-j2nng): /proc/driver/nvidia/version does not exist
~~~
https://jira.iguazeng.com/browse/ML-3338