### PR TITLE
[Runtimes] Avoid hang on large stderr output in `run_exec` [1.3.x]

### DIFF
--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -14,11 +14,13 @@
 
 import importlib.util as imputil
 import inspect
+import io
 import json
 import os
 import socket
 import sys
 import tempfile
+import threading
 import traceback
 from contextlib import redirect_stdout
 from copy import copy
@@ -358,21 +360,38 @@ def load_module(file_name, handler, context):
 def run_exec(cmd, args, env=None, cwd=None):
     if args:
         cmd += args
-    out = ""
     if env and "SYSTEMROOT" in os.environ:
         env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
     print("running:", cmd)
-    process = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ, cwd=cwd)
-    while True:
-        nextline = process.stdout.readline()
-        if not nextline and process.poll() is not None:
-            break
-        print(nextline.decode("utf-8"), end="")
-        sys.stdout.flush()
-        out += nextline.decode("utf-8")
-    code = process.poll()
+    process = Popen(
+        cmd, stdout=PIPE, stderr=PIPE, env=os.environ, cwd=cwd, universal_newlines=True
+    )
 
-    err = process.stderr.read().decode("utf-8") if code != 0 else ""
+    def read_stderr(stderr):
+        while True:
+            nextline = process.stderr.readline()
+            if not nextline:
+                break
+            stderr.write(nextline)
+
+    # ML-3710. We must read stderr in a separate thread to drain the stderr pipe so that the spawned process won't
+    # hang if it tries to write more to stderr than the buffer size (default of approx 8kb).
+    with io.StringIO() as stderr:
+        stderr_consumer_thread = threading.Thread(target=read_stderr, args=[stderr])
+        stderr_consumer_thread.start()
+
+        with io.StringIO() as stdout:
+            while True:
+                nextline = process.stdout.readline()
+                if not nextline:
+                    break
+                print(nextline, end="")
+                sys.stdout.flush()
+                stdout.write(nextline)
+            out = stdout.getvalue()
+
+        stderr_consumer_thread.join()
+        err = stderr.getvalue()
     return out, err
 
 

--- a/tests/runtimes/assets/verbose_stderr.py
+++ b/tests/runtimes/assets/verbose_stderr.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+print("some output")
+
+for i in range(10000):
+    print("123456789", file=sys.stderr)
+
+sys.exit(1)

--- a/tests/runtimes/test_local.py
+++ b/tests/runtimes/test_local.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+
+from mlrun.runtimes.local import run_exec
+
+
+def test_run_exec_basic():
+    out, err = run_exec(["echo"], ["hello"])
+    assert out == "hello\n"
+    assert err == ""
+
+
+# ML-3710
+def test_run_exec_verbose_stderr():
+    script_path = str(pathlib.Path(__file__).parent / "assets" / "verbose_stderr.py")
+    out, err = run_exec(["python"], [script_path])
+    assert out == "some output\n"
+    assert len(err) == 100000


### PR DESCRIPTION
Cherry picked from commit bf07df6eb0aa986da5e1ce805a87b58e02239433. Corresponding development PR is #3364