### PR TITLE
[Requirements] Bump nuclio-jupyter to 0.9.11

### DIFF
--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,7 +6,7 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.20.0
 python-dotenv~=0.17.0
-nuclio-jupyter[jupyter-server]~=0.9.10
+nuclio-jupyter[jupyter-server]~=0.9.11
 nbclassic>=0.2.8
 # added to tackle security vulnerabilities
 notebook~=6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ nest-asyncio~=1.0
 # ipython 8.0 + only supports python3.8 +, so to keep backwards compatibility with python 3.7 we support 7.x
 # we rely on pip and nuclio-jupyter requirements to install the right package per python version
 ipython>=7.0, <9.0
-nuclio-jupyter~=0.9.10
+nuclio-jupyter~=0.9.11
 # >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
 numpy>=1.16.5, <1.23.0
 # limiting pandas to <1.5.0 since 1.5.0 causes exception in storey on casting from ns to us


### PR DESCRIPTION
Following some fixes released in https://github.com/nuclio/nuclio-jupyter/releases/tag/v0.9.11 