### PR TITLE
[System tests] Fix test run notifications

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -618,7 +618,7 @@ class HTTPRunDB(RunDBInterface):
             "start_time_to": datetime_to_iso(start_time_to),
             "last_update_time_from": datetime_to_iso(last_update_time_from),
             "last_update_time_to": datetime_to_iso(last_update_time_to),
-            "with_notifications": with_notifications,
+            "with-notifications": with_notifications,
         }
 
         if partition_by:

--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -32,11 +32,13 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
             )
             assert len(runs) == 1
             assert len(runs[0]["status"]["notifications"]) == 2
-            for notification in runs[0]["status"]["notifications"]:
+            for notification_name, notification in runs[0]["status"][
+                "notifications"
+            ].items():
                 if notification["name"] == error_notification.name:
-                    assert notification["status"] == "error"
+                    assert notification_name["status"] == "error"
                 elif notification["name"] == success_notification.name:
-                    assert notification["status"] == "sent"
+                    assert notification_name["status"] == "sent"
 
         error_notification = self._create_notification(
             name=error_notification_name,


### PR DESCRIPTION
`test_run_notifications` fails in the open source system tests.
The issue was that we had an inconsistent name for the "with-notifications" option, with a dash in the runs endpoint but an underscore in the httpdb.