### PR TITLE
[Notifications] Add validation to required fields

### DIFF
--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -45,7 +45,7 @@ class Notification(pydantic.BaseModel):
     kind: NotificationKind
     name: str = None
     message: str
-    severity: NotificationSeverity = None
+    severity: NotificationSeverity
     when: typing.List[str]
     condition: str = None
     params: typing.Dict[str, typing.Any] = None

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -42,11 +42,11 @@ class NotificationStatus(mlrun.common.types.StrEnum):
 
 
 class Notification(pydantic.BaseModel):
-    kind: NotificationKind = None
+    kind: NotificationKind
     name: str = None
-    message: str = None
+    message: str
     severity: NotificationSeverity = None
-    when: typing.List[str] = None
+    when: typing.List[str]
     condition: str = None
     params: typing.Dict[str, typing.Any] = None
     status: NotificationStatus = None

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -569,7 +569,7 @@ class Notification(ModelObj):
                 " The following fields are required: 'when', 'severity', 'kind', and 'message'."
                 " Please make sure to provide values for these fields."
             ) from exc
-\
+
     @staticmethod
     def validate_notification_uniqueness(notifications: List["Notification"]):
         """Validate that all notifications in the list are unique by name"""

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -550,7 +550,7 @@ class Notification(ModelObj):
         sent_time=None,
     ):
         self.kind = kind
-        self.name = name
+        self.name = name or ""
         self.message = message
         self.severity = severity
         self.when = when
@@ -558,7 +558,6 @@ class Notification(ModelObj):
         self.params = params or {}
         self.status = status
         self.sent_time = sent_time
-
         self.validate_notification()
 
     def validate_notification(self):
@@ -566,9 +565,11 @@ class Notification(ModelObj):
             mlrun.common.schemas.notification.Notification(**self.to_dict())
         except pydantic.error_wrappers.ValidationError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Invalid notification object"
+                "Invalid notification object."
+                " The following fields are required: 'when', 'severity', 'kind', and 'message'."
+                " Please make sure to provide values for these fields."
             ) from exc
-
+\
     @staticmethod
     def validate_notification_uniqueness(notifications: List["Notification"]):
         """Validate that all notifications in the list are unique by name"""

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -112,7 +112,6 @@ def test_notification_should_notify(
         when=when,
         condition=condition,
         status="pending" if not notification_previously_sent else "sent",
-
     )
 
     notification_pusher = (
@@ -141,7 +140,7 @@ def test_condition_evaluation_timeout():
         message="completed",
         when=["completed"],
         condition=condition,
-        status="pending"
+        status="pending",
     )
 
     notification_pusher = (
@@ -461,7 +460,7 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
             "kind": "invalid-kind",
             "message": "valid",
             "severity": "info",
-            "when": ["completed"]
+            "when": ["completed"],
         },
         pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
     ),
@@ -470,7 +469,7 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
             "kind": mlrun.common.schemas.notification.NotificationKind.slack,
             "message": "valid",
             "severity": "info",
-            "when": ["completed"]
+            "when": ["completed"],
         },
         does_not_raise(),
     ),
@@ -479,8 +478,7 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
             "severity": "invalid-severity",
             "message": "valid",
             "when": ["completed"],
-            "kind": "console"
-
+            "kind": "console",
         },
         pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
     ),
@@ -489,7 +487,7 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
             "severity": mlrun.common.schemas.notification.NotificationSeverity.INFO,
             "kind": "console",
             "message": "valid",
-            "when": ["completed"]
+            "when": ["completed"],
         },
         does_not_raise(),
     ),
@@ -499,7 +497,7 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
             "kind": "console",
             "message": "valid",
             "severity": "info",
-            "when": ["completed"]
+            "when": ["completed"],
         },
         pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
     ),
@@ -509,7 +507,7 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
             "kind": "console",
             "message": "valid",
             "severity": "info",
-            "when": ["completed"]
+            "when": ["completed"],
         },
         does_not_raise(),
     ),
@@ -533,7 +531,11 @@ def test_notification_validation_on_object(
 )
 def test_notification_validation_on_run(monkeypatch, notification_kwargs, expectation):
     notification = mlrun.model.Notification(
-        name="test-notification", when=["completed"], kind="console", severity="info", message="completed"
+        name="test-notification",
+        when=["completed"],
+        kind="console",
+        severity="info",
+        message="completed",
     )
     for key, value in notification_kwargs.items():
         setattr(notification, key, value)
@@ -590,7 +592,11 @@ def test_notification_sent_on_dask_run(monkeypatch):
     monkeypatch.setattr(mlrun.utils.notifications.NotificationPusher, "push", push_mock)
 
     notification = mlrun.model.Notification(
-        name="test-notification", when=["completed"], kind="console", severity="info", message="completed"
+        name="test-notification",
+        when=["completed"],
+        kind="console",
+        severity="info",
+        message="completed",
     )
 
     function = mlrun.new_function(
@@ -622,10 +628,18 @@ def test_notification_name_uniqueness_validation(
     notification1_name, notification2_name, expectation
 ):
     notification1 = mlrun.model.Notification(
-        name=notification1_name, when=["completed"], kind="console", severity="info", message="completed"
+        name=notification1_name,
+        when=["completed"],
+        kind="console",
+        severity="info",
+        message="completed",
     )
     notification2 = mlrun.model.Notification(
-        name=notification2_name, when=["completed"], kind="console", severity="info", message="completed"
+        name=notification2_name,
+        when=["completed"],
+        kind="console",
+        severity="info",
+        message="completed",
     )
     function = mlrun.new_function(
         "function-from-module",


### PR DESCRIPTION
resolves: [ML-4090](https://jira.iguazeng.com/browse/ML-4090) and [ML-4091](https://jira.iguazeng.com/browse/ML-4091)

Notification must contain the fields: `kind`, `when`, `message` and `severity`, the rest are optional.  
This PR ensures that a request will fail if they are not passed, and adds default values to some of optional fields.