### PR TITLE
[Project] Optionally add function tag to key of project function dicts

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2799,7 +2799,7 @@ def _set_as_current_default_project(project: MlrunProject):
 
 def _init_function_from_dict(
     f: dict,
-    project: mlrun.projects.MlrunProject,
+    project: MlrunProject,
     name: typing.Optional[str] = None,
 ) -> typing.Tuple[str, mlrun.runtimes.BaseRuntime]:
     name = name or f.get("name", "")
@@ -2877,7 +2877,7 @@ def _init_function_from_dict(
 
 def _init_function_from_obj(
     func: mlrun.runtimes.BaseRuntime,
-    project: mlrun.projects.MlrunProject,
+    project: MlrunProject,
     name: typing.Optional[str] = None,
 ) -> typing.Tuple[str, mlrun.runtimes.BaseRuntime]:
     build = func.spec.build

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1678,7 +1678,7 @@ class MlrunProject(ModelObj):
         :param enrich:          add project info/config/source info to the function object
         :param ignore_cache:    read the function object from the DB (ignore the local cache)
         :param copy_function:   return a copy of the function object
-        :param tag:             provide if the function was set with a tag (function key is tagged)
+        :param tag:             provide if the function key is tagged under the project (function was set with a tag)
 
         :returns: function object
         """

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -513,6 +513,49 @@ def test_set_func_with_tag():
     assert func.metadata.tag is None
 
 
+def test_set_function_with_tagged_key():
+    project = mlrun.new_project("set-func-tagged-key", save=False)
+    tag = "v1"
+    my_func = mlrun.code_to_function(
+        filename=str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
+        kind="job",
+        tag=tag,
+    )
+    # function key is <function name>:<tag>
+    project.set_function(
+        my_func,
+        tag=tag,
+    )
+    # function key is <function name>
+    project.set_function(
+        my_func,
+    )
+    # function key is "my_func"
+    project.set_function(
+        my_func,
+        name="my_func",
+    )
+    # function key is "my_func:v2" (tag should remain "v1")
+    project.set_function(
+        my_func,
+        name="my_func:v2",
+    )
+
+    assert len(project.spec._function_objects) == 4
+
+    func = project.get_function(f"{my_func.metadata.name}:{tag}")
+    assert func.metadata.tag == tag
+
+    func = project.get_function(my_func.metadata.name)
+    assert func.metadata.tag == tag
+
+    func = project.get_function("my_func")
+    assert func.metadata.tag == tag
+
+    func = project.get_function("my_func:v2")
+    assert func.metadata.tag == tag
+
+
 def test_set_function_with_relative_path(context):
     project = mlrun.new_project("inline", context=str(assets_path()), save=False)
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -546,6 +546,9 @@ def test_set_function_with_tagged_key():
     func = project.get_function(f"{my_func.metadata.name}:{tag}")
     assert func.metadata.tag == tag
 
+    func = project.get_function(my_func.metadata.name, tag=tag)
+    assert func.metadata.tag == tag
+
     func = project.get_function(my_func.metadata.name)
     assert func.metadata.tag == tag
 
@@ -553,6 +556,12 @@ def test_set_function_with_tagged_key():
     assert func.metadata.tag == tag
 
     func = project.get_function("my_func:v2")
+    assert func.metadata.tag == tag
+
+    func = project.get_function("my_func", tag="v2")
+    assert func.metadata.tag == tag
+
+    func = project.get_function("my_func:v2", tag="v2")
     assert func.metadata.tag == tag
 
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -531,20 +531,12 @@ def test_set_function_with_tagged_key():
     )
 
     # set the functions
-    # function key is <function name>:<tag>
-    project.set_function(
-        my_func_v1,
-        tag=tag_v1,
-    )
-    # function key is <function name>
-    project.set_function(
-        my_func_v1,
-    )
+    # function key is <function name> ("handler")
+    project.set_function(my_func_v1)
+    # function key is <function name>:<tag> ("handler:v1")
+    project.set_function(my_func_v1, tag=tag_v1)
     # function key is "my_func"
-    project.set_function(
-        my_func_v2,
-        name=my_func_v2.metadata.name,
-    )
+    project.set_function(my_func_v2, name=my_func_v2.metadata.name)
     # function key is "my_func:v2"
     project.set_function(my_func_v2, name=f"{my_func_v2.metadata.name}:{tag_v2}")
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -515,54 +515,61 @@ def test_set_func_with_tag():
 
 def test_set_function_with_tagged_key():
     project = mlrun.new_project("set-func-tagged-key", save=False)
-    tag = "v1"
-    my_func = mlrun.code_to_function(
+    # create 2 functions with different tags
+    tag_v1 = "v1"
+    tag_v2 = "v2"
+    my_func_v1 = mlrun.code_to_function(
         filename=str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
         kind="job",
-        tag=tag,
+        tag=tag_v1,
     )
+    my_func_v2 = mlrun.code_to_function(
+        filename=str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
+        kind="job",
+        name="my_func",
+        tag=tag_v2,
+    )
+
+    # set the functions
     # function key is <function name>:<tag>
     project.set_function(
-        my_func,
-        tag=tag,
+        my_func_v1,
+        tag=tag_v1,
     )
     # function key is <function name>
     project.set_function(
-        my_func,
+        my_func_v1,
     )
     # function key is "my_func"
     project.set_function(
-        my_func,
-        name="my_func",
+        my_func_v2,
+        name=my_func_v2.metadata.name,
     )
-    # function key is "my_func:v2" (tag should remain "v1")
-    project.set_function(
-        my_func,
-        name="my_func:v2",
-    )
+    # function key is "my_func:v2"
+    project.set_function(my_func_v2, name=f"{my_func_v2.metadata.name}:{tag_v2}")
 
     assert len(project.spec._function_objects) == 4
 
-    func = project.get_function(f"{my_func.metadata.name}:{tag}")
-    assert func.metadata.tag == tag
+    func = project.get_function(f"{my_func_v1.metadata.name}:{tag_v1}")
+    assert func.metadata.tag == tag_v1
 
-    func = project.get_function(my_func.metadata.name, tag=tag)
-    assert func.metadata.tag == tag
+    func = project.get_function(my_func_v1.metadata.name, tag=tag_v1)
+    assert func.metadata.tag == tag_v1
 
-    func = project.get_function(my_func.metadata.name)
-    assert func.metadata.tag == tag
+    func = project.get_function(my_func_v1.metadata.name)
+    assert func.metadata.tag == tag_v1
 
-    func = project.get_function("my_func")
-    assert func.metadata.tag == tag
+    func = project.get_function(my_func_v2.metadata.name)
+    assert func.metadata.tag == tag_v2
 
-    func = project.get_function("my_func:v2")
-    assert func.metadata.tag == tag
+    func = project.get_function(f"{my_func_v2.metadata.name}:{tag_v2}")
+    assert func.metadata.tag == tag_v2
 
-    func = project.get_function("my_func", tag="v2")
-    assert func.metadata.tag == tag
+    func = project.get_function(my_func_v2.metadata.name, tag=tag_v2)
+    assert func.metadata.tag == tag_v2
 
-    func = project.get_function("my_func:v2", tag="v2")
-    assert func.metadata.tag == tag
+    func = project.get_function(f"{my_func_v2.metadata.name}:{tag_v2}", tag=tag_v2)
+    assert func.metadata.tag == tag_v2
 
 
 def test_set_function_with_relative_path(context):


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3992
In order to enable function versioning in the project's function dicts we will add the function tag if it was provided and the function name was not.

- [x] Add tag option to `get_function`
- [x] Add unit tests