### PR TITLE
[Nuclio] `with_service_type` SDK

### DIFF
--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -141,6 +141,8 @@ class NuclioSpec(KubeResourceSpec):
         "function_handler",
         "nuclio_runtime",
         "base_image_pull",
+        "service_type",
+        "add_templated_ingress_host_mode",
     ]
 
     def __init__(
@@ -179,6 +181,8 @@ class NuclioSpec(KubeResourceSpec):
         tolerations=None,
         preemption_mode=None,
         security_context=None,
+        service_type=None,
+        add_templated_ingress_host_mode=None,
     ):
 
         super().__init__(
@@ -218,6 +222,8 @@ class NuclioSpec(KubeResourceSpec):
         self.nuclio_runtime = None
         self.no_cache = no_cache
         self.readiness_timeout = readiness_timeout
+        self.service_type = service_type
+        self.add_templated_ingress_host_mode = add_templated_ingress_host_mode
 
         self.min_replicas = min_replicas or 1
         self.max_replicas = max_replicas or 4
@@ -693,6 +699,18 @@ class RemoteRuntime(KubeResource):
     def with_priority_class(self, name: typing.Optional[str] = None):
         """k8s priority class"""
         super().with_priority_class(name)
+
+    def with_service_type(
+        self, service_type: str, add_templated_ingress_host_mode: str = None
+    ):
+        """
+        :param service_type:                      service type (ClusterIP, NodePort)
+        :param add_templated_ingress_host_mode:   ingress host mode (never, always, onClusterIP),
+                                                  see mlrun.mlconf.httpdb.nuclio.add_templated_ingress_host_mode
+                                                  for full description
+        """
+        self.spec.service_type = service_type
+        self.spec.add_templated_ingress_host_mode = add_templated_ingress_host_mode
 
     def _get_state(
         self,
@@ -1210,8 +1228,9 @@ def deploy_nuclio_function(
     # if mode allows it, enrich function http trigger with an ingress
     enrich_function_with_ingress(
         function_config,
-        mlconf.httpdb.nuclio.add_templated_ingress_host_mode,
-        mlconf.httpdb.nuclio.default_service_type,
+        function.spec.add_templated_ingress_host_mode
+        or mlconf.httpdb.nuclio.add_templated_ingress_host_mode,
+        function.spec.service_type or mlconf.httpdb.nuclio.default_service_type,
     )
 
     try:
@@ -1377,7 +1396,8 @@ def compile_function_config(
 
     # In Nuclio >= 1.6.x default serviceType has changed to "ClusterIP".
     nuclio_spec.set_config(
-        "spec.serviceType", mlconf.httpdb.nuclio.default_service_type
+        "spec.serviceType",
+        function.spec.service_type or mlconf.httpdb.nuclio.default_service_type,
     )
     if function.spec.readiness_timeout:
         nuclio_spec.set_config(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -706,7 +706,7 @@ class RemoteRuntime(KubeResource):
         """
         Enables to control the service type of the pod and the addition of templated ingress host
 
-        :param service_type:                      service type (ClusterIP, NodePort), default to
+        :param service_type:                      service type (ClusterIP, NodePort), defaults to
                                                   mlrun.mlconf.httpdb.nuclio.service_type
         :param add_templated_ingress_host_mode:   add templated ingress host mode (never, always, onClusterIP),
                                                   see mlrun.mlconf.httpdb.nuclio.add_templated_ingress_host_mode

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -704,10 +704,14 @@ class RemoteRuntime(KubeResource):
         self, service_type: str, add_templated_ingress_host_mode: str = None
     ):
         """
-        :param service_type:                      service type (ClusterIP, NodePort)
-        :param add_templated_ingress_host_mode:   ingress host mode (never, always, onClusterIP),
+        Enables to control the service type of the pod and the addition of templated ingress host
+
+        :param service_type:                      service type (ClusterIP, NodePort), default to
+                                                  mlrun.mlconf.httpdb.nuclio.service_type
+        :param add_templated_ingress_host_mode:   add templated ingress host mode (never, always, onClusterIP),
                                                   see mlrun.mlconf.httpdb.nuclio.add_templated_ingress_host_mode
-                                                  for full description
+                                                  for the default and more information
+
         """
         self.spec.service_type = service_type
         self.spec.add_templated_ingress_host_mode = add_templated_ingress_host_mode

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -141,6 +141,8 @@ class ServingSpec(NuclioSpec):
         tolerations=None,
         preemption_mode=None,
         security_context=None,
+        service_type=None,
+        add_templated_ingress_host_mode=None,
     ):
 
         super().__init__(
@@ -178,6 +180,8 @@ class ServingSpec(NuclioSpec):
             tolerations=tolerations,
             preemption_mode=preemption_mode,
             security_context=security_context,
+            service_type=service_type,
+            add_templated_ingress_host_mode=add_templated_ingress_host_mode,
         )
 
         self.models = models or {}


### PR DESCRIPTION
Support overriding default `service_type` and `add_templated_ingress_host_mode` via SDK