### PR TITLE
Revert "[Workflows] Add validation and error message for invalid workflow setup"

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1211,14 +1211,8 @@ class MlrunProject(ModelObj):
         :param ttl:           pipeline ttl in secs (after that the pods will be removed)
         :param args:          argument values (key=value, ..)
         """
-        if not workflow_path or not (
-            (os.path.isfile(workflow_path) or "://" in workflow_path)
-            and workflow_path.endswith(".py")
-        ):
-            raise ValueError(
-                f"Invalid 'workflow_path': '{workflow_path}', please provide a valid URL/path to a python file."
-            )
-
+        if not workflow_path:
+            raise ValueError("valid workflow_path must be specified")
         if embed:
             if (
                 self.context

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -15,7 +15,6 @@
 import os
 import os.path
 import pathlib
-import re
 import shutil
 import tempfile
 import unittest.mock
@@ -909,55 +908,6 @@ def test_project_ops():
     run = proj2.run_function("f2", params={"x": 2}, local=True)
     assert run.spec.function.startswith("proj2/f2")
     assert run.output("y") == 4  # = x * 2
-
-
-@pytest.mark.parametrize(
-    "workflow_path,exception",
-    [
-        (
-            "./",
-            pytest.raises(
-                ValueError,
-                match=str(
-                    re.escape(
-                        "Invalid 'workflow_path': './', please provide a valid URL/path to a python file."
-                    )
-                ),
-            ),
-        ),
-        (
-            "https://test",
-            pytest.raises(
-                ValueError,
-                match=str(
-                    re.escape(
-                        "Invalid 'workflow_path': 'https://test', please provide a valid URL/path to a python file."
-                    )
-                ),
-            ),
-        ),
-        (
-            "",
-            pytest.raises(
-                ValueError,
-                match=str(
-                    re.escape(
-                        "Invalid 'workflow_path': '', please provide a valid URL/path to a python file."
-                    )
-                ),
-            ),
-        ),
-        ("https://test.py", does_not_raise()),
-        (
-            str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
-            does_not_raise(),
-        ),
-    ],
-)
-def test_set_workflow_with_invalid_path(workflow_path, exception):
-    proj = mlrun.new_project("proj", save=False)
-    with exception:
-        proj.set_workflow("main", workflow_path)
 
 
 def test_clear_context():


### PR DESCRIPTION
Reverts mlrun/mlrun#3797
Breaks BC - see test `test_run_artifact_path`


see - 
```
E           ValueError: Invalid 'workflow_path': './kflow.py', please provide a valid URL/path to a python file.
```