### PR TITLE
[Spark] Fix storing multiple keys from a Spark dataframe into Redis

### DIFF
--- a/mlrun/datastore/spark_udf.py
+++ b/mlrun/datastore/spark_udf.py
@@ -25,7 +25,11 @@ def _hash_list(*list_to_hash):
     return sha1.hexdigest()
 
 
-def _redis_stringify_key(key_list):
+def _redis_stringify_key(*args):
+    if len(args) == 1:
+        key_list = args[0]
+    else:
+        key_list = list(args)
     suffix = "}:static"
     if isinstance(key_list, list):
         if len(key_list) >= 2:


### PR DESCRIPTION
The Spark User Defined Function (UDF), which is responsible for creating synthetic entry names for Redis during dataframe storage, should accommodate varying input formats. Depending on the calling context, Spark may provide entity arguments as a list or as separate variable parameters. This variability in argument presentation must be handled within the UDF
[ML-4008] (https://jira.iguazeng.com/browse/ML-4008)