### PR TITLE
[Notifications] Fix notifications pusher failing to initialize

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -51,7 +51,7 @@ class NotificationPusher(object):
             for notification in run.spec.notifications:
                 notification.status = run.status.notifications.get(
                     notification.name
-                ).status
+                ).get("status", mlrun.common.schemas.NotificationStatus.PENDING)
                 if self._should_notify(run, notification):
                     self._notification_data.append((run, notification))
 


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/ML-3887

There was an `AttributeError: 'dict' object has no attribute 'status'` because of accessing the notification status as an object instead of a dict.