### PR TITLE
[Artifacts] Fix resolving target path in artifacts html

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -381,42 +381,6 @@ class Artifact(ModelObj):
             source_path
         )
 
-    def resolve_target_path(self, artifact_path: str = None):
-        """
-        Resolve the target path for the artifact,
-        if the user didn't specify a target path, and mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash is
-        True, the target path will be resolved from the artifact hash
-        if the artifact has a body, the target path will be resolved from
-        the body, otherwise it will be resolved from the source path
-
-        :param artifact_path:   the artifact path to use when generating the target path
-        :return:                the target path
-        """
-        if self.spec.target_path:
-            return self.spec.target_path
-
-        if not mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "Unable to resolve target path, no target path is defined and "
-                "mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash is set to false"
-            )
-
-        body = self.spec.get_body()
-        if body:
-            (self.metadata.hash, target_path,) = self.resolve_body_target_hash_path(
-                body=body, artifact_path=artifact_path
-            )
-
-        else:
-            if not os.path.isfile(self.src_path):
-                raise ValueError(f"artifact file {self.src_path} not found")
-
-            (self.metadata.hash, target_path,) = self.resolve_file_target_hash_path(
-                source_path=self.src_path, artifact_path=artifact_path
-            )
-
-        return target_path
-
     def resolve_body_target_hash_path(
         self, body: typing.Union[bytes, str], artifact_path: str
     ) -> (str, str):

--- a/mlrun/lists.py
+++ b/mlrun/lists.py
@@ -38,7 +38,6 @@ list_header = [
     "results",
     "artifacts",
     "error",
-    "output_path",
 ]
 
 iter_index = list_header.index("iter")
@@ -66,7 +65,6 @@ class RunList(list):
                 get_in(run, "status.results", ""),
                 get_in(run, "status.artifacts", []),
                 get_in(run, "status.error", ""),
-                get_in(run, "spec.output_path", ""),
             ]
             if extend_iterations and iterations:
                 parameters_dict = {

--- a/mlrun/lists.py
+++ b/mlrun/lists.py
@@ -38,6 +38,7 @@ list_header = [
     "results",
     "artifacts",
     "error",
+    "output_path",
 ]
 
 iter_index = list_header.index("iter")
@@ -65,6 +66,7 @@ class RunList(list):
                 get_in(run, "status.results", ""),
                 get_in(run, "status.artifacts", []),
                 get_in(run, "status.error", ""),
+                get_in(run, "spec.output_path", ""),
             ]
             if extend_iterations and iterations:
                 parameters_dict = {
@@ -92,7 +94,9 @@ class RunList(list):
 
         return [list_header] + rows
 
-    def to_df(self, flat=False, extend_iterations=False, cache=True):
+    def to_df(
+        self, flat: bool = False, extend_iterations: bool = False, cache: bool = True
+    ) -> pd.DataFrame:
         """convert the run list to a dataframe"""
         if hasattr(self, "_df") and cache:
             return self._df

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -416,6 +416,7 @@ def runs_to_html(
             lambda artifacts_tuple: artifacts_html(artifacts_tuple, "target_path"),
             axis=1,
         )
+        # no need for the output path to be displayed (there is a link to the artifacts)
         df.drop("output_path", axis=1, inplace=True)
 
     def expand_error(x):

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -389,7 +389,7 @@ def runs_to_html(
     else:
         df["labels"] = df["labels"].apply(dict_html)
         df["inputs"] = df["inputs"].apply(inputs_html)
-        df["artifacts"] = df["artifacts", "output_path"].apply(_artifacts_html, axis=1)
+        df["artifacts"] = df[["artifacts", "output_path"]].apply(_artifacts_html, axis=1)
 
     def expand_error(x):
         if x["state"] == "error":

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -104,7 +104,10 @@ def link_html(text, link=""):
     return f'<div {ref}title="{link}">{text}</div>'
 
 
-def artifacts_html(artifacts_tuple: typing.Tuple, attribute_name: str = "path"):
+def artifacts_html(
+    artifacts_tuple: typing.Tuple[dict, str],
+    attribute_name: str = "path",
+):
     """
     Generate HTML for a list of artifacts. The HTML will be a list of links to the artifacts to be presented in the
     jupyter notebook. The links will be clickable and will open the artifact in a new tab.

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -398,6 +398,7 @@ def runs_to_html(
         df["artifacts"] = df[["artifacts", "output_path"]].apply(
             lambda x: artifacts_html(x, "target_path"), axis=1
         )
+        df.drop("output_path", axis=1, inplace=True)
 
     def expand_error(x):
         if x["state"] == "error":

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -18,7 +18,7 @@ from os import environ, path
 
 import pandas as pd
 
-import mlrun.artifacts
+import mlrun.utils
 
 from .config import config
 from .datastore import uri_to_ipython
@@ -134,7 +134,7 @@ def artifacts_html(
 
         if not attribute_value:
             mlrun.utils.logger.warning(
-                f"Artifact is incomplete, omitting from output (most likely due to a failed artifact logging).",
+                "Artifact is incomplete, omitting from output (most likely due to a failed artifact logging).",
                 artifact_key=key,
             )
             continue

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -353,7 +353,8 @@ def runs_to_html(
         except ValueError:
             return ""
 
-    def _artifacts_html(artifact_dict, output_path):
+    def _artifacts_html(artifact_tuple):
+        artifact_dict, output_path = artifact_tuple
         if config.artifacts.generate_target_path_from_artifact_hash:
             artifact = mlrun.artifacts.dict_to_artifact(artifact_dict)
             return artifact.resolve_target_path(artifact_path=output_path)
@@ -388,8 +389,7 @@ def runs_to_html(
     else:
         df["labels"] = df["labels"].apply(dict_html)
         df["inputs"] = df["inputs"].apply(inputs_html)
-        df["artifacts"] = list(zip(df["artifacts"], df["output_path"]))
-        df["artifacts"] = df["artifacts"].apply(_artifacts_html)
+        df["artifacts"] = df["artifacts", "output_path"].apply(_artifacts_html, axis=1)
 
     def expand_error(x):
         if x["state"] == "error":

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -134,13 +134,12 @@ def artifacts_html(
 
         if not attribute_value:
             mlrun.utils.logger.warning(
-                "Artifact is incomplete, omitting from output (most likely due to a failed artifact logging).",
+                "Artifact is incomplete, omitting from output (most likely due to a failed artifact logging)",
                 artifact_key=key,
             )
             continue
 
         link, ref = link_to_ipython(attribute_value)
-
         html += f'<div {ref}title="{link}">{key}</div>'
     return html
 

--- a/tests/assets/log_function.py
+++ b/tests/assets/log_function.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pandas as pd
+
+features = {
+    "feature_1": [
+        {"a": 4, "b": 8, "c": 5},
+        {"a": 5, "b": 6, "c": 3},
+        {"a": 3, "b": 10, "c": 2},
+    ],
+    "feature_2": [
+        {"a": 3, "b": 2, "c": 10},
+        {"a": 9, "b": 10, "c": 9},
+        {"a": 4, "b": 9, "c": 2},
+        {"a": 3, "b": 6, "c": 4},
+    ],
+}
+
+
+def log_dataset(context):
+    for dataset_name, dataset_content in (features or {}).items():
+        df = pd.DataFrame(dataset_content)
+        context.log_dataset(
+            dataset_name,
+            df=df,
+            format="csv",
+        )

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -14,10 +14,11 @@
 #
 import shutil
 import unittest
+from datetime import datetime
 from http import HTTPStatus
 from os import environ
 from pathlib import Path
-from typing import Callable, Generator
+from typing import Callable, Generator, List, Optional, Union
 from unittest.mock import Mock
 
 import deepdiff
@@ -274,6 +275,33 @@ class RunDBMock:
 
     def read_run(self, uid, project, iter=0):
         return self._runs.get(uid, {})
+
+    def list_runs(
+        self,
+        name: Optional[str] = None,
+        uid: Optional[Union[str, List[str]]] = None,
+        project: Optional[str] = None,
+        labels: Optional[Union[str, List[str]]] = None,
+        state: Optional[str] = None,
+        sort: bool = True,
+        last: int = 0,
+        iter: bool = False,
+        start_time_from: Optional[datetime] = None,
+        start_time_to: Optional[datetime] = None,
+        last_update_time_from: Optional[datetime] = None,
+        last_update_time_to: Optional[datetime] = None,
+        partition_by: Optional[
+            Union[mlrun.common.schemas.RunPartitionByField, str]
+        ] = None,
+        rows_per_partition: int = 1,
+        partition_sort_by: Optional[Union[mlrun.common.schemas.SortField, str]] = None,
+        partition_order: Union[
+            mlrun.common.schemas.OrderType, str
+        ] = mlrun.common.schemas.OrderType.desc,
+        max_partitions: int = 0,
+        with_notifications: bool = False,
+    ) -> mlrun.lists.RunList:
+        return mlrun.lists.RunList(self._runs.values())
 
     def get_function(self, function, project, tag, hash_key=None):
         if function not in self._functions:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -31,13 +31,13 @@ def get_db():
 @pytest.mark.parametrize(
     "generate_artifact_hash_mode, expected_target_paths",
     [
-        # (
-        #     False,
-        #     [
-        #         f"{results}/log-function-log-dataset/0/feature_1.csv",
-        #         f"{results}/log-function-log-dataset/0/feature_2.csv",
-        #     ],
-        # ),
+        (
+            False,
+            [
+                f"{results}/log-function-log-dataset/0/feature_1.csv",
+                f"{results}/log-function-log-dataset/0/feature_2.csv",
+            ],
+        ),
         (
             True,
             [

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -62,8 +62,8 @@ def test_list_runs(rundb_mock, generate_artifact_hash_mode, expected_target_path
 
     html = runs.show(display=False)
     for expected_target_path in expected_target_paths:
-        expected_title, _ = mlrun.render.link_to_ipython(expected_target_path)
-        assert expected_title in html
+        expected_link, _ = mlrun.render.link_to_ipython(expected_target_path)
+        assert expected_link in html
 
 
 # FIXME: this test was counting on the fact it's running after some test (I think test_httpdb) which leaves runs and

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -31,13 +31,13 @@ def get_db():
 @pytest.mark.parametrize(
     "generate_artifact_hash_mode, expected_target_paths",
     [
-        (
-            False,
-            [
-                f"{results}/log-function-log-dataset/0/feature_1.csv",
-                f"{results}/log-function-log-dataset/0/feature_2.csv",
-            ],
-        ),
+        # (
+        #     False,
+        #     [
+        #         f"{results}/log-function-log-dataset/0/feature_1.csv",
+        #         f"{results}/log-function-log-dataset/0/feature_2.csv",
+        #     ],
+        # ),
         (
             True,
             [

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -12,32 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pathlib
+
 import pytest
 
 import mlrun
+import mlrun.render
 from tests.conftest import results, rundb_path
+
+assets_path = pathlib.Path(__file__).parent / "assets"
+function_path = str(assets_path / "log_function.py")
 
 
 def get_db():
     return mlrun.get_run_db(rundb_path)
 
 
-#
-# pprint.pprint(db.list_runs()[:2])
-
-# FIXME: this test was counting on the fact it's running after some test (I think test_httpdb) which leaves runs and
-#  artifacts in the `results` dir, it should generate its own stuff, skipping for now
-@pytest.mark.skip("FIX_ME")
-def test_list_runs():
+@pytest.mark.parametrize(
+    "generate_artifact_hash_mode, expected_target_paths",
+    [
+        (
+            False,
+            [
+                f"{results}/log-function-log-dataset/0/feature_1.csv",
+                f"{results}/log-function-log-dataset/0/feature_2.csv",
+            ],
+        ),
+        (
+            True,
+            [
+                f"{results}/6154c46f1a6fffb0b6b716882279d7e09ecb6b8a.csv",
+                f"{results}/c88c2dc877a6595cb2eb834449aac6e2789d301c.csv",
+            ],
+        ),
+    ],
+)
+def test_list_runs(rundb_mock, generate_artifact_hash_mode, expected_target_paths):
+    mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash = (
+        generate_artifact_hash_mode
+    )
+    func = mlrun.code_to_function(
+        filename=function_path, kind="job", handler="log_dataset"
+    )
+    func.run(local=True, out_path=str(results))
 
     db = get_db()
     runs = db.list_runs()
     assert runs, "empty runs result"
 
     html = runs.show(display=False)
-
-    with open(f"{results}/runs.html", "w") as fp:
-        fp.write(html)
+    for expected_target_path in expected_target_paths:
+        expected_title, _ = mlrun.render.link_to_ipython(expected_target_path)
+        assert expected_title in html
 
 
 # FIXME: this test was counting on the fact it's running after some test (I think test_httpdb) which leaves runs and


### PR DESCRIPTION
When we show the results html in a jupyter notebook we link the artifacts to their target paths.
If logging the artifact failed and `generate_target_path_from_artifact_hash` is enabled the target path might not have been set - if that happens, warn and continue.

https://jira.iguazeng.com/browse/ML-2880
