### PR TITLE
[Requirements] Bump humanfriendly to 9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ distributed~=2021.11.2
 kubernetes~=12.0
 # TODO: move to API requirements (shouldn't really be here, the sql run db using the API sqldb is preventing us from
 #  separating the SDK and API code) (referring to humanfriendly and fastapi)
-humanfriendly~=8.2
+humanfriendly~=9.2
 fastapi~=0.92.0
 fsspec~=2023.1.0
 v3iofs~=0.1.15


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-2254
The reason for the major version bump is that one of the bug fixes it not backward compatible (should not affect us explained below)
see - https://humanfriendly.readthedocs.io/en/latest/changelog.html#release-9-0-2020-12-01
> The major version number was bumped because the bug fix for [pluralize()](https://humanfriendly.readthedocs.io/en/latest/api.html#humanfriendly.text.pluralize) is backwards incompatible

The reason this does not affect us is because we don't use format timespan. We use human friendly to parse timespan and this change does not affect parsing.