### PR TITLE
[System Tests] Change `test_run` project name

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -64,6 +64,10 @@ class TestProject(TestMLRunSystem):
         pass
 
     def custom_teardown(self):
+        self._logger.debug(
+            "Deleting custom projects",
+            num_projects_to_delete=len(self.custom_project_names_to_delete),
+        )
         for name in self.custom_project_names_to_delete:
             self._delete_test_project(name)
 
@@ -123,7 +127,7 @@ class TestProject(TestMLRunSystem):
         )
 
     def test_run(self):
-        name = "pipe1"
+        name = "pipe0"
         self.custom_project_names_to_delete.append(name)
         # create project in context
         self._create_project(name)


### PR DESCRIPTION
In `test_project.py` every test creates/loads a project with a different name, except `test_run` and `test_run_artifact_path` that used the same project - `pipe1`. 

When running in the enterprise system tests on github, the test failed saying that the project had 4 functions instead of the expected 2 functions.
This was probably due to a race condition in the Github runners where the same project from the previous test did not finish deletion before the next test ran, causing the project to not be empty.

Changed the project's name so the tests will use 2 different tests. 