### PR TITLE
[Tests] Fix `test_sync_pipeline_chunks`

### DIFF
--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1853,7 +1853,7 @@ class TestFeatureStore(TestMLRunSystem):
         self._logger.info(f"output df:\n{df}")
 
         reference_df = pd.read_csv(csv_file)
-        reference_df = reference_df[0:chunksize].set_index("patient_id")
+        reference_df = reference_df.set_index("patient_id")
 
         # patient_id (index) and timestamp (timestamp_key) are not in features list
         assert features + ["timestamp"] == list(reference_df.columns)


### PR DESCRIPTION
Before #3449, `ingest()` ignored all but the first chunk. This PR adjusts `test_sync_pipeline_chunks` to expect all data to be returned, not just the first chunk.