### PR TITLE
[HTTPDB] Run compatibility check only once

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -43,6 +43,7 @@ from ..runtimes import BaseRuntime
 from ..utils import (
     datetime_to_iso,
     dict_to_json,
+    helpers,
     logger,
     new_pipe_metadata,
     normalize_name,
@@ -2584,6 +2585,7 @@ class HTTPRunDB(RunDBInterface):
         )
 
     @staticmethod
+    @helpers.run_once
     def _validate_version_compatibility(server_version, client_version) -> bool:
         try:
             parsed_server_version = semver.VersionInfo.parse(server_version)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1467,6 +1467,27 @@ def ensure_git_branch(url: str, repo: git.Repo) -> str:
     return url
 
 
+def run_once(f):
+    """A decorator to run a function only once.
+
+    NOTE: This decorator is not thread-safe and do not support async functions.
+    use with caution.
+    """
+
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            return_value = f(*args, **kwargs)
+            wrapper.response = return_value
+            return return_value
+        return wrapper.return_value
+
+    # set the initial values to ensure function will invoke at least once
+    wrapper.return_value = None
+    wrapper.has_run = False
+    return wrapper
+
+
 def is_file_path(filepath):
     root, ext = os.path.splitext(filepath)
     return os.path.isfile(filepath) and ext

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1477,9 +1477,7 @@ def run_once(f):
     def wrapper(*args, **kwargs):
         if not wrapper.has_run:
             wrapper.has_run = True
-            return_value = f(*args, **kwargs)
-            wrapper.response = return_value
-            return return_value
+            wrapper.return_value = f(*args, **kwargs)
         return wrapper.return_value
 
     # set the initial values to ensure function will invoke at least once

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -418,6 +418,9 @@ def test_version_compatibility_validation(server_version, client_version, compat
         server_version, client_version
     )
 
+    # reset has_run to ensure function can run more than once
+    HTTPRunDB._validate_version_compatibility.has_run = False
+
 
 def _create_feature_set(name):
     return {


### PR DESCRIPTION
When running an operation that performs multiple compatibility checks it spams the code with results of client vs server are not compatible but valid and etc

Added a wrapper to ensure code is running once (mind the note)