### PR TITLE
[Nuclio] Resolve full image names if enrichment prefix is given

### DIFF
--- a/mlrun/api/crud/runtimes/nuclio/function.py
+++ b/mlrun/api/crud/runtimes/nuclio/function.py
@@ -472,6 +472,8 @@ def _resolve_and_set_base_image(
         or function.spec.build.base_image
     )
     if base_image:
+        # we ignore the returned registry secret as nuclio uses the image pull secret, which is resolved in the
+        # build params
         (
             base_image,
             _,

--- a/mlrun/api/crud/runtimes/nuclio/function.py
+++ b/mlrun/api/crud/runtimes/nuclio/function.py
@@ -27,6 +27,7 @@ import mlrun.api.utils.singletons.k8s
 import mlrun.datastore
 import mlrun.errors
 import mlrun.runtimes.function
+import mlrun.runtimes.pod
 import mlrun.utils
 from mlrun.utils import logger
 
@@ -63,6 +64,7 @@ def deploy_nuclio_function(
     )
 
     try:
+        logger.info("Starting Nuclio function deployment")
         return nuclio.deploy.deploy_config(
             function_config,
             dashboard_url=mlrun.mlconf.nuclio_dashboard_url,
@@ -171,12 +173,88 @@ def _compile_function_config(
     builder_env=None,
     auth_info=None,
 ):
+    _set_function_labels(function)
+
+    # resolve env vars before compiling the nuclio spec, as we need to set them in the spec
+    env_dict, external_source_env_dict = _resolve_env_vars(function)
+
+    nuclio_spec = nuclio.ConfigSpec(
+        env=env_dict,
+        external_source_env=external_source_env_dict,
+        config=function.spec.config,
+    )
+    nuclio_spec.cmd = function.spec.build.commands or []
+
+    _resolve_and_set_build_requirements(function, nuclio_spec)
+    _resolve_and_set_nuclio_runtime(
+        function, nuclio_spec, client_version, client_python_version
+    )
+
+    project = function.metadata.project or "default"
+    tag = function.metadata.tag
+    handler = function.spec.function_handler
+
+    _set_build_params(function, nuclio_spec, builder_env, project, auth_info)
+    _set_function_scheduling_params(function, nuclio_spec)
+    _set_function_replicas(function, nuclio_spec)
+    _set_misc_specs(function, nuclio_spec)
+
+    # if the user code is given explicitly or from a source, we need to set the handler and relevant attributes
+    if (
+        function.spec.base_spec
+        or function.spec.build.functionSourceCode
+        or function.spec.build.source
+        or function.kind == mlrun.runtimes.RuntimeKinds.serving  # serving can be empty
+    ):
+        config = function.spec.base_spec
+        if not config:
+            # if base_spec was not set (when not using code_to_function) and we have base64 code
+            # we create the base spec with essential attributes
+            config = nuclio.config.new_config()
+            mlrun.utils.update_in(config, "spec.handler", handler or "main:handler")
+
+        config = nuclio.config.extend_config(
+            config, nuclio_spec, tag, function.spec.build.code_origin
+        )
+
+        if (
+            function.kind == mlrun.runtimes.RuntimeKinds.serving
+            and not mlrun.utils.get_in(config, "spec.build.functionSourceCode")
+        ):
+            _set_source_code_and_handler(function, config)
+    else:
+        # this may also be called in case of using single file code_to_function(embed_code=False)
+        # this option need to be removed or be limited to using remote files (this code runs in server)
+        function_name, config, code = nuclio.build_file(
+            function.spec.source,
+            name=function.metadata.name,
+            project=project,
+            handler=handler,
+            tag=tag,
+            spec=nuclio_spec,
+            kind=function.spec.function_kind,
+            verbose=function.verbose,
+        )
+
+    mlrun.utils.update_in(
+        config, "spec.volumes", function.spec.generate_nuclio_volumes()
+    )
+
+    _resolve_and_set_base_image(function, config, client_version, client_python_version)
+    function_name = _set_function_name(function, config, project, tag)
+
+    return function_name, project, config
+
+
+def _set_function_labels(function):
     labels = function.metadata.labels or {}
     labels.update({"mlrun/class": function.kind})
     for key, value in labels.items():
         # Adding escaping to the key to prevent it from being split by dots if it contains any
         function.set_config(f"metadata.labels.\\{key}\\", value)
 
+
+def _resolve_env_vars(function):
     # Add secret configurations to function's pod spec, if secret sources were added.
     # Needs to be here, since it adds env params, which are handled in the next lines.
     # This only needs to run if we're running within k8s context. If running in Docker, for example, skip.
@@ -187,6 +265,22 @@ def _compile_function_config(
 
     env_dict, external_source_env_dict = function._get_nuclio_config_spec_env()
 
+    # In nuclio 1.6.0<=v<1.8.0, python runtimes default behavior was to not decode event strings
+    # Our code is counting on the strings to be decoded, so add the needed env var for those versions
+    if (
+        mlrun.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
+            "1.6.0", "1.8.0"
+        )
+        and "NUCLIO_PYTHON_DECODE_EVENT_STRINGS" not in env_dict
+    ):
+        env_dict["NUCLIO_PYTHON_DECODE_EVENT_STRINGS"] = "true"
+
+    return env_dict, external_source_env_dict
+
+
+def _resolve_and_set_nuclio_runtime(
+    function, nuclio_spec, client_version, client_python_version
+):
     nuclio_runtime = (
         function.spec.nuclio_runtime
         or mlrun.api.crud.runtimes.nuclio.helpers.resolve_nuclio_runtime_python_image(
@@ -194,6 +288,7 @@ def _compile_function_config(
         )
     )
 
+    # For backwards compatibility, we need to adjust the runtime for old Nuclio versions
     if mlrun.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
         "0.0.0", "1.6.0"
     ) and nuclio_runtime in [
@@ -209,23 +304,10 @@ def _compile_function_config(
             # our default is python:3.9, simply set it to python:3.6 to keep supporting envs with old Nuclio
             nuclio_runtime = "python:3.6"
 
-    # In nuclio 1.6.0<=v<1.8.0, python runtimes default behavior was to not decode event strings
-    # Our code is counting on the strings to be decoded, so add the needed env var for those versions
-    if (
-        mlrun.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.6.0", "1.8.0"
-        )
-        and "NUCLIO_PYTHON_DECODE_EVENT_STRINGS" not in env_dict
-    ):
-        env_dict["NUCLIO_PYTHON_DECODE_EVENT_STRINGS"] = "true"
+    nuclio_spec.set_config("spec.runtime", nuclio_runtime)
 
-    nuclio_spec = nuclio.ConfigSpec(
-        env=env_dict,
-        external_source_env=external_source_env_dict,
-        config=function.spec.config,
-    )
-    nuclio_spec.cmd = function.spec.build.commands or []
 
+def _resolve_and_set_build_requirements(function, nuclio_spec):
     if function.spec.build.requirements:
         resolved_requirements = []
         # wrap in single quote to ensure that the requirement is treated as a single string
@@ -246,28 +328,14 @@ def _compile_function_config(
         encoded_requirements = " ".join(resolved_requirements)
         nuclio_spec.cmd.append(f"python -m pip install {encoded_requirements}")
 
-    project = function.metadata.project or "default"
-    tag = function.metadata.tag
-    handler = function.spec.function_handler
 
+def _set_build_params(function, nuclio_spec, builder_env, project, auth_info=None):
+    # handle archive build params
     if function.spec.build.source:
         mlrun.api.crud.runtimes.nuclio.helpers.compile_nuclio_archive_config(
             nuclio_spec, function, builder_env, project, auth_info=auth_info
         )
 
-    nuclio_spec.set_config("spec.runtime", nuclio_runtime)
-
-    # In Nuclio >= 1.6.x default serviceType has changed to "ClusterIP".
-    nuclio_spec.set_config(
-        "spec.serviceType",
-        function.spec.service_type or mlrun.mlconf.httpdb.nuclio.default_service_type,
-    )
-    if function.spec.readiness_timeout:
-        nuclio_spec.set_config(
-            "spec.readinessTimeoutSeconds", function.spec.readiness_timeout
-        )
-    if function.spec.resources:
-        nuclio_spec.set_config("spec.resources", function.spec.resources)
     if function.spec.no_cache:
         nuclio_spec.set_config("spec.build.noCache", True)
     if function.spec.build.functionSourceCode:
@@ -285,6 +353,9 @@ def _compile_function_config(
 
     if function.spec.base_image_pull:
         nuclio_spec.set_config("spec.build.noBaseImagesPull", False)
+
+
+def _set_function_scheduling_params(function, nuclio_spec):
     # don't send node selections if nuclio is not compatible
     if mlrun.runtimes.function.validate_nuclio_version_compatibility(
         "1.5.20", "1.6.10"
@@ -316,18 +387,9 @@ def _compile_function_config(
                 function.spec.preemption_mode,
             )
 
-    # don't send default or any priority class name if nuclio is not compatible
-    if (
-        function.spec.priority_class_name
-        and mlrun.runtimes.function.validate_nuclio_version_compatibility("1.6.18")
-        and len(mlrun.mlconf.get_valid_function_priority_class_names())
-    ):
-        nuclio_spec.set_config(
-            "spec.priorityClassName", function.spec.priority_class_name
-        )
 
+def _set_function_replicas(function, nuclio_spec):
     if function.spec.replicas:
-
         nuclio_spec.set_config(
             "spec.minReplicas",
             mlrun.utils.as_number("spec.Replicas", function.spec.replicas),
@@ -336,7 +398,6 @@ def _compile_function_config(
             "spec.maxReplicas",
             mlrun.utils.as_number("spec.Replicas", function.spec.replicas),
         )
-
     else:
         nuclio_spec.set_config(
             "spec.minReplicas",
@@ -345,6 +406,30 @@ def _compile_function_config(
         nuclio_spec.set_config(
             "spec.maxReplicas",
             mlrun.utils.as_number("spec.maxReplicas", function.spec.max_replicas),
+        )
+
+
+def _set_misc_specs(function, nuclio_spec):
+    # in Nuclio >= 1.6.x default serviceType has changed to "ClusterIP".
+    nuclio_spec.set_config(
+        "spec.serviceType",
+        function.spec.service_type or mlrun.mlconf.httpdb.nuclio.default_service_type,
+    )
+    if function.spec.readiness_timeout:
+        nuclio_spec.set_config(
+            "spec.readinessTimeoutSeconds", function.spec.readiness_timeout
+        )
+    if function.spec.resources:
+        nuclio_spec.set_config("spec.resources", function.spec.resources)
+
+    # don't send default or any priority class name if nuclio is not compatible
+    if (
+        function.spec.priority_class_name
+        and mlrun.runtimes.function.validate_nuclio_version_compatibility("1.6.18")
+        and len(mlrun.mlconf.get_valid_function_priority_class_names())
+    ):
+        nuclio_spec.set_config(
+            "spec.priorityClassName", function.spec.priority_class_name
         )
 
     if function.spec.service_account:
@@ -358,99 +443,47 @@ def _compile_function_config(
             ),
         )
 
-    if (
-        function.spec.base_spec
-        or function.spec.build.functionSourceCode
-        or function.spec.build.source
-        or function.kind == mlrun.runtimes.RuntimeKinds.serving  # serving can be empty
-    ):
-        config = function.spec.base_spec
-        if not config:
-            # if base_spec was not set (when not using code_to_function) and we have base64 code
-            # we create the base spec with essential attributes
-            config = nuclio.config.new_config()
-            mlrun.utils.update_in(config, "spec.handler", handler or "main:handler")
 
-        config = nuclio.config.extend_config(
-            config, nuclio_spec, tag, function.spec.build.code_origin
-        )
-
-        mlrun.utils.update_in(config, "metadata.name", function.metadata.name)
+def _set_source_code_and_handler(function, config):
+    if not function.spec.build.source:
+        # set the source to the mlrun serving wrapper
+        body = nuclio.build.mlrun_footer.format(mlrun.runtimes.serving.serving_subkind)
         mlrun.utils.update_in(
-            config, "spec.volumes", function.spec.generate_nuclio_volumes()
+            config,
+            "spec.build.functionSourceCode",
+            base64.b64encode(body.encode("utf-8")).decode("utf-8"),
         )
-        base_image = (
-            mlrun.utils.get_in(config, "spec.build.baseImage")
-            or function.spec.image
-            or function.spec.build.base_image
-        )
-        if base_image:
-            mlrun.utils.update_in(
-                config,
-                "spec.build.baseImage",
-                mlrun.utils.enrich_image_url(
-                    base_image, client_version, client_python_version
-                ),
-            )
-
-        logger.info("deploy started")
-        name = mlrun.runtimes.function.get_fullname(
-            function.metadata.name, project, tag
-        )
-        function.status.nuclio_name = name
-        mlrun.utils.update_in(config, "metadata.name", name)
-
-        if (
-            function.kind == mlrun.runtimes.RuntimeKinds.serving
-            and not mlrun.utils.get_in(config, "spec.build.functionSourceCode")
-        ):
-            if not function.spec.build.source:
-                # set the source to the mlrun serving wrapper
-                body = nuclio.build.mlrun_footer.format(
-                    mlrun.runtimes.serving.serving_subkind
-                )
-                mlrun.utils.update_in(
-                    config,
-                    "spec.build.functionSourceCode",
-                    base64.b64encode(body.encode("utf-8")).decode("utf-8"),
-                )
-            elif not function.spec.function_handler:
-                # point the nuclio function handler to mlrun serving wrapper handlers
-                mlrun.utils.update_in(
-                    config,
-                    "spec.handler",
-                    "mlrun.serving.serving_wrapper:handler",
-                )
-    else:
-        # this may also be called in case of using single file code_to_function(embed_code=False)
-        # this option need to be removed or be limited to using remote files (this code runs in server)
-        name, config, code = nuclio.build_file(
-            function.spec.source,
-            name=function.metadata.name,
-            project=project,
-            handler=handler,
-            tag=tag,
-            spec=nuclio_spec,
-            kind=function.spec.function_kind,
-            verbose=function.verbose,
-        )
-
+    elif not function.spec.function_handler:
+        # point the nuclio function handler to mlrun serving wrapper handlers
         mlrun.utils.update_in(
-            config, "spec.volumes", function.spec.generate_nuclio_volumes()
+            config,
+            "spec.handler",
+            "mlrun.serving.serving_wrapper:handler",
         )
-        base_image = function.spec.image or function.spec.build.base_image
-        if base_image:
-            mlrun.utils.update_in(
-                config,
-                "spec.build.baseImage",
-                mlrun.utils.enrich_image_url(
-                    base_image, client_version, client_python_version
-                ),
-            )
 
-        name = mlrun.runtimes.function.get_fullname(name, project, tag)
-        function.status.nuclio_name = name
 
-        mlrun.utils.update_in(config, "metadata.name", name)
+def _resolve_and_set_base_image(
+    function, config, client_version, client_python_version
+):
 
-    return name, project, config
+    # TODO: resolve actual image if given with `.` prefix
+    base_image = (
+        mlrun.utils.get_in(config, "spec.build.baseImage")
+        or function.spec.image
+        or function.spec.build.base_image
+    )
+    if base_image:
+        mlrun.utils.update_in(
+            config,
+            "spec.build.baseImage",
+            mlrun.utils.enrich_image_url(
+                base_image, client_version, client_python_version
+            ),
+        )
+
+
+def _set_function_name(function, config, project, tag):
+    name = mlrun.runtimes.function.get_fullname(function.metadata.name, project, tag)
+    function.status.nuclio_name = name
+    mlrun.utils.update_in(config, "metadata.name", name)
+    return name

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -26,13 +26,8 @@ import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.utils
+import mlrun.utils
 from mlrun.config import config
-from mlrun.utils import (
-    enrich_image_url,
-    get_parsed_docker_registry,
-    logger,
-    normalize_name,
-)
 
 
 def make_dockerfile(
@@ -86,7 +81,7 @@ def make_dockerfile(
         dock += f"RUN python -m pip install -r {requirements_path}\n"
     if extra:
         dock += extra
-    logger.debug("Resolved dockerfile", dockfile_contents=dock)
+    mlrun.utils.logger.debug("Resolved dockerfile", dockfile_contents=dock)
     return dock
 
 
@@ -329,7 +324,7 @@ def build_image(
 ):
     runtime_spec = runtime.spec if runtime else None
     builder_env = builder_env or {}
-    image_target, secret_name = _resolve_image_target_and_registry_secret(
+    image_target, secret_name = resolve_image_target_and_registry_secret(
         image_target, registry, secret_name
     )
     if requirements and isinstance(requirements, list):
@@ -353,7 +348,7 @@ def build_image(
             commands.append(mlrun_command)
 
     if not inline_code and not source and not commands and not requirements:
-        logger.info("skipping build, nothing to add")
+        mlrun.utils.logger.info("skipping build, nothing to add")
         return "skipped"
 
     context = "/context"
@@ -479,7 +474,9 @@ def build_image(
         return k8s.run_job(kpod)
     else:
         pod, ns = k8s.create_pod(kpod)
-        logger.info(f'started build, to watch build logs use "mlrun watch {pod} {ns}"')
+        mlrun.utils.logger.info(
+            f'started build, to watch build logs use "mlrun watch {pod} {ns}"'
+        )
         return f"build:{pod}"
 
 
@@ -597,13 +594,13 @@ def build_runtime(
         raise mlrun.errors.MLRunInvalidArgumentError(
             "build spec must have a target image, set build.image = <target image>"
         )
-    logger.info(f"building image ({build.image})")
+    mlrun.utils.logger.info(f"building image ({build.image})")
 
-    name = normalize_name(f"mlrun-build-{runtime.metadata.name}")
+    name = mlrun.utils.normalize_name(f"mlrun-build-{runtime.metadata.name}")
     base_image: str = (
         build.base_image or runtime.spec.image or config.default_base_image
     )
-    enriched_base_image = enrich_image_url(
+    enriched_base_image = mlrun.utils.enrich_image_url(
         base_image,
         client_version,
         client_python_version,
@@ -646,7 +643,7 @@ def build_runtime(
         runtime.spec.build.base_image = base_image
         return False
 
-    logger.info(f"build completed with {status}")
+    mlrun.utils.logger.info(f"build completed with {status}")
     if status in ["failed", "error"]:
         runtime.status.state = mlrun.common.schemas.FunctionState.error
         return False
@@ -655,6 +652,38 @@ def build_runtime(
     runtime.spec.image = local + build.image
     runtime.status.state = mlrun.common.schemas.FunctionState.ready
     return True
+
+
+def resolve_image_target_and_registry_secret(
+    image_target: str, registry: str = None, secret_name: str = None
+) -> (str, str):
+    if registry:
+        return "/".join([registry, image_target]), secret_name
+
+    # if dest starts with a dot, we add the configured registry to the start of the dest
+    if image_target.startswith(
+        mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX
+    ):
+
+        # remove prefix from image name
+        image_target = image_target[
+            len(mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX) :
+        ]
+
+        registry, repository = mlrun.utils.get_parsed_docker_registry()
+        secret_name = secret_name or config.httpdb.builder.docker_registry_secret
+        if not registry:
+            raise ValueError(
+                "Default docker registry is not defined, set "
+                "MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY/MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET env vars"
+            )
+        image_target_components = [registry, image_target]
+        if repository and repository not in image_target:
+            image_target_components = [registry, repository, image_target]
+
+        return "/".join(image_target_components), secret_name
+
+    return image_target, secret_name
 
 
 def _generate_builder_env(project, builder_env):
@@ -673,35 +702,3 @@ def _generate_builder_env(project, builder_env):
     for key, value in builder_env.items():
         env.append(client.V1EnvVar(name=key, value=value))
     return env
-
-
-def _resolve_image_target_and_registry_secret(
-    image_target: str, registry: str = None, secret_name: str = None
-) -> (str, str):
-    if registry:
-        return "/".join([registry, image_target]), secret_name
-
-    # if dest starts with a dot, we add the configured registry to the start of the dest
-    if image_target.startswith(
-        mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX
-    ):
-
-        # remove prefix from image name
-        image_target = image_target[
-            len(mlrun.common.constants.IMAGE_NAME_ENRICH_REGISTRY_PREFIX) :
-        ]
-
-        registry, repository = get_parsed_docker_registry()
-        secret_name = secret_name or config.httpdb.builder.docker_registry_secret
-        if not registry:
-            raise ValueError(
-                "Default docker registry is not defined, set "
-                "MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY/MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET env vars"
-            )
-        image_target_components = [registry, image_target]
-        if repository and repository not in image_target:
-            image_target_components = [registry, repository, image_target]
-
-        return "/".join(image_target_components), secret_name
-
-    return image_target, secret_name

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -650,6 +650,20 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         self._assert_deploy_called_basic_config(expected_class=self.class_name)
 
+    def test_deploy_image_with_enrich_registry_prefix(self):
+        function = self._generate_runtime(self.runtime_kind)
+        function.spec.image = ".my/image:latest"
+
+        with unittest.mock.patch(
+            "mlrun.utils.get_parsed_docker_registry",
+            return_value=["some.registry", "some-repository"],
+        ):
+            self.execute_function(function)
+            self._assert_deploy_called_basic_config(
+                expected_class=self.class_name,
+                expected_build_base_image="some.registry/some-repository/my/image:latest",
+            )
+
     @pytest.mark.parametrize(
         "requirements,expected_commands",
         [

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -653,7 +653,7 @@ def test_resolve_image_dest(image_target, registry, default_repository, expected
     config.httpdb.builder.docker_registry = default_repository
     config.httpdb.builder.docker_registry_secret = docker_registry_secret
 
-    image_target, _ = mlrun.api.utils.builder._resolve_image_target_and_registry_secret(
+    image_target, _ = mlrun.api.utils.builder.resolve_image_target_and_registry_secret(
         image_target, registry
     )
     assert image_target == expected_dest
@@ -727,7 +727,7 @@ def test_resolve_registry_secret(
     config.httpdb.builder.docker_registry = docker_registry
     config.httpdb.builder.docker_registry_secret = default_secret_name
 
-    _, secret_name = mlrun.api.utils.builder._resolve_image_target_and_registry_secret(
+    _, secret_name = mlrun.api.utils.builder.resolve_image_target_and_registry_secret(
         image_target, registry, secret_name
     )
     assert secret_name == expected_secret_name


### PR DESCRIPTION
When an image name starts with a `.`, the mlrun builder enriches the image name and with the system's docker registry url.
Before this PR it was done only on non-nuclio runtimes, and now it will happen for nuclio runtimes as well :)

Also, I refactored the extensive `_compile_function_config` by splitting it into smaller functions and adding some comments.

Resolves https://jira.iguazeng.com/browse/ML-3858 