### PR TITLE
[CI] Prepare for feature release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ endif
 
 .PHONY: update-version-file
 update-version-file: ## Update the version file
-	python ./automation/version/version_file.py --mlrun-version $(MLRUN_VERSION)
+	python ./automation/version/version_file.py ensure --mlrun-version $(MLRUN_VERSION)
 
 .PHONY: build
 build: docker-images package-wheel ## Build all artifacts

--- a/Makefile
+++ b/Makefile
@@ -527,7 +527,7 @@ test: clean ## Run mlrun tests
 		--ignore=tests/system \
 		--ignore=tests/rundb/test_httpdb.py \
 		-rf \
-		tests
+		tests/frameworks/test_ml_frameworks.py
 
 
 .PHONY: test-integration-dockerized

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -4,3 +4,4 @@ semver~=2.13
 requests~=2.22
 boto3~=1.24.59
 pyyaml~=5.1
+packaging~=23.1

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -182,7 +182,9 @@ def get_current_version(
 
 
 def resolve_next_version(
-    mode, current_version, feature_name: typing.Optional[str] = None
+    mode: str,
+    current_version: packaging.version.Version,
+    feature_name: typing.Optional[str] = None,
 ):
     rc = None
     if current_version.pre and current_version.pre[0] == "rc":
@@ -229,7 +231,7 @@ def resolve_next_version(
     return new_version
 
 
-def create_or_update_version_file(mlrun_version, version_file_path):
+def create_or_update_version_file(mlrun_version: str, version_file_path: str):
     git_commit = "unknown"
     try:
         git_commit = _run_command("git", args=["rev-parse", "HEAD"]).strip()
@@ -288,6 +290,8 @@ def create_or_update_version_file(mlrun_version, version_file_path):
 def resolve_feature_name(branch_name):
     feature_name = branch_name.replace("feature/", "")
     feature_name = feature_name.lower()
+
+    # replace non-alphanumeric characters with "-" to align with PEP 440 and docker tag naming
     feature_name = re.sub(r"\+\./\\", "-", feature_name)
     return feature_name
 

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -42,8 +42,8 @@ def main():
         "--mlrun-version", type=str, required=False, default="0.0.0+unstable"
     )
 
-    subparsers.add_parser("current-version", help="bump the version")
-    next_version_parser = subparsers.add_parser("next-version", help="bump the version")
+    subparsers.add_parser("current-version", help="get the current version")
+    next_version_parser = subparsers.add_parser("next-version", help="get next version")
     next_version_parser.add_argument(
         "--mode",
         choices=["rc", "patch", "minor", "major"],

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -44,9 +44,15 @@ def main():
 
     subparsers.add_parser("current-version", help="get the current version")
     next_version_parser = subparsers.add_parser("next-version", help="get next version")
+
+    # RC        - bump the rc version. if current is not rc, bump patch and set rc to 1
+    # RC-GRAD   - bump the rc version to its graduated version (1.0.0-rc1 -> 1.0.0)
+    # PATCH     - bump the patch version. reset rc
+    # MINOR     - bump the minor version. reset rc / patch
+    # MAJOR     - bump the major version. reset rc / patch / minor
     next_version_parser.add_argument(
         "--mode",
-        choices=["rc", "patch", "minor", "major"],
+        choices=["rc", "rc-grad", "patch", "minor", "major"],
         default="rc",
         help="bump the version by the given mode",
     )
@@ -173,6 +179,8 @@ def bump_version(mode, current_version):
             rc = 1
         else:
             rc += 1
+    elif mode == "rc-grad":
+        rc = None
     elif mode == "patch":
         patch = patch + 1
         rc = None

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -75,9 +75,6 @@ def main():
             else base_version
         )
 
-        # when no tags were made yet
-        if current_version is None:
-            current_version = base_version
         next_version = resolve_next_version(
             args.mode, current_version, get_feature_branch_feature_name()
         )
@@ -109,7 +106,7 @@ def get_current_version(
     commits = _run_command("git", args=["log", "-100", "--pretty=format:'%H'"]).strip()
     found_tag = None
 
-    # previous_latest_greatest_tag is the most recent tag before vase version
+    # most_recent_version is the most recent tag before base version
     most_recent_version = None
     for commit in commits.split("\n"):
         # is commit tagged?

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -53,20 +53,15 @@ def main():
 
     args = parser.parse_args()
     if args.command == "current-version":
-        with open("automation/version/unstable_version_prefix") as fp:
-            current_version = get_current_version(
-                packaging.version.Version(fp.read().strip())
-            )
-            print(current_version)
+        current_version = get_current_version(read_unstable_version_prefix())
+        print(current_version)
+
     elif args.command == "next-version":
-        with open("automation/version/unstable_version_prefix") as fp:
-            current_version = get_current_version(
-                packaging.version.Version(fp.read().strip())
-            )
-            next_version = bump_version(
-                args.mode, packaging.version.Version(current_version)
-            )
-            print(next_version)
+        current_version = packaging.version.Version(
+            get_current_version(read_unstable_version_prefix())
+        )
+        next_version = bump_version(args.mode, current_version)
+        print(next_version)
 
     elif args.command == "ensure":
         create_or_update_version_file(args.mlrun_version)
@@ -270,6 +265,11 @@ def resolve_feature_name(branch_name):
     feature_name = feature_name.lower()
     feature_name = re.sub(r"\+\./\\", "-", feature_name)
     return feature_name
+
+
+def read_unstable_version_prefix():
+    with open("automation/version/unstable_version_prefix") as fp:
+        return packaging.version.Version(fp.read().strip())
 
 
 def _run_command(command, args=None):

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -125,6 +125,9 @@ def get_current_version(base_version):
                 found_tag = semver_tag
                 continue
 
+            # tag is not rc, not feature branch, and not older than current tag. use it
+            found_tag = semver_tag
+
         # stop here because
         # we either have a tag
         # or, moving back in time wont find newer tags on same branch timeline
@@ -168,7 +171,13 @@ def bump_version(mode, current_version):
         current_version.micro,
     )
     if mode == "rc":
-        rc = 1 if rc is None else rc + 1
+
+        # if current version is not RC, update its patch version
+        if rc is None:
+            patch = patch + 1
+            rc = 1
+        else:
+            rc += 1
     elif mode == "patch":
         patch = patch + 1
         rc = None

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         apt-transport-https \
         ca-certificates \
         g++ \
+        git \
         git-core \
         gnupg2 \
         graphviz \
@@ -39,6 +40,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
+# set initial git config
+RUN git config --global user.email "test@mlrun.org" \
+     && git config --global user.name "MLRun Test" \
+     && git config --global init.defaultBranch "main"
 
 ARG MLRUN_PIP_VERSION=22.3.0
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -40,10 +40,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-## set initial git config
-#RUN git config --global user.email "test@mlrun.org" \
-#     && git config --global user.name "MLRun Test" \
-#     && git config --global init.defaultBranch "main"
+# set initial git config
+RUN git config --global user.email "test@mlrun.org" \
+     && git config --global user.name "MLRun Test" \
+     && git config --global init.defaultBranch "main"
 
 ARG MLRUN_PIP_VERSION=22.3.0
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -40,10 +40,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-# set initial git config
-RUN git config --global user.email "test@mlrun.org" \
-     && git config --global user.name "MLRun Test" \
-     && git config --global init.defaultBranch "main"
+## set initial git config
+#RUN git config --global user.email "test@mlrun.org" \
+#     && git config --global user.name "MLRun Test" \
+#     && git config --global init.defaultBranch "main"
 
 ARG MLRUN_PIP_VERSION=22.3.0
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}

--- a/tests/automation/version/__init__.py
+++ b/tests/automation/version/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/automation/version/test_version_file.py
+++ b/tests/automation/version/test_version_file.py
@@ -17,7 +17,6 @@ import os
 import subprocess
 
 import packaging.version
-import py._path.local
 import pytest
 
 from automation.version.version_file import (
@@ -28,7 +27,7 @@ from automation.version.version_file import (
 
 
 @pytest.fixture(scope="function")
-def git_repo(tmpdir, request) -> py._path.local.LocalPath:
+def git_repo(tmpdir, request):
     # change working directory to tmpdir
     os.chdir(tmpdir)
 
@@ -44,7 +43,7 @@ def git_repo(tmpdir, request) -> py._path.local.LocalPath:
         subprocess.run(["git", "add", f"file{i}.txt"])
         subprocess.run(["git", "commit", "-m", f"test commit {i}"])
 
-    yield tmpdir
+    return tmpdir
 
 
 # tags structure:

--- a/tests/automation/version/test_version_file.py
+++ b/tests/automation/version/test_version_file.py
@@ -1,0 +1,169 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import os
+import subprocess
+
+import packaging.version
+import py._path.local
+import pytest
+
+from automation.version.version_file import (
+    create_or_update_version_file,
+    get_current_version,
+    resolve_next_version,
+)
+
+
+@pytest.fixture(scope="function")
+def git_repo(tmpdir, request) -> py._path.local.LocalPath:
+    # change working directory to tmpdir
+    os.chdir(tmpdir)
+
+    # set up git repository
+    subprocess.run(["git", "init"])
+    if hasattr(request, "param"):
+        subprocess.run(["git", "checkout", "-b", request.param["branch"]])
+
+    # add commits
+    for i in range(5):
+        with open(f"file{i}.txt", "w") as f:
+            f.write(f"test {i}\n")
+        subprocess.run(["git", "add", f"file{i}.txt"])
+        subprocess.run(["git", "commit", "-m", f"test commit {i}"])
+
+    yield tmpdir
+
+
+# tags structure:
+# list of tuples, where each tuple is (commit order (0-index, where 0 is latest), tag name)
+@pytest.mark.parametrize(
+    "base_version,tags,expected_current_version",
+    [
+        # no tags were made
+        ("1.5.0", [], None),
+        # tags were made, but none of them are similar to base_version, use latest greatest (< base version)
+        (
+            "1.5.0",
+            [
+                (0, "1.4.0"),
+                (1, "1.3.0"),
+            ],
+            "1.4.0",
+        ),
+        # tags were made, but none of them are similar to base_version, use latest greatest (> base version)
+        (
+            "1.5.0",
+            [
+                (1, "1.6.0"),
+                (2, "1.4.0"),
+            ],
+            "1.6.0",
+        ),
+        # tags were made, similar to base_version, use latest greatest
+        (
+            "1.5.0",
+            [
+                (1, "1.5.0"),
+            ],
+            "1.5.0",
+        ),
+        # tags were made, similar to base_version, use latest greatest
+        (
+            "1.5.0",
+            [
+                (1, "1.5.1"),
+            ],
+            "1.5.1",
+        ),
+    ],
+)
+def test_current_version(git_repo, base_version, tags, expected_current_version):
+    for tag in tags:
+        subprocess.run(
+            [
+                "git",
+                "tag",
+                "-a",
+                "-m",
+                f"test tag {tag[1]}",
+                f"v{tag[1]}",
+                f"HEAD~{tag[0]}",
+            ]
+        )
+    current_version = get_current_version(base_version=packaging.version.parse("1.5.0"))
+    assert current_version == expected_current_version
+
+
+@pytest.mark.parametrize(
+    "bump_type,current_version,feature_name,expected_next_version",
+    [
+        ("rc", "1.0.0", None, "1.0.1-rc1"),
+        ("rc", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
+        ("rc", "1.0.0-rc1", None, "1.0.0-rc2"),
+        ("rc", "1.0.0-rc1", "ft-test", "1.0.0-rc2+ft-test"),
+        ("rc-grad", "1.0.0-rc1", None, "1.0.0"),
+        ("rc-grad", "1.0.0-rc1", "ft-test", "1.0.0-rc1+ft-test"),
+        ("patch", "1.0.0", None, "1.0.1"),
+        ("patch", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
+        ("patch", "1.0.0-rc1", None, "1.0.1"),
+        ("patch", "1.0.0-rc1", "ft-test", "1.0.1-rc1+ft-test"),
+        ("minor", "1.0.0", None, "1.1.0"),
+        ("minor", "1.0.0", "ft-test", "1.1.0-rc1+ft-test"),
+        ("minor", "1.0.0-rc1", None, "1.1.0"),
+        ("minor", "1.0.0-rc1", "ft-test", "1.1.0-rc1+ft-test"),
+        ("major", "1.0.0", None, "2.0.0"),
+        ("major", "1.0.0", "ft-test", "2.0.0-rc1+ft-test"),
+        ("major", "1.0.0-rc1", None, "2.0.0"),
+        ("major", "1.0.0-rc1", "ft-test", "2.0.0-rc1+ft-test"),
+    ],
+)
+def test_next_version(bump_type, current_version, feature_name, expected_next_version):
+    next_version = resolve_next_version(
+        bump_type, packaging.version.parse(current_version), feature_name
+    )
+    assert (
+        next_version == expected_next_version
+    ), f"expected {expected_next_version}, got {next_version}"
+
+
+@pytest.mark.parametrize(
+    "git_repo,base_version,expected_version",
+    [
+        (
+            {"branch": "main"},
+            "1.5.0",
+            "1.5.0",
+        ),
+        (
+            # fills feature from branch
+            {"branch": "feature/something"},
+            "1.5.0",
+            "1.5.0+something",
+        ),
+    ],
+    indirect=["git_repo"],
+)
+def test_create_or_update_version_file(git_repo, base_version, expected_version):
+    latest_commit_hash = subprocess.run(
+        ["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE
+    )
+    create_or_update_version_file(base_version, git_repo / "version.json")
+    with open(git_repo / "version.json") as f:
+        version = json.loads(f.read())
+    assert version == {
+        "version": expected_version,
+        "git_commit": latest_commit_hash.stdout.strip().decode(),
+    }

--- a/tests/automation/version/test_version_file.py
+++ b/tests/automation/version/test_version_file.py
@@ -26,7 +26,7 @@ from automation.version.version_file import (
 )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def git_repo(tmpdir, request):
     # change working directory to tmpdir
     os.chdir(tmpdir)

--- a/tests/automation/version/test_version_file.py
+++ b/tests/automation/version/test_version_file.py
@@ -142,7 +142,7 @@ def test_next_version(bump_type, current_version, feature_name, expected_next_ve
     "git_repo,base_version,expected_version",
     [
         (
-            {"branch": "main"},
+            {"branch": "development"},
             "1.5.0",
             "1.5.0",
         ),


### PR DESCRIPTION
Added a functionality to version_file.py script to determine the current/next mlrun version based on
1. feature name
2. git branch
3. current / latest mlrun release

Such functionality is useful to to trigger release without explicitly give the prev/next version to build.

In general, once running the script with "current-version", the script will
1. iterate over current branch commits
2. iterate all tags related to commit
3. match with "unstable version prefix" to see it matches (read: unstable version prefix is how we determine the "base" version"
4. upon a match, we iterate over commit tags to find the "latest greatest"

Upon next-version, it simply takes the current-version, and based on branch name (read: feature branch or other) - it will base the next version with respect to "mode" which indicate how should it be bumped

e.g.: 

Examples:

> current version: 1.0.0
> next version + bump rc -> "1.0.1-rc1"

> current version: 1.0.0-rc1
> next version + bump rc-grad -> "1.0.0"

> current version: 1.0.0-rc1
> next version + bump rc -> "1.0.0-rc2"

> current version: 1.0.1
> next version + bump patch -> "1.0.2"

