### PR TITLE
[Docs] Update remote cfg and hints-n-returns in cheat-sheet; and...

### DIFF
--- a/docs/change-log/index.md
+++ b/docs/change-log/index.md
@@ -153,7 +153,7 @@ These MLRun APIs have been deprecated since at least v1.0.0 and were removed fro
 These APIs will be removed from the v1.5.0 code. A FutureWarning appears if you try to use them in v1.3.0.
 | Deprecated / to be removed                       | Use instead                                   |
 | ------------------------------------------------ | --------------------------------------------- |
-| project-related parameters of `set_environment`. (Global-related parameters will not be deprecated.) | 
+| project-related parameters of `set_environment`. (Global-related parameters will not be deprecated.) | The same parameters in project-related APIs, such as `get_or_create_project` |
 | `KubeResource.gpus`                              | `with_limits`                 |
 | Dask `gpus`                                      | `with_scheduler_limits` / `with_worker_limits`   |
 | `ExecutorTypes`                                  | `ParallelRunnerModes`         |

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -33,25 +33,34 @@ MLRun has two main components, the service and the client (SDK):
 - MLRun client SDK is installed in your development environment via `pip` and interacts with the service using REST API calls
 
 ### Remote connection (laptop, CI/CD, etc.)
+Docs: [Configure remote environment](../install/remote.html#configure-remote-environment)
 
-Create a `mlrun.env` file for environment variables:
+**Localhost**: Create a `mlrun.env` file for environment variables. MLRUN_DBPATH saves the URL endpoint of the MLRun APIs 
+service endpoint. Since it is localhost, username and access_key are not required:
 ```
+mlrun config set -a http://localhost:8080
 # MLRun DB
 MLRUN_DBPATH=<URL endpoint of the MLRun APIs service endpoint; e.g., "https://mlrun-api.default-tenant.app.mycluster.iguazio.com">
-
-# Iguazio filesystem
-V3IO_USERNAME=<username of a platform user with access to the MLRun service>
-V3IO_ACCESS_KEY=<platform access key>
 ```
 
-Connect via MLRun Python SDK:
-```python
-# Import MLRun
-import mlrun
-
-# Set environment variables - secrets, remote API endpoint, etc.
-mlrun.set_env_from_file("mlrun.env")
+**Iguazio MLOps Platform** (not MLRun CE).
 ```
+mlrun config set -a https://mlrun-api.default-tenant.app.xxx.iguazio-cd1.com -u joe -k mykey -e 
+# this is another env file
+V3IO_USERNAME=joe
+V3IO_ACCESS_KEY=mykey
+MLRUN_DBPATH=https://mlrun-api.default-tenant.app.xxx.iguazio-cd1.com
+```
+
+**Connect via MLRun Python SDK**:
+
+```
+# Use local service
+mlrun.set_environment("http://localhost:8080", artifact_path="./")
+# Use remote service
+mlrun.set_environment("<remote-service-url>", access_key="xyz", username="joe")
+```
+
 
 ## MLRun projects
 Docs: [Projects and automation](./projects/project.html)
@@ -453,11 +462,15 @@ context.log_model(key="model", model_file="model.pkl")
 context.log_dataset(key="model", df=df, format="csv", index=False)
 ```
 
-### Track returning values using `returns`
+### Track returning values using `hints` and `returns`
 
-Pass objects from one MLRun function to another:
-- Inputs are automatically parsed to their hinted type. If type hints are not in code, they can be passed in the inputs keys.
-- Use the `returns` argument to specify how to log a function's returning values.
+Use the mlrun.handler decorator on top of every run in the local runner to parse inputs using type hints, and log the returning 
+values using log hints.
+- Pass type hints into the inputs parameter of the run method. Inputs are automatically parsed to their hinted type. If type hints are 
+not in code, they can be passed in the inputs keys. Hints use the structure: `key : type_hint`
+- Pass log hints: how to log the returning values from a handler. The log hints are passed via the returns parameter in the run method. 
+A log hint can be passed as a string or a dictionary.
+- Use the `returns` argument to specify how to log a function's returned values.
 
 ```
 def my_handler(df):
@@ -465,7 +478,7 @@ def my_handler(df):
     return processed_df, result
     
 log_with_returns_run = my_func.run(
-    handler="",
+    handler="my_handler",
     inputs={"df: pandas.DataFrame": DATA_PATH},
     returns=["processed_data", "sum"],
     local=True,

--- a/docs/install/remote.md
+++ b/docs/install/remote.md
@@ -57,7 +57,7 @@ You have a few options to configure your remote environment:
 
 ### Using `mlrun config set` command in MLRun CLI
 
-**Example1**<br>
+**Example 1**<br>
 Run this command in MLRun CLI:
  ```
  mlrun config set -a http://localhost:8080
@@ -71,7 +71,7 @@ MLRUN_DBPATH=http://localhost:8080
 
 MLRUN_DBPATH saves the URL endpoint of the MLRun APIs service endpoint. Since it is localhost, username and access_key are not required (as in Example2) <br>
 
-**Example2**<br>
+**Example 2**<br>
 **Note:** Only relevant if your remote service is on an instance of the Iguazio MLOps Platform (**not MLRun CE**). <br>
 Run this command in MLRun CLI:
  ```


### PR DESCRIPTION
…add "use instead" for `set_environment`