### PR TITLE
[Pipelines] Support passing pipeline param to function spec resources

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -136,6 +136,7 @@ from .project import (
     ProjectSummariesOutput,
     ProjectSummary,
 )
+from .regex import RegexMatchModes
 from .runs import RunIdentifier
 from .runtime_resource import (
     GroupedByJobRuntimeResourcesOutput,

--- a/mlrun/common/schemas/regex.py
+++ b/mlrun/common/schemas/regex.py
@@ -1,0 +1,24 @@
+# Copyright 2018 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import mlrun.common.types
+
+
+class RegexMatchModes(mlrun.common.types.StrEnum):
+    """Regex match modes"""
+
+    # all regexes must match
+    all = "all"
+    # any of the regexes must match
+    any = "any"

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -14,6 +14,7 @@
 import enum
 import getpass
 import http
+import re
 import traceback
 import warnings
 from abc import ABC, abstractmethod
@@ -600,7 +601,10 @@ class BaseRuntime(ModelObj):
             raise RunError(f"handler must be provided for {self.kind} runtime")
 
     def _has_pipeline_param(self) -> bool:
-        return self.to_json().find("{{pipelineparam:op") > 0
+        # check if the runtime has pipeline parameters
+        # https://www.kubeflow.org/docs/components/pipelines/v1/sdk/parameters/
+        matches = re.findall(mlrun.utils.regex.pipeline_param[0], self.to_json())
+        return bool(matches)
 
     def full_image_path(
         self, image=None, client_version: str = None, client_python_version: str = None
@@ -681,9 +685,9 @@ class BaseRuntime(ModelObj):
         :return: KubeFlow containerOp
         """
 
-        # if the function spec contain KFP PipelineParams (futures) pass the full spec to the
+        # if the function contain KFP PipelineParams (futures) pass the full spec to the
         # ContainerOp this way KFP will substitute the params with previous step outputs
-        if (use_db or use_db is None) and not self._has_pipeline_param():
+        if use_db and not self._has_pipeline_param():
             # if the same function is built as part of the pipeline we do not use the versioned function
             # rather the latest function w the same tag so we can pick up the updated image/status
             versioned = False if hasattr(self, "_build_in_pipeline") else True

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -599,7 +599,7 @@ class BaseRuntime(ModelObj):
         if not handler:
             raise RunError(f"handler must be provided for {self.kind} runtime")
 
-    def has_pipeline_param(self) -> bool:
+    def _has_pipeline_param(self) -> bool:
         return self.to_json().find("{{pipelineparam:op") > 0
 
     def full_image_path(
@@ -683,7 +683,7 @@ class BaseRuntime(ModelObj):
 
         # if the function spec contain KFP PipelineParams (futures) pass the full spec to the
         # ContainerOp this way KFP will substitute the params with previous step outputs
-        if (use_db or use_db is None) and not self.has_pipeline_param():
+        if (use_db or use_db is None) and not self._has_pipeline_param():
             # if the same function is built as part of the pipeline we do not use the versioned function
             # rather the latest function w the same tag so we can pick up the updated image/status
             versioned = False if hasattr(self, "_build_in_pipeline") else True

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -813,7 +813,7 @@ class RemoteRuntime(KubeResource):
             or use_function_from_db is None
             # if the function spec contain KFP PipelineParams (futures) pass the full spec to the
             # ContainerOp this way KFP will substitute the params with previous step outputs
-            and not self.has_pipeline_param()
+            and not self._has_pipeline_param()
         ):
             url = self.save(versioned=True, refresh=True)
         else:

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -811,7 +811,7 @@ class RemoteRuntime(KubeResource):
         if (
             use_function_from_db
             or use_function_from_db is None
-            # if the function spec contain KFP PipelineParams (futures) pass the full spec to the
+            # if the function contain KFP PipelineParams (futures) pass the full spec to the
             # ContainerOp this way KFP will substitute the params with previous step outputs
             and not self._has_pipeline_param()
         ):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -808,13 +808,12 @@ class RemoteRuntime(KubeResource):
         # verify auto mount is applied (with the client credentials)
         self.try_auto_mount_based_on_config()
 
-        # if the function spec contain KFP PipelineParams (futures) pass the full spec to the
-        # ContainerOp this way KFP will substitute the params with previous step outputs
-        func_has_pipeline_params = self.to_json().find("{{pipelineparam:op") > 0
         if (
             use_function_from_db
             or use_function_from_db is None
-            and not func_has_pipeline_params
+            # if the function spec contain KFP PipelineParams (futures) pass the full spec to the
+            # ContainerOp this way KFP will substitute the params with previous step outputs
+            and not self.has_pipeline_param()
         ):
             url = self.save(versioned=True, refresh=True)
         else:

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -26,6 +26,7 @@ from kubernetes import client
 import mlrun
 import mlrun.api.utils.builder
 import mlrun.common.constants
+import mlrun.common.schemas
 import mlrun.utils.regex
 from mlrun.api.utils.clients import nuclio
 from mlrun.errors import err_to_str
@@ -474,20 +475,26 @@ def verify_limits(
         verify_field_regex(
             f"function.spec.{resources_field_name}.limits.memory",
             mem,
-            mlrun.utils.regex.k8s_resource_quantity_regex,
+            mlrun.utils.regex.k8s_resource_quantity_regex
+            + mlrun.utils.regex.pipeline_param,
+            mode=mlrun.common.schemas.RegexMatchModes.any,
         )
     if cpu:
         verify_field_regex(
             f"function.spec.{resources_field_name}.limits.cpu",
             cpu,
-            mlrun.utils.regex.k8s_resource_quantity_regex,
+            mlrun.utils.regex.k8s_resource_quantity_regex
+            + mlrun.utils.regex.pipeline_param,
+            mode=mlrun.common.schemas.RegexMatchModes.any,
         )
     # https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
     if gpus:
         verify_field_regex(
             f"function.spec.{resources_field_name}.limits.gpus",
             gpus,
-            mlrun.utils.regex.k8s_resource_quantity_regex,
+            mlrun.utils.regex.k8s_resource_quantity_regex
+            + mlrun.utils.regex.pipeline_param,
+            mode=mlrun.common.schemas.RegexMatchModes.any,
         )
     return generate_resources(mem=mem, cpu=cpu, gpus=gpus, gpu_type=gpu_type)
 
@@ -501,13 +508,17 @@ def verify_requests(
         verify_field_regex(
             f"function.spec.{resources_field_name}.requests.memory",
             mem,
-            mlrun.utils.regex.k8s_resource_quantity_regex,
+            mlrun.utils.regex.k8s_resource_quantity_regex
+            + mlrun.utils.regex.pipeline_param,
+            mode=mlrun.common.schemas.RegexMatchModes.any,
         )
     if cpu:
         verify_field_regex(
             f"function.spec.{resources_field_name}.requests.cpu",
             cpu,
-            mlrun.utils.regex.k8s_resource_quantity_regex,
+            mlrun.utils.regex.k8s_resource_quantity_regex
+            + mlrun.utils.regex.pipeline_param,
+            mode=mlrun.common.schemas.RegexMatchModes.any,
         )
     return generate_resources(mem=mem, cpu=cpu)
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -39,6 +39,7 @@ from pandas._libs.tslibs.timestamps import Timedelta, Timestamp
 from yaml.representer import RepresenterError
 
 import mlrun
+import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.version.version
 from mlrun.errors import err_to_str
@@ -148,6 +149,7 @@ def verify_field_regex(
     patterns,
     raise_on_failure: bool = True,
     log_message: str = "Field is malformed. Does not match required pattern",
+    mode: mlrun.common.schemas.RegexMatchModes = mlrun.common.schemas.RegexMatchModes.all,
 ) -> bool:
     for pattern in patterns:
         if not re.match(pattern, str(field_value)):
@@ -158,12 +160,14 @@ def verify_field_regex(
                 field_value=field_value,
                 pattern=pattern,
             )
-            if raise_on_failure:
+            if raise_on_failure and mode == mlrun.common.schemas.RegexMatchModes.all:
                 raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Field '{field_name}' is malformed. Does not match required pattern: {pattern}"
+                    f"Field '{field_name}' is malformed. {field_value} does not match required pattern: {pattern}"
                 )
             else:
                 return False
+        elif mode == mlrun.common.schemas.RegexMatchModes.any:
+            return True
     return True
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -173,7 +173,8 @@ def verify_field_regex(
     elif mode == mlrun.common.schemas.RegexMatchModes.any:
         if raise_on_failure:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Field '{field_name}' is malformed. {field_value} does not match any of the required patterns: {patterns}"
+                f"Field '{field_name}' is malformed. {field_value} does not match any of the"
+                f" required patterns: {patterns}"
             )
         return False
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -160,15 +160,22 @@ def verify_field_regex(
                 field_value=field_value,
                 pattern=pattern,
             )
-            if raise_on_failure and mode == mlrun.common.schemas.RegexMatchModes.all:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Field '{field_name}' is malformed. {field_value} does not match required pattern: {pattern}"
-                )
-            else:
+            if mode == mlrun.common.schemas.RegexMatchModes.all:
+                if raise_on_failure:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Field '{field_name}' is malformed. {field_value} does not match required pattern: {pattern}"
+                    )
                 return False
         elif mode == mlrun.common.schemas.RegexMatchModes.any:
             return True
-    return True
+    if mode == mlrun.common.schemas.RegexMatchModes.all:
+        return True
+    elif mode == mlrun.common.schemas.RegexMatchModes.any:
+        if raise_on_failure:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Field '{field_name}' is malformed. {field_value} does not match any of the required patterns: {patterns}"
+            )
+        return False
 
 
 def validate_builder_source(

--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -14,8 +14,9 @@
 #
 
 # pipeline param format which is passed when running a pipeline (e.g. {{pipelineparam:op=;name=mem}})
-# this is expected to be resolved on runtime
-pipeline_param = [r"\{\{pipelineparam:op=([^;]*);name=([^}]+)\}\}"]
+# https://github.com/kubeflow/pipelines/blob/16edebf4eaf84cd7478e2601ef4878ab339a7854/sdk/python/kfp/dsl/_pipeline_param.py#L213
+# this is expected to be resolved at runtime
+pipeline_param = [r"{{pipelineparam:op=([\w\s_-]*);name=([\w\s_-]+)}}"]
 
 # k8s character limit is for 63 characters
 k8s_character_limit = [r"^.{0,63}$"]

--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 #
 
+# pipeline param format which is passed when running a pipeline (e.g. {{pipelineparam:op=;name=mem}})
+# this is expected to be resolved on runtime
+pipeline_param = [r"\{\{pipelineparam:op=([^;]*);name=([^}]+)\}\}"]
+
 # k8s character limit is for 63 characters
 k8s_character_limit = [r"^.{0,63}$"]
 

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -55,7 +55,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
             match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix()}"
             r"\/projects: Failed creating project some_p"
             r"roject details: MLRunInvalidArgumentError\(\"Field \'project\.metadata\.name\' is malformed"
-            r"\. Does not match required pattern: (.*)\"\)",
+            rf"\.{invalid_project_name} does not match required pattern: (.*)\"\)",
         ):
             mlrun.get_run_db().create_project(project)
 

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -55,7 +55,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
             match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix()}"
             r"\/projects: Failed creating project some_p"
             r"roject details: MLRunInvalidArgumentError\(\"Field \'project\.metadata\.name\' is malformed"
-            rf"\.{invalid_project_name} does not match required pattern: (.*)\"\)",
+            rf"\. some_project does not match required pattern: (.*)\"\)",
         ):
             mlrun.get_run_db().create_project(project)
 

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -55,7 +55,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
             match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix()}"
             r"\/projects: Failed creating project some_p"
             r"roject details: MLRunInvalidArgumentError\(\"Field \'project\.metadata\.name\' is malformed"
-            rf"\. some_project does not match required pattern: (.*)\"\)",
+            r"\. some_project does not match required pattern: (.*)\"\)",
         ):
             mlrun.get_run_db().create_project(project)
 

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -55,7 +55,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
             match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix()}"
             r"\/projects: Failed creating project some_p"
             r"roject details: MLRunInvalidArgumentError\(\"Field \'project\.metadata\.name\' is malformed"
-            r"\. some_project does not match required pattern: (.*)\"\)",
+            rf"\. {invalid_project_name} does not match required pattern: (.*)\"\)",
         ):
             mlrun.get_run_db().create_project(project)
 

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -97,7 +97,7 @@ def test_invalid_name():
         # name cannot have / in it
         new_function().run(name="asd/asd", handler=my_func)
     assert (
-        "Field 'run.metadata.name' is malformed. Does not match required pattern"
+        "Field 'run.metadata.name' is malformed. asd/asd does not match required pattern"
         in str(excinfo.value)
     )
 

--- a/tests/system/projects/assets/pipeline_with_resource_param.py
+++ b/tests/system/projects/assets/pipeline_with_resource_param.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import kfp
+
+import mlrun
+
+
+@kfp.dsl.pipeline(
+    name="Demo passing param to function spec", description="Shows how to use mlrun."
+)
+def kfpipeline(memory: str = "10Mi"):
+    time_to_sleep = 2
+    project: mlrun.projects.MlrunProject = mlrun.get_current_project()
+    func: mlrun.runtimes.KubejobRuntime = project.get_function("func-1")
+    func.with_requests(mem=str(memory))
+    mlrun.run_function(
+        func,
+        params={"time_to_sleep": time_to_sleep},
+        outputs=["return"],
+    )

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -502,7 +502,16 @@ class TestProject(TestMLRunSystem):
         )
         # set and run a two-step workflow in the project
         project.set_workflow("paramflow", workflow_path)
-        project.run("paramflow", engine="kfp", arguments={"memory": "11Mi"}, watch=True)
+
+        arguments = {"memory": "11Mi"}
+        pipeline_status = project.run(
+            "paramflow", engine="kfp", arguments=arguments, watch=True
+        )
+        assert pipeline_status.workflow.args == arguments
+
+        # get the function from the db
+        function = project.get_function("func-1", ignore_cache=True)
+        assert function.spec.resources["requests"]["memory"] == arguments["memory"]
 
     def _test_remote_pipeline_from_github(
         self, name, workflow_name, engine=None, local=None, watch=False

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -485,6 +485,25 @@ class TestProject(TestMLRunSystem):
     def test_kfp_pipeline(self):
         self._test_new_pipeline("kfppipe", engine="kfp")
 
+    def test_kfp_pipeline_with_resource_param_passed(self):
+        project_name = "test-pipeline-with-resource-param"
+        self.custom_project_names_to_delete.append(project_name)
+        project = mlrun.new_project(project_name, context=str(self.assets_path))
+
+        code_path = str(self.assets_path / "sleep.py")
+        workflow_path = str(self.assets_path / "pipeline_with_resource_param.py")
+
+        project.set_function(
+            name="func-1",
+            func=code_path,
+            kind="job",
+            image="mlrun/mlrun",
+            handler="handler",
+        )
+        # set and run a two-step workflow in the project
+        project.set_workflow("paramflow", workflow_path)
+        project.run("paramflow", engine="kfp", watch=True)
+
     def _test_remote_pipeline_from_github(
         self, name, workflow_name, engine=None, local=None, watch=False
     ):

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -502,7 +502,7 @@ class TestProject(TestMLRunSystem):
         )
         # set and run a two-step workflow in the project
         project.set_workflow("paramflow", workflow_path)
-        project.run("paramflow", engine="kfp", watch=True)
+        project.run("paramflow", engine="kfp", arguments={"memory": "11Mi"}, watch=True)
 
     def _test_remote_pipeline_from_github(
         self, name, workflow_name, engine=None, local=None, watch=False

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -95,6 +95,19 @@ def test_run_name_regex(value, expected):
 
 
 @pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("{{pipelineparam:op=;name=mem}}", does_not_raise()),
+        ("{{pipelineparam:op=2;name=mem}}", does_not_raise()),
+        ("{{pipelineparam:op=10Mb;name=mem}}", does_not_raise()),
+    ],
+)
+def test_pipeline_param(value, expected):
+    with expected:
+        verify_field_regex("test_field", value, mlrun.utils.regex.pipeline_param)
+
+
+@pytest.mark.parametrize(
     "value,expected",
     [
         ("asd", does_not_raise()),


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3713

Until now we weren't able to pass pipeline param to function spec due to two reasons:
- strict regex validation that was applied on function attributes specifically resources attribute
- when running a function inside a pipeline we were storing the function to the DB and holding only the function url inside the workflow spec, this caused failure in converting the pipeline param to actual value because that this transformation happens when kfp transforms the kfp step to actual k8s resource, therefor we had to add logic that if we find pipelineparam in the function spec we don't save the function to the db but rather saves the full function spec in the workflow spec so that pipeline will convert that placeholder to value.

Actions made -
- Added an option to manage more lose validation on regex which allows to have "any" ( at least one ) match on regex
- Added logic that looks for `{{pipelineparam:op` in function spec while in workflow generation and if exists saves the whole function spec in the workflow spec, so that kfp will transform that placeholder to a value.