### PR TITLE
[Serving] Fix response for readiness status

### DIFF
--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
+
 import threading
 import time
 import traceback
@@ -261,28 +261,17 @@ class V2ModelServer(StepToDict):
             setattr(event, "terminated", True)
             if self.ready:
                 # Generate a response, confirming that the model is ready
-                data = {
-                    "id": event_id,
-                    "model_name": self.name,
-                    "status": "Model is ready",
-                }
                 event.body = self.context.Response(
                     status_code=200,
-                    body=json.dumps(data),
-                    content_type="application/json",
+                    body=bytes(
+                        f"Model {self.name} is ready (event_id = {event_id})",
+                        encoding="utf-8",
+                    ),
                 )
-            else:
-                # Generate a response, indicating that the model is yet to be ready
-                data = {
-                    "id": event_id,
-                    "model_name": self.name,
-                    "status": "Model not ready",
-                }
 
+            else:
                 event.body = self.context.Response(
-                    status_code=408,
-                    body=json.dumps(data),
-                    content_type="application/json",
+                    status_code=408, body=b"model not ready"
                 )
 
             return event

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import threading
 import time
 import traceback
@@ -259,7 +260,17 @@ class V2ModelServer(StepToDict):
             # get model health operation
             setattr(event, "terminated", True)
             if self.ready:
-                event.body = self.context.Response()
+                # Generate a response, confirming that the model is ready
+                data = {
+                    "id": event_id,
+                    "model_name": self.name,
+                    "status": "Model is ready",
+                }
+                event.body = self.context.Response(
+                    status_code=200,
+                    body=json.dumps(data),
+                    content_type="application/json",
+                )
             else:
                 event.body = self.context.Response(
                     status_code=408, body=b"model not ready"

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -272,9 +272,19 @@ class V2ModelServer(StepToDict):
                     content_type="application/json",
                 )
             else:
+                # Generate a response, indicating that the model is yet to be ready
+                data = {
+                    "id": event_id,
+                    "model_name": self.name,
+                    "status": "Model not ready",
+                }
+
                 event.body = self.context.Response(
-                    status_code=408, body=b"model not ready"
+                    status_code=409,
+                    body=json.dumps(data),
+                    content_type="application/json",
                 )
+
             return event
 
         elif op == "" and event.method == "GET":

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -280,7 +280,7 @@ class V2ModelServer(StepToDict):
                 }
 
                 event.body = self.context.Response(
-                    status_code=409,
+                    status_code=408,
                     body=json.dumps(data),
                     content_type="application/json",
                 )

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -555,9 +555,8 @@ def test_v2_model_ready():
     event = MockEvent("", path="/v2/models/m1/ready", method="GET")
     resp = context.mlrun_handler(context, event)
     assert resp.status_code == 200, f"didnt get proper ready resp {resp.body}"
-    event_body = json.loads(resp.body)
-    assert event_body["model_name"] == "m1"
-    assert event_body["status"] == "Model is ready"
+    resp_body = resp.body.decode("utf-8")
+    assert resp_body == f"Model m1 is ready (event_id = {event.id})"
 
 
 def test_v2_health():

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -555,6 +555,9 @@ def test_v2_model_ready():
     event = MockEvent("", path="/v2/models/m1/ready", method="GET")
     resp = context.mlrun_handler(context, event)
     assert resp.status_code == 200, f"didnt get proper ready resp {resp.body}"
+    event_body = json.loads(resp.body)
+    assert event_body["model_name"] == "m1"
+    assert event_body["status"] == "Model is ready"
 
 
 def test_v2_health():


### PR DESCRIPTION
In order to check if the serving model has been deployed successfully and that is ready to process new events, the user can invoke the function under the `/ready` path. At the moment, the user receives an empty response with no details about the serving model status.

In this PR, we generate a valid response object that will be returned to the user when the function is ready for process new events.

A fix for https://jira.iguazeng.com/browse/ML-3362.