### PR TITLE
[Datastore] Fix leading zeros in time partition names [1.3.x]

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -525,8 +525,8 @@ class BaseStoreTarget(DataTargetBase):
                     ("minute", "%M"),
                 ]:
                     partition_cols.append(unit)
-                    target_df[unit] = getattr(
-                        pd.DatetimeIndex(target_df[timestamp_key]), unit
+                    target_df[unit] = pd.DatetimeIndex(target_df[timestamp_key]).format(
+                        date_format=fmt
                     )
                     if unit == time_partitioning_granularity:
                         break


### PR DESCRIPTION
backport of https://github.com/mlrun/mlrun/pull/3325

[ML-3404](https://jira.iguazeng.com/browse/ML-3404)