### PR TITLE
[Model Monitoring] Fix BC issue when deleting a model endpoint from KV

### DIFF
--- a/mlrun/common/model_monitoring.py
+++ b/mlrun/common/model_monitoring.py
@@ -30,6 +30,7 @@ class EventFieldType:
     VERSIONED_MODEL = "versioned_model"
     MODEL_CLASS = "model_class"
     TIMESTAMP = "timestamp"
+    # `endpoint_id` is deprecated as a field in the model endpoint schema since 1.3.1, replaced by `uid`.
     ENDPOINT_ID = "endpoint_id"
     UID = "uid"
     ENDPOINT_TYPE = "endpoint_type"
@@ -40,7 +41,6 @@ class EventFieldType:
     NAMED_FEATURES = "named_features"
     LABELS = "labels"
     LATENCY = "latency"
-    LABEL_COLUMNS = "label_columns"
     LABEL_NAMES = "label_names"
     PREDICTION = "prediction"
     PREDICTIONS = "predictions"
@@ -50,12 +50,9 @@ class EventFieldType:
     FIRST_REQUEST = "first_request"
     LAST_REQUEST = "last_request"
     METRICS = "metrics"
-    BATCH_TIMESTAMP = "batch_timestamp"
     TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
     BATCH_INTERVALS_DICT = "batch_intervals_dict"
     DEFAULT_BATCH_INTERVALS = "default_batch_intervals"
-    DEFAULT_BATCH_IMAGE = "default_batch_image"
-    STREAM_IMAGE = "stream_image"
     MINUTES = "minutes"
     HOURS = "hours"
     DAYS = "days"
@@ -74,7 +71,6 @@ class EventFieldType:
     MONITOR_CONFIGURATION = "monitor_configuration"
     FEATURE_SET_URI = "monitoring_feature_set_uri"
     ALGORITHM = "algorithm"
-    ACCURACY = "accuracy"
 
 
 class EventLiveStats:
@@ -120,7 +116,6 @@ class FileTargetKind:
     STREAM = "stream"
     PARQUET = "parquet"
     LOG_STREAM = "log_stream"
-    DEFAULT_HTTP_SINK = "default_http_sink"
 
 
 class ModelMonitoringMode(str, enum.Enum):

--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -168,7 +168,6 @@ class KVModelEndpointStore(ModelEndpointStore):
 
         # Retrieve the raw data from the KV table and get the endpoint ids
         try:
-
             cursor = self.client.kv.new_cursor(
                 container=self.container,
                 table_path=self.path,
@@ -219,8 +218,17 @@ class KVModelEndpointStore(ModelEndpointStore):
 
         # Delete model endpoint record from KV table
         for endpoint_dict in endpoints:
+            if model_monitoring_constants.EventFieldType.UID not in endpoint_dict:
+                # This is kept for backwards compatibility - in old versions the key column named endpoint_id
+                endpoint_id = endpoint_dict[
+                    model_monitoring_constants.EventFieldType.ENDPOINT_ID
+                ]
+            else:
+                endpoint_id = endpoint_dict[
+                    model_monitoring_constants.EventFieldType.UID
+                ]
             self.delete_model_endpoint(
-                endpoint_dict[model_monitoring_constants.EventFieldType.UID],
+                endpoint_id,
             )
 
         # Delete remain records in the KV
@@ -420,7 +428,6 @@ class KVModelEndpointStore(ModelEndpointStore):
 
         # Add labels filters
         if labels:
-
             for label in labels:
                 if not label.startswith("_"):
                     label = f"_{label}"


### PR DESCRIPTION
A fix for [ML-3795](https://jira.iguazeng.com/browse/ML-3795).

For projects that have been deployed in previous versions (<1.3.1), the model endpoint unique id was stored under a key named `endpoint_id`. Since [#2685](https://github.com/mlrun/mlrun/pull/2685), the key is named `uid`. 

In this PR, we fix backwards compatibility issue when trying to delete model endpoints with the old key name. 