### PR TITLE
[System tests] Mark test_run_state_completion as enterprise

### DIFF
--- a/tests/system/runtimes/test_mpijob.py
+++ b/tests/system/runtimes/test_mpijob.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
+
 import mlrun
 import tests.system.base
 from mlrun.runtimes.constants import RunStates
@@ -21,6 +23,10 @@ from mlrun.runtimes.constants import RunStates
 class TestMpiJobRuntime(tests.system.base.TestMLRunSystem):
     project_name = "does-not-exist-mpijob"
 
+    # TODO: This test is failing in the open source system tests due to a lack of resources
+    #  (running in git action worker with limited resources).
+    #  This mark should be removed if we shift to a new CE testing environment with adequate resources
+    @pytest.mark.enterprise
     def test_run_state_completion(self):
         code_path = str(self.assets_path / "mpijob_function.py")
 


### PR DESCRIPTION
Due to a shortage of resources, the test '`test_run_state_completion`' fails in the open source system tests. 
Adding a skip for this test by labeling it as enterprise in this PR.
In the future, we should consider executing this in a different environment with adequate resources.