### PR TITLE
[Notifications] Fix raising exception when git notification gets a Bad Request

### DIFF
--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -120,7 +120,7 @@ class GitNotification(NotificationBase):
             if not resp.ok:
                 resp_text = await resp.text()
                 raise mlrun.errors.MLRunBadRequestError(
-                    f"Failed commenting on PR: {resp_text}", status=resp.status
+                    f"Failed commenting on PR: {resp_text}"
                 )
             data = await resp.json()
             return data.get("id")


### PR DESCRIPTION
The `mlrun.errors.MLRunBadRequestError` doesn't expect the `status_code` param. Removed it.

Fixes - https://jira.iguazeng.com/browse/ML-3849