### PR TITLE
[Model Monitoring] Fix EndpointType imports 

### DIFF
--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -82,7 +82,6 @@ class SQLModelEndpointStore(ModelEndpointStore):
         """
 
         with self._engine.connect() as connection:
-
             # Adjust timestamps fields
             endpoint[
                 model_monitoring_constants.EventFieldType.FIRST_REQUEST
@@ -112,7 +111,6 @@ class SQLModelEndpointStore(ModelEndpointStore):
 
         # Update the model endpoint record using sqlalchemy ORM
         with create_session(dsn=self.sql_connection_string) as session:
-
             # Remove endpoint id (foreign key) from the update query
             attributes.pop(model_monitoring_constants.EventFieldType.ENDPOINT_ID, None)
 
@@ -131,7 +129,6 @@ class SQLModelEndpointStore(ModelEndpointStore):
 
         # Delete the model endpoint record using sqlalchemy ORM
         with create_session(dsn=self.sql_connection_string) as session:
-
             # Generate and commit the delete query
             session.query(self.ModelEndpointsTable).filter_by(uid=endpoint_id).delete()
             session.commit()
@@ -152,7 +149,6 @@ class SQLModelEndpointStore(ModelEndpointStore):
 
         # Get the model endpoint record using sqlalchemy ORM
         with create_session(dsn=self.sql_connection_string) as session:
-
             # Generate the get query
             endpoint_record = (
                 session.query(self.ModelEndpointsTable)
@@ -195,7 +191,6 @@ class SQLModelEndpointStore(ModelEndpointStore):
 
         # Get the model endpoints records using sqlalchemy ORM
         with create_session(dsn=self.sql_connection_string) as session:
-
             # Generate the list query
             query = session.query(self.ModelEndpointsTable).filter_by(
                 project=self.project
@@ -225,8 +220,8 @@ class SQLModelEndpointStore(ModelEndpointStore):
                     combined=False,
                 )
             if top_level:
-                node_ep = str(mlrun.model_monitoring.EndpointType.NODE_EP.value)
-                router_ep = str(mlrun.model_monitoring.EndpointType.ROUTER.value)
+                node_ep = str(mlrun.common.model_monitoring.EndpointType.NODE_EP.value)
+                router_ep = str(mlrun.common.model_monitoring.EndpointType.ROUTER.value)
                 endpoint_types = [node_ep, router_ep]
                 query = self._filter_values(
                     query=query,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -33,6 +33,7 @@ import mlrun.common.model_monitoring as model_monitoring_constants
 import mlrun.common.schemas
 import mlrun.feature_store
 import mlrun.utils
+from mlrun.common.model_monitoring import EndpointType, ModelMonitoringMode
 from mlrun.common.schemas import (
     ModelEndpoint,
     ModelEndpointMetadata,
@@ -41,7 +42,6 @@ from mlrun.common.schemas import (
 )
 from mlrun.errors import MLRunNotFoundError
 from mlrun.model import BaseMetadata
-from mlrun.model_monitoring import EndpointType, ModelMonitoringMode
 from mlrun.runtimes import BaseRuntime
 from mlrun.utils.v3io_clients import get_frames_client
 from tests.system.base import TestMLRunSystem
@@ -547,7 +547,6 @@ class TestVotingModelMonitoring(TestMLRunSystem):
         train = mlrun.import_function("hub://auto-trainer")
 
         for name, pkg in model_names.items():
-
             # Run the function and specify input dataset path and some parameters (algorithm and label column name)
             train_run = train.run(
                 name=name,


### PR DESCRIPTION
Following the refactoring process in https://github.com/mlrun/mlrun/pull/3461, the `EndpointType` is now stored within `mlrun.common.model_monitoring.py`. In this PR, we update two references for that class that were missing in the refactoring process. 

@liranbg @TomerShor FYI