### PR TITLE
[Feature Store] Fix passing `with _index` to `RemoteVectorResponse` & test fix

### DIFF
--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -506,6 +506,9 @@ class OnlineVectorService:
             data = result.body
             if data:
                 actual_columns = data.keys()
+                if all([col in self._index_columns for col in actual_columns]):
+                    results.append(None)
+                    continue
                 for column in self._requested_columns:
                     if (
                         column not in actual_columns

--- a/mlrun/feature_store/retrieval/base.py
+++ b/mlrun/feature_store/retrieval/base.py
@@ -366,12 +366,12 @@ class BaseMerger(abc.ABC):
         return OfflineVectorResponse(self)
 
     def init_online_vector_service(
-        self, entity_rows_keys, fixed_window_type, update_stats=False
+        self, entity_keys, fixed_window_type, update_stats=False
     ):
         """
         initialize the `OnlineVectorService`
 
-        :param entity_rows_keys:    list of the feature_vector indexes.
+        :param entity_keys:    list of the feature_vector indexes.
         :param fixed_window_type:   determines how to query the fixed window values which were previously
                                     inserted by ingest
         :param update_stats:        update features statistics from the requested feature sets on the vector.

--- a/mlrun/feature_store/retrieval/job.py
+++ b/mlrun/feature_store/retrieval/job.py
@@ -130,15 +130,16 @@ def run_merge_job(
         watch=run_config.watch,
     )
     logger.info(f"feature vector merge job started, run id = {run.uid()}")
-    return RemoteVectorResponse(vector, run)
+    return RemoteVectorResponse(vector, run, with_indexes)
 
 
 class RemoteVectorResponse:
     """get_offline_features response object"""
 
-    def __init__(self, vector, run):
+    def __init__(self, vector, run, with_indexes=False):
         self.run = run
         self.vector = vector
+        self.with_indexes = with_indexes or self.vector.spec.with_indexes
 
     @property
     def status(self):
@@ -164,7 +165,7 @@ class RemoteVectorResponse:
         df = mlrun.get_dataitem(self.target_uri).as_df(
             columns=columns, df_module=df_module, format=file_format, **kwargs
         )
-        if self.vector.spec.with_indexes:
+        if self.with_indexes:
             df.set_index(
                 list(self.vector.spec.entity_fields.keys()), inplace=True, drop=True
             )

--- a/mlrun/feature_store/retrieval/storey_merger.py
+++ b/mlrun/feature_store/retrieval/storey_merger.py
@@ -128,6 +128,10 @@ class StoreyFeatureMerger(BaseMerger):
         feature_set_objects, feature_set_fields = self.vector.parse_features(
             offline=False, update_stats=update_stats
         )
+        if not feature_set_fields:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"No features found for feature vector '{self.vector.metadata.name}'"
+            )
         (
             graph,
             requested_columns,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -3612,7 +3612,7 @@ class TestFeatureStore(TestMLRunSystem):
         )
         assert_frame_equal(join_employee_department, resp_1.to_dataframe())
 
-        with fstore.get_online_feature_service(vector, ["id"]) as svc:
+        with fstore.get_online_feature_service(vector, entity_keys=["id"]) as svc:
             resp = svc.get({"id": 100})
             assert resp[0] == {"n": "employee100", "n2": "dept1"}
 
@@ -3636,7 +3636,7 @@ class TestFeatureStore(TestMLRunSystem):
         )
         assert_frame_equal(join_employee_managers, resp_2.to_dataframe())
 
-        with fstore.get_online_feature_service(vector, ["id"]) as svc:
+        with fstore.get_online_feature_service(vector, entity_keys=["id"]) as svc:
             resp = svc.get({"id": 100})
             assert resp[0] == {
                 "n": "employee100",
@@ -3659,7 +3659,7 @@ class TestFeatureStore(TestMLRunSystem):
             order_by="name",
         )
         assert_frame_equal(join_employee_sets, resp_3.to_dataframe())
-        with fstore.get_online_feature_service(vector, ["id"]) as svc:
+        with fstore.get_online_feature_service(vector, entity_keys=["id"]) as svc:
             resp = svc.get({"id": 100})
             assert resp[0] == {"n": "employee100", "mini_name": "employee100"}
 
@@ -3684,7 +3684,7 @@ class TestFeatureStore(TestMLRunSystem):
         )
         assert_frame_equal(join_all, resp_4.to_dataframe())
 
-        with fstore.get_online_feature_service(vector, ["id"]) as svc:
+        with fstore.get_online_feature_service(vector, entity_keys=["id"]) as svc:
             resp = svc.get({"id": 100})
             assert resp[0] == {
                 "n": "employee100",


### PR DESCRIPTION
Fixing : 
TestFeatureStore::test_online_impute
TestFeatureStore::test_online_impute
TestFeatureStore::test_relation_join[local-True]
TestFeatureStore::test_relation_join[local-False] 
TestFeatureStore::test_relation_join[dask-True] 
TestFeatureStore::test_relation_join[dask-False]
TestFeatureStore::test_get_online_features_after_ingest_without_inference 
TestFeatureStoreSparkEngine::test_aggregations
TestFeatureStoreSparkEngine::test_relation_join[True]
TestFeatureStoreSparkEngine::test_relation_asof_join[True] 