### PR TITLE
[Runtime] Add `has_args` and `has_kwargs` to function doc

### DIFF
--- a/mlrun/runtimes/funcdoc.py
+++ b/mlrun/runtimes/funcdoc.py
@@ -49,13 +49,23 @@ def param_dict(name="", type="", doc="", default=""):
     }
 
 
-def func_dict(name, doc, params, returns, lineno):
+def func_dict(
+    name,
+    doc,
+    params,
+    returns,
+    lineno,
+    has_varargs: bool = False,
+    has_kwargs: bool = False,
+):
     return {
         "name": name,
         "doc": doc,
         "params": params,
         "return": returns,
         "lineno": lineno,
+        "has_varargs": has_varargs,
+        "has_kwargs": has_kwargs,
     }
 
 
@@ -165,6 +175,9 @@ def ast_func_info(func: ast.FunctionDef):
     doc = ast.get_docstring(func) or ""
     rtype = getattr(func.returns, "id", "")
     params = [ast_param_dict(p) for p in func.args.args]
+    # adds info about *args and **kwargs to the function doc
+    has_varargs = func.args.vararg is not None
+    has_kwargs = func.args.kwarg is not None
     defaults = func.args.defaults
     if defaults:
         for param, default in zip(params[-len(defaults) :], defaults):
@@ -176,6 +189,8 @@ def ast_func_info(func: ast.FunctionDef):
         params=params,
         returns=param_dict(type=rtype),
         lineno=func.lineno,
+        has_varargs=has_varargs,
+        has_kwargs=has_kwargs,
     )
 
     if not doc.strip():

--- a/tests/runtimes/info_cases.yml
+++ b/tests/runtimes/info_cases.yml
@@ -30,6 +30,8 @@
           doc: ""
           default: ""
       lineno: 1
+      has_varargs: false
+      has_kwargs: false
   id: inc_ann
 - code: |
     def inc(n):
@@ -48,6 +50,8 @@
           doc: ""
           default: ""
       lineno: 1
+      has_varargs: false
+      has_kwargs: false
   id: inc_no_ann
 - code: |
     def inc(n: int) -> int:
@@ -72,6 +76,8 @@
           doc: number to increment
           default: ""
       lineno: 1
+      has_varargs: false
+      has_kwargs: false
   id: inc_ann_doc
 - code: |
     def inc(n: int, delta: int = 1) -> int:
@@ -95,6 +101,8 @@
           doc: ""
           default: "1"
       lineno: 1
+      has_varargs: false
+      has_kwargs: false
   id: inc_ann_default
 - code: |
     def open_archive(context, 
@@ -129,4 +137,6 @@
           doc: "source archive path/url"
           default: "''"
       lineno: 1
+      has_varargs: false
+      has_kwargs: false
   id: undocumented param


### PR DESCRIPTION
Until now when we were resolving the function description we didn't include any information whether the function was accepting `*args` or `**kwargs`. This information is useful for UI to allow the user to pass more params from what are recorded in the function doc params 