### PR TITLE
[Tests] Fix `RunDBMock` runs dictionary

### DIFF
--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -257,11 +257,13 @@ class RunDBMock:
         return ArtifactList(filter(filter_artifact, self._artifacts.values()))
 
     def store_run(self, struct, uid, project="", iter=0):
-        self._runs[uid] = {
-            "struct": struct,
-            "project": project,
-            "iter": iter,
-        }
+        if project:
+            struct["metadata"]["project"] = project
+
+        if iter:
+            struct["status"]["iteration"] = iter
+
+        self._runs[uid] = struct
 
     def read_run(self, uid, project, iter=0):
         return self._runs.get(uid, {})
@@ -342,7 +344,7 @@ class RunDBMock:
 
     def update_run(self, updates: dict, uid, project="", iter=0):
         for key, value in updates.items():
-            update_in(self._runs[uid]["struct"], key, value)
+            update_in(self._runs[uid], key, value)
 
     def assert_no_mount_or_creds_configured(self, function_name=None):
         function = self._get_function_internal(function_name)

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -257,6 +257,9 @@ class RunDBMock:
         return ArtifactList(filter(filter_artifact, self._artifacts.values()))
 
     def store_run(self, struct, uid, project="", iter=0):
+        if hasattr(struct, "to_dict"):
+            struct = struct.to_dict()
+
         if project:
             struct["metadata"]["project"] = project
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -28,7 +28,7 @@ def test_local_context(rundb_mock):
     context = mlrun.get_or_create_ctx("xx", project=project_name, upload_artifacts=True)
     db = mlrun.get_run_db()
     run = db.read_run(context._uid, project=project_name)
-    assert run["struct"]["status"]["state"] == "running", "run status not updated in db"
+    assert run["status"]["state"] == "running", "run status not updated in db"
 
     # calls __exit__ and commits the context
     with context:
@@ -48,7 +48,6 @@ def test_local_context(rundb_mock):
     assert context._state == "completed", "task did not complete"
 
     run = db.read_run(context._uid, project=project_name)
-    run = run["struct"]
 
     # run state should not be updated by the context
     assert run["status"]["state"] == "running", "run status was updated in db"
@@ -126,7 +125,7 @@ def test_context_set_state(rundb_mock, state, error, expected_state):
     context = mlrun.get_or_create_ctx("xx", project=project_name, upload_artifacts=True)
     db = mlrun.get_run_db()
     run = db.read_run(context._uid, project=project_name)
-    assert run["struct"]["status"]["state"] == "running", "run status not updated in db"
+    assert run["status"]["state"] == "running", "run status not updated in db"
 
     # calls __exit__ and commits the context
     with context:


### PR DESCRIPTION
Runs should not be under "struct". There is no value for it and we want to always return the run from `read_run` to align the behavior of real dbs.