### PR TITLE
[Model Monitoring] Filter router models from the total average latency in Grafana

### DIFF
--- a/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/iguazio-3.5.2-and-older/model-monitoring-overview.json
@@ -156,7 +156,7 @@
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "project=$PROJECT;target_endpoint=list_endpoints",
+          "target": "project=$PROJECT;target_endpoint=list_endpoints;filter_router=True;",
           "type": "table"
         }
       ],
@@ -233,7 +233,7 @@
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "project=$PROJECT;target_endpoint=list_endpoints",
+          "target": "project=$PROJECT;target_endpoint=list_endpoints;filter_router=True;",
           "type": "table"
         }
       ],
@@ -570,7 +570,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;filter=endpoint_type!='2';",
           "type": "timeserie"
         }
       ],
@@ -667,7 +667,7 @@
         {
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;filter=endpoint_type!='2';",
           "type": "timeserie"
         }
       ],

--- a/docs/monitoring/dashboards/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/model-monitoring-overview.json
@@ -163,7 +163,7 @@
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=metrics;",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=metrics;filter=endpoint_type!='2';",
           "type": "table"
         }
       ],
@@ -248,7 +248,7 @@
           "hide": false,
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=metrics;",
+          "target": "backend=kv;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/endpoints;\nfields=metrics;filter=endpoint_type!='2';",
           "type": "table"
         }
       ],
@@ -738,7 +738,7 @@
           "datasource": "iguazio",
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=predictions_per_second;filter=endpoint_type!='2';",
           "type": "timeserie"
         }
       ],
@@ -842,7 +842,7 @@
           "datasource": "iguazio",
           "rawQuery": true,
           "refId": "A",
-          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;",
+          "target": "backend=tsdb;\ncontainer=users;\ntable=pipelines/$PROJECT/model-endpoints/events;\nfields=latency_avg_1h;filter=endpoint_type!='2';",
           "type": "timeserie"
         }
       ],

--- a/mlrun/api/crud/model_monitoring/grafana.py
+++ b/mlrun/api/crud/model_monitoring/grafana.py
@@ -128,7 +128,11 @@ async def grafana_list_endpoints(
 
     table = mlrun.common.schemas.GrafanaTable(columns=columns)
     for endpoint in endpoint_list.endpoints:
-        if filter_router and endpoint.status.endpoint_type == 2:
+        if (
+            filter_router
+            and endpoint.status.endpoint_type
+            == mlrun.common.model_monitoring.EndpointType.ROUTER
+        ):
             continue
         row = [
             endpoint.metadata.uid,

--- a/mlrun/api/crud/model_monitoring/grafana.py
+++ b/mlrun/api/crud/model_monitoring/grafana.py
@@ -55,8 +55,7 @@ def grafana_list_projects(
     return projects_output.projects
 
 
-# TODO: remove in 1.5.0 the following functions: grafana_list_endpoints, grafana_individual_feature_analysis,
-#  grafana_overall_feature_analysis, grafana_income_features, parse_query_parameters, drop_grafana_escape_chars,
+# The following functions were not removed due to backward compatibility that is related to iguazio version <= 3.5.2
 
 
 async def grafana_list_endpoints(
@@ -79,6 +78,9 @@ async def grafana_list_endpoints(
     # Time range for metrics
     start = body.get("rangeRaw", {}).get("start", "now-1h")
     end = body.get("rangeRaw", {}).get("end", "now")
+
+    # Endpoint type filter - will be used to filter the router models
+    filter_router = query_parameters.get("filter_router", None)
 
     if project:
         await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
@@ -126,6 +128,8 @@ async def grafana_list_endpoints(
 
     table = mlrun.common.schemas.GrafanaTable(columns=columns)
     for endpoint in endpoint_list.endpoints:
+        if filter_router and endpoint.status.endpoint_type == 2:
+            continue
         row = [
             endpoint.metadata.uid,
             endpoint.spec.function_uri,

--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -325,6 +325,7 @@ class EventStreamProcessor:
                     index_cols=[
                         EventFieldType.ENDPOINT_ID,
                         EventFieldType.RECORD_TYPE,
+                        EventFieldType.ENDPOINT_TYPE,
                     ],
                     max_events=self.tsdb_batching_max_events,
                     flush_after_seconds=self.tsdb_batching_timeout_secs,
@@ -471,6 +472,7 @@ class ProcessBeforeTSDB(mlrun.feature_store.steps.MapClass):
         base_fields = [
             EventFieldType.TIMESTAMP,
             EventFieldType.ENDPOINT_ID,
+            EventFieldType.ENDPOINT_TYPE,
         ]
 
         # Getting event timestamp and endpoint_id
@@ -873,6 +875,9 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
         self.feature_names = {}
         self.label_columns = {}
 
+        # Dictionary to manage the model endpoint types - important for the V3IO TSDB
+        self.endpoint_type = {}
+
     def _infer_feature_names_from_data(self, event):
         for endpoint_id in self.feature_names:
             if len(self.feature_names[endpoint_id]) >= len(
@@ -904,7 +909,7 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
             label_columns = endpoint_record.get(EventFieldType.LABEL_NAMES)
             label_columns = json.loads(label_columns) if label_columns else None
 
-            # Ff feature names were not found,
+            # If feature names were not found,
             # try to retrieve them from the previous events of the current process
             if not feature_names and self._infer_columns_from_data:
                 feature_names = self._infer_feature_names_from_data(event)
@@ -956,6 +961,10 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
                 "Feature names", endpoint_id=endpoint_id, feature_names=feature_names
             )
 
+            # Update the endpoint type within the endpoint types dictionary
+            endpoint_type = int(endpoint_record.get(EventFieldType.ENDPOINT_TYPE))
+            self.endpoint_type[endpoint_id] = endpoint_type
+
         # Add feature_name:value pairs along with a mapping dictionary of all of these pairs
         feature_names = self.feature_names[endpoint_id]
         feature_values = event[EventFieldType.FEATURES]
@@ -975,6 +984,9 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
             values_iters=label_values,
             mapping_dictionary=EventFieldType.NAMED_PREDICTIONS,
         )
+
+        # Add endpoint type to the event
+        event[EventFieldType.ENDPOINT_TYPE] = self.endpoint_type[endpoint_id]
 
         logger.info("Mapped event", event=event)
         return event


### PR DESCRIPTION
A fix for https://jira.iguazeng.com/browse/ML-1767.

This PR is a fix for a bug in the `model monitoring overview` dashboard within Grafana when the project includes a router model. The latency of the router model is combined from the router process time along with the latency time of the related child models. That means, when calculating the average latency of all of the models in the project, the latency of the router model should be excluded. At the moment, Grafana also considers the average latency time of the router model in both the **Average Latency KPI** at the top of the screen and the **Average Latency time series chart** at the bottom of the screen. In this PR, we fix it by excluding the router model from these calculations. 

Please note that due to changes in Grafana dashboards (https://github.com/mlrun/mlrun/pull/3271) and following Grafana service update in iguazio `3.5.3`, we have implemented different fixes for both `iguazio >= 3.5.3` and  `iguazio < 3.5.3`:

**IGZ <3.5.3:**

- **Average Latency KPI** - Filter out the router model endpoint from the result of listing model endpoints from MLRun API. 
- **Average Latency time series chart** - Adding the field `endpoint_type` to the TSDB table. 

**IGZ >= 3.5.3**

- **Average Latency KPI** - Filter out the router model endpoint directly in the KV query within Grafana.

- **Average Latency time series chart** - Adding the field `endpoint_type` to the TSDB table.





