### PR TITLE
[Model Monitoring] Fix event error message in monitoring stream graph

### DIFF
--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -620,9 +620,10 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
 
         # If error key has been found in the current event,
         # increase the error counter by 1 and raise the error description
-        if "error" in event:
+        error = event.get("error")
+        if error:
             self.error_count[endpoint_id] += 1
-            raise mlrun.errors.MLRunInvalidArgumentError(f"{event['error']}")
+            raise mlrun.errors.MLRunInvalidArgumentError(str(error))
 
         # Validate event fields
         model_class = event.get("model_class") or event.get("class")


### PR DESCRIPTION
A fix for https://jira.iguazeng.com/browse/ML-3791.

When there is an error in the event dictionary, the monitoring stream graph returns `None` instead of raising an exception with the related error information. As a result, instead of getting the correct error information, the monitoring stream pod raise an error from `Storey` that can't handle a `None` event object. 

In this PR we fix this issue and raise the correct error event description instead of returning a `None` object. Therefore, storey will push the right error message to the error stream and the monitoring stream will log the right error message as expected.  