### PR TITLE
[Projects] Minimal Project Response and Request Iguazio Projects Separately During Sync

### DIFF
--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -46,7 +46,13 @@ class Projects(
     def create_project(
         self, session: sqlalchemy.orm.Session, project: mlrun.api.schemas.Project
     ):
-        logger.debug("Creating project", project=project)
+        logger.debug(
+            "Creating project",
+            name=project.metadata.name,
+            owner=project.spec.owner,
+            function_amount=len(project.spec.functions),
+            artifact_amount=len(project.spec.artifacts),
+        )
         mlrun.api.utils.singletons.db.get_db().create_project(session, project)
 
     def store_project(
@@ -55,7 +61,13 @@ class Projects(
         name: str,
         project: mlrun.api.schemas.Project,
     ):
-        logger.debug("Storing project", name=name, project=project)
+        logger.debug(
+            "Storing project",
+            name=project.metadata.name,
+            owner=project.spec.owner,
+            function_amount=len(project.spec.functions),
+            artifact_amount=len(project.spec.artifacts),
+        )
         mlrun.api.utils.singletons.db.get_db().store_project(session, name, project)
 
     def patch_project(

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -53,8 +53,8 @@ class Projects(
             created_time=project.metadata.created,
             desired_state=project.spec.desired_state,
             state=project.status.state,
-            function_amount=len(project.spec.functions),
-            artifact_amount=len(project.spec.artifacts),
+            function_amount=len(project.spec.functions or []),
+            artifact_amount=len(project.spec.artifacts or []),
         )
         mlrun.api.utils.singletons.db.get_db().create_project(session, project)
 
@@ -71,8 +71,8 @@ class Projects(
             created_time=project.metadata.created,
             desired_state=project.spec.desired_state,
             state=project.status.state,
-            function_amount=len(project.spec.functions),
-            artifact_amount=len(project.spec.artifacts),
+            function_amount=len(project.spec.functions or []),
+            artifact_amount=len(project.spec.artifacts or []),
         )
         mlrun.api.utils.singletons.db.get_db().store_project(session, name, project)
 

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -55,6 +55,7 @@ class Projects(
             state=project.status.state,
             function_amount=len(project.spec.functions or []),
             artifact_amount=len(project.spec.artifacts or []),
+            workflows_amount=len(project.spec.workflows or []),
         )
         mlrun.api.utils.singletons.db.get_db().create_project(session, project)
 
@@ -73,6 +74,7 @@ class Projects(
             state=project.status.state,
             function_amount=len(project.spec.functions or []),
             artifact_amount=len(project.spec.artifacts or []),
+            workflows_amount=len(project.spec.workflows or []),
         )
         mlrun.api.utils.singletons.db.get_db().store_project(session, name, project)
 

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -50,6 +50,9 @@ class Projects(
             "Creating project",
             name=project.metadata.name,
             owner=project.spec.owner,
+            created_time=project.metadata.created,
+            desired_state=project.spec.desired_state,
+            state=project.status.state,
             function_amount=len(project.spec.functions),
             artifact_amount=len(project.spec.artifacts),
         )
@@ -65,6 +68,9 @@ class Projects(
             "Storing project",
             name=project.metadata.name,
             owner=project.spec.owner,
+            created_time=project.metadata.created,
+            desired_state=project.spec.desired_state,
+            state=project.status.state,
             function_amount=len(project.spec.functions),
             artifact_amount=len(project.spec.artifacts),
         )

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import Session, aliased
 
 import mlrun
 import mlrun.api.db.session
+import mlrun.api.utils.helpers
 import mlrun.api.utils.projects.remotes.follower
 import mlrun.errors
 from mlrun.api import schemas
@@ -1322,6 +1323,14 @@ class SQLDB(DBInterface):
             if format_ == mlrun.api.schemas.ProjectsFormat.name_only:
                 projects = [project_record.name for project_record in project_records]
             # leader format is only for follower mode which will format the projects returned from here
+            elif format_ == mlrun.api.schemas.ProjectsFormat.minimal:
+                projects.append(
+                    mlrun.api.utils.helpers.minimize_project_schema(
+                        self._transform_project_record_to_schema(
+                            session, project_record
+                        )
+                    )
+                )
             elif format_ in [
                 mlrun.api.schemas.ProjectsFormat.full,
                 mlrun.api.schemas.ProjectsFormat.leader,

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -24,6 +24,7 @@ from .object import ObjectKind, ObjectStatus
 class ProjectsFormat(str, enum.Enum):
     full = "full"
     name_only = "name_only"
+    minimal = "minimal"
     # internal - allowed only in follower mode, only for the leader for upgrade purposes
     leader = "leader"
 

--- a/mlrun/api/schemas/project.py
+++ b/mlrun/api/schemas/project.py
@@ -24,6 +24,8 @@ from .object import ObjectKind, ObjectStatus
 class ProjectsFormat(str, enum.Enum):
     full = "full"
     name_only = "name_only"
+    # minimal format removes large fields from the response (e.g. functions, workflows, artifacts)
+    # and is used for faster response times (in the UI)
     minimal = "minimal"
     # internal - allowed only in follower mode, only for the leader for upgrade purposes
     leader = "leader"

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -260,33 +260,10 @@ class Client(
     ) -> typing.Tuple[
         typing.List[mlrun.api.schemas.Project], typing.Optional[datetime.datetime]
     ]:
-        params = {}
-        if updated_after is not None:
-            time_string = updated_after.isoformat().split("+")[0]
-            params = {"filter[updated_at]": f"[$gt]{time_string}Z"}
-        if page_size is None:
-            page_size = (
-                mlrun.mlconf.httpdb.projects.iguazio_list_projects_default_page_size
-            )
-        if page_size is not None:
-            params["page[size]"] = int(page_size)
-
-        params["include"] = "owner"
-        response = self._send_request_to_api(
-            "GET",
-            "projects",
-            "Failed listing projects from Iguazio",
-            session,
-            params=params,
+        project_names, latest_updated_at = self._list_project_names(
+            session, updated_after, page_size
         )
-        response_body = response.json()
-        projects = []
-        for iguazio_project in response_body["data"]:
-            projects.append(
-                self._transform_iguazio_project_to_mlrun_project(iguazio_project)
-            )
-        latest_updated_at = self._find_latest_updated_at(response_body)
-        return projects, latest_updated_at
+        return self._list_projects_data(session, project_names), latest_updated_at
 
     def get_project(
         self,
@@ -326,6 +303,46 @@ class Client(
         return mlrun.api.schemas.IguazioProject(
             data=self._transform_mlrun_project_to_iguazio_project(project)["data"]
         )
+
+    def _list_project_names(
+        self,
+        session: str,
+        updated_after: typing.Optional[datetime.datetime] = None,
+        page_size: typing.Optional[int] = None,
+    ) -> typing.Tuple[typing.List[str], typing.Optional[datetime.datetime]]:
+        params = {}
+        if updated_after is not None:
+            time_string = updated_after.isoformat().split("+")[0]
+            params = {"filter[updated_at]": f"[$gt]{time_string}Z"}
+        if page_size is None:
+            page_size = (
+                mlrun.mlconf.httpdb.projects.iguazio_list_projects_default_page_size
+            )
+        if page_size is not None:
+            params["page[size]"] = int(page_size)
+
+        response = self._send_request_to_api(
+            "GET",
+            "projects",
+            "Failed listing projects from Iguazio",
+            session,
+            params=params,
+        )
+        response_body = response.json()
+        project_names = [
+            iguazio_project["attributes"]["name"]
+            for iguazio_project in response_body["data"]
+        ]
+        latest_updated_at = self._find_latest_updated_at(response_body)
+        return project_names, latest_updated_at
+
+    def _list_projects_data(
+        self, session: str, project_names: typing.List[str]
+    ) -> typing.List[mlrun.api.schemas.Project]:
+        return [
+            self._get_project_from_iguazio(session, project_name)
+            for project_name in project_names
+        ]
 
     def _find_latest_updated_at(
         self, response_body: dict

--- a/mlrun/api/utils/helpers.py
+++ b/mlrun/api/utils/helpers.py
@@ -58,3 +58,12 @@ def ensure_running_on_chief(function):
     if asyncio.iscoroutinefunction(function):
         return async_wrapper
     return wrapper
+
+
+def minimize_project_schema(
+    project: mlrun.api.schemas.Project,
+) -> mlrun.api.schemas.Project:
+    project.spec.functions = None
+    project.spec.workflows = None
+    project.spec.artifacts = None
+    return project

--- a/mlrun/api/utils/projects/remotes/nop_follower.py
+++ b/mlrun/api/utils/projects/remotes/nop_follower.py
@@ -18,6 +18,7 @@ import mergedeep
 import sqlalchemy.orm
 
 import mlrun.api.schemas
+import mlrun.api.utils.helpers
 import mlrun.api.utils.projects.remotes.follower
 import mlrun.errors
 
@@ -95,6 +96,13 @@ class Member(mlrun.api.utils.projects.remotes.follower.Member):
             ]
         if format_ == mlrun.api.schemas.ProjectsFormat.full:
             return mlrun.api.schemas.ProjectsOutput(projects=projects)
+        elif format_ == mlrun.api.schemas.ProjectsFormat.minimal:
+            return mlrun.api.schemas.ProjectsOutput(
+                projects=[
+                    mlrun.api.utils.helpers.minimize_project_schema(project)
+                    for project in projects
+                ]
+            )
         elif format_ == mlrun.api.schemas.ProjectsFormat.name_only:
             project_names = [project.metadata.name for project in projects]
             return mlrun.api.schemas.ProjectsOutput(projects=project_names)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2137,6 +2137,7 @@ class HTTPRunDB(RunDBInterface):
         :param format_: Format of the results. Possible values are:
 
             - ``full`` (default value) - Return full project objects.
+            - ``minimal`` - Return minimal project objects (minimization happens in the BE).
             - ``name_only`` - Return just the names of the projects.
 
         :param labels: Filter by labels attached to the project.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -28,6 +28,7 @@ import semver
 
 import mlrun
 import mlrun.projects
+import mlrun.api.utils.helpers
 from mlrun.api import schemas
 from mlrun.errors import MLRunInvalidArgumentError
 
@@ -2153,7 +2154,10 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", "projects", error_message, params=params)
         if format_ == mlrun.api.schemas.ProjectsFormat.name_only:
             return response.json()["projects"]
-        elif format_ == mlrun.api.schemas.ProjectsFormat.full:
+        elif format_ in [
+            mlrun.api.schemas.ProjectsFormat.full,
+            mlrun.api.schemas.ProjectsFormat.minimal,
+        ]:
             return [
                 mlrun.projects.MlrunProject.from_dict(project_dict)
                 for project_dict in response.json()["projects"]

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -27,8 +27,8 @@ import requests
 import semver
 
 import mlrun
-import mlrun.projects
 import mlrun.api.utils.helpers
+import mlrun.projects
 from mlrun.api import schemas
 from mlrun.errors import MLRunInvalidArgumentError
 

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -194,7 +194,9 @@ def test_list_project_minimal(
                 ),
             ),
         )
-    projects_output = db.list_projects(db_session, format_=mlrun.api.schemas.ProjectsFormat.minimal)
+    projects_output = db.list_projects(
+        db_session, format_=mlrun.api.schemas.ProjectsFormat.minimal
+    )
     for index, project in enumerate(projects_output.projects):
         assert project.metadata.name == expected_projects[index]
         assert project.spec.artifacts is None

--- a/tests/api/db/test_projects.py
+++ b/tests/api/db/test_projects.py
@@ -174,6 +174,45 @@ def test_list_project(
 @pytest.mark.parametrize(
     "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
 )
+def test_list_project_minimal(
+    db: DBInterface,
+    db_session: sqlalchemy.orm.Session,
+):
+    expected_projects = ["project-name-1", "project-name-2", "project-name-3"]
+    for project in expected_projects:
+        db.create_project(
+            db_session,
+            mlrun.api.schemas.Project(
+                metadata=mlrun.api.schemas.ProjectMetadata(
+                    name=project,
+                ),
+                spec=mlrun.api.schemas.ProjectSpec(
+                    description="some-proj",
+                    artifacts=[{"key": "value"}],
+                    workflows=[{"key": "value"}],
+                    functions=[{"key": "value"}],
+                ),
+            ),
+        )
+    projects_output = db.list_projects(db_session, format_=mlrun.api.schemas.ProjectsFormat.minimal)
+    for index, project in enumerate(projects_output.projects):
+        assert project.metadata.name == expected_projects[index]
+        assert project.spec.artifacts is None
+        assert project.spec.workflows is None
+        assert project.spec.functions is None
+
+    projects_output = db.list_projects(db_session)
+    for index, project in enumerate(projects_output.projects):
+        assert project.metadata.name == expected_projects[index]
+        assert project.spec.artifacts == [{"key": "value"}]
+        assert project.spec.workflows == [{"key": "value"}]
+        assert project.spec.functions == [{"key": "value"}]
+
+
+# running only on sqldb cause filedb is not really a thing anymore, will be removed soon
+@pytest.mark.parametrize(
+    "db,db_session", [(dbs[0], dbs[0])], indirect=["db", "db_session"]
+)
 def test_list_project_names_filter(
     db: DBInterface,
     db_session: sqlalchemy.orm.Session,

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -310,7 +310,6 @@ def test_list_project_with_updated_after(
             "filter[updated_at]": [
                 f"[$gt]{updated_after.isoformat().split('+')[0]}Z".lower()
             ],
-            "include": ["owner"],
             "page[size]": [
                 str(
                     mlrun.mlconf.httpdb.projects.iguazio_list_projects_default_page_size
@@ -325,6 +324,14 @@ def test_list_project_with_updated_after(
     requests_mock.get(
         f"{api_url}/api/projects",
         json=verify_list,
+    )
+    requests_mock.get(
+        f"{api_url}/api/projects/__name__/{project.metadata.name}",
+        json={
+            "data": _build_project_response(
+                iguazio_client, project, with_mlrun_project=True
+            )
+        },
     )
     iguazio_client.list_projects(
         session,
@@ -354,22 +361,35 @@ def test_list_project(
             "annotations": {"annotation-key2": "annotation-value2"},
         },
     ]
+    project_objects = [
+        _generate_project(
+            mock_project["name"],
+            mock_project.get("description", ""),
+            mock_project.get("labels", {}),
+            mock_project.get("annotations", {}),
+            owner=mock_project.get("owner", None),
+        )
+        for mock_project in mock_projects
+    ]
     response_body = {
         "data": [
             _build_project_response(
                 iguazio_client,
-                _generate_project(
-                    mock_project["name"],
-                    mock_project.get("description", ""),
-                    mock_project.get("labels", {}),
-                    mock_project.get("annotations", {}),
-                    owner=mock_project.get("owner", None),
-                ),
+                mock_project,
             )
-            for mock_project in mock_projects
+            for mock_project in project_objects
         ]
     }
     requests_mock.get(f"{api_url}/api/projects", json=response_body)
+    for mock_project in project_objects:
+        requests_mock.get(
+            f"{api_url}/api/projects/__name__/{mock_project.metadata.name}",
+            json={
+                "data": _build_project_response(
+                    iguazio_client, mock_project, with_mlrun_project=True
+                )
+            },
+        )
     projects, latest_updated_at = iguazio_client.list_projects(None)
     for index, project in enumerate(projects):
         assert project.metadata.name == mock_projects[index]["name"]
@@ -851,6 +871,7 @@ def _build_project_response(
     job_id: typing.Optional[str] = None,
     operational_status: typing.Optional[mlrun.api.schemas.ProjectState] = None,
     owner_access_key: typing.Optional[str] = None,
+    with_mlrun_project: bool = False,
 ):
     body = {
         "type": "project",
@@ -862,11 +883,14 @@ def _build_project_response(
             "updated_at": datetime.datetime.utcnow().isoformat(),
             "admin_status": project.spec.desired_state
             or mlrun.api.schemas.ProjectState.online,
-            "mlrun_project": iguazio_client._transform_mlrun_project_to_iguazio_mlrun_project_attribute(
-                project
-            ),
         },
     }
+    if with_mlrun_project:
+        body["attributes"][
+            "mlrun_project"
+        ] = iguazio_client._transform_mlrun_project_to_iguazio_mlrun_project_attribute(
+            project
+        )
     if project.spec.description:
         body["attributes"]["description"] = project.spec.description
     if project.spec.owner:

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -676,7 +676,7 @@ def test_format_as_leader_project(
     iguazio_project = iguazio_client.format_as_leader_project(project)
     assert (
         deepdiff.DeepDiff(
-            _build_project_response(iguazio_client, project),
+            _build_project_response(iguazio_client, project, with_mlrun_project=True),
             iguazio_project.data,
             ignore_order=True,
             exclude_paths=[


### PR DESCRIPTION
In order to save on the size of the responses (as many real world projects are over a couple MBs large), Listing projects from iguazio will not return the project struct, therefore we need to GET each projects separately once we get there names.