### PR TITLE
[CI] Use CE Deployer in Open Source System Tests CI

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -183,7 +183,7 @@ jobs:
             --registry-secret-name="" \
             --skip-registry-validation \
             --disable-prometheus-stack \
-            --sqlite \
+            --sqlite /mlrun/db/mlrun.db \
             --override-mlrun-api-image="${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
             --override-mlrun-ui-image="ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}" \
             --set mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}" \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -178,13 +178,13 @@ jobs:
         python automation/deployment/ce.py deploy \
             --verbose \
             --minikube \
-            --namespace ${NAMESPACE} \
-            --registry-url $(minikube ip):5000 \
-            --registry-secret-name "" \
+            --namespace=${NAMESPACE} \
+            --registry-url=$(minikube ip):5000 \
+            --registry-secret-name="" \
             --disable-prometheus-stack \
             --sqlite \
-            --override-mlrun-api-image ${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }} \
-            --override-mlrun-ui-image ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }} \
+            --override-mlrun-api-image="${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
+            --override-mlrun-ui-image="ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}" \
             --set mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}" \
             --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ steps.computed_params.outputs.mlrun_docker_registry }}"
 

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -186,7 +186,7 @@ jobs:
             --sqlite /mlrun/db/mlrun.db \
             --override-mlrun-api-image="${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
             --override-mlrun-ui-image="ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}" \
-            --set mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}" \
+            --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}"' \
             --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ steps.computed_params.outputs.mlrun_docker_registry }}"
 
     - name: Prepare system tests env

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -179,9 +179,7 @@ jobs:
             --verbose \
             --minikube \
             --namespace=${NAMESPACE} \
-            --registry-url=$(minikube ip):5000 \
             --registry-secret-name="" \
-            --skip-registry-validation \
             --disable-prometheus-stack \
             --sqlite /mlrun/db/mlrun.db \
             --override-mlrun-api-image="${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }}" \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -181,6 +181,7 @@ jobs:
             --namespace=${NAMESPACE} \
             --registry-url=$(minikube ip):5000 \
             --registry-secret-name="" \
+            --skip-registry-validation \
             --disable-prometheus-stack \
             --sqlite \
             --override-mlrun-api-image="${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }}" \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -164,47 +164,29 @@ jobs:
         # but this seems to work
         start args: '--addons=registry --insecure-registry="192.168.49.2:5000"'
 
-    - name: Get mlrun ce charts and create namespace
-      run: |
-        helm repo add mlrun-ce https://mlrun.github.io/ce
-        helm repo update
-        minikube kubectl -- create namespace ${NAMESPACE}
-
     - name: Install MLRun CE helm chart
       run: |
         # TODO: There are a couple of modifications to the helm chart that we are doing right now:
         #       1. The grafana prometheus stack is disabled as there are currently no system tests checking its
         #          functionality. Once the model monitoring feature is complete and we have system tests for it, we
-        #          can enable it. (flags: --set kube-prometheus-stack.enabled=false)
+        #          can enable it.
         #       2. The mlrun DB is set as the old SQLite db. There is a bug in github workers when trying to run a mysql
         #          server pod in minikube installed on the worker, the mysql pod crashes. There isn't much information
         #          about this issue online as this isn't how github expect you to use mysql in workflows - the worker
         #          has a mysql server installed directly on it and should be enabled and used as the DB. So we might
         #          want in the future to use that instead, unless the mysql will be able to come up without crashing.
-        #          (flags: --set mlrun.httpDB.dbType="sqlite" --set mlrun.httpDB.dirPath="/mlrun/db"
-        #          --set mlrun.httpDB.dsn="sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
-        #          --set mlrun.httpDB.oldDsn="")
-        helm --namespace ${NAMESPACE} \
-            install mlrun-ce \
-            --debug \
-            --wait \
-            --timeout 600s \
-            --set kube-prometheus-stack.enabled=false \
-            --set mlrun.httpDB.dbType="sqlite" \
-            --set mlrun.httpDB.dirPath="/mlrun/db" \
-            --set mlrun.httpDB.dsn="sqlite:////mlrun/db/mlrun.db?check_same_thread=false" \
-            --set mlrun.httpDB.oldDsn="" \
-            --set global.registry.url=$(minikube ip):5000 \
-            --set global.registry.secretName="" \
-            --set global.externalHostAddress=$(minikube ip) \
-            --set nuclio.dashboard.externalIPAddresses[0]=$(minikube ip) \
-            --set mlrun.api.image.repository=${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api \
-            --set mlrun.api.image.tag=${{ steps.computed_params.outputs.mlrun_docker_tag }} \
-            --set mlrun.ui.image.repository=ghcr.io/mlrun/mlrun-ui \
-            --set mlrun.ui.image.tag=${{ steps.computed_params.outputs.mlrun_ui_version }} \
+        python automation/deployment/ce.py deploy \
+            --verbose \
+            --minikube \
+            --namespace ${NAMESPACE} \
+            --registry-url $(minikube ip):5000 \
+            --registry-secret-name "" \
+            --disable-prometheus-stack \
+            --sqlite \
+            --override-mlrun-api-image ${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }} \
+            --override-mlrun-ui-image ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }} \
             --set mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ steps.computed_params.outputs.mlrun_hash }}" \
-            --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
-            mlrun-ce/mlrun-ce
+            --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ steps.computed_params.outputs.mlrun_docker_registry }}"
 
     - name: Prepare system tests env
       run: |

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -87,7 +87,6 @@ def cli():
 @click.option(
     "--registry-url",
     help="URL of the container registry to use for storing images",
-    required=True,
 )
 @click.option(
     "--registry-username",

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -146,6 +146,11 @@ def cli():
     is_flag=True,
     help="Upgrade the existing mlrun installation",
 )
+@click.option(
+    "--skip-registry-validation",
+    is_flag=True,
+    help="Skip validation of the registry URL",
+)
 @add_options(common_options)
 @add_options(common_deployment_options)
 def deploy(
@@ -164,6 +169,7 @@ def deploy(
     disable_pipelines: bool = False,
     disable_prometheus_stack: bool = False,
     disable_spark_operator: bool = False,
+    skip_registry_validation: bool = False,
     sqlite: str = None,
     devel: bool = False,
     minikube: bool = False,
@@ -188,6 +194,7 @@ def deploy(
         disable_pipelines=disable_pipelines,
         disable_prometheus_stack=disable_prometheus_stack,
         disable_spark_operator=disable_spark_operator,
+        skip_registry_validation=skip_registry_validation,
         devel=devel,
         minikube=minikube,
         sqlite=sqlite,

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -16,7 +16,6 @@ import sys
 import typing
 
 import click
-
 from deployer import CommunityEditionDeployer
 
 common_options = [

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -17,7 +17,7 @@ import typing
 
 import click
 
-from automation.deployment.deployer import CommunityEditionDeployer
+from deployer import CommunityEditionDeployer
 
 common_options = [
     click.option(

--- a/automation/deployment/deployer.py
+++ b/automation/deployment/deployer.py
@@ -318,8 +318,9 @@ class CommunityEditionDeployer:
             "--namespace",
             self._namespace,
             "upgrade",
-            "--install",
             Constants.helm_release_name,
+            Constants.helm_chart_name,
+            "--install",
             "--wait",
             "--timeout",
             "960s",
@@ -358,8 +359,6 @@ class CommunityEditionDeployer:
                     value,
                 ]
             )
-
-        helm_arguments.append(Constants.helm_chart_name)
 
         if chart_version:
             self._logger.warning(

--- a/automation/deployment/deployer.py
+++ b/automation/deployment/deployer.py
@@ -441,7 +441,7 @@ class CommunityEditionDeployer:
             helm_values.update(
                 {
                     "mlrun.httpDB.dbType": "sqlite",
-                    "mlrun.httpDB.dirPath": {dir_path},
+                    "mlrun.httpDB.dirPath": dir_path,
                     "mlrun.httpDB.dsn": f"sqlite:///{sqlite}?check_same_thread=false",
                     "mlrun.httpDB.oldDsn": "",
                 }

--- a/automation/deployment/deployer.py
+++ b/automation/deployment/deployer.py
@@ -67,6 +67,7 @@ class CommunityEditionDeployer:
         disable_pipelines: bool = False,
         disable_prometheus_stack: bool = False,
         disable_spark_operator: bool = False,
+        skip_registry_validation: bool = False,
         devel: bool = False,
         minikube: bool = False,
         sqlite: str = None,
@@ -94,7 +95,11 @@ class CommunityEditionDeployer:
         :param custom_values: List of custom values to pass to the helm chart
         """
         self._prepare_prerequisites(
-            registry_url, registry_username, registry_password, registry_secret_name
+            registry_url,
+            registry_username,
+            registry_password,
+            registry_secret_name,
+            skip_registry_validation,
         )
         helm_arguments = self._generate_helm_install_arguments(
             registry_url,
@@ -227,6 +232,7 @@ class CommunityEditionDeployer:
         registry_username: str = None,
         registry_password: str = None,
         registry_secret_name: str = None,
+        skip_registry_validation: bool = False,
     ) -> None:
         """
         Prepare the prerequisites for the MLRun CE stack deployment.
@@ -237,7 +243,8 @@ class CommunityEditionDeployer:
         :param registry_secret_name: Name of the registry secret to use
         """
         self._logger.info("Preparing prerequisites")
-        self._validate_registry_url(registry_url)
+        if not skip_registry_validation:
+            self._validate_registry_url(registry_url)
 
         self._logger.info("Creating namespace", namespace=self._namespace)
         run_command("kubectl", ["create", "namespace", self._namespace])

--- a/automation/deployment/deployer.py
+++ b/automation/deployment/deployer.py
@@ -122,7 +122,14 @@ class CommunityEditionDeployer:
         self._logger.info(
             "Installing helm chart with arguments", helm_arguments=helm_arguments
         )
-        run_command("helm", helm_arguments)
+        stdout, stderr, exit_status = run_command("helm", helm_arguments)
+        if exit_status != 0:
+            self._logger.error(
+                "Failed to install helm chart",
+                stderr=stderr,
+                exit_status=exit_status,
+            )
+            raise RuntimeError("Failed to install helm chart")
 
         self._teardown()
 
@@ -443,7 +450,7 @@ class CommunityEditionDeployer:
                     "mlrun.httpDB.dbType": "sqlite",
                     "mlrun.httpDB.dirPath": dir_path,
                     "mlrun.httpDB.dsn": f"sqlite:///{sqlite}?check_same_thread=false",
-                    "mlrun.httpDB.oldDsn": "",
+                    "mlrun.httpDB.oldDsn": '""',
                 }
             )
 


### PR DESCRIPTION
Fix deployer cli tool with a couple of changes and make the Open Source System Tests workflow use the cli tool

Example run - https://github.com/quaark/mlrun/actions/runs/4913793406/jobs/8774364851