### PR TITLE
[Runtimes] Fix funcdoc AST attributes parsing

### DIFF
--- a/tests/runtimes/arc.txt
+++ b/tests/runtimes/arc.txt
@@ -10,6 +10,9 @@ def arc_to_parquet(
     key: str = "data",
     dataset: Optional[str] = None,
     part_cols = [],
+    str_list: List[str] = [],
+    full_import: mlrun.run.RunObject = [],
+    full_import_with_slice: typing.Union[typing.List[str], mlrun.run.RunObject] = [],
 ) -> None:
     """Open a file/object archive and save as a parquet file.
     Partitioning requires precise specification of column types.

--- a/tests/runtimes/test_funcdoc.py
+++ b/tests/runtimes/test_funcdoc.py
@@ -206,7 +206,7 @@ def test_ast_compound():
 
         # collect the types of the function parameters
         # assumes each param is in a new line for simplicity
-        for line in code.splitlines()[3:12]:
+        for line in code.splitlines()[3:15]:
             if ":" not in line:
                 param_types.append(None)
                 continue


### PR DESCRIPTION
Fix parsing of full path types e.g. `a.b.c` or `a.b.c[a.b.d]`
previously it would ignore the prefix and for `a.b.c` it would return `c`