### PR TITLE
[API] Reflect correct message wen waiting for chief

### DIFF
--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -70,20 +70,34 @@ def verify_api_state(request: Request):
             "memory-reports",
         ]
         if not any(enabled_endpoint in path for enabled_endpoint in enabled_endpoints):
+
+            # waiting for migration
             message = (
                 "API is waiting for migrations to be triggered. Send POST request to /api/operations/migrations to"
                 " trigger it"
             )
+
+            # migration in progress
             if (
                 mlrun.mlconf.httpdb.state
                 == mlrun.api.schemas.APIStates.migrations_in_progress
             ):
                 message = "Migrations are in progress"
+
+            # migration failed
             elif (
                 mlrun.mlconf.httpdb.state
                 == mlrun.api.schemas.APIStates.migrations_failed
             ):
                 message = "Migrations failed, API can't be started"
+
+            # waiting for chief
+            elif (
+                mlrun.mlconf.httpdb.state
+                == mlrun.api.schemas.APIStates.waiting_for_chief
+            ):
+                message = "API is waiting for chief to be ready."
+
             raise mlrun.errors.MLRunPreconditionFailedError(message)
 
 

--- a/mlrun/api/api/deps.py
+++ b/mlrun/api/api/deps.py
@@ -70,34 +70,7 @@ def verify_api_state(request: Request):
             "memory-reports",
         ]
         if not any(enabled_endpoint in path for enabled_endpoint in enabled_endpoints):
-
-            # waiting for migration
-            message = (
-                "API is waiting for migrations to be triggered. Send POST request to /api/operations/migrations to"
-                " trigger it"
-            )
-
-            # migration in progress
-            if (
-                mlrun.mlconf.httpdb.state
-                == mlrun.api.schemas.APIStates.migrations_in_progress
-            ):
-                message = "Migrations are in progress"
-
-            # migration failed
-            elif (
-                mlrun.mlconf.httpdb.state
-                == mlrun.api.schemas.APIStates.migrations_failed
-            ):
-                message = "Migrations failed, API can't be started"
-
-            # waiting for chief
-            elif (
-                mlrun.mlconf.httpdb.state
-                == mlrun.api.schemas.APIStates.waiting_for_chief
-            ):
-                message = "API is waiting for chief to be ready."
-
+            message = mlrun.api.schemas.APIStates.description(mlrun.mlconf.httpdb.state)
             raise mlrun.errors.MLRunPreconditionFailedError(message)
 
 

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -174,7 +174,8 @@ class APIStates:
     def description(state: str):
         return {
             APIStates.online: "API is online",
-            APIStates.waiting_for_migrations: "API is waiting for migrations to be triggered. Send POST request to /api/operations/migrations to trigger it",
+            APIStates.waiting_for_migrations: "API is waiting for migrations to be triggered. "
+            "Send POST request to /api/operations/migrations to trigger it",
             APIStates.migrations_in_progress: "Migrations are in progress",
             APIStates.migrations_failed: "Migrations failed, API can't be started",
             APIStates.migrations_completed: "Migrations completed, API is waiting to become online",

--- a/mlrun/api/schemas/constants.py
+++ b/mlrun/api/schemas/constants.py
@@ -170,6 +170,18 @@ class APIStates:
     def terminal_states():
         return [APIStates.online, APIStates.offline]
 
+    @staticmethod
+    def description(state: str):
+        return {
+            APIStates.online: "API is online",
+            APIStates.waiting_for_migrations: "API is waiting for migrations to be triggered. Send POST request to /api/operations/migrations to trigger it",
+            APIStates.migrations_in_progress: "Migrations are in progress",
+            APIStates.migrations_failed: "Migrations failed, API can't be started",
+            APIStates.migrations_completed: "Migrations completed, API is waiting to become online",
+            APIStates.offline: "API is offline",
+            APIStates.waiting_for_chief: "API is waiting for chief to be ready",
+        }.get(state, f"Unknown API state '{state}'")
+
 
 class ClusterizationRole:
     chief = "chief"

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -40,25 +40,18 @@ def test_offline_state(
 
 
 @pytest.mark.parametrize(
-    "state,expected_message",
+    "state",
     [
-        (
-            mlrun.api.schemas.APIStates.waiting_for_migrations,
-            "API is waiting for migrations to be triggered",
-        ),
-        (
-            mlrun.api.schemas.APIStates.migrations_in_progress,
-            "Migrations are in progress",
-        ),
-        (mlrun.api.schemas.APIStates.migrations_failed, "Migrations failed"),
-        (mlrun.api.schemas.APIStates.waiting_for_chief, "API is waiting for chief"),
+        mlrun.api.schemas.APIStates.waiting_for_migrations,
+        mlrun.api.schemas.APIStates.migrations_in_progress,
+        mlrun.api.schemas.APIStates.migrations_failed,
+        mlrun.api.schemas.APIStates.waiting_for_chief,
     ],
 )
 def test_api_states(
     db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,
     state,
-    expected_message,
 ) -> None:
     mlrun.mlconf.httpdb.state = state
     response = client.get("healthz")
@@ -71,6 +64,7 @@ def test_api_states(
     assert response.status_code == http.HTTPStatus.OK.value
 
     response = client.get("projects")
+    expected_message = mlrun.api.schemas.APIStates.description(state)
     assert response.status_code == http.HTTPStatus.PRECONDITION_FAILED.value
     assert (
         expected_message in response.text

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -16,6 +16,7 @@ import http
 import unittest.mock
 
 import fastapi.testclient
+import pytest
 import sqlalchemy.orm
 
 import mlrun.api.initial_data
@@ -38,28 +39,42 @@ def test_offline_state(
     assert "API is in offline state" in response.text
 
 
-def test_migrations_states(
-    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+@pytest.mark.parametrize(
+    "state,expected_message",
+    [
+        (
+            mlrun.api.schemas.APIStates.waiting_for_migrations,
+            "API is waiting for migrations to be triggered",
+        ),
+        (
+            mlrun.api.schemas.APIStates.migrations_in_progress,
+            "Migrations are in progress",
+        ),
+        (mlrun.api.schemas.APIStates.migrations_failed, "Migrations failed"),
+        (mlrun.api.schemas.APIStates.waiting_for_chief, "API is waiting for chief"),
+    ],
+)
+def test_api_states(
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    state,
+    expected_message,
 ) -> None:
-    expected_message_map = {
-        mlrun.api.schemas.APIStates.waiting_for_migrations: "API is waiting for migrations to be triggered",
-        mlrun.api.schemas.APIStates.migrations_in_progress: "Migrations are in progress",
-        mlrun.api.schemas.APIStates.migrations_failed: "Migrations failed",
-    }
-    for state, expected_message in expected_message_map.items():
-        mlrun.mlconf.httpdb.state = state
-        response = client.get("healthz")
-        assert response.status_code == http.HTTPStatus.OK.value
+    mlrun.mlconf.httpdb.state = state
+    response = client.get("healthz")
+    assert response.status_code == http.HTTPStatus.OK.value
 
-        response = client.get("projects/some-project/background-tasks/some-task")
-        assert response.status_code == http.HTTPStatus.NOT_FOUND.value
+    response = client.get("projects/some-project/background-tasks/some-task")
+    assert response.status_code == http.HTTPStatus.NOT_FOUND.value
 
-        response = client.get("client-spec")
-        assert response.status_code == http.HTTPStatus.OK.value
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
 
-        response = client.get("projects")
-        assert response.status_code == http.HTTPStatus.PRECONDITION_FAILED.value
-        assert expected_message in response.text
+    response = client.get("projects")
+    assert response.status_code == http.HTTPStatus.PRECONDITION_FAILED.value
+    assert (
+        expected_message in response.text
+    ), f"Expected message: {expected_message}, actual: {response.text}"
 
 
 def test_init_data_migration_required_recognition(monkeypatch) -> None:


### PR DESCRIPTION
When worker is waiting for chief to be available, reflect a correct message and not just "migration is required"

https://jira.iguazeng.com/browse/ML-3678

Next: make worker wait for chief upon deployment