### PR TITLE
[Spark] Remove UDF dependencies

### DIFF
--- a/mlrun/datastore/spark_udf.py
+++ b/mlrun/datastore/spark_udf.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hashlib
+
+from pyspark.sql.functions import udf
+from pyspark.sql.types import StringType
+
+
+def hash_list(list_to_hash):
+    list_to_hash = [str(element) for element in list_to_hash]
+    str_concatted = "".join(list_to_hash)
+    sha1 = hashlib.sha1()
+    sha1.update(str_concatted.encode("utf8"))
+    return sha1.hexdigest()
+
+
+def stringify_key(key_list):
+    if isinstance(key_list, list):
+        if len(key_list) >= 3:
+            return str(key_list[0]) + "." + hash_list(key_list[1:])
+        if len(key_list) == 2:
+            return str(key_list[0]) + "." + str(key_list[1])
+        return key_list[0]
+    else:
+        return key_list
+
+
+def hash_and_concat_v3io_udf(*x):
+    return udf(hash_list([str(i) for i in x]), StringType())
+
+
+def hash_and_concat_redis_multiple_udf(*x):
+    return udf(stringify_key([str(i) for i in x]) + "}:static", StringType())
+
+
+def hash_and_concat_redis_udf(x):
+    return udf(str(x) + "}:static", StringType())

--- a/mlrun/datastore/spark_udf.py
+++ b/mlrun/datastore/spark_udf.py
@@ -40,7 +40,7 @@ def hash_and_concat_v3io_udf(*x):
     return udf(hash_list([str(i) for i in x]), StringType())
 
 
-def hash_and_concat_redis_multiple_udf(*x):
+def hash_and_concat_redis_multiple_keys_udf(*x):
     return udf(stringify_key([str(i) for i in x]) + "}:static", StringType())
 
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1125,7 +1125,7 @@ class NoSqlTarget(NoSqlBaseTarget):
     def prepare_spark_df(self, df, key_columns):
         from pyspark.sql.functions import col
 
-        import spark_udf
+        from . import spark_udf
 
         df.rdd.context.addFile(spark_udf.__file__)
 
@@ -1136,7 +1136,7 @@ class NoSqlTarget(NoSqlBaseTarget):
         if len(key_columns) > 2:
             return df.withColumn(
                 "_spark_object_name",
-                hash_and_concat_v3io_udf(*[col(c) for c in key_columns[1:]]),
+                spark_udf.hash_and_concat_v3io_udf(*[col(c) for c in key_columns[1:]]),
             )
         return df
 
@@ -1201,18 +1201,21 @@ class RedisNoSqlTarget(NoSqlBaseTarget):
     def prepare_spark_df(self, df, key_columns):
         from pyspark.sql.functions import col
 
-        import spark_udf
+        from . import spark_udf
 
         df.rdd.context.addFile(spark_udf.__file__)
 
         if len(key_columns) > 1:
             return df.withColumn(
                 "_spark_object_name",
-                hash_and_concat_redis_multiple_keys_udf(*[col(c) for c in key_columns[1:]]),
+                spark_udf.hash_and_concat_redis_multiple_keys_udf(
+                    *[col(c) for c in key_columns[1:]]
+                ),
             )
         else:
             return df.withColumn(
-                "_spark_object_name", hash_and_concat_redis_udf(key_columns[0])
+                "_spark_object_name",
+                spark_udf.hash_and_concat_redis_udf(key_columns[0]),
             )
 
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 import ast
 import datetime
+import hashlib
 import os
 import random
 import time
-import hashlib
 from collections import Counter
 from copy import copy
 from typing import Any, Dict, List, Optional, Union
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import sqlalchemy
+
 import mlrun
 import mlrun.utils.helpers
 from mlrun.config import config
@@ -1135,8 +1136,9 @@ class NoSqlTarget(NoSqlBaseTarget):
                 # UDF has no access to all the hash_list(), so we do all inline in lambda:
                 # lambda *x: storey.hash_list([str(i) for i in x]), StringType()
                 lambda *x: (
-                    lambda l: (l := [str(e) for e in l])
-                    and hashlib.sha1("".join(l).encode("utf8")).hexdigest()
+                    lambda l: hashlib.sha1(
+                        "".join([str(e) for e in l]).encode("utf8")
+                    ).hexdigest()
                 )(x),
                 StringType(),
             )
@@ -1219,8 +1221,11 @@ class RedisNoSqlTarget(NoSqlBaseTarget):
                         str(k[0])
                         + "."
                         + (
-                            lambda l: (l := [str(e) for e in l])
-                            and hashlib.sha1("".join(l).encode("utf8")).hexdigest()
+                            lambda l: hashlib.sha1(
+                                "".join([str(e) for e in l]).encode("utf8")
+                            ).hexdigest()
+                            if l and len(l) >= 2
+                            else str(l[0])
                         )(k[1:])
                         if len(k) >= 3
                         else (str(k[1]) if len(k) == 2 else str(k[0]))

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -386,7 +386,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
     @pytest.mark.parametrize(
         "target_kind",
-        ["Redis", "v3io"] if mlrun.mlconf.redis.url is not None else ["v3io"],
+        ["Redis", "v3io"] if mlrun.mlconf.redis.url else ["v3io"],
     )
     def test_ingest_multiple_entities(self, target_kind):
         key1 = "patient_id"


### PR DESCRIPTION
When running Spark UDF (User-Defined Function) in Python, the UDF is executed on the Spark worker nodes, which are separate from the machine where you run the Spark driver program. This means that any Python modules installed on local machine may not be available on the worker nodes, which can cause import errors or other issues. In order to resolve this we inline content of any custom functions inside the Spark UDFs