### PR TITLE
[Run] Deprecate `run_local`

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -106,6 +106,12 @@ class RunStatuses(object):
         ]
 
 
+# TODO: remove in 1.6.0
+@deprecated(
+    version="1.4.0",
+    reason="'run_local' will be removed in 1.6.0, use 'function.run(local=True)' instead",
+    category=FutureWarning,
+)
 def run_local(
     task=None,
     command="",


### PR DESCRIPTION
I decided to not replace the code with a call to the launcher because some parameters can not be passed to the launcher and they should be set by the user upon creating the function:
1. tag
2. secret - this is used to extract the "command" file from remote source and is not supported with `fn.run`
3. mode
4. allow_empty_resources
https://jira.iguazeng.com/browse/ML-3547