### PR TITLE
[Project] Fix `run_function` use in pipeline docstring

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -112,7 +112,7 @@ def run_function(
 
         @dsl.pipeline(name="test pipeline", description="test")
         def my_pipe(url=""):
-            run1 = run_function("loaddata", params={"url": url})
+            run1 = run_function("loaddata", params={"url": url}, outputs=["data"])
             run2 = run_function("train", params={"label_columns": LABELS, "model_class": MODEL_CLASS},
                                          inputs={"dataset": run1.outputs["data"]})
 


### PR DESCRIPTION
With pipelines, must specify the outputs that can be passed to other steps.
Relates to - https://jira.iguazeng.com/browse/ML-3548 (not a fix)