### PR TITLE
[Launcher] Fix duplicate push notification call for local runs

### DIFF
--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -226,7 +226,7 @@ def mlrun_op(
     :param labels:   labels to tag the job/run with ({key:val, ..})
     :param inputs:   dictionary of input objects + optional paths (if path is
                      omitted the path will be the in_path/key.
-    :param outputs:  dictionary of input objects + optional paths (if path is
+    :param outputs:  dictionary of output objects + optional paths (if path is
                      omitted the path will be the out_path/key.
     :param in_path:  default input path/url (prefix) for inputs
     :param out_path: default output path/url (prefix) for artifacts

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -122,7 +122,6 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
             run=run,
         )
 
-        self._save_or_push_notifications(result)
         return result
 
     def execute(
@@ -188,6 +187,7 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
                 result = runtime._update_run_state(task=run, err=err)
 
         self._save_or_push_notifications(run)
+
         # run post run hooks
         runtime._post_run(result, execution)  # hook for runtime specific cleanup
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -43,7 +43,7 @@ from mlrun.api.constants import LogSources
 from mlrun.api.db.base import DBInterface
 from mlrun.utils.helpers import generate_object_uri, verify_field_regex
 
-from ..config import config, is_running_as_api
+from ..config import config
 from ..datastore import store_manager
 from ..db import RunDBError, get_or_set_dburl, get_run_db
 from ..errors import err_to_str

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -623,47 +623,6 @@ class BaseRuntime(ModelObj):
 
         return resp
 
-    def _save_or_push_notifications(self, runobj: RunObject, local: bool = False):
-
-        if not runobj.spec.notifications:
-            logger.debug(
-                "No notifications to push for run", run_uid=runobj.metadata.uid
-            )
-            return
-
-        # TODO: add support for other notifications per run iteration
-        if runobj.metadata.iteration and runobj.metadata.iteration > 0:
-            logger.debug(
-                "Notifications per iteration are not supported, skipping",
-                run_uid=runobj.metadata.uid,
-            )
-            return
-
-        # If the run is remote, and we are in the SDK, we let the api deal with the notifications
-        # so there's nothing to do here.
-        # Otherwise, we continue on.
-        if is_running_as_api():
-
-            # import here to avoid circular imports and to avoid importing api requirements
-            from mlrun.api.crud import Notifications
-
-            # If in the api server, we can assume that watch=False, so we save notification
-            # configs to the DB, for the run monitor to later pick up and push.
-            session = mlrun.api.db.sqldb.session.create_session()
-            Notifications().store_run_notifications(
-                session,
-                runobj.spec.notifications,
-                runobj.metadata.uid,
-                runobj.metadata.project,
-            )
-
-        elif local:
-            # If the run is local, we can assume that watch=True, therefore this code runs
-            # once the run is completed, and we can just push the notifications.
-            # TODO: add store_notifications API endpoint so we can store notifications pushed from the
-            #       SDK for documentation purposes.
-            mlrun.utils.notifications.NotificationPusher([runobj]).push()
-
     def _force_handler(self, handler):
         if not handler:
             raise RunError(f"handler must be provided for {self.kind} runtime")


### PR DESCRIPTION
The `_save_or_push_notifications` method was called twice once in `launch` and once in `execute` while it should have been pushed once.
The method moved from the runtimes to the launchers so we can remove it from the BaseRuntime class.