### PR TITLE
[SchemaCompiler] Fix building container image

### DIFF
--- a/go/cmd/logcollector/docker/Dockerfile
+++ b/go/cmd/logcollector/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN GOOS=linux \
 
 FROM alpine:latest as install-health-probe
 
-ARG GRPC_HEALTH_PROBE_VERSION=v0.4.18
+ARG GRPC_HEALTH_PROBE_VERSION=v0.4.19
 
 RUN mkdir /app
 WORKDIR /app

--- a/go/cmd/schemas_compiler/docker/Dockerfile
+++ b/go/cmd/schemas_compiler/docker/Dockerfile
@@ -18,7 +18,7 @@ FROM golang:${GO_VERSION}
 
 ARG PROTOC_GEN_GO_VERSION=v1.28
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
-ARG GRPCIO_TOOLS_VERSION="~=1.41.0"
+ARG GRPCIO_TOOLS_VERSION="~=1.54.2"
 
 WORKDIR /app/go
 
@@ -31,4 +31,6 @@ RUN apt-get update && apt install -y \
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} && \
   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
-RUN pip install grpcio-tools${GRPCIO_TOOLS_VERSION}
+# use --break-system-packages to avoid "pip error "externally managed environment" on latest python/pip
+# ftr, the alternative is using venv, but it's more complicated
+RUN pip install grpcio-tools${GRPCIO_TOOLS_VERSION} --break-system-packages


### PR DESCRIPTION
Seems like latest pip refuses to install on system, fixed by feeding it with `--break-system-packages` to avoid such errors.
