### PR TITLE
[Model Monitoring] Fix monitoring feature set target

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -244,11 +244,12 @@ class ModelEndpoints:
         )
         parquet_target = mlrun.datastore.targets.ParquetTarget("parquet", parquet_path)
         driver = mlrun.datastore.targets.get_target_driver(parquet_target, feature_set)
-        driver.update_resource_status("created")
+
         feature_set.set_targets(
             [mlrun.datastore.targets.ParquetTarget(path=parquet_path)],
             with_defaults=False,
         )
+        driver.update_resource_status("created")
 
         # Save the new feature set
         feature_set._override_run_db(db_session)


### PR DESCRIPTION
When creating a model monitoring feature set, we need to define the parquet target that will be used for storing the endpoint events for a later drift analysis. Before applying `update_resource_status()` in order to update the model monitoring feature set status target we need to define the target using the `set_targets()` method.