### PR TITLE
[Projects] Fix forwarding project subpath value to schedule workflow

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -754,6 +754,7 @@ class _RemoteRunner(_PipelineRunner):
         workflow_spec: WorkflowSpec,
         artifact_path: str,
         workflow_handler: str,
+        subpath: str,
         namespace: str,
     ) -> typing.Tuple[mlrun.runtimes.RemoteRuntime, "mlrun.RunObject"]:
         """
@@ -766,6 +767,7 @@ class _RemoteRunner(_PipelineRunner):
         :param workflow_spec:       workflow to run
         :param artifact_path:       path to store artifacts
         :param workflow_handler:    workflow function handler (for running workflow function directly)
+        :param subpath:    project subpath (within the archive)
         :param namespace:           kubernetes namespace if other than default
         :return:
         """
@@ -791,6 +793,7 @@ class _RemoteRunner(_PipelineRunner):
                     "ttl": workflow_spec.cleanup_ttl or workflow_spec.ttl,
                     "engine": workflow_spec.engine,
                     "local": workflow_spec.run_local,
+                    "subpath": subpath,
                     "schedule": workflow_spec.schedule,
                 },
                 handler="mlrun.projects.load_and_run",
@@ -839,6 +842,7 @@ class _RemoteRunner(_PipelineRunner):
             workflow_spec=workflow_spec,
             artifact_path=artifact_path,
             workflow_handler=workflow_handler,
+            subpath = project.spec.subpath,
             namespace=namespace,
         )
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -842,7 +842,7 @@ class _RemoteRunner(_PipelineRunner):
             workflow_spec=workflow_spec,
             artifact_path=artifact_path,
             workflow_handler=workflow_handler,
-            subpath = project.spec.subpath,
+            subpath=project.spec.subpath,
             namespace=namespace,
         )
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -754,8 +754,8 @@ class _RemoteRunner(_PipelineRunner):
         workflow_spec: WorkflowSpec,
         artifact_path: str,
         workflow_handler: str,
-        subpath: str,
         namespace: str,
+        subpath: str,
     ) -> typing.Tuple[mlrun.runtimes.RemoteRuntime, "mlrun.RunObject"]:
         """
         Helper function for creating the runspec of the load and run function.
@@ -767,8 +767,8 @@ class _RemoteRunner(_PipelineRunner):
         :param workflow_spec:       workflow to run
         :param artifact_path:       path to store artifacts
         :param workflow_handler:    workflow function handler (for running workflow function directly)
-        :param subpath:             project subpath (within the archive)
         :param namespace:           kubernetes namespace if other than default
+        :param subpath:             project subpath (within the archive)
         :return:
         """
         # Creating the load project and workflow running function:
@@ -793,8 +793,8 @@ class _RemoteRunner(_PipelineRunner):
                     "ttl": workflow_spec.cleanup_ttl or workflow_spec.ttl,
                     "engine": workflow_spec.engine,
                     "local": workflow_spec.run_local,
-                    "subpath": subpath,
                     "schedule": workflow_spec.schedule,
+                    "subpath": subpath,
                 },
                 handler="mlrun.projects.load_and_run",
             ),
@@ -842,8 +842,8 @@ class _RemoteRunner(_PipelineRunner):
             workflow_spec=workflow_spec,
             artifact_path=artifact_path,
             workflow_handler=workflow_handler,
-            subpath=project.spec.subpath,
             namespace=namespace,
+            subpath=project.spec.subpath,
         )
 
         # The returned engine for this runner is the engine of the workflow.

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -767,7 +767,7 @@ class _RemoteRunner(_PipelineRunner):
         :param workflow_spec:       workflow to run
         :param artifact_path:       path to store artifacts
         :param workflow_handler:    workflow function handler (for running workflow function directly)
-        :param subpath:    project subpath (within the archive)
+        :param subpath:             project subpath (within the archive)
         :param namespace:           kubernetes namespace if other than default
         :return:
         """

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -139,7 +139,7 @@ def new_project(
     :param context:      project local directory path (default value = "./")
     :param init_git:     if True, will git init the context dir
     :param user_project: add the current user name to the provided project name (making it unique per user)
-    :param remote:       remote Git urlproject subpath (rel
+    :param remote:       remote Git url
     :param from_template:     path to project YAML/zip file that will be used as a template
     :param secrets:      key:secret dict or SecretsStore used to download sources
     :param description:  text describing the project

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -139,7 +139,7 @@ def new_project(
     :param context:      project local directory path (default value = "./")
     :param init_git:     if True, will git init the context dir
     :param user_project: add the current user name to the provided project name (making it unique per user)
-    :param remote:       remote Git url
+    :param remote:       remote Git urlproject subpath (rel
     :param from_template:     path to project YAML/zip file that will be used as a template
     :param secrets:      key:secret dict or SecretsStore used to download sources
     :param description:  text describing the project

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -820,16 +820,15 @@ class TestProject(TestMLRunSystem):
         assert schedule.scheduled_object["schedule"] == schedule_str
 
     def test_remote_workflow_source_with_subpath(self):
-        #Test running remote workflow when the project files are store in a reltive path (the subpath)
-        project_source = "git://github.com/GiladShapira94/test-working-dir.git#master"
+        # Test running remote workflow when the project files are store in a relative path (the subpath)
+        project_source = "git://github.com/mlrun/system-tests.git#main"
         project_context = "./test_subpath_remote"
         project_name = "test-remote-workflow-source-with-subpath"
+        self.custom_project_names_to_delete.append(project_name)
         project = mlrun.load_project(
             context=project_context,
             url=project_source,
-            user_project=True,
-            subpath="./project",
-            name=project_name,
-            clone=True,
+            subpath="./test_remote_workflow_subpath",
+            name=project_name
         )
-        project.run("main", arguments={"x": 1}, engine="remote:kfp")
+        project.run("main", arguments={"x": 1}, engine="remote:kfp", watch=True)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -829,6 +829,6 @@ class TestProject(TestMLRunSystem):
             context=project_context,
             url=project_source,
             subpath="./test_remote_workflow_subpath",
-            name=project_name
+            name=project_name,
         )
         project.run("main", arguments={"x": 1}, engine="remote:kfp", watch=True)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -818,3 +818,18 @@ class TestProject(TestMLRunSystem):
     def _assert_scheduled(self, project_name, schedule_str):
         schedule = self._run_db.get_schedule(project_name, "main")
         assert schedule.scheduled_object["schedule"] == schedule_str
+
+    def test_remote_workflow_source_with_subpath(self):
+        #Test running remote workflow when the project files are store in a reltive path (the subpath)
+        project_source = "git://github.com/GiladShapira94/test-working-dir.git#master"
+        project_context = "./test_subpath_remote"
+        project_name = "test-remote-workflow-source-with-subpath"
+        project = mlrun.load_project(
+            context=project_context,
+            url=project_source,
+            user_project=True,
+            subpath="./project",
+            name=project_name,
+            clone=True,
+        )
+        project.run("main", arguments={"x": 1}, engine="remote:kfp")


### PR DESCRIPTION
Currently, we didn't forward the project subpath value to the scheduled job workflow which is an issue when trying to schedule a workflow that is stored in a relative path in the source e.g git repo.


https://github.com/mlrun/system-tests/pull/1