### PR TITLE
[Schedule] Update type hints for ScheduleCronTrigger to avoid unexpected pydantic behaviour

### DIFF
--- a/mlrun/api/schemas/schedule.py
+++ b/mlrun/api/schemas/schedule.py
@@ -36,8 +36,8 @@ class ScheduleCronTrigger(BaseModel):
     hour: Optional[Union[int, str]]
     minute: Optional[Union[int, str]]
     second: Optional[Union[int, str]]
-    start_date: Optional[Union[datetime, str]]
-    end_date: Optional[Union[datetime, str]]
+    start_date: Union[datetime, str] = None
+    end_date: Union[datetime, str] = None
 
     # APScheduler also supports datetime.tzinfo type, but Pydantic doesn't - so we don't
     timezone: Optional[str]


### PR DESCRIPTION
When defining type hints for `pydantic` objects with `typing.Union`, `pydantic` will attempt to match any of the types defined under `typing.Union` and will use the first one that matches.
However, when adding `typing.Optional`  (e.g. `Optional[Union[datetime, str]]`) the user may face unexpected behaviour in which the order within the `Union` has been changed and `pydantic` will match the wrong type (e.g. trying to match `str` before `datetime` although `datetime` is the first type in the `Union` list). This bug occurs following different imports of 3rd libraries. More info about this `pydantic` behaviour can be found here: https://github.com/pydantic/pydantic/issues/4474 
https://github.com/pydantic/pydantic/issues/4519

To avoid this unexpected behaviour, in this PR we replace `typing.Optional` with default `None` value for the fields `start_date` and `end_date` within `ScheduleCronTrigger` object.

Pleas note that new tests are not required as this behaviour is already being tested through `test_update_schedule()`. 

A related JIRA ticket - https://jira.iguazeng.com/browse/ML-3624
