### PR TITLE
[Notifications] Add default values and validation to notifications

### DIFF
--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -48,7 +48,7 @@ class Notification(pydantic.BaseModel):
     severity: NotificationSeverity
     when: typing.List[str]
     condition: str
-    params: typing.Dict[str, typing.Any] = {}
+    params: typing.Dict[str, typing.Any] = None
     status: NotificationStatus = None
     sent_time: typing.Union[str, datetime.datetime] = None
 

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -42,13 +42,13 @@ class NotificationStatus(mlrun.common.types.StrEnum):
 
 
 class Notification(pydantic.BaseModel):
-    kind: NotificationKind = None
-    name: str = None
-    message: str = None
-    severity: NotificationSeverity = None
-    when: typing.List[str] = None
-    condition: str = None
-    params: typing.Dict[str, typing.Any] = None
+    kind: NotificationKind
+    name: str
+    message: str
+    severity: NotificationSeverity
+    when: typing.List[str]
+    condition: str
+    params: typing.Dict[str, typing.Any] = {}
     status: NotificationStatus = None
     sent_time: typing.Union[str, datetime.datetime] = None
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -549,11 +549,13 @@ class Notification(ModelObj):
         status=None,
         sent_time=None,
     ):
-        self.kind = kind
-        self.name = name
-        self.message = message
-        self.severity = severity
-        self.when = when
+        self.kind = kind or mlrun.common.schemas.notification.NotificationKind.slack
+        self.name = name or ""
+        self.message = message or ""
+        self.severity = (
+            severity or mlrun.common.schemas.notification.NotificationSeverity.INFO
+        )
+        self.when = when or ["completed"]
         self.condition = condition or ""
         self.params = params or {}
         self.status = status

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -496,18 +496,6 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
     ),
     (
         {
-            "name": ["invalid-name"],
-        },
-        pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
-    ),
-    (
-        {
-            "name": "my-amazing-notification",
-        },
-        does_not_raise(),
-    ),
-    (
-        {
             "message": {"my-message": "invalid"},
         },
         pytest.raises(mlrun.errors.MLRunInvalidArgumentError),

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -557,7 +557,6 @@ def test_notification_validation_defaults(monkeypatch):
 
     for field, expected_value in notification_fields.items():
         value = getattr(notification, field)
-        assert value is not None, f"{field} field in the notification object is None"
         assert (
             value == expected_value
         ), f"{field} field value is {value}, expected {expected_value}"

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -482,6 +482,54 @@ NOTIFICATION_VALIDATION_PARMETRIZE = [
         },
         does_not_raise(),
     ),
+    (
+        {
+            "when": "invalid-when",
+        },
+        pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+    ),
+    (
+        {
+            "when": ["completed", "error"],
+        },
+        does_not_raise(),
+    ),
+    (
+        {
+            "name": ["invalid-name"],
+        },
+        pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+    ),
+    (
+        {
+            "name": "my-amazing-notification",
+        },
+        does_not_raise(),
+    ),
+    (
+        {
+            "message": {"my-message": "invalid"},
+        },
+        pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+    ),
+    (
+        {
+            "message": "completed",
+        },
+        does_not_raise(),
+    ),
+    (
+        {
+            "condition": ["invalid-condition"],
+        },
+        pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+    ),
+    (
+        {
+            "condition": "valid-condition",
+        },
+        does_not_raise(),
+    ),
 ]
 
 
@@ -494,6 +542,25 @@ def test_notification_validation_on_object(
 ):
     with expectation:
         mlrun.model.Notification(**notification_kwargs)
+
+
+def test_notification_validation_defaults(monkeypatch):
+    notification = mlrun.model.Notification()
+    notification_fields = {
+        "kind": mlrun.common.schemas.notification.NotificationKind.slack,
+        "message": "",
+        "severity": mlrun.common.schemas.notification.NotificationSeverity.INFO,
+        "when": ["completed"],
+        "condition": "",
+        "name": "",
+    }
+
+    for field, expected_value in notification_fields.items():
+        value = getattr(notification, field)
+        assert value is not None, f"{field} field in the notification object is None"
+        assert (
+            value == expected_value
+        ), f"{field} field value is {value}, expected {expected_value}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
resolves: [ML-4090](https://jira.iguazeng.com/browse/ML-4090) and [ML-4091](https://jira.iguazeng.com/browse/ML-4091)

The following fields must be present in the notification: kind, when, message, and severity; the rest are optional.
This PR ensures that if they are not passed, the request will not fail and will have default values, and adds validation that it is as intended when they are.

Please note that this change affects backward compatibility, but the notification feature has not been released to users yet, so we can disregard the breakage.