### PR TITLE
[DB] Perform data migrations to rename 'Marketplace' source type to 'Hub'

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -3429,6 +3429,9 @@ class SQLDB(DBInterface):
                 results.append(ordered_source)
         return results
 
+    def _list_hub_sources_without_transform(self, session) -> List[HubSource]:
+        return self._query(session, HubSource).all()
+
     def delete_hub_source(self, session, name):
         logger.debug("Deleting hub source from DB", name=name)
 

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -428,12 +428,6 @@ def _perform_version_2_data_migrations(
     _align_runs_table(db, db_session)
 
 
-def _perform_version_3_data_migrations(
-    db: mlrun.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
-):
-    _rename_marketplace_kind_to_hub(db, db_session)
-
-
 def _align_runs_table(
     db: mlrun.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
 ):
@@ -473,6 +467,12 @@ def _align_runs_table(
         db._update_run_updated_time(run, run_dict, updated)
         run.struct = run_dict
         db._upsert(db_session, [run], ignore=True)
+
+
+def _perform_version_3_data_migrations(
+    db: mlrun.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
+):
+    _rename_marketplace_kind_to_hub(db, db_session)
 
 
 def _rename_marketplace_kind_to_hub(

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -69,25 +69,43 @@ def test_perform_data_migrations_from_zero_version():
     # set version to 0
     db.create_data_version(db_session, "0")
 
+    # keep a reference to the original functions, so we can restore them later
     original_perform_version_1_data_migrations = (
         mlrun.api.initial_data._perform_version_1_data_migrations
     )
     mlrun.api.initial_data._perform_version_1_data_migrations = unittest.mock.Mock()
+    original_perform_version_2_data_migrations = (
+        mlrun.api.initial_data._perform_version_2_data_migrations
+    )
+    mlrun.api.initial_data._perform_version_2_data_migrations = unittest.mock.Mock()
+    original_perform_version_3_data_migrations = (
+        mlrun.api.initial_data._perform_version_3_data_migrations
+    )
+    mlrun.api.initial_data._perform_version_3_data_migrations = unittest.mock.Mock()
 
+    # perform migrations
+    mlrun.api.initial_data._perform_data_migrations(db_session)
+
+    # calling again should not trigger migrations again, since we're already at the latest version
     mlrun.api.initial_data._perform_data_migrations(db_session)
 
     mlrun.api.initial_data._perform_version_1_data_migrations.assert_called_once()
+    mlrun.api.initial_data._perform_version_2_data_migrations.assert_called_once()
+    mlrun.api.initial_data._perform_version_3_data_migrations.assert_called_once()
 
-    # calling again should trigger migrations again
-    mlrun.api.initial_data._perform_data_migrations(db_session)
+    assert db.get_current_data_version(db_session, raise_on_not_found=True) == str(
+        mlrun.api.initial_data.latest_data_version
+    )
 
-    mlrun.api.initial_data._perform_version_1_data_migrations.assert_called_once()
-
+    # restore original functions
     mlrun.api.initial_data._perform_version_1_data_migrations = (
         original_perform_version_1_data_migrations
     )
-    assert db.get_current_data_version(db_session, raise_on_not_found=True) == str(
-        mlrun.api.initial_data.latest_data_version
+    mlrun.api.initial_data._perform_version_2_data_migrations = (
+        original_perform_version_2_data_migrations
+    )
+    mlrun.api.initial_data._perform_version_3_data_migrations = (
+        original_perform_version_3_data_migrations
     )
 
 


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/3409, hub sources present in the db with a `MarketplaceSource` kind failed pydantic validation during schema migrations with the following error:
 ```
pydantic.error_wrappers.ValidationError: 1 validation error for HubSource
kind
  value is not a valid enumeration member; permitted: 'project', 'FeatureSet', 'BackgroundTask', 'FeatureVector', 'model-endpoint', 'HubSource', 'HubItem', 'HubCatalog' (type=type_error.enum; enum_values=[project, FeatureSet, BackgroundTask, FeatureVector, model-endpoint, HubSource, HubItem, HubCatalog])
```

To fix this, we add a data migration to modify the `kind` name from `MarketplaceSource` to `HubSource`.

Furthermore, when making sure a default hub source exists, we handle the above error specifically, as it means that the source exists, but with a stale kind, so we don't fail.
The data migration that follows handles the issue.