### PR TITLE
[Artifacts] Fix list artifacts `name` docstring

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -738,7 +738,7 @@ class HTTPRunDB(RunDBInterface):
             result_labels = db.list_artifacts('results', tag='*', project='iris', labels=['uploaded', 'type=binary'])
 
         :param name: Name of artifacts to retrieve. Name with '~' prefix is used as a like query, and is not
-            case-sensitive. This means that querying for ``name`` may return artifacts named
+            case-sensitive. This means that querying for ``~name`` may return artifacts named
             ``my_Name_1`` or ``surname``.
         :param project: Project name.
         :param tag: Return artifacts assigned this tag.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -737,8 +737,9 @@ class HTTPRunDB(RunDBInterface):
             # Show artifacts with label filters - both uploaded and of binary type
             result_labels = db.list_artifacts('results', tag='*', project='iris', labels=['uploaded', 'type=binary'])
 
-        :param name: Name of artifacts to retrieve. Name is used as a like query, and is not case-sensitive. This means
-            that querying for ``name`` may return artifacts named ``my_Name_1`` or ``surname``.
+        :param name: Name of artifacts to retrieve. Name with '~' prefix is used as a like query, and is not
+            case-sensitive. This means that querying for ``name`` may return artifacts named
+            ``my_Name_1`` or ``surname``.
         :param project: Project name.
         :param tag: Return artifacts assigned this tag.
         :param labels: Return artifacts that have these labels. Labels can either be a dictionary {"label": "value"} or

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2791,7 +2791,7 @@ class MlrunProject(ModelObj):
             result_versions = project.list_artifacts('results', tag='*').to_objects()
 
         :param name: Name of artifacts to retrieve. Name with '~' prefix is used as a like query, and is not
-            case-sensitive. This means that querying for ``name`` may return artifacts named
+            case-sensitive. This means that querying for ``~name`` may return artifacts named
             ``my_Name_1`` or ``surname``.
         :param tag: Return artifacts assigned this tag.
         :param labels: Return artifacts that have these labels. Labels can either be a dictionary {"label": "value"} or
@@ -2839,7 +2839,7 @@ class MlrunProject(ModelObj):
 
 
         :param name: Name of artifacts to retrieve. Name with '~' prefix is used as a like query, and is not
-            case-sensitive. This means that querying for ``name`` may return artifacts named
+            case-sensitive. This means that querying for ``~name`` may return artifacts named
             ``my_Name_1`` or ``surname``.
         :param tag: Return artifacts assigned this tag.
         :param labels: Return artifacts that have these labels. Labels can either be a dictionary {"label": "value"} or

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2790,8 +2790,9 @@ class MlrunProject(ModelObj):
             # check different artifact versions for a specific artifact, return as objects list
             result_versions = project.list_artifacts('results', tag='*').to_objects()
 
-        :param name: Name of artifacts to retrieve. Name is used as a like query, and is not case-sensitive. This means
-            that querying for ``name`` may return artifacts named ``my_Name_1`` or ``surname``.
+        :param name: Name of artifacts to retrieve. Name with '~' prefix is used as a like query, and is not
+            case-sensitive. This means that querying for ``name`` may return artifacts named
+            ``my_Name_1`` or ``surname``.
         :param tag: Return artifacts assigned this tag.
         :param labels: Return artifacts that have these labels. Labels can either be a dictionary {"label": "value"} or
             a list of "label=value" (match label key and value) or "label" (match just label key) strings.
@@ -2837,8 +2838,9 @@ class MlrunProject(ModelObj):
             latest_models = project.list_models('', tag='latest')
 
 
-        :param name: Name of artifacts to retrieve. Name is used as a like query, and is not case-sensitive. This means
-            that querying for ``name`` may return artifacts named ``my_Name_1`` or ``surname``.
+        :param name: Name of artifacts to retrieve. Name with '~' prefix is used as a like query, and is not
+            case-sensitive. This means that querying for ``name`` may return artifacts named
+            ``my_Name_1`` or ``surname``.
         :param tag: Return artifacts assigned this tag.
         :param labels: Return artifacts that have these labels. Labels can either be a dictionary {"label": "value"} or
             a list of "label=value" (match label key and value) or "label" (match just label key) strings.


### PR DESCRIPTION
The `name` parameter is query like only when it is used with `~` prefix.