### PR TITLE
[CI] Make Community Edition Deployer Self Contained

### DIFF
--- a/ce.logs
+++ b/ce.logs
@@ -1,0 +1,7 @@
+Cleaning up helm release: {'release': 'mlrun-ce'}
+Cleaning up mlrun volumes
+Cleaning up registry secret: {'secret_name': None}
+Cleaning up entire namespace: {'namespace': 'mlrun'}
+Cleaning up entire namespace: {'namespace': 'mlrun'}
+Cleaning up entire namespace: {'namespace': 'mlrun'}
+namespace "mlrun" deleted

--- a/ce.logs
+++ b/ce.logs
@@ -1,7 +1,0 @@
-Cleaning up helm release: {'release': 'mlrun-ce'}
-Cleaning up mlrun volumes
-Cleaning up registry secret: {'secret_name': None}
-Cleaning up entire namespace: {'namespace': 'mlrun'}
-Cleaning up entire namespace: {'namespace': 'mlrun'}
-Cleaning up entire namespace: {'namespace': 'mlrun'}
-namespace "mlrun" deleted


### PR DESCRIPTION
By using its own logger, the deployer is now self contained and doesn't need to import mlrun. Making it so it can run without any prerequisites.