### PR TITLE
[Projects] Fix BC for GET requests of non-normalized function names 

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -984,6 +984,30 @@ class SQLDB(DBInterface):
         self.tag_objects_v2(session, [fn], project, tag)
         return hash_key
 
+    def get_function(self, session, name, project="", tag="", hash_key="") -> dict:
+        """
+        In version 1.4.0 we added a normalization to the function name before storing.
+        To be backwards compatible and allow users to query old non-normalized functions,
+        we're providing a fallback to get_function:
+        normalize the requested name and try to retrieve it from the database.
+        If no answer is received, we will check to see if the original name contained underscores,
+        if so, the retrieval will be repeated and the result (if it exists) returned.
+        """
+        normalized_function_name = mlrun.utils.normalize_name(name)
+        try:
+            return self._get_function(
+                session, normalized_function_name, project, tag, hash_key
+            )
+        except mlrun.errors.MLRunNotFoundError as exc:
+            if "_" in name:
+                logger.debug(
+                    f"Function {normalized_function_name} was not found,"
+                    f" trying to find function by its original name"
+                )
+                return self._get_function(session, name, project, tag, hash_key)
+            else:
+                raise exc
+
     def _get_function(self, session, name, project="", tag="", hash_key=""):
         project = project or config.default_project
         query = self._query(session, Function, name=name, project=project)
@@ -1022,25 +1046,6 @@ class SQLDB(DBInterface):
         else:
             function_uri = generate_object_uri(project, name, tag, hash_key)
             raise mlrun.errors.MLRunNotFoundError(f"Function not found {function_uri}")
-
-    def get_function(self, session, name, project="", tag="", hash_key=""):
-        """
-        In version 1.4.0 we added a normalization to the function name before storing.
-        To be backwards compatible and allow users to query old non-normalized functions,
-        we're providing a fallback to get_function:
-        normalize the requested name and try to retrieve it from the database.
-        If no answer is received, we will check to see if the original name contained underscores,
-        if so, the retrieval will be repeated and the result (if it exists) returned.
-        """
-        try:
-            return self._get_function(
-                session, mlrun.utils.normalize_name(name), project, tag, hash_key
-            )
-        except mlrun.errors.MLRunNotFoundError as exc:
-            if "_" in name:
-                return self._get_function(session, name, project, tag, hash_key)
-            else:
-                raise exc
 
     def delete_function(self, session: Session, project: str, name: str):
         logger.debug("Removing function from db", project=project, name=name)

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -985,6 +985,7 @@ class SQLDB(DBInterface):
         return hash_key
 
     def _get_function(self, session, name, project="", tag="", hash_key=""):
+        project = project or config.default_project
         query = self._query(session, Function, name=name, project=project)
         computed_tag = tag or "latest"
         tag_function_uid = None

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1000,9 +1000,9 @@ class SQLDB(DBInterface):
             )
         except mlrun.errors.MLRunNotFoundError as exc:
             if "_" in name:
-                logger.debug(
-                    f"Function {normalized_function_name} was not found,"
-                    f" trying to find function by its original name"
+                logger.warning(
+                    "Failed to get underscore-named function, trying without normalization",
+                    function_name=name,
                 )
                 return self._get_function(session, name, project, tag, hash_key)
             else:

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1023,6 +1023,14 @@ class SQLDB(DBInterface):
             raise mlrun.errors.MLRunNotFoundError(f"Function not found {function_uri}")
 
     def get_function(self, session, name, project="", tag="", hash_key=""):
+        """
+        In version 1.4.0 we added a normalization to the function name before storing.
+        To be backwards compatible and allow users to query old non-normalized functions,
+        we're providing a fallback to get_function:
+        normalize the requested name and try to retrieve it from the database.
+        If no answer is received, we will check to see if the original name contained underscores,
+        if so, the retrieval will be repeated and the result (if it exists) returned.
+        """
         try:
             return self._get_function(
                 session, mlrun.utils.normalize_name(name), project, tag, hash_key

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1661,7 +1661,7 @@ class MlrunProject(ModelObj):
     def _get_function(self, key, sync, ignore_cache):
         """
         Function can be retrieved from the project spec (cache) or from the database.
-        In sync mode, we first preform a sync of the function_objects from the function_definitions,
+        In sync mode, we first perform a sync of the function_objects from the function_definitions,
         and then returning it from the function_objects (if exists).
         When not in sync mode, we verify and return from the function objects directly.
         In ignore_cache mode, we query the function from the database rather than from the project spec.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -14,6 +14,7 @@
 import datetime
 import getpass
 import glob
+import http
 import json
 import pathlib
 import shutil
@@ -31,6 +32,7 @@ import git.exc
 import inflection
 import kfp
 import nuclio
+import requests
 import yaml
 
 import mlrun.common.model_monitoring as model_monitoring_constants
@@ -1621,6 +1623,24 @@ class MlrunProject(ModelObj):
         """
         self.spec.remove_function(name)
 
+    def _get_function(self, key, sync, ignore_cache):
+        if key in self.spec._function_objects and not sync and not ignore_cache:
+            function = self.spec._function_objects[key]
+
+        elif key in self.spec._function_definitions and not ignore_cache:
+            self.sync_functions([key])
+            function = self.spec._function_objects[key]
+        else:
+            try:
+                function = get_db_function(self, key)
+                self.spec._function_objects[key] = function
+            except requests.HTTPError as exc:
+                if exc.response.status_code != http.HTTPStatus.NOT_FOUND.value:
+                    raise exc
+                return None, exc
+
+        return function, None
+
     def get_function(
         self,
         key,
@@ -1639,19 +1659,21 @@ class MlrunProject(ModelObj):
 
         :returns: function object
         """
-        if key in self.spec._function_objects and not sync and not ignore_cache:
-            function = self.spec._function_objects[key]
-        elif key in self.spec._function_definitions and not ignore_cache:
-            self.sync_functions([key])
-            function = self.spec._function_objects[key]
-        else:
-            function = get_db_function(self, key)
-            self.spec._function_objects[key] = function
+        function, err = self._get_function(
+            mlrun.utils.normalize_name(key), sync, ignore_cache
+        )
+        if not function and "_" in key:
+            function, err = self._get_function(key, sync, ignore_cache)
+
+        if not function:
+            raise err
+
         if enrich:
             function = enrich_function_object(
                 self, function, copy_function=copy_function
             )
             self.spec._function_objects[key] = function
+
         return function
 
     def get_function_objects(self) -> typing.Dict[str, mlrun.runtimes.BaseRuntime]:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1624,6 +1624,13 @@ class MlrunProject(ModelObj):
         self.spec.remove_function(name)
 
     def _get_function(self, key, sync, ignore_cache):
+        """
+        Function can be retrieved from the project spec (cache) or from the database.
+        In sync mode, we first preform a sync of the function_objects from the function_definitions,
+        and then returning it from the function_objects (if exists).
+        When not in sync mode, we verify and return from the function objects directly.
+        In ignore_cache mode, we query the function from the database rather than from the project spec.
+        """
         if key in self.spec._function_objects and not sync and not ignore_cache:
             function = self.spec._function_objects[key]
 

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -46,7 +46,6 @@ import mlrun.common.schemas
 import mlrun.errors
 import tests.api.conftest
 import tests.api.utils.clients.test_log_collector
-from mlrun.api.db.base import DBInterface
 from mlrun.api.db.sqldb.models import (
     Artifact,
     Entity,
@@ -129,54 +128,6 @@ def test_redirection_from_worker_to_chief_delete_project(
             except json.decoder.JSONDecodeError:
                 # NO_CONTENT response doesn't return json serializable response
                 assert response.text == expected_response
-
-
-def test_get_project_function_when_using_not_normalize_name(
-    db_session: Session,
-    db: DBInterface,
-    client: TestClient,
-    project_member_mode: str,
-    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
-) -> None:
-
-    project_name = "project-name"
-    project = mlrun.common.schemas.Project(
-        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
-    )
-
-    # create project
-    response = client.post("projects", json=project.dict())
-    assert response.status_code == HTTPStatus.CREATED.value
-    _assert_project_response(project, response)
-
-    # add a function with a non-normalized name to the database
-    function_name = "function_name"
-    _generate_and_insert_function_record(
-        db=db, function_name=function_name, project_name=project_name
-    )
-
-    # getting the function using the non-normalized name, and ensure that it works
-    response = client.get(f"func/{project_name}/{function_name}")
-    assert response.status_code == HTTPStatus.OK.value
-    response_json = response.json()
-    assert response_json["func"]["metadata"]["name"] == function_name
-
-
-def _generate_and_insert_function_record(
-    db: DBInterface, function_name: str, project_name: str
-):
-    function = {
-        "metadata": {"name": function_name, "project": project_name},
-        "spec": {"asd": "asdasd"},
-    }
-    fn = Function(
-        name=function_name, project=project_name, struct=function, uid="1", id="1"
-    )
-    tag = Function.Tag(project=project_name, name="latest", obj_name=fn.name)
-    tag.obj_id, tag.uid = fn.id, fn.uid
-    db.add(fn)
-    db.add(tag)
-    db.commit()
 
 
 def test_create_project_failure_already_exists(

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -121,6 +121,36 @@ def test_get_function_by_hash_key(db: DBInterface, db_session: Session):
     assert function_queried_with_hash_key["metadata"]["tag"] == ""
 
 
+def test_get_function_when_using_not_normalize_name(
+    db: DBInterface, db_session: Session
+):
+    # add a function with a non-normalized name to the database
+    function_name = "function_name"
+    project_name = "project"
+    _generate_and_insert_function_record(db_session, function_name, project_name)
+
+    # getting the function using the non-normalized name, and ensure that it works
+    response = db.get_function(db_session, function_name, project_name)
+    assert response["metadata"]["name"] == function_name
+
+
+def _generate_and_insert_function_record(
+    db_session: Session, function_name: str, project_name: str
+):
+    function = {
+        "metadata": {"name": function_name, "project": project_name},
+        "spec": {"asd": "test"},
+    }
+    fn = Function(
+        name=function_name, project=project_name, struct=function, uid="1", id="1"
+    )
+    tag = Function.Tag(project=project_name, name="latest", obj_name=fn.name)
+    tag.obj_id, tag.uid = fn.id, fn.uid
+    db_session.add(fn)
+    db_session.add(tag)
+    db_session.commit()
+
+
 def test_get_function_by_tag(db: DBInterface, db_session: Session):
     function_1 = _generate_function()
     function_hash_key = db.store_function(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -465,12 +465,12 @@ def test_set_function_underscore_name(rundb_mock):
     )
     project.set_function(name=func_name, func=func)
 
-    # attempt to get the function using the original name (with underscores) and ensure that it fails
-    with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        project.get_function(key=func_name)
+    # get the function using the original name (with underscores) and ensure that it works and returns normalized name
+    normalized_name = mlrun.utils.normalize_name(func_name)
+    enriched_function = project.get_function(key=func_name)
+    assert enriched_function.metadata.name == normalized_name
 
     # get the function using a normalized name and make sure it works
-    normalized_name = mlrun.utils.normalize_name(func_name)
     enriched_function = project.get_function(key=normalized_name)
     assert enriched_function.metadata.name == normalized_name
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -406,13 +406,55 @@ def test_set_function_requirements():
     ]
 
 
+def test_backwards_compatibility_get_non_normalized_function_name(rundb_mock):
+    project = mlrun.projects.MlrunProject(
+        "project", default_requirements=["pandas>1, <3"]
+    )
+    func_name = "name_with_underscores"
+    func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
+
+    func = mlrun.code_to_function(
+        name=func_name,
+        kind="job",
+        image="mlrun/mlrun",
+        handler="myhandler",
+        filename=func_path,
+    )
+    # nuclio also normalizes the name, so we de-normalize the function name before storing it
+    func.metadata.name = func_name
+
+    # mock the normalize function response in order to insert a non-normalized function name to the db
+    with unittest.mock.patch("mlrun.utils.normalize_name", return_value=func_name):
+        project.set_function(name=func_name, func=func)
+
+    # getting the function using the original non-normalized name, and ensure that querying it works
+    enriched_function = project.get_function(key=func_name)
+    assert enriched_function.metadata.name == func_name
+
+    enriched_function = project.get_function(key=func_name, sync=True)
+    assert enriched_function.metadata.name == func_name
+
+    # override the function by sending an update request,
+    # a new function is created, and the old one is no longer accessible
+    normalized_function_name = mlrun.utils.normalize_name(func_name)
+    func.metadata.name = normalized_function_name
+    project.set_function(name=func_name, func=func)
+
+    # using both normalized and non-normalized names to query the function
+    enriched_function = project.get_function(key=normalized_function_name)
+    assert enriched_function.metadata.name == normalized_function_name
+
+    resp = project.get_function(key=func_name)
+    assert resp.metadata.name == normalized_function_name
+
+
 def test_set_function_underscore_name(rundb_mock):
     project = mlrun.projects.MlrunProject(
         "project", default_requirements=["pandas>1, <3"]
     )
     func_name = "name_with_underscores"
 
-    # Create a function with a name that includes underscores
+    # create a function with a name that includes underscores
     func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
     func = mlrun.code_to_function(
         name=func_name,
@@ -423,11 +465,11 @@ def test_set_function_underscore_name(rundb_mock):
     )
     project.set_function(name=func_name, func=func)
 
-    # Attempt to get the function using the original name (with underscores) and ensure that it fails
+    # attempt to get the function using the original name (with underscores) and ensure that it fails
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
         project.get_function(key=func_name)
 
-    # Get the function using a normalized name and make sure it works
+    # get the function using a normalized name and make sure it works
     normalized_name = mlrun.utils.normalize_name(func_name)
     enriched_function = project.get_function(key=normalized_name)
     assert enriched_function.metadata.name == normalized_name


### PR DESCRIPTION
follow up for: https://github.com/mlrun/mlrun/pull/3287
In this previous PR we added a normalization to a function name before saving it, and notify the user of the change.

We realized that in case our users ignored/missed the warning when setting the function, and then attempted to access (import or update) it later,  they would be unable to do so using the old name, and would not know why their function was not found.

As a result, as long as we do not block requests with non-normalized names, we will normalize GET requests as well.
In this fix we handle this case by adding fall-back to get_function:
Normalize the requested name and attempt to retrieve it from the database. if no response is received, we will check to see if the original name contained underscores,  if so, we will repeat the retrieval and return the result (if exists).

The backwards compatibility behavior here is:
In circumstances when the user has an old function with non-normalized name already saved in the database, he will be able to retrieve it.
If he makes an update request, we will create a new updated function, with a normalized name. Now if he attempts to retrieve it using the old name, we will first normalize the name in the request for him, and return the updated function.
