### PR TITLE
[Dask] Remove commented out "is client" test

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -352,10 +352,6 @@ class DaskCluster(KubejobRuntime):
                     f"remote scheduler at {addr} not ready, will try to restart {err_to_str(exc)}"
                 )
 
-                # todo: figure out if test is needed
-                # if self._is_remote_api():
-                #     raise Exception('no access to Kubernetes API')
-
                 status = self.get_status()
                 if status != "running":
                     self._start()


### PR DESCRIPTION
This works both from the client and the server (dask logic needs to be split for client-server separation)