### PR TITLE
[API] Fail `healthz` requests when offline / waiting for chief

### DIFF
--- a/mlrun/api/api/endpoints/healthz.py
+++ b/mlrun/api/api/endpoints/healthz.py
@@ -12,20 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import http
+
 from fastapi import APIRouter
 
-import mlrun.api.crud
 import mlrun.api.schemas
+from mlrun.config import config as mlconfig
 
 router = APIRouter()
 
 
 @router.get(
     "/healthz",
-    response_model=mlrun.api.schemas.ClientSpec,
+    status_code=http.HTTPStatus.OK.value,
 )
 def health():
 
-    # TODO: From 0.7.0 client uses the /client-spec endpoint,
-    #  when this is the oldest relevant client, remove this logic from the healthz endpoint
-    return mlrun.api.crud.ClientSpec().get_client_spec()
+    # offline is the initial state
+    # waiting for chief is set for workers waiting for chief to be ready and then clusterize against it
+    if mlconfig.httpdb.state in [
+        mlrun.api.schemas.APIStates.offline,
+        mlrun.api.schemas.APIStates.waiting_for_chief,
+    ]:
+        raise mlrun.errors.MLRunServiceUnavailableError()
+
+    return {"status": "ok"}

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -179,6 +179,10 @@ class MLRunInternalServerError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
 
 
+class MLRunServiceUnavailableError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.SERVICE_UNAVAILABLE.value
+
+
 class MLRunRuntimeError(MLRunHTTPStatusError, RuntimeError):
     error_status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
 
@@ -213,4 +217,5 @@ STATUS_ERRORS = {
     HTTPStatus.CONFLICT.value: MLRunConflictError,
     HTTPStatus.PRECONDITION_FAILED.value: MLRunPreconditionFailedError,
     HTTPStatus.INTERNAL_SERVER_ERROR.value: MLRunInternalServerError,
+    HTTPStatus.SERVICE_UNAVAILABLE.value: MLRunServiceUnavailableError,
 }

--- a/tests/api/api/test_healthz.py
+++ b/tests/api/api/test_healthz.py
@@ -17,8 +17,8 @@ import http
 import fastapi.testclient
 import sqlalchemy.orm
 
-import mlrun.config
 import mlrun.api.schemas
+import mlrun.config
 
 
 def test_health(

--- a/tests/api/api/test_healthz.py
+++ b/tests/api/api/test_healthz.py
@@ -17,25 +17,19 @@ import http
 import fastapi.testclient
 import sqlalchemy.orm
 
-import mlrun
-import mlrun.api.crud
+import mlrun.config
 import mlrun.api.schemas
-import mlrun.api.utils.clients.iguazio
-import mlrun.errors
-import mlrun.runtimes
 
 
 def test_health(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
-    overridden_ui_projects_prefix = "some-prefix"
-    mlrun.mlconf.ui.projects_prefix = overridden_ui_projects_prefix
-    nuclio_version = "x.x.x"
-    mlrun.mlconf.nuclio_version = nuclio_version
+
+    # sanity
     response = client.get("healthz")
     assert response.status_code == http.HTTPStatus.OK.value
-    response_body = response.json()
-    for key in ["scrape_metrics", "hub_url"]:
-        assert response_body[key] is None
-    assert response_body["ui_projects_prefix"] == overridden_ui_projects_prefix
-    assert response_body["nuclio_version"] == nuclio_version
+
+    # fail
+    mlrun.config.config.httpdb.state = mlrun.api.schemas.APIStates.offline
+    response = client.get("healthz")
+    assert response.status_code == http.HTTPStatus.SERVICE_UNAVAILABLE.value

--- a/tests/api/test_api_states.py
+++ b/tests/api/test_api_states.py
@@ -31,7 +31,7 @@ def test_offline_state(
 ) -> None:
     mlrun.mlconf.httpdb.state = mlrun.api.schemas.APIStates.offline
     response = client.get("healthz")
-    assert response.status_code == http.HTTPStatus.OK.value
+    assert response.status_code == http.HTTPStatus.SERVICE_UNAVAILABLE.value
 
     response = client.get("projects")
     assert response.status_code == http.HTTPStatus.PRECONDITION_FAILED.value


### PR DESCRIPTION
To ensure that k8s deployment finishes only when worker find and clusterize with its chief

part (2) of https://github.com/mlrun/mlrun/pull/3336