### PR TITLE
[Functions] Add usability fixes to build function 

### DIFF
--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -663,8 +663,6 @@ def build_runtime(
 def resolve_image_target_and_registry_secret(
     image_target: str, registry: str = None, secret_name: str = None
 ) -> (str, str):
-    mlrun.utils.logger.debug("Innnnn!!!")
-    mlrun.utils.logger.info("Innnnn!!!")
     if registry:
         return "/".join([registry, image_target]), secret_name
 

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -663,6 +663,8 @@ def build_runtime(
 def resolve_image_target_and_registry_secret(
     image_target: str, registry: str = None, secret_name: str = None
 ) -> (str, str):
+    mlrun.utils.logger.debug("Innnnn!!!")
+    mlrun.utils.logger.info("Innnnn!!!")
     if registry:
         return "/".join([registry, image_target]), secret_name
 

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -689,6 +689,9 @@ def resolve_image_target_and_registry_secret(
 
         return "/".join(image_target_components), secret_name
 
+    if image_target.startswith("http"):
+        image_target.removeprefix("https://").removeprefix("http://")
+
     return image_target, secret_name
 
 

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import warnings
 from typing import Dict, List, Optional, Union
 
 import kfp

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -263,16 +263,6 @@ def build_function(
     :param overwrite_build_params:  overwrite the function build parameters with the provided ones, or attempt to add
      to existing parameters
     """
-
-    def _remove_image_protocol_prefix(image_name):
-        prefixes = ["https://", "https://"]
-        if any(prefix in image_name for prefix in prefixes):
-            warnings.warn(
-                "The image has an unexpected protocol prefix, The prefix was removed."
-            )
-            image_name = image_name.removeprefix("https://").removeprefix("http://")
-        return image_name
-
     engine, function = _get_engine_and_function(function, project_object)
     if function.kind in mlrun.runtimes.RuntimeKinds.nuclio_runtimes():
         raise mlrun.errors.MLRunInvalidArgumentError(
@@ -294,7 +284,6 @@ def build_function(
             skip_deployed=skip_deployed,
         )
     else:
-        image = _remove_image_protocol_prefix(image)
         function.build_config(
             image=image,
             base_image=base_image,
@@ -303,21 +292,13 @@ def build_function(
             requirements=requirements,
             overwrite=overwrite_build_params,
         )
-        try:
-            ready = function.deploy(
-                watch=True,
-                with_mlrun=with_mlrun,
-                skip_deployed=skip_deployed,
-                mlrun_version_specifier=mlrun_version_specifier,
-                builder_env=builder_env,
-            )
-        except mlrun.errors.MLRunRuntimeError as exc:
-            if not secret_name and not image.startswith("."):
-                warnings.warn(
-                    "There is no prefix for the image name, and no secret is provided."
-                    " Try again using a prefix (use '.' for local registry), or supply a docker registry secret.",
-                )
-            raise exc
+        ready = function.deploy(
+            watch=True,
+            with_mlrun=with_mlrun,
+            skip_deployed=skip_deployed,
+            mlrun_version_specifier=mlrun_version_specifier,
+            builder_env=builder_env,
+        )
 
         # return object with the same outputs as the KFP op (allow using the same pipeline)
         return BuildStatus(ready, {"image": function.spec.image}, function=function)

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -268,7 +268,7 @@ def build_function(
         prefixes = ["https://", "https://"]
         if any(prefix in image_name for prefix in prefixes):
             warnings.warn(
-                "The image has an unexpected protocol prefix. The prefix was removed"
+                "The image has an unexpected protocol prefix, The prefix was removed."
             )
             image_name = image_name.removeprefix("https://").removeprefix("http://")
         return image_name
@@ -315,7 +315,7 @@ def build_function(
             if not secret_name and not image.startswith("."):
                 warnings.warn(
                     "There is no prefix for the image name, and no secret is provided."
-                    " Try again using a prefix or supply a Docker registry secret",
+                    " Try again using a prefix (use '.' for local registry), or supply a docker registry secret.",
                 )
             raise exc
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2373,21 +2373,31 @@ class MlrunProject(ModelObj):
         :param overwrite_build_params:  overwrite the function build parameters with the provided ones, or attempt to
          add to existing parameters
         """
-        return build_function(
-            function,
-            with_mlrun=with_mlrun,
-            skip_deployed=skip_deployed,
-            image=image,
-            base_image=base_image,
-            commands=commands,
-            secret_name=secret_name,
-            requirements=requirements,
-            requirements_file=requirements_file,
-            mlrun_version_specifier=mlrun_version_specifier,
-            builder_env=builder_env,
-            project_object=self,
-            overwrite_build_params=overwrite_build_params,
-        )
+        image = image.removeprefix("https://").removeprefix("http://")
+        try:
+            return build_function(
+                function,
+                with_mlrun=with_mlrun,
+                skip_deployed=skip_deployed,
+                image=image,
+                base_image=base_image,
+                commands=commands,
+                secret_name=secret_name,
+                requirements=requirements,
+                requirements_file=requirements_file,
+                mlrun_version_specifier=mlrun_version_specifier,
+                builder_env=builder_env,
+                project_object=self,
+                overwrite_build_params=overwrite_build_params,
+            )
+        except mlrun.errors.MLRunRuntimeError as exc:
+            if not secret_name and image.startswith("."):
+                logger.warnning(
+                    "There is no prefix for the image name, and no secret is provided. Try again using a prefix or supply a Docker registry secret",
+                    image=image,
+                    secret_name=secret_name,
+                )
+                raise exc
 
     def build_config(
         self,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2373,31 +2373,21 @@ class MlrunProject(ModelObj):
         :param overwrite_build_params:  overwrite the function build parameters with the provided ones, or attempt to
          add to existing parameters
         """
-        image = image.removeprefix("https://").removeprefix("http://")
-        try:
-            return build_function(
-                function,
-                with_mlrun=with_mlrun,
-                skip_deployed=skip_deployed,
-                image=image,
-                base_image=base_image,
-                commands=commands,
-                secret_name=secret_name,
-                requirements=requirements,
-                requirements_file=requirements_file,
-                mlrun_version_specifier=mlrun_version_specifier,
-                builder_env=builder_env,
-                project_object=self,
-                overwrite_build_params=overwrite_build_params,
-            )
-        except mlrun.errors.MLRunRuntimeError as exc:
-            if not secret_name and image.startswith("."):
-                logger.warnning(
-                    "There is no prefix for the image name, and no secret is provided. Try again using a prefix or supply a Docker registry secret",
-                    image=image,
-                    secret_name=secret_name,
-                )
-                raise exc
+        return build_function(
+            function,
+            with_mlrun=with_mlrun,
+            skip_deployed=skip_deployed,
+            image=image,
+            base_image=base_image,
+            commands=commands,
+            secret_name=secret_name,
+            requirements=requirements,
+            requirements_file=requirements_file,
+            mlrun_version_specifier=mlrun_version_specifier,
+            builder_env=builder_env,
+            project_object=self,
+            overwrite_build_params=overwrite_build_params,
+        )
 
     def build_config(
         self,

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -259,7 +259,6 @@ class KubejobRuntime(KubeResource):
             raise mlrun.errors.MLRunRuntimeError("Deploy failed")
         return ready
 
-
     def _remove_image_protocol_prefix(self, image):
         prefixes = ["https://", "https://"]
         if any(prefix in image for prefix in prefixes):

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -143,21 +143,26 @@ class TestProject(TestMLRunSystem):
             )
             assert len(w) == 1
             assert (
-                "There is no prefix for the image name, and no secret is provided."
-                " Try again using a prefix (use '.' for local registry), or supply a docker registry secret."
+                "Failed to deploy function,  unable to push image to the specified docker registry."
+                "If you wish to use the default configured registry, place '.' before the supplied image name,"
+                "or, if you want to upload your image to dockerhub or another remote registry,"
+                " please include a repository in the provided image."
+                " make sure to provide a docker registry secret in your request if necessary."
                 in str(w[-1].message)
             )
 
         with warnings.catch_warnings(record=True) as w:
             self.project.build_function(
                 fn,
-                image="https://docker-registry.default-tenant.app.cust-cs-il-3-5-2.iguazio-cd2.com/test/image:v3",
+                image=f"https://{mlrun.config.config.httpdb.builder.docker_registry}/test/image:v3",
                 base_image="mlrun/mlrun",
                 commands=["echo 1"],
             )
             assert len(w) == 1
             assert (
-                "The image has an unexpected protocol prefix, The prefix was removed."
+                "The image has an unexpected protocol prefix ('http://' or 'https://'),"
+                " if you wish to use the default configured registry, no protocol prefix is required "
+                "(note that you can also simply use '.' instead of the full URL). "
                 in str(w[-1].message)
             )
 


### PR DESCRIPTION
fixes for: [ML-3826](https://jira.iguazeng.com/browse/ML-3826), [ML-3827](https://jira.iguazeng.com/browse/ML-3827)

Adding a warning to the user if a local registry image is provided without a prefix or if a protocol prefix is passed.

![image](https://github.com/mlrun/mlrun/assets/62285310/e6b16a57-3bcf-4505-a971-1c372029c25d)

![image](https://github.com/mlrun/mlrun/assets/62285310/9d89c4e6-9240-41fb-8304-a8673eb5ae3f)
