### PR TITLE
[Model Monitoring] Fix Grafana datasource name in details dashboard

### DIFF
--- a/docs/monitoring/dashboards/model-monitoring-details.json
+++ b/docs/monitoring/dashboards/model-monitoring-details.json
@@ -49,10 +49,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -213,10 +210,7 @@
       "pluginVersion": "9.2.2",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-simple-json-datasource",
-            "uid": "PiBy-ta4z"
-          },
+          "datasource": "iguazio",
           "hide": false,
           "rawQuery": true,
           "refId": "A",
@@ -272,10 +266,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "grafana-simple-json-datasource",
-        "uid": "PiBy-ta4z"
-      },
+      "datasource": "iguazio",
       "description": "",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
Instead of providing datasource type and uid, we need to define only the relevant datasource name (`iguazio` in this case). 