### PR TITLE
[Notifications] Fix sending duplicate notifications

### DIFF
--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -166,18 +166,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
             )
 
     def _save_notifications(self, runobj):
-        if not runobj.spec.notifications:
-            mlrun.utils.logger.debug(
-                "No notifications to push for run", run_uid=runobj.metadata.uid
-            )
-            return
-
-        # TODO: add support for other notifications per run iteration
-        if runobj.metadata.iteration and runobj.metadata.iteration > 0:
-            mlrun.utils.logger.debug(
-                "Notifications per iteration are not supported, skipping",
-                run_uid=runobj.metadata.uid,
-            )
+        if not self._validate_notifications(runobj):
             return
 
         # If in the api server, we can assume that watch=False, so we save notification

--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -166,7 +166,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
             )
 
     def _save_notifications(self, runobj):
-        if not self._validate_notifications(runobj):
+        if not self._run_has_valid_notifications(runobj):
             return
 
         # If in the api server, we can assume that watch=False, so we save notification

--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -137,7 +137,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
             finally:
                 result = runtime._update_run_state(resp=resp, task=run, err=last_err)
 
-        self._save_or_push_notifications(run)
+        self._save_notifications(run)
 
         runtime._post_run(result, execution)  # hook for runtime specific cleanup
 
@@ -165,7 +165,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
                 project, runtime, copy_function=False
             )
 
-    def _save_or_push_notifications(self, runobj):
+    def _save_notifications(self, runobj):
         if not runobj.spec.notifications:
             mlrun.utils.logger.debug(
                 "No notifications to push for run", run_uid=runobj.metadata.uid

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -305,7 +305,7 @@ class BaseLauncher(abc.ABC):
         return run
 
     @staticmethod
-    def _validate_notifications(runobj) -> bool:
+    def _run_has_valid_notifications(runobj) -> bool:
         if not runobj.spec.notifications:
             logger.debug(
                 "No notifications to push for run", run_uid=runobj.metadata.uid

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -369,10 +369,6 @@ class BaseLauncher(abc.ABC):
     ):
         pass
 
-    @abc.abstractmethod
-    def _save_or_push_notifications(self, runobj):
-        pass
-
     @staticmethod
     @abc.abstractmethod
     def _store_function(

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -305,7 +305,7 @@ class BaseLauncher(abc.ABC):
         return run
 
     @staticmethod
-    def _are_valid_notifications(runobj) -> bool:
+    def _validate_notifications(runobj) -> bool:
         if not runobj.spec.notifications:
             logger.debug(
                 "No notifications to push for run", run_uid=runobj.metadata.uid

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -258,7 +258,7 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
         return command, args
 
     def _push_notifications(self, runobj):
-        if not self._validate_notifications(runobj):
+        if not self._run_has_valid_notifications(runobj):
             return
         # TODO: add store_notifications API endpoint so we can store notifications pushed from the
         #       SDK for documentation purposes.

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -258,7 +258,7 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
         return command, args
 
     def _push_notifications(self, runobj):
-        if not self._are_valid_notifications(runobj):
+        if not self._validate_notifications(runobj):
             return
         # TODO: add store_notifications API endpoint so we can store notifications pushed from the
         #       SDK for documentation purposes.

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -186,7 +186,7 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
                 last_err = err
                 result = runtime._update_run_state(task=run, err=err)
 
-        self._save_or_push_notifications(run)
+        self._push_notifications(run)
 
         # run post run hooks
         runtime._post_run(result, execution)  # hook for runtime specific cleanup
@@ -257,11 +257,13 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
                     args = sp[1:]
         return command, args
 
-    def _save_or_push_notifications(self, runobj):
+    def _push_notifications(self, runobj):
         if not self._are_valid_notifications(runobj):
             return
-        # The run is local, so we can assume that watch=True, therefore this code runs
-        # once the run is completed, and we can just push the notifications.
         # TODO: add store_notifications API endpoint so we can store notifications pushed from the
         #       SDK for documentation purposes.
-        mlrun.utils.notifications.NotificationPusher([runobj]).push()
+        # The run is local, so we can assume that watch=True, therefore this code runs
+        # once the run is completed, and we can just push the notifications.
+        # Only push from jupyter, not from the CLI.
+        if self._is_run_local:
+            mlrun.utils.notifications.NotificationPusher([runobj]).push()

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -174,6 +174,3 @@ class ClientRemoteLauncher(mlrun.launcher.client.ClientBaseLauncher):
             resp = runtime._get_db_run(run)
 
         return self._wrap_run_result(runtime, resp, run, schedule=schedule)
-
-    def _save_or_push_notifications(self, runobj):
-        pass


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/ML-3850

- In client local launcher only push notifications from jupyter client and not from CLI (run pod) - this caused the duplicate notifications.
- Refactor `save_or_push_notifications`, separated to `save_notifications` for api launcher and `push_notifications` for client local launcher.
- api launcher uses notification validation function (remove code dup)