### PR TITLE
[SDK] Bring back the `overwrite` flag with deprecation warning

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1040,6 +1040,13 @@ def logs(uid, project, offset, db, watch):
     "https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron."
     "For using the pre-defined workflow's schedule, set --schedule 'true'",
 )
+# TODO: Remove in 1.5.0
+@click.option(
+    "--overwrite-schedule",
+    "-os",
+    is_flag=True,
+    help="Overwrite a schedule when submitting a new one with the same name.",
+)
 @click.option(
     "--save-secrets",
     is_flag=True,
@@ -1070,6 +1077,7 @@ def project(
     timeout,
     ensure_project,
     schedule,
+    overwrite_schedule,
     save_secrets,
     save,
 ):
@@ -1159,6 +1167,7 @@ def project(
                 local=local,
                 schedule=schedule,
                 timeout=timeout,
+                overwrite=overwrite_schedule,
             )
 
         except Exception as exc:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1864,6 +1864,7 @@ class MlrunProject(ModelObj):
         local: bool = None,
         schedule: typing.Union[str, mlrun.api.schemas.ScheduleCronTrigger, bool] = None,
         timeout: int = None,
+        overwrite: bool = False,
         source: str = None,
         cleanup_ttl: int = None,
     ) -> _PipelineRunStatus:
@@ -1895,6 +1896,8 @@ class MlrunProject(ModelObj):
                           https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
                           for using the pre-defined workflow's schedule, set `schedule=True`
         :param timeout:   timeout in seconds to wait for pipeline completion (watch will be activated)
+        :param overwrite: (deprecated) replacing the schedule of the same workflow (under the same name) if exists
+                          with the new one.
         :param source:    remote source to use instead of the actual `project.spec.source` (used when engine is remote).
                           for other engines the source is to validate that the code is up-to-date
         :param cleanup_ttl:
@@ -1906,6 +1909,14 @@ class MlrunProject(ModelObj):
         if ttl:
             warnings.warn(
                 "'ttl' is deprecated, use 'cleanup_ttl' instead. "
+                "This will be removed in 1.5.0",
+                # TODO: Remove this in 1.5.0
+                FutureWarning,
+            )
+
+        if overwrite:
+            warnings.warn(
+                "'overwrite' is deprecated, running a schedule is now an upsert operation. "
                 "This will be removed in 1.5.0",
                 # TODO: Remove this in 1.5.0
                 FutureWarning,


### PR DESCRIPTION
https://github.com/mlrun/mlrun/pull/3265 assumed the `overwrite` flag was introduced in 1.3.0. However it is also in 1.1.3 and 1.2.1. Therefore, for backwards compatibility, the flag still exists and can be used but now does nothing except raise a deprecation warning.