### PR TITLE
[Images] Pin schemas-compile base image to iguazio gcr

### DIFF
--- a/go/cmd/schemas_compiler/docker/Dockerfile
+++ b/go/cmd/schemas_compiler/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION=1.19
 
-FROM golang:${GO_VERSION}
+FROM gcr.io/iguazio/golang:${GO_VERSION}
 
 ARG PROTOC_GEN_GO_VERSION=v1.28
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
@@ -33,4 +33,5 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERS
 
 # use --break-system-packages to avoid "pip error "externally managed environment" on latest python/pip
 # ftr, the alternative is using venv, but it's more complicated
-RUN pip install grpcio-tools${GRPCIO_TOOLS_VERSION} --break-system-packages
+# TODO: uncomment --break-system-packages once we upgrade pip to > 23.0.1 https://pip.pypa.io/en/stable/news/#v23-0-1
+RUN pip install grpcio-tools${GRPCIO_TOOLS_VERSION} #--break-system-packages


### PR DESCRIPTION
`--break-system-packages` was introduced in pip [23.0.1](https://pip.pypa.io/en/stable/news/#v23-0-1) 
The reason the error poped up is that go released a new [1.19](https://hub.docker.com/layers/library/golang/1.19/images/sha256-2582d66dcf86646199c081554791c3bac35e18766a9210c931a0bac6a30b7875?context=explore) patch with updated pip 
We should pin the golang base image so that we don't get unwanted changes like this in the future.