### PR TITLE
[Tests] System test prepare purge DB

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -208,6 +208,9 @@ jobs:
           "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
           "${{ secrets.LATEST_SYSTEM_TEST_PASSWORD }}" \
           "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_MYSQL_USER }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_MYSQL_PASSWORD }}" \
+          --purge-db \
           --mlrun-commit "${{ steps.computed_params.outputs.mlrun_hash }}" \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
           --override-image-repo ${{ steps.computed_params.outputs.mlrun_docker_repo }} \

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -42,6 +42,7 @@ class SystemTestPreparer:
         mlrun_code_path = workdir / "mlrun"
         provctl_path = workdir / "provctl"
         system_tests_env_yaml = pathlib.Path("tests") / "system" / "env.yml"
+        namespace = "default-tenant"
 
         git_url = "https://github.com/mlrun/mlrun.git"
 
@@ -69,6 +70,9 @@ class SystemTestPreparer:
         spark_service: str = None,
         password: str = None,
         slack_webhook_url: str = None,
+        mysql_user: str = None,
+        mysql_password: str = None,
+        purge_db: bool = False,
         debug: bool = False,
     ):
         self._logger = logger
@@ -91,6 +95,9 @@ class SystemTestPreparer:
         self._provctl_download_s3_access_key = provctl_download_s3_access_key
         self._provctl_download_s3_key_id = provctl_download_s3_key_id
         self._iguazio_version = iguazio_version
+        self._mysql_user = mysql_user
+        self._mysql_password = mysql_password
+        self._purge_db = purge_db
 
         self._env_config = {
             "MLRUN_DBPATH": mlrun_dbpath,
@@ -124,17 +131,19 @@ class SystemTestPreparer:
         self.connect_to_remote()
 
         # for sanity clean up before starting the run
-        self.clean_up_remote_workdir()
-
-        self._prepare_env_remote()
-
-        self._resolve_iguazio_version()
-
-        self._download_provctl()
-
-        self._override_mlrun_api_env()
-
-        self._patch_mlrun()
+        # self.clean_up_remote_workdir()
+        #
+        # self._prepare_env_remote()
+        #
+        # self._resolve_iguazio_version()
+        #
+        # self._download_provctl()
+        #
+        # self._override_mlrun_api_env()
+        #
+        # self._patch_mlrun()
+        if self._purge_db:
+            self._purge_mlrun_db()
 
     def clean_up_remote_workdir(self):
         self._logger.info(
@@ -334,7 +343,10 @@ class SystemTestPreparer:
             "apiVersion": "v1",
             "data": data,
             "kind": "ConfigMap",
-            "metadata": {"name": "mlrun-override-env", "namespace": "default-tenant"},
+            "metadata": {
+                "name": "mlrun-override-env",
+                "namespace": self.Constants.namespace,
+            },
         }
         manifest_file_name = "override_mlrun_registry.yml"
         self._run_command(
@@ -503,6 +515,86 @@ class SystemTestPreparer:
             "Resolved iguazio version", iguazio_version=self._iguazio_version
         )
 
+    def _purge_mlrun_db(self):
+        """
+        Purge mlrun db - exec into mlrun-db pod, delete the database and restart mlrun pods
+        """
+        self._delete_mlrun_db()
+        self._rollout_restart_mlrun()
+        self._wait_for_mlrun_to_be_ready()
+
+    def _delete_mlrun_db(self):
+        self._logger.info("Deleting mlrun db")
+
+        get_mlrun_db_pod_name_cmd = self._get_pod_name_command(
+            labels={
+                "app.kubernetes.io/component": "db",
+                "app.kubernetes.io/instance": "mlrun",
+            },
+        )
+
+        password = ""
+        if self._mysql_password:
+            password = f"-p {self._mysql_password} "
+
+        drop_db_cmd = f"mysql --socket=/run/mysqld/mysql.sock -u {self._mysql_user} {password}-e 'DROP DATABASE mlrun;'"
+        self._run_kubectl_command(
+            args=[
+                "exec",
+                "-n",
+                self.Constants.namespace,
+                "-it",
+                f"$({get_mlrun_db_pod_name_cmd})",
+                "--",
+                drop_db_cmd,
+            ],
+            # verbose=False,
+        )
+
+    def _get_pod_name_command(self, labels, namespace=None):
+        namespace = namespace or self.Constants.namespace
+        labels_selector = ",".join([f"{k}={v}" for k, v in labels.items()])
+        return "kubectl get pods -n {namespace} -l {labels_selector} | tail -n 1 | awk '{{print $1}}'".format(
+            namespace=namespace, labels_selector=labels_selector
+        )
+
+    def _rollout_restart_mlrun(self):
+        self._logger.info("Restarting mlrun")
+        self._run_kubectl_command(
+            args=[
+                "rollout",
+                "restart",
+                "deployment",
+                "-n",
+                self.Constants.namespace,
+                "mlrun-api-chief",
+                "mlrun-api-worker",
+                "mlrun-db",
+            ]
+        )
+
+    def _wait_for_mlrun_to_be_ready(self):
+        self._logger.info("Waiting for mlrun to be ready")
+        self._run_kubectl_command(
+            args=[
+                "wait",
+                "--for=condition=available",
+                "--timeout=300s",
+                "deployment",
+                "-n",
+                self.Constants.namespace,
+                "mlrun-api-chief",
+                "mlrun-db",
+            ]
+        )
+
+    def _run_kubectl_command(self, args, verbose=True):
+        self._run_command(
+            command="kubectl",
+            args=args,
+            verbose=verbose,
+        )
+
 
 @click.group()
 def main():
@@ -552,6 +644,9 @@ def main():
 @click.argument("spark-service", type=str, required=True)
 @click.argument("password", type=str, default=None, required=False)
 @click.argument("slack-webhook-url", type=str, default=None, required=False)
+@click.argument("mysql-user", type=str, default=None, required=False)
+@click.argument("mysql-password", type=str, default=None, required=False)
+@click.option("--purge-db", "-pdb", is_flag=True, help="Purge mlrun db")
 @click.option(
     "--debug",
     "-d",
@@ -581,6 +676,9 @@ def run(
     spark_service: str,
     password: str,
     slack_webhook_url: str,
+    mysql_user: str,
+    mysql_password: str,
+    purge_db: bool,
     debug: bool,
 ):
     system_test_preparer = SystemTestPreparer(
@@ -606,6 +704,9 @@ def run(
         spark_service,
         password,
         slack_webhook_url,
+        mysql_user,
+        mysql_password,
+        purge_db,
         debug,
     )
     try:

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -131,17 +131,18 @@ class SystemTestPreparer:
         self.connect_to_remote()
 
         # for sanity clean up before starting the run
-        # self.clean_up_remote_workdir()
-        #
-        # self._prepare_env_remote()
-        #
-        # self._resolve_iguazio_version()
-        #
-        # self._download_provctl()
-        #
-        # self._override_mlrun_api_env()
-        #
-        # self._patch_mlrun()
+        self.clean_up_remote_workdir()
+
+        self._prepare_env_remote()
+
+        self._resolve_iguazio_version()
+
+        self._download_provctl()
+
+        self._override_mlrun_api_env()
+
+        self._patch_mlrun()
+
         if self._purge_db:
             self._purge_mlrun_db()
 
@@ -548,7 +549,7 @@ class SystemTestPreparer:
                 "--",
                 drop_db_cmd,
             ],
-            # verbose=False,
+            verbose=False,
         )
 
     def _get_pod_name_command(self, labels, namespace=None):


### PR DESCRIPTION
With the coming up introduction of system tests over patch development branches (e.g. 1.3.x) we need to purge the DB before running the system tests since we do not support migrating mlrun db to lower versions.
**Note the mysql credentials secrets need to be created before merging**