### PR TITLE
[Feature Store] Change `test_read_csv` to use mlrun CSVSource - ML-3820

### DIFF
--- a/tests/system/feature_store/assets/testdata_short.csv
+++ b/tests/system/feature_store/assets/testdata_short.csv
@@ -1,0 +1,4 @@
+id,name,number,float_number,date_of_birth
+1,John,10,1.5,1990-01-01
+2,Jane,20,2.5,1995-05-10
+3,Bob,30,3.5,1985-12-15

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1099,36 +1099,29 @@ class TestFeatureStore(TestMLRunSystem):
         assert res.shape[0] == left.shape[0]
 
     def test_read_csv(self):
-        from storey import CSVSource, ReduceToDataFrame, build_flow
-
         csv_path = str(self.results_path / _generate_random_name() / ".csv")
         targets = [CSVTarget("mycsv", path=csv_path)]
         stocks_set = fstore.FeatureSet(
             "tests", entities=[Entity("ticker", ValueType.STRING)]
         )
-        fstore.ingest(
+        result = fstore.ingest(
             stocks_set,
             stocks,
             infer_options=fstore.InferOptions.default(),
             targets=targets,
         )
 
-        # reading csv file
         final_path = stocks_set.get_target_path("mycsv")
-        controller = build_flow([CSVSource(final_path), ReduceToDataFrame()]).run()
-        termination_result = controller.await_termination()
 
         expected = pd.DataFrame(
             {
-                0: ["ticker", "MSFT", "GOOG", "AAPL"],
-                1: ["name", "Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
-                2: ["exchange", "NASDAQ", "NASDAQ", "NASDAQ"],
+                "ticker": ["MSFT", "GOOG", "AAPL"],
+                "name": ["Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
+                "exchange": ["NASDAQ", "NASDAQ", "NASDAQ"],
             }
         )
 
-        assert termination_result.equals(
-            expected
-        ), f"{termination_result}\n!=\n{expected}"
+        assert result.equals(expected), f"{result}\n!=\n{expected}"
         os.remove(final_path)
 
     def test_multiple_entities(self):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1099,8 +1099,6 @@ class TestFeatureStore(TestMLRunSystem):
         assert res.shape[0] == left.shape[0]
 
     def test_read_csv(self):
-        csv_path = str(self.results_path / _generate_random_name() / ".csv")
-        targets = [CSVTarget("mycsv", path=csv_path)]
         stocks_set = fstore.FeatureSet(
             "tests", entities=[Entity("ticker", ValueType.STRING)]
         )
@@ -1108,21 +1106,15 @@ class TestFeatureStore(TestMLRunSystem):
             stocks_set,
             stocks,
             infer_options=fstore.InferOptions.default(),
-            targets=targets,
         )
-
-        final_path = stocks_set.get_target_path("mycsv")
-
         expected = pd.DataFrame(
             {
-                "ticker": ["MSFT", "GOOG", "AAPL"],
                 "name": ["Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
                 "exchange": ["NASDAQ", "NASDAQ", "NASDAQ"],
-            }
+            },
+            index=pd.Index(["MSFT", "GOOG", "AAPL"], name="ticker"),
         )
-
-        assert result.equals(expected), f"{result}\n!=\n{expected}"
-        os.remove(final_path)
+        assert result.equals(expected)
 
     def test_multiple_entities(self):
         name = f"measurements_{uuid.uuid4()}"

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1105,7 +1105,7 @@ class TestFeatureStore(TestMLRunSystem):
             parse_dates=["date_of_birth"],
         )
         stocks_set = fstore.FeatureSet(
-            "tests", entities=[Entity("id", ValueType.STRING)]
+            "tests", entities=[Entity("id", ValueType.INT64)]
         )
         result = fstore.ingest(
             stocks_set,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1099,20 +1099,31 @@ class TestFeatureStore(TestMLRunSystem):
         assert res.shape[0] == left.shape[0]
 
     def test_read_csv(self):
+        source = CSVSource(
+            "mycsv",
+            path=os.path.relpath(str(self.assets_path / "testdata_short.csv")),
+            parse_dates=["date_of_birth"],
+        )
         stocks_set = fstore.FeatureSet(
-            "tests", entities=[Entity("ticker", ValueType.STRING)]
+            "tests", entities=[Entity("id", ValueType.STRING)]
         )
         result = fstore.ingest(
             stocks_set,
-            stocks,
+            source=source,
             infer_options=fstore.InferOptions.default(),
         )
         expected = pd.DataFrame(
             {
-                "name": ["Microsoft Corporation", "Alphabet Inc", "Apple Inc"],
-                "exchange": ["NASDAQ", "NASDAQ", "NASDAQ"],
+                "name": ["John", "Jane", "Bob"],
+                "number": [10, 20, 30],
+                "float_number": [1.5, 2.5, 3.5],
+                "date_of_birth": [
+                    datetime(1990, 1, 1),
+                    datetime(1995, 5, 10),
+                    datetime(1985, 12, 15),
+                ],
             },
-            index=pd.Index(["MSFT", "GOOG", "AAPL"], name="ticker"),
+            index=pd.Index([1, 2, 3], name="id"),
         )
         assert result.equals(expected)
 


### PR DESCRIPTION
`mlrun` does not use `storey.CSVSource` directly.

Therefore, the `test_read_csv` test has been updated to utilize 
mlrun's `sources.CSVSource` instead of `storey.CSVSource`.