### PR TITLE
[Feature Store] -  Save the engine as "storey" when the input engine is None.

### DIFF
--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -186,10 +186,13 @@ class FeatureSetSpec(ModelObj):
     @engine.setter
     def engine(self, engine: str):
         engine_list = ["pandas", "spark", "storey"]
-        if engine and engine not in engine_list:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"engine must be one of {','.join(engine_list)}"
-            )
+        if engine:
+            if engine not in engine_list:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"engine must be one of {','.join(engine_list)}"
+                )
+        else:
+            engine = "storey"
         self.graph.engine = "sync" if engine and engine in ["pandas", "spark"] else None
         self._engine = engine
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -186,13 +186,11 @@ class FeatureSetSpec(ModelObj):
     @engine.setter
     def engine(self, engine: str):
         engine_list = ["pandas", "spark", "storey"]
-        if engine:
-            if engine not in engine_list:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"engine must be one of {','.join(engine_list)}"
-                )
-        else:
-            engine = "storey"
+        engine = engine if engine else "storey"
+        if engine not in engine_list:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"engine must be one of {','.join(engine_list)}"
+            )
         self.graph.engine = "sync" if engine and engine in ["pandas", "spark"] else None
         self._engine = engine
 


### PR DESCRIPTION
In order to display the engine name `"storey"` in the UI, 
the `storey` engine will be saved in the `feature_set` as `storey` (not as None).

https://jira.iguazeng.com/browse/ML-3938