### PR TITLE
[CI] Fix failing tests

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -291,10 +291,13 @@ class TestMLRunSystem:
         iteration_results: bool = False,
     ):
         self._logger.debug("Verifying run outputs", spec=run_outputs)
-        assert run_outputs["model"].startswith(str(output_path))
-        assert run_outputs["html_result"].startswith(str(output_path))
         assert run_outputs["chart"].startswith(str(output_path))
         assert run_outputs["mydf"] == f"store://artifacts/{project}/{name}_mydf:{uid}"
+        assert run_outputs["model"] == f"store://artifacts/{project}/{name}model:{uid}"
+        assert (
+            run_outputs["html_result"]
+            == f"store://artifacts/{project}/{name}_html_result:{uid}"
+        )
         if accuracy:
             assert run_outputs["accuracy"] == accuracy
         if loss:


### PR DESCRIPTION
Tests were failing because before 1.4.x it expected artifact run outputs to be full path (the source path) rather than the "reference" mlrun holds for those artifacts (aka destination path).

see origin change at https://github.com/mlrun/mlrun/pull/3333/files#diff-391847342995c01c5190eef868647ffd33183b03eba033b71baa13e3df39b0c5R100-R104
