### PR TITLE
[Config] Fix overriding API SQL DB with nopDB

### DIFF
--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -25,7 +25,7 @@ _running_inside_kubernetes_cluster = None
 
 def is_running_inside_kubernetes_cluster():
     global _running_inside_kubernetes_cluster
-    if _running_inside_kubernetes_cluster is not None:
+    if _running_inside_kubernetes_cluster is None:
         try:
             kubernetes.config.load_incluster_config()
             _running_inside_kubernetes_cluster = True

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -75,6 +75,7 @@ def resolve_mpijob_crd_version():
     if not cached_mpijob_crd_version:
 
         # config override everything
+        # on client side, expecting it to get enriched from the API through the client-spec
         mpijob_crd_version = config.mpijob_crd_version
 
         if not mpijob_crd_version:
@@ -95,13 +96,8 @@ def resolve_mpijob_crd_version():
                     mpijob_crd_version = mpi_operator_pod.metadata.labels.get(
                         "crd-version"
                     )
-            elif not in_k8s_cluster:
-                # connect will populate the config from the server config
-                # TODO: something nicer
-                get_run_db()
-                mpijob_crd_version = config.mpijob_crd_version
 
-            # If resolution failed simply use default
+            # backoff to use default if wasn't resolved in API
             if not mpijob_crd_version:
                 mpijob_crd_version = MPIJobCRDVersions.default()
 

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -28,7 +28,6 @@ import mlrun.api.utils.builder
 import mlrun.common.constants
 import mlrun.utils.regex
 from mlrun.api.utils.clients import nuclio
-from mlrun.db import get_run_db
 from mlrun.errors import err_to_str
 from mlrun.frameworks.parallel_coordinates import gen_pcp_plot
 from mlrun.runtimes.constants import MPIJobCRDVersions


### PR DESCRIPTION
Issue was that in #3426 ([here](https://github.com/mlrun/mlrun/pull/3426/files#diff-5ad3789c7abfd42e2535960d6b11ba72e69337af52cf26f05274afd9736c3d3bR97)) I modified the resolution of `resolve_mpijob_crd_version` to `get_run_db` even if running in `api_context` this caused the default dbpath to change to `./` which was supposed to stay empty. 
Decided to remove the the whole resolution of the `mpi_version` using the `get_run_db` due to the existence of the `client-spec` enrichment on the client side that resolves the `mpi_version` from the API.