### PR TITLE
[Builder] Move `builder.py` to `api/utils/builder.py` 

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -34,7 +34,6 @@ from tabulate import tabulate
 
 import mlrun
 
-from .builder import upload_tarball
 from .config import config as mlconf
 from .db import get_run_db
 from .errors import err_to_str
@@ -544,7 +543,7 @@ def build(
         logger.info(f"uploading data from {src} to {archive}")
         target = archive if archive.endswith("/") else archive + "/"
         target += f"src-{meta.project}-{meta.name}-{meta.tag or 'latest'}.tar.gz"
-        upload_tarball(src, target)
+        mlrun.datastore.utils.upload_tarball(src, target)
         # todo: replace function.yaml inside the tar
         b.source = target
 

--- a/mlrun/api/api/endpoints/frontend_spec.py
+++ b/mlrun/api/api/endpoints/frontend_spec.py
@@ -18,8 +18,8 @@ import fastapi
 import semver
 
 import mlrun.api.api.deps
+import mlrun.api.utils.builder
 import mlrun.api.utils.clients.iguazio
-import mlrun.builder
 import mlrun.common.schemas
 import mlrun.runtimes
 import mlrun.runtimes.utils
@@ -76,7 +76,7 @@ def get_frontend_spec(
         function_deployment_target_image_template=function_deployment_target_image_template,
         function_deployment_target_image_name_prefix_template=function_target_image_name_prefix_template,
         function_deployment_target_image_registries_to_enforce_prefix=registries_to_enforce_prefix,
-        function_deployment_mlrun_command=mlrun.builder.resolve_mlrun_install_command(),
+        function_deployment_mlrun_command=mlrun.api.utils.builder.resolve_mlrun_install_command(),
         auto_mount_type=config.storage.auto_mount_type,
         auto_mount_params=config.get_storage_auto_mount_params(),
         default_artifact_path=config.artifact_path,

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -46,7 +46,7 @@ import mlrun.common.schemas
 from mlrun.api.api import deps
 from mlrun.api.api.utils import get_run_db_instance, log_and_raise, log_path
 from mlrun.api.crud.secrets import Secrets, SecretsClientType
-from mlrun.builder import build_runtime
+from mlrun.api.utils.builder import build_runtime
 from mlrun.config import config
 from mlrun.errors import MLRunRuntimeError, err_to_str
 from mlrun.run import new_function

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from kubernetes import client
 
 import mlrun.api.utils.singletons.k8s
+import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.utils
@@ -32,8 +33,6 @@ from mlrun.utils import (
     logger,
     normalize_name,
 )
-
-IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."
 
 
 def make_dockerfile(
@@ -668,10 +667,14 @@ def _resolve_image_target_and_registry_secret(
         return "/".join([registry, image_target]), secret_name
 
     # if dest starts with a dot, we add the configured registry to the start of the dest
-    if image_target.startswith(IMAGE_NAME_ENRICH_REGISTRY_PREFIX):
+    if image_target.startswith(
+        mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX
+    ):
 
         # remove prefix from image name
-        image_target = image_target[len(IMAGE_NAME_ENRICH_REGISTRY_PREFIX) :]
+        image_target = image_target[
+            len(mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX) :
+        ]
 
         registry, repository = get_parsed_docker_registry()
         secret_name = secret_name or config.httpdb.builder.docker_registry_secret

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -14,7 +14,6 @@
 import os.path
 import pathlib
 import re
-import tarfile
 import tempfile
 from base64 import b64decode, b64encode
 from os import path
@@ -26,10 +25,13 @@ import mlrun.api.utils.singletons.k8s
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.utils
-
-from .config import config
-from .datastore import store_manager
-from .utils import enrich_image_url, get_parsed_docker_registry, logger, normalize_name
+from mlrun.config import config
+from mlrun.utils import (
+    enrich_image_url,
+    get_parsed_docker_registry,
+    logger,
+    normalize_name,
+)
 
 IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."
 
@@ -301,17 +303,6 @@ def configure_kaniko_ecr_init_container(
         env=init_container_env,
         name="create-repos",
     )
-
-
-def upload_tarball(source_dir, target, secrets=None):
-
-    # will delete the temp file
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_fh:
-        with tarfile.open(mode="w:gz", fileobj=temp_fh) as tar:
-            tar.add(source_dir, arcname="")
-        stores = store_manager.set(secrets)
-        datastore, subpath = stores.get_or_create_store(target)
-        datastore.upload(subpath, temp_fh.name)
 
 
 def build_image(

--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -1,0 +1,1 @@
+IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."  # prefix for image name to enrich with registry

--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -1,1 +1,15 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."  # prefix for image name to enrich with registry

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -22,7 +22,6 @@ import mlrun.common.schemas
 import mlrun.errors
 from mlrun.runtimes.base import BaseRuntimeHandler
 
-from ..builder import build_runtime
 from ..db import RunDBError
 from ..errors import err_to_str
 from ..kfpops import build_op
@@ -215,6 +214,7 @@ class KubejobRuntime(KubeResource):
         if is_kfp:
             watch = True
 
+        ready = False
         if self._is_remote_api():
             db = self._get_db()
             data = db.remote_builder(
@@ -240,17 +240,6 @@ class KubejobRuntime(KubeResource):
                 state = self._build_watch(watch, show_on_failure=show_on_failure)
                 ready = state == "ready"
                 self.status.state = state
-        else:
-            self.save(versioned=False)
-            ready = build_runtime(
-                mlrun.common.schemas.AuthInfo(),
-                self,
-                with_mlrun,
-                mlrun_version_specifier,
-                skip_deployed,
-                watch,
-            )
-            self.save(versioned=False)
 
         if watch and not ready:
             raise mlrun.errors.MLRunRuntimeError("Deploy failed")

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -24,7 +24,7 @@ import pandas as pd
 from kubernetes import client
 
 import mlrun
-import mlrun.builder
+import mlrun.api.utils.builder
 import mlrun.utils.regex
 from mlrun.api.utils.clients import nuclio
 from mlrun.db import get_run_db
@@ -346,7 +346,11 @@ def generate_function_image_name(project: str, name: str, tag: str) -> str:
     _, repository = helpers.get_parsed_docker_registry()
     repository = helpers.get_docker_repository_or_default(repository)
     return fill_function_image_name_template(
-        mlrun.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX, repository, project, name, tag
+        mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX,
+        repository,
+        project,
+        name,
+        tag,
     )
 
 
@@ -371,7 +375,7 @@ def resolve_function_target_image_registries_to_enforce_prefix():
     registry, repository = helpers.get_parsed_docker_registry()
     repository = helpers.get_docker_repository_or_default(repository)
     return [
-        f"{mlrun.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}{repository}/",
+        f"{mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}{repository}/",
         f"{registry}/{repository}/",
     ]
 

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -25,6 +25,7 @@ from kubernetes import client
 
 import mlrun
 import mlrun.api.utils.builder
+import mlrun.common.constants
 import mlrun.utils.regex
 from mlrun.api.utils.clients import nuclio
 from mlrun.db import get_run_db
@@ -346,7 +347,7 @@ def generate_function_image_name(project: str, name: str, tag: str) -> str:
     _, repository = helpers.get_parsed_docker_registry()
     repository = helpers.get_docker_repository_or_default(repository)
     return fill_function_image_name_template(
-        mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX,
+        mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX,
         repository,
         project,
         name,
@@ -375,7 +376,7 @@ def resolve_function_target_image_registries_to_enforce_prefix():
     registry, repository = helpers.get_parsed_docker_registry()
     repository = helpers.get_docker_repository_or_default(repository)
     return [
-        f"{mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}{repository}/",
+        f"{mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}{repository}/",
         f"{registry}/{repository}/",
     ]
 

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -22,7 +22,6 @@ from fastapi.concurrency import run_in_threadpool
 
 import mlrun.api.db.base
 import mlrun.api.db.session
-import mlrun.api.utils.singletons.k8s
 import mlrun.common.schemas
 import mlrun.config
 import mlrun.lists
@@ -192,6 +191,7 @@ class NotificationPusher(object):
         status: str = None,
         sent_time: datetime.datetime = None,
     ):
+        # TODO: move to api side
         db_session = mlrun.api.db.session.create_session()
         notification.status = status or notification.status
         notification.sent_time = sent_time or notification.sent_time

--- a/tests/api/runtimes/base.py
+++ b/tests/api/runtimes/base.py
@@ -30,6 +30,7 @@ from kubernetes import client
 from kubernetes import client as k8s_client
 from kubernetes.client import V1EnvVar
 
+import mlrun.api.api.endpoints.functions
 import mlrun.common.schemas
 import mlrun.k8s_utils
 import mlrun.runtimes.pod
@@ -389,6 +390,13 @@ class TestRuntimeBase:
         # set watch to False, to mimic the API behavior (API doesn't watch on the job)
         kwargs.update({"watch": False})
         self._execute_run(runtime, **kwargs)
+
+    @staticmethod
+    def deploy(db_session, runtime, with_mlrun=True):
+        auth_info = mlrun.common.schemas.AuthInfo()
+        mlrun.api.api.endpoints.functions._build_function(
+            db_session, auth_info, runtime, with_mlrun=with_mlrun
+        )
 
     def _reset_mocks(self):
         get_k8s_helper().v1api.create_namespaced_pod.reset_mock()

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -23,6 +23,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+import mlrun.api.api.endpoints.functions
 import mlrun.api.utils.builder
 import mlrun.common.schemas
 import mlrun.errors
@@ -755,7 +756,7 @@ def my_func(context):
         runtime = self._generate_runtime()
         runtime.spec.build.base_image = "some/image"
         runtime.spec.build.commands = copy.deepcopy(commands)
-        runtime.deploy(with_mlrun=with_mlrun, watch=False)
+        self.deploy(db, runtime, with_mlrun=with_mlrun)
         dockerfile = mlrun.api.utils.builder.make_kaniko_pod.call_args[1]["dockertext"]
         if expected_to_upgrade:
             expected_str = ""

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -23,7 +23,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-import mlrun.builder
+import mlrun.api.utils.builder
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.k8s_utils
@@ -750,13 +750,13 @@ def my_func(context):
         expected_to_upgrade,
     ):
         mlrun.mlconf.httpdb.builder.docker_registry = "localhost:5000"
-        mlrun.builder.make_kaniko_pod = unittest.mock.MagicMock()
+        mlrun.api.utils.builder.make_kaniko_pod = unittest.mock.MagicMock()
 
         runtime = self._generate_runtime()
         runtime.spec.build.base_image = "some/image"
         runtime.spec.build.commands = copy.deepcopy(commands)
         runtime.deploy(with_mlrun=with_mlrun, watch=False)
-        dockerfile = mlrun.builder.make_kaniko_pod.call_args[1]["dockertext"]
+        dockerfile = mlrun.api.utils.builder.make_kaniko_pod.call_args[1]["dockertext"]
         if expected_to_upgrade:
             expected_str = ""
             if commands:

--- a/tests/api/runtimes/test_mpijob.py
+++ b/tests/api/runtimes/test_mpijob.py
@@ -36,18 +36,20 @@ class TestMpiV1Runtime(TestRuntimeBase):
 
     def test_run_v1_sanity(self, db: Session, client: TestClient):
         mlconf.httpdb.builder.docker_registry = "localhost:5000"
-        mlrun.api.utils.builder.make_kaniko_pod = unittest.mock.MagicMock()
-        self._mock_list_pods()
-        self._mock_create_namespaced_custom_object()
-        self._mock_get_namespaced_custom_object()
-        mpijob_function = self._generate_runtime(self.runtime_kind)
-        self.deploy(db, mpijob_function)
-        run = mpijob_function.run(
-            artifact_path="v3io:///mypath",
-            watch=False,
-        )
+        with unittest.mock.patch(
+            "mlrun.api.utils.builder.make_kaniko_pod", unittest.mock.MagicMock()
+        ):
+            self._mock_list_pods()
+            self._mock_create_namespaced_custom_object()
+            self._mock_get_namespaced_custom_object()
+            mpijob_function = self._generate_runtime(self.runtime_kind)
+            self.deploy(db, mpijob_function)
+            run = mpijob_function.run(
+                artifact_path="v3io:///mypath",
+                watch=False,
+            )
 
-        assert run.status.state == "running"
+            assert run.status.state == "running"
 
     def _mock_get_namespaced_custom_object(self, workers=1):
         get_k8s_helper().crdapi.get_namespaced_custom_object = unittest.mock.Mock(

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -24,6 +24,7 @@ import mlrun
 import mlrun.api.api.utils
 import mlrun.api.utils.builder
 import mlrun.api.utils.singletons.k8s
+import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.k8s_utils
 import mlrun.utils.version
@@ -148,7 +149,7 @@ def test_build_runtime_target_image(monkeypatch):
     # assert the same with the registry enrich prefix
     # assert we can override the target image as long as we stick to the prefix
     function.spec.build.image = (
-        f"{mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username"
+        f"{mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username"
         f"/{image_name_prefix}-some-addition:{function.metadata.tag}"
     )
     mlrun.api.utils.builder.build_runtime(
@@ -163,7 +164,7 @@ def test_build_runtime_target_image(monkeypatch):
 
     # assert it raises if we don't stick to the prefix
     for invalid_image in [
-        f"{mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username/without-prefix:{function.metadata.tag}",
+        f"{mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username/without-prefix:{function.metadata.tag}",
         f"{registry}/without-prefix:{function.metadata.tag}",
     ]:
         function.spec.build.image = invalid_image

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -21,8 +21,9 @@ import deepdiff
 import pytest
 
 import mlrun
+import mlrun.api.api.utils
+import mlrun.api.utils.builder
 import mlrun.api.utils.singletons.k8s
-import mlrun.builder
 import mlrun.common.schemas
 import mlrun.k8s_utils
 import mlrun.utils.version
@@ -34,7 +35,7 @@ def test_build_runtime_use_base_image_when_no_build():
     base_image = "mlrun/ml-models"
     fn.build_config(base_image=base_image)
     assert fn.spec.image == ""
-    ready = mlrun.builder.build_runtime(
+    ready = mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         fn,
     )
@@ -48,39 +49,13 @@ def test_build_runtime_use_image_when_no_build():
         "some-function", "some-project", "some-tag", image=image, kind="job"
     )
     assert fn.spec.image == image
-    ready = mlrun.builder.build_runtime(
+    ready = mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         fn,
         with_mlrun=False,
     )
     assert ready is True
     assert fn.spec.image == image
-
-
-def test_build_config_with_multiple_commands():
-    image = "mlrun/ml-models"
-    fn = mlrun.new_function(
-        "some-function", "some-project", "some-tag", image=image, kind="job"
-    )
-    fn.build_config(commands=["pip install pandas", "pip install numpy"])
-    assert len(fn.spec.build.commands) == 2
-
-    fn.build_config(commands=["pip install pandas"])
-    assert len(fn.spec.build.commands) == 2
-
-
-def test_build_config_preserve_order():
-    function = mlrun.new_function("some-function", kind="job")
-    # run a lot of times as order change
-    commands = []
-    for index in range(10):
-        commands.append(str(index))
-    # when using un-stable (doesn't preserve order) methods to make a list unique (like list(set(x))) it's random
-    # whether the order will be preserved, therefore run in a loop
-    for _ in range(100):
-        function.spec.build.commands = []
-        function.build_config(commands=commands)
-        assert function.spec.build.commands == commands
 
 
 @pytest.mark.parametrize(
@@ -112,7 +87,7 @@ def test_build_runtime_insecure_registries(
     mlrun.mlconf.httpdb.builder.insecure_pull_registry_mode = pull_mode
     mlrun.mlconf.httpdb.builder.insecure_push_registry_mode = push_mode
     mlrun.mlconf.httpdb.builder.docker_registry_secret = secret
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -150,7 +125,7 @@ def test_build_runtime_target_image(monkeypatch):
         )
     )
 
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -163,7 +138,7 @@ def test_build_runtime_target_image(monkeypatch):
     function.spec.build.image = (
         f"{registry}/{image_name_prefix}-some-addition:{function.metadata.tag}"
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -173,10 +148,10 @@ def test_build_runtime_target_image(monkeypatch):
     # assert the same with the registry enrich prefix
     # assert we can override the target image as long as we stick to the prefix
     function.spec.build.image = (
-        f"{mlrun.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username"
+        f"{mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username"
         f"/{image_name_prefix}-some-addition:{function.metadata.tag}"
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -188,12 +163,12 @@ def test_build_runtime_target_image(monkeypatch):
 
     # assert it raises if we don't stick to the prefix
     for invalid_image in [
-        f"{mlrun.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username/without-prefix:{function.metadata.tag}",
+        f"{mlrun.api.utils.builder.IMAGE_NAME_ENRICH_REGISTRY_PREFIX}username/without-prefix:{function.metadata.tag}",
         f"{registry}/without-prefix:{function.metadata.tag}",
     ]:
         function.spec.build.image = invalid_image
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-            mlrun.builder.build_runtime(
+            mlrun.api.utils.builder.build_runtime(
                 mlrun.common.schemas.AuthInfo(),
                 function,
             )
@@ -203,7 +178,7 @@ def test_build_runtime_target_image(monkeypatch):
         f"registry.hub.docker.com/some-other-username/image-not-by-prefix"
         f":{function.metadata.tag}"
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -229,7 +204,7 @@ def test_build_runtime_use_default_node_selector(monkeypatch):
         kind="job",
         requirements=["some-package"],
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -262,7 +237,7 @@ def test_function_build_with_attributes_from_spec(monkeypatch):
     function.spec.node_name = node_name
     function.spec.node_selector = node_selector
     function.spec.priority_class_name = priority_class_name
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -299,7 +274,7 @@ def test_function_build_with_default_requests(monkeypatch):
         kind="job",
         requirements=["some-package"],
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -320,7 +295,7 @@ def test_function_build_with_default_requests(monkeypatch):
     }
     expected_resources = {"requests": {"cpu": "25m", "memory": "1m"}}
 
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -347,7 +322,7 @@ def test_function_build_with_default_requests(monkeypatch):
     }
     expected_resources = {"requests": {"cpu": "25m", "memory": "1m"}}
 
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -434,7 +409,7 @@ def test_resolve_mlrun_install_command():
         client_version = case.get("client_version")
         expected_result = case.get("expected_mlrun_install_command")
 
-        result = mlrun.builder.resolve_mlrun_install_command(
+        result = mlrun.api.utils.builder.resolve_mlrun_install_command(
             mlrun_version_specifier, client_version
         )
         assert (
@@ -459,7 +434,7 @@ def test_build_runtime_ecr_with_ec2_iam_policy(monkeypatch):
         name="some-function",
         kind="job",
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -522,7 +497,7 @@ def test_build_runtime_resolve_ecr_registry(monkeypatch):
         if case.get("tag"):
             image += f":{case.get('tag')}"
         function.spec.build.image = image
-        mlrun.builder.build_runtime(
+        mlrun.api.utils.builder.build_runtime(
             mlrun.common.schemas.AuthInfo(),
             function,
         )
@@ -554,7 +529,7 @@ def test_build_runtime_ecr_with_aws_secret(monkeypatch):
         kind="job",
         requirements=["some-package"],
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -612,7 +587,7 @@ def test_build_runtime_ecr_with_repository(monkeypatch):
         kind="job",
         requirements=["some-package"],
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -675,7 +650,7 @@ def test_resolve_image_dest(image_target, registry, default_repository, expected
     config.httpdb.builder.docker_registry = default_repository
     config.httpdb.builder.docker_registry_secret = docker_registry_secret
 
-    image_target, _ = mlrun.builder._resolve_image_target_and_registry_secret(
+    image_target, _ = mlrun.api.utils.builder._resolve_image_target_and_registry_secret(
         image_target, registry
     )
     assert image_target == expected_dest
@@ -749,7 +724,7 @@ def test_resolve_registry_secret(
     config.httpdb.builder.docker_registry = docker_registry
     config.httpdb.builder.docker_registry_secret = default_secret_name
 
-    _, secret_name = mlrun.builder._resolve_image_target_and_registry_secret(
+    _, secret_name = mlrun.api.utils.builder._resolve_image_target_and_registry_secret(
         image_target, registry, secret_name
     )
     assert secret_name == expected_secret_name
@@ -770,7 +745,7 @@ def test_kaniko_pod_spec_default_service_account_enrichment(monkeypatch):
         image="mlrun/mlrun",
         kind="job",
     )
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -794,7 +769,7 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
     )
     service_account = "my-actual-sa"
     function.spec.service_account = service_account
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
@@ -814,7 +789,7 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
 )
 def test_builder_workdir(monkeypatch, clone_target_dir, expected_workdir):
     _patch_k8s_helper(monkeypatch)
-    mlrun.builder.make_kaniko_pod = unittest.mock.MagicMock()
+    mlrun.api.utils.builder.make_kaniko_pod = unittest.mock.MagicMock()
     docker_registry = "default.docker.registry/default-repository"
     config.httpdb.builder.docker_registry = docker_registry
 
@@ -828,11 +803,11 @@ def test_builder_workdir(monkeypatch, clone_target_dir, expected_workdir):
     if clone_target_dir is not None:
         function.spec.clone_target_dir = clone_target_dir
     function.spec.build.source = "some-source.tgz"
-    mlrun.builder.build_runtime(
+    mlrun.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,
     )
-    dockerfile = mlrun.builder.make_kaniko_pod.call_args[1]["dockertext"]
+    dockerfile = mlrun.api.utils.builder.make_kaniko_pod.call_args[1]["dockertext"]
     dockerfile_lines = dockerfile.splitlines()
     expected_workdir_re = re.compile(expected_workdir)
     assert expected_workdir_re.match(dockerfile_lines[1])

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -205,3 +205,29 @@ def test_volume_mounts_addition():
         sanitized_dict_volume_mount,
     ]
     assert len(function.spec.volume_mounts) == 1
+
+
+def test_build_config_with_multiple_commands():
+    image = "mlrun/ml-models"
+    fn = mlrun.new_function(
+        "some-function", "some-project", "some-tag", image=image, kind="job"
+    )
+    fn.build_config(commands=["pip install pandas", "pip install numpy"])
+    assert len(fn.spec.build.commands) == 2
+
+    fn.build_config(commands=["pip install pandas"])
+    assert len(fn.spec.build.commands) == 2
+
+
+def test_build_config_preserve_order():
+    function = mlrun.new_function("some-function", kind="job")
+    # run a lot of times as order change
+    commands = []
+    for index in range(10):
+        commands.append(str(index))
+    # when using un-stable (doesn't preserve order) methods to make a list unique (like list(set(x))) it's random
+    # whether the order will be preserved, therefore run in a loop
+    for _ in range(100):
+        function.spec.build.commands = []
+        function.build_config(commands=commands)
+        assert function.spec.build.commands == commands


### PR DESCRIPTION
Part of the client server separation moved builder under the API hierarchy as it is only used by the API 