### PR TITLE
[Notifications] Fix notification param masking on run object

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -211,10 +211,16 @@ def mask_notification_params_on_task(task):
     run_uid = get_in(task, "metadata.uid")
     project = get_in(task, "metadata.project")
     notifications = task.get("spec", {}).get("notifications", [])
+    masked_notifications = []
     if notifications:
         for notification in notifications:
             notification_object = mlrun.model.Notification.from_dict(notification)
-            mask_notification_params_with_secret(project, run_uid, notification_object)
+            masked_notifications.append(
+                mask_notification_params_with_secret(
+                    project, run_uid, notification_object
+                ).to_dict()
+            )
+    task.setdefault("spec", {})["notifications"] = masked_notifications
 
 
 def mask_notification_params_with_secret(


### PR DESCRIPTION
The param masking in the Notifications CRUD worked properly, therefore the secret was created and the secret name was in the notification db record.
However the masking wasn't being applied properly on the notifications in the run struct, fixed the masking function for the run struct.