### PR TITLE
[Utils] Add named logger

### DIFF
--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -58,7 +58,12 @@ class HumanReadableExtendedFormatter(HumanReadableFormatter):
     def format(self, record):
         record_with = self._record_with(record)
         more = f": {record_with}" if record_with else ""
-        return f"> {self.formatTime(record, self.datefmt)} [{record.name}:{record.levelname.lower()}] {record.getMessage()}{more}"
+        return (
+            "> "
+            f"{self.formatTime(record, self.datefmt)} "
+            f"[{record.name}:{record.levelname.lower()}] "
+            f"{record.getMessage()}{more}"
+        )
 
 
 class Logger(object):
@@ -108,7 +113,8 @@ class Logger(object):
         """
         Get a child logger with the given suffix.
         This is useful for when you want to have a logger for a specific component.
-        Once the formatter will support logger name, it will be easier to understand which component logged the message.
+        Once the formatter will support logger name, it will be easier to understand
+        which component logged the message.
 
         :param suffix: The suffix to add to the logger name.
         """

--- a/tests/utils/logger/test_logger.py
+++ b/tests/utils/logger/test_logger.py
@@ -106,3 +106,21 @@ def test_redundant_logger_creation():
     assert stream.getvalue().count("[info] 2\n") == 1
     logger3.info("3")
     assert stream.getvalue().count("[info] 3\n") == 1
+
+
+def test_child_logger():
+    stream = StringIO()
+    logger = create_logger(
+        "debug",
+        name="test-logger",
+        stream=stream,
+        formatter_kind=FormatterKinds.HUMAN_EXTENDED.name,
+    )
+    child_logger = logger.get_child("child")
+    logger.debug("")
+    child_logger.debug("")
+    log_lines = stream.getvalue().strip().splitlines()
+
+    # validate parent and child log lines
+    assert "test-logger:debug" in log_lines[0]
+    assert "test-logger.child:debug" in log_lines[1]


### PR DESCRIPTION
Support creating child logger
Added formatter kind that will log the logger name as well

Eventually, we would want the api logger to include the logger name, to differentiate  between which component logged what