### PR TITLE
[gRPC] Fix compiling schemas docker image [1.3.x]

### DIFF
--- a/go/cmd/schemas_compiler/docker/Dockerfile
+++ b/go/cmd/schemas_compiler/docker/Dockerfile
@@ -12,25 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG PYTHON_VERSION=3.9
 ARG GO_VERSION=1.19
 
-FROM golang:${GO_VERSION}
+FROM golang:${GO_VERSION}-alpine AS golang
+
+FROM python:${PYTHON_VERSION}-alpine
 
 ARG PROTOC_GEN_GO_VERSION=v1.28
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
-ARG GRPCIO_TOOLS_VERSION="~=1.54.2"
+ARG GRPCIO_TOOLS_VERSION="~=1.41.0"
 
 WORKDIR /app/go
 
-RUN apt-get update && apt install -y \
-    protobuf-compiler \
-    python3 \
-    python3-setuptools  \
-    python3-pip
+RUN apk add --no-cache protoc build-base linux-headers
+
+COPY --from=golang /usr/local/go/ /usr/local/go/
+
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} && \
   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
-# use --break-system-packages to avoid "pip error "externally managed environment" on latest python/pip
-# ftr, the alternative is using venv, but it's more complicated
-RUN pip install grpcio-tools${GRPCIO_TOOLS_VERSION} --break-system-packages
+RUN pip install grpcio-tools${GRPCIO_TOOLS_VERSION}

--- a/go/cmd/schemas_compiler/docker/Dockerfile
+++ b/go/cmd/schemas_compiler/docker/Dockerfile
@@ -29,7 +29,8 @@ RUN apk add --no-cache protoc build-base linux-headers
 
 COPY --from=golang /usr/local/go/ /usr/local/go/
 
-ENV PATH="/usr/local/go/bin:${PATH}"
+# add copied golang binary to path, add go bin to path (where we install go binaries)
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
 
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} && \
   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}


### PR DESCRIPTION
Seems like the compiled schemas were malformed with
<details><summary>Details</summary>
<p>

```python
  File "/mlrun/mlrun/api/utils/periodic.py", line 34, in _periodic_function_wrapper
    await function(*args, **kwargs)
  File "/mlrun/mlrun/api/main.py", line 278, in _initiate_logs_collection
    await _start_log_and_update_runs(start_logs_limit, db_session, runs)
  File "/mlrun/mlrun/api/main.py", line 296, in _start_log_and_update_runs
    results = await asyncio.gather(
  File "/mlrun/mlrun/api/main.py", line 340, in _start_log_for_run
    mlrun.api.utils.clients.log_collector.LogCollectorClient()
  File "/mlrun/mlrun/utils/singleton.py", line 23, in __call__
    cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
  File "/mlrun/mlrun/api/utils/clients/log_collector.py", line 77, in __init__
    self._initialize_proto_client_imports()
  File "/mlrun/mlrun/api/utils/clients/log_collector.py", line 84, in _initialize_proto_client_imports
    import mlrun.api.proto.log_collector_pb2
  File "/mlrun/mlrun/api/proto/log_collector_pb2.py", line 5, in <module>
    from google.protobuf.internal import builder as _builder
```

</p>
</details> 

due to https://github.com/mlrun/mlrun/commit/390bcb02baea017ef11088bdfabf9344573dfdc3 

In this PR ive changed the image to be based on python 3.9 as golang:1.19 has changed its python version to 3.11 which raised another issue (that led to https://github.com/mlrun/mlrun/commit/390bcb02baea017ef11088bdfabf9344573dfdc3)

Anyhow,  this PR should do the trick as I moved back to py39 and changed GRPCIO_TOOLS_VERSION back to 1.41

