### PR TITLE
[Datastore] Fix DataItem as DF from url with query params

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import sys
 import tempfile
+import urllib.parse
 from base64 import b64encode
 from os import path, remove
 
@@ -148,13 +149,15 @@ class DataStore:
         **kwargs,
     ):
         df_module = df_module or pd
-        if url.endswith(".csv") or format == "csv":
+        parsed_url = urllib.parse.urlparse(url)
+        filepath = parsed_url.path
+        if filepath.endswith(".csv") or format == "csv":
             if columns:
                 kwargs["usecols"] = columns
             reader = df_module.read_csv
             filesystem = self.get_filesystem()
             if filesystem:
-                if filesystem.isdir(url):
+                if filesystem.isdir(filepath):
 
                     def reader(*args, **kwargs):
                         base_path = args[0]
@@ -176,7 +179,11 @@ class DataStore:
                             dfs.append(df_module.read_csv(*updated_args, **kwargs))
                         return pd.concat(dfs)
 
-        elif url.endswith(".parquet") or url.endswith(".pq") or format == "parquet":
+        elif (
+            filepath.endswith(".parquet")
+            or filepath.endswith(".pq")
+            or format == "parquet"
+        ):
             if columns:
                 kwargs["columns"] = columns
 
@@ -208,7 +215,7 @@ class DataStore:
 
                 return df_module.read_parquet(*args, **kwargs)
 
-        elif url.endswith(".json") or format == "json":
+        elif filepath.endswith(".json") or format == "json":
             reader = df_module.read_json
 
         else:

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -40,6 +40,13 @@ def test_http_fs_parquet_as_df():
     data_item.as_df()
 
 
+def test_http_fs_parquet_with_params_as_df():
+    data_item = mlrun.datastore.store_manager.object(
+        "https://s3.wasabisys.com/iguazio/data/market-palce/aggregate/metrics.pq?param1=1&param2=2"
+    )
+    data_item.as_df()
+
+
 def test_s3_fs_parquet_as_df():
     data_item = mlrun.datastore.store_manager.object(
         "s3://aws-roda-hcls-datalake/gnomad/chrm/run-DataSink0-1-part-block-0-r-00009-snappy.parquet"


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-525
Check the file extension of the actual file in the URL and not the suffix of the URL itself as it may contain query params