### PR TITLE
[RFC] Add script to deploy branch and replace mlrun-api on app node

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -3,3 +3,4 @@ paramiko~=2.12
 semver~=2.13
 requests~=2.22
 boto3~=1.24.59
+giturlparse~=0.10.0

--- a/deploy_env_template.yml
+++ b/deploy_env_template.yml
@@ -1,0 +1,33 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The deploy scripts expect the yaml file to be in the same directory
+# this is a template file for the deploy env file
+
+
+# App node IP/hostname (required)
+APP_NODE:
+
+# User name for ssh (required)
+USER:
+
+# Password for above user (required)
+PASSWORD:
+
+# Git repo to fetch on remote (optional). Will use whatever is set as origin if not defined
+GIT_REPO:
+
+# Git branch to fetch on remote (optional). Will use whatever is set as current branch if not defined
+GIT_BRANCH:
+

--- a/deploy_remote.py
+++ b/deploy_remote.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import subprocess
+from typing import List
+
+import giturlparse
+import paramiko
+import yaml
+
+
+class MlRunDeployer(object):
+    class Consts(object):
+        mandatory_fields = ["APP_NODE", "USER", "PASSWORD"]
+        fetch_folder = "/tmp/mlrun_temp"
+
+    def __init__(self, args):
+        self._verbose = args.verbose
+        self._config = yaml.safe_load(args.config)
+        for key in self.Consts.mandatory_fields:
+            if self._config.get(key, None) is None:
+                raise RuntimeError(f"Mandatory {key} not defined")
+
+    def _exec_local(self, cmd: List[str]) -> str:
+        if self._verbose:
+            print("Exec local: ", " ".join(cmd))
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+
+    def _exec_remote(self, cmd: List[str], set_work_dir=False, live=False):
+        if set_work_dir:
+            cmd_str = f"cd {self.Consts.fetch_folder}; " + " ".join(cmd)
+        else:
+            cmd_str = " ".join(cmd)
+        if self._verbose:
+            print("Exec remote: ", cmd_str)
+
+        stdin_stream, stdout_stream, stderr_stream = self._ssh_client.exec_command(
+            cmd_str
+        )
+
+        stdout = ""
+        if live:
+            while True:
+                line = stdout_stream.readline()
+                stdout += line
+                if not line:
+                    break
+                print(line, end="")
+        else:
+            stdout = stdout_stream.read()
+
+        stderr = stderr_stream.read().decode("utf8")
+
+        exit_status = stdout_stream.channel.recv_exit_status()
+
+        if exit_status:
+            raise RuntimeError(
+                f"Command '{cmd_str}' exited with failure ({exit_status})\n{stderr}"
+            )
+
+    def _find_git_repo(self) -> str:
+        cmd = ["git", "remote", "get-url", "origin"]
+
+        return self._exec_local(cmd).strip()
+
+    def _find_current_git_branch(self) -> str:
+        cmd = ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        return self._exec_local(cmd).strip()
+
+    def _connect_to_node(self):
+        if self._verbose:
+            print("Connecting to {}", self._config["APP_NODE"])
+
+        self._ssh_client = paramiko.SSHClient()
+        self._ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy)
+        self._ssh_client.connect(
+            self._config["APP_NODE"],
+            username=self._config["USER"],
+            password=self._config["PASSWORD"],
+        )
+
+    def do_replacing(self):
+        def get_config(self, var, func):
+            val = self._config.get(var, None)
+            if val is None:
+                val = func()
+                print(f"Using {val}, as {var} was not set")
+            return val
+
+        repo = get_config(self, "GIT_REPO", self._find_git_repo)
+        branch = get_config(self, "GIT_BRANCH", self._find_current_git_branch)
+
+        if repo.startswith("git"):
+            p = giturlparse.parse(repo)
+            repo = p.url2https
+
+        self._connect_to_node()
+
+        try:
+            self._exec_remote(["rm", "-rf", self.Consts.fetch_folder])
+            self._exec_remote(["mkdir", "-p", self.Consts.fetch_folder])
+            print("Cloning repo on remote")
+            self._exec_remote(
+                ["git", "clone", "--progress", "--branch", branch, repo],
+                set_work_dir=True,
+                live=True,
+            )
+            replace_cmd = ["cd", "mlrun", ";", "./replace_mlrun.py"]
+            if self._verbose:
+                replace_cmd.append("--verbose")
+            print("Running replace commands on remote")
+            self._exec_remote(replace_cmd, set_work_dir=True, live=True)
+            print("Deployed branch sucessfully! Yay!")
+        finally:
+            self._ssh_client.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replace mlrun on an app node")
+
+    parser.add_argument(
+        "--verbose", help="Print what we are doing", action="store_true"
+    )
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        help="Config file (default: %(default)s)",
+        default="deploy_env.yml",
+        type=argparse.FileType("r"),
+        metavar="FILE",
+    )
+
+    args = parser.parse_args()
+
+    MlRunDeployer(args).do_replacing()
+
+
+if __name__ == "__main__":
+    main()

--- a/replace_mlrun.py
+++ b/replace_mlrun.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import os
+import subprocess
+from typing import List, Union
+
+
+class MlRunReplacer(object):
+    def __init__(self, args):
+        self._verbose = args.verbose
+
+    def _exec_cmd(self, cmd: List[str]) -> str:
+        if self._verbose:
+            print(" ".join(cmd))
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+
+    def _exec_silent_cmd(self, cmd: List[str]):
+        if self._verbose:
+            print(" ".join(cmd))
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
+
+    def _get_mlrun_api_pod(self) -> Union[str, None]:
+        print("Get mlrun-api pod name")
+        cmd = ["kubectl", "-n", "default-tenant", "get", "pod"]
+
+        for line in self._exec_cmd(cmd).splitlines()[1:]:
+            if "mlrun-api-chief" in line:
+                return line.split()[0]
+
+    def _get_mlrun_api_image(self, pod_name: str) -> Union[str, None]:
+        print("Get mlrun-api image name")
+        cmd = ["kubectl", "-n", "default-tenant", "get", "pods", pod_name, "-o", "yaml"]
+
+        for line in self._exec_cmd(cmd).splitlines():
+            if "image" in line and "mlrun-api" in line:
+                return line.split("image:")[1].strip()
+
+    def _build_api_docker(self, version: str) -> Union[str, None]:
+        os.environ["MLRUN_VERSION"] = version
+        image_tag_str = "Successfully tagged "
+
+        print("Build mlrun-api image")
+
+        cmd = ["make", "api"]
+
+        for line in self._exec_cmd(cmd).splitlines():
+            if image_tag_str in line and "mlrun-api" in line:
+                return line.split(image_tag_str)[-1].strip()
+
+    def _replace_docker_tag(self, new_image: str, orig_image: str):
+        print("Replace docker tag")
+        cmd = ["docker", "tag", new_image, orig_image]
+        self._exec_silent_cmd(cmd)
+
+    def _delete_orig_pod(self):
+        print("Delete dockers, so that new images will replace them")
+        cmd = [
+            "kubectl",
+            "-n",
+            "default-tenant",
+            "delete",
+            "pod",
+            "-l",
+            "app.kubernetes.io/instance=mlrun",
+            "-l",
+            "app.kubernetes.io/component=api",
+        ]
+        self._exec_silent_cmd(cmd)
+
+    def do_replacing(self):
+        api_pod = self._get_mlrun_api_pod()
+        if not api_pod:
+            raise RuntimeError(
+                "mlrun-api pod name not found. perhaps you are running on old version without chief pod"
+            )
+
+        api_image = self._get_mlrun_api_image(api_pod)
+        if not api_image:
+            raise RuntimeError("mlrun-api image name not found")
+
+        api_image_version = api_image.split("mlrun-api:")[-1].strip()
+
+        if self._verbose:
+            print(f"Version: {api_image_version} from {api_image}")
+
+        new_image_name = self._build_api_docker(api_image_version)
+        if not new_image_name:
+            raise RuntimeError("unable to build api docker")
+
+        self._replace_docker_tag(new_image_name, api_image)
+        self._delete_orig_pod()
+        print("Replaced mlrun-api image sucessfully! Yay!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replace mlrun")
+
+    parser.add_argument(
+        "--verbose", help="Print what we are doing", action="store_true"
+    )
+
+    args = parser.parse_args()
+
+    MlRunReplacer(args).do_replacing()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A script for deploying mlrun-api pods on an app node based on a branch.
There are 2 ways of using this:
1. run deploy_remote.py from developer machine. this requires the branch to be updated in github
2. login into the app node and replace just the pod while running from source directory (which may have been fetched by script above previously, or fetched manually)

Number of questions to address:
1. Where does it make sense to put these in the repo
2. Currently re-deploying vi deploy_remote.py will fail, as some go sources are owned by root. I would like to avoid running rm as sudo
3. Currently it needs packages from automation requirements.txt. Not sure if it should be that way