### PR TITLE
[Images/Base] Update conda to 23.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ MLRUN_PYTHON_VERSION ?= 3.9
 MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 22.3.0
+MLRUN_CONDA_VERSION ?= 23.5
 MLRUN_CACHE_DATE ?= $(shell date +%s)
 # empty by default, can be set to something like "tag-name" which will cause to:
 # 1. docker pull the same image with the given tag (cache image) before the build
@@ -247,6 +248,7 @@ base-core: pull-cache update-version-file ## Build base core docker image
 		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 		--build-arg MLRUN_ANACONDA_PYTHON_DISTRIBUTION=$(MLRUN_ANACONDA_PYTHON_DISTRIBUTION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
+		--build-arg MLRUN_CONDA_VERSION=$(MLRUN_CONDA_VERSION) \
 		$(MLRUN_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_CORE_BASE_IMAGE_NAME_TAGGED) .

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ MLRUN_PYTHON_VERSION ?= 3.9
 MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 22.3.0
-MLRUN_CONDA_VERSION ?= 23.5
 MLRUN_CACHE_DATE ?= $(shell date +%s)
 # empty by default, can be set to something like "tag-name" which will cause to:
 # 1. docker pull the same image with the given tag (cache image) before the build
@@ -248,7 +247,6 @@ base-core: pull-cache update-version-file ## Build base core docker image
 		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 		--build-arg MLRUN_ANACONDA_PYTHON_DISTRIBUTION=$(MLRUN_ANACONDA_PYTHON_DISTRIBUTION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
-		--build-arg MLRUN_CONDA_VERSION=$(MLRUN_CONDA_VERSION) \
 		$(MLRUN_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_CORE_BASE_IMAGE_NAME_TAGGED) .

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -53,8 +53,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
 
 ENV PATH /opt/conda/bin:$PATH
 
-ARG MLRUN_CONDA_VERSION=23.5
-RUN conda update -n base -c defaults conda~=${MLRUN_CONDA_VERSION} && \
+RUN conda update -n base -c defaults conda && \
     conda clean -aqy
 
 ARG MLRUN_PIP_VERSION=22.3.0

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -44,7 +44,7 @@ RUN chmod 777 /mlrun
 ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py39"
 
 # install miniconda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_4.12.0-Linux-x86_64.sh -O ~/installconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_23.1.0-1-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \
     rm ~/installconda.sh && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
@@ -52,9 +52,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
     echo "conda activate base" >> ~/.bashrc
 
 ENV PATH /opt/conda/bin:$PATH
-
-RUN conda update -n base -c defaults conda && \
-    conda clean -aqy
 
 ARG MLRUN_PIP_VERSION=22.3.0
 RUN conda config --add channels conda-forge && \

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -53,6 +53,9 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
 
 ENV PATH /opt/conda/bin:$PATH
 
+ARG MLRUN_CONDA_VERSION=23.5
+RUN conda update -n base -c defaults conda~=${MLRUN_PYTHON_VERSION}
+
 ARG MLRUN_PIP_VERSION=22.3.0
 RUN conda config --add channels conda-forge && \
     conda install python=${MLRUN_PYTHON_VERSION} pip~=${MLRUN_PIP_VERSION} && \

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -54,7 +54,8 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
 ENV PATH /opt/conda/bin:$PATH
 
 ARG MLRUN_CONDA_VERSION=23.5
-RUN conda update -n base -c defaults conda~=${MLRUN_PYTHON_VERSION}
+RUN conda update -n base -c defaults conda~=${MLRUN_CONDA_VERSION} && \
+    conda clean -aqy
 
 ARG MLRUN_PIP_VERSION=22.3.0
 RUN conda config --add channels conda-forge && \


### PR DESCRIPTION
Updating the conda environment resolves an issue we experience with compiling scikit packages
I chose 23.1.0 because the next version does not support python 3.7