### PR TITLE
[Serving] Fix process executer in `ParallelRun` 

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -380,7 +380,7 @@ class TaskStep(BaseStep):
         for key in ["name", "context", "input_path", "result_path", "full_event"]:
             if argspec.varkw or key in argspec.args:
                 class_args[key] = getattr(self, key)
-        if argspec.varkw or "graph_step" in argspec.args:
+        if "graph_step" in argspec.args:
             class_args["graph_step"] = self
         return class_args
 


### PR DESCRIPTION
Process executer in `ParallelRun` is failing due to serialization error. 
Fix `TaskStep` to insert self to _kwargs only if explicitly asked.  