### PR TITLE
[Project] Fix project.clear_context() deletes all the context and not subpath

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2159,7 +2159,9 @@ class MlrunProject(ModelObj):
                 logger.info(f"Subpath is defined, Clearing path: {path_to_clear}")
             else:
                 path_to_clear = self.spec.context
-                logger.info(f"Subpath is not defined, Clearing context: {path_to_clear}")
+                logger.info(
+                    f"Subpath is not defined, Clearing context: {path_to_clear}"
+                )
             if path.exists(path_to_clear) and path.isdir(path_to_clear):
                 shutil.rmtree(path_to_clear)
             else:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -16,6 +16,7 @@ import getpass
 import glob
 import http
 import json
+import os.path
 import pathlib
 import shutil
 import tempfile
@@ -34,6 +35,7 @@ import kfp
 import nuclio
 import requests
 import yaml
+from deprecated import deprecated
 
 import mlrun.common.model_monitoring as model_monitoring_constants
 import mlrun.common.schemas
@@ -2135,14 +2137,40 @@ class MlrunProject(ModelObj):
             notifiers=notifiers,
         )
 
+    # TODO: remove in 1.6.0
+    @deprecated(
+        version="1.4.0",
+        reason="'clear_context' will be removed in 1.6.0, this can cause unexpected issues",
+        category=FutureWarning,
+    )
     def clear_context(self):
         """delete all files and clear the context dir"""
-        if (
-            self.spec.context
-            and path.exists(self.spec.context)
-            and path.isdir(self.spec.context)
-        ):
-            shutil.rmtree(self.spec.context)
+        warnings.warn(
+            "This method deletes all files and clears the context directory or subdirectory (if defined)!"
+            "  Please keep in mind that this method can produce unexpected outcomes and is not recommended,"
+            " it will be deprecated in 1.6.0."
+        )
+        # clear only if the context path exists and not relative
+        if self.spec.context and os.path.isabs(self.spec.context):
+
+            # if a subpath is defined, will empty the subdir instead of the entire context
+            path_to_clear = (
+                path.join(self.spec.context, self.spec.subpath)
+                if self.spec.subpath
+                else self.spec.context
+            )
+            if path.exists(path_to_clear) and path.isdir(path_to_clear):
+                shutil.rmtree(path_to_clear)
+            else:
+                logger.warn(
+                    f"Attempt to clear {path} failed."
+                    f" Please ensure that your context or subdir is properly defined."
+                )
+        else:
+            logger.warn(
+                "Your context path is a relative path;"
+                " in order to avoid unexpected results, we do not allow the deletion of relative paths."
+            )
 
     def save(self, filepath=None, store=True):
         """export project to yaml file and save project in database

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2146,7 +2146,7 @@ class MlrunProject(ModelObj):
     def clear_context(self):
         """delete all files and clear the context dir"""
         warnings.warn(
-            "This method deletes all files and clears the context directory or subdirectory (if defined)!"
+            "This method deletes all files and clears the context directory or subpath (if defined)!"
             "  Please keep in mind that this method can produce unexpected outcomes and is not recommended,"
             " it will be deprecated in 1.6.0."
         )
@@ -2154,17 +2154,18 @@ class MlrunProject(ModelObj):
         if self.spec.context and os.path.isabs(self.spec.context):
 
             # if a subpath is defined, will empty the subdir instead of the entire context
-            path_to_clear = (
-                path.join(self.spec.context, self.spec.subpath)
-                if self.spec.subpath
-                else self.spec.context
-            )
+            if self.spec.subpath:
+                path_to_clear = path.join(self.spec.context, self.spec.subpath)
+                logger.info(f"Subpath is defined, Clearing path: {path_to_clear}")
+            else:
+                path_to_clear = self.spec.context
+                logger.info(f"Subpath is not defined, Clearing context: {path_to_clear}")
             if path.exists(path_to_clear) and path.isdir(path_to_clear):
                 shutil.rmtree(path_to_clear)
             else:
                 logger.warn(
-                    f"Attempt to clear {path} failed."
-                    f" Please ensure that your context or subdir is properly defined."
+                    f"Attempt to clear {path_to_clear} failed. Path either does not exist or is not a directory."
+                    " Please ensure that your context or subdpath are properly defined."
                 )
         else:
             logger.warn(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 #
 import os
+import os.path
 import pathlib
 import shutil
 import tempfile
 import unittest.mock
+import warnings
 import zipfile
 from contextlib import nullcontext as does_not_raise
 
@@ -813,6 +815,44 @@ def test_project_ops():
     run = proj2.run_function("f2", params={"x": 2}, local=True)
     assert run.spec.function.startswith("proj2/f2")
     assert run.output("y") == 4  # = x * 2
+
+
+def test_clear_context():
+    proj = mlrun.new_project("proj", save=False)
+    proj_with_subpath = mlrun.new_project(
+        "proj",
+        subpath="test",
+        context=pathlib.Path(tests.conftest.tests_root_directory),
+        save=False,
+    )
+    subdir_path = os.path.join(
+        proj_with_subpath.spec.context, proj_with_subpath.spec.subpath
+    )
+    # when the context is relative, assert no deletion called
+    with unittest.mock.patch(
+        "shutil.rmtree", return_value=True
+    ) as rmtree, warnings.catch_warnings(record=True) as w:
+        proj.clear_context()
+        rmtree.assert_not_called()
+
+        assert len(w) == 2
+        assert issubclass(w[-2].category, FutureWarning)
+        assert (
+            "This method deletes all files and clears the context directory or subdirectory (if defined)!."
+            "  Please keep in mind that this method can produce unexpected outcomes and is not recommended,"
+            " it will be deprecated in 1.6.0." in str(w[-1].message)
+        )
+
+    # when the context is not relative and subdir specified, assert that the subdir is deleted rather than the context
+    with unittest.mock.patch(
+        "shutil.rmtree", return_value=True
+    ) as rmtree, unittest.mock.patch(
+        "os.path.exists", return_value=True
+    ), unittest.mock.patch(
+        "os.path.isdir", return_value=True
+    ):
+        proj_with_subpath.clear_context()
+        rmtree.assert_called_once_with(subdir_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -838,7 +838,7 @@ def test_clear_context():
         assert len(w) == 2
         assert issubclass(w[-2].category, FutureWarning)
         assert (
-            "This method deletes all files and clears the context directory or subdirectory (if defined)!."
+            "This method deletes all files and clears the context directory or subpath (if defined)!"
             "  Please keep in mind that this method can produce unexpected outcomes and is not recommended,"
             " it will be deprecated in 1.6.0." in str(w[-1].message)
         )


### PR DESCRIPTION
resolves: https://jira.iguazeng.com/browse/ML-3621

The` clear_context()` method deleted all the context with no warning, this action is extremely dangerous, essentially deleting everything in the context dir. 
Since the context is by default` ./`, if the user changed working directory for example, then very bad and unexpected things can happen.

In this PR, a deprecation warning for 1.6.0 was included, and for the time being:
- Issue a warning to the user
- If the context is a relative path, no action is taken
- If a subpath exists, it is considered and only the sub dir is cleared
