### PR TITLE
[DevEnv] Added pycharm MLRun API run configuration

### DIFF
--- a/.run/MLRun API.run.xml
+++ b/.run/MLRun API.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MLRun API" type="PythonConfigurationType" factoryName="Python">
+    <module name="mlrun" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="MLRUN_DEFAULT_ENV_FILE" value="$PROJECT_DIR$/hack/mlrun.env" />
+      <env name="MLRUN_IS_API_SERVER" value="true" />
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/mlrun/api" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/mlrun/api/main.py" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
assuming `mlrun.env` file to be located under `hack/mlrun.env`. running mlrun api via this run configuration will allow using debugger from pycharm.
mlrun.env file should include relevant mlrun configuration in form of "envvars" so that config.py will be able to parse it and load it accordingly.
e.g.:


```
MLRUN_HTTPDB__DSN=mysql+pymysql://root@localhost:3306/mlrun
MLRUN_LOG_LEVEL=DEBUG
...
```