### PR TITLE
[Notifications] Fix notification failed when no condition defined

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -554,7 +554,7 @@ class Notification(ModelObj):
         self.message = message
         self.severity = severity
         self.when = when
-        self.condition = condition
+        self.condition = condition or ""
         self.params = params or {}
         self.status = status
         self.sent_time = sent_time

--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -195,7 +195,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
             when=when or ["completed"],
             name=name or "test-notification",
             message=message or "test-notification-message",
-            condition=condition or "",
+            condition=condition,
             severity=severity or "info",
             params=params or {},
         )


### PR DESCRIPTION
resolves[ ML-4038](https://jira.iguazeng.com/browse/ML-4038)

The default value for notification condition was `None`, and we encountered a failure when we attempted to define notification without a condition.
Instead of `None`, the default was replaced with an empty string.