### PR TITLE
[Notification] Fix gitlab notification not being posted on issues

### DIFF
--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -98,13 +98,9 @@ class GitNotification(NotificationBase):
             repo = repo.replace("/", "%2F")
 
             if merge_request:
-                url = (
-                    f"https://{server}/api/v4/projects/{repo}/merge_requests/{issue}/notes"
-                )
+                url = f"https://{server}/api/v4/projects/{repo}/merge_requests/{merge_request}/notes"
             elif issue:
-                url = (
-                    f"https://{server}/api/v4/projects/{repo}/issues/{issue}/notes"
-                )
+                url = f"https://{server}/api/v4/projects/{repo}/issues/{issue}/notes"
             else:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     "GitLab issue or merge request id not specified"

--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -41,6 +41,7 @@ class GitNotification(NotificationBase):
     ):
         git_repo = self.params.get("repo", None)
         git_issue = self.params.get("issue", None)
+        git_merge_request = self.params.get("merge_request", None)
         token = (
             self.params.get("token", None)
             or self.params.get("GIT_TOKEN", None)
@@ -52,6 +53,7 @@ class GitNotification(NotificationBase):
             self._get_html(message, severity, runs, custom_html),
             git_repo,
             git_issue,
+            merge_request=git_merge_request,
             token=token,
             server=server,
             gitlab=gitlab,
@@ -62,6 +64,7 @@ class GitNotification(NotificationBase):
         message: str,
         repo: str = None,
         issue: int = None,
+        merge_request: int = None,
         token: str = None,
         server: str = None,
         gitlab: bool = False,
@@ -89,12 +92,23 @@ class GitNotification(NotificationBase):
             headers = {"PRIVATE-TOKEN": token}
             repo = repo or os.environ.get("CI_PROJECT_ID")
             # auto detect GitLab pr id from the environment
-            issue = issue or os.environ.get("CI_MERGE_REQUEST_IID")
+            issue = issue or os.environ.get("CI_ISSUE_IID")
+            merge_request = merge_request or os.environ.get("CI_MERGE_REQUEST_IID")
             # replace slash with url encoded slash for GitLab to accept a repo name with slash
             repo = repo.replace("/", "%2F")
-            url = (
-                f"https://{server}/api/v4/projects/{repo}/merge_requests/{issue}/notes"
-            )
+
+            if merge_request:
+                url = (
+                    f"https://{server}/api/v4/projects/{repo}/merge_requests/{issue}/notes"
+                )
+            elif issue:
+                url = (
+                    f"https://{server}/api/v4/projects/{repo}/issues/{issue}/notes"
+                )
+            else:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "GitLab issue or merge request id not specified"
+                )
         else:
             server = server or "api.github.com"
             repo = repo or os.environ.get("GITHUB_REPOSITORY")

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -278,7 +278,19 @@ def test_slack_notification(runs, expected):
                 "token": "test-token",
                 "gitlab": True,
             },
-            "https://gitlab.com/api/v4/projects/test-repo/merge_requests/test-issue/notes",
+            "https://gitlab.com/api/v4/projects/test-repo/issues/test-issue/notes",
+            {
+                "PRIVATE-TOKEN": "test-token",
+            },
+        ),
+        (
+            {
+                "repo": "test-repo",
+                "merge_request": "test-merge-request",
+                "token": "test-token",
+                "gitlab": True,
+            },
+            "https://gitlab.com/api/v4/projects/test-repo/merge_requests/test-merge-request/notes",
             {
                 "PRIVATE-TOKEN": "test-token",
             },
@@ -290,7 +302,7 @@ def test_slack_notification(runs, expected):
                 "token": "test-token",
                 "server": "custom-gitlab",
             },
-            "https://custom-gitlab/api/v4/projects/test-repo/merge_requests/test-issue/notes",
+            "https://custom-gitlab/api/v4/projects/test-repo/issues/test-issue/notes",
             {
                 "PRIVATE-TOKEN": "test-token",
             },


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-3924

Gitlab notifications were only being posted to merge requests. Added distinction between issues and merge requests to allow both.