### PR TITLE
[Launcher] Remove unused local variable from `launch`

### DIFF
--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -46,7 +46,6 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
         hyper_param_options: Optional[mlrun.model.HyperParamOptions] = None,
         verbose: Optional[bool] = None,
         scrape_metrics: Optional[bool] = None,
-        local: Optional[bool] = False,
         local_code_path: Optional[str] = None,
         auto_build: Optional[bool] = None,
         param_file_secrets: Optional[Dict[str, str]] = None,

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -101,7 +101,6 @@ class BaseLauncher(abc.ABC):
         hyper_param_options: Optional[mlrun.model.HyperParamOptions] = None,
         verbose: Optional[bool] = None,
         scrape_metrics: Optional[bool] = None,
-        local: Optional[bool] = False,
         local_code_path: Optional[str] = None,
         auto_build: Optional[bool] = None,
         param_file_secrets: Optional[Dict[str, str]] = None,

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -64,7 +64,6 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
         hyper_param_options: Optional[mlrun.model.HyperParamOptions] = None,
         verbose: Optional[bool] = None,
         scrape_metrics: Optional[bool] = None,
-        local: Optional[bool] = False,
         local_code_path: Optional[str] = None,
         auto_build: Optional[bool] = None,
         param_file_secrets: Optional[Dict[str, str]] = None,

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -53,7 +53,6 @@ class ClientRemoteLauncher(mlrun.launcher.client.ClientBaseLauncher):
         hyper_param_options: Optional[mlrun.model.HyperParamOptions] = None,
         verbose: Optional[bool] = None,
         scrape_metrics: Optional[bool] = None,
-        local: Optional[bool] = False,
         local_code_path: Optional[str] = None,
         auto_build: Optional[bool] = None,
         param_file_secrets: Optional[Dict[str, str]] = None,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -370,7 +370,6 @@ class BaseRuntime(ModelObj):
             hyper_param_options=hyper_param_options,
             verbose=verbose,
             scrape_metrics=scrape_metrics,
-            local=local,
             local_code_path=local_code_path,
             auto_build=auto_build,
             param_file_secrets=param_file_secrets,


### PR DESCRIPTION
the local param is passed to the launcher object