### PR TITLE
[API] Add k8s util exception logging 

### DIFF
--- a/mlrun/api/utils/singletons/k8s.py
+++ b/mlrun/api/utils/singletons/k8s.py
@@ -56,7 +56,10 @@ class K8sHelper:
             self._init_k8s_config(log)
             self.v1api = client.CoreV1Api()
             self.crdapi = client.CustomObjectsApi()
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "cannot initialize kubernetes client", exc=mlrun.errors.err_to_str(exc)
+            )
             if not silent:
                 raise
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -954,7 +954,7 @@ def retry_until_successful(
         f" last_exception: {last_exception},"
         f" function_name: {_function.__name__},"
         f" timeout: {timeout}"
-    )
+    ) from last_exception
 
 
 def get_ui_url(project, uid=None):


### PR DESCRIPTION
When running locally and trying to use remote k8s, it is needed to understand the exception when loading kubeconfig