### PR TITLE
[Tests] Fix pipeline system tests

### DIFF
--- a/docs/tutorial/src/workflow.py
+++ b/docs/tutorial/src/workflow.py
@@ -16,7 +16,7 @@ def pipeline(model_name="cancer-classifier"):
 
     # Train a model using the auto_trainer hub function
     train = mlrun.run_function(
-        "hub://auto_trainer",
+        "hub://auto-trainer",
         inputs={"dataset": ingest.outputs["dataset"]},
         params={
             "model_class": "sklearn.ensemble.RandomForestClassifier",

--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -218,7 +218,7 @@ class RunConfig:
             config = RunConfig("mycode.py", image="mlrun/mlrun", requirements=["spacy"])
 
             # config for using function object
-            function = mlrun.import_function("hub://some_function")
+            function = mlrun.import_function("hub://some-function")
             config = RunConfig(function)
 
         :param function:    this can be function uri or function object or path to function code (.py/.ipynb)

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -92,7 +92,7 @@ def run_function(
         LABELS = "is_error"
         MODEL_CLASS = "sklearn.ensemble.RandomForestClassifier"
         DATA_PATH = "s3://bigdata/data.parquet"
-        function = mlrun.import_function("hub://auto_trainer")
+        function = mlrun.import_function("hub://auto-trainer")
         run1 = run_function(function, params={"label_columns": LABELS, "model_class": MODEL_CLASS},
                                       inputs={"dataset": DATA_PATH})
 
@@ -101,7 +101,7 @@ def run_function(
         # create a project with two functions (local and from marketplace)
         project = mlrun.new_project(project_name, "./proj)
         project.set_function("mycode.py", "myfunc", image="mlrun/mlrun")
-        project.set_function("hub://auto_trainer", "train")
+        project.set_function("hub://auto-trainer", "train")
 
         # run functions (refer to them by name)
         run1 = run_function("myfunc", params={"x": 7})

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -117,7 +117,7 @@ def new_project(
         # create a project with local and marketplace functions, a workflow, and an artifact
         project = mlrun.new_project("myproj", "./", init_git=True, description="my new project")
         project.set_function('prep_data.py', 'prep-data', image='mlrun/mlrun', handler='prep_data')
-        project.set_function('hub://auto_trainer', 'train')
+        project.set_function('hub://auto-trainer', 'train')
         project.set_artifact('data', Artifact(target_path=data_url))
         project.set_workflow('main', "./myflow.py")
         project.save()
@@ -1522,7 +1522,7 @@ class MlrunProject(ModelObj):
 
             object (s3://, v3io://, ..)
             MLRun DB e.g. db://project/func:ver
-            functions hub/market: e.g. hub://auto_trainer:master
+            functions hub/market: e.g. hub://auto-trainer:master
 
         examples::
 
@@ -2180,7 +2180,7 @@ class MlrunProject(ModelObj):
             # create a project with two functions (local and from marketplace)
             project = mlrun.new_project(project_name, "./proj")
             project.set_function("mycode.py", "myfunc", image="mlrun/mlrun")
-            project.set_function("hub://auto_trainer", "train")
+            project.set_function("hub://auto-trainer", "train")
 
             # run functions (refer to them by name)
             run1 = project.run_function("myfunc", params={"x": 7})

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -236,7 +236,7 @@ def function_to_module(code="", workdir=None, secrets=None, silent=False):
         mod.my_job(context, p1=1, p2='x')
         print(context.to_yaml())
 
-        fn = mlrun.import_function('hub://open_archive')
+        fn = mlrun.import_function('hub://open-archive')
         mod = mlrun.function_to_module(fn)
         data = mlrun.run.get_dataitem("https://fpsignals-public.s3.amazonaws.com/catsndogs.tar.gz")
         context = mlrun.get_or_create_ctx('myfunc')
@@ -458,7 +458,7 @@ def import_function(url="", secrets=None, db="", project=None, new_name=None):
 
     examples::
 
-        function = mlrun.import_function("hub://auto_trainer")
+        function = mlrun.import_function("hub://auto-trainer")
         function = mlrun.import_function("./func.yaml")
         function = mlrun.import_function("https://raw.githubusercontent.com/org/repo/func.yaml")
 

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -317,7 +317,7 @@ class ServingRuntime(RemoteRuntime):
                                 example::
 
                                     # initialize a new serving function
-                                    serving_fn = mlrun.import_function("hub://v2_model_server", new_name="serving")
+                                    serving_fn = mlrun.import_function("hub://v2-model-server", new_name="serving")
                                     # apply model monitoring and set monitoring batch job to run every 3 hours
                                     tracking_policy = {'default_batch_intervals':"0 */3 * * *"}
                                     serving_fn.set_tracking(tracking_policy=tracking_policy)

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -1181,7 +1181,7 @@ def test_generate_function_and_task_from_submit_run_body_imported_function_proje
     _mock_import_function(monkeypatch)
     submit_job_body = {
         "task": {
-            "spec": {"function": "hub://gen_class_data"},
+            "spec": {"function": "hub://gen-class-data"},
             "metadata": {"name": task_name, "project": PROJECT},
         },
         "function": {"spec": {"resources": {"limits": {}, "requests": {}}}},

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -61,7 +61,7 @@ def test_sync_functions():
     assert fn.metadata.name == "describe", "func did not return"
 
     # test that functions can be fetched from the DB (w/o set_function)
-    mlrun.import_function("hub://auto_trainer", new_name="train").save()
+    mlrun.import_function("hub://auto-trainer", new_name="train").save()
     fn = project.get_function("train")
     assert fn.metadata.name == "train", "train func did not return"
 

--- a/tests/system/demos/churn/test_churn.py
+++ b/tests/system/demos/churn/test_churn.py
@@ -59,11 +59,11 @@ class TestChurn(TestDemo):
         self._logger.debug("Setting project functions")
         demo_project.set_function(clean_data_function)
         demo_project.set_function("hub://describe", "describe")
-        demo_project.set_function("hub://xgb_trainer", "classify")
-        demo_project.set_function("hub://xgb_test", "xgbtest")
-        demo_project.set_function("hub://coxph_trainer", "survive")
-        demo_project.set_function("hub://coxph_test", "coxtest")
-        demo_project.set_function("hub://churn_server", "server")
+        demo_project.set_function("hub://xgb-trainer", "classify")
+        demo_project.set_function("hub://xgb-test", "xgbtest")
+        demo_project.set_function("hub://coxph-trainer", "survive")
+        demo_project.set_function("hub://coxph-test", "coxtest")
+        demo_project.set_function("hub://churn-server", "server")
 
         self._logger.debug("Setting project workflow")
         demo_project.set_workflow(

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -73,7 +73,7 @@ class TestHorovodTFv2(TestDemo):
         trainer.spec.service_type = "NodePort"
 
         demo_project.set_function(trainer)
-        demo_project.set_function("hub://tf2_serving", "serving")
+        demo_project.set_function("hub://tf2-serving", "serving")
 
         demo_project.log_artifact(
             "images",

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -52,9 +52,9 @@ class TestSKLearn(TestDemo):
         self._logger.debug("Setting project functions")
         demo_project.set_function(iris_generator_function)
         demo_project.set_function("hub://describe", "describe")
-        demo_project.set_function("hub://auto_trainer", "auto_trainer")
+        demo_project.set_function("hub://auto-trainer", "auto-trainer")
         demo_project.set_function("hub://model_server", "serving")
-        demo_project.set_function("hub://model_server_tester", "live_tester")
+        demo_project.set_function("hub://model_server_tester", "live-tester")
 
         self._logger.debug("Setting project workflow")
         demo_project.set_workflow(

--- a/tests/system/demos/sklearn/test_sklearn.py
+++ b/tests/system/demos/sklearn/test_sklearn.py
@@ -53,8 +53,8 @@ class TestSKLearn(TestDemo):
         demo_project.set_function(iris_generator_function)
         demo_project.set_function("hub://describe", "describe")
         demo_project.set_function("hub://auto-trainer", "auto-trainer")
-        demo_project.set_function("hub://model_server", "serving")
-        demo_project.set_function("hub://model_server_tester", "live-tester")
+        demo_project.set_function("hub://model-server", "serving")
+        demo_project.set_function("hub://model-server-tester", "live-tester")
 
         self._logger.debug("Setting project workflow")
         demo_project.set_workflow(

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -253,7 +253,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
 
         # Import the serving function from the function hub
         serving_fn = mlrun.import_function(
-            "hub://v2_model_server", project=self.project_name
+            "hub://v2-model-server", project=self.project_name
         ).apply(mlrun.auto_mount())
         # enable model monitoring
         serving_fn.set_tracking()
@@ -396,7 +396,7 @@ class TestModelMonitoringRegression(TestMLRunSystem):
 
         # Set the serving topology to simple model routing
         # with data enrichment and imputing from the feature vector
-        serving_fn = mlrun.import_function("hub://v2_model_server", new_name="serving")
+        serving_fn = mlrun.import_function("hub://v2-model-server", new_name="serving")
         serving_fn.set_topology(
             "router",
             mlrun.serving.routers.EnrichmentModelRouter(
@@ -512,7 +512,7 @@ class TestVotingModelMonitoring(TestMLRunSystem):
 
         # Import the serving function from the function hub
         serving_fn = mlrun.import_function(
-            "hub://v2_model_server", project=self.project_name
+            "hub://v2-model-server", project=self.project_name
         ).apply(mlrun.auto_mount())
 
         serving_fn.set_topology(

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -366,7 +366,7 @@ class TestModelMonitoringRegression(TestMLRunSystem):
         )
 
         # Train the model using the auto trainer from the marketplace
-        train = mlrun.import_function("hub://auto_trainer", new_name="train")
+        train = mlrun.import_function("hub://auto-trainer", new_name="train")
         train.deploy()
         model_class = "sklearn.linear_model.LinearRegression"
         model_name = "diabetes_model"
@@ -530,7 +530,7 @@ class TestVotingModelMonitoring(TestMLRunSystem):
         }
 
         # Import the auto trainer function from the marketplace (hub://)
-        train = mlrun.import_function("hub://auto_trainer")
+        train = mlrun.import_function("hub://auto-trainer")
 
         for name, pkg in model_names.items():
 

--- a/tests/system/projects/assets/kflow.py
+++ b/tests/system/projects/assets/kflow.py
@@ -42,7 +42,7 @@ def kfpipeline(model_class=default_pkg_class, build=0):
 
     # train the model using a library (hub://) function and the generated data
     # no need to define handler in this step because the train function is the default handler
-    train = funcs["auto_trainer"].as_step(
+    train = funcs["auto-trainer"].as_step(
         name="train",
         inputs={"dataset": prep_data.outputs["cleaned_data"]},
         params={
@@ -53,7 +53,7 @@ def kfpipeline(model_class=default_pkg_class, build=0):
     )
 
     # test the model using a library (hub://) function and the generated model
-    funcs["auto_trainer"].as_step(
+    funcs["auto-trainer"].as_step(
         name="test",
         handler="evaluate",
         params={"label_columns": "label", "model": train.outputs["model"]},

--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -87,7 +87,7 @@ def newpipe():
 
     # test out new model server (via REST API calls), use imported function
     run_function(
-        "hub://v2_model_tester",
+        "hub://v2-model-tester",
         name="model-tester",
         params={"addr": deploy.outputs["endpoint"], "model": f"{DATASET}:v1"},
         inputs={"table": train.outputs["test_set"]},

--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -52,7 +52,7 @@ def newpipe():
 
     # train with hyper-paremeters
     train = run_function(
-        "auto_trainer",
+        "auto-trainer",
         name="train",
         params={"label_columns": LABELS, "train_test_split_size": 0.10},
         hyperparams={
@@ -70,7 +70,7 @@ def newpipe():
 
     # test and visualize our model
     run_function(
-        "auto_trainer",
+        "auto-trainer",
         name="test",
         handler="evaluate",
         params={"label_columns": LABELS, "model": train.outputs["model"]},

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -45,7 +45,7 @@ def exec_project(args):
 @dsl.pipeline(name="test pipeline", description="test")
 def pipe_test():
     # train the model using a library (hub://) function and the generated data
-    funcs["auto_trainer"].as_step(
+    funcs["auto-trainer"].as_step(
         name="train",
         inputs={"dataset": data_url},
         params={"model_class": model_class, "label_columns": "label"},
@@ -86,7 +86,7 @@ class TestProject(TestMLRunSystem):
             with_repo=with_repo,
         )
         proj.set_function("hub://describe")
-        proj.set_function("hub://auto_trainer", "auto_trainer")
+        proj.set_function("hub://auto-trainer", "auto-trainer")
         proj.set_function("hub://v2_model_server", "serving")
         proj.set_artifact("data", Artifact(target_path=data_url))
         proj.spec.params = {"label_columns": "label"}

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -87,7 +87,7 @@ class TestProject(TestMLRunSystem):
         )
         proj.set_function("hub://describe")
         proj.set_function("hub://auto-trainer", "auto-trainer")
-        proj.set_function("hub://v2_model_server", "serving")
+        proj.set_function("hub://v2-model-server", "serving")
         proj.set_artifact("data", Artifact(target_path=data_url))
         proj.spec.params = {"label_columns": "label"}
         arg = EntrypointParam(


### PR DESCRIPTION
Fix failing tests during (#3287) by replacing all underscores used when setting a getting function.
You can see the system tests failures [here](https://iguazio.slack.com/archives/C04GL7EE65R/p1680580973029999)

There will be a client-side follow-up PR that includes the following changes:
- Make it clearer to the user that underscores have been replaced with dashes.
- If a user attempts to obtain a function with an underscore-containing name and receives a 404, we will try to query the name with dashes in case the user missed the message.