### PR TITLE
[Notifications] Fix secret unmasking fails the whole notification mechanism

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -263,7 +263,7 @@ def unmask_notification_params_secret_on_task(
             )
         except Exception as exc:
             logger.warning(
-                "Failed to unmask notification params, notification will be ignored",
+                "Failed to unmask notification params, notification will not be sent",
                 project=run.metadata.project,
                 run_uid=run.metadata.uid,
                 notification=notification.name,

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -28,6 +28,7 @@ from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import mlrun.api.crud
+import mlrun.api.db.base
 import mlrun.api.utils.auth.verifier
 import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.singletons.k8s
@@ -245,14 +246,43 @@ def mask_notification_params_with_secret(
     return notification_object
 
 
-def unmask_notification_params_secret_on_task(run):
+def unmask_notification_params_secret_on_task(
+    db: mlrun.api.db.base.DBInterface,
+    db_session: Session,
+    run: typing.Union[dict, mlrun.model.RunObject],
+):
     if isinstance(run, dict):
         run = mlrun.model.RunObject.from_dict(run)
 
-    run.spec.notifications = [
-        unmask_notification_params_secret(run.metadata.project, notification)
-        for notification in run.spec.notifications
-    ]
+    notifications = []
+    for notification in run.spec.notifications:
+        invalid_notifications = []
+        try:
+            notifications.append(
+                unmask_notification_params_secret(run.metadata.project, notification)
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to unmask notification params, notification will be ignored",
+                project=run.metadata.project,
+                run_uid=run.metadata.uid,
+                notification=notification.name,
+                exc=err_to_str(exc),
+            )
+            # set error status in order to later save the db
+            notification.status = mlrun.common.schemas.NotificationStatus.ERROR
+            invalid_notifications.append(notification)
+
+        if invalid_notifications:
+            db.store_run_notifications(
+                db_session,
+                invalid_notifications,
+                run.metadata.uid,
+                run.metadata.project,
+            )
+
+    run.spec.notifications = notifications
+
     return run
 
 

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -607,7 +607,9 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     # Unmasking the run parameters from secrets before handing them over to the notification handler
     # as importing the `Secrets` crud in the notification handler will cause a circular import
     unmasked_runs = [
-        mlrun.api.api.utils.unmask_notification_params_secret_on_task(run)
+        mlrun.api.api.utils.unmask_notification_params_secret_on_task(
+            db, db_session, run
+        )
         for run in runs
     ]
 


### PR DESCRIPTION
Fixes https://jira.iguazeng.com/browse/ML-4035

While trying to unmask a notification's params, if failed unmasking, Instead of raising the exception and stopping the notification sending iteration, log the error and save the notification with `ERROR` status.