### PR TITLE
[Requirements] ARM64 requirements over conda env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ install-requirements: ## Install all requirements needed for development
 		-r dockerfiles/mlrun-api/requirements.txt \
 		-r docs/requirements.txt
 
+.PHONY: install-conda-requirements
+install-conda-requirements: install-requirements ## Install all requirements needed for development with specific conda packages for arm64
+	conda install --yes --file conda-arm64-requirements.txt
+
 .PHONY: install-complete-requirements
 install-complete-requirements: ## Install all requirements needed for development and testing
 	python -m pip install --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)

--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -1,0 +1,4 @@
+# with moving to arm64 for the new M1/M2 macs some packages are not yet compatible via pip and require
+# conda which supports different architecture environments on the same machine
+protobuf>=3.13, <3.20
+lightgbm>=3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,6 +17,6 @@ avro~=1.11
 # needed for mlutils tests
 scikit-learn~=1.0
 # needed for frameworks tests
-lightgbm~=3.0
+lightgbm~=3.0; platform_machine != 'arm64'
 xgboost~=1.1
 sqlalchemy_utils~=0.39.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -171,6 +171,8 @@ def test_requirement_specifiers_inconsistencies():
         # The empty specifier is from tests/runtimes/assets/requirements.txt which is there specifically to test the
         # scenario of requirements without version specifiers
         "python-dotenv": {"", "~=0.17.0"},
+        # conda requirements since conda does not support ~= operator
+        "lightgbm": {"~=3.0", "~=3.0; platform_machine != 'arm64'", ">=3.0"},
     }
 
     for (

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -171,7 +171,8 @@ def test_requirement_specifiers_inconsistencies():
         # The empty specifier is from tests/runtimes/assets/requirements.txt which is there specifically to test the
         # scenario of requirements without version specifiers
         "python-dotenv": {"", "~=0.17.0"},
-        # conda requirements since conda does not support ~= operator
+        # conda requirements since conda does not support ~= operator and
+        # since platform condition is not required for docker
         "lightgbm": {"~=3.0", "~=3.0; platform_machine != 'arm64'", ">=3.0"},
     }
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -139,6 +139,8 @@ def test_requirement_specifiers_convention():
         "plotly": {"~=5.4, <5.12.0"},
         # used in tests
         "aioresponses": {"~=0.7"},
+        # conda requirements since conda does not support ~= operator
+        "lightgbm": {">=3.0"},
     }
 
     for (


### PR DESCRIPTION
With moving to ARM64 (apple silicon) some packages are not working properly when installing with pip.
This forces us to find other solutions, one of them is setting a conda environment.
Once the conda environment is set up, run `make install-conda-requirements` to install all dev requirements with specific requirements installed with conda to mitigate the migration to ARM64.