### PR TITLE
[CI] Fix generating env for OSS tests

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -189,9 +189,9 @@ jobs:
 
     - name: Prepare system tests env
       run: |
-        echo "MLRUN_DBPATH: http://$(minikube ip):${MLRUN_API_NODE_PORT}" > tests/system/env.yml
-        echo "MLRUN_SYSTEM_TESTS_GIT_TOKEN: ${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" >> tests/system/env.yml
-        # TODO: use `prepare.py` for open source system tests as well
+        python automation/system_test/prepare.py env \
+          "http://$(minikube ip):${MLRUN_API_NODE_PORT}" \
+          "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}"
 
     # Enable tmate debugging of manually-triggered workflows if the input option was provided
     - name: Setup tmate session

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -18,6 +18,7 @@ import logging
 import os
 import pathlib
 import subprocess
+import shutil
 import sys
 import tempfile
 import time
@@ -29,8 +30,10 @@ import click
 import paramiko
 import yaml
 
+# TODO: remove and use local logger
 import mlrun.utils
 
+project_dir = pathlib.Path(__file__).resolve().parent.parent.parent
 logger = mlrun.utils.create_logger(level="debug", name="automation")
 logging.getLogger("paramiko").setLevel(logging.DEBUG)
 
@@ -43,7 +46,7 @@ class SystemTestPreparer:
         igz_version_file = homedir / "igz" / "version.txt"
         mlrun_code_path = workdir / "mlrun"
         provctl_path = workdir / "provctl"
-        system_tests_env_yaml = pathlib.Path("tests") / "system" / "env.yml"
+        system_tests_env_yaml = project_dir / pathlib.Path("tests") / "system" / "env.yml"
         namespace = "default-tenant"
 
         git_url = "https://github.com/mlrun/mlrun.git"
@@ -293,16 +296,18 @@ class SystemTestPreparer:
         )
 
     def _prepare_env_local(self):
-        contents = yaml.safe_dump(self._env_config)
         filepath = str(self.Constants.system_tests_env_yaml)
+        backup_filepath = str(self.Constants.system_tests_env_yaml) + ".bak"
         self._logger.debug("Populating system tests env.yml", filepath=filepath)
-        self._run_command(
-            "cat > ",
-            workdir=".",
-            args=[filepath],
-            stdin=contents,
-            local=True,
-        )
+
+        # if filepath exists, backup the file first (to avoid overriding it)
+        if os.path.isfile(filepath) and not os.path.isfile(backup_filepath):
+            self._logger.debug("Backing up existing env.yml", destination=backup_filepath)
+            shutil.copy(filepath, backup_filepath)
+
+        serialized_env_config = self._serialize_env_config()
+        with open(filepath, "w") as f:
+            f.write(serialized_env_config)
 
     def _override_mlrun_api_env(self):
         version_specifier = (
@@ -613,6 +618,17 @@ class SystemTestPreparer:
             verbose=verbose,
         )
 
+    def _serialize_env_config(self, allow_none_values: bool = False):
+        env_config = self._env_config.copy()
+
+        # we sanitize None values from config to avoid "null" values in yaml
+        if not allow_none_values:
+            for key in list(env_config):
+                if env_config[key] is None:
+                    del env_config[key]
+
+        return yaml.safe_dump(env_config)
+
 
 @click.group()
 def main():
@@ -736,11 +752,11 @@ def run(
 
 @main.command(context_settings=dict(ignore_unknown_options=True))
 @click.argument("mlrun-dbpath", type=str, required=True)
-@click.argument("webapi-direct-url", type=str, required=True)
-@click.argument("framesd-url", type=str, required=True)
-@click.argument("username", type=str, required=True)
-@click.argument("access-key", type=str, required=True)
-@click.argument("spark-service", type=str, required=True)
+@click.argument("webapi-direct-url", type=str, required=False)
+@click.argument("framesd-url", type=str, required=False)
+@click.argument("username", type=str, required=False)
+@click.argument("access-key", type=str, required=False)
+@click.argument("spark-service", type=str, required=False)
 @click.argument("password", type=str, default=None, required=False)
 @click.argument("slack-webhook-url", type=str, default=None, required=False)
 @click.option(

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -17,8 +17,8 @@ import datetime
 import logging
 import os
 import pathlib
-import subprocess
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -46,7 +46,9 @@ class SystemTestPreparer:
         igz_version_file = homedir / "igz" / "version.txt"
         mlrun_code_path = workdir / "mlrun"
         provctl_path = workdir / "provctl"
-        system_tests_env_yaml = project_dir / pathlib.Path("tests") / "system" / "env.yml"
+        system_tests_env_yaml = (
+            project_dir / pathlib.Path("tests") / "system" / "env.yml"
+        )
         namespace = "default-tenant"
 
         git_url = "https://github.com/mlrun/mlrun.git"
@@ -302,7 +304,9 @@ class SystemTestPreparer:
 
         # if filepath exists, backup the file first (to avoid overriding it)
         if os.path.isfile(filepath) and not os.path.isfile(backup_filepath):
-            self._logger.debug("Backing up existing env.yml", destination=backup_filepath)
+            self._logger.debug(
+                "Backing up existing env.yml", destination=backup_filepath
+            )
             shutil.copy(filepath, backup_filepath)
 
         serialized_env_config = self._serialize_env_config()


### PR DESCRIPTION
Use mlrun automation prepare.env to generate env.yaml for OSS tests, which way, secrets including arg flags would be natively be generated

In addition, made sure to backup existing env so when generating on local, it wont override and kill the current copy.