### PR TITLE
[Docs] Document building custom transformations for multiple engines

### DIFF
--- a/docs/api/mlrun.feature_store.rst
+++ b/docs/api/mlrun.feature_store.rst
@@ -9,6 +9,13 @@ mlrun.feature_store
 .. autoclass:: mlrun.feature_store.feature_set.FeatureSetSpec
 .. autoclass:: mlrun.feature_store.feature_set.FeatureSetStatus
 
+.. autoclass:: mlrun.feature_store.steps.MLRunStep
+   :members:
+   :private-members: _do_pandas, _do_storey, _do_spark
+
 .. automodule:: mlrun.feature_store.steps
+   :exclude-members: MLRunStep
    :members:
    :special-members: __init__
+
+

--- a/docs/api/mlrun.serving.rst
+++ b/docs/api/mlrun.serving.rst
@@ -9,3 +9,6 @@ mlrun.serving
 .. automodule:: mlrun.serving.remote
    :members:
    :special-members: __init__
+
+.. autoclass:: mlrun.serving.utils.StepToDict
+   :members:

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -221,7 +221,7 @@ the graph. For the `storey` engine the same instance's {py:func}`~mlrun.feature_
 function will be invoked per input row. As the graph is initialized, this class instance can receive global parameters 
 in its `__init__` method that determines its behavior.
 
-The following example class multiples a feature by a value and adds it to the event. (For simplicity, data type 
+The following example class multiplies a feature by a value and adds it to the event. (For simplicity, data type 
 checks and validations were omitted as well as needed imports.) Note that the class also extends 
 {py:class}`~mlrun.serving.utils.StepToDict` - this class implements generic serialization of graph steps to
 a python dictionary. This functionality allows passing instances of this class to `graph.to()` and `graph.add_step()`:

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -194,7 +194,7 @@ that was added previously. The class is initialized with a multiplier of 3.
 ## Supporting multiple engines
 
 MLRun supports multiple processing engines for executing graphs. These engines differ in the way they invoke graph
-steps. When implementing custom transformations, the code has to support all engines which are expected to run it. 
+steps. When implementing custom transformations, the code has to support all engines that are expected to run it. 
 
 ```{admonition} Note
 The vast majority of MLRun's built-in transformations support all engines. The support matrix is available 
@@ -207,22 +207,22 @@ The following are the main differences between transformation steps executing on
   `full_event` is configured for the step). The step is expected to process the event and return the modified event.
 * `spark` - the step receives a Spark dataframe object. Steps are expected to add their processing and calculations to 
   the dataframe (either in-place or not) and return the resulting dataframe without materializing the data. 
-* `pandas` - the step receives a Pandas dataframe, and processes it. It then returns the dataframe.
+* `pandas` - the step receives a Pandas dataframe, processes it, and returns the dataframe.
 
-To support multiple engines, a custom transformation should extend the {py:class}`~mlrun.feature_store.steps.MLRunStep` 
-class. This class allows implementing engine-specific code by overriding the following methods:
+To support multiple engines, extend the {py:class}`~mlrun.feature_store.steps.MLRunStep` class with a custom
+transformation. This class allows implementing engine-specific code by overriding the following methods:
 {py:func}`~mlrun.feature_store.steps.MLRunStep._do_storey`, {py:func}`~mlrun.feature_store.steps.MLRunStep._do_pandas` 
 and {py:func}`~mlrun.feature_store.steps.MLRunStep._do_spark`. To add support for a given engine, the relevant `do` 
 method needs to be implemented. 
 
 When a graph is executed, each step is a single instance of the relevant class that gets invoked as events flow through 
-the graph. For `spark` and `pandas` engines, this only happens once per ingestion, as the entire data-frame is fed to 
+the graph. For `spark` and `pandas` engines, this only happens once per ingestion, since the entire data-frame is fed to 
 the graph. For the `storey` engine the same instance's {py:func}`~mlrun.feature_store.steps.MLRunStep._do_storey` 
 function will be invoked per input row. As the graph is initialized, this class instance can receive global parameters 
-in its `__init__` method that will determine its behavior.
+in its `__init__` method that determines its behavior.
 
-The following example class multiples a feature by a value and adds it to the event (for simplicity, data type 
-checks and validations were omitted as well as needed imports). Note that the class also extends 
+The following example class multiples a feature by a value and adds it to the event. (For simplicity, data type 
+checks and validations were omitted as well as needed imports.) Note that the class also extends 
 {py:class}`~mlrun.serving.utils.StepToDict` - this class implements generic serialization of graph steps to
 a python dictionary. This functionality allows passing instances of this class to `graph.to()` and `graph.add_step()`:
 

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -211,14 +211,15 @@ The following are the main differences between transformation steps executing on
 
 To support multiple engines, a custom transformation should extend the {py:class}`~mlrun.feature_store.steps.MLRunStep` 
 class. This class allows implementing engine-specific code by overriding the following methods:
-`_do_storey`, `_do_pandas` and `_do_spark`. To add support for a given engine, the relevant `do` method needs to be 
-implemented. 
+{py:func}`~mlrun.feature_store.steps.MLRunStep._do_storey`, {py:func}`~mlrun.feature_store.steps.MLRunStep._do_pandas` 
+and {py:func}`~mlrun.feature_store.steps.MLRunStep._do_spark`. To add support for a given engine, the relevant `do` 
+method needs to be implemented. 
 
 When a graph is executed, each step is a single instance of the relevant class that gets invoked as events flow through 
 the graph. For `spark` and `pandas` engines, this only happens once per ingestion, as the entire data-frame is fed to 
-the graph. For the `storey` engine the same instance's `_do_storey` function will be invoked per input row. 
-As the graph is initialized, this class instance can receive global parameters in its `__init__` method that will
-determine its behavior.
+the graph. For the `storey` engine the same instance's {py:func}`~mlrun.feature_store.steps.MLRunStep._do_storey` 
+function will be invoked per input row. As the graph is initialized, this class instance can receive global parameters 
+in its `__init__` method that will determine its behavior.
 
 The following example class multiples a feature by a value and adds it to the event (for simplicity, data type 
 checks and validations were omitted as well as needed imports). Note that the class also extends 
@@ -245,17 +246,22 @@ class MultiplyFeature(StepToDict, MLRunStep):
 
     def _do_spark(self, event):
         # event is a pyspark.sql.DataFrame
-        return event.withColumn(self._new_feature, col(self._feature) * lit(self._value))
+        return event.withColumn(self._new_feature, 
+                                col(self._feature) * lit(self._value)
+                                )
 ```
 
-Using this step in a feature-set graph using the `pandas` engine. This example will add a feature called 
-`number1_times_4` with the value of the `number1` feature multiplied by 4. Note how the global parameters are sent to
-the class when defining the graph step:
+The following example uses this step in a feature-set graph with the `pandas` engine. This example adds a feature called 
+`number1_times_4` with the value of the `number1` feature multiplied by 4. Note how the global parameters are passed
+when creating the graph step:
 
 ```python
 import mlrun.feature_store as fstore
 
-feature_set = fstore.FeatureSet("fs-new", entities=[fstore.Entity("id")], engine="pandas")
+feature_set = fstore.FeatureSet("fs-new", 
+                                entities=[fstore.Entity("id")], 
+                                engine="pandas",
+                                )
 # Adding multiply step, with specific parameters
 feature_set.graph.to(MultiplyFeature(feature="number1", value=4))
 df_pandas = fstore.ingest(feature_set, data)

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -190,3 +190,74 @@ quotes_set.graph.add_step("MyMap", "multi", after="filter", multiplier=3)
 
 This uses the `add_step` function of the graph to add a step called `multi` utilizing `MyMap` after the `filter` step 
 that was added previously. The class is initialized with a multiplier of 3.
+
+## Supporting multiple engines
+
+MLRun supports multiple processing engines for executing graphs. These engines differ in the way they invoke graph
+steps. When implementing custom transformations, the code has to support all engines which are expected to run it. 
+
+```{admonition} Note
+The vast majority of MLRun's built-in transformations support all engines. The support matrix is available 
+[here](../serving/available-steps.html#data-transformations).
+```
+
+The following are the main differences between transformation steps executing on different engines:
+
+* `storey` - the step receives a single event (either as a dictionary or as an Event object, depending on whether 
+  `full_event` is configured for the step). The step is expected to process the event and return the modified event.
+* `spark` - the step receives a Spark dataframe object. Steps are expected to add their processing and calculations to 
+  the dataframe (either in-place or not) and return the resulting dataframe without materializing the data. 
+* `pandas` - the step receives a Pandas dataframe, and processes it. It then returns the dataframe.
+
+To support multiple engines, a custom transformation should extend the {py:class}`~mlrun.feature_store.steps.MLRunStep` 
+class. This class allows implementing engine-specific code by overriding the following methods:
+`_do_storey`, `_do_pandas` and `_do_spark`. To add support for a given engine, the relevant `do` method needs to be 
+implemented. 
+
+When a graph is executed, each step is a single instance of the relevant class that gets invoked as events flow through 
+the graph. For `spark` and `pandas` engines, this only happens once per ingestion, as the entire data-frame is fed to 
+the graph. For the `storey` engine the same instance's `_do_storey` function will be invoked per input row. 
+As the graph is initialized, this class instance can receive global parameters in its `__init__` method that will
+determine its behavior.
+
+The following example class multiples a feature by a value and adds it to the event (for simplicity, data type 
+checks and validations were omitted as well as needed imports):
+
+```python
+class MultiplyFeature(StepToDict, MLRunStep):
+    def __init__(self, feature: str, value: int, **kwargs):
+        super().__init__(**kwargs)
+        self._feature = feature
+        self._value = value
+        self._new_feature = f"{feature}_times_{value}"
+
+    def _do_storey(self, event):
+        # event is a single row represented by a dictionary
+        event[self._new_feature] = event[self._feature] * self._value  
+        return event
+
+    def _do_pandas(self, event):
+        # event is a pandas.DataFrame
+        event[self._new_feature] = event[self._feature].multiply(self._value)
+        return event
+
+    def _do_spark(self, event):
+        # event is a pyspark.sql.DataFrame
+        return event.withColumn(self._new_feature, col(self._feature) * lit(self._value))
+```
+
+Using this step in a feature-set graph using the `pandas` engine. This example will add a feature called 
+`number1_times_4` with the value of the `number1` feature multiplied by 4. Note how the global parameters are sent to
+the class when defining the graph step:
+
+```python
+import mlrun.feature_store as fstore
+
+feature_set = fstore.FeatureSet("fs-new", entities=[fstore.Entity("id")], engine="pandas")
+# Adding multiply step, with specific parameters
+feature_set.graph.to(MultiplyFeature(feature="number1", value=4))
+df_pandas = fstore.ingest(feature_set, data)
+```
+
+
+

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -221,7 +221,9 @@ As the graph is initialized, this class instance can receive global parameters i
 determine its behavior.
 
 The following example class multiples a feature by a value and adds it to the event (for simplicity, data type 
-checks and validations were omitted as well as needed imports):
+checks and validations were omitted as well as needed imports). Note that the class also extends 
+{py:class}`~mlrun.serving.utils.StepToDict` - this class implements generic serialization of graph steps to
+a python dictionary. This functionality allows passing instances of this class to `graph.to()` and `graph.add_step()`:
 
 ```python
 class MultiplyFeature(StepToDict, MLRunStep):

--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -42,7 +42,7 @@ class MLRunStep(MapClass):
     def __init__(self, **kwargs):
         """Abstract class for mlrun step.
         Can be used in pandas/storey/spark feature set ingestion. Extend this class and implement the relevant
-        `_do_XXX` methods to support the execution engines needed.
+        `_do_XXX` methods to support the required execution engines.
         """
         super().__init__(**kwargs)
         self._engine_to_do_method = {
@@ -56,7 +56,7 @@ class MLRunStep(MapClass):
         This method defines the do method of this class according to the first event type.
 
         .. warning::
-            When extending this class, do not override this method - only override the `_do_XXX` methods.
+            When extending this class, do not override this method; only override the `_do_XXX` methods.
         """
         engine = get_engine(event)
         self.do = self._engine_to_do_method.get(engine, None)

--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -41,7 +41,9 @@ def get_engine(first_event):
 class MLRunStep(MapClass):
     def __init__(self, **kwargs):
         """Abstract class for mlrun step.
-        Can be used in pandas/storey/spark feature set ingestion"""
+        Can be used in pandas/storey/spark feature set ingestion. Extend this class and implement the relevant
+        `_do_XXX` methods to support the execution engines needed.
+        """
         super().__init__(**kwargs)
         self._engine_to_do_method = {
             "pandas": self._do_pandas,
@@ -52,6 +54,9 @@ class MLRunStep(MapClass):
     def do(self, event):
         """
         This method defines the do method of this class according to the first event type.
+
+        .. warning::
+            When extending this class, do not override this method - only override the `_do_XXX` methods.
         """
         engine = get_engine(event)
         self.do = self._engine_to_do_method.get(engine, None)
@@ -63,12 +68,27 @@ class MLRunStep(MapClass):
         return self.do(event)
 
     def _do_pandas(self, event):
+        """
+        The execution method for pandas engine.
+
+        :param event: Incoming event, a `pandas.DataFrame` object.
+        """
         raise NotImplementedError
 
     def _do_storey(self, event):
+        """
+        The execution method for storey engine.
+
+        :param event: Incoming event, a dictionary or `storey.Event` object, depending on the `full_event` value.
+        """
         raise NotImplementedError
 
     def _do_spark(self, event):
+        """
+        The execution method for spark engine.
+
+        :param event: Incoming event, a `pyspark.sql.DataFrame` object.
+        """
         raise NotImplementedError
 
 


### PR DESCRIPTION
Adding documentation for building graph steps that support multiple engines (up until now only doc was for `storey` steps extending `MapClass`). 

As requested in https://jira.iguazeng.com/browse/ML-3670. 