### PR TITLE
[Notifications] Fix missed notifications in notifications pusher

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -24,7 +24,6 @@ import sqlalchemy.orm
 import uvicorn
 from fastapi.exception_handlers import http_exception_handler
 
-import mlrun.api.api.utils
 import mlrun.api.db.base
 import mlrun.api.utils.clients.chief
 import mlrun.api.utils.clients.log_collector
@@ -567,6 +566,8 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     Get all runs with notification configs which became terminal since the last call to the function
     and push their notifications if they haven't been pushed yet.
     """
+    # Import here to avoid circular import
+    import mlrun.api.api.utils
 
     # When pushing notifications, push notifications only for runs that entered a terminal state
     # since the last time we pushed notifications.

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -24,6 +24,7 @@ import sqlalchemy.orm
 import uvicorn
 from fastapi.exception_handlers import http_exception_handler
 
+import mlrun.api.api.utils
 import mlrun.api.db.base
 import mlrun.api.utils.clients.chief
 import mlrun.api.utils.clients.log_collector
@@ -567,14 +568,13 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     and push their notifications if they haven't been pushed yet.
     """
 
-    # Import here to avoid circular import
-    import mlrun.api.api.utils
-
     # When pushing notifications, push notifications only for runs that entered a terminal state
     # since the last time we pushed notifications.
     # On the first time we push notifications, we'll push notifications for all runs that are in a terminal state
     # and their notifications haven't been sent yet.
     global _last_notification_push_time
+
+    now = datetime.datetime.now(datetime.timezone.utc)
 
     runs = db.list_runs(
         db_session,
@@ -599,7 +599,7 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     )
     mlrun.utils.notifications.NotificationPusher(unmasked_runs).push(db)
 
-    _last_notification_push_time = datetime.datetime.now(datetime.timezone.utc)
+    _last_notification_push_time = now
 
 
 async def _stop_logs():

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -56,7 +56,10 @@ async def scheduler(db: Session) -> typing.Generator:
 
 
 call_counter: int = 0
-schedule_end_time_margin = 0.8
+
+# TODO: The margin will need to rise for each additional CPU-consuming operation added along the flow,
+#  we need to consider how to decouple in the future
+schedule_end_time_margin = 0.7
 
 
 async def bump_counter():

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -56,7 +56,7 @@ async def scheduler(db: Session) -> typing.Generator:
 
 
 call_counter: int = 0
-schedule_end_time_margin = 0.5
+schedule_end_time_margin = 0.8
 
 
 async def bump_counter():


### PR DESCRIPTION
Adding a fix to `_push_terminal_run_notifications`. 
`_last_notification_push_time` was calculated after querying and pushing all runs, therefore a run could have been missed. Taking the time now before running the query.

This change lead to some scheduler tests taking longer and fail. 
We computed a margin of `0.5` seconds for these tests, which was already quite insufficient (`0.4` is not enough), and increased it to `0.8` in this PR.
It looks like adding even one CPU-consuming code line along the flow will cause a delay in the run time. 

This margin will only work temporarily, and we don't want this actions to influence the run time. In the future, we should consider separating this server code, but for now, we should discuss a better solution (maybe make scheduler tests not run the periodic run monitor + add a test for the real flow expected time).
