### PR TITLE
[Feature Store] Fix empty dataframe result from `preview()` with pandas engine

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -719,7 +719,9 @@ def preview(
             )
         # reduce the size of the ingestion if we do not infer stats
         rows_limit = (
-            0 if InferOptions.get_common_options(options, InferOptions.Stats) else 1000
+            None
+            if InferOptions.get_common_options(options, InferOptions.Stats)
+            else 1000
         )
         source = init_featureset_graph(
             source,


### PR DESCRIPTION
[ML-3793](https://jira.iguazeng.com/browse/ML-3793)

Fixes `TestFeatureStore::test_pandas_stats_include_index`