### PR TITLE
[Builder] Fix pushing to ECR

### DIFF
--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -229,7 +229,21 @@ def make_kaniko_pod(
         if end == -1:
             end = len(dest)
         repo = dest[dest.find("/") + 1 : end]
-        configure_kaniko_ecr_init_container(kpod, registry, repo)
+
+        # if no secret is given, assume ec2 instance has attached role which provides read/write access to ECR
+        assume_instance_role = not config.httpdb.builder.docker_registry_secret
+        configure_kaniko_ecr_init_container(kpod, registry, repo, assume_instance_role)
+
+        # project secret might conflict with the attached instance role
+        # ensure "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" have no values or else kaniko will fail
+        # due to credentials conflict / lack of permission on given credentials
+        if assume_instance_role:
+            kpod.pod.spec.containers[0].env.extend(
+                [
+                    client.V1EnvVar(name="AWS_ACCESS_KEY_ID", value=""),
+                    client.V1EnvVar(name="AWS_SECRET_ACCESS_KEY", value=""),
+                ]
+            )
 
     # mount regular docker config secret
     elif secret_name:
@@ -239,7 +253,9 @@ def make_kaniko_pod(
     return kpod
 
 
-def configure_kaniko_ecr_init_container(kpod, registry, repo):
+def configure_kaniko_ecr_init_container(
+    kpod, registry, repo, assume_instance_role=True
+):
     region = registry.split(".")[3]
 
     # fail silently in order to ignore "repository already exists" errors
@@ -250,21 +266,12 @@ def configure_kaniko_ecr_init_container(kpod, registry, repo):
     )
     init_container_env = {}
 
-    if not config.httpdb.builder.docker_registry_secret:
+    if assume_instance_role:
 
         # assume instance role has permissions to register and store a container image
         # https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr
         # we only need this in the kaniko container
         kpod.env.append(client.V1EnvVar(name="AWS_SDK_LOAD_CONFIG", value="true"))
-
-        # ensure "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" have no values
-        # as they might be volumized via a project secret and will conflict with the instance role
-        kpod.pod.spec.containers[0].env.extend(
-            [
-                client.V1EnvVar(name="AWS_ACCESS_KEY_ID", value=""),
-                client.V1EnvVar(name="AWS_SECRET_ACCESS_KEY", value=""),
-            ]
-        )
 
     else:
         aws_credentials_file_env_key = "AWS_SHARED_CREDENTIALS_FILE"

--- a/mlrun/builder.py
+++ b/mlrun/builder.py
@@ -256,6 +256,16 @@ def configure_kaniko_ecr_init_container(kpod, registry, repo):
         # https://github.com/GoogleContainerTools/kaniko#pushing-to-amazon-ecr
         # we only need this in the kaniko container
         kpod.env.append(client.V1EnvVar(name="AWS_SDK_LOAD_CONFIG", value="true"))
+
+        # ensure "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" have no values
+        # as they might be volumized via a project secret and will conflict with the instance role
+        kpod.pod.spec.containers[0].env.extend(
+            [
+                client.V1EnvVar(name="AWS_ACCESS_KEY_ID", value=""),
+                client.V1EnvVar(name="AWS_SECRET_ACCESS_KEY", value=""),
+            ]
+        )
+
     else:
         aws_credentials_file_env_key = "AWS_SHARED_CREDENTIALS_FILE"
         aws_credentials_file_env_value = "/tmp/credentials"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -447,13 +447,17 @@ def test_build_runtime_ecr_with_ec2_iam_policy(monkeypatch):
     mlrun.mlconf.httpdb.builder.docker_registry = (
         "aws_account_id.dkr.ecr.region.amazonaws.com"
     )
-    function = mlrun.new_function(
-        "some-function",
-        "some-project",
-        "some-tag",
-        image="mlrun/mlrun",
+    project = mlrun.new_project("some-project")
+    project.set_secrets(
+        secrets={
+            "AWS_ACCESS_KEY_ID": "test-a",
+            "AWS_SECRET_ACCESS_KEY": "test-b",
+        }
+    )
+    function = project.set_function(
+        "hub://describe",
+        name="some-function",
         kind="job",
-        requirements=["some-package"],
     )
     mlrun.builder.build_runtime(
         mlrun.api.schemas.AuthInfo(),
@@ -463,6 +467,19 @@ def test_build_runtime_ecr_with_ec2_iam_policy(monkeypatch):
     assert {"name": "AWS_SDK_LOAD_CONFIG", "value": "true", "value_from": None} in [
         env.to_dict() for env in pod_spec.containers[0].env
     ]
+
+    # ensure both envvars are set without values so they wont interfere with the iam policy
+    for env_name in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]:
+        assert {"name": env_name, "value": "", "value_from": None} in [
+            env.to_dict() for env in pod_spec.containers[0].env
+        ]
+
+    # 1 for the AWS_SDK_LOAD_CONFIG=true
+    # 2 for the AWS_ACCESS_KEY_ID="" and AWS_SECRET_ACCESS_KEY=""
+    # 1 for the project secret
+    # == 4
+    assert len(pod_spec.containers[0].env) == 4, "expected 4 env items"
+
     assert len(pod_spec.init_containers) == 2
     for init_container in pod_spec.init_containers:
         if init_container.name == "create-repos":


### PR DESCRIPTION
When building a pod to EKS node having attached policy with build permission role, project with secrets "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" will conflict kaniko thinking those are the credentials required to push to ECR

This PR fixes the race by emptying the project secret for those specific envvars by adding explicit envvar on container as they take precedence over the project secrets (which are mounted).

The only issue would raise by this PR is that, if access to some AWS resource (not ecr) is required during buildtime - it would fail as the secrets are not available anymore (reset with empty values)

https://jira.iguazeng.com/browse/ML-3743