### PR TITLE
[CI] Dynamically enrich env-vars for system tests

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: |
         pip install -r automation/requirements.txt && pip install -e .
-        sudo apt-get install curl jq gnupg2
+        sudo apt-get install curl jq gnupg
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info
       run: |
@@ -314,7 +314,7 @@ jobs:
 
     - name: Install GPG
       run: |
-        sudo apt-get update -qqy && sudo apt-get install -y gnupg2
+        sudo apt-get update -qqy && sudo apt-get install -y gnupg
 
     - name: Decrypt file
       run: |

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -271,7 +271,7 @@ jobs:
       run: |
         gpg \
           --batch \
-          --passphrase ${{ env.GPG_PASSPHRASE }} \
+          --passphrase "${{ env.GPG_PASSPHRASE }}" \
           --output "${{ github.workspace }}/env.yaml.gpg" \
           --symmetric "${{ github.workspace }}/env.yaml"
       env:
@@ -324,9 +324,9 @@ jobs:
       run: |
         gpg \
           --batch \
-          --passphrase ${{ env.GPG_PASSPHRASE }} \
-          --output ${{ github.workspace }}/tests/system/env.yaml \
-          --decrypt ${{ github.workspace }}/tests/system/env.yaml.gpg
+          --passphrase "${{ env.GPG_PASSPHRASE }}" \
+          --output "${{ github.workspace }}/tests/system/env.yaml" \
+          --decrypt "${{ github.workspace }}/tests/system/env.yaml.gpg"
 
         # ensure file created
         test -f ${{ github.workspace }}/tests/system/env.yaml

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: |
         pip install -r automation/requirements.txt && pip install -e .
-        sudo apt-get install curl jq
+        sudo apt-get install curl jq gnupg2
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info
       run: |
@@ -311,6 +311,10 @@ jobs:
       with:
         name: env
         path: "${{ github.workspace }}/env.yaml.gpg"
+
+    - name: Install GPG
+      run: |
+        sudo apt-get update -qqy && sudo apt-get install -y gnupg2
 
     - name: Decrypt file
       run: |

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -164,7 +164,7 @@ jobs:
         cache: pip
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: |
-        pip install -r automation/requirements.txt && pip install -e .
+        pip install -r automation/requirements.txt
         sudo apt-get install curl jq gnupg
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -269,7 +269,11 @@ jobs:
 
     - name: Encrypt file
       run: |
-        gpg --batch --output "${{ github.workspace }}/env.yaml.gpg" --passphrase ${{ GPG_PASSPHRASE }} --symmetric "${{ github.workspace }}/env.yaml"
+        gpg \
+          --batch \
+          --passphrase ${{ env.GPG_PASSPHRASE }} \
+          --output "${{ github.workspace }}/env.yaml.gpg" \
+          --symmetric "${{ github.workspace }}/env.yaml"
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
@@ -310,7 +314,7 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: env
-        path: "${{ github.workspace }}/env.yaml.gpg"
+        path: "${{ github.workspace }}/tests/system"
 
     - name: Install GPG
       run: |
@@ -318,8 +322,12 @@ jobs:
 
     - name: Decrypt file
       run: |
-        gpg --batch --output ${{ github.workspace }}/tests/system/env.yaml --passphrase ${{ GPG_PASSPHRASE }} --decrypt ${{ github.workspace }}/env.yaml.gpg
-        
+        gpg \
+          --batch \
+          --passphrase ${{ env.GPG_PASSPHRASE }} \
+          --output ${{ github.workspace }}/tests/system/env.yaml \
+          --decrypt ${{ github.workspace }}/tests/system/env.yaml.gpg
+
         # ensure file created
         test -f ${{ github.workspace }}/tests/system/env.yaml
       env:

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -237,18 +237,12 @@ jobs:
           --data-cluster-ssh-username "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
           --data-cluster-ssh-password "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           --app-cluster-ssh-password "${{ secrets.LATEST_SYSTEM_TEST_APP_CLUSTER_SSH_PASSWORD }}" \
-          --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" \
           --provctl-download-url "${{ secrets.LATEST_SYSTEM_TEST_PROVCTL_DOWNLOAD_PATH }}" \
           --provctl-download-s3-access-key "${{ secrets.LATEST_SYSTEM_TEST_PROVCTL_DOWNLOAD_URL_S3_ACCESS_KEY }}" \
           --provctl-download-s3-key-id "${{ secrets.LATEST_SYSTEM_TEST_PROVCTL_DOWNLOAD_URL_S3_KEY_ID }}" \
-          --mlrun-dbpath "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
-          --webapi-direct-url "${{ secrets.LATEST_SYSTEM_TEST_WEBAPI_DIRECT_URL }}" \
-          --framesd-url "${{ secrets.LATEST_SYSTEM_TEST_FRAMESD_URL }}" \
           --username "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
           --access-key "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
           --iguazio-version "${{ steps.computed_params.outputs.iguazio_version }}" \
-          --spark-service "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
-          --slack-webhook-url "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
           --mysql-user "${{ secrets.LATEST_SYSTEM_TEST_MYSQL_USER }}" \
           --mysql-password "${{ secrets.LATEST_SYSTEM_TEST_MYSQL_PASSWORD }}" \
           --purge-db \
@@ -298,12 +292,12 @@ jobs:
       timeout-minutes: 5
       run: |
         python automation/system_test/prepare.py env \
+          --data-cluster-ip "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
+          --data-cluster-ssh-username "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
+          --data-cluster-ssh-password "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           --mlrun-dbpath "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
-          --webapi-direct-url "${{ secrets.LATEST_SYSTEM_TEST_WEBAPI_DIRECT_URL }}" \
-          --framesd-url "${{ secrets.LATEST_SYSTEM_TEST_FRAMESD_URL }}" \
           --username "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
           --access-key "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
-          --spark-service "${{ secrets.LATEST_SYSTEM_TEST_SPARK_SERVICE }}" \
           --slack-webhook-url "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
           --branch "${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}" \
           --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}"

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -252,6 +252,33 @@ jobs:
           --override-mlrun-images \
           "${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }},ghcr.io/mlrun/mlrun:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/ml-models:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/ml-base:${{ steps.computed_params.outputs.mlrun_docker_tag }},ghcr.io/mlrun/log-collector:${{ steps.computed_params.outputs.mlrun_docker_tag }}"
 
+    - name: Prepare System Test env.yaml and MLRun installation from current branch
+      timeout-minutes: 5
+      run: |
+        python automation/system_test/prepare.py env \
+          --data-cluster-ip "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
+          --data-cluster-ssh-username "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
+          --data-cluster-ssh-password "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          --mlrun-dbpath "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
+          --username "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
+          --access-key "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
+          --slack-webhook-url "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
+          --branch "${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}" \
+          --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" \
+          --save-to-path "${{ github.workspace }}/env.yaml"
+
+    - name: Encrypt file
+      run: |
+        gpg --batch --output "${{ github.workspace }}/env.yaml.gpg" --passphrase ${{ GPG_PASSPHRASE }} --symmetric "${{ github.workspace }}/env.yaml"
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+    - name: Upload env file
+      uses: actions/upload-artifact@v3
+      with:
+        name: env
+        path: "${{ github.workspace }}/env.yaml.gpg"
+        if-no-files-found: error
 
     outputs:
       mlrunVersion: ${{ steps.computed_params.outputs.mlrun_version }}
@@ -279,28 +306,21 @@ jobs:
       # than the mlrun version we deployed on the previous job (can have features that the resolved branch doesn't have)
       with:
         ref: ${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}
-    - name: Set up python
-      uses: actions/setup-python@v4
+
+    - uses: actions/download-artifact@v3
       with:
-        python-version: 3.9
-        cache: pip
-    - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: pip install -r automation/requirements.txt && pip install -e .
-    - name: Install curl and jq
-      run: sudo apt-get install curl jq
-    - name: Prepare System Test env.yaml and MLRun installation from current branch
-      timeout-minutes: 5
+        name: env
+        path: "${{ github.workspace }}/env.yaml.gpg"
+
+    - name: Decrypt file
       run: |
-        python automation/system_test/prepare.py env \
-          --data-cluster-ip "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
-          --data-cluster-ssh-username "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
-          --data-cluster-ssh-password "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-          --mlrun-dbpath "${{ secrets.LATEST_SYSTEM_TEST_MLRUN_DB_PATH }}" \
-          --username "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
-          --access-key "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
-          --slack-webhook-url "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
-          --branch "${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}" \
-          --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}"
+        gpg --batch --output ${{ github.workspace }}/tests/system/env.yaml --passphrase ${{ GPG_PASSPHRASE }} --decrypt ${{ github.workspace }}/env.yaml.gpg
+        
+        # ensure file created
+        test -f ${{ github.workspace }}/tests/system/env.yaml
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
     - name: Run System Tests
       run: |
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunSystemTestsCleanResources }}" \

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -3,3 +3,4 @@ paramiko~=2.12
 semver~=2.13
 requests~=2.22
 boto3~=1.24.59
+pyyaml~=5.1

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -101,6 +101,7 @@ class SystemTestPreparer:
         self._mysql_user = mysql_user
         self._mysql_password = mysql_password
         self._purge_db = purge_db
+        self._ssh_client = None
 
         self._env_config = {
             "MLRUN_DBPATH": mlrun_dbpath,
@@ -767,10 +768,10 @@ def run(
 
 
 @main.command(context_settings=dict(ignore_unknown_options=True))
-@click.option("--data-cluster-ip", required=True)
-@click.option("--data-cluster-ssh-username", required=True)
-@click.option("--data-cluster-ssh-password", required=True)
 @click.option("--mlrun-dbpath", help="The mlrun api address", required=True)
+@click.option("--data-cluster-ip")
+@click.option("--data-cluster-ssh-username")
+@click.option("--data-cluster-ssh-password")
 @click.option("--username", help="Iguazio running username")
 @click.option("--access-key", help="Iguazio running user access key")
 @click.option(

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -118,10 +118,10 @@ class SystemTestPreparer:
         self._prepare_env_local(save_to_path)
 
     def connect_to_remote(self):
-        self._logger.info(
-            "Connecting to data-cluster", data_cluster_ip=self._data_cluster_ip
-        )
         if not self._debug and self._data_cluster_ip:
+            self._logger.info(
+                "Connecting to data-cluster", data_cluster_ip=self._data_cluster_ip
+            )
             self._ssh_client = paramiko.SSHClient()
             self._ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy)
             self._ssh_client.connect(

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -114,8 +114,8 @@ class SystemTestPreparer:
             "MLRUN_SYSTEM_TESTS_GIT_TOKEN": github_access_token,
         }
 
-    def prepare_local_env(self):
-        self._prepare_env_local()
+    def prepare_local_env(self, save_to_path: str = ""):
+        self._prepare_env_local(save_to_path)
 
     def connect_to_remote(self):
         self._logger.info(
@@ -290,8 +290,8 @@ class SystemTestPreparer:
             workdir=str(self.Constants.homedir),
         )
 
-    def _prepare_env_local(self):
-        filepath = str(self.Constants.system_tests_env_yaml)
+    def _prepare_env_local(self, save_to_path: str = ""):
+        filepath = save_to_path or str(self.Constants.system_tests_env_yaml)
         backup_filepath = str(self.Constants.system_tests_env_yaml) + ".bak"
         self._logger.debug("Populating system tests env.yml", filepath=filepath)
 
@@ -788,6 +788,10 @@ def run(
     "--github-access-token",
     help="Github access token to use for fetching private functions",
 )
+@click.option(
+    "--save-to-path",
+    help="Path to save the compiled env file to",
+)
 def env(
     data_cluster_ip: str,
     data_cluster_ssh_username: str,
@@ -799,6 +803,7 @@ def env(
     debug: bool,
     branch: str,
     github_access_token: str,
+    save_to_path: str,
 ):
     system_test_preparer = SystemTestPreparer(
         data_cluster_ip=data_cluster_ip,
@@ -814,7 +819,7 @@ def env(
     )
     try:
         system_test_preparer.connect_to_remote()
-        system_test_preparer.prepare_local_env()
+        system_test_preparer.prepare_local_env(save_to_path)
     except Exception as exc:
         logger.error("Failed preparing local system test environment", exc=exc)
         raise

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2145,10 +2145,18 @@ class TestFeatureStore(TestMLRunSystem):
             api = None
             if config.v3io_api:
                 api = config.v3io_api
+
+                # strip protocol
                 if "//" in api:
                     api = api[api.find("//") + 2 :]
+
+                # strip port
                 if ":" in api:
                     api = api[: api.find(":")]
+
+                # ensure webapi prefix
+                if not api.startswith("webapi."):
+                    api = f"webapi.{api}"
             return api
 
         key = "patient_id"
@@ -2166,7 +2174,7 @@ class TestFeatureStore(TestMLRunSystem):
             ),
             NoSqlTarget(
                 name="fullpath",
-                path=f"v3io://webapi.{get_v3io_api_host()}/bigdata/system-test-project/nosql-purge-full",
+                path=f"v3io://{get_v3io_api_host()}/bigdata/system-test-project/nosql-purge-full",
             ),
         ]
 


### PR DESCRIPTION
This will allow us to move from iguazio env to another without needing to explicitly tell what/where.
In addition, make another step to support dev-utilities and enrich dynamic envvar more easily.

In addition:

1. removed unneeded stuff from "prepare.py run" as they are not being used. 
2. moved `prepare.env` to development channel to ensure using latest file (and to avoid backporting stuff)
3. env.yaml is moved from step A to step B via upload_artifact. important to know that file is encrypted (for its sensitive data)

