### PR TITLE
[Datastore] Fix time zone error

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -177,7 +177,12 @@ class DataStore:
                     )
 
                 partitions_time_attributes = find_partitions(url, file_system)
-                set_filters(partitions_time_attributes, kwargs)
+                set_filters(
+                    partitions_time_attributes,
+                    start_time,
+                    end_time,
+                    kwargs,
+                )
                 try:
                     return df_module.read_parquet(*args, **kwargs)
                 except pyarrow.lib.ArrowInvalid as ex:

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -11,17 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
 import tempfile
 import urllib.parse
 from base64 import b64encode
 from os import path, remove
-from typing import Union
+from typing import Optional, Union
 
 import dask.dataframe as dd
 import fsspec
 import orjson
 import pandas as pd
+import pyarrow
+import pytz
 import requests
 import urllib3
 
@@ -87,7 +88,7 @@ class DataStore:
     def uri_to_ipython(endpoint, subpath):
         return ""
 
-    def get_filesystem(self, silent=True):
+    def get_filesystem(self, silent=True) -> Optional[fsspec.AbstractFileSystem]:
         """return fsspec file system object, if supported"""
         return None
 
@@ -151,6 +152,59 @@ class DataStore:
     def upload(self, key, src_path):
         pass
 
+    @staticmethod
+    def _parquet_reader(df_module, url, file_system, time_column, start_time, end_time):
+        from storey.utils import find_filters, find_partitions
+
+        def set_filters(
+            partitions_time_attributes, start_time_inner, end_time_inner, kwargs
+        ):
+            filters = []
+            find_filters(
+                partitions_time_attributes,
+                start_time_inner,
+                end_time_inner,
+                filters,
+                time_column,
+            )
+            kwargs["filters"] = filters
+
+        def reader(*args, **kwargs):
+            if start_time or end_time:
+                if time_column is None:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        "When providing start_time or end_time, must provide time_column"
+                    )
+
+                partitions_time_attributes = find_partitions(url, file_system)
+                set_filters(partitions_time_attributes, kwargs)
+                try:
+                    return df_module.read_parquet(*args, **kwargs)
+                except pyarrow.lib.ArrowInvalid as ex:
+                    if not str(ex).startswith(
+                        "Cannot compare timestamp with timezone to timestamp without timezone"
+                    ):
+                        raise ex
+
+                    if start_time.tzinfo:
+                        start_time_inner = start_time.replace(tzinfo=None)
+                        end_time_inner = end_time.replace(tzinfo=None)
+                    else:
+                        start_time_inner = start_time.replace(tzinfo=pytz.utc)
+                        end_time_inner = end_time.replace(tzinfo=pytz.utc)
+
+                    set_filters(
+                        partitions_time_attributes,
+                        start_time_inner,
+                        end_time_inner,
+                        kwargs,
+                    )
+                    return df_module.read_parquet(*args, **kwargs)
+            else:
+                return df_module.read_parquet(*args, **kwargs)
+
+        return reader
+
     def as_df(
         self,
         url,
@@ -166,6 +220,7 @@ class DataStore:
         df_module = df_module or pd
         file_url = self._sanitize_url(url)
         is_csv, is_json, drop_time_column = False, False, False
+        file_system = self.get_filesystem()
         if file_url.endswith(".csv") or format == "csv":
             is_csv = True
             drop_time_column = False
@@ -180,13 +235,12 @@ class DataStore:
                 kwargs["usecols"] = columns
 
             reader = df_module.read_csv
-            filesystem = self.get_filesystem()
-            if filesystem:
-                if filesystem.isdir(file_url):
+            if file_system:
+                if file_system.isdir(file_url):
 
                     def reader(*args, **kwargs):
                         base_path = args[0]
-                        file_entries = filesystem.listdir(base_path)
+                        file_entries = file_system.listdir(base_path)
                         filenames = []
                         for file_entry in file_entries:
                             if (
@@ -212,33 +266,9 @@ class DataStore:
             if columns:
                 kwargs["columns"] = columns
 
-            def reader(*args, **kwargs):
-                if start_time or end_time:
-                    if sys.version_info < (3, 7):
-                        raise ValueError(
-                            f"feature not supported for python version {sys.version_info}"
-                        )
-
-                    if time_column is None:
-                        raise mlrun.errors.MLRunInvalidArgumentError(
-                            "When providing start_time or end_time, must provide time_column"
-                        )
-
-                    from storey.utils import find_filters, find_partitions
-
-                    filters = []
-                    partitions_time_attributes = find_partitions(url, file_system)
-
-                    find_filters(
-                        partitions_time_attributes,
-                        start_time,
-                        end_time,
-                        filters,
-                        time_column,
-                    )
-                    kwargs["filters"] = filters
-
-                return df_module.read_parquet(*args, **kwargs)
+            reader = self._parquet_reader(
+                df_module, url, file_system, time_column, start_time, end_time
+            )
 
         elif file_url.endswith(".json") or format == "json":
             is_json = True
@@ -247,7 +277,6 @@ class DataStore:
         else:
             raise Exception(f"file type unhandled {url}")
 
-        file_system = self.get_filesystem()
         if file_system:
             if self.supports_isdir() and file_system.isdir(file_url) or df_module == dd:
                 storage_options = self.get_storage_options()

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -29,6 +29,7 @@ import pandas as pd
 import pyarrow
 import pyarrow.parquet as pq
 import pytest
+import pytz
 import requests
 from pandas.util.testing import assert_frame_equal
 from storey import MapClass
@@ -763,7 +764,8 @@ class TestFeatureStore(TestMLRunSystem):
             verify_ingest(data, key, targets=[TargetTypes.nosql])
             verify_ingest(data, key, targets=[TargetTypes.nosql], infer=True)
 
-    def test_filtering_parquet_by_time(self):
+    @pytest.mark.parametrize("with_tz", [False, True])
+    def test_filtering_parquet_by_time(self, with_tz):
         key = "patient_id"
         measurements = fstore.FeatureSet(
             "measurements", entities=[Entity(key)], timestamp_key="timestamp"
@@ -771,8 +773,10 @@ class TestFeatureStore(TestMLRunSystem):
         source = ParquetSource(
             "myparquet",
             path=os.path.relpath(str(self.assets_path / "testdata.parquet")),
-            start_time=datetime(2020, 12, 1, 17, 33, 15),
-            end_time="2020-12-01 17:33:16",
+            start_time=datetime(
+                2020, 12, 1, 17, 33, 15, tzinfo=pytz.UTC if with_tz else None
+            ),
+            end_time="2020-12-01 17:33:16" + ("+00:00" if with_tz else ""),
         )
 
         resp = fstore.ingest(
@@ -786,8 +790,10 @@ class TestFeatureStore(TestMLRunSystem):
         source = ParquetSource(
             "myparquet",
             path=os.path.relpath(str(self.assets_path / "testdata.parquet")),
-            start_time=datetime(2022, 12, 1, 17, 33, 15),
-            end_time="2022-12-01 17:33:16",
+            start_time=datetime(
+                2022, 12, 1, 17, 33, 15, tzinfo=pytz.UTC if with_tz else None
+            ),
+            end_time="2022-12-01 17:33:16" + ("+00:00" if with_tz else ""),
         )
 
         resp = fstore.ingest(


### PR DESCRIPTION
[ML-4025](https://jira.iguazeng.com/browse/ML-4025)

Fixes PyArrow error
```
Cannot compare timestamp with timezone to timestamp without timezone, got: timestamp[us, tz=UTC] and timestamp[us]
```
similar to the solution for [ML-3566](https://jira.iguazeng.com/browse/ML-3566).

This fixes a regression in v1.4.0-rc13 that was introduced by https://github.com/mlrun/mlrun/pull/3637, which propagated time filtering from `preview()`.