### PR TITLE
[Build] Install requirements using `pip --upgrade`

### DIFF
--- a/mlrun/api/crud/runtimes/nuclio/function.py
+++ b/mlrun/api/crud/runtimes/nuclio/function.py
@@ -331,7 +331,9 @@ def _resolve_and_set_build_requirements(function, nuclio_spec):
             resolved_requirements.append(shlex.quote(requirement))
 
         encoded_requirements = " ".join(resolved_requirements)
-        nuclio_spec.cmd.append(f"python -m pip install {encoded_requirements}")
+        nuclio_spec.cmd.append(
+            f"python -m pip install --upgrade {encoded_requirements}"
+        )
 
 
 def _set_build_params(function, nuclio_spec, builder_env, project, auth_info=None):

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -78,7 +78,7 @@ def make_dockerfile(
         dock += (
             f"RUN echo 'Installing {requirements_path}...'; cat {requirements_path}\n"
         )
-        dock += f"RUN python -m pip install -r {requirements_path}\n"
+        dock += f"RUN python -m pip install --upgrade -r {requirements_path}\n"
     if extra:
         dock += extra
     mlrun.utils.logger.debug("Resolved dockerfile", dockfile_contents=dock)

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -667,21 +667,28 @@ class TestNuclioRuntime(TestRuntimeBase):
     @pytest.mark.parametrize(
         "requirements,expected_commands",
         [
-            (["pandas", "numpy"], ["python -m pip install pandas numpy"]),
+            (["pandas", "numpy"], ["python -m pip install --upgrade pandas numpy"]),
             (
                 ["-r requirements.txt", "numpy"],
-                ["python -m pip install -r requirements.txt numpy"],
+                ["python -m pip install --upgrade -r requirements.txt numpy"],
             ),
-            (["pandas>=1.0.0, <2"], ["python -m pip install 'pandas>=1.0.0, <2'"]),
-            (["pandas>=1.0.0,<2"], ["python -m pip install 'pandas>=1.0.0,<2'"]),
+            (
+                ["pandas>=1.0.0, <2"],
+                ["python -m pip install --upgrade 'pandas>=1.0.0, <2'"],
+            ),
+            (
+                ["pandas>=1.0.0,<2"],
+                ["python -m pip install --upgrade 'pandas>=1.0.0,<2'"],
+            ),
             (
                 ["-r somewhere/requirements.txt"],
-                ["python -m pip install -r somewhere/requirements.txt"],
+                ["python -m pip install --upgrade -r somewhere/requirements.txt"],
             ),
             (
                 ["something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something"],
                 [
-                    "python -m pip install 'something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something'"
+                    "python -m pip install --upgrade "
+                    "'something @ git+https://somewhere.com/a/b.git@v0.0.0#egg=something'"
                 ],
             ),
         ],
@@ -709,7 +716,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         self.execute_function(function)
         expected_commands = [
             "python -m pip install scikit-learn",
-            "python -m pip install pandas numpy",
+            "python -m pip install --upgrade pandas numpy",
         ]
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name, expected_build_commands=expected_commands


### PR DESCRIPTION
Sometimes when a user gives requirements that are already present in the base image, `pip` doesn't install them, since it didn't consider it an update.

In this PR we run `pip --upgrade` when deploying installing requested by the user, as these are specifically requested by the user so we should make an effort to install the user's version.

Resolves https://jira.iguazeng.com/browse/ML-3859