### PR TITLE
[Feature Store] Fix preview to rename column headings containing the `space` char

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -661,10 +661,10 @@ def preview(
     :param verbose:        verbose log
     :param sample_size:    num of rows to sample from the dataset (for large datasets)
     """
-    # preview reads the source as a pandas df, which is not fully compatible with spark
     if isinstance(source, pd.DataFrame):
         source = _rename_source_dataframe_columns(source)
 
+    # preview reads the source as a pandas df, which is not fully compatible with spark
     if featureset.spec.engine == "spark":
         raise mlrun.errors.MLRunInvalidArgumentError(
             "preview with spark engine is not supported"

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -662,6 +662,9 @@ def preview(
     :param sample_size:    num of rows to sample from the dataset (for large datasets)
     """
     # preview reads the source as a pandas df, which is not fully compatible with spark
+    if isinstance(source, pd.DataFrame):
+        source = _rename_source_dataframe_columns(source)
+
     if featureset.spec.engine == "spark":
         raise mlrun.errors.MLRunInvalidArgumentError(
             "preview with spark engine is not supported"

--- a/tests/system/feature_store/assets/fields_with_space.csv
+++ b/tests/system/feature_store/assets/fields_with_space.csv
@@ -1,4 +1,4 @@
-Name,City of Birth
+name,city of birth
 John,New York
 Emma,London
 Michael,Los Angeles

--- a/tests/system/feature_store/assets/fields_with_space.csv
+++ b/tests/system/feature_store/assets/fields_with_space.csv
@@ -1,0 +1,6 @@
+Name,City of Birth
+John,New York
+Emma,London
+Michael,Los Angeles
+Sophia,Paris
+David,Sydney

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4208,7 +4208,7 @@ class TestFeatureStore(TestMLRunSystem):
         data = pd.read_csv(csv_path)
         expected_result = data.copy().rename(
             columns={"city of birth": "city_of_birth"}
-        )[["city_of_birth"]]
+        ).set_index('name')
         feature_set = fstore.FeatureSet(
             name=name,
             entities=[fstore.Entity("name")],
@@ -4223,13 +4223,10 @@ class TestFeatureStore(TestMLRunSystem):
         feature_vector = fstore.FeatureVector(
             name=name, features=[f"{self.project_name}/{name}.*"]
         )
-        offline_feature_df = fstore.get_offline_features(feature_vector).to_dataframe()
-        assert offline_feature_df.reset_index(drop=True).equals(
-            result.reset_index(drop=True)
-        )
-        assert offline_feature_df.reset_index(drop=True).equals(
-            expected_result.reset_index(drop=True)
-        )
+        feature_vector.spec.with_indexes = True
+        offline_features_df = fstore.get_offline_features(feature_vector).to_dataframe()
+        assert offline_features_df.equals(result)
+        assert offline_features_df.equals(expected_result)
 
 
 def verify_purge(fset, targets):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4204,8 +4204,7 @@ class TestFeatureStore(TestMLRunSystem):
 
     def test_ingest_with_rename_columns(self):
         csv_path = str(self.assets_path / "fields_with_space.csv")
-        run_id = str(uuid.uuid4())
-        name = f"test_ingest_with_rename_columns_{run_id}"
+        name = f"test_ingest_with_rename_columns_{uuid.uuid4()}"
         data = pd.read_csv(csv_path)
         expected_result = data.copy().rename(
             columns={"city of birth": "city_of_birth"}
@@ -4222,7 +4221,7 @@ class TestFeatureStore(TestMLRunSystem):
             feature_set, data, run_config=fstore.RunConfig(local=True)
         )
         feature_vector = fstore.FeatureVector(
-            name=run_id, features=[f"{self.project_name}/{name}.*"]
+            name=name, features=[f"{self.project_name}/{name}.*"]
         )
         training_data = fstore.get_offline_features(feature_vector).to_dataframe()
         assert training_data.reset_index(drop=True).equals(

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4208,7 +4208,8 @@ class TestFeatureStore(TestMLRunSystem):
         data = pd.read_csv(csv_path)
         expected_result = data.copy().rename(
             columns={"city of birth": "city_of_birth"}
-        ).set_index('name')
+        )
+        expected_result.set_index("name", inplace=True)
         feature_set = fstore.FeatureSet(
             name=name,
             entities=[fstore.Entity("name")],

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4216,15 +4216,15 @@ class TestFeatureStore(TestMLRunSystem):
             feature_set,
             data,
         )
-        result = fstore.ingest(
-            feature_set, data, run_config=fstore.RunConfig(local=True)
+        inspect_result = fstore.ingest(
+            feature_set, data
         )
         feature_vector = fstore.FeatureVector(
             name=name, features=[f"{self.project_name}/{name}.*"]
         )
         feature_vector.spec.with_indexes = True
         offline_features_df = fstore.get_offline_features(feature_vector).to_dataframe()
-        assert offline_features_df.equals(result)
+        assert offline_features_df.equals(inspect_result)
         assert offline_features_df.equals(expected_result)
 
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4206,9 +4206,7 @@ class TestFeatureStore(TestMLRunSystem):
         csv_path = str(self.assets_path / "fields_with_space.csv")
         name = f"test_ingest_with_rename_columns_{uuid.uuid4()}"
         data = pd.read_csv(csv_path)
-        expected_result = data.copy().rename(
-            columns={"city of birth": "city_of_birth"}
-        )
+        expected_result = data.copy().rename(columns={"city of birth": "city_of_birth"})
         expected_result.set_index("name", inplace=True)
         feature_set = fstore.FeatureSet(
             name=name,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4205,24 +4205,33 @@ class TestFeatureStore(TestMLRunSystem):
     def test_ingest_with_rename_columns(self):
         csv_path = str(self.assets_path / "fields_with_space.csv")
         run_id = str(uuid.uuid4())
-        name = f'test_ingest_with_rename_columns_{run_id}'
+        name = f"test_ingest_with_rename_columns_{run_id}"
         data = pd.read_csv(csv_path)
-        expected_result = data.copy().rename(columns={'city of birth': 'city_of_birth'})[["city_of_birth"]]
+        expected_result = data.copy().rename(
+            columns={"city of birth": "city_of_birth"}
+        )[["city_of_birth"]]
         feature_set = fstore.FeatureSet(
             name=name,
-            entities=[fstore.Entity('name')],
+            entities=[fstore.Entity("name")],
         )
         fstore.preview(
             feature_set,
             data,
         )
-        result = fstore.ingest(feature_set, data, run_config=fstore.RunConfig(local=True))
-        feature_vector = fstore.FeatureVector(name=run_id,
-                                              features=[f'{self.project_name}/{name}.*'])
+        result = fstore.ingest(
+            feature_set, data, run_config=fstore.RunConfig(local=True)
+        )
+        feature_vector = fstore.FeatureVector(
+            name=run_id, features=[f"{self.project_name}/{name}.*"]
+        )
         training_data = fstore.get_offline_features(feature_vector).to_dataframe()
         assert training_data.reset_index(drop=True).equals(
-            result.reset_index(drop=True))
-        assert training_data.reset_index(drop=True).equals(expected_result.reset_index(drop=True))
+            result.reset_index(drop=True)
+        )
+        assert training_data.reset_index(drop=True).equals(
+            expected_result.reset_index(drop=True)
+        )
+
 
 def verify_purge(fset, targets):
     fset.reload(update_spec=False)

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4223,11 +4223,11 @@ class TestFeatureStore(TestMLRunSystem):
         feature_vector = fstore.FeatureVector(
             name=name, features=[f"{self.project_name}/{name}.*"]
         )
-        training_data = fstore.get_offline_features(feature_vector).to_dataframe()
-        assert training_data.reset_index(drop=True).equals(
+        offline_feature_df = fstore.get_offline_features(feature_vector).to_dataframe()
+        assert offline_feature_df.reset_index(drop=True).equals(
             result.reset_index(drop=True)
         )
-        assert training_data.reset_index(drop=True).equals(
+        assert offline_feature_df.reset_index(drop=True).equals(
             expected_result.reset_index(drop=True)
         )
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4216,9 +4216,7 @@ class TestFeatureStore(TestMLRunSystem):
             feature_set,
             data,
         )
-        inspect_result = fstore.ingest(
-            feature_set, data
-        )
+        inspect_result = fstore.ingest(feature_set, data)
         feature_vector = fstore.FeatureVector(
             name=name, features=[f"{self.project_name}/{name}.*"]
         )


### PR DESCRIPTION
Columns with special characters, such as spaces, need to be renamed.

In the `ingest` function, we have implemented the renaming of these columns by utilizing the `_rename_source_dataframe_columns` function.

This PR also updates the `preview` function to behave in the same way.

https://jira.iguazeng.com/browse/ML-3539