### PR TITLE
[Test] Fix transient scheduler unit test failure

### DIFF
--- a/tests/api/utils/function.py
+++ b/tests/api/utils/function.py
@@ -20,4 +20,4 @@ def do_nothing():
 
 
 def sleep_two_seconds():
-    time.sleep(1.99)
+    time.sleep(2)

--- a/tests/api/utils/function.py
+++ b/tests/api/utils/function.py
@@ -20,4 +20,4 @@ def do_nothing():
 
 
 def sleep_two_seconds():
-    time.sleep(2)
+    time.sleep(1.99)


### PR DESCRIPTION
Moved the creation of the cron trigger to after the IOs that store the function and list the runs because they might take too long and cause the schedule to skip the 1st-second run.
For example (schedule triggered every second with no concurrent runs):
```
11:51:05,854479 - Start time (scheduler skipped 11:51:06)
11:51:07,044 - Trigger run
11:51:09,087 - Run finished
11:51:09,854479  - End time
```

**Note** I encountered a problem locally where the function takes 3 seconds to finish and this fix will not cover it.
I'm not sure yet why it happens, could be something we can't control on the scheduler or the Python event loop.
If it pops again in CI I will look for ways to resolve it.