### PR TITLE
[System Tests] Fix Run Notifications System Test

### DIFF
--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -31,8 +31,8 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
                 with_notifications=True,
             )
             assert len(runs) == 1
-            assert len(runs[0]["spec"]["notifications"]) == 2
-            for notification in runs[0]["spec"]["notifications"]:
+            assert len(runs[0]["status"]["notifications"]) == 2
+            for notification in runs[0]["status"]["notifications"]:
                 if notification["name"] == error_notification.name:
                     assert notification["status"] == "error"
                 elif notification["name"] == success_notification.name:


### PR DESCRIPTION
The notification status moved from the run spec to the run status. Fixed the test to reflect the change.