### PR TITLE
[Project] Fix function name isn't treated uniformly 

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1536,6 +1536,7 @@ class MlrunProject(ModelObj):
                 func = path.relpath(func, self.spec.context)
 
         func = func or ""
+        name = mlrun.utils.normalize_name(name) if name else name
         if isinstance(func, str):
             # in hub or db functions name defaults to the function name
             if not name and not (func.startswith("db://") or func.startswith("hub://")):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -400,6 +400,33 @@ def test_set_func_requirements():
     ]
 
 
+def test_set_function_underscore_name():
+    project = mlrun.projects.MlrunProject(
+        "project", default_requirements=["pandas>1, <3"]
+    )
+    func_name = "name_with_underscores"
+
+    # Create a function with a name that includes underscores
+    func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
+    func = mlrun.code_to_function(
+        name=func_name,
+        kind="job",
+        image="mlrun/mlrun",
+        handler="myhandler",
+        filename=func_path,
+    )
+    project.set_function(name=func_name, func=func)
+
+    # Attempt to get the function using the original name (with underscores) and ensure that it fails
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        project.get_function(key=func_name)
+
+    # Get the function using a normalized name and make sure it works
+    normalized_name = mlrun.utils.normalize_name(func_name)
+    enriched_function = project.get_function(key=normalized_name)
+    assert enriched_function.metadata.name == normalized_name
+
+
 def test_set_func_with_tag():
     project = mlrun.projects.MlrunProject("newproj", default_requirements=["pandas"])
     project.set_function(


### PR DESCRIPTION
A fix for: https://jira.iguazeng.com/browse/ML-3071

The function name will now be normalized in set_function, and any underscores will be replaced with dashes.
The user will be warned, and we intend to reject such requests in the future.