### PR TITLE
[Run] Fix runtime error log

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -356,12 +356,12 @@ class BaseLauncher(abc.ABC):
         if result:
             run = mlrun.run.RunObject.from_dict(result)
             logger.info(
-                f"run executed, status={run.status.state}", name=run.metadata.name
+                f"Run executed, status={run.status.state}", name=run.metadata.name
             )
             if run.status.state == "error":
                 if runtime._is_remote and not runtime.is_child:
-                    logger.error(f"runtime error: {run.status.error}")
-                raise mlrun.runtimes.utils.RunError(run.status.error)
+                    logger.error("Runtime error", status=run.status)
+                raise mlrun.runtimes.utils.RunError(run.error)
             return run
 
         return None

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -360,7 +360,7 @@ class BaseLauncher(abc.ABC):
             )
             if run.status.state == "error":
                 if runtime._is_remote and not runtime.is_child:
-                    logger.error("Runtime error", status=run.status)
+                    logger.error("Runtime error", status=run.status.to_dict())
                 raise mlrun.runtimes.utils.RunError(run.error)
             return run
 

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -360,7 +360,7 @@ class BaseLauncher(abc.ABC):
             )
             if run.status.state == "error":
                 if runtime._is_remote and not runtime.is_child:
-                    logger.error("Runtime error", status=run.status.to_dict())
+                    logger.error("Run error", status=run.status.to_dict())
                 raise mlrun.runtimes.utils.RunError(run.error)
             return run
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1183,6 +1183,16 @@ class RunObject(RunTemplate):
     def status(self, status):
         self._status = self._verify_dict(status, "status", RunStatus)
 
+    @property
+    def error(self) -> str:
+        """error string if failed"""
+        if self.status:
+            if not self.status.state == "error":
+                return f"Run state ({self.status.state}) is not in error state"
+
+            return self.status.error or self.status.reason
+        return ""
+
     def output(self, key):
         """return the value of a specific result or artifact by key"""
         self._outputs_wait_for_completion()

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1187,10 +1187,14 @@ class RunObject(RunTemplate):
     def error(self) -> str:
         """error string if failed"""
         if self.status:
-            if not self.status.state == "error":
+            if self.status.state != "error":
                 return f"Run state ({self.status.state}) is not in error state"
-
-            return self.status.error or self.status.reason
+            return (
+                self.status.error
+                or self.status.reason
+                or self.status.status_text
+                or "Unknown error"
+            )
         return ""
 
     def output(self, key):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -338,9 +338,7 @@ def get_or_create_project(
     from_template: str = None,
     save: bool = True,
 ) -> "MlrunProject":
-    """
-    Load a project from MLRun DB
-    If the project doesn't exist in the DB, it will be created from the provided url or template.
+    """Load a project from MLRun DB, or create/import if doesnt exist
 
     example::
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -338,7 +338,9 @@ def get_or_create_project(
     from_template: str = None,
     save: bool = True,
 ) -> "MlrunProject":
-    """Load a project from MLRun DB, or create/import if doesnt exist
+    """
+    Load a project from MLRun DB
+    If the project doesn't exist in the DB, it will be created from the provided url or template.
 
     example::
 

--- a/tests/launcher/test_remote.py
+++ b/tests/launcher/test_remote.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import pathlib
+import unittest.mock
 
 import pytest
 
@@ -28,9 +29,12 @@ def test_launch_remote_job(rundb_mock):
     launcher = mlrun.launcher.remote.ClientRemoteLauncher()
     mlrun.config.config.artifact_path = "v3io:///users/admin/mlrun"
     runtime = mlrun.code_to_function(
-        name="test", kind="job", filename=str(func_path), handler=handler
+        name="test",
+        kind="job",
+        filename=str(func_path),
+        handler=handler,
+        image="mlrun/mlrun",
     )
-    runtime.spec.image = "mlrun/mlrun"
 
     # store the run is done by the API so we need to mock it
     uid = "123"
@@ -46,9 +50,12 @@ def test_launch_remote_job_no_watch(rundb_mock):
     launcher = mlrun.launcher.remote.ClientRemoteLauncher()
     mlrun.config.config.artifact_path = "v3io:///users/admin/mlrun"
     runtime = mlrun.code_to_function(
-        name="test", kind="job", filename=str(func_path), handler=handler
+        name="test",
+        kind="job",
+        filename=str(func_path),
+        handler=handler,
+        image="mlrun/mlrun",
     )
-    runtime.spec.image = "mlrun/mlrun"
     result = launcher.launch(runtime, watch=False)
     assert result.status.state == "created"
 
@@ -99,3 +106,32 @@ def test_prepare_image_for_deploy(
     launcher.prepare_image_for_deploy(runtime)
     assert runtime.spec.build.base_image == expected_base_image
     assert runtime.spec.image == expected_image
+
+
+def test_run_error_status(rundb_mock):
+    launcher = mlrun.launcher.remote.ClientRemoteLauncher()
+    mlrun.config.config.artifact_path = "v3io:///users/admin/mlrun"
+    runtime = mlrun.code_to_function(
+        name="test",
+        kind="job",
+        filename=str(func_path),
+        handler=handler,
+        image="mlrun/mlrun",
+    )
+
+    # store the run is done by the API so we need to mock it
+    uid = "123"
+    run = mlrun.run.RunObject(
+        metadata=mlrun.model.RunMetadata(uid=uid),
+    )
+    rundb_mock.store_run(run, uid)
+
+    result = mlrun.run.RunObject(
+        metadata=mlrun.model.RunMetadata(uid=uid),
+        status=mlrun.model.RunStatus(state="error", reason="some error"),
+    )
+    runtime._get_db_run = unittest.mock.MagicMock(return_value=result.to_dict())
+
+    with pytest.raises(mlrun.runtimes.utils.RunError) as exc:
+        launcher.launch(runtime, run, watch=True)
+    assert "some error" in str(exc.value)


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3562
When the `error` attribute of state is not populated the user will not see any error.
Log the run status and raise an error with either 'error' 'reason' or 'status_text'
```
> 2023-06-07 14:10:10,740 [info] Run executed, status=error: {'name': 'sleepy-breast-cancer-generator'}
> 2023-06-07 14:10:10,740 [error] Runtime error: {'status': {'state': 'error', 'artifacts': [], 'start_time': '2023-06-07T13:59:48.163090+00:00', 'last_update': '2023-06-07T14:10:10.038952+00:00', 'reason': 'A runtime resource related to this run could not be found'}}
```
The exception:
```
File ~/.pythonlibs/mlrun-base/lib/python3.9/site-packages/mlrun/launcher/base.py:364, in BaseLauncher._wrap_run_result(self, runtime, result, run, schedule, err)
    362         if runtime._is_remote and not runtime.is_child:
    363             logger.error("Runtime error", status=run.status.to_dict())
--> 364         raise mlrun.runtimes.utils.RunError(run.error)
    365     return run
    367 return None

RunError: A runtime resource related to this run could not be found
```