### PR TITLE
[Workflows] Fix fields being set to misleading value when setting workflow

### DIFF
--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -222,22 +222,8 @@ class Pipelines(
         if format_ == mlrun.common.schemas.PipelinesFormat.full:
             return run
         elif format_ == mlrun.common.schemas.PipelinesFormat.metadata_only:
-            return {
-                k: str(v) if v is not None else v
-                for k, v in run.items()
-                if k
-                in [
-                    "id",
-                    "name",
-                    "project",
-                    "status",
-                    "error",
-                    "created_at",
-                    "scheduled_at",
-                    "finished_at",
-                    "description",
-                ]
-            }
+            return mlrun.utils.helpers.get_format_run(run, with_project=True)
+
         elif format_ == mlrun.common.schemas.PipelinesFormat.name_only:
             return run.get("name")
         elif format_ == mlrun.common.schemas.PipelinesFormat.summary:

--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -222,7 +222,7 @@ class Pipelines(
         if format_ == mlrun.common.schemas.PipelinesFormat.full:
             return run
         elif format_ == mlrun.common.schemas.PipelinesFormat.metadata_only:
-            return mlrun.utils.helpers.compile_format_run(run, with_project=True)
+            return mlrun.utils.helpers.format_run(run, with_project=True)
 
         elif format_ == mlrun.common.schemas.PipelinesFormat.name_only:
             return run.get("name")

--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -222,7 +222,7 @@ class Pipelines(
         if format_ == mlrun.common.schemas.PipelinesFormat.full:
             return run
         elif format_ == mlrun.common.schemas.PipelinesFormat.metadata_only:
-            return mlrun.utils.helpers.get_format_run(run, with_project=True)
+            return mlrun.utils.helpers.compile_format_run(run, with_project=True)
 
         elif format_ == mlrun.common.schemas.PipelinesFormat.name_only:
             return run.get("name")

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -758,21 +758,7 @@ def format_summary_from_kfp_run(kfp_run, project=None, session=None):
 
     short_run = {
         "graph": dag,
-        "run": {
-            k: str(v) if v is not None else v
-            for k, v in kfp_run["run"].items()
-            if k
-            in [
-                "id",
-                "name",
-                "status",
-                "error",
-                "created_at",
-                "scheduled_at",
-                "finished_at",
-                "description",
-            ]
-        },
+        "run": mlrun.utils.helpers.get_format_run(kfp_run["run"]),
     }
     short_run["run"]["project"] = project
     short_run["run"]["message"] = message

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -758,7 +758,7 @@ def format_summary_from_kfp_run(kfp_run, project=None, session=None):
 
     short_run = {
         "graph": dag,
-        "run": mlrun.utils.helpers.compile_format_run(kfp_run["run"]),
+        "run": mlrun.utils.helpers.format_run(kfp_run["run"]),
     }
     short_run["run"]["project"] = project
     short_run["run"]["message"] = message

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -758,7 +758,7 @@ def format_summary_from_kfp_run(kfp_run, project=None, session=None):
 
     short_run = {
         "graph": dag,
-        "run": mlrun.utils.helpers.get_format_run(kfp_run["run"]),
+        "run": mlrun.utils.helpers.compile_format_run(kfp_run["run"]),
     }
     short_run["run"]["project"] = project
     short_run["run"]["message"] = message

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1266,7 +1266,7 @@ def is_legacy_artifact(artifact):
         return not hasattr(artifact, "metadata")
 
 
-def get_format_run(run: dict, with_project=False) -> dict:
+def compile_format_run(run: dict, with_project=False) -> dict:
     fields = [
         "id",
         "name",

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1266,7 +1266,7 @@ def is_legacy_artifact(artifact):
         return not hasattr(artifact, "metadata")
 
 
-def get_format_run(run: list, with_project=False):
+def get_format_run(run: dict, with_project=False) -> dict:
     fields = [
         "id",
         "name",
@@ -1276,8 +1276,10 @@ def get_format_run(run: list, with_project=False):
         "scheduled_at",
         "finished_at",
         "description",
-        "project" if with_project else "",
     ]
+
+    if with_project:
+        fields.append("project")
 
     # create a run object that contains all fields,
     run = {
@@ -1288,11 +1290,12 @@ def get_format_run(run: list, with_project=False):
 
     # if the time_keys values is from 1970, this indicates that the field has not yet been specified yet,
     # and we want to return a None value instead
-    time_keys = ["scheduled_at", "finished_at"]
-    run = {
-        key: None if (key in time_keys and "1970" in value) else value
-        for key, value in run.items()
-    }
+    time_keys = ["scheduled_at", "finished_at", "created_at"]
+
+    for key, value in run.items():
+        if key in time_keys and isinstance(value, (str, datetime)) and parser.parse(str(value)).year == 1970:
+            run[key] = None
+
     return run
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1266,7 +1266,7 @@ def is_legacy_artifact(artifact):
         return not hasattr(artifact, "metadata")
 
 
-def compile_format_run(run: dict, with_project=False) -> dict:
+def format_run(run: dict, with_project=False) -> dict:
     fields = [
         "id",
         "name",

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1265,6 +1265,35 @@ def is_legacy_artifact(artifact):
     else:
         return not hasattr(artifact, "metadata")
 
+def get_format_run(run: list, with_project=False):
+    fields = [
+                "id",
+                "name",
+                "status",
+                "error",
+                "created_at",
+                "scheduled_at",
+                "finished_at",
+                "description",
+                "project" if with_project else ""
+            ]
+
+    # create a run object that contains all fields,
+    run = {
+        key: str(value) if value is not None else value
+        for key, value in run.items()
+        if key in fields
+    }
+
+    # if the time_keys values is from 1970, this indicates that the field has not yet been specified yet,
+    # and we want to return a None value instead
+    time_keys = ["scheduled_at", "finished_at"]
+    run = {
+        key: None if (key in time_keys and "1970" in value) else value
+        for key, value in run.items()
+    }
+    return run
+
 
 def get_in_artifact(artifact: dict, key, default=None, raise_on_missing=False):
     """artifact can be dict or Artifact object"""

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1293,7 +1293,11 @@ def get_format_run(run: dict, with_project=False) -> dict:
     time_keys = ["scheduled_at", "finished_at", "created_at"]
 
     for key, value in run.items():
-        if key in time_keys and isinstance(value, (str, datetime)) and parser.parse(str(value)).year == 1970:
+        if (
+            key in time_keys
+            and isinstance(value, (str, datetime))
+            and parser.parse(str(value)).year == 1970
+        ):
             run[key] = None
 
     return run

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1265,18 +1265,19 @@ def is_legacy_artifact(artifact):
     else:
         return not hasattr(artifact, "metadata")
 
+
 def get_format_run(run: list, with_project=False):
     fields = [
-                "id",
-                "name",
-                "status",
-                "error",
-                "created_at",
-                "scheduled_at",
-                "finished_at",
-                "description",
-                "project" if with_project else ""
-            ]
+        "id",
+        "name",
+        "status",
+        "error",
+        "created_at",
+        "scheduled_at",
+        "finished_at",
+        "description",
+        "project" if with_project else "",
+    ]
 
     # create a run object that contains all fields,
     run = {

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -193,8 +193,14 @@ def test_list_pipelines_time_fields_default(
     response = response.json()["runs"][0]
 
     assert response["created_at"] == str(created_at)
-    assert not response["finished_at"]
-    assert not response["scheduled_at"]
+    assert not response["finished_at"], (
+        "Expected value to be None after format,"
+        " since field has not been specified yet"
+    )
+    assert not response["scheduled_at"], (
+        "Expected value to be None after format,"
+        " since field has not been specified yet"
+    )
 
 
 def test_list_pipelines_specific_project(

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 import http
 import importlib
 import json
@@ -163,13 +164,14 @@ def test_get_pipeline_specific_project(
 
 
 def test_list_pipelines_time_fields_default(
-        db: sqlalchemy.orm.Session,
-        client: fastapi.testclient.TestClient,
-        kfp_client_mock: kfp.Client,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    kfp_client_mock: kfp.Client,
 ) -> None:
     created_at = datetime.datetime.now()
     workflow_manifest = _generate_workflow_manifest()
-    runs = [kfp_server_api.models.api_run.ApiRun(
+    runs = [
+        kfp_server_api.models.api_run.ApiRun(
             id="id1",
             name="run",
             description="desc",
@@ -180,7 +182,8 @@ def test_list_pipelines_time_fields_default(
                 pipeline_id="pipe_id",
                 workflow_manifest=workflow_manifest,
             ),
-        )]
+        )
+    ]
 
     _mock_list_runs(kfp_client_mock, runs)
     response = client.get(
@@ -192,6 +195,7 @@ def test_list_pipelines_time_fields_default(
     assert response["created_at"] == str(created_at)
     assert not response["finished_at"]
     assert not response["scheduled_at"]
+
 
 def test_list_pipelines_specific_project(
     db: sqlalchemy.orm.Session,


### PR DESCRIPTION
resolves: [ML-3912](https://jira.iguazeng.com/browse/ML-3912?filter=-1)

A run's time field that has not yet occurred (such ad `finished_at`, when there is still no finished time) is represented by `1970-01-01 00:00:00+00:00`, which appears as a deceptive date in the UI.

In this PR, changing the value to `None`, and  it appears as follows in the UI:
![image](https://github.com/mlrun/mlrun/assets/62285310/614bf02d-01e2-4a87-ba65-166476712903)
