### PR TITLE
[Frameworks] Support SciKit-Learn 1.3 deprecated normalize

### DIFF
--- a/mlrun/frameworks/_ml_common/plans/calibration_curve_plan.py
+++ b/mlrun/frameworks/_ml_common/plans/calibration_curve_plan.py
@@ -33,7 +33,6 @@ class CalibrationCurvePlan(MLPlotPlan):
 
     def __init__(
         self,
-        normalize: bool = False,
         n_bins: int = 5,
         strategy: str = "uniform",
     ):
@@ -43,14 +42,11 @@ class CalibrationCurvePlan(MLPlotPlan):
         To read more about the parameters, head to the SciKit-Learn docs at:
         https://scikit-learn.org/stable/modules/generated/sklearn.calibration.calibration_curve.html
 
-        :param normalize: Whether the probabilities needs to be normalized into the [0, 1] interval, i.e. is not a
-                          proper probability.
         :param n_bins:    Number of bins to discretize the [0, 1] interval.
         :param strategy:  Strategy used to define the widths of the bins. Can be on of {‘uniform’, ‘quantile’}.
                           Default: "uniform".
         """
         # Store the parameters:
-        self._normalize = normalize
         self._n_bins = n_bins
         self._strategy = strategy
 
@@ -94,7 +90,6 @@ class CalibrationCurvePlan(MLPlotPlan):
             y,
             y_pred[:, -1],  # Take only the second class probabilities (1, not 0).
             n_bins=self._n_bins,
-            normalize=self._normalize,
             strategy=self._strategy,
         )
 


### PR DESCRIPTION
Support SciKit-Learn 1.3 in `mlrun.frameworks`.