### PR TITLE
[Notifications] Fix notifications not being sent if previous run was configured with wrong param

### DIFF
--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import typing
+
+import pydantic
 
 import mlrun.common.types
 
@@ -35,3 +39,15 @@ class NotificationStatus(mlrun.common.types.StrEnum):
     PENDING = "pending"
     SENT = "sent"
     ERROR = "error"
+
+
+class Notification(pydantic.BaseModel):
+    kind: NotificationKind = None
+    name: str = None
+    message: str = None
+    severity: NotificationSeverity = None
+    when: typing.List[str] = None
+    condition: str = None
+    params: typing.Dict[str, typing.Any] = None
+    status: NotificationStatus = None
+    sent_time: typing.Union[str, datetime.datetime] = None

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -16,6 +16,13 @@
 import mlrun.common.types
 
 
+class NotificationKind(mlrun.common.types.StrEnum):
+    console = "console"
+    git = "git"
+    ipython = "ipython"
+    slack = "slack"
+
+
 class NotificationSeverity(mlrun.common.types.StrEnum):
     INFO = "info"
     DEBUG = "debug"

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -310,6 +310,9 @@ class BaseLauncher(abc.ABC):
             )
 
         run.spec.notifications = notifications or run.spec.notifications or []
+        for notification in run.spec.notifications:
+            notification.validate_notification()
+
         return run
 
     @staticmethod

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -556,7 +556,7 @@ class Notification(ModelObj):
             mlrun.common.schemas.notification.Notification(**self.to_dict())
         except pydantic.error_wrappers.ValidationError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Invalid notification object"
+                "Invalid notification object"
             ) from exc
 
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -24,6 +24,8 @@ from datetime import datetime
 from os import environ
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import pydantic.error_wrappers
+
 import mlrun
 import mlrun.common.schemas.notification
 
@@ -550,29 +552,12 @@ class Notification(ModelObj):
         self.validate_notification()
 
     def validate_notification(self):
-        if self.kind:
-            try:
-                mlrun.common.schemas.notification.NotificationKind(self.kind)
-            except ValueError as exc:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"notification kind {self.kind} is not supported"
-                ) from exc
-
-        if self.severity:
-            try:
-                mlrun.common.schemas.notification.NotificationSeverity(self.severity)
-            except ValueError as exc:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"notification severity {self.severity} is not supported"
-                ) from exc
-
-        if self.status:
-            try:
-                mlrun.common.schemas.notification.NotificationStatus(self.status)
-            except ValueError as exc:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"notification status {self.status} is not supported"
-                ) from exc
+        try:
+            mlrun.common.schemas.notification.Notification(**self.to_dict())
+        except pydantic.error_wrappers.ValidationError as exc:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Invalid notification object"
+            ) from exc
 
 
 class RunMetadata(ModelObj):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -25,6 +25,7 @@ from os import environ
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlrun
+import mlrun.common.schemas.notification
 
 from .utils import (
     dict_to_json,
@@ -545,6 +546,33 @@ class Notification(ModelObj):
         self.params = params or {}
         self.status = status
         self.sent_time = sent_time
+
+        self.validate_notification()
+
+    def validate_notification(self):
+        if self.kind:
+            try:
+                mlrun.common.schemas.notification.NotificationKind(self.kind)
+            except ValueError as exc:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"notification kind {self.kind} is not supported"
+                ) from exc
+
+        if self.severity:
+            try:
+                mlrun.common.schemas.notification.NotificationSeverity(self.severity)
+            except ValueError as exc:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"notification severity {self.severity} is not supported"
+                ) from exc
+
+        if self.status:
+            try:
+                mlrun.common.schemas.notification.NotificationStatus(self.status)
+            except ValueError as exc:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"notification status {self.status} is not supported"
+                ) from exc
 
 
 class RunMetadata(ModelObj):

--- a/mlrun/utils/notifications/notification/__init__.py
+++ b/mlrun/utils/notifications/notification/__init__.py
@@ -15,6 +15,8 @@
 import enum
 import typing
 
+from mlrun.common.schemas.notification import NotificationKind
+
 from .base import NotificationBase
 from .console import ConsoleNotification
 from .git import GitNotification
@@ -23,10 +25,10 @@ from .slack import SlackNotification
 
 
 class NotificationTypes(str, enum.Enum):
-    console = "console"
-    git = "git"
-    ipython = "ipython"
-    slack = "slack"
+    console = NotificationKind.console.value
+    git = NotificationKind.git.value
+    ipython = NotificationKind.ipython.value
+    slack = NotificationKind.slack.value
 
     def get_notification(self) -> typing.Type[NotificationBase]:
         return {


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-3910

Made validation method run on notifications when the object is created, and on enriching run objects to fail fast and not save corrupted notifications in the DB.

* note - tests currently failing until https://github.com/mlrun/mlrun/pull/3700 is merged