### PR TITLE
[Feature Set] Fix set_targets to overwrite the existing targets and allow no-target ingest if running locally

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -433,8 +433,7 @@ def ingest(
         and (run_config is not None and not run_config.local)
     ):
         raise mlrun.errors.MLRunInvalidArgumentError(
-            f"No targets provided to feature set {featureset.metadata.name} ingest, aborting.\n"
-            "(preview can be used as an alternative to local ingest when targets are not needed)"
+            f"Feature set {featureset.metadata.name} is remote ingested with no targets defined, aborting"
         )
 
     if featureset is not None:

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -30,7 +30,6 @@ from ..datastore.store_resources import parse_store_uri
 from ..datastore.targets import (
     BaseStoreTarget,
     get_default_prefix_for_source,
-    get_default_targets,
     get_target_driver,
     kind_to_driver,
     validate_target_list,
@@ -431,6 +430,7 @@ def ingest(
         not mlrun_context
         and not targets
         and not (featureset.spec.targets or featureset.spec.with_default_targets)
+        and (run_config is not None and not run_config.local)
     ):
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"No targets provided to feature set {featureset.metadata.name} ingest, aborting.\n"
@@ -522,7 +522,7 @@ def ingest(
     if not namespace:
         namespace = _get_namespace(run_config)
 
-    targets_to_ingest = targets or featureset.spec.targets or get_default_targets()
+    targets_to_ingest = targets or featureset.spec.targets
     targets_to_ingest = copy.deepcopy(targets_to_ingest)
 
     validate_target_paths_for_engine(targets_to_ingest, featureset.spec.engine, source)
@@ -805,7 +805,7 @@ def deploy_ingestion_service(
             name=featureset.metadata.name,
         )
 
-    targets_to_ingest = targets or featureset.spec.targets or get_default_targets()
+    targets_to_ingest = targets or featureset.spec.targets
     targets_to_ingest = copy.deepcopy(targets_to_ingest)
     featureset.update_targets_for_ingest(targets_to_ingest)
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -331,9 +331,7 @@ class FeatureSet(ModelObj):
         relations: Dict[str, Union[Entity, str]] = None,
         passthrough: bool = None,
     ):
-        """Feature set object, defines a set of features and their data pipeline,
-        The object created with default targets (nosql & parquet)
-        that can be overwritten by set_targets function.
+        """Feature set object, defines a set of features and their data pipeline
 
         example::
 
@@ -483,12 +481,12 @@ class FeatureSet(ModelObj):
             self.spec.with_default_targets = False
 
         self.spec.targets = []
-        self.add_targets(targets)
+        self.__set_targets_add_targets_helper(targets)
 
         if default_final_step:
             self.spec.graph.final_step = default_final_step
 
-    def add_targets(self, targets):
+    def __set_targets_add_targets_helper(self, targets):
         """
         Add the desired target list
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2380,7 +2380,7 @@ class TestFeatureStore(TestMLRunSystem):
             attributes=["aug"],
             inner_join=True,
         )
-        df = fstore.preview(
+        df = fstore.ingest(
             fset,
             df,
         )
@@ -2425,7 +2425,7 @@ class TestFeatureStore(TestMLRunSystem):
             attributes=["aug"],
             inner_join=True,
         )
-        df = fstore.preview(fset, df)
+        df = fstore.ingest(fset, df)
         assert df.to_dict() == {
             "foreignkey1": {
                 "mykey1_1": "AB",
@@ -2745,7 +2745,7 @@ class TestFeatureStore(TestMLRunSystem):
             group_by_key=True,
             _fn="map_with_state_test_function",
         )
-        df = fstore.preview(fset, df)
+        df = fstore.ingest(fset, df)
         assert df.to_dict() == {
             "name": {"a": "a", "b": "b"},
             "sum": {"a": 16, "b": 26},


### PR DESCRIPTION
1.  set_targets now is acutely a set function.
2. allow no-target ingest if running locally 
3. default targets are part of the featureset targets,  no need to use `get_default_targets` in the ingest process 

[ML-3800](https://jira.iguazeng.com/browse/ML-3800)