### PR TITLE
[CI] Add options to github workflow manual dispatches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,10 @@ on:
         description: 'Whether to build images from cache or not. Default: true, set to false only if required because that will cause a significant increase in build time'
         required: true
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   matrix_prep:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,13 +26,21 @@ on:
         description: 'The previous version, without prefix v (e.g. 1.1.0-rc9)'
         required: true
       pre_release:
-        description: 'Whether to mark release as pre-release or not (default: false)'
+        description: 'Whether to mark release as pre-release or not (default: true)'
         required: false
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       generate_release_notes:
         description: 'Whether to generate release notes or not (default: true)'
         required: false
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       skip_images:
         description: 'Comma separated list of images to skip building, example with all possible images: mlrun,ui,api,base,models,models-gpu,jupyter,test'
         required: false
@@ -41,10 +49,18 @@ on:
         description: 'Whether to skip publishing the python package to Pypi, (true/false)'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       skip_create_tag_release:
         description: 'Whether to skip creating tag & release in Github, (true/false)'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   trigger-and-wait-for-mlrun-image-building:

--- a/.github/workflows/security_scan.yaml
+++ b/.github/workflows/security_scan.yaml
@@ -43,10 +43,21 @@ on:
         description: 'The minimum severity of vulnerabilities to report ("negligible", "low", "medium", "high" and "critical".)'
         required: false
         default: 'medium'
+        type: choice
+        options:
+          - 'negligible'
+          - 'low'
+          - 'medium'
+          - 'high'
+          - 'critical'
       only_fixed:
         description: 'Whether to scan only fixed vulnerabilities ("true" or "false")'
         required: false
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   matrix_prep:

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -39,6 +39,10 @@ on:
         description: 'Clean resources created by test (like project) in each test teardown (default: true - perform clean)'
         required: true
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       override_iguazio_version:
         description: 'Override the configured target system iguazio version (leave empty to resolve automatically)'
         required: false

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -39,10 +39,18 @@ on:
         description: 'Clean resources created by test (like project) in each test teardown (default: true - perform clean)'
         required: true
         default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
       debug_enabled:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 env:
   NAMESPACE: mlrun


### PR DESCRIPTION
To reduce human error when need to fill values in manual dispatch, taking advantage of [options](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#example-of-onworkflow_dispatchinputs) in defining workflow dispatch parameters.

<img width="381" alt="Screenshot 2023-07-02 at 14 50 03" src="https://github.com/mlrun/mlrun/assets/59158507/034c7314-3164-41ed-a85a-9ea3eff27fea">

