### PR TITLE
[LogCollector] Reduce readdirent when finding run log file path

### DIFF
--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -43,7 +43,7 @@ import (
 
 type LogCollectorTestSuite struct {
 	suite.Suite
-	LogCollectorServer *Server
+	logCollectorServer *Server
 	logger             logger.Logger
 	ctx                context.Context
 	kubeClientSet      fake.Clientset
@@ -74,7 +74,7 @@ func (suite *LogCollectorTestSuite) SetupSuite() {
 	suite.Require().NoError(err, "Failed to create base dir")
 
 	// create log collector server
-	suite.LogCollectorServer, err = NewLogCollectorServer(suite.logger,
+	suite.logCollectorServer, err = NewLogCollectorServer(suite.logger,
 		suite.namespace,
 		suite.baseDir,
 		stateFileUpdateIntervalStr,
@@ -160,7 +160,7 @@ func (suite *LogCollectorTestSuite) TestValidateOffsetAndSize() {
 		},
 	} {
 		suite.Run(testCase.name, func() {
-			offset, size := suite.LogCollectorServer.validateOffsetAndSize(testCase.offset, testCase.size, testCase.fileSize)
+			offset, size := suite.logCollectorServer.validateOffsetAndSize(testCase.offset, testCase.size, testCase.fileSize)
 			suite.Require().Equal(testCase.expectedOffset, offset)
 			suite.Require().Equal(testCase.expectedSize, size)
 		})
@@ -204,14 +204,14 @@ func (suite *LogCollectorTestSuite) TestStreamPodLogs() {
 	startedChan := make(chan bool)
 
 	// stream pod logs
-	go suite.LogCollectorServer.startLogStreaming(ctx, runId, pod.Name, suite.projectName, startedChan, cancel)
+	go suite.logCollectorServer.startLogStreaming(ctx, runId, pod.Name, suite.projectName, startedChan, cancel)
 
 	// wait for log streaming to start
 	started := <-startedChan
 	suite.Require().True(started, "Log streaming didn't start")
 
 	// resolve log file path
-	logFilePath := suite.LogCollectorServer.resolvePodLogFilePath(suite.projectName, runId, pod.Name)
+	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runId, pod.Name)
 
 	// read log file until it has content, or timeout
 	timeout := time.After(30 * time.Second)
@@ -249,9 +249,9 @@ func (suite *LogCollectorTestSuite) TestStartLogBestEffort() {
 		Selector:    "app=some-app",
 		BestEffort:  true,
 	}
-	suite.LogCollectorServer.startLogsFindingPodsTimeout = 50 * time.Millisecond
-	suite.LogCollectorServer.startLogsFindingPodsInterval = 20 * time.Millisecond
-	response, err := suite.LogCollectorServer.StartLog(suite.ctx, request)
+	suite.logCollectorServer.startLogsFindingPodsTimeout = 50 * time.Millisecond
+	suite.logCollectorServer.startLogsFindingPodsInterval = 20 * time.Millisecond
+	response, err := suite.logCollectorServer.StartLog(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to start log")
 	suite.Require().True(response.Success, "Failed to start log")
 }
@@ -262,7 +262,7 @@ func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 	podName := "my-pod"
 
 	// creat log file for runUID and pod
-	logFilePath := suite.LogCollectorServer.resolvePodLogFilePath(suite.projectName, runUID, podName)
+	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID, podName)
 
 	// write log file
 	logText := "Some fake pod logs\n"
@@ -273,7 +273,7 @@ func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 	nopStream := &nop.GetLogsResponseStreamNop{}
 
 	// get logs
-	err = suite.LogCollectorServer.GetLogs(&log_collector.GetLogsRequest{
+	err = suite.logCollectorServer.GetLogs(&log_collector.GetLogsRequest{
 		RunUID:      runUID,
 		Offset:      0,
 		Size:        100,
@@ -299,7 +299,7 @@ func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 	}
 
 	// get logs with offset and size -1, to get all logs at once
-	err = suite.LogCollectorServer.GetLogs(&log_collector.GetLogsRequest{
+	err = suite.logCollectorServer.GetLogs(&log_collector.GetLogsRequest{
 		RunUID:      runUID,
 		Offset:      1,
 		Size:        -1,
@@ -360,7 +360,7 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 
 		var j int
 		for {
-			logs, err := suite.LogCollectorServer.readLogsFromFile(ctx,
+			logs, err := suite.logCollectorServer.readLogsFromFile(ctx,
 				"1",
 				filePath,
 				int64(offset),
@@ -405,13 +405,13 @@ func (suite *LogCollectorTestSuite) TestHasLogs() {
 	}
 
 	// call has logs with no logs
-	hasLogsResponse, err := suite.LogCollectorServer.HasLogs(suite.ctx, request)
+	hasLogsResponse, err := suite.logCollectorServer.HasLogs(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to check if has logs")
 	suite.Require().True(hasLogsResponse.Success, "Expected has logs request to succeed")
 	suite.Require().False(hasLogsResponse.HasLogs, "Expected run to not have logs")
 
 	// create log file for runUID and pod
-	logFilePath := suite.LogCollectorServer.resolvePodLogFilePath(suite.projectName, runUID, podName)
+	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID, podName)
 
 	// write log file
 	logText := "Some fake pod logs\n"
@@ -419,7 +419,7 @@ func (suite *LogCollectorTestSuite) TestHasLogs() {
 	suite.Require().NoError(err, "Failed to write to file")
 
 	// check if run has logs
-	hasLogsResponse, err = suite.LogCollectorServer.HasLogs(suite.ctx, request)
+	hasLogsResponse, err = suite.logCollectorServer.HasLogs(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to check if has logs")
 	suite.Require().True(hasLogsResponse.Success, "Expected has logs request to succeed")
 	suite.Require().True(hasLogsResponse.HasLogs, "Expected run to have logs")
@@ -442,21 +442,21 @@ func (suite *LogCollectorTestSuite) TestStopLog() {
 			selector := fmt.Sprintf("run=%s", runUID)
 
 			// Add state to the log collector's state manifest
-			err = suite.LogCollectorServer.stateManifest.AddLogItem(suite.ctx, runUID, selector, projectName)
+			err = suite.logCollectorServer.stateManifest.AddLogItem(suite.ctx, runUID, selector, projectName)
 			suite.Require().NoError(err, "Failed to add log item to the state manifest")
 
 			// Add state to the log collector's current state
-			err = suite.LogCollectorServer.currentState.AddLogItem(suite.ctx, runUID, selector, projectName)
+			err = suite.logCollectorServer.currentState.AddLogItem(suite.ctx, runUID, selector, projectName)
 			suite.Require().NoError(err, "Failed to add log item to the current state")
 		}
 	}
 
 	// write state
-	err = suite.LogCollectorServer.stateManifest.WriteState(suite.LogCollectorServer.stateManifest.GetState())
+	err = suite.logCollectorServer.stateManifest.WriteState(suite.logCollectorServer.stateManifest.GetState())
 	suite.Require().NoError(err, "Failed to write state")
 
 	// verify all items are in progress
-	logItemsInProgress, err := suite.LogCollectorServer.stateManifest.GetItemsInProgress()
+	logItemsInProgress, err := suite.logCollectorServer.stateManifest.GetItemsInProgress()
 	suite.Require().NoError(err, "Failed to get items in progress")
 
 	suite.Require().Equal(projectNum, common.SyncMapLength(logItemsInProgress), "Expected items to be in progress")
@@ -474,17 +474,17 @@ func (suite *LogCollectorTestSuite) TestStopLog() {
 			Project: project,
 			RunUIDs: runs,
 		}
-		response, err := suite.LogCollectorServer.StopLogs(suite.ctx, request)
+		response, err := suite.logCollectorServer.StopLogs(suite.ctx, request)
 		suite.Require().NoError(err, "Failed to stop log")
 		suite.Require().True(response.Success, "Expected stop log request to succeed")
 	}
 
 	// write state again
-	err = suite.LogCollectorServer.stateManifest.WriteState(suite.LogCollectorServer.stateManifest.GetState())
+	err = suite.logCollectorServer.stateManifest.WriteState(suite.logCollectorServer.stateManifest.GetState())
 	suite.Require().NoError(err, "Failed to write state")
 
 	// verify no items in progress
-	logItemsInProgress, err = suite.LogCollectorServer.stateManifest.GetItemsInProgress()
+	logItemsInProgress, err = suite.logCollectorServer.stateManifest.GetItemsInProgress()
 	suite.Require().NoError(err, "Failed to get items in progress")
 
 	suite.Require().Equal(0,
@@ -521,13 +521,13 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			for i := 0; i < testCase.logsNumToCreate; i++ {
 				runUID := uuid.New().String()
 				runUIDs = append(runUIDs, runUID)
-				logFilePath := suite.LogCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+				logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
 				err := common.WriteToFile(logFilePath, []byte("some log"), false)
 				suite.Require().NoError(err, "Failed to write to file")
 			}
 
 			// verify files exist
-			dirPath := path.Join(suite.LogCollectorServer.baseDir, projectName)
+			dirPath := path.Join(suite.logCollectorServer.baseDir, projectName)
 			dirEntries, err := os.ReadDir(dirPath)
 			suite.Require().NoError(err, "Failed to read dir")
 			suite.Require().Equal(testCase.logsNumToCreate, len(dirEntries), "Expected logs to exist")
@@ -537,7 +537,7 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 				Project: projectName,
 				RunUIDs: runUIDs[testCase.expectedLogsNumLeft:],
 			}
-			response, err := suite.LogCollectorServer.DeleteLogs(suite.ctx, request)
+			response, err := suite.logCollectorServer.DeleteLogs(suite.ctx, request)
 			suite.Require().NoError(err, "Failed to stop log")
 			suite.Require().True(response.Success, "Expected stop log request to succeed")
 
@@ -558,13 +558,13 @@ func (suite *LogCollectorTestSuite) TestDeleteProjectLogs() {
 	for i := 0; i < logsNum; i++ {
 		runUID := uuid.New().String()
 		runUIDs = append(runUIDs, runUID)
-		logFilePath := suite.LogCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+		logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
 		err := common.WriteToFile(logFilePath, []byte("some log"), false)
 		suite.Require().NoError(err, "Failed to write to file")
 	}
 
 	// verify files exist
-	dirPath := path.Join(suite.LogCollectorServer.baseDir, projectName)
+	dirPath := path.Join(suite.logCollectorServer.baseDir, projectName)
 	dirEntries, err := os.ReadDir(dirPath)
 	suite.Require().NoError(err, "Failed to read dir")
 	suite.Require().Equal(logsNum, len(dirEntries), "Expected logs to exist")
@@ -574,7 +574,7 @@ func (suite *LogCollectorTestSuite) TestDeleteProjectLogs() {
 		Project: projectName,
 		RunUIDs: runUIDs[1:],
 	}
-	response, err := suite.LogCollectorServer.DeleteLogs(suite.ctx, request)
+	response, err := suite.logCollectorServer.DeleteLogs(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to stop log")
 	suite.Require().True(response.Success, "Expected stop log request to succeed")
 
@@ -587,7 +587,7 @@ func (suite *LogCollectorTestSuite) TestDeleteProjectLogs() {
 func (suite *LogCollectorTestSuite) TestGetLogFilePath() {
 	runUID := "123"
 	projectName := "someProject"
-	_, err := suite.LogCollectorServer.getLogFilePath(suite.ctx, runUID, projectName)
+	_, err := suite.logCollectorServer.getLogFilePath(suite.ctx, runUID, projectName)
 	suite.Require().Error(err, "Expected error when getting log file path for non-existing project")
 	suite.Require().Contains(errors.RootCause(err).Error(), "not found", "Expected error to contain 'not found'")
 
@@ -596,14 +596,51 @@ func (suite *LogCollectorTestSuite) TestGetLogFilePath() {
 	suite.Require().NoError(err)
 
 	// make the run file
-	runFilePath := suite.LogCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
 	err = common.WriteToFile(runFilePath, []byte("some log"), false)
 	suite.Require().NoError(err, "Failed to write to file")
 
 	// get the log file path
-	logFilePath, err := suite.LogCollectorServer.getLogFilePath(suite.ctx, runUID, projectName)
+	logFilePath, err := suite.logCollectorServer.getLogFilePath(suite.ctx, runUID, projectName)
 	suite.Require().NoError(err, "Failed to get log file path")
 	suite.Require().Equal(runFilePath, logFilePath, "Expected log file path to be the same as the run file path")
+}
+
+func (suite *LogCollectorTestSuite) TestGetLogFilePathConcurrently() {
+	runUID := "1234"
+	projectName := "someProjectB"
+	var err error
+
+	projectMutex := &sync.Mutex{}
+	suite.logCollectorServer.readDirentProjectNameSyncMap = &sync.Map{}
+	suite.logCollectorServer.readDirentProjectNameSyncMap.Store(projectName, projectMutex)
+	projectMutex.Lock()
+	startTime := time.Now()
+
+	// unlock the mutex after 1 second
+	time.AfterFunc(1500*time.Millisecond, func() {
+		projectMutex.Unlock()
+	})
+
+	// make the project dir
+	err = os.MkdirAll(path.Join(suite.baseDir, projectName), 0755)
+	suite.Require().NoError(err)
+
+	// make the run file
+	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+	err = common.WriteToFile(runFilePath, []byte("some log"), false)
+	suite.Require().NoError(err, "Failed to write to file")
+
+	// get the log file path
+	logFilePath, err := suite.logCollectorServer.getLogFilePath(suite.ctx, runUID, projectName)
+	suite.Require().NoError(err, "Failed to get log file path")
+	suite.Require().Equal(runFilePath, logFilePath, "Expected log file path to be the same as the run file path")
+
+	endTime := time.Since(startTime)
+	suite.Require().Truef(endTime >= 1*time.Second, "Expected getLogFilePath to take more than a second (took %v)", endTime)
+
+	// make sure the mutex is unlocked
+	suite.Require().True(projectMutex.TryLock(), "Expected project mutex to be unlocked")
 }
 
 func TestLogCollectorTestSuite(t *testing.T) {

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -74,6 +74,10 @@ type Server struct {
 	// log file cache to reduce sys calls finding the log file paths.
 	logFilesCache    *cache.Expiring
 	logFilesCacheTTL time.Duration
+
+	// map of project name to its mutex lock
+	// using project mutex to prevent listing project dir concurrently
+	readDirentProjectNameSyncMap *sync.Map
 }
 
 // NewLogCollectorServer creates a new log collector server
@@ -164,12 +168,13 @@ func NewLogCollectorServer(logger logger.Logger,
 		logFilesCache:                logFilesCache,
 		startLogsFindingPodsInterval: 3 * time.Second,
 		startLogsFindingPodsTimeout:  15 * time.Second,
+		readDirentProjectNameSyncMap: &sync.Map{},
 
 		// we delete log files only when deleting the project
 		// that means, if project is gone, log files are gone too
 		// hasLogFiles is called during get_logs on project runs
 		// so if no project, no runs, no get_logs, and this one is pretty much safe to cache
-		// that being said, limit to 5 minutes (hard coded for now)
+		// that being said, limit to few minutes (hard coded for now)
 		// this cache is done to reduce IOs
 		logFilesCacheTTL: 5 * time.Minute,
 	}, nil
@@ -302,7 +307,12 @@ func (s *Server) StartLog(ctx context.Context,
 	startedStreamingGoroutine := make(chan bool, 1)
 
 	// stream logs to file
-	go s.startLogStreaming(logStreamCtx, request.RunUID, pod.Name, request.ProjectName, startedStreamingGoroutine, cancelCtxFunc)
+	go s.startLogStreaming(logStreamCtx,
+		request.RunUID,
+		pod.Name,
+		request.ProjectName,
+		startedStreamingGoroutine,
+		cancelCtxFunc)
 
 	// wait for the streaming goroutine to start
 	<-startedStreamingGoroutine
@@ -441,7 +451,7 @@ func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogs
 
 		// if there was an error, return it
 		s.Logger.ErrorWithCtx(ctx,
-			"Failed to get log file path",
+			"Failed to check if has log file",
 			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
 			"runUID", request.RunUID,
 			"projectName", request.ProjectName)
@@ -655,6 +665,9 @@ func (s *Server) startLogStreaming(ctx context.Context,
 		return
 	}
 
+	// add log file path to cache
+	s.logFilesCache.Set(s.getLogFilCacheKey(runUID, projectName), logFilePath, s.logFilesCacheTTL)
+
 	// open log file in read/write and append, to allow reading the logs while we write more logs to it
 	openFlags := os.O_RDWR | os.O_APPEND
 	file, err := os.OpenFile(logFilePath, openFlags, 0644)
@@ -785,7 +798,16 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 		return filePath.(string), nil
 	}
 
-	logFilePath := ""
+	// get project mutex or create one
+	projectMutex, _ := s.readDirentProjectNameSyncMap.LoadOrStore(projectName, &sync.Mutex{})
+
+	// lock project mutex, we want only one project dir to be read at a time
+	projectMutex.(*sync.Mutex).Lock()
+
+	// unlock project mutex when done
+	defer projectMutex.(*sync.Mutex).Unlock()
+
+	var logFilePath string
 	var latestModTime time.Time
 
 	if err := common.RetryUntilSuccessful(5*time.Second, 1*time.Second, func() (bool, error) {
@@ -794,7 +816,12 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 		if _, err := os.Stat(filepath.Join(s.baseDir, projectName)); err != nil {
 			if os.IsNotExist(err) {
 				return true, errors.New("Project directory not found")
+
+				// give v3io-fuse some slack
+			} else if strings.Contains(err.Error(), "resource temporarily unavailable") {
+				return true, errors.New("Project directory is not ready yet")
 			}
+
 			return false, errors.Wrap(err, "Failed to get project directory")
 		}
 
@@ -827,7 +854,9 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 
 				return nil
 			}); err != nil {
-			return false, errors.Wrap(err, "Failed to list files in base directory")
+
+			// retry
+			return true, errors.Wrap(err, "Failed to list files in base directory")
 		}
 
 		if logFilePath == "" {
@@ -838,7 +867,7 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 		return false, nil
 
 	}); err != nil {
-		return "", errors.Wrap(err, "Failed to get log file path")
+		return "", errors.Wrap(err, "Exhausted getting log file path")
 	}
 
 	// store in cache

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -666,7 +666,7 @@ func (s *Server) startLogStreaming(ctx context.Context,
 	}
 
 	// add log file path to cache
-	s.logFilesCache.Set(s.getLogFilCacheKey(runUID, projectName), logFilePath, s.logFilesCacheTTL)
+	s.logFilesCache.Set(s.getLogFileCacheKey(runUID, projectName), logFilePath, s.logFilesCacheTTL)
 
 	// open log file in read/write and append, to allow reading the logs while we write more logs to it
 	openFlags := os.O_RDWR | os.O_APPEND
@@ -794,7 +794,7 @@ func (s *Server) resolvePodLogFilePath(projectName, runUID, podName string) stri
 func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string) (string, error) {
 
 	// first try load from cache
-	if filePath, found := s.logFilesCache.Get(s.getLogFilCacheKey(runUID, projectName)); found {
+	if filePath, found := s.logFilesCache.Get(s.getLogFileCacheKey(runUID, projectName)); found {
 		return filePath.(string), nil
 	}
 
@@ -871,7 +871,7 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 	}
 
 	// store in cache
-	s.logFilesCache.Set(s.getLogFilCacheKey(runUID, projectName), logFilePath, s.logFilesCacheTTL)
+	s.logFilesCache.Set(s.getLogFileCacheKey(runUID, projectName), logFilePath, s.logFilesCacheTTL)
 	return logFilePath, nil
 }
 
@@ -1132,6 +1132,6 @@ func (s *Server) deleteProjectLogs(project string) error {
 	return nil
 }
 
-func (s *Server) getLogFilCacheKey(runUID, project string) string {
+func (s *Server) getLogFileCacheKey(runUID, project string) string {
 	return fmt.Sprintf("%s/%s", runUID, project)
 }

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -549,7 +549,7 @@ def get_model(model_dir, suffix=""):
         if not model_spec or model_spec.kind != "model":
             raise ValueError(f"store artifact ({model_dir}) is not model kind")
         # in case model_target_file is specified, use it, because that means that the actual model target path
-        # in the store is different than the local model_file it was generated from
+        # in the store is different from the local model_file it was generated from
         model_file = _get_file_path(
             target, model_spec.model_target_file or model_spec.model_file
         )

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1804,7 +1804,7 @@ class BaseRuntimeHandler(ABC):
         group_by: Optional[mlrun.api.schemas.ListRuntimeResourcesGroupByField] = None,
     ):
         """
-        Override this to add runtime resources other then pods or CRDs (which are handled by the base class) to the
+        Override this to add runtime resources other than pods or CRDs (which are handled by the base class) to the
         output
         """
         return response


### PR DESCRIPTION
Reducing by providing a mutex on top of walking project dir files, this should ensure only one project dir file listing to occur at a specific time.
In addition, increased the scope of errors to retry on when failing listing dir

https://jira.iguazeng.com/browse/ML-3488
