### PR TITLE
[Release] Introducing version promotion

### DIFF
--- a/dockerfiles/Dockerfile.promote
+++ b/dockerfiles/Dockerfile.promote
@@ -1,0 +1,26 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This docker file is used to build a stable version out of a RC version
+
+ARG IMAGE_NAME
+
+FROM ${IMAGE_NAME}
+
+ARG MLRUN_DIR="."
+ARG MLRUN_DEP_OPTS="complete"
+ARG TARGET_VERSION_PATH="./mlrun/utils/version/version.json"
+
+COPY ./mlrun/utils/version/version.json $TARGET_VERSION_PATH
+RUN python -m pip install "$MLRUN_DIR[$MLRUN_DEP_OPTS]"

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -53,7 +53,7 @@ RUN python -m pip install \
     -r /tmp/requirements/requirement.txt
 
 COPY --chown=$NB_UID:$NB_GID . /tmp/mlrun
-RUN cd /tmp/mlrun && python -m pip install ".[complete-api]"
+RUN python -m pip install "/tmp/mlrun[complete-api]"
 
 # This will usually cause a cache miss - so keep it in the last layers
 ARG MLRUN_CACHE_DATE=initial


### PR DESCRIPTION
Version promotion is introduced to reduce the need of rerun the entire flow of building image for an existing RC
The idea is to take a qa-qualified rc, change its internal version (from rc to stable) and push its image.
Some images does not require internal version changing as they simply do not hold internal mlrun version (log collector, etc).

Note that, since images already have their mlrun deps pre-installed, rerunning the python install command on existing image yields "requirement is already satisfied".

This PR introduces the Makefile needed part, next thing is to bind it to the release flow (or create a dedicated action)