### PR TITLE
[Function] Fix deleting a function with schedule only 

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -47,6 +47,7 @@ from mlrun.api.api import deps
 from mlrun.api.api.utils import get_run_db_instance, log_and_raise, log_path
 from mlrun.api.crud.secrets import Secrets, SecretsClientType
 from mlrun.api.utils.builder import build_runtime
+from mlrun.api.utils.singletons.scheduler import get_scheduler
 from mlrun.config import config
 from mlrun.errors import MLRunRuntimeError, err_to_str
 from mlrun.run import new_function
@@ -160,6 +161,32 @@ async def delete_function(
         mlrun.common.schemas.AuthorizationAction.delete,
         auth_info,
     )
+
+    #  If the removed function has a schedule, we must delete it before deleting the function
+    schedule = await run_in_threadpool(
+        get_scheduler().get_schedule,
+        db_session,
+        project,
+        name,
+    )
+    if schedule:
+        # schedules are only supposed to be run by the chief, therefore, if the run is configured to run as scheduled,
+        # and we are running in worker, we forward the request to the chief
+        if (
+            mlrun.mlconf.httpdb.clusterization.role
+            != mlrun.common.schemas.ClusterizationRole.chief
+        ):
+            logger.info(
+                "Function has a schedule, deleting",
+                function=name,
+                project=project,
+            )
+            chief_client = mlrun.api.utils.clients.chief.Client()
+            await chief_client.delete_schedule(project=project, name=name)
+        else:
+            await run_in_threadpool(
+                get_scheduler().delete_schedule, db_session, project, name
+            )
     await run_in_threadpool(
         mlrun.api.crud.Functions().delete_function, db_session, project, name
     )

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -162,7 +162,7 @@ async def delete_function(
         auth_info,
     )
 
-    #  If the removed function has a schedule, we must delete it before deleting the function
+    #  If the requested function has a schedule, we must delete it before deleting the function
     schedule = await run_in_threadpool(
         get_scheduler().get_schedule,
         db_session,

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -170,8 +170,9 @@ async def delete_function(
         name,
     )
     if schedule:
-        # schedules are only supposed to be run by the chief, therefore, if the run is configured to run as scheduled,
-        # and we are running in worker, we forward the request to the chief
+        # when deleting a function, we should also delete its schedules if exists
+        # schedules are only supposed to be run by the chief, therefore, if the function has a schedule,
+        # and we are running in worker, we send the request to the chief client
         if (
             mlrun.mlconf.httpdb.clusterization.role
             != mlrun.common.schemas.ClusterizationRole.chief

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1056,7 +1056,6 @@ class SQLDB(DBInterface):
 
         # deleting tags and labels, because in sqlite the relationships aren't necessarily cascading
         self._delete_function_tags(session, project, name, commit=False)
-        self._delete_function_schedules(session, project, name)
         self._delete_class_labels(
             session, Function, project=project, name=name, commit=False
         )
@@ -1140,16 +1139,6 @@ class SQLDB(DBInterface):
             session.delete(obj)
         if commit:
             session.commit()
-
-    def _delete_function_schedules(self, session, project, function_name, commit=True):
-        try:
-            self.delete_schedule(session=session, project=project, name=function_name)
-        except mlrun.errors.MLRunNotFoundError:
-            logger.info(
-                "No schedules were found for function",
-                project=project,
-                function=function_name,
-            )
 
     def _list_function_tags(self, session, project, function_id):
         query = (

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -100,36 +100,6 @@ def test_store_function_not_versioned(db: DBInterface, db_session: Session):
     assert len(functions) == 1
 
 
-def test_delete_schedule_when_deleting_function(db: DBInterface, db_session: Session):
-    project_name, func_name = "project", "function"
-    func = _generate_function()
-
-    db.store_function(db_session, func.to_dict(), func.metadata.name, versioned=True)
-
-    # creating a schedule for the created function
-    db.create_schedule(
-        db_session,
-        project=project_name,
-        name=func_name,
-        kind=mlrun.common.schemas.ScheduleKinds.local_function,
-        scheduled_object="*/15 * * * *",
-        cron_trigger=mlrun.common.schemas.ScheduleCronTrigger(minute="*/15"),
-        concurrency_limit=15,
-    )
-
-    # get the schedule and make sure it was created
-    schedule = db.get_schedule(session=db_session, project=project_name, name=func_name)
-    assert schedule.name == func_name
-
-    db.delete_function(session=db_session, project=project_name, name=func_name)
-
-    # ensure that both the function and the schedule have been removed
-    with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        db.get_function(session=db_session, project=project_name, name=func_name)
-    with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        db.get_schedule(session=db_session, project=project_name, name=func_name)
-
-
 def test_get_function_by_hash_key(db: DBInterface, db_session: Session):
     function_1 = _generate_function()
     function_hash_key = db.store_function(


### PR DESCRIPTION
fix for previous PR: https://github.com/mlrun/mlrun/pull/3642
resolves: https://jira.iguazeng.com/browse/ML-933

Schedules are supposed to be operated only by the chief, therefore, in this PR, we shift the deletion of the schedule to the `delete_function` endpoint and ensure that the delete request is sent only by the chief.

