### PR TITLE
[Launcher][Run-separation] Move `save` method from `BaseRuntime` to launcher

### DIFF
--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -149,10 +149,6 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
         pass
 
     @staticmethod
-    def save(runtime):
-        pass
-
-    @staticmethod
     def _enrich_runtime(runtime):
         """
         Enrich the function with:
@@ -199,3 +195,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
                 struct, runtime.metadata.name, runtime.metadata.project, versioned=True
             )
             run.spec.function = runtime._function_uri(hash_key=hash_key)
+
+    def _refresh_function_metadata(self, runtime: "mlrun.runtimes.BaseRuntime"):
+        """metadata refresh is not required in the API"""
+        pass

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -42,10 +42,6 @@ class ClientLocalLauncher(BaseLauncher):
     def verify_base_image(runtime):
         pass
 
-    @staticmethod
-    def save(runtime):
-        pass
-
     def launch(
         self,
         runtime: "mlrun.runtimes.BaseRuntime",

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -40,10 +40,6 @@ class ClientRemoteLauncher(BaseLauncher):
     def verify_base_image(runtime):
         pass
 
-    @staticmethod
-    def save(runtime):
-        pass
-
     def launch(
         self,
         runtime: "mlrun.runtimes.KubejobRuntime",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -1217,35 +1217,12 @@ class BaseRuntime(ModelObj):
         return self
 
     def save(self, tag="", versioned=False, refresh=False) -> str:
-        db = self._get_db()
-        if not db:
-            logger.error("database connection is not configured")
-            return ""
-
-        if refresh and self._is_remote_api():
-            try:
-                meta = self.metadata
-                db_func = db.get_function(meta.name, meta.project, meta.tag)
-                if db_func and "status" in db_func:
-                    self.status = db_func["status"]
-                    if (
-                        self.status.state
-                        and self.status.state == "ready"
-                        and not hasattr(self.status, "nuclio_name")
-                    ):
-                        self.spec.image = get_in(db_func, "spec.image", self.spec.image)
-            except mlrun.errors.MLRunNotFoundError:
-                pass
-
-        tag = tag or self.metadata.tag
-
-        obj = self.to_dict()
-        logger.debug(f"saving function: {self.metadata.name}, tag: {tag}")
-        hash_key = db.store_function(
-            obj, self.metadata.name, self.metadata.project, tag, versioned
+        launcher = mlrun.launcher.factory.LauncherFactory.create_launcher(
+            is_remote=self._is_remote
         )
-        hash_key = hash_key if versioned else None
-        return "db://" + self._function_uri(hash_key=hash_key, tag=tag)
+        return launcher.save_function(
+            self, tag=tag, versioned=versioned, refresh=refresh
+        )
 
     def to_dict(self, fields=None, exclude=None, strip=False):
         struct = super().to_dict(fields, exclude=exclude)


### PR DESCRIPTION
Save logic should be moved to the launcher as it depends on if running on the server or client.
Since `save` is used in many places, we keep the current method but make it use the launchers instead of conditioning the flow on whether we run on a server or client.
In the future, `save` should be removed and we should always use the launcher's `save_function`. 