### PR TITLE
[LogCollector] Stop log collection for pod in unknown state

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -431,7 +431,9 @@ async def _verify_log_collection_stopped_on_startup():
             db_session,
             requested_logs_modes=[True],
             only_uids=False,
-            states=mlrun.runtimes.constants.RunStates.terminal_states(),
+            states=mlrun.runtimes.constants.RunStates.terminal_states() + [
+                mlrun.runtimes.constants.RunStates.unknown,
+            ],
         )
 
         if len(runs) > 0:

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -433,6 +433,9 @@ async def _verify_log_collection_stopped_on_startup():
             only_uids=False,
             states=mlrun.runtimes.constants.RunStates.terminal_states()
             + [
+
+                # add unknown state as well, as it's possible that the run reached such state
+                # usually it happens when run pods get preempted
                 mlrun.runtimes.constants.RunStates.unknown,
             ],
         )

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -433,7 +433,6 @@ async def _verify_log_collection_stopped_on_startup():
             only_uids=False,
             states=mlrun.runtimes.constants.RunStates.terminal_states()
             + [
-
                 # add unknown state as well, as it's possible that the run reached such state
                 # usually it happens when run pods get preempted
                 mlrun.runtimes.constants.RunStates.unknown,

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -431,7 +431,8 @@ async def _verify_log_collection_stopped_on_startup():
             db_session,
             requested_logs_modes=[True],
             only_uids=False,
-            states=mlrun.runtimes.constants.RunStates.terminal_states() + [
+            states=mlrun.runtimes.constants.RunStates.terminal_states()
+            + [
                 mlrun.runtimes.constants.RunStates.unknown,
             ],
         )

--- a/tests/api/test_collect_runs_logs.py
+++ b/tests/api/test_collect_runs_logs.py
@@ -324,16 +324,27 @@ class TestCollectRunSLogs:
         log_collector = mlrun.api.utils.clients.log_collector.LogCollectorClient()
 
         project_name = "some-project"
-        run_uids = ["some_uid", "some_uid2", "some_uid3"]
-        for run_uid in run_uids:
+
+        # iterate over some runs, for each run assign different state
+        run_uids_to_state = [
+            ("some_uid", mlrun.runtimes.constants.RunStates.completed),
+            ("some_uid2", mlrun.runtimes.constants.RunStates.unknown),
+            ("some_uid3", mlrun.runtimes.constants.RunStates.completed),
+            ("some_uid4", mlrun.runtimes.constants.RunStates.completed),
+            # keep it last, as we later on omit it from the run_uids list
+            ("some_uid5", mlrun.runtimes.constants.RunStates.running),
+        ]
+        for run_uid, state in run_uids_to_state:
             _create_new_run(
                 db,
                 project_name,
                 uid=run_uid,
                 name=run_uid,
                 kind="job",
-                state=mlrun.runtimes.constants.RunStates.completed,
+                state=state,
             )
+
+        run_uids = [run_uid for run_uid, _ in run_uids_to_state]
 
         # update requested logs field to True
         mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs(
@@ -345,7 +356,7 @@ class TestCollectRunSLogs:
             requested_logs_modes=[True],
             only_uids=False,
         )
-        assert len(runs) == 3
+        assert len(runs) == 5
 
         log_collector._call = unittest.mock.AsyncMock(return_value=None)
 
@@ -355,7 +366,10 @@ class TestCollectRunSLogs:
         assert log_collector._call.call_args[0][0] == "StopLogs"
         stop_log_request = log_collector._call.call_args[0][1]
         assert stop_log_request.project == project_name
-        assert len(stop_log_request.runUIDs) == 3
+
+        # one of the runs is in running state
+        run_uids = run_uids[: len(run_uids) - 1]
+        assert len(stop_log_request.runUIDs) == len(run_uids)
         assert (
             deepdiff.DeepDiff(
                 list(stop_log_request.runUIDs),
@@ -375,7 +389,7 @@ class TestCollectRunSLogs:
             requested_logs_modes=[True],
             only_uids=False,
         )
-        assert len(runs) == 2
+        assert len(runs) == 4
 
         await mlrun.api.main._verify_log_collection_stopped_on_startup()
 
@@ -383,7 +397,7 @@ class TestCollectRunSLogs:
         assert log_collector._call.call_args[0][0] == "StopLogs"
         stop_log_request = log_collector._call.call_args[0][1]
         assert stop_log_request.project == project_name
-        assert len(stop_log_request.runUIDs) == 2
+        assert len(stop_log_request.runUIDs) == 3
         assert (
             deepdiff.DeepDiff(
                 list(stop_log_request.runUIDs),


### PR DESCRIPTION
run might get into unknown state when its pod get evicted or moved from one node to another