### PR TITLE
[Log Collector] Remove project mutex

### DIFF
--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -467,7 +467,10 @@ func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogs
 			ErrorMessage: common.GetErrorStack(err, common.DefaultErrorStackDepth),
 		}, nil
 	}
-
+	s.Logger.DebugWithCtx(ctx,
+		"Sending Response for has logs",
+		"runUID", request.RunUID,
+		"projectName", request.ProjectName)
 	return &protologcollector.HasLogsResponse{
 		Success: true,
 		HasLogs: true,

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -40,7 +40,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -69,9 +68,6 @@ type Server struct {
 	// interval durations
 	readLogWaitTime    time.Duration
 	monitoringInterval time.Duration
-
-	// log file cache to reduce sys calls finding the log file paths.
-	logFilesCache *cache.Expiring
 }
 
 // NewLogCollectorServer creates a new log collector server

--- a/go/pkg/services/logcollector/server.go
+++ b/go/pkg/services/logcollector/server.go
@@ -1087,7 +1087,3 @@ func (s *Server) deleteProjectLogs(project string) error {
 
 	return nil
 }
-
-func (s *Server) getLogFileCacheKey(runUID, project string) string {
-	return fmt.Sprintf("%s/%s", runUID, project)
-}

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -150,7 +150,9 @@ class LogCollectorClient(
 
         # check if this run has logs to collect
         try:
+            logger.debug("Checking if run has logs to collect", run_uid=run_uid)
             has_logs = await self.has_logs(run_uid, project, verbose, raise_on_error)
+            logger.debug("Result of checking if run has logs to collect", has_logs=has_logs, run_uid=run_uid)
             if not has_logs:
                 logger.debug(
                     "Run has no logs to collect",
@@ -182,7 +184,9 @@ class LogCollectorClient(
         try_count = 0
         while True:
             try:
+                logger.debug("Getting logs", run_uid=run_uid, project=project)
                 response_stream = self._call_stream("GetLogs", request)
+                logger.debug("Got logs", run_uid=run_uid, project=project)
                 async for chunk in response_stream:
                     if not chunk.success:
                         msg = f"Failed to get logs for run {run_uid}"

--- a/mlrun/api/utils/clients/log_collector.py
+++ b/mlrun/api/utils/clients/log_collector.py
@@ -150,9 +150,7 @@ class LogCollectorClient(
 
         # check if this run has logs to collect
         try:
-            logger.debug("Checking if run has logs to collect", run_uid=run_uid)
             has_logs = await self.has_logs(run_uid, project, verbose, raise_on_error)
-            logger.debug("Result of checking if run has logs to collect", has_logs=has_logs, run_uid=run_uid)
             if not has_logs:
                 logger.debug(
                     "Run has no logs to collect",
@@ -184,9 +182,7 @@ class LogCollectorClient(
         try_count = 0
         while True:
             try:
-                logger.debug("Getting logs", run_uid=run_uid, project=project)
                 response_stream = self._call_stream("GetLogs", request)
-                logger.debug("Got logs", run_uid=run_uid, project=project)
                 async for chunk in response_stream:
                     if not chunk.success:
                         msg = f"Failed to get logs for run {run_uid}"


### PR DESCRIPTION
We had project mutex for when trying to get the filepath of the run, this was relevant for when we were listing the directory of the project because we wanted to reduce the amount IO load. Now because we already know the run log path we don't the list dir and therefor the mutex is redundant.

This PR also fixes a bug we experienced when the log collector request hung on acquiring the mutex lock which was increasing the response time by a lot.

prior to the change, you can see that between receiving the log and looking for whether to log exists it took 9sec
```
30-05-23 12:08:32.436 collector.grpcserver (D) Received has log request :: who="log-collector.grpcserver" || runUID="460bf54e40874417b2c28a2cd0a86f0e" || project="testing-logs-admin"
30-05-23 12:08:41.257 collector.grpcserver (W) Run log file not found :: who="log-collector.grpcserver" || retryCount=0 || runUID="460bf54e40874417b2c28a2cd0a86f0e" || projectName="testing-logs-admin"
```
after the removal of the mutex lock, it takes 1 milli second to find whether the file exists or not
```
30-05-23 16:05:46.550 collector.grpcserver (D) Received has log request :: project="testing-logs-admin" || who="log-collector.grpcserver" || runUID="d868e983d8374daa871df4d881bfa89d"
30-05-23 16:05:46.551 collector.grpcserver (W) Run log file not found :: who="log-collector.grpcserver" || retryCount=0 || runUID="d868e983d8374daa871df4d881bfa89d" || projectName="testing-logs-admin"
```