### PR TITLE
[Runs] Add configurable timeout to abort_run

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -49,7 +49,7 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def abort_run(self, uid, project="", iter=0):
+    def abort_run(self, uid, project="", iter=0, timeout=45):
         pass
 
     @abstractmethod

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -500,16 +500,16 @@ class HTTPRunDB(RunDBInterface):
         body = _as_json(struct)
         self.api_call("POST", path, error, params=params, body=body)
 
-    def update_run(self, updates: dict, uid, project="", iter=0):
+    def update_run(self, updates: dict, uid, project="", iter=0, timeout=45):
         """Update the details of a stored run in the DB."""
 
         path = self._path_of("run", project, uid)
         params = {"iter": iter}
         error = f"update run {project}/{uid}"
         body = _as_json(updates)
-        self.api_call("PATCH", path, error, params=params, body=body)
+        self.api_call("PATCH", path, error, params=params, body=body, timeout=timeout)
 
-    def abort_run(self, uid, project="", iter=0):
+    def abort_run(self, uid, project="", iter=0, timeout=45):
         """
         Abort a running run - will remove the run's runtime resources and mark its state as aborted
         """
@@ -518,6 +518,7 @@ class HTTPRunDB(RunDBInterface):
             uid,
             project,
             iter,
+            timeout,
         )
 
     def read_run(self, uid, project="", iter=0):

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -66,7 +66,7 @@ class NopDB(RunDBInterface):
     def update_run(self, updates: dict, uid, project="", iter=0):
         pass
 
-    def abort_run(self, uid, project="", iter=0):
+    def abort_run(self, uid, project="", iter=0, timeout=45):
         pass
 
     def read_run(self, uid, project="", iter=0):

--- a/mlrun/db/sqldb.py
+++ b/mlrun/db/sqldb.py
@@ -94,7 +94,7 @@ class SQLDB(RunDBInterface):
             updates,
         )
 
-    def abort_run(self, uid, project="", iter=0):
+    def abort_run(self, uid, project="", iter=0, timeout=45):
         raise NotImplementedError()
 
     def read_run(self, uid, project=None, iter=None):


### PR DESCRIPTION
resolves: https://jira.iguazeng.com/browse/ML-3457

Add a configurable timeout for `abort_run`, allowing users to set it higher than the default when necessary,
We could consider making this operation async in the future.