### PR TITLE
[Artifact] Enforce the update of artifacts with conflicting keys

### DIFF
--- a/mlrun/api/crud/artifacts.py
+++ b/mlrun/api/crud/artifacts.py
@@ -49,12 +49,13 @@ class Artifacts(
                 f"Artifact with conflicting project name - {data['project']} while request project : {project}."
                 f"key={key}, uid={uid}, data={data}"
             )
-        data_key = data["metadata"]["key"]
-        if (key and data_key) and data_key != key:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Artifact with conflicting key name - {data_key} while request key : {key}."
-                f"key={key}, uid={uid}, data={data}"
-            )
+        if data.get("metadata"):
+            data_key = data["metadata"].get("key")
+            if (key and data_key) and data_key != key:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Artifact with conflicting key name - {data_key} while request key : {key}."
+                    f"key={key}, uid={uid}, data={data}"
+                )
         mlrun.api.utils.singletons.db.get_db().store_artifact(
             db_session,
             key,

--- a/mlrun/api/crud/artifacts.py
+++ b/mlrun/api/crud/artifacts.py
@@ -49,6 +49,12 @@ class Artifacts(
                 f"Artifact with conflicting project name - {data['project']} while request project : {project}."
                 f"key={key}, uid={uid}, data={data}"
             )
+        data_key = data["metadata"]["key"]
+        if (key and data_key) and data_key != key:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Artifact with conflicting key name - {data_key} while request key : {key}."
+                f"key={key}, uid={uid}, data={data}"
+            )
         mlrun.api.utils.singletons.db.get_db().store_artifact(
             db_session,
             key,

--- a/mlrun/api/crud/artifacts.py
+++ b/mlrun/api/crud/artifacts.py
@@ -49,13 +49,7 @@ class Artifacts(
                 f"Artifact with conflicting project name - {data['project']} while request project : {project}."
                 f"key={key}, uid={uid}, data={data}"
             )
-        if data.get("metadata"):
-            data_key = data["metadata"].get("key")
-            if (key and data_key) and data_key != key:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Artifact with conflicting key name - {data_key} while request key : {key}."
-                    f"key={key}, uid={uid}, data={data}"
-                )
+
         mlrun.api.utils.singletons.db.get_db().store_artifact(
             db_session,
             key,

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -543,6 +543,12 @@ class SQLDB(DBInterface):
             )
         if not db_key:
             artifact["spec"]["db_key"] = key
+
+        data_key = artifact.get("metadata", {}).get("key")
+        if (key and data_key) and data_key != key:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Artifact with conflicting key name - {data_key} while request key : {key}."
+            )
         if iter:
             key = f"{iter}-{key}"
         labels = artifact["metadata"].get("labels", {})
@@ -564,6 +570,13 @@ class SQLDB(DBInterface):
             )
         if not db_key:
             artifact["db_key"] = key
+
+        data_key = artifact.get("key")
+        if (key and data_key) and data_key != key:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Artifact with conflicting key name - {data_key} while request key : {key}."
+            )
+
         if iter:
             key = f"{iter}-{key}"
         labels = artifact.get("labels", {})

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -547,7 +547,7 @@ class SQLDB(DBInterface):
         data_key = artifact.get("metadata", {}).get("key")
         if (key and data_key) and data_key != key:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Artifact with conflicting key name - {data_key} while request key : {key}."
+                f"Conflict between requested key ({key}) and key in artifact metadata ({data_key})"
             )
         if iter:
             key = f"{iter}-{key}"

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -539,7 +539,7 @@ class SQLDB(DBInterface):
         db_key = artifact["spec"].get("db_key")
         if db_key and db_key != key:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Conflict between requested key and key in artifact body"
+                f"Conflict between requested key ({key}) and key in artifact metadata ({db_key})"
             )
         if not db_key:
             artifact["spec"]["db_key"] = key
@@ -574,7 +574,7 @@ class SQLDB(DBInterface):
         data_key = artifact.get("key")
         if (key and data_key) and data_key != key:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Artifact with conflicting key name - {data_key} while request key : {key}."
+                f"Conflict between requested key ({key}) and key in artifact metadata ({data_key})"
             )
 
         if iter:

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -133,7 +133,10 @@ def test_update_artifact_with_conflicted_key_names(db: Session, client: TestClie
         STORE_API_ARTIFACTS_PATH.format(project=PROJECT, uid=UID, key="test", tag=TAG),
         data=artifact.to_json(),
     )
-    assert resp.status_code == HTTPStatus.BAD_REQUEST.value
+    assert (
+        resp.status_code == HTTPStatus.BAD_REQUEST.value
+        and "Artifact with conflicting key name" in resp.json()["detail"]
+    )
 
 
 def test_store_artifact_with_invalid_tag(db: Session, client: TestClient):

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -135,7 +135,7 @@ def test_update_artifact_with_conflicted_key_names(db: Session, client: TestClie
     )
     assert (
         resp.status_code == HTTPStatus.BAD_REQUEST.value
-        and "Artifact with conflicting key name" in resp.json()["detail"]
+        and "Conflict between requested key" in resp.json()["detail"]
     )
 
 

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -119,6 +119,23 @@ def test_store_artifact_backwards_compatibility(db: Session, client: TestClient)
     )
 
 
+def test_update_artifact_with_conflicted_key_names(db: Session, client: TestClient):
+    _create_project(client)
+    artifact = mlrun.artifacts.Artifact(key=KEY, body="123")
+
+    resp = client.post(
+        STORE_API_ARTIFACTS_PATH.format(project=PROJECT, uid=UID, key=KEY, tag=TAG),
+        data=artifact.to_json(),
+    )
+    assert resp.status_code == HTTPStatus.OK.value
+
+    resp = client.post(
+        STORE_API_ARTIFACTS_PATH.format(project=PROJECT, uid=UID, key="test", tag=TAG),
+        data=artifact.to_json(),
+    )
+    assert resp.status_code == HTTPStatus.BAD_REQUEST.value
+
+
 def test_store_artifact_with_invalid_tag(db: Session, client: TestClient):
     _create_project(client)
     tag = "test_tag_with_characters@#$#%^"


### PR DESCRIPTION
Adding a fix for: https://jira.iguazeng.com/browse/ML-3604

While the body key is a non-empty string, we will not allow POSTing  that includes "key" with bodies that contain a different "key".