### PR TITLE
[Functions] Remove protocol prefix from image name

### DIFF
--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -29,6 +29,7 @@ import mlrun.errors
 import mlrun.runtimes.utils
 import mlrun.utils
 from mlrun.config import config
+from mlrun.utils.helpers import remove_image_protocol_prefix
 
 
 def make_dockerfile(
@@ -683,6 +684,8 @@ def resolve_image_target_and_registry_secret(
             image_target_components = [registry, repository, image_target]
 
         return "/".join(image_target_components), secret_name
+
+    image_target = remove_image_protocol_prefix(image_target)
 
     return image_target, secret_name
 

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -139,6 +139,7 @@ class KubejobRuntime(KubeResource):
         :param prepare_image_for_deploy:    prepare the image/base_image spec for deployment
         """
 
+        image = mlrun.utils.helpers.remove_image_protocol_prefix(image)
         self.spec.build.build_config(
             image,
             base_image,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -238,6 +238,19 @@ def is_yaml_path(url):
     return url.endswith(".yaml") or url.endswith(".yml")
 
 
+def remove_image_protocol_prefix(image):
+    prefixes = ["https://", "https://"]
+    if any(prefix in image for prefix in prefixes):
+        image = image.removeprefix("https://").removeprefix("http://")
+        warnings.warn(
+            "The image has an unexpected protocol prefix ('http://' or 'https://'),"
+            " if you wish to use the default configured registry, no protocol prefix is required "
+            "(note that you can also simply use '.' instead of the full URL). "
+            f"protocol prefix was removed, trying to push the image to: {image}"
+        )
+    return image
+
+
 # Verifying that a field input is of the expected type. If not the method raises a detailed MLRunInvalidArgumentError
 def verify_field_of_type(field_name: str, field_value, expected_type: type):
     if not isinstance(field_value, expected_type):

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -15,9 +15,9 @@
 import os
 import pathlib
 import re
-import warnings
 import shutil
 import sys
+import warnings
 from sys import executable
 
 import pytest
@@ -143,11 +143,12 @@ class TestProject(TestMLRunSystem):
             )
             assert len(w) == 2
             assert (
-                    "The image has an unexpected protocol prefix ('http://' or 'https://'),"
-                    " if you wish to use the default configured registry, no protocol prefix is required "
-                    "(note that you can also simply use '.' instead of the full URL). "
-                    in str(w[-1].message)
+                "The image has an unexpected protocol prefix ('http://' or 'https://'),"
+                " if you wish to use the default configured registry, no protocol prefix is required "
+                "(note that you can also simply use '.' instead of the full URL). "
+                in str(w[-1].message)
             )
+
     def test_run(self):
         name = "pipe0"
         self.custom_project_names_to_delete.append(name)


### PR DESCRIPTION
resolves [ML-3826](https://jira.iguazeng.com/browse/ML-3826)

follow up for: https://github.com/mlrun/mlrun/pull/3676
The two flows can be separated, and as we agree on the solution for this one, we'll continue to think about how to handle [ML-3827](https://jira.iguazeng.com/browse/ML-3827)