### PR TITLE
[Notifications] Fix local job with notification fails with `AttributeError: 'NoneType' object has no attribute 'get'`

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -54,7 +54,9 @@ class NotificationPusher(object):
                         notification.name
                     ).get("status", mlrun.common.schemas.NotificationStatus.PENDING)
                 except (AttributeError, KeyError):
-                    notification.status = mlrun.common.schemas.NotificationStatus.PENDING
+                    notification.status = (
+                        mlrun.common.schemas.NotificationStatus.PENDING
+                    )
 
                 if self._should_notify(run, notification):
                     self._notification_data.append((run, notification))

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -49,9 +49,13 @@ class NotificationPusher(object):
                 run = mlrun.model.RunObject.from_dict(run)
 
             for notification in run.spec.notifications:
-                notification.status = run.status.notifications.get(
-                    notification.name
-                ).get("status", mlrun.common.schemas.NotificationStatus.PENDING)
+                try:
+                    notification.status = run.status.notifications.get(
+                        notification.name
+                    ).get("status", mlrun.common.schemas.NotificationStatus.PENDING)
+                except (AttributeError, KeyError):
+                    notification.status = mlrun.common.schemas.NotificationStatus.PENDING
+
                 if self._should_notify(run, notification):
                     self._notification_data.append((run, notification))
 


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-3908

Backend notifications have statuses on them where local notifications don't necessarily have a status, so defaulting to PENDING.