### PR TITLE
[Models] Set CFLAGS before requirements installation

### DIFF
--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -43,11 +43,11 @@ RUN HOROVOD_WITH_MPI=1 HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_PYTORCH=1  \
 # TODO: find nicer solution
 RUN ln -sf /opt/conda/bin/python3 /usr/local/bin/python3
 
-COPY ./dockerfiles/models/requirements.txt ./models-image-requirements.txt
-
-RUN python -m pip install -r models-image-requirements.txt
-
 # Resolves anaconda issue on top of python 3.7 - https://github.com/cocodataset/cocoapi/issues/94
 # TODO: remove when we drop support for python 3.7
 ARG MLRUN_CFLAGS
 ENV CFLAGS="$MLRUN_CFLAGS $CFLAGS"
+
+COPY ./dockerfiles/models/requirements.txt ./models-image-requirements.txt
+
+RUN python -m pip install -r models-image-requirements.txt


### PR DESCRIPTION
Since we added mpi4py to the image requirements we now need to set the CFLAGS before