### PR TITLE
[Log Collector] Change log file names to old format

### DIFF
--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -211,7 +211,7 @@ func (suite *LogCollectorTestSuite) TestStreamPodLogs() {
 	suite.Require().True(started, "Log streaming didn't start")
 
 	// resolve log file path
-	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runId, pod.Name)
+	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runId)
 
 	// read log file until it has content, or timeout
 	timeout := time.After(30 * time.Second)
@@ -259,10 +259,9 @@ func (suite *LogCollectorTestSuite) TestStartLogBestEffort() {
 func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 
 	runUID := uuid.New().String()
-	podName := "my-pod"
 
 	// creat log file for runUID and pod
-	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID, podName)
+	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID)
 
 	// write log file
 	logText := "Some fake pod logs\n"
@@ -397,8 +396,6 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 
 func (suite *LogCollectorTestSuite) TestHasLogs() {
 	runUID := uuid.New().String()
-	podName := "my-pod"
-
 	request := &log_collector.HasLogsRequest{
 		RunUID:      runUID,
 		ProjectName: suite.projectName,
@@ -411,7 +408,7 @@ func (suite *LogCollectorTestSuite) TestHasLogs() {
 	suite.Require().False(hasLogsResponse.HasLogs, "Expected run to not have logs")
 
 	// create log file for runUID and pod
-	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID, podName)
+	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID)
 
 	// write log file
 	logText := "Some fake pod logs\n"
@@ -521,7 +518,7 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			for i := 0; i < testCase.logsNumToCreate; i++ {
 				runUID := uuid.New().String()
 				runUIDs = append(runUIDs, runUID)
-				logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+				logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
 				err := common.WriteToFile(logFilePath, []byte("some log"), false)
 				suite.Require().NoError(err, "Failed to write to file")
 			}
@@ -558,7 +555,7 @@ func (suite *LogCollectorTestSuite) TestDeleteProjectLogs() {
 	for i := 0; i < logsNum; i++ {
 		runUID := uuid.New().String()
 		runUIDs = append(runUIDs, runUID)
-		logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+		logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
 		err := common.WriteToFile(logFilePath, []byte("some log"), false)
 		suite.Require().NoError(err, "Failed to write to file")
 	}
@@ -596,7 +593,7 @@ func (suite *LogCollectorTestSuite) TestGetLogFilePath() {
 	suite.Require().NoError(err)
 
 	// make the run file
-	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
 	err = common.WriteToFile(runFilePath, []byte("some log"), false)
 	suite.Require().NoError(err, "Failed to write to file")
 
@@ -627,7 +624,7 @@ func (suite *LogCollectorTestSuite) TestGetLogFilePathConcurrently() {
 	suite.Require().NoError(err)
 
 	// make the run file
-	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID, "pod")
+	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
 	err = common.WriteToFile(runFilePath, []byte("some log"), false)
 	suite.Require().NoError(err, "Failed to write to file")
 

--- a/go/pkg/services/logcollector/logcollector_test.go
+++ b/go/pkg/services/logcollector/logcollector_test.go
@@ -211,7 +211,7 @@ func (suite *LogCollectorTestSuite) TestStreamPodLogs() {
 	suite.Require().True(started, "Log streaming didn't start")
 
 	// resolve log file path
-	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runId)
+	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runId)
 
 	// read log file until it has content, or timeout
 	timeout := time.After(30 * time.Second)
@@ -261,7 +261,7 @@ func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 	runUID := uuid.New().String()
 
 	// creat log file for runUID and pod
-	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID)
+	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
 
 	// write log file
 	logText := "Some fake pod logs\n"
@@ -408,7 +408,7 @@ func (suite *LogCollectorTestSuite) TestHasLogs() {
 	suite.Require().False(hasLogsResponse.HasLogs, "Expected run to not have logs")
 
 	// create log file for runUID and pod
-	logFilePath := suite.logCollectorServer.resolvePodLogFilePath(suite.projectName, runUID)
+	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
 
 	// write log file
 	logText := "Some fake pod logs\n"
@@ -518,7 +518,7 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			for i := 0; i < testCase.logsNumToCreate; i++ {
 				runUID := uuid.New().String()
 				runUIDs = append(runUIDs, runUID)
-				logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
+				logFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
 				err := common.WriteToFile(logFilePath, []byte("some log"), false)
 				suite.Require().NoError(err, "Failed to write to file")
 			}
@@ -555,7 +555,7 @@ func (suite *LogCollectorTestSuite) TestDeleteProjectLogs() {
 	for i := 0; i < logsNum; i++ {
 		runUID := uuid.New().String()
 		runUIDs = append(runUIDs, runUID)
-		logFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
+		logFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
 		err := common.WriteToFile(logFilePath, []byte("some log"), false)
 		suite.Require().NoError(err, "Failed to write to file")
 	}
@@ -593,7 +593,7 @@ func (suite *LogCollectorTestSuite) TestGetLogFilePath() {
 	suite.Require().NoError(err)
 
 	// make the run file
-	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
+	runFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
 	err = common.WriteToFile(runFilePath, []byte("some log"), false)
 	suite.Require().NoError(err, "Failed to write to file")
 
@@ -624,7 +624,7 @@ func (suite *LogCollectorTestSuite) TestGetLogFilePathConcurrently() {
 	suite.Require().NoError(err)
 
 	// make the run file
-	runFilePath := suite.logCollectorServer.resolvePodLogFilePath(projectName, runUID)
+	runFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
 	err = common.WriteToFile(runFilePath, []byte("some log"), false)
 	suite.Require().NoError(err, "Failed to write to file")
 

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -659,7 +659,7 @@ func (s *Server) startLogStreaming(ctx context.Context,
 	startedStreamingGoroutine <- true
 
 	// create a log file to the pod
-	logFilePath := s.resolvePodLogFilePath(projectName, runUID)
+	logFilePath := s.resolveRunLogFilePath(projectName, runUID)
 	if err := common.EnsureFileExists(logFilePath); err != nil {
 		s.Logger.ErrorWithCtx(ctx,
 			"Failed to ensure log file",
@@ -788,8 +788,8 @@ func (s *Server) streamPodLogs(ctx context.Context,
 	return true, nil
 }
 
-// resolvePodLogFilePath returns the path to the pod log file
-func (s *Server) resolvePodLogFilePath(projectName, runUID string) string {
+// resolveRunLogFilePath returns the path to the pod log file
+func (s *Server) resolveRunLogFilePath(projectName, runUID string) string {
 	return path.Join(s.baseDir, projectName, runUID)
 }
 
@@ -838,7 +838,7 @@ func (s *Server) getLogFilePath(ctx context.Context, runUID, projectName string)
 		}
 
 		// get run log file path
-		runLogFilePath := s.resolvePodLogFilePath(projectName, runUID)
+		runLogFilePath := s.resolveRunLogFilePath(projectName, runUID)
 
 		if exists, err := common.FileExists(runLogFilePath); err != nil {
 			s.Logger.WarnWithCtx(ctx,

--- a/mlrun/api/crud/logs.py
+++ b/mlrun/api/crud/logs.py
@@ -244,10 +244,7 @@ class Logs(
     def log_file_exists_for_run_uid(project: str, uid: str) -> (bool, pathlib.Path):
         """
         Checks if the log file exists for the given project and uid
-        There could be two types of log files:
-        1. Log file which was created by the legacy logger with the following file format - project/<run-uid>)
-        2. Log file which was created by the new logger with the following file format- /project/<run-uid>-<pod-name>
-        Therefore, we check if the log file exists for both formats
+        A Run's log file path is: /mlrun/logs/{project}/{uid}
         :param project: project name
         :param uid: run uid
         :return: True if the log file exists, False otherwise, and the log file path
@@ -255,9 +252,10 @@ class Logs(
         project_logs_dir = project_logs_path(project)
         if not project_logs_dir.exists():
             return False, None
-        for file in os.listdir(str(project_logs_dir)):
-            if file.startswith(uid):
-                return True, project_logs_dir / file
+
+        log_file = log_path(project, uid)
+        if log_file.exists():
+            return True, log_file
 
         return False, None
 

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -152,6 +152,11 @@ class LogCollectorClient(
         try:
             has_logs = await self.has_logs(run_uid, project, verbose, raise_on_error)
             if not has_logs:
+                logger.debug(
+                    "Run has no logs to collect",
+                    run_uid=run_uid,
+                    project=project,
+                )
 
                 # run has no logs - return empty logs and exit so caller won't wait for logs or retry
                 yield b""


### PR DESCRIPTION
**Issue:**
We have seen in the field that the current implementation, of storing the log files in the `<project>/<run_uid>_<pod_name>` format, proves to be problematic when getting the log files in systems with an extensive number of runs.
The issue happens when listing the logs directory to find the latest run log. Our flex fuse that mlrun is using for storing the logs cannot handle listing a directory with >2000 runs in it, and the log collector sidecar gets stuck.

**Fix:**
To fix it, we revert back to the old log file path format - `<project>/<run_uid>`.
We have done some research and found that currently each run has only one pod, and thus it will have only one file.
This enables us to remove the listDir operation to find the most recent log file, and just use the constant filename and getting it directly.

The change is relevant both in the log collector and in the API's legacy method.