### PR TITLE
[Spark] Support more than 2 keys in spark online target ingestion engine [1.3.x]

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import sqlalchemy
+from storey.utils import hash_list, stringify_key
 
 import mlrun
 import mlrun.utils.helpers
@@ -1050,39 +1051,17 @@ class NoSqlBaseTarget(BaseStoreTarget):
             **self.attributes,
         )
 
+    def prepare_spark_df(self, df, key_columns):
+        raise NotImplementedError()
+
     def get_spark_options(self, key_column=None, timestamp_key=None, overwrite=True):
-        spark_options = {
-            "path": store_path_to_spark(self.get_target_path()),
-            "format": "io.iguaz.v3io.spark.sql.kv",
-        }
-        if isinstance(key_column, list) and len(key_column) >= 1:
-            if len(key_column) > 2:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Spark supports maximun of 2 keys and {key_column} are provided"
-                )
-            spark_options["key"] = key_column[0]
-            if len(key_column) > 1:
-                spark_options["sorting-key"] = key_column[1]
-        else:
-            spark_options["key"] = key_column
-        if not overwrite:
-            spark_options["columnUpdate"] = True
-        return spark_options
+        raise NotImplementedError()
 
     def get_dask_options(self):
         return {"format": "csv"}
 
     def as_df(self, columns=None, df_module=None, **kwargs):
         raise NotImplementedError()
-
-    def prepare_spark_df(self, df, key_columns):
-        import pyspark.sql.functions as funcs
-
-        for col_name, col_type in df.dtypes:
-            if col_type.startswith("decimal("):
-                # V3IO does not support this level of precision
-                df = df.withColumn(col_name, funcs.col(col_name).cast("double"))
-        return df
 
     def write_dataframe(
         self, df, key_column=None, timestamp_key=None, chunk_id=0, **kwargs
@@ -1126,6 +1105,41 @@ class NoSqlTarget(NoSqlBaseTarget):
             V3ioDriver(webapi=endpoint),
             flush_interval_secs=mlrun.mlconf.feature_store.flush_interval,
         )
+
+    def get_spark_options(self, key_column=None, timestamp_key=None, overwrite=True):
+        spark_options = {
+            "path": store_path_to_spark(self.get_target_path()),
+            "format": "io.iguaz.v3io.spark.sql.kv",
+        }
+        if isinstance(key_column, list) and len(key_column) >= 1:
+            spark_options["key"] = key_column[0]
+            if len(key_column) > 2:
+                spark_options["sorting-key"] = "_spark_object_sorting_key"
+            if len(key_column) == 2:
+                spark_options["sorting-key"] = key_column[1]
+        else:
+            spark_options["key"] = key_column
+        if not overwrite:
+            spark_options["columnUpdate"] = True
+        return spark_options
+
+    def prepare_spark_df(self, df, key_columns):
+        from pyspark.sql.functions import col, udf
+        from pyspark.sql.types import StringType
+
+        for col_name, col_type in df.dtypes:
+            if col_type.startswith("decimal("):
+                # V3IO does not support this level of precision
+                df = df.withColumn(col_name, col(col_name).cast("double"))
+        if len(key_columns) > 2:
+            hash_and_concat_udf = udf(
+                lambda *x: hash_list([str(i) for i in x]), StringType()
+            )
+            return df.withColumn(
+                "_spark_object_sorting_key",
+                hash_and_concat_udf(*[col(c) for c in key_columns[1:]]),
+            )
+        return df
 
 
 class RedisNoSqlTarget(NoSqlBaseTarget):
@@ -1186,11 +1200,20 @@ class RedisNoSqlTarget(NoSqlBaseTarget):
         return endpoint
 
     def prepare_spark_df(self, df, key_columns):
-        from pyspark.sql.functions import udf
+        from pyspark.sql.functions import col, udf
         from pyspark.sql.types import StringType
 
-        udf1 = udf(lambda x: str(x) + "}:static", StringType())
-        return df.withColumn("_spark_object_name", udf1(key_columns[0]))
+        if len(key_columns) > 1:
+            hash_and_concat_udf = udf(
+                lambda *x: stringify_key([str(i) for i in x]) + "}:static", StringType()
+            )
+            return df.withColumn(
+                "_spark_object_name",
+                hash_and_concat_udf(*[col(c) for c in key_columns]),
+            )
+        else:
+            udf1 = udf(lambda x: str(x) + "}:static", StringType())
+            return df.withColumn("_spark_object_name", udf1(key_columns[0]))
 
 
 class StreamTarget(BaseStoreTarget):

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -384,6 +384,66 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
                 }
             ]
 
+    @pytest.mark.parametrize(
+        "target_kind",
+        ["Redis", "v3io"] if mlrun.mlconf.redis.url is not None else ["v3io"],
+    )
+    def test_ingest_multiple_entities(self, target_kind):
+        key1 = "patient_id"
+        key2 = "bad"
+        key3 = "department"
+        name = "measurements_spark"
+
+        measurements = fstore.FeatureSet(
+            name,
+            entities=[fstore.Entity(key1), fstore.Entity(key2), fstore.Entity(key3)],
+            timestamp_key="timestamp",
+            engine="spark",
+        )
+        source = ParquetSource("myparquet", path=self.get_remote_pq_source_path())
+        if target_kind == "Redis":
+            targets = [RedisNoSqlTarget()]
+        else:
+            targets = [NoSqlTarget()]
+        measurements.set_targets(targets, with_defaults=False)
+
+        fstore.ingest(
+            measurements,
+            source,
+            spark_context=self.spark_service,
+            run_config=fstore.RunConfig(False),
+            overwrite=True,
+        )
+        # read the dataframe
+        vector = fstore.FeatureVector("myvector", features=[f"{name}.*"])
+        with fstore.get_online_feature_service(vector) as svc:
+            resp = svc.get(
+                [
+                    {
+                        "patient_id": "305-90-1613",
+                        "bad": 95,
+                        "department": "01e9fe31-76de-45f0-9aed-0f94cc97bca0",
+                    }
+                ]
+            )
+            assert resp == [
+                {
+                    "room": 2,
+                    "hr": 220.0,
+                    "hr_is_error": False,
+                    "rr": 25,
+                    "rr_is_error": False,
+                    "spo2": 99,
+                    "spo2_is_error": False,
+                    "movements": 4.614601941071927,
+                    "movements_is_error": False,
+                    "turn_count": 0.3582583538239813,
+                    "turn_count_is_error": False,
+                    "is_in_bed": 1,
+                    "is_in_bed_is_error": False,
+                }
+            ]
+
     @pytest.mark.skipif(
         not mlrun.mlconf.redis.url,
         reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",


### PR DESCRIPTION
[ML-3443](https://jira.iguazeng.com/browse/ML-3443)