### PR TITLE
[Debug] Improve flows for better debugging

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -1390,7 +1390,7 @@ class SQLDB(DBInterface):
         self._upsert(session, tags)
 
     def create_project(self, session: Session, project: mlrun.common.schemas.Project):
-        logger.debug("Creating project in DB", project=project)
+        logger.debug("Creating project in DB", project_name=project.metadata.name)
         created = datetime.utcnow()
         project.metadata.created = created
         # TODO: handle taking out the functions/workflows/artifacts out of the project and save them separately

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -198,7 +198,9 @@ def new_project(
 
     if save and mlrun.mlconf.dbpath:
         if overwrite:
-            logger.info(f"Deleting project {name} from MLRun DB due to overwrite")
+            logger.info(
+                "Overwriting project (by deleting and then creating)", name=name
+            )
             _delete_project_from_db(
                 name, secrets, mlrun.common.schemas.DeletionStrategy.cascade
             )
@@ -211,7 +213,8 @@ def new_project(
                 "Use overwrite=True to overwrite the existing project."
             ) from exc
         logger.info(
-            f"Created and saved project {name}",
+            "Created and saved project",
+            name=name,
             from_template=from_template,
             overwrite=overwrite,
             context=context,
@@ -389,14 +392,11 @@ def get_or_create_project(
 
     except mlrun.errors.MLRunNotFoundError:
         logger.debug("Project not found in db", project_name=name)
-        pass
 
     # do not nest under "try" or else the exceptions raised below will be logged along with the "not found" message
     if load_from_path:
         # loads a project from archive or local project.yaml
-        logger.debug(
-            "Loading project from path", project_name=name, path=url or context
-        )
+        logger.info("Loading project from path", project_name=name, path=url or context)
         project = load_project(
             context,
             url,

--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import logging
+import platform
 import typing
 from typing import List, Optional
 
@@ -134,6 +135,13 @@ class _CustomRequestContext(_RequestContext):
                     params = self._params_list[-1]
 
                 headers = {k: v for k, v in params.headers.items() if v is not None}
+
+                # enrich user agent
+                # will help traceability and debugging
+                headers[
+                    aiohttp.hdrs.USER_AGENT
+                ] = f"{aiohttp.http.SERVER_SOFTWARE} mlrun/{config.version} hostname/{platform.node()}"
+
                 response: typing.Optional[
                     aiohttp.ClientResponse
                 ] = await self._request_func(

--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import logging
-import platform
 import typing
 from typing import List, Optional
 
@@ -140,7 +139,7 @@ class _CustomRequestContext(_RequestContext):
                 # will help traceability and debugging
                 headers[
                     aiohttp.hdrs.USER_AGENT
-                ] = f"{aiohttp.http.SERVER_SOFTWARE} mlrun/{config.version} hostname/{platform.node()}"
+                ] = f"{aiohttp.http.SERVER_SOFTWARE} mlrun/{config.version}"
 
                 response: typing.Optional[
                     aiohttp.ClientResponse

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import platform
+
 import time
 
 import requests
@@ -105,7 +105,7 @@ class HTTPSessionWithRetry(requests.Session):
         kwargs.setdefault("headers", {})
         kwargs["headers"][
             "User-Agent"
-        ] = f"{requests.utils.default_user_agent()} mlrun/{config.version} hostname/{platform.node()}"
+        ] = f"{requests.utils.default_user_agent()} mlrun/{config.version}"
         while True:
             try:
                 response = super().request(method, url, **kwargs)

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import platform
 import time
 
 import requests
 import requests.adapters
+import requests.utils
 import urllib3.exceptions
 import urllib3.util.retry
 
@@ -100,6 +102,10 @@ class HTTPSessionWithRetry(requests.Session):
 
     def request(self, method, url, **kwargs):
         retry_count = 0
+        kwargs.setdefault("headers", {})
+        kwargs["headers"][
+            "User-Agent"
+        ] = f"{requests.utils.default_user_agent()} mlrun/{config.version} hostname/{platform.node()}"
         while True:
             try:
                 response = super().request(method, url, **kwargs)


### PR DESCRIPTION
1. Separated try/except flow for get or create project so that when load fails + create fails -> the stacktrace does not include both exceptions but rather fall and shows the create exception only.
2. Added "User-Agent" to requests/ client containing mlrun version

related to https://jira.iguazeng.com/browse/ML-4001