### PR TITLE
[Datastore] Fix HttpSource initialization

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -251,7 +251,6 @@ class ParquetSource(BaseSourceDriver):
         start_time: Optional[Union[datetime, str]] = None,
         end_time: Optional[Union[datetime, str]] = None,
     ):
-
         super().__init__(
             name,
             path,
@@ -738,8 +737,8 @@ class OnlineSource(BaseSourceDriver):
 class HttpSource(OnlineSource):
     kind = "http"
 
-    def __init__(self, path: str = None):
-        super().__init__(path=path)
+    def __init__(self, path: str = None, **kwargs):
+        super().__init__(path=path, **kwargs)
 
     def add_nuclio_trigger(self, function):
         trigger_args = self.attributes.get("trigger_args")

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -737,9 +737,6 @@ class OnlineSource(BaseSourceDriver):
 class HttpSource(OnlineSource):
     kind = "http"
 
-    def __init__(self, path: str = None, **kwargs):
-        super().__init__(path=path, **kwargs)
-
     def add_nuclio_trigger(self, function):
         trigger_args = self.attributes.get("trigger_args")
         if trigger_args:


### PR DESCRIPTION
A fix for https://jira.iguazeng.com/browse/ML-3792.

`HttpSource` inherits from `OnlineSource` but in the current code it calls `super().__init__(path=path)` which is not required because the argument `path` is already exist in the base class. In addition, the other keyword arguments were not provided through the initialization (which eventually let to the mentioned bug).   

In this PR, we remove the unnecessary initialization function of the `HttpSource`.
