### PR TITLE
[Package] Add all `pandas` file formats

### DIFF
--- a/mlrun/package/packagers/pandas_packagers.py
+++ b/mlrun/package/packagers/pandas_packagers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import importlib
 import os
 import pathlib
 import tempfile
@@ -313,8 +314,7 @@ class _XMLFormatter(_Formatter):
         parser = to_kwargs.pop("parser", None)
         if parser is None:
             try:
-                import lxml
-
+                importlib.import_module("lxml")
                 parser = "lxml"
             except ModuleNotFoundError:
                 parser = "etree"

--- a/mlrun/package/packagers/pandas_packagers.py
+++ b/mlrun/package/packagers/pandas_packagers.py
@@ -35,28 +35,117 @@ class _Formatter(ABC):
 
     @classmethod
     @abstractmethod
-    def to(cls, obj: pd.DataFrame, file_path: str, **to_kwargs: dict):
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
         """
-        Save the given dataframe / series to the file path given.
+        Save the given dataframe to the file path given.
 
-        :param obj:       The dataframe / series to save.
+        :param obj:       The dataframe to save.
         :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
         :param to_kwargs: Additional keyword arguments to pass to the relevant `to_x` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
         """
         pass
 
     @classmethod
     @abstractmethod
-    def read(cls, file_path: str, **read_kwargs: dict) -> pd.DataFrame:
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
         """
-        Read the dataframe / series from the given file path.
+        Read the dataframe from the given file path.
 
-        :param file_path:   The file to read the dataframe from.
-        :param read_kwargs: Additional keyword arguments to pass to the relevant read function of pandas.
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the relevant read function of pandas.
 
-        :return: The loaded dataframe / series.
+        :return: The loaded dataframe.
         """
         pass
+
+    @staticmethod
+    def _flatten_dataframe(dataframe: pd.DataFrame) -> Tuple[pd.DataFrame, dict]:
+        """
+        Flatten the dataframe: moving all indexes to be columns at the start (from column 0) and lowering the columns
+        levels to 1, renaming them from tuples. All columns and index info is stored so it can be unflatten later on.
+
+        :param dataframe: The dataframe to flatten.
+
+        :return: The flat dataframe.
+        """
+        # Save columns info:
+        columns = list(dataframe.columns)
+        if isinstance(dataframe.columns, pd.MultiIndex):
+            columns = [list(column_tuple) for column_tuple in columns]
+        columns_levels = list(dataframe.columns.names)
+
+        # Save index info:
+        index_levels = list(dataframe.index.names)
+
+        # Turn multi-index columns into single columns:
+        if len(columns_levels) > 1:
+            # We turn the column tuple into a string to eliminate parsing issues during savings to text formats:
+            dataframe.columns = pd.Index(
+                "-".join(column_tuple) for column_tuple in columns
+            )
+
+        # Rename indexes in case they appear in the columns so it won't get overriden when the index reset:
+        dataframe.index.set_names(
+            names=[
+                name
+                if name is not None and name not in dataframe.columns
+                else f"INDEX_{name}_{i}"
+                for i, name in enumerate(dataframe.index.names)
+            ],
+            inplace=True,
+        )
+
+        # Reset the index, moving the current index to a column:
+        dataframe.reset_index(inplace=True)
+
+        return dataframe, {
+            "columns": columns,
+            "columns_levels": columns_levels,
+            "index_levels": index_levels,
+        }
+
+    @staticmethod
+    def _unflatten_dataframe(
+        dataframe: pd.DataFrame,
+        columns: list,
+        columns_levels: list,
+        index_levels: list,
+    ) -> pd.DataFrame:
+        """
+        Unflatten the dataframe, moving the indexes from the columns and resuming the columns levels and names.
+
+        :param dataframe:      The dataframe to unflatten.
+        :param columns:        The original list of columns.
+        :param columns_levels: The original columns levels names.
+        :param index_levels:   The original index levels names.
+
+        :return: The un-flatted dataframe.
+        """
+        # Move back index from columns:
+        dataframe.set_index(
+            keys=list(dataframe.columns[: len(index_levels)]), inplace=True
+        )
+        dataframe.index.set_names(names=index_levels, inplace=True)
+
+        # Set the columns back in case they were multi-leveled:
+        if len(columns_levels) > 1:
+            dataframe.columns = pd.MultiIndex.from_tuples(
+                tuples=columns, names=columns_levels
+            )
+        else:
+            dataframe.columns.set_names(names=columns_levels, inplace=True)
+
+        return dataframe
 
 
 class _ParquetFormatter(_Formatter):
@@ -65,25 +154,34 @@ class _ParquetFormatter(_Formatter):
     """
 
     @classmethod
-    def to(cls, obj: pd.DataFrame, file_path: str, **to_kwargs: dict):
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
         """
-        Save the given dataframe / series to the file path given.
+        Save the given dataframe to the parquet file path given.
 
-        :param obj:       The dataframe / series to save.
+        :param obj:       The dataframe to save.
         :param file_path: The file to save to.
-        :param to_kwargs: Additional keyword arguments to pass to the relevant `to_parquet` function.
+        :param flatten:   Ignored for parquet format.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_parquet` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
         """
         obj.to_parquet(path=file_path, **to_kwargs)
+        return {}
 
     @classmethod
-    def read(cls, file_path: str, **read_kwargs: dict) -> pd.DataFrame:
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
         """
-        Read the dataframe / series from the given parquet file path.
+        Read the dataframe from the given parquet file path.
 
-        :param file_path:   The file to read the dataframe from.
-        :param read_kwargs: Additional keyword arguments to pass to the `read_parquet` function.
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Ignored for parquet format.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_parquet` function.
 
-        :return: The loaded dataframe / series.
+        :return: The loaded dataframe.
         """
         return pd.read_parquet(path=file_path, **read_kwargs)
 
@@ -94,27 +192,453 @@ class _CSVFormatter(_Formatter):
     """
 
     @classmethod
-    def to(cls, obj: pd.DataFrame, file_path: str, **to_kwargs: dict):
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
         """
-        Save the given dataframe / series to the file path given.
+        Save the given dataframe to the csv file path given.
 
-        :param obj:       The dataframe / series to save.
+        :param obj:       The dataframe to save.
         :param file_path: The file to save to.
-        :param to_kwargs: Additional keyword arguments to pass to the relevant `to_csv` function.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_csv` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
         """
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        instructions = {}
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to csv:
         obj.to_csv(path_or_buf=file_path, **to_kwargs)
 
+        return instructions
+
     @classmethod
-    def read(cls, file_path: str, **read_kwargs: dict) -> pd.DataFrame:
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
         """
-        Read the dataframe / series from the given parquet file path.
+        Read the dataframe from the given csv file path.
 
-        :param file_path:   The file to read the dataframe from.
-        :param read_kwargs: Additional keyword arguments to pass to the `read_csv` function.
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_csv` function.
 
-        :return: The loaded dataframe / series.
+        :return: The loaded dataframe.
         """
-        return pd.read_csv(filepath_or_buffer=file_path, **read_kwargs)
+        # Read the csv:
+        obj = pd.read_csv(filepath_or_buffer=file_path, **read_kwargs)
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            # Remove the default index (joined with reset index):
+            if obj.columns[0] == "Unnamed: 0":
+                obj.drop(columns=["Unnamed: 0"], inplace=True)
+            # Unflatten the dataframe:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
+
+
+class _H5Formatter(_Formatter):
+    """
+    A static class for managing pandas h5 files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the h5 file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Ignored for h5 format.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_hdf` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
+        """
+        # If user didn't provide a key for the dataframe, use default key 'table':
+        key = to_kwargs.pop("key", "table")
+
+        # Write to h5:
+        obj.to_hdf(path_or_buf=file_path, key=key, **to_kwargs)
+
+        return {"key": key}
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read the dataframe from the given h5 file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Ignored for h5 format.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_hdf` function.
+
+        :return: The loaded dataframe.
+        """
+        return pd.read_hdf(path_or_buf=file_path, **read_kwargs)
+
+
+class _XMLFormatter(_Formatter):
+    """
+    A static class for managing pandas xml files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the xml file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_xml` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
+        """
+        # Get the parser (if not provided, try to use `lxml`, otherwise `etree`):
+        parser = to_kwargs.pop("parser", None)
+        if parser is None:
+            try:
+                import lxml
+
+                parser = "lxml"
+            except ModuleNotFoundError:
+                parser = "etree"
+        instructions = {"parser": parser}
+
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to xml:
+        obj.to_xml(path_or_buffer=file_path, parser="etree", **to_kwargs)
+
+        return instructions
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read the dataframe from the given xml file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_xml` function.
+
+        :return: The loaded dataframe.
+        """
+        # Read the xml:
+        obj = pd.read_xml(path_or_buffer=file_path, **read_kwargs)
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            # Remove the default index (joined with reset index):
+            if obj.columns[0] == "index":
+                obj.drop(columns=["index"], inplace=True)
+            # Unflatten the dataframe:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
+
+
+class _XLSXFormatter(_Formatter):
+    """
+    A static class for managing pandas xlsx files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the xlsx file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_excel` function.
+        """
+        # Get the engine to pass when unpacked:
+        instructions = {"engine": to_kwargs.get("engine", None)}
+
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to xlsx:
+        obj.to_excel(excel_writer=file_path, **to_kwargs)
+
+        return instructions
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read the dataframe from the given xlsx file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_excel` function.
+
+        :return: The loaded dataframe.
+        """
+        # Read the xlsx:
+        obj = pd.read_excel(io=file_path, **read_kwargs)
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            # Remove the default index (joined with reset index):
+            if obj.columns[0] == "Unnamed: 0":
+                obj.drop(columns=["Unnamed: 0"], inplace=True)
+            # Unflatten the dataframe:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
+
+
+class _HTMLFormatter(_Formatter):
+    """
+    A static class for managing pandas html files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the html file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_html` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
+        """
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        instructions = {}
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to html:
+        obj.to_html(buf=file_path, **to_kwargs)
+        return instructions
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read dataframes from the given html file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_html` function.
+
+        :return: The loaded dataframe.
+        """
+        # Read the html:
+        obj = pd.read_html(io=file_path, **read_kwargs)[0]
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            # Remove the default index (joined with reset index):
+            if obj.columns[0] == "Unnamed: 0":
+                obj.drop(columns=["Unnamed: 0"], inplace=True)
+            # Unflatten the dataframe:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
+
+
+class _JSONFormatter(_Formatter):
+    """
+    A static class for managing pandas json files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the json file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_json` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
+        """
+        # Get the orient to pass when unpacked:
+        instructions = {"orient": to_kwargs.get("orient", None)}
+
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to json:
+        obj.to_json(path_or_buf=file_path, **to_kwargs)
+
+        return instructions
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read dataframes from the given json file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_json` function.
+
+        :return: The loaded dataframe.
+        """
+        # Read the json:
+        obj = pd.read_json(path_or_buf=file_path, **read_kwargs)
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
+
+
+class _FeatherFormatter(_Formatter):
+    """
+    A static class for managing pandas feather files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the feather file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_feather` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
+        """
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        instructions = {}
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to feather:
+        obj.to_feather(path=file_path, **to_kwargs)
+
+        return instructions
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read dataframes from the given feather file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_feather` function.
+
+        :return: The loaded dataframe.
+        """
+        # Read the feather:
+        obj = pd.read_feather(path=file_path, **read_kwargs)
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
+
+
+class _ORCFormatter(_Formatter):
+    """
+    A static class for managing pandas orc files.
+    """
+
+    @classmethod
+    def to(
+        cls, obj: pd.DataFrame, file_path: str, flatten: bool = True, **to_kwargs
+    ) -> dict:
+        """
+        Save the given dataframe to the orc file path given.
+
+        :param obj:       The dataframe to save.
+        :param file_path: The file to save to.
+        :param flatten:   Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                          flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                          especially in case it is multi-level or multi-index. Default to True.
+        :param to_kwargs: Additional keyword arguments to pass to the `to_orc` function.
+
+        :return A dictionary of keyword arguments for reading the dataframe from file.
+        """
+        # Flatten the dataframe (this format have problems saving multi-level dataframes):
+        instructions = {}
+        if flatten:
+            obj, unflatten_kwargs = cls._flatten_dataframe(dataframe=obj)
+            instructions["unflatten_kwargs"] = unflatten_kwargs
+
+        # Write to feather:
+        obj.to_orc(path=file_path, **to_kwargs)
+
+        return instructions
+
+    @classmethod
+    def read(
+        cls, file_path: str, unflatten_kwargs: dict = None, **read_kwargs
+    ) -> pd.DataFrame:
+        """
+        Read dataframes from the given orc file path.
+
+        :param file_path:        The file to read the dataframe from.
+        :param unflatten_kwargs: Unflatten keyword arguments for unflattening the read dataframe.
+        :param read_kwargs:      Additional keyword arguments to pass to the `read_orc` function.
+
+        :return: The loaded dataframe.
+        """
+        # Read the feather:
+        obj = pd.read_orc(path=file_path, **read_kwargs)
+
+        # Check if it was flattened in packing:
+        if unflatten_kwargs is not None:
+            obj = cls._unflatten_dataframe(dataframe=obj, **unflatten_kwargs)
+
+        return obj
 
 
 class PandasSupportedFormat(SupportedFormat[_Formatter]):
@@ -124,25 +648,24 @@ class PandasSupportedFormat(SupportedFormat[_Formatter]):
 
     PARQUET = "parquet"
     CSV = "csv"
-    # TODO: Add support for all the below formats:
-    # H5 = "h5"
-    # XML = "xml"
-    # XLSX = "xlsx"
-    # HTML = "html"
-    # JSON = "json"
-    # FEATHER = "feather"
-    # ORC = "orc"
+    H5 = "h5"
+    XML = "xml"
+    XLSX = "xlsx"
+    HTML = "html"
+    JSON = "json"
+    FEATHER = "feather"
+    ORC = "orc"
 
     _FORMAT_HANDLERS_MAP = {
         PARQUET: _ParquetFormatter,
         CSV: _CSVFormatter,
-        # H5: _H5Formatter,
-        # XML: _XMLFormatter,
-        # XLSX: _XLSXFormatter,
-        # HTML: _HTMLFormatter,
-        # JSON: _JSONFormatter,
-        # FEATHER: _FeatherFormatter,
-        # ORC: _ORCFormatter,
+        H5: _H5Formatter,
+        XML: _XMLFormatter,
+        XLSX: _XLSXFormatter,
+        HTML: _HTMLFormatter,
+        JSON: _JSONFormatter,
+        FEATHER: _FeatherFormatter,
+        ORC: _ORCFormatter,
     }
 
 
@@ -211,6 +734,7 @@ class PandasDataFramePackager(DefaultPackager):
         obj: pd.DataFrame,
         key: str,
         file_format: str = None,
+        flatten: bool = True,
         **to_kwargs,
     ) -> Tuple[Artifact, dict]:
         """
@@ -220,6 +744,9 @@ class PandasDataFramePackager(DefaultPackager):
         :param key:         The key to use for the artifact.
         :param file_format: The file format to save as. Default is parquet or csv (depends on the column names as
                             parquet cannot be used for non string column names).
+        :param flatten:     Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                            flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                            especially in case it is multi-level or multi-index. Default to True.
         :param to_kwargs:   Additional keyword arguments to pass to the pandas `to_x` functions.
 
         :return: The packed artifact and instructions.
@@ -232,20 +759,19 @@ class PandasDataFramePackager(DefaultPackager):
                 else NON_STRING_COLUMN_NAMES_DEFAULT_PANDAS_FORMAT
             )
 
-        # Get the indexes as they may get changed during saving in some file formats:
-        indexes_names = list(obj.index.names)  # No index will yield '[None]'.
-
         # Save to file:
         formatter = PandasSupportedFormat.get_format_handler(fmt=file_format)
         temp_directory = pathlib.Path(tempfile.mkdtemp())
         cls.add_future_clearing_path(path=temp_directory)
         file_path = temp_directory / f"{key}.{file_format}"
-        formatter.to(obj=obj, file_path=str(file_path), **to_kwargs)
+        read_kwargs = formatter.to(
+            obj=obj, file_path=str(file_path), flatten=flatten, **to_kwargs
+        )
 
         # Create the artifact and instructions:
         artifact = Artifact(key=key, src_path=os.path.abspath(file_path))
 
-        return artifact, {"file_format": file_format, "indexes_names": indexes_names}
+        return artifact, {"file_format": file_format, "read_kwargs": read_kwargs}
 
     @classmethod
     def pack_dataset(cls, obj: pd.DataFrame, key: str, file_format: str = "parquet"):
@@ -265,7 +791,7 @@ class PandasDataFramePackager(DefaultPackager):
         cls,
         data_item: DataItem,
         file_format: str = None,
-        indexes_names: List[Union[str, int]] = None,
+        read_kwargs: dict = None,
     ) -> pd.DataFrame:
         """
         Unpack a pandas dataframe from file.
@@ -273,7 +799,7 @@ class PandasDataFramePackager(DefaultPackager):
         :param data_item:   The data item to unpack.
         :param file_format: The file format to use for reading the series. Default is None - will be read by the file
                             extension.
-        :param indexes_names: Names of the indexes in the dataframe.
+        :param read_kwargs: Keyword arguments to pass to the read of the formatter.
 
         :return: The unpacked series.
         """
@@ -292,21 +818,9 @@ class PandasDataFramePackager(DefaultPackager):
 
         # Read the object:
         formatter = PandasSupportedFormat.get_format_handler(fmt=file_format)
-        obj = formatter.read(file_path=file_path)
-
-        # Set indexes if given by instructions and the default index (without name) is currently set in the dataframe:
-        if indexes_names is not None and list(obj.index.names) == [None]:
-            if indexes_names == [None]:
-                # If the default index was used (an index without a column name), it will be the first column, and it's
-                # name may be 'Unnamed: 0' so we need override it:
-                if obj.columns[0] == "Unnamed: 0":
-                    obj.set_index(keys=["Unnamed: 0"], drop=True, inplace=True)
-                obj.index.set_names(names=[None], inplace=True)
-            else:
-                # Otherwise, simply set the original indexes from the available columns:
-                obj.set_index(keys=indexes_names, drop=True, inplace=True)
-
-        return obj
+        if read_kwargs is None:
+            read_kwargs = {}
+        return formatter.read(file_path=file_path, **read_kwargs)
 
     @classmethod
     def unpack_dataset(cls, data_item: DataItem):
@@ -380,6 +894,7 @@ class PandasSeriesPackager(PandasDataFramePackager):
         obj: pd.Series,
         key: str,
         file_format: str = None,
+        flatten: bool = True,
         **to_kwargs,
     ) -> Tuple[Artifact, dict]:
         """
@@ -389,6 +904,9 @@ class PandasSeriesPackager(PandasDataFramePackager):
         :param key:         The key to use for the artifact.
         :param file_format: The file format to save as. Default is parquet or csv (depends on the column names as
                             parquet cannot be used for non string column names).
+        :param flatten:     Whether to flatten the dataframe before saving. For some formats it is mandatory to enable
+                            flattening, otherwise saving and loading the dataframe will cause unexpected behavior
+                            especially in case it is multi-level or multi-index. Default to True.
         :param to_kwargs:   Additional keyword arguments to pass to the pandas `to_x` functions.
 
         :return: The packed artifact and instructions.
@@ -398,7 +916,11 @@ class PandasSeriesPackager(PandasDataFramePackager):
 
         # Cast to dataframe and call the parent `pack_file`:
         artifact, instructions = super().pack_file(
-            obj=pd.DataFrame(obj), key=key, file_format=file_format, **to_kwargs
+            obj=pd.DataFrame(obj),
+            key=key,
+            file_format=file_format,
+            flatten=flatten,
+            **to_kwargs,
         )
 
         # Return the artifact with the updated instructions:
@@ -409,7 +931,7 @@ class PandasSeriesPackager(PandasDataFramePackager):
         cls,
         data_item: DataItem,
         file_format: str = None,
-        indexes_names: List[Union[str, int]] = None,
+        read_kwargs: dict = None,
         column_name: Union[str, int] = None,
     ) -> pd.Series:
         """
@@ -418,14 +940,16 @@ class PandasSeriesPackager(PandasDataFramePackager):
         :param data_item:     The data item to unpack.
         :param file_format:   The file format to use for reading the series. Default is None - will be read by the file
                               extension.
-        :param indexes_names: Names of the indexes in the series.
+        :param read_kwargs:   Keyword arguments to pass to the read of the formatter.
         :param column_name:   The name of the series column.
 
         :return: The unpacked series.
         """
         # Read the object:
         obj = super().unpack_file(
-            data_item=data_item, file_format=file_format, indexes_names=indexes_names
+            data_item=data_item,
+            file_format=file_format,
+            read_kwargs=read_kwargs,
         )
 
         # Cast the dataframe into a series:
@@ -436,8 +960,9 @@ class PandasSeriesPackager(PandasDataFramePackager):
             )
         obj = obj[obj.columns[0]]
 
-        # Edit the column name:
-        if column_name is not None:
+        # Edit the column name (if `read_kwargs` is not None we can be sure it is a packed file artifact, so the column
+        # name, even if None, should be set to restore the object as it was):
+        if read_kwargs is not None:
             obj.name = column_name
 
         return obj

--- a/tests/package/packagers/test_pandas_packagers.py
+++ b/tests/package/packagers/test_pandas_packagers.py
@@ -43,7 +43,7 @@ def check_skipping_pandas_format(fmt: str):
 
     # TODO: Remove when padnas>=1.5 in requirements
     if fmt == PandasSupportedFormat.ORC:
-        # ORC format is added only since pandas 1.5.0, so we skip if padnas is older than this:
+        # ORC format is added only since pandas 1.5.0, so we skip if pandas is older than this:
         v1, v2, v3 = pd.__version__.split(".")
         if int(v1) == 1 and int(v2) < 5:
             return True

--- a/tests/package/packagers/test_pandas_packagers.py
+++ b/tests/package/packagers/test_pandas_packagers.py
@@ -40,6 +40,13 @@ def check_skipping_pandas_format(fmt: str):
             importlib.import_module(FORMAT_REQUIREMENTS[fmt])
         except ModuleNotFoundError:
             return True
+
+    # TODO: Remove when padnas>=1.5 in requirements
+    if fmt == PandasSupportedFormat.ORC:
+        # ORC format is added only since pandas 1.5.0, so we skip if padnas is older than this:
+        v1, v2, v3 = pd.__version__.split(".")
+        if int(v1) == 1 and int(v2) < 5:
+            return True
     return False
 
 

--- a/tests/package/packagers/test_pandas_packagers.py
+++ b/tests/package/packagers/test_pandas_packagers.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import importlib
 import tempfile
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -22,34 +22,129 @@ import pytest
 
 from mlrun.package.packagers.pandas_packagers import PandasSupportedFormat
 
+# Set up the format requirements dictionary:
+FORMAT_REQUIREMENTS = {
+    PandasSupportedFormat.PARQUET: "pyarrow",
+    PandasSupportedFormat.H5: "tables",
+    PandasSupportedFormat.XLSX: "openpyxl",
+    PandasSupportedFormat.XML: "lxml",
+    PandasSupportedFormat.HTML: "lxml",
+    PandasSupportedFormat.FEATHER: "pyarrow",
+    PandasSupportedFormat.ORC: "pyarrow",
+}
 
-@pytest.mark.parametrize(
-    "obj",
-    [
-        pd.DataFrame(
-            data=np.random.randint(0, 256, (1000, 10)),
-            columns=[f"column_{i}" for i in range(10)],
+
+def check_skipping_pandas_format(fmt: str):
+    if fmt in FORMAT_REQUIREMENTS:
+        try:
+            importlib.import_module(FORMAT_REQUIREMENTS[fmt])
+        except ModuleNotFoundError:
+            return True
+    return False
+
+
+def get_test_dataframes():
+    # Configurations:
+    _n_rows = 100
+    _n_columns = 24
+    _single_level_column_names = [f"column_{i}" for i in range(_n_columns)]
+    _multi_level_column_names = [
+        [f"{chr(n)}1" for n in range(ord("A"), ord("A") + 2)],
+        [f"{chr(n)}2" for n in range(ord("A"), ord("A") + 3)],
+        [f"{chr(n)}3" for n in range(ord("A"), ord("A") + 4)],
+    ]  # 2 * 3 * 4 = 24 (_n_columns)
+    _column_levels_names = ["letter_level_1", "letter_level_2", "letter_level_3"]
+    _single_index = [i for i in range(0, _n_rows * 2, 2)]
+    _multi_index = [
+        list(range(2)),
+        list(range(5)),
+        list(range(10)),
+    ]  # 2 * 5 * 10 = 100 (_n_rows)
+
+    # Initialize the data and options for dataframes:
+    data = np.random.randint(0, 256, (_n_rows, _n_columns))
+    columns_options = [
+        # Single level:
+        _single_level_column_names,
+        # Multi-level:
+        pd.MultiIndex.from_product(_multi_level_column_names),
+        # Multi-level with names:
+        pd.MultiIndex.from_product(
+            _multi_level_column_names,
+            names=_column_levels_names,
         ),
-        pd.DataFrame(
-            data=np.random.randint(0, 256, (1000, 10)),
-            columns=[f"column_{i}" for i in range(10)],
-            index=[i for i in range(1000)],
+    ]
+    index_options = [
+        # Default:
+        None,
+        # Single level:
+        _single_index,
+        # Single level with name:
+        pd.Index(data=_single_index, name="my_index"),
+        # Multi-level:
+        pd.MultiIndex.from_product(_multi_index),
+        # Multi-level with names:
+        pd.MultiIndex.from_product(
+            _multi_index, names=["index_5", "index_10", "index_20"]
         ),
-        pd.DataFrame(
-            data=np.random.randint(0, 256, (1000, 10)),
-            columns=[f"column_{i}" for i in range(10)],
-        ).set_index(keys=["column_1", "column_3", "column_4"]),
-    ],
-)
+    ]
+
+    # Initialize the dataframes:
+    dataframes = []
+    for columns in columns_options:
+        for index in index_options:
+            df = pd.DataFrame(data=data, columns=columns, index=index)
+            dataframes.append(df)
+            # Add same name of columns and indexes scenarios if index has a name:
+            if index is not None and all(
+                index_name is not None for index_name in df.index.names
+            ):
+                same_name_df = df.copy()
+                if isinstance(df.index, pd.MultiIndex):
+                    if isinstance(df.columns, pd.MultiIndex):
+                        same_name_df.index.set_names(
+                            names=df.columns.names[: len(df.index.names)], inplace=True
+                        )
+                    else:  # Single index
+                        same_name_df.index.set_names(
+                            names=df.columns[: len(df.index.names)], inplace=True
+                        )
+                else:  # Single index
+                    if isinstance(df.columns, pd.MultiIndex):
+                        same_name_df.index.set_names(
+                            names=str(df.columns.names[0]), inplace=True
+                        )
+                    else:  # Single index
+                        same_name_df.index.set_names(
+                            names=str(df.columns[0]), inplace=True
+                        )
+                dataframes.append(same_name_df)
+
+    return dataframes
+
+
+@pytest.mark.parametrize("obj", get_test_dataframes())
 @pytest.mark.parametrize(
     "file_format",
     PandasSupportedFormat.get_all_formats(),
 )
 def test_formatter(
-    obj: Union[pd.DataFrame, pd.Series],
+    obj: pd.DataFrame,
     file_format: str,
-    **to_kwargs,
 ):
+    """
+    Test the pandas formatters for writing and reading dataframes.
+
+    :param obj:         The dataframe to write.
+    :param file_format: The pandas file format to use.
+    """
+    # Check if needed to skip this file format test:
+    if check_skipping_pandas_format(fmt=file_format):
+        pytest.skip(
+            f"Skipping test of pandas file format '{file_format}' "
+            f"due to missing requirement: '{FORMAT_REQUIREMENTS[file_format]}'"
+        )
+
     # Create a temporary directory for the test outputs:
     test_directory = tempfile.TemporaryDirectory()
 
@@ -59,17 +154,17 @@ def test_formatter(
 
     # Save the dataframe to file:
     formatter = PandasSupportedFormat.get_format_handler(fmt=file_format)
-    formatter.to(obj=obj, file_path=str(file_path), **to_kwargs)
+    read_kwargs = formatter.to(obj=obj.copy(), file_path=str(file_path))
     assert file_path.exists()
 
     # Read the file:
-    saved_object = formatter.read(file_path=str(file_path))
-    if saved_object.columns[0] == "Unnamed: 0":
-        saved_object.set_index(keys=["Unnamed: 0"], drop=True, inplace=True)
-        saved_object.index.set_names(names=[None], inplace=True)
-    if len(obj.index.names) > 1 and len(saved_object.index.names) == 1:
-        saved_object.set_index(keys=obj.index.names, inplace=True)
+    saved_object = formatter.read(file_path=str(file_path), **read_kwargs)
+
+    # Assert equality post reading:
     assert isinstance(saved_object, type(obj))
+    assert list(saved_object.columns) == list(obj.columns)
+    assert saved_object.columns.names == obj.columns.names
+    assert saved_object.index.names == obj.index.names
     assert (saved_object == obj).all().all()
 
     # Clean the test outputs:


### PR DESCRIPTION
Add support for packing and unpacking all `pandas` file formats:
* parquet (was already implemented)
* csv (was already implemented)
* h5
* xml
* xlsx
* html
* json
* feather
* orc

Part of the magic is a function that flattens data frames and restores them. Read in doc strings of `_Formatter` class to understand more.