### PR TITLE
[Workflows] Add validation and error message for invalid workflow setup

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1212,12 +1212,10 @@ class MlrunProject(ModelObj):
         :param args:          argument values (key=value, ..)
         """
 
-        if mlrun.utils.helpers.is_file_path_invalid(
+        # validate the provided workflow_path
+        mlrun.utils.helpers.is_file_path_invalid(
             self.spec.get_code_path(), workflow_path
-        ):
-            raise ValueError(
-                f"Invalid 'workflow_path': '{workflow_path}'. Please provide a valid URL/path to a file."
-            )
+        )
 
         if embed:
             if (

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1211,8 +1211,22 @@ class MlrunProject(ModelObj):
         :param ttl:           pipeline ttl in secs (after that the pods will be removed)
         :param args:          argument values (key=value, ..)
         """
-        if not workflow_path:
-            raise ValueError("valid workflow_path must be specified")
+
+        abs_workflow_path = (
+            os.path.join(self.spec.get_code_path(), workflow_path.removeprefix("./"))
+            if workflow_path.startswith("./")
+            else workflow_path
+        )
+
+        if (
+            not workflow_path
+            or not (os.path.isfile(abs_workflow_path) or "://" in workflow_path)
+            or not pathlib.Path(workflow_path).suffix
+        ):
+            raise ValueError(
+                f"Invalid 'workflow_path': '{workflow_path}'. Please provide a valid URL/path to a file."
+            )
+
         if embed:
             if (
                 self.context

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1212,16 +1212,8 @@ class MlrunProject(ModelObj):
         :param args:          argument values (key=value, ..)
         """
 
-        abs_workflow_path = (
-            os.path.join(self.spec.get_code_path(), workflow_path.removeprefix("./"))
-            if workflow_path.startswith("./")
-            else workflow_path
-        )
-
-        if (
-            not workflow_path
-            or not (os.path.isfile(abs_workflow_path) or "://" in workflow_path)
-            or not pathlib.Path(workflow_path).suffix
+        if mlrun.utils.helpers.is_file_path_invalid(
+            self.spec.get_code_path(), workflow_path
         ):
             raise ValueError(
                 f"Invalid 'workflow_path': '{workflow_path}'. Please provide a valid URL/path to a file."

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1217,7 +1217,7 @@ class MlrunProject(ModelObj):
             if workflow_path.startswith("./")
             else workflow_path
         )
-
+        logger.info("abs_path!!!!", is_file=os.path.isfile(abs_workflow_path), code_path=self.spec.get_code_path(), abs_workflow_path=abs_workflow_path)
         if (
             not workflow_path
             or not (os.path.isfile(abs_workflow_path) or "://" in workflow_path)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1213,9 +1213,12 @@ class MlrunProject(ModelObj):
         """
 
         # validate the provided workflow_path
-        mlrun.utils.helpers.is_file_path_invalid(
+        if mlrun.utils.helpers.is_file_path_invalid(
             self.spec.get_code_path(), workflow_path
-        )
+        ):
+            raise ValueError(
+                f"Invalid 'workflow_path': '{workflow_path}'. Please provide a valid URL/path to a file."
+            )
 
         if embed:
             if (

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1217,7 +1217,10 @@ class MlrunProject(ModelObj):
             if workflow_path.startswith("./")
             else workflow_path
         )
-        logger.info("abs_path!!!!", is_file=os.path.isfile(abs_workflow_path), code_path=self.spec.get_code_path(), abs_workflow_path=abs_workflow_path)
+        logger.info("abs_path!!!!", is_file=os.path.isfile(abs_workflow_path),
+                    current_dir=os.getcwd(),
+                    code_path=self.spec.get_code_path(),
+                    abs_workflow_path=abs_workflow_path)
         if (
             not workflow_path
             or not (os.path.isfile(abs_workflow_path) or "://" in workflow_path)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1217,10 +1217,7 @@ class MlrunProject(ModelObj):
             if workflow_path.startswith("./")
             else workflow_path
         )
-        logger.info("abs_path!!!!", is_file=os.path.isfile(abs_workflow_path),
-                    current_dir=os.getcwd(),
-                    code_path=self.spec.get_code_path(),
-                    abs_workflow_path=abs_workflow_path)
+
         if (
             not workflow_path
             or not (os.path.isfile(abs_workflow_path) or "://" in workflow_path)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -246,7 +246,7 @@ def get_regex_list_as_string(regex_list: List) -> str:
     return "".join(["(?={regex})".format(regex=regex) for regex in regex_list]) + ".*$"
 
 
-def is_file_path_invalid(code_path: str, file_path: str) -> None:
+def is_file_path_invalid(code_path: str, file_path: str) -> bool:
     """
     The function checks if the given file_path is a valid path, if it's invalid it will raise ValueError.
     If the file_path is a relative path, it is completed by joining it with the code_path.
@@ -257,7 +257,7 @@ def is_file_path_invalid(code_path: str, file_path: str) -> None:
 
     """
     if not file_path:
-        raise ValueError("Invalid request, please provide a valid URL/path to a file.")
+        return True
 
     if file_path.startswith("./") or (
         "://" not in file_path and os.path.basename(file_path) == file_path
@@ -266,13 +266,10 @@ def is_file_path_invalid(code_path: str, file_path: str) -> None:
     else:
         abs_path = file_path
 
-    if (
+    return (
         not (os.path.isfile(abs_path) or "://" in file_path)
         or not pathlib.Path(file_path).suffix
-    ):
-        raise ValueError(
-            f"Invalid file path: '{file_path}'. Please provide a valid URL/path to a file."
-        )
+    )
 
 
 def tag_name_regex_as_string() -> str:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -248,13 +248,15 @@ def get_regex_list_as_string(regex_list: List) -> str:
 
 def is_file_path_invalid(code_path: str, file_path: str) -> bool:
     """
-    The function checks if the given file_path is a valid path, if it's invalid it will raise ValueError.
+    The function checks if the given file_path is a valid path.
     If the file_path is a relative path, it is completed by joining it with the code_path.
     Otherwise, the file_path is used as is.
     Additionally, it checks if the resulting path exists as a file, unless the file_path is a remote URL.
     If the file_path has no suffix, it is considered invalid.
 
-
+    :param code_path: The base directory or code path to search for the file in case of relative file_path
+    :param file_path: The file path to be validated
+    :return: True if the file path is invalid, False otherwise
     """
     if not file_path:
         return True

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -246,15 +246,19 @@ def get_regex_list_as_string(regex_list: List) -> str:
     return "".join(["(?={regex})".format(regex=regex) for regex in regex_list]) + ".*$"
 
 
-def is_file_path_invalid(code_path, file_path):
+def is_file_path_invalid(code_path: str, file_path: str) -> None:
     """
-    The function checks if the given file_path is a valid path
+    The function checks if the given file_path is a valid path, if it's invalid it will raise ValueError.
     If the file_path is a relative path, it is completed by joining it with the code_path.
     Otherwise, the file_path is used as is.
     Additionally, it checks if the resulting path exists as a file, unless the file_path is a remote URL.
     If the file_path has no suffix, it is considered invalid.
 
+
     """
+    if not file_path:
+        raise ValueError("Invalid request, please provide a valid URL/path to a file.")
+
     if file_path.startswith("./") or (
         "://" not in file_path and os.path.basename(file_path) == file_path
     ):
@@ -262,11 +266,13 @@ def is_file_path_invalid(code_path, file_path):
     else:
         abs_path = file_path
 
-    return (
-        not file_path
-        or not (os.path.isfile(abs_path) or "://" in file_path)
+    if (
+        not (os.path.isfile(abs_path) or "://" in file_path)
         or not pathlib.Path(file_path).suffix
-    )
+    ):
+        raise ValueError(
+            f"Invalid file path: '{file_path}'. Please provide a valid URL/path to a file."
+        )
 
 
 def tag_name_regex_as_string() -> str:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -17,6 +17,7 @@ import hashlib
 import inspect
 import json
 import os
+import pathlib
 import re
 import sys
 import time
@@ -243,6 +244,29 @@ def get_regex_list_as_string(regex_list: List) -> str:
     with and condition between them.
     """
     return "".join(["(?={regex})".format(regex=regex) for regex in regex_list]) + ".*$"
+
+
+def is_file_path_invalid(code_path, file_path):
+    """
+    The function checks if the given file_path is a valid path
+    If the file_path is a relative path, it is completed by joining it with the code_path.
+    Otherwise, the file_path is used as is.
+    Additionally, it checks if the resulting path exists as a file, unless the file_path is a remote URL.
+    If the file_path has no suffix, it is considered invalid.
+
+    """
+    if file_path.startswith("./") or (
+        "://" not in file_path and os.path.basename(file_path) == file_path
+    ):
+        abs_path = os.path.join(code_path, file_path.lstrip("./"))
+    else:
+        abs_path = file_path
+
+    return (
+        not file_path
+        or not (os.path.isfile(abs_path) or "://" in file_path)
+        or not pathlib.Path(file_path).suffix
+    )
 
 
 def tag_name_regex_as_string() -> str:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -943,10 +943,13 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
 )
 def test_set_workflow_with_invalid_path(workflow_path, exception):
     proj = mlrun.new_project("proj", save=False)
-    tests_working_dir = os.getcwd()
 
+    # TODO: make this a fixture
     # because the working directory inside the dockerized test is '/mlrun'
     # modify cwd to the current file's dir to ensure the workflow files are located
+    # modify it back after the test case for other tests
+    tests_working_dir = os.getcwd()
+
     current_file_abspath = os.path.abspath(__file__)
     current_dirname = os.path.dirname(current_file_abspath)
     os.chdir(current_dirname)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -902,7 +902,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 ValueError,
                 match=str(
                     re.escape(
-                        "Invalid 'workflow_path': './'. Please provide a valid URL/path to a file."
+                        "Invalid file path: './'. Please provide a valid URL/path to a file."
                     )
                 ),
             ),
@@ -913,7 +913,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 ValueError,
                 match=str(
                     re.escape(
-                        "Invalid 'workflow_path': 'https://test'. Please provide a valid URL/path to a file."
+                        "Invalid file path: 'https://test'. Please provide a valid URL/path to a file."
                     )
                 ),
             ),
@@ -924,12 +924,17 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 ValueError,
                 match=str(
                     re.escape(
-                        "Invalid 'workflow_path': ''. Please provide a valid URL/path to a file."
+                        "Invalid request, please provide a valid URL/path to a file."
                     )
                 ),
             ),
         ),
         ("https://test.py", does_not_raise()),
+        # relative path
+        ("./workflow.py", does_not_raise()),
+        # only file name
+        ("workflow.py", does_not_raise()),
+        # absolute path
         (
             str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
             does_not_raise(),
@@ -938,6 +943,13 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
 )
 def test_set_workflow_with_invalid_path(workflow_path, exception):
     proj = mlrun.new_project("proj", save=False)
+
+    # because the working directory inside the dockerized test is '/mlrun'
+    # modify cwd to the current file's dir to ensure the workflow files are located
+    current_file_abspath = os.path.abspath(__file__)
+    current_dirname = os.path.dirname(current_file_abspath)
+    os.chdir(current_dirname)
+
     with exception:
         proj.set_workflow("main", workflow_path)
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -930,7 +930,6 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
             ),
         ),
         ("https://test.py", does_not_raise()),
-        ("./workflow.py", does_not_raise()),
         (
             str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
             does_not_raise(),

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -943,6 +943,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
 )
 def test_set_workflow_with_invalid_path(workflow_path, exception):
     proj = mlrun.new_project("proj", save=False)
+    tests_working_dir = os.getcwd()
 
     # because the working directory inside the dockerized test is '/mlrun'
     # modify cwd to the current file's dir to ensure the workflow files are located
@@ -952,6 +953,8 @@ def test_set_workflow_with_invalid_path(workflow_path, exception):
 
     with exception:
         proj.set_workflow("main", workflow_path)
+
+    os.chdir(tests_working_dir)
 
 
 def test_project_ops():

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -902,7 +902,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 ValueError,
                 match=str(
                     re.escape(
-                        "Invalid file path: './'. Please provide a valid URL/path to a file."
+                        "Invalid 'workflow_path': './'. Please provide a valid URL/path to a file."
                     )
                 ),
             ),
@@ -913,7 +913,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 ValueError,
                 match=str(
                     re.escape(
-                        "Invalid file path: 'https://test'. Please provide a valid URL/path to a file."
+                        "Invalid 'workflow_path': 'https://test'. Please provide a valid URL/path to a file."
                     )
                 ),
             ),
@@ -924,7 +924,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 ValueError,
                 match=str(
                     re.escape(
-                        "Invalid request, please provide a valid URL/path to a file."
+                        "Invalid 'workflow_path': ''. Please provide a valid URL/path to a file."
                     )
                 ),
             ),


### PR DESCRIPTION
resolves: [ML-3702](https://jira.iguazeng.com/browse/ML-3702)

The issue was when setting a workflow like this:
my_workflow = project.set_workflow('main', "./"), and no error message was presented to the user.

reopen for: https://github.com/mlrun/mlrun/pull/3797
should fix the issue - in case of a relative workflow_path, checking the existence of the file in the project code_path.