### PR TITLE
[Requirements] Blacklist orjson 3.8.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,8 @@ sqlalchemy~=1.4
 tabulate~=0.8.6
 v3io~=0.5.20
 pydantic~=1.5
-orjson~=3.3
+# blacklist 3.8.12 due to a bug not being able to collect traceback of exceptions
+orjson~=3.3, <3.8.12
 alembic~=1.9
 mergedeep~=1.3
 v3io-frames~=0.10.4

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -132,6 +132,7 @@ def test_requirement_specifiers_convention():
         "ipython": {">=7.0, <9.0"},
         "importlib_metadata": {">=3.6"},
         "gitpython": {"~=3.1, >= 3.1.30"},
+        "orjson": {"~=3.3, <3.8.12"},
         "pyopenssl": {">=23"},
         "google-cloud-bigquery": {"[pandas, bqstorage]~=3.2"},
         # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding


### PR DESCRIPTION
orjson does not behave well with latest pytest due to a bug with the stack trace below.
orjson 3.8.12 changelog mentiones the following (https://github.com/ijl/orjson/releases/tag/3.8.12)
> Exceptions raised in default are now chained as the __cause__ attribute on orjson.JSONEncodeError.

and it seems that pytest is yet to catch up on this change.
<details>
  <summary>
    Stack trace
  </summary>

```
2023-05-08T19:23:08.8033830Z INTERNALERROR> Traceback (most recent call last):
2023-05-08T19:23:08.8034674Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 269, in wrap_session
2023-05-08T19:23:08.8035073Z INTERNALERROR>     session.exitstatus = doit(config, session) or 0
2023-05-08T19:23:08.8086045Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 323, in _main
2023-05-08T19:23:08.8086454Z INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
2023-05-08T19:23:08.8086952Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265, in __call__
2023-05-08T19:23:08.8087375Z INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
2023-05-08T19:23:08.8087874Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80, in _hookexec
2023-05-08T19:23:08.8088284Z INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2023-05-08T19:23:08.8088776Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 60, in _multicall
2023-05-08T19:23:08.8091653Z INTERNALERROR>     return outcome.get_result()
2023-05-08T19:23:08.8092145Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_result.py", line 60, in get_result
2023-05-08T19:23:08.8092505Z INTERNALERROR>     raise ex[1].with_traceback(ex[2])
2023-05-08T19:23:08.8092954Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39, in _multicall
2023-05-08T19:23:08.8093296Z INTERNALERROR>     res = hook_impl.function(*args)
2023-05-08T19:23:08.8093927Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/main.py", line 348, in pytest_runtestloop
2023-05-08T19:23:08.8094362Z INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
2023-05-08T19:23:08.8094865Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265, in __call__
2023-05-08T19:23:08.8095257Z INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
2023-05-08T19:23:08.8095751Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80, in _hookexec
2023-05-08T19:23:08.8096234Z INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2023-05-08T19:23:08.8096890Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 60, in _multicall
2023-05-08T19:23:08.8097232Z INTERNALERROR>     return outcome.get_result()
2023-05-08T19:23:08.8097677Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_result.py", line 60, in get_result
2023-05-08T19:23:08.8098029Z INTERNALERROR>     raise ex[1].with_traceback(ex[2])
2023-05-08T19:23:08.8098542Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39, in _multicall
2023-05-08T19:23:08.8098886Z INTERNALERROR>     res = hook_impl.function(*args)
2023-05-08T19:23:08.8099367Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 109, in pytest_runtest_protocol
2023-05-08T19:23:08.8099754Z INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
2023-05-08T19:23:08.8100217Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 126, in runtestprotocol
2023-05-08T19:23:08.8100606Z INTERNALERROR>     reports.append(call_and_report(item, "call", log))
2023-05-08T19:23:08.8101089Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 217, in call_and_report
2023-05-08T19:23:08.8101638Z INTERNALERROR>     report: TestReport = hook.pytest_runtest_makereport(item=item, call=call)
2023-05-08T19:23:08.8102143Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_hooks.py", line 265, in __call__
2023-05-08T19:23:08.8102609Z INTERNALERROR>     return self._hookexec(self.name, self.get_hookimpls(), kwargs, firstresult)
2023-05-08T19:23:08.8103100Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_manager.py", line 80, in _hookexec
2023-05-08T19:23:08.8103488Z INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
2023-05-08T19:23:08.8103970Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 55, in _multicall
2023-05-08T19:23:08.8104297Z INTERNALERROR>     gen.send(outcome)
2023-05-08T19:23:08.8104753Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/skipping.py", line 272, in pytest_runtest_makereport
2023-05-08T19:23:08.8105113Z INTERNALERROR>     rep = outcome.get_result()
2023-05-08T19:23:08.8105553Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_result.py", line 60, in get_result
2023-05-08T19:23:08.8105908Z INTERNALERROR>     raise ex[1].with_traceback(ex[2])
2023-05-08T19:23:08.8106344Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/_callers.py", line 39, in _multicall
2023-05-08T19:23:08.8106683Z INTERNALERROR>     res = hook_impl.function(*args)
2023-05-08T19:23:08.8107154Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/runner.py", line 337, in pytest_runtest_makereport
2023-05-08T19:23:08.8107539Z INTERNALERROR>     return TestReport.from_item_and_call(item, call)
2023-05-08T19:23:08.8108039Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/reports.py", line 322, in from_item_and_call
2023-05-08T19:23:08.8108405Z INTERNALERROR>     longrepr = item.repr_failure(excinfo)
2023-05-08T19:23:08.8108867Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/python.py", line 1677, in repr_failure
2023-05-08T19:23:08.8109246Z INTERNALERROR>     return self._repr_failure_py(excinfo, style=style)
2023-05-08T19:23:08.8109727Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/nodes.py", line 398, in _repr_failure_py
2023-05-08T19:23:08.8110080Z INTERNALERROR>     return excinfo.getrepr(
2023-05-08T19:23:08.8110516Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 648, in getrepr
2023-05-08T19:23:08.8110860Z INTERNALERROR>     return fmt.repr_excinfo(self)
2023-05-08T19:23:08.8111316Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 905, in repr_excinfo
2023-05-08T19:23:08.8111744Z INTERNALERROR>     reprtraceback = self.repr_traceback(excinfo_)
2023-05-08T19:23:08.8112220Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 846, in repr_traceback
2023-05-08T19:23:08.8112604Z INTERNALERROR>     reprentry = self.repr_traceback_entry(entry, einfo)
2023-05-08T19:23:08.8113101Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 798, in repr_traceback_entry
2023-05-08T19:23:08.8113548Z INTERNALERROR>     s = self.get_source(source, line_index, excinfo, short=short)
2023-05-08T19:23:08.8114024Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 736, in get_source
2023-05-08T19:23:08.8114425Z INTERNALERROR>     lines.extend(self.get_exconly(excinfo, indent=indent, markall=True))
2023-05-08T19:23:08.8115047Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 748, in get_exconly
2023-05-08T19:23:08.8155828Z INTERNALERROR>     exlines = excinfo.exconly(tryshort=True).split("\n")
2023-05-08T19:23:08.8156509Z INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/_pytest/_code/code.py", line 567, in exconly
2023-05-08T19:23:08.8156977Z INTERNALERROR>     lines = format_exception_only(self.type, self.value)
2023-05-08T19:23:08.8157554Z INTERNALERROR>   File "/usr/local/lib/python3.9/traceback.py", line 140, in format_exception_only
2023-05-08T19:23:08.8158057Z INTERNALERROR>     return list(TracebackException(etype, value, None).format_exception_only())
2023-05-08T19:23:08.8158581Z INTERNALERROR>   File "/usr/local/lib/python3.9/traceback.py", line 495, in __init__
2023-05-08T19:23:08.8158982Z INTERNALERROR>     context = TracebackException(
2023-05-08T19:23:08.8159401Z INTERNALERROR>   File "/usr/local/lib/python3.9/traceback.py", line 486, in __init__
2023-05-08T19:23:08.8159799Z INTERNALERROR>     exc_value.__cause__.__traceback__,
2023-05-08T19:23:08.8160272Z INTERNALERROR> AttributeError: 'str' object has no attribute '__traceback__'
```