### PR TITLE
[Launcher] Fix pipeline steps being saved as functions to the DB

### DIFF
--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -133,13 +133,15 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
         if "V3IO_USERNAME" in os.environ and "v3io_user" not in run.metadata.labels:
             run.metadata.labels["v3io_user"] = os.environ.get("V3IO_USERNAME")
 
-        logger.info(
-            "Storing function",
-            name=run.metadata.name,
-            uid=run.metadata.uid,
-            db=runtime.spec.rundb,
-        )
-        self._store_function(runtime, run)
+        # store function object in db unless running from within a run pod
+        if not runtime.is_child:
+            logger.info(
+                "Storing function",
+                name=run.metadata.name,
+                uid=run.metadata.uid,
+                db=runtime.spec.rundb,
+            )
+            self._store_function(runtime, run)
 
         execution = mlrun.run.MLClientCtx.from_dict(
             run.to_dict(),


### PR DESCRIPTION
The `TestProject::test_run` was failing on too many functions in the DB. The reason for which was the pipeline steps were saving themselves as functions to the DB as a result of the client server separation refactor. 

Reintroduced the `if not is_child` condition, as it was before the refactor, to remedy the issue.