### PR TITLE
[Projects] Query db for name only when listing projects with `name_only` format

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1437,6 +1437,12 @@ class SQLDB(DBInterface):
         names: typing.Optional[typing.List[str]] = None,
     ) -> mlrun.common.schemas.ProjectsOutput:
         query = self._query(session, Project, owner=owner, state=state)
+
+        # if format is name_only, we don't need to query the full project object, we can just query the name
+        # and return it as a list of strings
+        if format_ == mlrun.common.schemas.ProjectsFormat.name_only:
+            query = self._query(session, Project.name, owner=owner, state=state)
+
         if labels:
             query = self._add_labels_filter(session, query, Project, labels)
         if names is not None:
@@ -1446,6 +1452,8 @@ class SQLDB(DBInterface):
         for project_record in project_records:
             if format_ == mlrun.common.schemas.ProjectsFormat.name_only:
                 projects = [project_record.name for project_record in project_records]
+                break
+
             # leader format is only for follower mode which will format the projects returned from here
             elif format_ == mlrun.common.schemas.ProjectsFormat.minimal:
                 projects.append(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1443,18 +1443,20 @@ class SQLDB(DBInterface):
         if format_ == mlrun.common.schemas.ProjectsFormat.name_only:
             query = self._query(session, Project.name, owner=owner, state=state)
 
+        # attach filters to the query
         if labels:
             query = self._add_labels_filter(session, query, Project, labels)
         if names is not None:
             query = query.filter(Project.name.in_(names))
+
         project_records = query.all()
+
+        # format the projects according to the requested format
         projects = []
         for project_record in project_records:
             if format_ == mlrun.common.schemas.ProjectsFormat.name_only:
-                projects = [project_record.name for project_record in project_records]
-                break
+                projects.append(project_record.name)
 
-            # leader format is only for follower mode which will format the projects returned from here
             elif format_ == mlrun.common.schemas.ProjectsFormat.minimal:
                 projects.append(
                     mlrun.api.utils.helpers.minimize_project_schema(
@@ -1463,6 +1465,8 @@ class SQLDB(DBInterface):
                         )
                     )
                 )
+
+            # leader format is only for follower mode which will format the projects returned from here
             elif format_ in [
                 mlrun.common.schemas.ProjectsFormat.full,
                 mlrun.common.schemas.ProjectsFormat.leader,


### PR DESCRIPTION
When listing all projects, the API first loads all projects from the DB, extracts their names, filters them against OPA, and then loads the filtered projects again and returns them.

Instead of loading the entire project objects for all objects, in case the given format is `name_only` - the first query to the DB will return just the `name` column for every project.
This will reduce the number of loaded project in every request.

CAVEAT: In case the requesting user has permissions for every project in the system, listing projects will still be a heavy request and will possibly cause issues.

Fixes https://jira.iguazeng.com/browse/ML-3823