### PR TITLE
[Runtimes] Remove option to deploy Nuclio function straight from client

### DIFF
--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -16,6 +16,7 @@ import json
 import os
 import pathlib
 import time
+import unittest.mock
 
 import pandas as pd
 import pytest
@@ -711,3 +712,30 @@ def test_mock_invoke():
 
     # return config valued
     mlrun.mlconf.mock_nuclio_deployment = mock_nuclio_config
+
+
+def test_deploy_with_dashboard_argument():
+    fn = mlrun.new_function("tests", kind="serving")
+    fn.add_model("my", ".", class_name=ModelTestingClass(multiplier=100))
+    db_instance = fn._get_db()
+    db_instance.remote_builder = unittest.mock.Mock(
+        return_value={
+            "data": {
+                "metadata": {
+                    "name": "test",
+                },
+                "status": {
+                    "state": "ready",
+                    "external_invocation_urls": ["http://test-url.com"],
+                },
+            },
+        },
+    )
+    db_instance.get_builder_status = unittest.mock.Mock(
+        return_value=(None, None),
+    )
+
+    mlrun.deploy_function(fn, dashboard="bad-address")
+
+    # test that the remote builder was called even with dashboard argument
+    assert db_instance.remote_builder.call_count == 1


### PR DESCRIPTION
MLRun client should always request the api to deploy nuclio functions, and go through the same flow for validation/enrichment.

When using the `dashboard` argument, the following warning is displayed:
![image](https://user-images.githubusercontent.com/90552140/235345890-a2ff9c4d-47aa-4f99-97ff-75984db57deb.png)


Resolves https://jira.iguazeng.com/browse/ML-3777 