### PR TITLE
[Model Monitoring] Replace `endpoint_id` with `uid` to handle old model endpoint schemas

### DIFF
--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -121,7 +121,7 @@ class KVModelEndpointStore(ModelEndpointStore):
             raise mlrun.errors.MLRunNotFoundError(f"Endpoint {endpoint_id} not found")
 
         # For backwards compatability: replace null values for `error_count` and `metrics`
-        mlrun.utils.model_monitoring.validate_errors_and_metrics(endpoint=endpoint)
+        mlrun.utils.model_monitoring.validate_old_schema_fields(endpoint=endpoint)
 
         return endpoint
 

--- a/mlrun/utils/model_monitoring.py
+++ b/mlrun/utils/model_monitoring.py
@@ -162,7 +162,6 @@ def get_stream_path(project: str = None):
     """Get stream path from the project secret. If wasn't set, take it from the system configurations"""
 
     if is_running_as_api():
-
         # Running on API server side
         import mlrun.api.crud.secrets
         import mlrun.common.schemas
@@ -179,7 +178,6 @@ def get_stream_path(project: str = None):
         )
 
     else:
-
         import mlrun
 
         stream_uri = mlrun.get_secret_or_env(
@@ -205,11 +203,13 @@ def get_stream_path(project: str = None):
     return stream_uri
 
 
-def validate_errors_and_metrics(endpoint: dict):
+def validate_old_schema_fields(endpoint: dict):
     """
-    Replace default null values for `error_count` and `metrics` for users that logged a model endpoint before 1.3.0
+    Replace default null values for `error_count` and `metrics` for users that logged a model endpoint before 1.3.0.
+    In addition, this function also validates that the key name of the endpoint unique id is `uid` and not
+     `endpoint_id` that has been used before 1.3.0.
 
-    Leaving here for backwards compatibility which related to the model endpoint schema
+    Leaving here for backwards compatibility which related to the model endpoint schema.
 
     :param endpoint: An endpoint flattened dictionary.
     """
@@ -241,3 +241,10 @@ def validate_errors_and_metrics(endpoint: dict):
                 }
             }
         )
+    # Validate key `uid` instead of `endpoint_id`
+    # For backwards compatibility reasons, we replace the `endpoint_id` with `uid` which is the updated key name
+    if model_monitoring_constants.EventFieldType.ENDPOINT_ID in endpoint:
+        endpoint[model_monitoring_constants.EventFieldType.UID] = endpoint[
+            model_monitoring_constants.EventFieldType.ENDPOINT_ID
+        ]
+        endpoint.pop(model_monitoring_constants.EventFieldType.ENDPOINT_ID)

--- a/mlrun/utils/model_monitoring.py
+++ b/mlrun/utils/model_monitoring.py
@@ -247,4 +247,3 @@ def validate_old_schema_fields(endpoint: dict):
         endpoint[model_monitoring_constants.EventFieldType.UID] = endpoint[
             model_monitoring_constants.EventFieldType.ENDPOINT_ID
         ]
-        endpoint.pop(model_monitoring_constants.EventFieldType.ENDPOINT_ID)


### PR DESCRIPTION
This PR is a fix for a backwards compatibility issue when calling `get_model_endpoint` API - https://jira.iguazeng.com/browse/ML-3866.

Following #2685, the key name of the unique model endpoint id in the database is stored as `uid` instead of `endpoint_id`. However, if a model endpoint record has been stored in the KV table before #2685 (`<1.3.1`) it still has the old key name - `endpoint_id`. As a result, the `uid` key has been missing from the result of `get_model_endpoint` API  when trying to get an old model endpoint record. In this PR, we fix that issue by replacing the key name `endpoint_id` with `uid`.

