### PR TITLE
[KFP] Align pipelines output with mlrun conventions

### DIFF
--- a/mlrun/api/api/endpoints/pipelines.py
+++ b/mlrun/api/api/endpoints/pipelines.py
@@ -118,6 +118,74 @@ async def create_pipeline(
     return response
 
 
+@router.get("/{run_id}")
+async def get_pipeline(
+    run_id: str,
+    project: str,
+    namespace: str = Query(config.namespace),
+    format_: mlrun.common.schemas.PipelinesFormat = Query(
+        mlrun.common.schemas.PipelinesFormat.summary, alias="format"
+    ),
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(
+        mlrun.api.api.deps.authenticate_request
+    ),
+    db_session: Session = Depends(deps.get_db_session),
+):
+    pipeline = await run_in_threadpool(
+        mlrun.api.crud.Pipelines().get_pipeline,
+        db_session,
+        run_id,
+        project,
+        namespace,
+        format_,
+    )
+    if project == "*":
+        # In some flows the user may use SDK functions that won't require them to specify the pipeline's project (for
+        # backwards compatibility reasons), so the client will just send * in the project, in that case we use the
+        # legacy flow in which we first get the pipeline, resolve the project out of it, and only then query permissions
+        # we don't use the return value from this function since the user may have asked for a different format than
+        # summary which is the one used inside
+        await _get_pipeline_without_project(db_session, auth_info, run_id, namespace)
+    else:
+        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+            mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
+            project,
+            run_id,
+            mlrun.common.schemas.AuthorizationAction.read,
+            auth_info,
+        )
+    return pipeline
+
+
+async def _get_pipeline_without_project(
+    db_session: Session,
+    auth_info: mlrun.common.schemas.AuthInfo,
+    run_id: str,
+    namespace: str,
+):
+    """
+    This function is for when we receive a get pipeline request without the client specifying the project
+    So we first get the pipeline, resolve the project out of it, and now that we know the project, we can verify
+    permissions
+    """
+    run = await run_in_threadpool(
+        mlrun.api.crud.Pipelines().get_pipeline,
+        db_session,
+        run_id,
+        namespace=namespace,
+        # minimal format that includes the project
+        format_=mlrun.common.schemas.PipelinesFormat.summary,
+    )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
+        run["run"]["project"],
+        run["run"]["id"],
+        mlrun.common.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+    return run
+
+
 async def _create_pipeline(
     auth_info: mlrun.common.schemas.AuthInfo,
     request: Request,
@@ -196,71 +264,3 @@ def _try_resolve_project_from_body(
     return mlrun.api.crud.Pipelines().resolve_project_from_workflow_manifest(
         workflow_manifest
     )
-
-
-@router.get("/{run_id}")
-async def get_pipeline(
-    run_id: str,
-    project: str,
-    namespace: str = Query(config.namespace),
-    format_: mlrun.common.schemas.PipelinesFormat = Query(
-        mlrun.common.schemas.PipelinesFormat.summary, alias="format"
-    ),
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        mlrun.api.api.deps.authenticate_request
-    ),
-    db_session: Session = Depends(deps.get_db_session),
-):
-    pipeline = await run_in_threadpool(
-        mlrun.api.crud.Pipelines().get_pipeline,
-        db_session,
-        run_id,
-        project,
-        namespace,
-        format_,
-    )
-    if project == "*":
-        # In some flows the user may use SDK functions that won't require them to specify the pipeline's project (for
-        # backwards compatibility reasons), so the client will just send * in the project, in that case we use the
-        # legacy flow in which we first get the pipeline, resolve the project out of it, and only then query permissions
-        # we don't use the return value from this function since the user may have asked for a different format than
-        # summary which is the one used inside
-        await _get_pipeline_without_project(db_session, auth_info, run_id, namespace)
-    else:
-        await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-            mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
-            project,
-            run_id,
-            mlrun.common.schemas.AuthorizationAction.read,
-            auth_info,
-        )
-    return pipeline
-
-
-async def _get_pipeline_without_project(
-    db_session: Session,
-    auth_info: mlrun.common.schemas.AuthInfo,
-    run_id: str,
-    namespace: str,
-):
-    """
-    This function is for when we receive a get pipeline request without the client specifying the project
-    So we first get the pipeline, resolve the project out of it, and now that we know the project, we can verify
-    permissions
-    """
-    run = await run_in_threadpool(
-        mlrun.api.crud.Pipelines().get_pipeline,
-        db_session,
-        run_id,
-        namespace=namespace,
-        # minimal format that includes the project
-        format_=mlrun.common.schemas.PipelinesFormat.summary,
-    )
-    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
-        run["run"]["project"],
-        run["run"]["id"],
-        mlrun.common.schemas.AuthorizationAction.read,
-        auth_info,
-    )
-    return run

--- a/mlrun/api/api/endpoints/pipelines.py
+++ b/mlrun/api/api/endpoints/pipelines.py
@@ -211,8 +211,13 @@ async def get_pipeline(
     ),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    pipeline = mlrun.api.crud.Pipelines().get_pipeline(
-        db_session, run_id, project, namespace, format_
+    pipeline = await run_in_threadpool(
+        mlrun.api.crud.Pipelines().get_pipeline,
+        db_session,
+        run_id,
+        project,
+        namespace,
+        format_,
     )
     if project == "*":
         # In some flows the user may use SDK functions that won't require them to specify the pipeline's project (for

--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -224,7 +224,7 @@ class Pipelines(
             return run
         elif format_ == mlrun.common.schemas.PipelinesFormat.metadata_only:
             return {
-                k: str(v)
+                k: str(v) if v is not None else v
                 for k, v in run.items()
                 if k
                 in [

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -751,10 +751,12 @@ def format_summary_from_kfp_run(kfp_run, project=None, session=None):
     for step in dag:
         # create snake_case for consistency.
         # retain the camelCase for compatibility
-        if "startedAt" in dag[step]:
-            dag[step]["started_at"] = dag[step]["startedAt"]
-        if "finishedAt" in dag[step]:
-            dag[step]["finished_at"] = dag[step]["finishedAt"]
+        for camelcase_field, snakecase_field in [
+            ("startedAt", "started_at"),
+            ("finishedAt", "finished_at"),
+        ]:
+            if camelcase_field in dag[step]:
+                dag[step][snakecase_field] = dag[step][camelcase_field]
 
     short_run = {
         "graph": dag,

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -747,21 +747,32 @@ def format_summary_from_kfp_run(kfp_run, project=None, session=None):
             if error:
                 dag[step]["error"] = error
 
-    short_run = {"graph": dag}
-    short_run["run"] = {
-        k: str(v)
-        for k, v in kfp_run["run"].items()
-        if k
-        in [
-            "id",
-            "name",
-            "status",
-            "error",
-            "created_at",
-            "scheduled_at",
-            "finished_at",
-            "description",
-        ]
+    # align kfp fields to mlrun snake case convention
+    for step in dag:
+        # create snake_case for consistency.
+        # retain the camelCase for compatibility
+        if "startedAt" in dag[step]:
+            dag[step]["started_at"] = dag[step]["startedAt"]
+        if "finishedAt" in dag[step]:
+            dag[step]["finished_at"] = dag[step]["finishedAt"]
+
+    short_run = {
+        "graph": dag,
+        "run": {
+            k: str(v) if v is not None else v
+            for k, v in kfp_run["run"].items()
+            if k
+            in [
+                "id",
+                "name",
+                "status",
+                "error",
+                "created_at",
+                "scheduled_at",
+                "finished_at",
+                "description",
+            ]
+        },
     }
     short_run["run"]["project"] = project
     short_run["run"]["message"] = message


### PR DESCRIPTION
1. Do not "str" on None fields - to avoid "None"
2. Use snake case for schema fields


In addition, 
1. fixed a potential hogging on main event loop where kfp get pipeline is a sync call on async function
2. on pipelines endpoint - move endpoints to first, help functions at bottom