### PR TITLE
[Models] Add mpi4py requirement

### DIFF
--- a/dockerfiles/models/requirements.txt
+++ b/dockerfiles/models/requirements.txt
@@ -2,3 +2,4 @@ gnureadline~=8.0
 transformers~=4.11.3
 xgboost~=1.1
 tensorboard~=2.5
+mpi4py~=3.1

--- a/tests/system/runtimes/test_mpijob.py
+++ b/tests/system/runtimes/test_mpijob.py
@@ -26,17 +26,16 @@ class TestMpiJobRuntime(tests.system.base.TestMLRunSystem):
 
         # Create the open mpi function:
         mpijob_function = mlrun.code_to_function(
-            name="mpijob_test",
+            name="mpijob-test",
             kind="mpijob",
             handler="handler",
             project=self.project_name,
             filename=code_path,
             image="mlrun/ml-models",
-            requirements=["mpi4py"],
         )
         mpijob_function.spec.replicas = 4
 
-        mpijob_run = mpijob_function.run(auto_build=True)
+        mpijob_run = mpijob_function.run()
         assert mpijob_run.status.state == RunStates.completed
 
         mpijob_time = mpijob_run.status.results["time"]


### PR DESCRIPTION
mpi4py is required when running mpijob with python.
Adding it helps with faster tests since there is no need to build the image which can take 8 mins on open source system tests and it does not introduce any new dependencies.