### PR TITLE
[Model Monitoring] Update system tests and fix endpoint_type in batch job

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -251,7 +251,6 @@ class ModelEndpoints:
             with_defaults=False,
         )
 
-
         # Save the new feature set
         feature_set._override_run_db(db_session)
         feature_set.save()

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -244,11 +244,12 @@ class ModelEndpoints:
         )
         parquet_target = mlrun.datastore.targets.ParquetTarget("parquet", parquet_path)
         driver = mlrun.datastore.targets.get_target_driver(parquet_target, feature_set)
-        driver.update_resource_status("created")
+
         feature_set.set_targets(
             [mlrun.datastore.targets.ParquetTarget(path=parquet_path)],
             with_defaults=False,
         )
+        driver.update_resource_status("created")
 
         # Save the new feature set
         feature_set._override_run_db(db_session)

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -244,12 +244,13 @@ class ModelEndpoints:
         )
         parquet_target = mlrun.datastore.targets.ParquetTarget("parquet", parquet_path)
         driver = mlrun.datastore.targets.get_target_driver(parquet_target, feature_set)
+        driver.update_resource_status("created")
 
         feature_set.set_targets(
             [mlrun.datastore.targets.ParquetTarget(path=parquet_path)],
             with_defaults=False,
         )
-        driver.update_resource_status("created")
+
 
         # Save the new feature set
         feature_set._override_run_db(db_session)

--- a/mlrun/model_monitoring/model_monitoring_batch.py
+++ b/mlrun/model_monitoring/model_monitoring_batch.py
@@ -627,6 +627,7 @@ class BatchProcessor:
             return
 
         for endpoint in endpoints:
+            print('[EYAL]: current endpoint: ', endpoint)
             if (
                 endpoint[mlrun.model_monitoring.EventFieldType.ACTIVE]
                 and endpoint[mlrun.model_monitoring.EventFieldType.MONITORING_MODE]
@@ -634,7 +635,7 @@ class BatchProcessor:
             ):
                 # Skip router endpoint:
                 if (
-                    endpoint[mlrun.model_monitoring.EventFieldType.ENDPOINT_TYPE]
+                    int(endpoint[mlrun.model_monitoring.EventFieldType.ENDPOINT_TYPE])
                     == mlrun.model_monitoring.EndpointType.ROUTER
                 ):
                     # Router endpoint has no feature stats
@@ -646,6 +647,7 @@ class BatchProcessor:
 
     def update_drift_metrics(self, endpoint: dict):
         try:
+            print('[EYAL]: right now working on endpoint: ', endpoint)
 
             # Convert feature set into dataframe and get the latest dataset
             (

--- a/mlrun/model_monitoring/model_monitoring_batch.py
+++ b/mlrun/model_monitoring/model_monitoring_batch.py
@@ -627,7 +627,6 @@ class BatchProcessor:
             return
 
         for endpoint in endpoints:
-            print('[EYAL]: current endpoint: ', endpoint)
             if (
                 endpoint[mlrun.model_monitoring.EventFieldType.ACTIVE]
                 and endpoint[mlrun.model_monitoring.EventFieldType.MONITORING_MODE]
@@ -647,8 +646,6 @@ class BatchProcessor:
 
     def update_drift_metrics(self, endpoint: dict):
         try:
-            print('[EYAL]: right now working on endpoint: ', endpoint)
-
             # Convert feature set into dataframe and get the latest dataset
             (
                 _,

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -1100,7 +1100,7 @@ def _init_endpoint_record(
                 db.create_model_endpoint(
                     project=project,
                     endpoint_id=model_endpoint,
-                    model_endpoint=current_endpoint.dict(),
+                    model_endpoint=current_endpoint,
                 )
 
         except Exception as exc:

--- a/tests/api/api/test_model_endpoints.py
+++ b/tests/api/api/test_model_endpoints.py
@@ -312,7 +312,7 @@ def _mock_random_endpoint(
 
     return mlrun.api.schemas.ModelEndpoint(
         metadata=mlrun.api.schemas.ModelEndpointMetadata(
-            project=TEST_PROJECT, labels=random_labels()
+            project=TEST_PROJECT, labels=random_labels(), uid=str(randint(1000, 5000))
         ),
         spec=mlrun.api.schemas.ModelEndpointSpec(
             function_uri=f"test/function_{randint(0, 100)}:v{randint(0, 100)}",


### PR DESCRIPTION
This PR includes minor fixes that were exposed due to system tests failures following https://github.com/mlrun/mlrun/pull/2685:
- **Model monitoring batch job** - `endpoint[endpoint_type]` value from the DB is retrieved as a `string`. Therefore we convert it to an `int` when checking if the endpoint type is a router (Which based on the `IntEnum` class `EndpointType` class).
- **Create children endpoints of a router** - No need to convert `current_endpoint` into a dictionary when writing the endpoint into the DB as this object is already from type `mlrun.model_monitoring.model_endpoint.ModelEndpoint`. The `HTTPDB` class will convert it to a dictionary before the API call. 
- **Generting endpoint id for model endpoints in system tests** - when using the `_mock_random_endpoint()` we have to define endpoint id as well to avoid an error when trying to write this model endpoint into DB. 
- **Update list model endpoints in system tests** - `list_model_endpoints()` API has been updated in https://github.com/mlrun/mlrun/pull/2685 to return a list of `mlrun.model_monitoring.model_endpoint.ModelEndpoint` objects instead of `mlrun.api.schemas.model_endpoints.ModelEndpointList` which should be used only in the BE. In this PR, we fix several system tests that are still based on this object.
