### PR TITLE
[Package] Add special handling for Python 3.7

### DIFF
--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -16,6 +16,7 @@ import importlib
 import inspect
 import os
 import shutil
+import sys
 import traceback
 from typing import Any, Dict, List, Tuple, Type, Union
 
@@ -264,7 +265,11 @@ class PackagersManager:
         :return: The unpacked object parsed as type hinted.
         """
         # Check if `DataItem` is hinted - meaning the user can expect a data item and do not want to unpack it:
-        if TypeHintUtils.is_matching(object_type=DataItem, type_hint=type_hint):
+        # TODO: Remove when we'll no longer support Python 3.7:
+        if sys.version_info[1] < 8:
+            if self._get_type_name(typ=DataItem) in str(type_hint):
+                return data_item
+        elif TypeHintUtils.is_matching(object_type=DataItem, type_hint=type_hint):
             return data_item
 
         # Set variables to hold the manager notes and packager instructions:


### PR DESCRIPTION
Python's `typing` module had major changes from Python 3.7 to 3.8, and the shift-reduce algorithm `mlrun.package` has is written for 3.9. For 3.7, we do not reduce type hints. That means `typing.Union[int, float]` in 3.9 will be reduced to `int` and `float` but in 3.7 we skip the reduce phase.

When the type hint has `DataItem` we want to skip the parsing, so we look in the type hint for `DataItem`. In Python 3.7 we didn't catch grouped hints like `typing.Union[list, dict, DataItem]` so I added a check - string check.