### PR TITLE
[Model Monitoring] Convert error_count value to integer in the monitoring stream graph

### DIFF
--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -783,7 +783,7 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
                 error_count = endpoint_record.get(EventFieldType.ERROR_COUNT)
 
                 if error_count:
-                    self.error_count[endpoint_id] = error_count
+                    self.error_count[endpoint_id] = int(error_count)
 
             # add endpoint to endpoints set
             self.endpoints.add(endpoint_id)


### PR DESCRIPTION
A fix for [#ML-3737](https://jira.iguazeng.com/browse/ML-3737).

Following [#2685](https://github.com/mlrun/mlrun/pull/2685), the monitoring stream graph retrieves the endpoint record directly from the DB. Therefore, the `error_count` value is provided as a `string` and not as an `integer`. When there is a new error in the monitoring stream graph, it tries to increase that `error_count` value by 1 but since it is a string we are getting the following `TypeError`:

`TypeError: can only concatenate str (not "int") to str`

In this PR, we validate that that the `error_count` value is converted into an integer before applying additional calculations on that value. Moreover, this PR also includes a new test for validating that `error_count` value is recorded as expected when the user provides invalid records. 

