### PR TITLE
[CI] Support multi branch system tests

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -145,7 +145,7 @@ jobs:
     - name: Override remote file from local resolved branch list
       run: |
         # Use sshpass to override the remote file with the new list of branches
-        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp system-tests-branches-list.txt -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/system-tests-branches-list.txt
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp system-tests-branches-list.txt -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
 
 #    - name: Select branch to work on
 #      id: select-branch

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -214,7 +214,7 @@ jobs:
           git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
-        echo "unstable_version_prefix=$(cd /tmp && cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
+        echo "unstable_version_prefix=$(cd base/mlrun && cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
     - name: Set computed versions params
       id: computed_params
       run: |

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -14,6 +14,9 @@
 #
 name: System Tests Enterprise
 
+env:
+  selectedbranch: 'development'
+
 on:
   push:
     branches:
@@ -107,6 +110,57 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Copy state branch file from remote 
+      run: |
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected branchselected
+
+
+    - name: Select next branch  parameter
+      id: select-parameter
+      run: |
+        IFS=',' read -ra selectedbranch_array <<< "$selectedbranch"
+        # Read the last used parameter from the cache
+        if [ ! -f branchselected ]
+        then
+           echo  "No last used parameter branchselected not  found"
+        else
+            last_parameter=$(cat  branchselected)
+            echo "Last used parameter: $last_parameter"
+        fi
+        # Find the index of the last used parameter in the array
+        if [ -n "$last_parameter" ]
+        then
+            for i in "${!selectedbranch_array[@]}"; do
+                if [[ "${selectedbranch_array[$i]}" == "$last_parameter" ]]; then
+                    last_index=$i
+                    break
+                fi
+            done
+        fi
+        # Print unique items from the list
+        echo "Unique items in the list:"
+        echo "${selectedbranch}" | tr ',' '\n' | sort -u
+        # Get the next item in the list
+        if [ -n "$last_index" ]
+        then
+            next_index=$((last_index + 1))
+            if [ "$next_index" -eq "${#selectedbranch_array[@]}" ]
+            then
+                next_index=0
+            fi
+        else
+            next_index=0
+        fi
+        next_parameter="${selectedbranch_array[$next_index]}"
+        echo "Next parameter: $next_parameter"
+        # Write the next parameter to the cache file
+        echo "$next_parameter" > last_parameter.txt
+        # Set the param output for the next step
+        echo "::set-output name=param::$next_parameter"
+        echo $next_parameter > branchselected
+
+
+
     - name: Set up python
       uses: actions/setup-python@v4
       with:
@@ -133,7 +187,7 @@ jobs:
       run: |
         echo "ui_hash=$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ steps.git_info.outputs.branch }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
@@ -143,14 +197,14 @@ jobs:
       run: |
         echo "mlrun_hash=$( \
           cd /tmp && \
-          git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
           cd mlrun-upstream && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
         echo "ui_hash=$( \
           cd /tmp && \
-          git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -228,11 +228,11 @@ jobs:
       run: |
         action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
-        export mlrun_hash=${$upstream_mlrun_hash:-`echo action_mlrun_hash`}
+        export mlrun_hash=${upstream_mlrun_hash:-`echo $action_mlrun_hash`}
         echo "mlrun_hash=$(echo $mlrun_hash)" >> $GITHUB_OUTPUT
         action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
         upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
-        export ui_hash=${$upstream_mlrun_ui_hash:-`echo action_mlrun_ui_hash`}
+        export ui_hash=${upstream_mlrun_ui_hash:-`echo $action_mlrun_ui_hash`}
         echo "ui_hash=$(echo $ui_hash)" >> $GITHUB_OUTPUT
         echo "mlrun_version=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}+$mlrun_hash)" >> $GITHUB_OUTPUT
         echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)" >> $GITHUB_OUTPUT

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -109,13 +109,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Copy state branch file from remote
       run: |
-        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected system-tests-branches-list
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/system-tests-branches-list.txt system-tests-branches-list.txt
 
     - name: resolve-current-branch
       id: current-branch
       run: |
         # Read branches from local file
-        branches=$(cat system-tests-branches-list)
+        branches=$(cat system-tests-branches-list.txt)
 
         # Split branches into an array
         IFS=',' read -ra branches_array <<< "$branches"
@@ -137,7 +137,7 @@ jobs:
         echo "$branches"
 
         # Write new branches order to a local file
-        echo "$branches" | cat > system-tests-branches-options
+        echo "$branches" | cat > system-tests-branches-list.txt
 
         # Set output
         echo "name=$(echo $first_branch)" >> $GITHUB_OUTPUT
@@ -145,7 +145,7 @@ jobs:
     - name: Override remote file from local resolved branch list
       run: |
         # Use sshpass to override the remote file with the new list of branches
-        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp system-tests-branches-list -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp system-tests-branches-list.txt -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/system-tests-branches-list.txt
 
 #    - name: Select branch to work on
 #      id: select-branch

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -17,7 +17,7 @@ name: System Tests Enterprise
 on:
   push:
     branches:
-      - 'branch-system-tests'
+      - '.+-system-tests'
 
   schedule:
 
@@ -43,7 +43,7 @@ on:
         description: 'Override the configured target system iguazio version (leave empty to resolve automatically)'
         required: false
       test_code_from_action:
-        description: 'Take tested code from action REF rather than upstream (default: true). If running on personal fork you will want to set to false in order to pull images from mlrun ghcr (note that test code will be taken from the action REF anyways)'
+        description: 'Take tested code from action from upstream rather than ref (default: false). If running on personal fork you will want to set to false in order to pull images from mlrun ghcr (note that test code will be taken from the action REF anyways)'
         required: true
         default: 'false'
       ui_code_from_action:
@@ -111,8 +111,13 @@ jobs:
       run: |
         sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/system-tests-branches-list.txt system-tests-branches-list.txt
 
-    - name: resolve-current-branch
+    - name: Resolve Branch To Run System Tests
       id: current-branch
+      # we store a file named /tmp/system-tests-branches-list.txt which contains a list of branches to run system tests
+      # on the branches are separated with commas, so each run we pop the first branch in the list and append it to the
+      # end of the list.
+      # This mechanism allows us to run on multiple branches without the need to modify the file or secrets each time
+      # a new branch is added or removed
       run: |
         # Read branches from local file
         branches=$(cat system-tests-branches-list.txt)
@@ -146,10 +151,11 @@ jobs:
 
     - name: Override remote file from local resolved branch list
       run: |
-        # Use sshpass to override the remote file with the new list of branches
+        # Override the remote file with the new list of branches
         sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no system-tests-branches-list.txt ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
-
-    - name: Checkout PR Base (target) Branch
+      # checking out to base branch and not the target(resolved) branch, to be able to run the changed preparation code
+      # before merging the changes to upstream.
+    - name: Checkout base branch
       uses: actions/checkout@v3
 
     - name: Set up python
@@ -162,8 +168,9 @@ jobs:
     - name: Install curl and jq
       run: sudo apt-get install curl jq
     - name: Extract git hash from action mlrun version
-      # by default when running as part of the CI this param doesn't get enriched meaning it will be empty.
-      # we want the mlrun_hash to be set from the $GITHUB_SHA when running in CI
+      # because it is being run mainly on CI and the code is of the development but can be run against multiple branches
+      # the default is false so it will use the code of the chosen branch
+      # TODO: remove - might not be relevant anymore due to multi branch system tests
       if: ${{ github.event.inputs.test_code_from_action != 'false' }}
       id: git_action_info
       run: |
@@ -286,6 +293,9 @@ jobs:
         test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
     steps:
     - uses: actions/checkout@v3
+      # checking out to the resolved branch to run system tests on, as now we run the actual tests, we don't want to run
+      # the system tests of the branch that triggered the system tests as it might be in a different version
+      # than the mlrun version we deployed on the previous job (can have features that the resolved branch doesn't have)
       with:
         ref: ${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}
     - name: Set up python

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -116,12 +116,14 @@ jobs:
       run: |
         # Read branches from local file
         branches=$(cat system-tests-branches-list.txt)
+        echo "branches found in system-tests-branches-list.txt: $branches"
 
         # Split branches into an array
         IFS=',' read -ra branches_array <<< "$branches"
 
-        # Get the first branch in the list
+        # Get the first branch in the list to work on
         first_branch="${branches_array[0]}"
+        echo "working on $first_branch"
 
         # Remove the first branch from the list
         branches_array=("${branches_array[@]:1}")
@@ -147,51 +149,6 @@ jobs:
         # Use sshpass to override the remote file with the new list of branches
         sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no system-tests-branches-list.txt ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
 
-#    - name: Select branch to work on
-#      id: select-branch
-#      run: |
-#        IFS=',' read -ra selectedbranch_array <<< "$selectedbranch"
-#        # Read the last used parameter from the cache
-#        if [ ! -f branchselected ]
-#        then
-#           echo  "No last used parameter branchselected not  found"
-#        else
-#            last_parameter=$(cat  branchselected)
-#            echo "Last used parameter: $last_parameter"
-#        fi
-#        # Find the index of the last used parameter in the array
-#        if [ -n "$last_parameter" ]
-#        then
-#            for i in "${!selectedbranch_array[@]}"; do
-#                if [[ "${selectedbranch_array[$i]}" == "$last_parameter" ]]; then
-#                    last_index=$i
-#                    break
-#                fi
-#            done
-#        fi
-#        # Print unique items from the list
-#        echo "Unique items in the list:"
-#        echo "${selectedbranch}" | tr ',' '\n' | sort -u
-#        # Get the next item in the list
-#        if [ -n "$last_index" ]
-#        then
-#            next_index=$((last_index + 1))
-#            if [ "$next_index" -eq "${#selectedbranch_array[@]}" ]
-#            then
-#                next_index=0
-#            fi
-#        else
-#            next_index=0
-#        fi
-#        next_parameter="${selectedbranch_array[$next_index]}"
-#        echo "Next parameter: $next_parameter"
-#        # Write the next parameter to the cache file
-#        echo "$next_parameter" > last_parameter.txt
-#        # Set the param output for the next step
-#        echo "::set-output name=param::$next_parameter"
-#        echo $next_parameter > branchselected
-
-
     - name: Checkout PR Base (target) Branch
       uses: actions/checkout@v3
 
@@ -204,18 +161,13 @@ jobs:
       run: pip install -r automation/requirements.txt && pip install -e .
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-#    - name: Extract git branch
-#      id: git_info
-#      run: |
-#        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-#
     - name: Extract git hash from action mlrun version
       # by default when running as part of the CI this param doesn't get enriched meaning it will be empty.
       # we want the mlrun_hash to be set from the $GITHUB_SHA when running in CI
       if: ${{ github.event.inputs.test_code_from_action != 'false' }}
       id: git_action_info
       run: |
-        echo "mlrun_hash=$(cd base/mlrun && git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_OUTPUT
+        echo "mlrun_hash=$(git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_OUTPUT
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
@@ -251,7 +203,6 @@ jobs:
           cat automation/version/unstable_version_prefix && \
           cd .. && \
           rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
-#        echo "unstable_version_prefix=$(cd base/mlrun && cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
     - name: Set computed versions params
       id: computed_params
       run: |
@@ -316,49 +267,51 @@ jobs:
 
     outputs:
       mlrunVersion: ${{ steps.computed_params.outputs.mlrun_version }}
+      mlrunBranch: ${{ steps.current-branch.outputs.name }}
       mlrunSystemTestsCleanResources: ${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}
 
-#  run-system-tests-enterprise-ci:
-#    # When increasing the timeout make sure it's not larger than the schedule cron interval
-#    timeout-minutes: 360
-#    name: Run System Tests Enterprise
-#    # requires prepare to finish before starting
-#    needs: [prepare-system-tests-enterprise-ci]
-#    runs-on: ubuntu-latest
-#    # let's not run this on every fork, change to your fork when developing
-#    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
-#    strategy:
-#      fail-fast: false
-#      max-parallel: 1
-#      matrix:
-#        test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
-#    steps:
-#    # checking out to the commit hash that the preparation step executed on
-#    - uses: actions/checkout@v3
-#    - name: Set up python
-#      uses: actions/setup-python@v4
-#      with:
-#        python-version: 3.9
-#        cache: pip
-#    - name: Install automation scripts dependencies and add mlrun to dev packages
-#      run: pip install -r automation/requirements.txt && pip install -e .
-#    - name: Install curl and jq
-#      run: sudo apt-get install curl jq
-#    - name: Prepare System Test env.yaml and MLRun installation from current branch
-#      timeout-minutes: 5
-#      run: |
-#        python automation/system_test/prepare.py env \
-#          "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_WEBAPI_DIRECT_URL }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_FRAMESD_URL }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_PASSWORD }}" \
-#          "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}"
-#    - name: Run System Tests
-#      run: |
-#        MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunSystemTestsCleanResources }}" \
-#        MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
-#        MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
-#          make test-system-dockerized
+  run-system-tests-enterprise-ci:
+    # When increasing the timeout make sure it's not larger than the schedule cron interval
+    timeout-minutes: 360
+    name: Run System Tests Enterprise
+    # requires prepare to finish before starting
+    needs: [prepare-system-tests-enterprise-ci]
+    runs-on: ubuntu-latest
+    # let's not run this on every fork, change to your fork when developing
+    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: pip
+    - name: Install automation scripts dependencies and add mlrun to dev packages
+      run: pip install -r automation/requirements.txt && pip install -e .
+    - name: Install curl and jq
+      run: sudo apt-get install curl jq
+    - name: Prepare System Test env.yaml and MLRun installation from current branch
+      timeout-minutes: 5
+      run: |
+        python automation/system_test/prepare.py env \
+          "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_WEBAPI_DIRECT_URL }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_FRAMESD_URL }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_PASSWORD }}" \
+          "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}"
+    - name: Run System Tests
+      run: |
+        MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunSystemTestsCleanResources }}" \
+        MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
+        MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
+          make test-system-dockerized

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -14,9 +14,6 @@
 #
 name: System Tests Enterprise
 
-env:
-  selectedbranch: 'development'
-
 on:
   push:
     branches:
@@ -112,59 +109,91 @@ jobs:
     - uses: actions/checkout@v3
     - name: Copy state branch file from remote
       run: |
-        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected branchselected
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected system-tests-branches-list
 
-
-    - name: Select next branch  parameter
-      id: select-parameter
+    - name: resolve-current-branch
+      id: current-branch
       run: |
-        IFS=',' read -ra selectedbranch_array <<< "$selectedbranch"
-        # Read the last used parameter from the cache
-        if [ ! -f branchselected ]
-        then
-           echo  "No last used parameter branchselected not  found"
-        else
-            last_parameter=$(cat  branchselected)
-            echo "Last used parameter: $last_parameter"
-        fi
-        # Find the index of the last used parameter in the array
-        if [ -n "$last_parameter" ]
-        then
-            for i in "${!selectedbranch_array[@]}"; do
-                if [[ "${selectedbranch_array[$i]}" == "$last_parameter" ]]; then
-                    last_index=$i
-                    break
-                fi
-            done
-        fi
-        # Print unique items from the list
-        echo "Unique items in the list:"
-        echo "${selectedbranch}" | tr ',' '\n' | sort -u
-        # Get the next item in the list
-        if [ -n "$last_index" ]
-        then
-            next_index=$((last_index + 1))
-            if [ "$next_index" -eq "${#selectedbranch_array[@]}" ]
-            then
-                next_index=0
-            fi
-        else
-            next_index=0
-        fi
-        next_parameter="${selectedbranch_array[$next_index]}"
-        echo "Next parameter: $next_parameter"
-        # Write the next parameter to the cache file
-        echo "$next_parameter" > last_parameter.txt
-        # Set the param output for the next step
-        echo "::set-output name=param::$next_parameter"
-        echo $next_parameter > branchselected
+        # Read branches from local file
+        branches=$(cat system-tests-branches-list)
+
+        # Split branches into an array
+        IFS=',' read -ra branche#s_array <<< "$branches"
+
+        # Get the first branch in the list
+        first_branch="${branches_array[0]}"
+
+        # Remove the first branch from the list
+        branches_array=("${branches_array[@]:1}")
+
+        # Add the first branch at the end of the list
+        branches_array+=("$first_branch")
+
+        # Join branches back into a string
+        branches=$(printf ",%s" "${branches_array[@]}")
+        branches=${branches:1}
+
+        # Output the new list of branches
+        echo "$branches"
+
+        # Write new branches order to a local file
+        echo "$branches" | cat > system-tests-branches-options
+
+        # Set output
+        echo "name=$(echo $first_branch)" >> $GITHUB_OUTPUT
+
+    - name: Override remote file from local resolved branch list
+      run: |
+        # Use sshpass to override the remote file with the new list of branches
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp system-tests-branches-list -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected
+
+#    - name: Select branch to work on
+#      id: select-branch
+#      run: |
+#        IFS=',' read -ra selectedbranch_array <<< "$selectedbranch"
+#        # Read the last used parameter from the cache
+#        if [ ! -f branchselected ]
+#        then
+#           echo  "No last used parameter branchselected not  found"
+#        else
+#            last_parameter=$(cat  branchselected)
+#            echo "Last used parameter: $last_parameter"
+#        fi
+#        # Find the index of the last used parameter in the array
+#        if [ -n "$last_parameter" ]
+#        then
+#            for i in "${!selectedbranch_array[@]}"; do
+#                if [[ "${selectedbranch_array[$i]}" == "$last_parameter" ]]; then
+#                    last_index=$i
+#                    break
+#                fi
+#            done
+#        fi
+#        # Print unique items from the list
+#        echo "Unique items in the list:"
+#        echo "${selectedbranch}" | tr ',' '\n' | sort -u
+#        # Get the next item in the list
+#        if [ -n "$last_index" ]
+#        then
+#            next_index=$((last_index + 1))
+#            if [ "$next_index" -eq "${#selectedbranch_array[@]}" ]
+#            then
+#                next_index=0
+#            fi
+#        else
+#            next_index=0
+#        fi
+#        next_parameter="${selectedbranch_array[$next_index]}"
+#        echo "Next parameter: $next_parameter"
+#        # Write the next parameter to the cache file
+#        echo "$next_parameter" > last_parameter.txt
+#        # Set the param output for the next step
+#        echo "::set-output name=param::$next_parameter"
+#        echo $next_parameter > branchselected
 
 
     - name: Checkout PR Base (target) Branch
       uses: actions/checkout@v3
-      with:
-        ref: ${{ steps.select-parameter.outputs.param }}
-        path: base/mlrun
 
     - name: Set up python
       uses: actions/setup-python@v4
@@ -193,7 +222,7 @@ jobs:
       run: |
         echo "ui_hash=$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.current-branch.outputs.name }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
@@ -203,21 +232,21 @@ jobs:
       run: |
         echo "mlrun_hash=$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.current-branch.outputs.name }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
           cd mlrun-upstream && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
         echo "ui_hash=$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.current-branch.outputs.name }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
           git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
         echo "unstable_version_prefix=$( \
           cd /tmp && \
-          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
+          git clone --single-branch --branch ${{ steps.current-branch.outputs.name }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
           cd mlrun-upstream && \
           cat automation/version/unstable_version_prefix && \
           cd .. && \

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -228,11 +228,11 @@ jobs:
       run: |
         action_mlrun_hash=${{ steps.git_action_info.outputs.mlrun_hash }} && \
         upstream_mlrun_hash=${{ steps.git_upstream_info.outputs.mlrun_hash }} && \
-        export mlrun_hash=${action_mlrun_hash:-`echo $upstream_mlrun_hash`}
+        export mlrun_hash=${$upstream_mlrun_hash:-`echo action_mlrun_hash`}
         echo "mlrun_hash=$(echo $mlrun_hash)" >> $GITHUB_OUTPUT
         action_mlrun_ui_hash=${{ steps.git_action_ui_info.outputs.ui_hash }} && \
         upstream_mlrun_ui_hash=${{ steps.git_upstream_info.outputs.ui_hash }} && \
-        export ui_hash=${action_mlrun_ui_hash:-`echo $upstream_mlrun_ui_hash`}
+        export ui_hash=${$upstream_mlrun_ui_hash:-`echo action_mlrun_ui_hash`}
         echo "ui_hash=$(echo $ui_hash)" >> $GITHUB_OUTPUT
         echo "mlrun_version=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}+$mlrun_hash)" >> $GITHUB_OUTPUT
         echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)" >> $GITHUB_OUTPUT

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -20,7 +20,7 @@ env:
 on:
   push:
     branches:
-      - '.+-system-tests'
+      - 'branch-system-tests'
 
   schedule:
 

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -145,7 +145,7 @@ jobs:
     - name: Override remote file from local resolved branch list
       run: |
         # Use sshpass to override the remote file with the new list of branches
-        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp system-tests-branches-list.txt -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
+        sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no system-tests-branches-list.txt ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
 
 #    - name: Select branch to work on
 #      id: select-branch

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -179,6 +179,7 @@ jobs:
 #      id: git_info
 #      run: |
 #        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+#
     - name: Extract git hash from action mlrun version
       # by default when running as part of the CI this param doesn't get enriched meaning it will be empty.
       # we want the mlrun_hash to be set from the $GITHUB_SHA when running in CI

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -48,7 +48,7 @@ on:
       test_code_from_action:
         description: 'Take tested code from action REF rather than upstream (default: true). If running on personal fork you will want to set to false in order to pull images from mlrun ghcr (note that test code will be taken from the action REF anyways)'
         required: true
-        default: 'true'
+        default: 'false'
       ui_code_from_action:
         description: 'Take ui code from action branch in mlrun/ui (default: false - take from upstream)'
         required: true

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Copy state branch file from remote 
+    - name: Copy state branch file from remote
       run: |
         sshpass -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" scp -o StrictHostKeyChecking=no   ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/branchselected branchselected
 
@@ -160,6 +160,11 @@ jobs:
         echo $next_parameter > branchselected
 
 
+    - name: Checkout PR Base (target) Branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ steps.select-parameter.outputs.param }}
+        path: base/mlrun
 
     - name: Set up python
       uses: actions/setup-python@v4
@@ -170,17 +175,17 @@ jobs:
       run: pip install -r automation/requirements.txt && pip install -e .
     - name: Install curl and jq
       run: sudo apt-get install curl jq
-    - name: Extract git branch
-      id: git_info
-      run: |
-        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+#    - name: Extract git branch
+#      id: git_info
+#      run: |
+#        echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
     - name: Extract git hash from action mlrun version
       # by default when running as part of the CI this param doesn't get enriched meaning it will be empty.
       # we want the mlrun_hash to be set from the $GITHUB_SHA when running in CI
       if: ${{ github.event.inputs.test_code_from_action != 'false' }}
       id: git_action_info
       run: |
-        echo "mlrun_hash=$(git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_OUTPUT
+        echo "mlrun_hash=$(cd base/mlrun && git rev-parse --short=8 $GITHUB_SHA)" >> $GITHUB_OUTPUT
     - name: Extract git hash from action mlrun version
       if: ${{ github.event.inputs.ui_code_from_action == 'true' }}
       id: git_action_ui_info
@@ -209,7 +214,7 @@ jobs:
           git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
-        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
+        echo "unstable_version_prefix=$(cd /tmp && cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
     - name: Set computed versions params
       id: computed_params
       run: |
@@ -276,47 +281,47 @@ jobs:
       mlrunVersion: ${{ steps.computed_params.outputs.mlrun_version }}
       mlrunSystemTestsCleanResources: ${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}
 
-  run-system-tests-enterprise-ci:
-    # When increasing the timeout make sure it's not larger than the schedule cron interval
-    timeout-minutes: 360
-    name: Run System Tests Enterprise
-    # requires prepare to finish before starting
-    needs: [prepare-system-tests-enterprise-ci]
-    runs-on: ubuntu-latest
-    # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
-    steps:
-    # checking out to the commit hash that the preparation step executed on
-    - uses: actions/checkout@v3
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-        cache: pip
-    - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: pip install -r automation/requirements.txt && pip install -e .
-    - name: Install curl and jq
-      run: sudo apt-get install curl jq
-    - name: Prepare System Test env.yaml and MLRun installation from current branch
-      timeout-minutes: 5
-      run: |
-        python automation/system_test/prepare.py env \
-          "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_WEBAPI_DIRECT_URL }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_FRAMESD_URL }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_PASSWORD }}" \
-          "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}"
-    - name: Run System Tests
-      run: |
-        MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunSystemTestsCleanResources }}" \
-        MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
-        MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
-          make test-system-dockerized
+#  run-system-tests-enterprise-ci:
+#    # When increasing the timeout make sure it's not larger than the schedule cron interval
+#    timeout-minutes: 360
+#    name: Run System Tests Enterprise
+#    # requires prepare to finish before starting
+#    needs: [prepare-system-tests-enterprise-ci]
+#    runs-on: ubuntu-latest
+#    # let's not run this on every fork, change to your fork when developing
+#    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
+#    strategy:
+#      fail-fast: false
+#      max-parallel: 1
+#      matrix:
+#        test_component: [api,runtimes,projects,model_monitoring,examples,backwards_compatibility,feature_store]
+#    steps:
+#    # checking out to the commit hash that the preparation step executed on
+#    - uses: actions/checkout@v3
+#    - name: Set up python
+#      uses: actions/setup-python@v4
+#      with:
+#        python-version: 3.9
+#        cache: pip
+#    - name: Install automation scripts dependencies and add mlrun to dev packages
+#      run: pip install -r automation/requirements.txt && pip install -e .
+#    - name: Install curl and jq
+#      run: sudo apt-get install curl jq
+#    - name: Prepare System Test env.yaml and MLRun installation from current branch
+#      timeout-minutes: 5
+#      run: |
+#        python automation/system_test/prepare.py env \
+#          "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_WEBAPI_DIRECT_URL }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_FRAMESD_URL }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_PASSWORD }}" \
+#          "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}"
+#    - name: Run System Tests
+#      run: |
+#        MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunSystemTestsCleanResources }}" \
+#        MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
+#        MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
+#          make test-system-dockerized

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -118,7 +118,7 @@ jobs:
         branches=$(cat system-tests-branches-list)
 
         # Split branches into an array
-        IFS=',' read -ra branche#s_array <<< "$branches"
+        IFS=',' read -ra branches_array <<< "$branches"
 
         # Get the first branch in the list
         first_branch="${branches_array[0]}"

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -214,7 +214,14 @@ jobs:
           git rev-parse --short=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
-        echo "unstable_version_prefix=$(cd base/mlrun && cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
+        echo "unstable_version_prefix=$( \
+          cd /tmp && \
+          git clone --single-branch --branch ${{ steps.select-parameter.outputs.param }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
+          cd mlrun-upstream && \
+          cat automation/version/unstable_version_prefix && \
+          cd .. && \
+          rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
+#        echo "unstable_version_prefix=$(cd base/mlrun && cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
     - name: Set computed versions params
       id: computed_params
       run: |

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -141,11 +141,13 @@ class SystemTestPreparer:
 
         self._override_mlrun_api_env()
 
+        # purge of the database needs to be executed before patching mlrun so that the mlrun migrations
+        # that run as part of the patch would succeed even if we move from a newer version to an older one
+        # e.g from development branch which is (1.4.0) and has a newer alembic revision than 1.3.x which is (1.3.1)
         if self._purge_db:
             self._purge_mlrun_db()
 
         self._patch_mlrun()
-
 
     def clean_up_remote_workdir(self):
         self._logger.info(
@@ -522,11 +524,10 @@ class SystemTestPreparer:
 
     def _purge_mlrun_db(self):
         """
-        Purge mlrun db - exec into mlrun-db pod, delete the database and restart mlrun pods
+        Purge mlrun db - exec into mlrun-db pod, delete the database and scale down mlrun pods
         """
         self._delete_mlrun_db()
         self._scale_down_mlrun_deployments()
-        # self._wait_for_mlrun_to_be_ready()
 
     def _delete_mlrun_db(self):
         self._logger.info("Deleting mlrun db")
@@ -564,7 +565,8 @@ class SystemTestPreparer:
         )
 
     def _scale_down_mlrun_deployments(self):
-        self._logger.info("scaling down mlrun")
+        # scaling down to avoid automatically deployments restarts and failures
+        self._logger.info("scaling down mlrun deployments")
         self._run_kubectl_command(
             args=[
                 "scale",
@@ -574,22 +576,7 @@ class SystemTestPreparer:
                 "mlrun-api-chief",
                 "mlrun-api-worker",
                 "mlrun-db",
-                "--replicas=0"
-            ]
-        )
-
-    def _wait_for_mlrun_to_be_ready(self):
-        self._logger.info("Waiting for mlrun to be ready")
-        self._run_kubectl_command(
-            args=[
-                "wait",
-                "--for=condition=available",
-                "--timeout=300s",
-                "deployment",
-                "-n",
-                self.Constants.namespace,
-                "mlrun-api-chief",
-                "mlrun-db",
+                "--replicas=0",
             ]
         )
 

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -524,8 +524,8 @@ class SystemTestPreparer:
         Purge mlrun db - exec into mlrun-db pod, delete the database and restart mlrun pods
         """
         self._delete_mlrun_db()
-        self._rollout_restart_mlrun()
-        self._wait_for_mlrun_to_be_ready()
+        self._scale_down_mlrun_deployments()
+        # self._wait_for_mlrun_to_be_ready()
 
     def _delete_mlrun_db(self):
         self._logger.info("Deleting mlrun db")
@@ -562,18 +562,18 @@ class SystemTestPreparer:
             namespace=namespace, labels_selector=labels_selector
         )
 
-    def _rollout_restart_mlrun(self):
-        self._logger.info("Restarting mlrun")
+    def _scale_down_mlrun_deployments(self):
+        self._logger.info("scaling down mlrun")
         self._run_kubectl_command(
             args=[
-                "rollout",
-                "restart",
+                "scale",
                 "deployment",
                 "-n",
                 self.Constants.namespace,
                 "mlrun-api-chief",
                 "mlrun-api-worker",
                 "mlrun-db",
+                "--replicas=0"
             ]
         )
 

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -484,11 +484,11 @@ class SystemTestPreparer:
                 self._app_cluster_ssh_password,
                 "--data-cluster-password",
                 self._data_cluster_ssh_password,
+                "patch",
+                "appservice",
                 # we force because by default provctl doesn't allow downgrading between version but due to system tests
                 # running on multiple branches this might occur.
                 "--force",
-                "patch",
-                "appservice",
                 "mlrun",
                 mlrun_archive,
             ],

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -141,10 +141,11 @@ class SystemTestPreparer:
 
         self._override_mlrun_api_env()
 
-        self._patch_mlrun()
-
         if self._purge_db:
             self._purge_mlrun_db()
+
+        self._patch_mlrun()
+
 
     def clean_up_remote_workdir(self):
         self._logger.info(

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -484,6 +484,9 @@ class SystemTestPreparer:
                 self._app_cluster_ssh_password,
                 "--data-cluster-password",
                 self._data_cluster_ssh_password,
+                # we force because by default provctl doesn't allow downgrading between version but due to system tests
+                # running on multiple branches this might occur.
+                "--force",
                 "patch",
                 "appservice",
                 "mlrun",


### PR DESCRIPTION
This PR will allow MLRun maintainers to easily choose the branches on which the system tests will run.

### Implementation
Instead of storing hard coded the branch on which we run on which was development in the workflow yaml, now we will store a configuration file in our datanode which will contain a list of branches separated with commas.
Each system test schedule the workflow will read the file and pop the first branch in the list and append it to the end of the list and will run the system tests against it (will patch all the images and system with the branch code and will run the branch tests).

### How to add / change branches
SSH to the datanode of the system tests and edit the `/tmp/system-tests-branches-list.txt`.

### TODOs
- [ ]  Add branch information to the slack message (might need to add that to all branches as the job that actually runs the tests checkout to the branch code
- [ ]  Support running on a cloned code instead of the branch in the configuration file
- [ ]  Make the file path configurable and add option to choose whether to change the order of the configuration file (in manual runs we don't want to effect the schedule runs)