### PR TITLE
[Model Monitoring] Fix deployment of monitoring V3IO stream 

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -490,7 +490,6 @@ def _handle_job_deploy_status(
     if (logs and state != "pending") or state in terminal_states:
         resp = mlrun.api.utils.singletons.k8s.get_k8s_helper(silent=False).logs(pod)
         if state in terminal_states:
-
             # TODO: move to log collector
             log_file.parent.mkdir(parents=True, exist_ok=True)
             with log_file.open("wb") as fp:
@@ -653,13 +652,17 @@ def _build_function(
                                 fn.metadata.project,
                                 mlrun.common.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
                             )
-                            if mlrun.utils.model_monitoring.get_stream_path(
+
+                            stream_path = mlrun.utils.model_monitoring.get_stream_path(
                                 project=fn.metadata.project
-                            ).startswith("v3io://"):
+                            )
+
+                            if stream_path.startswith("v3io://"):
                                 # Initialize model monitoring V3IO stream
                                 _create_model_monitoring_stream(
                                     project=fn.metadata.project,
                                     function=fn,
+                                    stream_path=stream_path,
                                 )
 
                         if fn.spec.tracking_policy:
@@ -832,12 +835,8 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
         )
 
 
-def _create_model_monitoring_stream(project: str, function):
+def _create_model_monitoring_stream(project: str, function, stream_path):
     _init_serving_function_stream_args(fn=function)
-
-    stream_path = mlrun.mlconf.get_model_monitoring_file_target_path(
-        project=project, kind="events"
-    )
 
     _, container, stream_path = parse_model_endpoint_store_prefix(stream_path)
 


### PR DESCRIPTION
A fix for https://jira.iguazeng.com/browse/ML-3860.

Before deploying the monitoring stream nuclio function, we need to create the V3IO monitoring stream. In general, this V3IO stream is being deployed through the function `_create_model_monitoring_stream()` which being called before the deployment of the monitoring nuclio function. At the same time, the model server which writes the events to the same stream is also trying to deploy this stream (for more info see `OutputStream` object).

However, there has been a bug in `_create_model_monitoring_stream()` that created the stream in invalid path. Then, when the monitoring stream function tries to add the V3IO stream trigger on the right path, it get's an error because the stream hasn't been deployed. After 1-2 retries, the monitoring stream is able to add the trigger because the V3IO stream has been deployed during that time by the `OutputStream` object of the model server. 

In this PR we fix that bug (that probably started here - https://github.com/mlrun/mlrun/pull/3355) by providing the correct stream path to `_create_model_monitoring_stream()`.



