### PR TITLE
[Notifications] Fix sensitive data appearing in api logs

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -156,7 +156,7 @@ class NotificationPusher(object):
         )
         logger.debug(
             "Pushing notification",
-            notification=notification_object.to_dict(),
+            notification=_sanitize_notification(notification_object),
             run_uid=run.metadata.uid,
         )
         try:
@@ -346,3 +346,9 @@ class CustomNotificationPusher(object):
         if state:
             text += f", state={state}"
         self.push(text, "info", runs=runs_list)
+
+
+def _sanitize_notification(notification: mlrun.model.Notification):
+    notification_dict = notification.to_dict()
+    notification_dict.pop("params", None)
+    return notification_dict


### PR DESCRIPTION
Sanitize notification params before logging them