### PR TITLE
[Project] Fix running pipelines with local code

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -371,8 +371,8 @@ class ImageBuilder(ModelObj):
             or source in [".", "./"]
         ):
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "source must be a compressed (tar.gz / zip) file, a git repo, "
-                "a file path or in the project's context (.)"
+                f"source ({source}) must be a compressed (tar.gz / zip) file, a git repo, "
+                f"a file path or in the project's context (.)"
             )
 
         self._source = source

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -119,6 +119,8 @@ class WorkflowSpec(mlrun.model.ModelObj):
             if (
                 context
                 and not workflow_path.startswith("/")
+                # since the user may provide a path the includes the context,
+                # we need to make sure we don't add it twice
                 and not workflow_path.startswith(context)
             ):
                 workflow_path = os.path.join(context, workflow_path)

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -116,7 +116,11 @@ class WorkflowSpec(mlrun.model.ModelObj):
                 self._tmp_path = workflow_path = workflow_fh.name
         else:
             workflow_path = self.path or ""
-            if context and not workflow_path.startswith("/"):
+            if (
+                context
+                and not workflow_path.startswith("/")
+                and not workflow_path.startswith(context)
+            ):
                 workflow_path = os.path.join(context, workflow_path)
         return workflow_path
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -585,8 +585,6 @@ class ProjectSpec(ModelObj):
                 if url:
                     self._source = url
 
-        # if self._source in [".", "./"]:
-        #     return path.abspath(self.context)
         return self._source
 
     @source.setter
@@ -1188,7 +1186,7 @@ class MlrunProject(ModelObj):
         # We don't want to change the url if the project has no context or if it is already absolute
         in_context = self.spec.context and not url.startswith("/")
         if in_context:
-            url = path.abspath(path.normpath(path.join(self.spec.get_code_path(), url)))
+            url = path.normpath(path.join(self.spec.get_code_path(), url))
 
         if (not in_context or check_path_in_context) and not path.isfile(url):
             raise mlrun.errors.MLRunNotFoundError(f"{url} not found")

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -585,8 +585,8 @@ class ProjectSpec(ModelObj):
                 if url:
                     self._source = url
 
-        if self._source in [".", "./"]:
-            return path.abspath(self.context)
+        # if self._source in [".", "./"]:
+        #     return path.abspath(self.context)
         return self._source
 
     @source.setter
@@ -1044,8 +1044,12 @@ class MlrunProject(ModelObj):
         if not workflow_path:
             raise ValueError("valid workflow_path must be specified")
         if embed:
-            if self.spec.context and not workflow_path.startswith("/"):
-                workflow_path = path.join(self.spec.context, workflow_path)
+            if (
+                self.context
+                and not workflow_path.startswith("/")
+                and not workflow_path.startswith(self.context)
+            ):
+                workflow_path = path.join(self.context, workflow_path)
             with open(workflow_path, "r") as fp:
                 txt = fp.read()
             workflow = {"name": name, "code": txt}
@@ -1184,7 +1188,7 @@ class MlrunProject(ModelObj):
         # We don't want to change the url if the project has no context or if it is already absolute
         in_context = self.spec.context and not url.startswith("/")
         if in_context:
-            url = path.normpath(path.join(self.spec.get_code_path(), url))
+            url = path.abspath(path.normpath(path.join(self.spec.get_code_path(), url)))
 
         if (not in_context or check_path_in_context) and not path.isfile(url):
             raise mlrun.errors.MLRunNotFoundError(f"{url} not found")

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1045,6 +1045,8 @@ class MlrunProject(ModelObj):
             if (
                 self.context
                 and not workflow_path.startswith("/")
+                # since the user may provide a path the includes the context,
+                # we need to make sure we don't add it twice
                 and not workflow_path.startswith(self.context)
             ):
                 workflow_path = path.join(self.context, workflow_path)

--- a/tests/integration/sdk_api/run/test_main.py
+++ b/tests/integration/sdk_api/run/test_main.py
@@ -349,8 +349,8 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
         with pytest.raises(Exception) as e:
             self._exec_run("./handler.py", args.split(), "test_main_local_source")
         assert (
-            "source must be a compressed (tar.gz / zip) file, a git repo, a file path or in the project's context (.)"
-            in str(e.value)
+            "source ({examples_path}) must be a compressed (tar.gz / zip) file, "
+            "a git repo, a file path or in the project's context (.)" in str(e.value)
         )
 
     def test_main_run_archive_subdir(self):

--- a/tests/integration/sdk_api/run/test_main.py
+++ b/tests/integration/sdk_api/run/test_main.py
@@ -349,8 +349,8 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
         with pytest.raises(Exception) as e:
             self._exec_run("./handler.py", args.split(), "test_main_local_source")
         assert (
-            "source ({examples_path}) must be a compressed (tar.gz / zip) file, "
-            "a git repo, a file path or in the project's context (.)" in str(e.value)
+            f"source ({examples_path}) must be a compressed (tar.gz / zip) file, "
+            f"a git repo, a file path or in the project's context (.)" in str(e.value)
         )
 
     def test_main_run_archive_subdir(self):

--- a/tests/system/projects/assets/handler_workflow.py
+++ b/tests/system/projects/assets/handler_workflow.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from kfp import dsl
+
+funcs = {}
+
+
+@dsl.pipeline(name="Demo training pipeline", description="Tests simple handler")
+def job_pipeline():
+    funcs["my-func"].as_step()

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -511,6 +511,32 @@ class TestProject(TestMLRunSystem):
         assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
         assert run.run_id, "workflow's run id failed to fetch"
 
+    def test_kfp_from_local_code(self):
+        name = "kfp-from-local-code"
+        self.custom_project_names_to_delete.append(name)
+        project = mlrun.get_or_create_project(name, user_project=True, context="./")
+
+        handler_fn = project.set_function(
+            func="./assets/handler.py",
+            handler="my_func",
+            name="my-func",
+            kind="job",
+            image="mlrun/mlrun",
+        )
+        project.build_function(handler_fn)
+
+        project.set_workflow(
+            "main", "./assets/handler_workflow.py", handler="job_pipeline"
+        )
+        project.save()
+
+        run = project.run(
+            "main",
+            watch=True,
+        )
+        assert run.state == mlrun.run.RunStatuses.succeeded, "pipeline failed"
+        assert run.run_id, "workflow's run id failed to fetch"
+
     def test_local_cli(self):
         # load project from git
         name = "lclclipipe"


### PR DESCRIPTION
In order to run a pipeline from local code without having to push it to git / upload a source archive it was needed that the project source value will not be dependant on the context path since we do not load directories into pods but we only allow archives and git sources.
The correct flow is that we use `code_to_function` in order to keep the code inside the pod env and not try to load it from a source.