### PR TITLE
[Feature Store] Raise a clear error when no features are found on retrieval

### DIFF
--- a/mlrun/feature_store/retrieval/online.py
+++ b/mlrun/feature_store/retrieval/online.py
@@ -69,6 +69,10 @@ def init_feature_vector_graph(vector, query_options, update_stats=False):
     feature_set_objects, feature_set_fields = vector.parse_features(
         offline=False, update_stats=update_stats
     )
+    if not feature_set_fields:
+        raise mlrun.errors.MLRunRuntimeError(
+            f"No features found for feature vector '{vector.metadata.name}'"
+        )
     graph = _build_feature_vector_graph(
         vector, feature_set_fields, feature_set_objects, query_options
     )

--- a/tests/integration/sdk_api/feature_store/test_feature_store.py
+++ b/tests/integration/sdk_api/feature_store/test_feature_store.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pandas as pd
 import pytest
 
 import mlrun
 import mlrun.feature_store as fstore
 import tests.integration.sdk_api.base
+from mlrun.data_types import InferOptions
 from mlrun.datastore import StreamSource
 from mlrun.features import Entity
 
@@ -39,3 +41,44 @@ class TestFeatureStore(tests.integration.sdk_api.base.TestMLRunIntegration):
                 featureset=fset,
                 source=v3io_source,
             )
+
+    def test_get_online_features_after_ingest_without_inference(self):
+        feature_set = fstore.FeatureSet(
+            "my-fset",
+            entities=[
+                fstore.Entity("fn0"),
+                fstore.Entity(
+                    "fn1",
+                    value_type=mlrun.data_types.data_types.ValueType.STRING,
+                ),
+            ],
+        )
+        # feature_set.set_targets(
+        #     targets=[mlrun.datastore.NoSqlTarget()], with_defaults=False
+        # )
+        # feature_set.save()
+
+        df = pd.DataFrame(
+            {
+                "fn0": [1, 2, 3, 4],
+                "fn1": [1, 2, 3, 4],
+                "fn2": [1, 1, 1, 1],
+                "fn3": [2, 2, 2, 2],
+            }
+        )
+
+        fstore.ingest(feature_set, df, infer_options=InferOptions.Null)
+
+        features = ["my-fset.*"]
+        vector = fstore.FeatureVector("my-vector", features)
+        vector.save()
+
+        sv = fstore.get_online_feature_service(
+            f"store://feature-vectors/{self.project_name}/my-vector:latest"
+        )
+        try:
+            with pytest.raises(mlrun.errors.MLRunRuntimeError) as err:
+                sv.get([{"fn0": "1", "fn1": "1"}])
+        finally:
+            sv.close()
+        assert err.value == "No features found for feature vector 'my-vector'"

--- a/tests/integration/sdk_api/feature_store/test_feature_store.py
+++ b/tests/integration/sdk_api/feature_store/test_feature_store.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pandas as pd
 import pytest
 
 import mlrun
 import mlrun.feature_store as fstore
 import tests.integration.sdk_api.base
-from mlrun.data_types import InferOptions
 from mlrun.datastore import StreamSource
 from mlrun.features import Entity
 
@@ -41,44 +39,3 @@ class TestFeatureStore(tests.integration.sdk_api.base.TestMLRunIntegration):
                 featureset=fset,
                 source=v3io_source,
             )
-
-    def test_get_online_features_after_ingest_without_inference(self):
-        feature_set = fstore.FeatureSet(
-            "my-fset",
-            entities=[
-                fstore.Entity("fn0"),
-                fstore.Entity(
-                    "fn1",
-                    value_type=mlrun.data_types.data_types.ValueType.STRING,
-                ),
-            ],
-        )
-        # feature_set.set_targets(
-        #     targets=[mlrun.datastore.NoSqlTarget()], with_defaults=False
-        # )
-        # feature_set.save()
-
-        df = pd.DataFrame(
-            {
-                "fn0": [1, 2, 3, 4],
-                "fn1": [1, 2, 3, 4],
-                "fn2": [1, 1, 1, 1],
-                "fn3": [2, 2, 2, 2],
-            }
-        )
-
-        fstore.ingest(feature_set, df, infer_options=InferOptions.Null)
-
-        features = ["my-fset.*"]
-        vector = fstore.FeatureVector("my-vector", features)
-        vector.save()
-
-        sv = fstore.get_online_feature_service(
-            f"store://feature-vectors/{self.project_name}/my-vector:latest"
-        )
-        try:
-            with pytest.raises(mlrun.errors.MLRunRuntimeError) as err:
-                sv.get([{"fn0": "1", "fn1": "1"}])
-        finally:
-            sv.close()
-        assert err.value == "No features found for feature vector 'my-vector'"

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4063,6 +4063,41 @@ class TestFeatureStore(TestMLRunSystem):
         ):
             fstore.ingest(measurements, source)
 
+    def test_get_online_features_after_ingest_without_inference(self):
+        feature_set = fstore.FeatureSet(
+            "my-fset",
+            entities=[
+                fstore.Entity("fn0"),
+                fstore.Entity(
+                    "fn1",
+                    value_type=mlrun.data_types.data_types.ValueType.STRING,
+                ),
+            ],
+        )
+
+        df = pd.DataFrame(
+            {
+                "fn0": [1, 2, 3, 4],
+                "fn1": [1, 2, 3, 4],
+                "fn2": [1, 1, 1, 1],
+                "fn3": [2, 2, 2, 2],
+            }
+        )
+
+        fstore.ingest(feature_set, df, infer_options=InferOptions.Null)
+
+        features = ["my-fset.*"]
+        vector = fstore.FeatureVector("my-vector", features)
+        vector.save()
+
+        with pytest.raises(
+            mlrun.errors.MLRunRuntimeError,
+            match="No features found for feature vector 'my-vector'",
+        ):
+            fstore.get_online_feature_service(
+                f"store://feature-vectors/{self.project_name}/my-vector:latest"
+            )
+
 
 def verify_purge(fset, targets):
     fset.reload(update_spec=False)

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4063,6 +4063,7 @@ class TestFeatureStore(TestMLRunSystem):
         ):
             fstore.ingest(measurements, source)
 
+    # ML-3900
     def test_get_online_features_after_ingest_without_inference(self):
         feature_set = fstore.FeatureSet(
             "my-fset",


### PR DESCRIPTION
[ML-3900](https://jira.iguazeng.com/browse/ML-3900)

Before this change, the error raised was
```
AttributeError: 'RootFlowStep' object has no attribute 'respond'
```

After this change, the error raised will be
```
MLRunRuntimeError: No features found for feature vector <vector name>
```