### PR TITLE
[Function] Reduce amount of storing to the DB on `/build/status` endpoint

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -531,7 +531,7 @@ def _handle_job_deploy_status(
             pod=pod,
             pod_state=build_pod_state,
         )
-    if build_pod_state == mlrun.common.schemas.FunctionState.error:
+    elif normalized_pod_function_state == mlrun.common.schemas.FunctionState.error:
         logger.error(
             "Build failed", function_name=name, pod_name=pod, pod_status=build_pod_state
         )
@@ -570,7 +570,7 @@ def _handle_job_deploy_status(
             # begin from the offset number and then encode
             out = resp[offset:].encode()
 
-    # check if the previous function state is different from the current build pod state, it that is the case then
+    # check if the previous function state is different from the current build pod state, if that is the case then
     # update the function and store to the database
     if function_state != normalized_pod_function_state:
         update_in(fn, "status.state", normalized_pod_function_state)

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -448,21 +448,21 @@ async def build_status(
 
 
 def _handle_job_deploy_status(
-    db_session,
-    fn,
-    name,
-    project,
-    tag,
-    offset,
-    logs,
+    db_session: Session,
+    fn: dict,
+    name: str,
+    project: str,
+    tag: str,
+    offset: int,
+    logs: bool,
 ):
     # job deploy status
-    state = get_in(fn, "status.state", "")
+    function_state = get_in(fn, "status.state", "")
     pod = get_in(fn, "status.build_pod", "")
     image = get_in(fn, "spec.build.image", "")
     out = b""
     if not pod:
-        if state == mlrun.common.schemas.FunctionState.ready:
+        if function_state == mlrun.common.schemas.FunctionState.ready:
             # when the function has been built we set the created image into the `spec.image` for reference see at the
             # end of the function where we resolve if the status is ready and then set the spec.build.image to
             # spec.image
@@ -474,17 +474,19 @@ def _handle_job_deploy_status(
             content=out,
             media_type="text/plain",
             headers={
-                "function_status": state,
+                "function_status": function_state,
                 "function_image": image,
                 "builder_pod": pod,
             },
         )
 
     # read from log file
-    terminal_states = ["failed", "error", "ready"]
     log_file = log_path(project, f"build_{name}__{tag or 'latest'}")
-    if state in terminal_states and log_file.exists():
-        if state == mlrun.common.schemas.FunctionState.ready:
+    if (
+        function_state in mlrun.common.schemas.FunctionState.terminal_states()
+        and log_file.exists()
+    ):
+        if function_state == mlrun.common.schemas.FunctionState.ready:
             # when the function has been built we set the created image into the `spec.image` for reference see at the
             # end of the function where we resolve if the status is ready and then set the spec.build.image to
             # spec.image
@@ -500,40 +502,64 @@ def _handle_job_deploy_status(
             content=out,
             media_type="text/plain",
             headers={
-                "x-mlrun-function-status": state,
-                "function_status": state,
+                "x-mlrun-function-status": function_state,
+                "function_status": function_state,
                 "function_image": image,
                 "builder_pod": pod,
             },
         )
 
-    # TODO: change state to pod_status
-    state = mlrun.api.utils.singletons.k8s.get_k8s_helper(silent=False).get_pod_status(
-        pod
+    build_pod_state = mlrun.api.utils.singletons.k8s.get_k8s_helper(
+        silent=False
+    ).get_pod_status(pod)
+    logger.debug(
+        "Resolved pod status",
+        function_name=name,
+        pod_status=build_pod_state,
+        pod_name=pod,
     )
-    logger.info("Resolved pod status", pod_status=state, pod_name=pod)
 
-    if state == "succeeded":
-        logger.info("Build completed successfully")
-        state = mlrun.common.schemas.FunctionState.ready
-    if state in ["failed", "error"]:
-        logger.error("Build failed", pod_name=pod, pod_status=state)
-        state = mlrun.common.schemas.FunctionState.error
+    normalized_build_pod_state = (
+        mlrun.common.schemas.FunctionState.get_function_state_from_pod_state(
+            build_pod_state
+        )
+    )
+    if normalized_build_pod_state == mlrun.common.schemas.FunctionState.ready:
+        logger.info(
+            "Build completed successfully",
+            function_name=name,
+            pod=pod,
+            pod_state=build_pod_state,
+        )
+    if build_pod_state == mlrun.common.schemas.FunctionState.error:
+        logger.error(
+            "Build failed", function_name=name, pod_name=pod, pod_status=build_pod_state
+        )
 
-    if (logs and state != "pending") or state in terminal_states:
+    if (
+        (
+            logs
+            and normalized_build_pod_state != mlrun.common.schemas.FunctionState.pending
+        )
+        or normalized_build_pod_state
+        in mlrun.common.schemas.FunctionState.terminal_states()
+    ):
         try:
             resp = mlrun.api.utils.singletons.k8s.get_k8s_helper(silent=False).logs(pod)
         except ApiException as exc:
             logger.warning(
                 "Failed to get build logs",
                 function_name=name,
-                function_state=state,
+                function_state=normalized_build_pod_state,
                 pod=pod,
                 exc_info=exc,
             )
             resp = ""
 
-        if state in terminal_states:
+        if (
+            normalized_build_pod_state
+            in mlrun.common.schemas.FunctionState.terminal_states()
+        ):
             # TODO: move to log collector
             log_file.parent.mkdir(parents=True, exist_ok=True)
             with log_file.open("wb") as fp:
@@ -543,28 +569,31 @@ def _handle_job_deploy_status(
             # begin from the offset number and then encode
             out = resp[offset:].encode()
 
-    update_in(fn, "status.state", state)
-    if state == mlrun.common.schemas.FunctionState.ready:
-        update_in(fn, "spec.image", image)
+    # check if the previous function state is different from the current build pod state, it that is the case then
+    # update the function and store to the database
+    if function_state != normalized_build_pod_state:
+        update_in(fn, "status.state", normalized_build_pod_state)
 
-    versioned = False
-    if state == mlrun.common.schemas.FunctionState.ready:
-        versioned = True
-    mlrun.api.crud.Functions().store_function(
-        db_session,
-        fn,
-        name,
-        project,
-        tag,
-        versioned=versioned,
-    )
+        versioned = False
+        if normalized_build_pod_state == mlrun.common.schemas.FunctionState.ready:
+            update_in(fn, "spec.image", image)
+            versioned = True
+
+        mlrun.api.crud.Functions().store_function(
+            db_session,
+            fn,
+            name,
+            project,
+            tag,
+            versioned=versioned,
+        )
 
     return Response(
         content=out,
         media_type="text/plain",
         headers={
-            "x-mlrun-function-status": state,
-            "function_status": state,
+            "x-mlrun-function-status": normalized_build_pod_state,
+            "function_status": normalized_build_pod_state,
             "function_image": image,
             "builder_pod": pod,
         },

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -45,6 +45,23 @@ class FunctionState:
     # same goes for the build which is not coming from the pod, but is used and we can't just omit it for BC reasons
     build = "build"
 
+    @classmethod
+    def get_function_state_from_pod_state(cls, pod_state: str):
+        if pod_state == "succeeded":
+            return cls.ready
+        if pod_state in ["failed", "error"]:
+            return cls.error
+        if pod_state in ["running", "pending"]:
+            return getattr(cls, pod_state)
+        return cls.unknown
+
+    @classmethod
+    def terminal_states(cls):
+        return [
+            cls.ready,
+            cls.error,
+        ]
+
 
 class PreemptionModes(mlrun.common.types.StrEnum):
     # makes function pods be able to run on preemptible nodes


### PR DESCRIPTION
Previously - we were storing the function to the DB for every get request on `/build/status`
Now - we will update the function status to the DB only when changes in function status were detected