### PR TITLE
[Spark] Allow ingesting to a local path

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -900,14 +900,6 @@ def _ingest_with_spark(
             target.set_resource(featureset)
             if featureset.spec.passthrough and target.is_offline:
                 continue
-            if target.path and urlparse(target.path).scheme == "":
-                if mlrun_context:
-                    mlrun_context.logger.error(
-                        "Paths for spark ingest must contain schema, i.e v3io, s3, az"
-                    )
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Paths for spark ingest must contain schema, i.e v3io, s3, az"
-                )
             spark_options = target.get_spark_options(
                 key_columns, timestamp_key, overwrite
             )

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -18,7 +18,6 @@ import sys
 import warnings
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urlparse
 
 import pandas as pd
 

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -275,7 +275,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
     def set_targets(self, feature_set, also_in_remote=False):
         dir_name = self.test_name()
         if self.run_local or also_in_remote:
-            target_path = f"{self.output_dir()}/{dir_name}"
+            target_path = f"{self.output_dir(url=False)}/{dir_name}"
             feature_set.set_targets(
                 [ParquetTarget(path=target_path)], with_defaults=False
             )


### PR DESCRIPTION
Fixes the output path when running system tests in local mode.

Before this fix, files were written to `tests/system/feature_store/file:/var/folders/qr/hxtsdg117_jftdk9wpgvkfqw0000gn/T/tmpcm5gar1d` (last part varies between runs) instead of `/var/folders/qr/hxtsdg117_jftdk9wpgvkfqw0000gn/T/tmpcm5gar1d`.