### PR TITLE
[System tests] Fix for test run notifications

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -576,6 +576,8 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     # and their notifications haven't been sent yet.
     global _last_notification_push_time
 
+    _time_before_last_runs_query = datetime.datetime.now(datetime.timezone.utc)
+
     runs = db.list_runs(
         db_session,
         project="*",
@@ -599,7 +601,7 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     )
     mlrun.utils.notifications.NotificationPusher(unmasked_runs).push(db)
 
-    _last_notification_push_time = datetime.datetime.now(datetime.timezone.utc)
+    _last_notification_push_time = _time_before_last_runs_query
 
 
 async def _stop_logs():

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -576,7 +576,7 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     # and their notifications haven't been sent yet.
     global _last_notification_push_time
 
-    _time_before_last_runs_query = datetime.datetime.now(datetime.timezone.utc)
+    _time_before_last_list_runs_query = datetime.datetime.now(datetime.timezone.utc)
 
     runs = db.list_runs(
         db_session,
@@ -601,7 +601,7 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     )
     mlrun.utils.notifications.NotificationPusher(unmasked_runs).push(db)
 
-    _last_notification_push_time = _time_before_last_runs_query
+    _last_notification_push_time = _time_before_last_list_runs_query
 
 
 async def _stop_logs():

--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -69,7 +69,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         # the notifications are sent asynchronously, so we need to wait for them
         mlrun.utils.retry_until_successful(
             1,
-            20,
+            50,
             self._logger,
             True,
             _assert_notifications,

--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -69,7 +69,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         # the notifications are sent asynchronously, so we need to wait for them
         mlrun.utils.retry_until_successful(
             1,
-            50,
+            40,
             self._logger,
             True,
             _assert_notifications,


### PR DESCRIPTION
`test_run_notifications` fails non-deterministically,
Adding two fixes that may fix the issue:
- increasing timeout - the time interval of the monitor is 30s, the test timeout used to be 20s, increasing to 40.
- last notification push time - Because `_last_notification_push_time` was taken after querying and pushing all runs, a run may have been missed. Taking the time now before running the query.