### PR TITLE
[Requirements] Remove protobuf requirement

### DIFF
--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -1,4 +1,3 @@
 # with moving to arm64 for the new M1/M2 macs some packages are not yet compatible via pip and require
 # conda which supports different architecture environments on the same machine
-protobuf>=3.20.3, <4
 lightgbm>=3.0

--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -1,4 +1,4 @@
 # with moving to arm64 for the new M1/M2 macs some packages are not yet compatible via pip and require
 # conda which supports different architecture environments on the same machine
-protobuf>=3.13, <3.20
+protobuf>=3.20.3, <4
 lightgbm>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ click~=8.0.0
 # when installing google-cloud-storage which required >=3.20.1, <5 it was upgrading the protobuf version to the latest
 # version and because kfp 1.8.13 requires protobuf>=3.13, <4 it resulted incompatibility between kfp and protobuf
 # this can be removed once kfp will support protobuf > 4
-# since google-cloud blacklisted 3.20.0 and 3.20.1 we start from 3.20.2
-protobuf>=3.13, <3.20
+# tensorflow 2.12.0 requires protobuf>=3.20.3
+protobuf>=3.20.3, <4
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
 # 1.8.14 introduced new features related to ParallelFor, while our actual kfp server is 1.8.1, which isn't compatible

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,11 +7,6 @@ aiohttp~=3.8
 aiohttp-retry~=2.8
 # 8.1.0+ breaks dask/distributed versions older than 2022.04.0, see here - https://github.com/dask/distributed/pull/6018
 click~=8.0.0
-# when installing google-cloud-storage which required >=3.20.1, <5 it was upgrading the protobuf version to the latest
-# version and because kfp 1.8.13 requires protobuf>=3.13, <4 it resulted incompatibility between kfp and protobuf
-# this can be removed once kfp will support protobuf > 4
-# tensorflow 2.12.0 requires protobuf>=3.20.3
-protobuf>=3.20.3, <4
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
 # 1.8.14 introduced new features related to ParallelFor, while our actual kfp server is 1.8.1, which isn't compatible

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -126,7 +126,7 @@ def test_requirement_specifiers_convention():
         "dask-ml": {"~=1.4,<1.9.0"},
         "pyarrow": {">=10.0, <12"},
         "nbclassic": {">=0.2.8"},
-        "protobuf": {">=3.20.3, <=4"},
+        "protobuf": {">=3.20.3, <4"},
         "pandas": {"~=1.2, <1.5.0"},
         "ipython": {">=7.0, <9.0"},
         "importlib_metadata": {">=3.6"},

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -126,7 +126,7 @@ def test_requirement_specifiers_convention():
         "dask-ml": {"~=1.4,<1.9.0"},
         "pyarrow": {">=10.0, <12"},
         "nbclassic": {">=0.2.8"},
-        "protobuf": {">=3.13, <3.20"},
+        "protobuf": {">=3.20.3, <=4"},
         "pandas": {"~=1.2, <1.5.0"},
         "ipython": {">=7.0, <9.0"},
         "importlib_metadata": {">=3.6"},

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -126,7 +126,6 @@ def test_requirement_specifiers_convention():
         "dask-ml": {"~=1.4,<1.9.0"},
         "pyarrow": {">=10.0, <12"},
         "nbclassic": {">=0.2.8"},
-        "protobuf": {">=3.20.3, <4"},
         "pandas": {"~=1.2, <1.5.0"},
         "ipython": {">=7.0, <9.0"},
         "importlib_metadata": {">=3.6"},


### PR DESCRIPTION
To support tensorflow 2.12.0 we need to have protobuf >= 3.20.3 - https://github.com/tensorflow/tensorflow/blob/v2.12.0/tensorflow/tools/pip_package/setup.py#L107
before that, tensorflow requires protobuf < 3.20
kfp requires protobuf <4
when installing mlrun you get protobuf 3.20.3.
if you install tensorflow after mlrun:
1. tensorflow 2.12.0 - OK
2. tensorflow < 2.12 - will downgrade protobuf to 3.19 which is good for us

https://jira.iguazeng.com/browse/ML-3824
