### PR TITLE
[Spark] Fix Redis key generation for single entity

### DIFF
--- a/mlrun/datastore/spark_udf.py
+++ b/mlrun/datastore/spark_udf.py
@@ -26,11 +26,14 @@ def _hash_list(*list_to_hash):
 
 
 def _redis_stringify_key(key_list):
-    if len(key_list) >= 2:
-        return str(key_list[0]) + "." + _hash_list(key_list[1:]) + "}:static"
-    if len(key_list) == 2:
-        return str(key_list[0]) + "." + str(key_list[1]) + "}:static"
-    return str(key_list[0]) + "}:static"
+    try:
+        if len(key_list) >= 2:
+            return str(key_list[0]) + "." + _hash_list(key_list[1:]) + "}:static"
+        if len(key_list) == 2:
+            return str(key_list[0]) + "." + str(key_list[1]) + "}:static"
+        return str(key_list[0]) + "}:static"
+    except TypeError:
+        return str(key_list) + "}:static"
 
 
 hash_and_concat_v3io_udf = udf(_hash_list, StringType())


### PR DESCRIPTION
ML-3754. Fixing bug introduced in https://github.com/mlrun/mlrun/pull/3412. As part of the refactoring case when single entity is saved to Redis was not handled properly 