### PR TITLE
[Requirements] Bump pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,9 @@ sqlalchemy~=1.4
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6
 v3io~=0.5.20
-pydantic~=1.5
+# pydantic 1.10.8 fixes a bug with literal and typing-extension 4.6.0
+# https://docs.pydantic.dev/latest/changelog/#v1108-2023-05-23
+pydantic~=1.10, >=1.10.8
 # blacklist 3.8.12 due to a bug not being able to collect traceback of exceptions
 orjson~=3.3, <3.8.12
 alembic~=1.9

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -131,7 +131,7 @@ def test_requirement_specifiers_convention():
         "importlib_metadata": {">=3.6"},
         "gitpython": {"~=3.1, >= 3.1.30"},
         "orjson": {"~=3.3, <3.8.12"},
-        "pydantic": {'~=1.10, >=1.10.8'},
+        "pydantic": {"~=1.10, >=1.10.8"},
         "pyopenssl": {">=23"},
         "google-cloud-bigquery": {"[pandas, bqstorage]~=3.2"},
         # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -131,6 +131,7 @@ def test_requirement_specifiers_convention():
         "importlib_metadata": {">=3.6"},
         "gitpython": {"~=3.1, >= 3.1.30"},
         "orjson": {"~=3.3, <3.8.12"},
+        "pydantic": {'~=1.10, >=1.10.8'},
         "pyopenssl": {">=23"},
         "google-cloud-bigquery": {"[pandas, bqstorage]~=3.2"},
         # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding


### PR DESCRIPTION
pydantic 1.10.8 fixes a bug with literal and typing-extension 4.6.0  https://docs.pydantic.dev/latest/changelog/#v1108-2023-05-23