### PR TITLE
[DB] Runtime configurable sql mode

### DIFF
--- a/mlrun/api/db/init_db.py
+++ b/mlrun/api/db/init_db.py
@@ -19,6 +19,6 @@ from mlrun.api.db.sqldb.session import get_engine
 from mlrun.config import config
 
 
-def init_db(db_session: Session) -> None:
+def init_db() -> None:
     if config.httpdb.db_type != "filedb":
         Base.metadata.create_all(bind=get_engine())

--- a/mlrun/api/db/init_db.py
+++ b/mlrun/api/db/init_db.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from sqlalchemy.orm import Session
 
 from mlrun.api.db.sqldb.models import Base
 from mlrun.api.db.sqldb.session import get_engine

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -105,9 +105,11 @@ def init_data(
 
 
 # If the data_table version doesn't exist, we can assume the data version is 1.
-# This is because data version 1 points to to a data migration which was added back in 0.6.0, and
+# This is because data version 1 points to a data migration which was added back in 0.6.0, and
 # upgrading from a version earlier than 0.6.0 to v>=0.8.0 is not supported.
 data_version_prior_to_table_addition = 1
+
+# NOTE: Bump this number when adding a new data migration
 latest_data_version = 3
 
 

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -44,7 +44,9 @@ def init_data(
     from_scratch: bool = False, perform_migrations_if_needed: bool = False
 ) -> None:
     logger.info("Initializing DB data")
-    mlrun.api.utils.db.mysql.MySQLUtil.wait_for_db_liveness(logger)
+    mysql_util = mlrun.api.utils.db.mysql.MySQLUtil(logger)
+    mysql_util.wait_for_db_liveness()
+    mysql_util.set_modes(mlrun.mlconf.httpdb.db.mysql.modes)
 
     sqlite_migration_util = None
     if not from_scratch and config.httpdb.db.database_migration_mode == "enabled":
@@ -82,9 +84,9 @@ def init_data(
 
             _perform_database_migration(sqlite_migration_util)
 
+            init_db()
             db_session = create_session()
             try:
-                init_db(db_session)
                 _add_initial_data(db_session)
                 _perform_data_migrations(db_session)
             finally:

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -66,7 +66,8 @@ class MySQLUtil(object):
             connection.close()
 
     def set_modes(self, modes):
-        if not modes:
+        if not modes or modes in ["nil", "none"]:
+            self._logger.debug("No sql modes were given, bailing", modes=modes)
             return
         connection = self._create_connection()
         try:

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -37,17 +37,7 @@ class MySQLUtil(object):
 
     def wait_for_db_liveness(self, retry_interval=3, timeout=2 * 60):
         self._logger.debug("Waiting for database liveness")
-        mysql_dsn_data = MySQLUtil.get_mysql_dsn_data()
-        if not mysql_dsn_data:
-            dsn = MySQLUtil.get_dsn()
-            if "sqlite" in dsn:
-                self._logger.debug("SQLite DB is used, liveness check not needed")
-            else:
-                self._logger.warn(
-                    f"Invalid mysql dsn: {MySQLUtil.get_dsn()}, assuming live and skipping liveness verification"
-                )
-            return
-
+        mysql_dsn_data = self.get_mysql_dsn_data()
         tmp_connection = mlrun.utils.retry_until_successful(
             retry_interval,
             timeout,

--- a/mlrun/api/utils/db/mysql.py
+++ b/mlrun/api/utils/db/mysql.py
@@ -78,6 +78,17 @@ class MySQLUtil(object):
         finally:
             connection.close()
 
+    def set_modes(self, modes):
+        if not modes:
+            return
+        connection = self._create_connection()
+        try:
+            self._logger.debug("Setting sql modes", modes=modes)
+            with connection.cursor() as cursor:
+                cursor.execute("SET GLOBAL sql_mode=%s;", (modes,))
+        finally:
+            connection.close()
+
     def check_db_has_data(self):
         connection = self._create_connection()
         try:

--- a/mlrun/api/utils/db/sqlite_migration.py
+++ b/mlrun/api/utils/db/sqlite_migration.py
@@ -64,7 +64,7 @@ class SQLiteMigrationUtil(object):
         self._migrator = self._create_migrator()
         self._mysql_util = None
         if self._mysql_dsn_data:
-            self._mysql_util = MySQLUtil()
+            self._mysql_util = MySQLUtil(logger)
 
     def is_database_migration_needed(self) -> bool:
         # if some data is missing, don't transfer the data

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -231,10 +231,10 @@ default_config = {
             "conflict_retry_interval": None,
             # Whether to perform data migrations on initialization. enabled or disabled
             "data_migrations_mode": "enabled",
-            # Whether or not to perform database migration from sqlite to mysql on initialization
+            # Whether to perform database migration from sqlite to mysql on initialization
             "database_migration_mode": "enabled",
             "backup": {
-                # Whether or not to use db backups on initialization
+                # Whether to use db backups on initialization
                 "mode": "enabled",
                 "file_format": "db_backup_%Y%m%d%H%M.db",
                 "use_rotation": True,
@@ -245,6 +245,14 @@ default_config = {
             # None will set this to be equal to the httpdb.max_workers
             "connections_pool_size": None,
             "connections_pool_max_overflow": None,
+            # below is a db-specific configuration
+            "mysql": {
+                # comma separated mysql modes (globally) to set on runtime
+                # optional values (as per https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-full):
+                #
+                # if not set, nothing would be set
+                "modes": "STRICT_TRANS_TABLES",
+            },
         },
         "jobs": {
             # whether to allow to run local runtimes in the API - configurable to allow the scheduler testing to work

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -250,7 +250,7 @@ default_config = {
                 # comma separated mysql modes (globally) to set on runtime
                 # optional values (as per https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-full):
                 #
-                # if not set, nothing would be set
+                # if set to "nil" or "none", nothing would be set
                 "modes": "STRICT_TRANS_TABLES",
             },
         },

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -158,5 +158,5 @@ def _initialize_db_without_migrations() -> typing.Tuple[
     db_session = mlrun.api.db.sqldb.session.create_session(dsn=dsn)
     db = mlrun.api.db.sqldb.db.SQLDB(dsn)
     db.initialize(db_session)
-    mlrun.api.db.init_db.init_db(db_session)
+    mlrun.api.db.init_db.init_db()
     return db, db_session

--- a/tests/system/api/assets/function.py
+++ b/tests/system/api/assets/function.py
@@ -12,15 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-def secret_test_function(context, secrets: list = []):
+
+
+def secret_test_function(context, secrets: list = None):
     """Validate that given secrets exists
 
     :param context: the MLRun context
     :param secrets: name of the secrets that we want to look at
     """
     context.logger.info("running function")
+    secrets = secrets or []
     for sec_name in secrets:
         sec_value = context.get_secret(sec_name)
         context.logger.info("Secret: {} ==> {}".format(sec_name, sec_value))
         context.log_result(sec_name, sec_value)
+    return True
+
+
+def log_artifact_test_function(context, body_size: int = 1000, inline: bool = True):
+    """Logs artifact given its event body
+    :param context: the MLRun context
+    :param body_size: size of the artifact body
+    :param inline: whether to log the artifact body inline or not
+    """
+    context.logger.info("running function")
+    body = b"a" * body_size
+    context.log_artifact("test", body=body, is_inline=inline)
+    context.logger.info("run complete!", body_len=len(body))
     return True

--- a/tests/system/api/test_artifacts.py
+++ b/tests/system/api/test_artifacts.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pathlib
+
+import pytest
+
+import mlrun.common.schemas
+import mlrun.errors
+from tests.system.base import TestMLRunSystem
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+class TestAPIArtifacts(TestMLRunSystem):
+    project_name = "db-system-test-project"
+
+    def test_fail_overflowing_artifact(self):
+        """
+        Test that we fail when trying to (inline) log an artifact that is too big
+        This is done to ensure that we don't corrupt the DB while truncating the data
+        """
+        filename = str(pathlib.Path(__file__).parent / "assets" / "function.py")
+        function = mlrun.code_to_function(
+            name="test-func",
+            project=self.project_name,
+            filename=filename,
+            handler="log_artifact_test_function",
+            kind="job",
+            image="mlrun/mlrun",
+        )
+        task = mlrun.new_task()
+
+        # run artifact field is MEDIUMBLOB which is limited to 16MB by mysql
+        # overflow and expect it to fail execution and not allow db to truncate the data
+        # to avoid data corruption
+        with pytest.raises(mlrun.runtimes.utils.RunError):
+            function.run(
+                task, params={"body_size": 16 * 1024 * 1024 + 1, "inline": True}
+            )
+
+        runs = mlrun.get_run_db().list_runs()
+        assert len(runs) == 1, "run should not be created"
+        run = runs[0]
+        assert run["status"]["state"] == "error", "run should fail"
+        assert (
+            "Failed committing changes to DB" in run["status"]["error"]
+        ), "run should fail with a reason"


### PR DESCRIPTION
Allow setting sql mode (mysql) globally when mlrun starts 
This way, we can ensure strict-level on mysql to avoid cases where inline artifacts are truncated during store artifact causing data corruption

if no modes are set, mlrun will *not* try to override existing sql modes.

mlrun will default to use `STRICT_TRANS_TABLES` mode, more info [here](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_strict_trans_tables)

https://jira.iguazeng.com/browse/ML-3420