### PR TITLE
[Feature Store] Fix `test_read_csv` to use mlrun CSVSource

### DIFF
--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1099,36 +1099,29 @@ class TestFeatureStore(TestMLRunSystem):
         assert res.shape[0] == left.shape[0]
 
     def test_read_csv(self):
-        from storey import CSVSource, ReduceToDataFrame, build_flow
-
         csv_path = str(self.results_path / _generate_random_name() / ".csv")
         targets = [CSVTarget("mycsv", path=csv_path)]
         stocks_set = fstore.FeatureSet(
             "tests", entities=[Entity("ticker", ValueType.STRING)]
         )
-        fstore.ingest(
+        result = fstore.ingest(
             stocks_set,
             stocks,
             infer_options=fstore.InferOptions.default(),
             targets=targets,
         )
 
-        # reading csv file
         final_path = stocks_set.get_target_path("mycsv")
-        controller = build_flow([CSVSource(final_path), ReduceToDataFrame()]).run()
-        termination_result = controller.await_termination()
 
         expected = pd.DataFrame(
             {
-                0: ["ticker", "MSFT", "GOOG", "AAPL"],
-                1: ["name", "Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
-                2: ["exchange", "NASDAQ", "NASDAQ", "NASDAQ"],
+                "ticker": ["MSFT", "GOOG", "AAPL"],
+                "name": ["Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
+                "exchange": ["NASDAQ", "NASDAQ", "NASDAQ"],
             }
         )
 
-        assert termination_result.equals(
-            expected
-        ), f"{termination_result}\n!=\n{expected}"
+        assert result.equals(expected), f"{result}\n!=\n{expected}"
         os.remove(final_path)
 
     def test_multiple_entities(self):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1099,8 +1099,6 @@ class TestFeatureStore(TestMLRunSystem):
         assert res.shape[0] == left.shape[0]
 
     def test_read_csv(self):
-        csv_path = str(self.results_path / _generate_random_name() / ".csv")
-        targets = [CSVTarget("mycsv", path=csv_path)]
         stocks_set = fstore.FeatureSet(
             "tests", entities=[Entity("ticker", ValueType.STRING)]
         )
@@ -1108,21 +1106,15 @@ class TestFeatureStore(TestMLRunSystem):
             stocks_set,
             stocks,
             infer_options=fstore.InferOptions.default(),
-            targets=targets,
         )
-
-        final_path = stocks_set.get_target_path("mycsv")
-
         expected = pd.DataFrame(
             {
-                "ticker": ["MSFT", "GOOG", "AAPL"],
                 "name": ["Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
                 "exchange": ["NASDAQ", "NASDAQ", "NASDAQ"],
-            }
+            },
+            index=pd.Index(["MSFT", "GOOG", "AAPL"], name="ticker"),
         )
-
-        assert result.equals(expected), f"{result}\n!=\n{expected}"
-        os.remove(final_path)
+        assert result.equals(expected)
 
     def test_multiple_entities(self):
         name = f"measurements_{uuid.uuid4()}"


### PR DESCRIPTION
`mlrun` does not use `storey.CSVSource` directly.

Therefore, the `test_read_csv` test has been updated to utilize 
mlrun's `sources.CSVSource` instead of `storey.CSVSource`.