### PR TITLE
[Artifact] Enforce the update of artifacts with conflicting keys

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -562,10 +562,17 @@ class SQLDB(DBInterface):
         db_key = artifact["spec"].get("db_key")
         if db_key and db_key != key:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Conflict between requested key and key in artifact body"
+                f"Conflict between requested key ({key}) and key in artifact body ({db_key})"
             )
         if not db_key:
             artifact["spec"]["db_key"] = key
+
+        data_key = artifact.get("metadata", {}).get("key")
+        if (key and data_key) and data_key != key:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Conflict between requested key ({key}) and key in artifact metadata ({data_key})"
+            )
+
         if iter:
             key = f"{iter}-{key}"
         labels = artifact["metadata"].get("labels", {})
@@ -587,6 +594,13 @@ class SQLDB(DBInterface):
             )
         if not db_key:
             artifact["db_key"] = key
+
+        data_key = artifact.get("key")
+        if (key and data_key) and data_key != key:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Conflict between requested key ({key}) and key in artifact body ({data_key})"
+            )
+
         if iter:
             key = f"{iter}-{key}"
         labels = artifact.get("labels", {})

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -598,7 +598,7 @@ class SQLDB(DBInterface):
         data_key = artifact.get("key")
         if (key and data_key) and data_key != key:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Conflict between requested key ({key}) and key in artifact body ({data_key})"
+                f"Conflict between requested key ({key}) and key in legacy artifact body ({data_key})"
             )
 
         if iter:

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -119,6 +119,54 @@ def test_store_artifact_backwards_compatibility(db: Session, client: TestClient)
     )
 
 
+def test_update_artifact_with_conflicted_key_names(db: Session, client: TestClient):
+    _create_project(client)
+    artifact = mlrun.artifacts.Artifact(key=KEY, body="123").to_json()
+
+    resp = client.post(
+        STORE_API_ARTIFACTS_PATH.format(project=PROJECT, uid=UID, key=KEY, tag=TAG),
+        data=artifact,
+    )
+    assert resp.status_code == HTTPStatus.OK.value
+
+    resp = client.post(
+        STORE_API_ARTIFACTS_PATH.format(project=PROJECT, uid=UID, key="test", tag=TAG),
+        data=artifact,
+    )
+    assert (
+        resp.status_code == HTTPStatus.BAD_REQUEST.value
+        and "Conflict between requested key" in resp.json()["detail"]
+    )
+
+
+def test_update_legacy_artifact_with_conflicted_key_names(
+    db: Session, client: TestClient
+):
+    _create_project(client)
+    another_key = "test"
+
+    resp = client.post(
+        f"{LEGACY_API_ARTIFACT_PATH}/{PROJECT}/{UID}/{KEY}?tag={TAG}",
+        json={
+            "kind": "artifact",
+            "key": KEY,
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK.value
+
+    resp = client.post(
+        f"{LEGACY_API_ARTIFACT_PATH}/{PROJECT}/{UID}/{another_key}?tag={TAG}&format=legacy",
+        json={
+            "kind": "artifact",
+            "key": KEY,
+        },
+    )
+    assert (
+        resp.status_code == HTTPStatus.BAD_REQUEST.value
+        and "Conflict between requested key" in resp.json()["detail"]
+    )
+
+
 def test_store_artifact_with_invalid_tag(db: Session, client: TestClient):
     _create_project(client)
     tag = "test_tag_with_characters@#$#%^"


### PR DESCRIPTION
Adding a fix for: https://jira.iguazeng.com/browse/ML-3604

While the body key is a non-empty string, we will not allow POSTing that includes "key" with bodies that contain a different "key".

(https://github.com/mlrun/mlrun/pull/3295)