### PR TITLE
[Runtime/Launcher] Use runtime db instead of launcher db

### DIFF
--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -90,7 +90,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
 
         execution = mlrun.execution.MLClientCtx.from_dict(
             run.to_dict(),
-            self.db,
+            runtime._get_db(),
             autocommit=False,
             is_api=True,
             store_run=False,
@@ -180,9 +180,10 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
         self, runtime: mlrun.runtimes.base.BaseRuntime, run: mlrun.run.RunObject
     ):
         run.metadata.labels["kind"] = runtime.kind
-        if self.db and runtime.kind != "handler":
+        db = runtime._get_db()
+        if db and runtime.kind != "handler":
             struct = runtime.to_dict()
-            hash_key = self.db.store_function(
+            hash_key = db.store_function(
                 struct, runtime.metadata.name, runtime.metadata.project, versioned=True
             )
             run.spec.function = runtime._function_uri(hash_key=hash_key)

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -63,7 +63,8 @@ class BaseLauncher(abc.ABC):
 
         :return:            function uri
         """
-        if not self.db:
+        db = runtime._get_db()
+        if not db:
             raise mlrun.errors.MLRunPreconditionFailedError(
                 "Database connection is not configured"
             )
@@ -75,7 +76,7 @@ class BaseLauncher(abc.ABC):
 
         obj = runtime.to_dict()
         logger.debug("Saving function", runtime_name=runtime.metadata.name, tag=tag)
-        hash_key = self.db.store_function(
+        hash_key = db.store_function(
             obj, runtime.metadata.name, runtime.metadata.project, tag, versioned
         )
         hash_key = hash_key if versioned else None
@@ -360,7 +361,8 @@ class BaseLauncher(abc.ABC):
 
         return None
 
-    def _refresh_function_metadata(self, runtime: "mlrun.runtimes.BaseRuntime"):
+    @staticmethod
+    def _refresh_function_metadata(runtime: "mlrun.runtimes.BaseRuntime"):
         pass
 
     @staticmethod

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -38,15 +38,6 @@ class BaseLauncher(abc.ABC):
     Each context will have its own implementation of the abstract methods while the common logic resides in this class
     """
 
-    def __init__(self):
-        self._db = None
-
-    @property
-    def db(self) -> mlrun.db.base.RunDBInterface:
-        if not self._db:
-            self._db = mlrun.db.get_run_db()
-        return self._db
-
     def save_function(
         self,
         runtime: "mlrun.runtimes.BaseRuntime",

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -371,9 +371,10 @@ class BaseLauncher(abc.ABC):
     def _save_or_push_notifications(self, runobj):
         pass
 
+    @staticmethod
     @abc.abstractmethod
     def _store_function(
-        self, runtime: "mlrun.runtimes.BaseRuntime", run: "mlrun.run.RunObject"
+        runtime: "mlrun.runtimes.BaseRuntime", run: "mlrun.run.RunObject"
     ):
         pass
 

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -35,8 +35,9 @@ class ClientBaseLauncher(mlrun.launcher.base.BaseLauncher, abc.ABC):
         runtime.try_auto_mount_based_on_config()
         runtime._fill_credentials()
 
+    @staticmethod
     def _store_function(
-        self, runtime: "mlrun.runtimes.BaseRuntime", run: "mlrun.run.RunObject"
+        runtime: "mlrun.runtimes.BaseRuntime", run: "mlrun.run.RunObject"
     ):
         run.metadata.labels["kind"] = runtime.kind
         if "owner" not in run.metadata.labels:

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -47,18 +47,20 @@ class ClientBaseLauncher(mlrun.launcher.base.BaseLauncher, abc.ABC):
             run.spec.output_path = run.spec.output_path.replace(
                 "{{run.user}}", run.metadata.labels["owner"]
             )
-
-        if self.db and runtime.kind != "handler":
+        db = runtime._get_db()
+        if db and runtime.kind != "handler":
             struct = runtime.to_dict()
-            hash_key = self.db.store_function(
+            hash_key = db.store_function(
                 struct, runtime.metadata.name, runtime.metadata.project, versioned=True
             )
             run.spec.function = runtime._function_uri(hash_key=hash_key)
 
-    def _refresh_function_metadata(self, runtime: "mlrun.runtimes.BaseRuntime"):
+    @staticmethod
+    def _refresh_function_metadata(runtime: "mlrun.runtimes.BaseRuntime"):
         try:
             meta = runtime.metadata
-            db_func = self.db.get_function(meta.name, meta.project, meta.tag)
+            db = runtime._get_db()
+            db_func = db.get_function(meta.name, meta.project, meta.tag)
             if db_func and "status" in db_func:
                 runtime.status = db_func["status"]
                 if (

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -149,7 +149,7 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
 
         execution = mlrun.run.MLClientCtx.from_dict(
             run.to_dict(),
-            self.db,
+            runtime._get_db(),
             autocommit=False,
             is_api=False,
             store_run=False,

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -121,7 +121,8 @@ class ClientRemoteLauncher(mlrun.launcher.client.ClientBaseLauncher):
         if runtime._secrets:
             run.spec.secret_sources = runtime._secrets.to_serial()
         try:
-            resp = self.db.submit_job(run, schedule=schedule)
+            db = runtime._get_db()
+            resp = db.submit_job(run, schedule=schedule)
             if schedule:
                 action = resp.pop("action", "created")
                 logger.info(f"task schedule {action}", **resp)
@@ -174,7 +175,7 @@ class ClientRemoteLauncher(mlrun.launcher.client.ClientBaseLauncher):
             resp = runtime._get_db_run(run)
 
         elif watch or runtime.kfp:
-            run.logs(True, self.db)
+            run.logs(True, runtime._get_db())
             resp = runtime._get_db_run(run)
 
         return self._wrap_run_result(runtime, resp, run, schedule=schedule)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -243,6 +243,7 @@ class BaseRuntime(ModelObj):
         self.spec.rundb = self.spec.rundb or get_or_set_dburl()
 
     def _get_db(self):
+        # TODO: remove this function and use the launcher db instead
         self._ensure_run_db()
         if not self._db_conn:
             if self.spec.rundb:


### PR DESCRIPTION
Issue that was found in our system tests, when running `deploy_function` we are setting the runtime `run_db` to point to the SQLDB with the `db_session` that is being created upon request. but the launcher it self doesn't hold that db and therefor initializes a `NopDB` instead as can be seen in the api logs.

For now decided to rollback the use of the launcher.db and use the runtime.db instead, and will set a design session on how to implement that with the launcher as there are multiple methods that the `runtime` uses to access the db.
