### PR TITLE
[Authz] Revert OPA `hub` path to `marketplace`

### DIFF
--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -86,7 +86,9 @@ class AuthorizationResourceTypes(mlrun.common.types.StrEnum):
             AuthorizationResourceTypes.model_endpoint: "/projects/{project_name}/model-endpoints/{resource_name}",
             AuthorizationResourceTypes.pipeline: "/projects/{project_name}/pipelines/{resource_name}",
             # Hub sources are not project-scoped, and auth is globally on the sources endpoint.
-            AuthorizationResourceTypes.hub_source: "/hub/sources",
+            # TODO - this was reverted to /marketplace since MLRun needs to be able to run with old igz versions. Once
+            # we only have support for igz versions that support /hub (>=3.5.4), change this to "/hub/sources".
+            AuthorizationResourceTypes.hub_source: "/marketplace/sources",
         }[self].format(project_name=project_name, resource_name=resource_name)
 
 


### PR DESCRIPTION
MLRun 1.5.0 will be using marketplace APIs, and this requires the OPA manifest to support it. We need to support older igz versions which only support the `/marketplace/sources` path, so we need to keep using the OPA `/marketplace/sources` rather than shift to the new `/hub/sources`, which will only be supported in igz 3.5.4.
Once MLRun will only be supported with igz >=3.5.4, this can be changed back to point at `/hub/sources`.