### PR TITLE
[API] Add version to healthz endpoint

### DIFF
--- a/mlrun/api/api/endpoints/healthz.py
+++ b/mlrun/api/api/endpoints/healthz.py
@@ -36,4 +36,9 @@ def health():
     ]:
         raise mlrun.errors.MLRunServiceUnavailableError()
 
-    return {"status": "ok"}
+    return {
+        # for old `align_mlrun.sh` scripts expecting `version` in the response
+        # TODO: remove on mlrun >= 1.6.0
+        "version": mlconfig.version,
+        "status": "ok",
+    }


### PR DESCRIPTION
some old scripts / clients expect mlrun server to be on healthz endpoint