### PR TITLE
[Builder] Fix requirements path when no requirements

### DIFF
--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -868,6 +868,85 @@ def test_builder_source(monkeypatch, source, expectation):
         assert expected_output_re.match(dockerfile_lines[expected_line_index].strip())
 
 
+@pytest.mark.parametrize(
+    "requirements, commands, with_mlrun, mlrun_version_specifier, client_version, expected_commands, "
+    "expected_requirements_list, expected_requirements_path",
+    [
+        ([], [], False, None, None, [], [], ""),
+        (
+            [],
+            [],
+            True,
+            None,
+            None,
+            [
+                f"python -m pip install --upgrade pip{mlrun.config.config.httpdb.builder.pip_version}"
+            ],
+            ["mlrun[complete] @ git+https://github.com/mlrun/mlrun@development"],
+            "/empty/requirements.txt",
+        ),
+        (
+            [],
+            ["some command"],
+            True,
+            "mlrun~=1.4",
+            None,
+            [
+                "some command",
+                f"python -m pip install --upgrade pip{mlrun.config.config.httpdb.builder.pip_version}",
+            ],
+            ["mlrun~=1.4"],
+            "/empty/requirements.txt",
+        ),
+        (
+            [],
+            [],
+            True,
+            "",
+            "1.4.0",
+            [
+                f"python -m pip install --upgrade pip{mlrun.config.config.httpdb.builder.pip_version}"
+            ],
+            ["mlrun[complete]==1.4.0"],
+            "/empty/requirements.txt",
+        ),
+        (
+            ["pandas"],
+            [],
+            True,
+            "",
+            "1.4.0",
+            [
+                f"python -m pip install --upgrade pip{mlrun.config.config.httpdb.builder.pip_version}"
+            ],
+            ["mlrun[complete]==1.4.0", "pandas"],
+            "/empty/requirements.txt",
+        ),
+        (["pandas"], [], False, "", "1.4.0", [], ["pandas"], "/empty/requirements.txt"),
+    ],
+)
+def test_resolve_build_requirements(
+    requirements,
+    commands,
+    with_mlrun,
+    mlrun_version_specifier,
+    client_version,
+    expected_commands,
+    expected_requirements_list,
+    expected_requirements_path,
+):
+    (
+        commands,
+        requirements_list,
+        requirements_path,
+    ) = mlrun.api.utils.builder._resolve_build_requirements(
+        requirements, commands, with_mlrun, mlrun_version_specifier, client_version
+    )
+    assert commands == expected_commands
+    assert requirements_list == expected_requirements_list
+    assert requirements_path == expected_requirements_path
+
+
 def _get_target_image_from_create_pod_mock():
     return _create_pod_mock_pod_spec().containers[0].args[5]
 


### PR DESCRIPTION
Unsets the requirements path when there are no requirements:
```
    if not requirements_list:
        # no requirements, we don't need a requirements file
        requirements_path = ""
```
Fixes trying to access the requirements file in the dockerfile but it was never created.