### PR TITLE
[Serving] Backport - Fix passing MLRun event headers with underscore in RemoteStep

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,32 @@
+[importlinter]
+root_package=mlrun
+include_external_packages=True
+
+
+[importlinter:contract:1]
+name=common modules shouldn't import other mlrun utilities
+type=forbidden
+source_modules=
+    mlrun.common
+
+forbidden_modules=
+    mlrun.api
+    mlrun.artifacts
+    mlrun.data_types
+    mlrun.datastore
+    mlrun.db
+    mlrun.feature_store
+    mlrun.frameworks
+    mlrun.mlutils
+    mlrun.model_monitoring
+    mlrun.platforms
+    mlrun.projects
+    mlrun.runtimes
+    mlrun.serving
+    mlrun.utils
+    mlrun.builder
+    mlrun.config
+    mlrun.errors
+    mlrun.lists
+    mlrun.model
+    mlrun.run

--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,7 @@ test: clean ## Run mlrun tests
 		--ignore=tests/test_notebooks.py \
 		--ignore=tests/rundb/test_httpdb.py \
 		-rf \
-		tests
+		tests/serving/test_remote.py::test_remote_step
 
 
 .PHONY: test-integration-dockerized
@@ -650,8 +650,13 @@ fmt: ## Format the code (using black and isort)
 	python -m black .
 	python -m isort .
 
+.PHONY: lint-imports
+lint-imports: ## making sure imports dependencies are aligned
+	@echo "Running import linter"
+	lint-imports
+
 .PHONY: lint
-lint: flake8 fmt-check ## Run lint on the code
+lint: flake8 fmt-check lint-imports ## Run lint on the code
 
 .PHONY: fmt-check
 fmt-check: ## Format and check the code (using black)

--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,7 @@ test: clean ## Run mlrun tests
 		--ignore=tests/test_notebooks.py \
 		--ignore=tests/rundb/test_httpdb.py \
 		-rf \
-		tests/serving/test_remote.py::test_remote_step
+		tests
 
 
 .PHONY: test-integration-dockerized

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,3 +20,4 @@ scikit-learn~=1.0
 lightgbm~=3.0
 xgboost~=1.1
 sqlalchemy_utils~=0.39.0
+import-linter~=1.8

--- a/mlrun/common/__init__.py
+++ b/mlrun/common/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -33,7 +33,12 @@ from ..errors import MLRunInvalidArgumentError
 from ..model import ModelObj
 from ..utils import get_caller_globals, parse_versioned_object_uri
 from .states import RootFlowStep, RouterStep, get_function, graph_root_setter
-from .utils import event_id_key, event_path_key
+from .utils import (
+    event_id_key,
+    event_path_key,
+    legacy_event_id_key,
+    legacy_event_path_key,
+)
 
 
 class _StreamContext:
@@ -240,10 +245,18 @@ class GraphServer(ModelObj):
         context = context or server_context
         event.content_type = event.content_type or self.default_content_type or ""
         if event.headers:
-            if event_id_key in event.headers:
-                event.id = event.headers.get(event_id_key)
-            if event_path_key in event.headers:
-                event.path = event.headers.get(event_path_key)
+            # TODO: remove old event id and path keys in 1.6.0
+            if event_id_key in event.headers or legacy_event_id_key in event.headers:
+                event.id = event.headers.get(event_id_key) or event.headers.get(
+                    legacy_event_id_key
+                )
+            if (
+                event_path_key in event.headers
+                or legacy_event_path_key in event.headers
+            ):
+                event.path = event.headers.get(event_path_key) or event.headers.get(
+                    legacy_event_path_key
+                )
 
         if isinstance(event.body, (str, bytes)) and (
             not event.content_type or event.content_type in ["json", "application/json"]

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -16,8 +16,14 @@ import inspect
 
 from mlrun.utils import get_in, update_in
 
-event_id_key = "MLRUN_EVENT_ID"
-event_path_key = "MLRUN_EVENT_PATH"
+# headers keys with underscore are getting ignored by werkzeug https://github.com/pallets/werkzeug/pull/2622
+# to avoid conflicts with WGSI which converts all header keys to uppercase with underscores.
+# more info https://github.com/benoitc/gunicorn/issues/2799, this comment can be removed once old keys are removed
+event_id_key = "MLRUN-EVENT-ID"
+event_path_key = "MLRUN-EVENT-PATH"
+# TODO: remove these keys in 1.6.0
+legacy_event_id_key = "MLRUN_EVENT_ID"
+legacy_event_path_key = "MLRUN_EVENT_PATH"
 
 
 def _extract_input_data(input_path, body):


### PR DESCRIPTION
(#3457)

(cherry picked from commit bd82117fd43744ae38a9aa1a73072628f32df199)