### PR TITLE
[Notifications] Fix notifications being resent when api restarts

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -943,6 +943,7 @@ class RunStatus(ModelObj):
         iterations=None,
         ui_url=None,
         reason: str = None,
+        notifications: Dict[str, Notification] = None,
     ):
         self.state = state or "created"
         self.status_text = status_text
@@ -956,6 +957,7 @@ class RunStatus(ModelObj):
         self.iterations = iterations
         self.ui_url = ui_url
         self.reason = reason
+        self.notifications = notifications or {}
 
 
 class RunTemplate(ModelObj):

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -49,7 +49,9 @@ class NotificationPusher(object):
                 run = mlrun.model.RunObject.from_dict(run)
 
             for notification in run.spec.notifications:
-                notification.status = run.status.notifications.get(notification.name).status
+                notification.status = run.status.notifications.get(
+                    notification.name
+                ).status
                 if self._should_notify(run, notification):
                     self._notification_data.append((run, notification))
 

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -49,6 +49,7 @@ class NotificationPusher(object):
                 run = mlrun.model.RunObject.from_dict(run)
 
             for notification in run.spec.notifications:
+                notification.status = run.status.notifications.get(notification.name).status
                 if self._should_notify(run, notification):
                     self._notification_data.append((run, notification))
 


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/ML-3851

When listing runs (with notifications) the notification data gets split between the run spec and run status. In order to check the notification status (whether it was already sent or is pending), we need to get the notification status from the run status before checking.