### PR TITLE
Revert "[API] Enrich function object before build"

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -37,7 +37,6 @@ from sqlalchemy.orm import Session
 import mlrun.api.crud
 import mlrun.api.crud.runtimes.nuclio.function
 import mlrun.api.db.session
-import mlrun.api.launcher
 import mlrun.api.utils.auth.verifier
 import mlrun.api.utils.background_tasks
 import mlrun.api.utils.clients.chief
@@ -663,7 +662,6 @@ def _build_function(
     ready = None
     try:
         fn = new_function(runtime=function)
-        mlrun.api.launcher.ServerSideLauncher.enrich_runtime(runtime=fn)
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(

--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -55,7 +55,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
         notifications: Optional[List[mlrun.model.Notification]] = None,
         returns: Optional[List[Union[str, Dict[str, str]]]] = None,
     ) -> mlrun.run.RunObject:
-        self.enrich_runtime(runtime, project)
+        self._enrich_runtime(runtime, project)
 
         run = self._create_run_object(task)
 
@@ -146,7 +146,7 @@ class ServerSideLauncher(mlrun.launcher.base.BaseLauncher):
         return self._wrap_run_result(runtime, result, run, err=last_err)
 
     @staticmethod
-    def enrich_runtime(
+    def _enrich_runtime(
         runtime: "mlrun.runtimes.base.BaseRuntime", project: Optional[str] = ""
     ):
         """

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -403,7 +403,7 @@ def build_image(
 
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Load of relative source ({source}) is not supported at build time "
+                f"Load of relative source ({source}) is not supported at build time"
                 "see 'mlrun.runtimes.kubejob.KubejobRuntime.with_source_archive' or "
                 "'mlrun.projects.project.MlrunProject.set_source' for more details"
             )

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -371,7 +371,7 @@ class BaseLauncher(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def enrich_runtime(
+    def _enrich_runtime(
         runtime: "mlrun.runtimes.base.BaseRuntime",
         project: Optional[str] = "",
     ):

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -32,7 +32,7 @@ class ClientBaseLauncher(mlrun.launcher.base.BaseLauncher, abc.ABC):
     """
 
     @staticmethod
-    def enrich_runtime(
+    def _enrich_runtime(
         runtime: "mlrun.runtimes.base.BaseRuntime", project: Optional[str] = ""
     ):
         runtime.try_auto_mount_based_on_config()

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -75,7 +75,7 @@ class ClientLocalLauncher(mlrun.launcher.client.ClientBaseLauncher):
                 "local and schedule cannot be used together"
             )
 
-        self.enrich_runtime(runtime)
+        self._enrich_runtime(runtime)
         run = self._create_run_object(task)
 
         if self._is_run_local:

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -57,7 +57,7 @@ class ClientRemoteLauncher(mlrun.launcher.client.ClientBaseLauncher):
         notifications: Optional[List[mlrun.model.Notification]] = None,
         returns: Optional[List[Union[str, Dict[str, str]]]] = None,
     ) -> "mlrun.run.RunObject":
-        self.enrich_runtime(runtime)
+        self._enrich_runtime(runtime)
         run = self._create_run_object(task)
 
         run = self._enrich_run(

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -30,7 +30,6 @@ import mlrun.api.api.endpoints.functions
 import mlrun.api.api.utils
 import mlrun.api.crud
 import mlrun.api.main
-import mlrun.api.utils.builder
 import mlrun.api.utils.clients.chief
 import mlrun.api.utils.singletons.db
 import mlrun.api.utils.singletons.k8s
@@ -442,52 +441,6 @@ def test_build_function_with_mlrun_bool(
             == with_mlrun
         )
     mlrun.api.api.endpoints.functions._build_function = original_build_function
-
-
-@pytest.mark.parametrize(
-    "source, load_source_on_run",
-    [
-        ("./", False),
-        (".", False),
-        ("./", True),
-        (".", True),
-    ],
-)
-def test_build_function_with_project_repo(
-    db: sqlalchemy.orm.Session,
-    client: fastapi.testclient.TestClient,
-    source,
-    load_source_on_run,
-):
-    git_repo = "git://github.com/mlrun/test.git"
-    tests.api.api.utils.create_project(
-        client, PROJECT, source=git_repo, load_source_on_run=load_source_on_run
-    )
-    function_dict = {
-        "kind": "job",
-        "metadata": {
-            "name": "function-name",
-            "project": "project-name",
-            "tag": "latest",
-        },
-        "spec": {
-            "build": {
-                "source": source,
-            },
-        },
-    }
-    original_build_runtime = mlrun.api.utils.builder.build_image
-    mlrun.api.utils.builder.build_image = unittest.mock.Mock(return_value="success")
-    response = client.post(
-        "build/function",
-        json={"function": function_dict},
-    )
-    assert response.status_code == HTTPStatus.OK.value
-    function = mlrun.new_function(runtime=response.json()["data"])
-    assert function.spec.build.source == git_repo
-    assert function.spec.build.load_source_on_run == load_source_on_run
-
-    mlrun.api.utils.builder.build_image = original_build_runtime
 
 
 def test_start_function_succeeded(

--- a/tests/api/api/utils.py
+++ b/tests/api/api/utils.py
@@ -31,16 +31,8 @@ import mlrun.errors
 PROJECT = "project-name"
 
 
-def create_project(
-    client: TestClient,
-    project_name: str = PROJECT,
-    artifact_path=None,
-    source="source",
-    load_source_on_run=False,
-):
-    project = _create_project_obj(
-        project_name, artifact_path, source, load_source_on_run
-    )
+def create_project(client: TestClient, project_name: str = PROJECT, artifact_path=None):
+    project = _create_project_obj(project_name, artifact_path)
     resp = client.post("projects", json=project.dict())
     assert resp.status_code == HTTPStatus.CREATED.value
     return resp
@@ -77,15 +69,12 @@ async def create_project_async(
     return resp
 
 
-def _create_project_obj(
-    project_name, artifact_path, source, load_source_on_run=False
-) -> mlrun.common.schemas.Project:
+def _create_project_obj(project_name, artifact_path) -> mlrun.common.schemas.Project:
     return mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
         spec=mlrun.common.schemas.ProjectSpec(
             description="banana",
-            source=source,
-            load_source_on_run=load_source_on_run,
+            source="source",
             goals="some goals",
             artifact_path=artifact_path,
         ),

--- a/tests/api/runtimes/test_kubejob.py
+++ b/tests/api/runtimes/test_kubejob.py
@@ -48,7 +48,6 @@ class TestKubejobRuntime(TestRuntimeBase):
     def _generate_runtime(self) -> mlrun.runtimes.KubejobRuntime:
         runtime = mlrun.runtimes.KubejobRuntime()
         runtime.spec.image = self.image_name
-        runtime.metadata.project = self.project
         return runtime
 
     def test_run_without_runspec(self, db: Session, client: TestClient):


### PR DESCRIPTION
Reverts mlrun/mlrun#3688

<details><summary>Details</summary>
<p>

```
> 2023-06-02 09:09:23,267 [info] build_function: ....
> 2023-06-02 09:09:23,272 [error] Traceback (most recent call last):
  File "/mlrun/mlrun/api/api/endpoints/functions.py", line 666, in _build_function
    mlrun.api.launcher.ServerSideLauncher.enrich_runtime(runtime=fn)
  File "/mlrun/mlrun/api/launcher.py", line 161, in enrich_runtime
    project = runtime._get_db().get_project(runtime.metadata.project)
AttributeError: 'NoneType' object has no attribute 'get_project'

> 2023-06-02 09:09:23,272 [error] {'reason': "runtime error: 'NoneType' object has no attribute 'get_project'"}
```
</p>
</details> 