### PR TITLE
[Package] `mlrun.DataItem` ignored when hinted in a group as well

### DIFF
--- a/mlrun/package/context_handler.py
+++ b/mlrun/package/context_handler.py
@@ -152,12 +152,10 @@ class ContextHandler:
         parsed_args = []
         type_hints_keys = list(type_hints.keys())
         for i, argument in enumerate(args):
-            if isinstance(argument, DataItem) and type_hints[
-                type_hints_keys[i]
-            ] not in [
-                inspect.Parameter.empty,
-                DataItem,
-            ]:
+            if (
+                isinstance(argument, DataItem)
+                and type_hints[type_hints_keys[i]] is not inspect.Parameter.empty
+            ):
                 parsed_args.append(
                     self._packagers_manager.unpack(
                         data_item=argument,
@@ -170,10 +168,10 @@ class ContextHandler:
 
         # Parse the keyword arguments:
         for key, value in kwargs.items():
-            if isinstance(value, DataItem) and type_hints[key] not in [
-                inspect.Parameter.empty,
-                DataItem,
-            ]:
+            if (
+                isinstance(value, DataItem)
+                and type_hints[key] is not inspect.Parameter.empty
+            ):
                 kwargs[key] = self._packagers_manager.unpack(
                     data_item=value, type_hint=type_hints[key]
                 )

--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -268,6 +268,7 @@ class Packager(ABC, metaclass=_PackagerMeta):
             if not TypeHintUtils.is_matching(
                 object_type=cls.PACKABLE_OBJECT_TYPE,
                 type_hint=type_hint,
+                reduce_type_hint=False,
             ):
                 return False
 

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -259,6 +259,7 @@ class DefaultPackager(Packager):
                 object_type=object_type,
                 type_hint=cls.PACKABLE_OBJECT_TYPE,
                 include_subclasses=cls.PACK_SUBCLASSES,
+                reduce_type_hint=False,
             ):
                 return False
 

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -253,6 +253,8 @@ class PackagersManager:
         * As a data item: If the data item is not a package or the type hint provided is not equal to the one noted in
           the package.
 
+        If the type hint is a `mlrun.DataItem` then it won't be unpacked.
+
         Notice: It is not recommended to use a different packager than the one who originally packed the object to
         unpack it. A warning will be shown in that case.
 
@@ -261,6 +263,10 @@ class PackagersManager:
 
         :return: The unpacked object parsed as type hinted.
         """
+        # Check if `DataItem` is hinted - meaning the user can expect a data item and do not want to unpack it:
+        if TypeHintUtils.is_matching(object_type=DataItem, type_hint=type_hint):
+            return data_item
+
         # Set variables to hold the manager notes and packager instructions:
         artifact_key = None
         packaging_instructions = None

--- a/tests/package/utils/test_type_hint_utils.py
+++ b/tests/package/utils/test_type_hint_utils.py
@@ -107,23 +107,28 @@ def test_parse_type_hint(type_string: str, expected_type: typing.Union[str, type
 
 
 @pytest.mark.parametrize(
-    "object_type, type_hint, include_subclasses, result",
+    "object_type, type_hint, include_subclasses, reduce_type_hint, result",
     [
-        (int, int, True, True),
-        (int, str, True, False),
-        (typing.Union[int, str], typing.Union[str, int], True, True),
-        (typing.Union[int, str, bool], typing.Union[str, int], True, False),
-        (int, typing.Union[int, str], True, False),
-        (AnotherClass, SomeClass, True, True),
-        (AnotherClass, SomeClass, False, False),
-        (SomeClass, AnotherClass, True, False),
-        (AnotherClass, {SomeClass, int, str}, True, True),
-        (AnotherClass, {SomeClass, int, str}, False, False),
-        (SomeClass, {AnotherClass, int, str}, True, False),
+        (int, int, True, False, True),
+        (int, str, True, True, False),
+        (typing.Union[int, str], typing.Union[str, int], True, True, True),
+        (typing.Union[int, str, bool], typing.Union[str, int], True, False, False),
+        (int, typing.Union[int, str], True, False, False),
+        (int, typing.Union[int, str], True, True, True),
+        (AnotherClass, SomeClass, True, False, True),
+        (AnotherClass, SomeClass, False, False, False),
+        (SomeClass, AnotherClass, True, False, False),
+        (AnotherClass, {SomeClass, int, str}, True, False, True),
+        (AnotherClass, {SomeClass, int, str}, False, False, False),
+        (SomeClass, {AnotherClass, int, str}, True, False, False),
     ],
 )
 def test_is_matching(
-    object_type: type, type_hint: type, include_subclasses: bool, result: bool
+    object_type: type,
+    type_hint: type,
+    include_subclasses: bool,
+    reduce_type_hint: bool,
+    result: bool,
 ):
     """
     Test the `TypeHintUtils.is_matching` function with multiple types.
@@ -131,6 +136,7 @@ def test_is_matching(
     :param object_type:        The type to match.
     :param type_hint:          The options to match to (the type hint of an object).
     :param include_subclasses: Whether subclasses considered a match.
+    :param reduce_type_hint:   Whether to reduce the type hint to match with its reduced hints.
     :param result:             Expected test result.
     """
     assert (
@@ -138,6 +144,7 @@ def test_is_matching(
             object_type=object_type,
             type_hint=type_hint,
             include_subclasses=include_subclasses,
+            reduce_type_hint=reduce_type_hint,
         )
         == result
     )


### PR DESCRIPTION
If a user hinted a function parameter as `mlrun.DataItem` he wish to get a `mlrun.DataItem` - hence it should not be unpacked. When `mlrun.DataItem` was part of a hint group (like `Union[pd.DataFrame, mlrun.DataItem]`) it was not ignored like it supposed to - bug. Now it is ignored.