### PR TITLE
[Model Monitoring] Validate access key in Grafana only in non-CE deployment

### DIFF
--- a/mlrun/api/api/endpoints/grafana_proxy.py
+++ b/mlrun/api/api/endpoints/grafana_proxy.py
@@ -53,7 +53,8 @@ def grafana_proxy_model_endpoints_check_connection(
     Root of grafana proxy for the model-endpoints API, used for validating the model-endpoints data source
     connectivity.
     """
-    mlrun.api.crud.ModelEndpoints().get_access_key(auth_info)
+    if not mlrun.mlconf.is_ce_mode():
+        mlrun.api.crud.ModelEndpoints().get_access_key(auth_info)
     return Response(status_code=HTTPStatus.OK.value)
 
 


### PR DESCRIPTION
When calling `/grafana-proxy/model-endpoints` endpoint for validating the grafana proxy for the model-endpoints API, we are verifying that the access key has a valid data session. However, this validation is unnecessary in CE deployments in which there is no access key. 