### PR TITLE
[CI] Introducing workflow reuse

### DIFF
--- a/.github/workflows/build-internal.yaml
+++ b/.github/workflows/build-internal.yaml
@@ -132,7 +132,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Docker login (quay.io)
-      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'quay.io') }} && ${{ secrets.QUAY_IO_DOCKER_REGISTRY_USERNAME != '' }}
+      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'quay.io') }}
+      continue-on-error: true
       uses: docker/login-action@v2
       with:
         registry: quay.io
@@ -140,7 +141,8 @@ jobs:
         password: ${{ secrets.QUAY_IO_DOCKER_REGISTRY_PASSWORD }}
 
     - name: Docker login (docker.com)
-      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'docker.com') }}  && ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_USERNAME != '' }}
+      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'docker.com') }}
+      continue-on-error: true
       uses: docker/login-action@v2
       with:
         registry: registry.hub.docker.com

--- a/.github/workflows/build-internal.yaml
+++ b/.github/workflows/build-internal.yaml
@@ -1,0 +1,202 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build (internal)
+
+run-name: Building ${{ inputs.version }} ${{ github.ref_name }}
+
+permissions:
+
+  # Allow the action to upload images to ghcr
+  packages: write
+
+on:
+
+  # FYI
+  # The event payload in the called workflow is the same event payload from the calling workflow
+  # The inputs are the inputs defined in the called workflow (by the "with")
+  workflow_call:
+    inputs:
+      docker_registries:
+        description: 'Comma separated list of docker registries to push images to (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
+        required: true
+        default: 'ghcr.io/'
+        type: string
+      docker_repo:
+        description: 'Docker repo to push images to (default: lowercase github repository owner name)'
+        required: false
+        default: ''
+        type: string
+      version:
+        description: 'The version to build, without prefix v (e.g. 1.1.0), if not provided version will be <unstable-version-prefix>-<commit-hash>, where <unstable-version-prefix> is taken from automation/version/unstable_version_prefix'
+        required: false
+        default: ''
+        type: string
+      skip_images:
+        description: 'Comma separated list of images to skip building, example with all possible images: mlrun,api,base,models,models-gpu,jupyter,test'
+        required: false
+        default: ''
+        type: string
+      build_from_cache:
+        description: 'Whether to build images from cache or not. Default: true, set to false only if required because that will cause a significant increase in build time'
+        required: true
+        default: 'true'
+        type: string
+
+jobs:
+  matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        uses: ./.github/actions/image-matrix-prep
+        with:
+          skip_images: ${{ github.event.inputs.skip_images }}
+
+  build-images:
+    name: Build and push image - ${{ matrix.image-name }} (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    needs: matrix_prep
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+    steps:
+    - uses: actions/checkout@v3
+
+    # since github-actions gives us 14G only, and fills it up with some garbage
+    - name: Freeing up disk space
+      run: |
+        "${GITHUB_WORKSPACE}/automation/scripts/github_workflow_free_space.sh"
+
+    - name: Install curl and jq
+      run: sudo apt-get install curl jq
+
+    - name: Extract git hash, ref and latest version
+      id: git_info
+      run: |
+        echo "mlrun_commit_hash=$(git rev-parse --short=8 $GITHUB_SHA)"  >> $GITHUB_OUTPUT
+        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)"  >> $GITHUB_OUTPUT
+
+    - name: Resolve docker cache tag
+      id: docker_cache
+      run: |
+        export version_suffix=$(echo "$GITHUB_REF_NAME" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.');
+        export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi);
+        export build_from_cache=$(if [ -z "$INPUT_BUILD_FROM_CACHE" ]; then echo "true" ; else echo "$INPUT_BUILD_FROM_CACHE";fi);
+        export no_cache=$(if [ "$build_from_cache" = "false" ]; then echo "true" ; else echo "";fi);
+        echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
+        echo "no_cache=$(echo $no_cache)" >> $GITHUB_OUTPUT
+      env:
+        INPUT_BUILD_FROM_CACHE: ${{ github.event.inputs.build_from_cache }}
+
+    - name: Set computed versions params
+      id: computed_params
+      run: |
+        echo "mlrun_version=$( \
+          input_mlrun_version=$INPUT_VERSION && \
+          default_mlrun_version=$(echo ${{ steps.git_info.outputs.unstable_version_prefix }}+${{ steps.git_info.outputs.mlrun_commit_hash }}) && \
+          echo ${input_mlrun_version:-`echo $default_mlrun_version`})" >> $GITHUB_OUTPUT
+        echo "mlrun_docker_repo=$( \
+          input_docker_repo=$INPUT_DOCKER_VERSION && \
+          default_docker_repo=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') && \
+          echo ${input_docker_repo:-`echo $default_docker_repo`})" >> $GITHUB_OUTPUT
+        echo "mlrun_docker_registries=$( \
+          input_docker_registries=$INPUT_DOCKER_REGISTRIES && \
+          echo ${input_docker_registries:-ghcr.io/})" >> $GITHUB_OUTPUT
+        echo "mlrun_cache_date=$(date +%s)" >> $GITHUB_OUTPUT
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}
+        INPUT_DOCKER_VERSION: ${{ github.event.inputs.docker_repo }}
+        INPUT_DOCKER_REGISTRIES: ${{ github.event.inputs.docker_registries }}
+
+    - name: Docker login (ghcr)
+      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'ghcr.io') }}
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Docker login (quay.io)
+      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'quay.io') }} && ${{ secrets.QUAY_IO_DOCKER_REGISTRY_USERNAME != '' }}
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_IO_DOCKER_REGISTRY_USERNAME }}
+        password: ${{ secrets.QUAY_IO_DOCKER_REGISTRY_PASSWORD }}
+
+    - name: Docker login (docker.com)
+      if: ${{ contains(steps.computed_params.outputs.mlrun_docker_registries, 'docker.com') }}  && ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_USERNAME != '' }}
+      uses: docker/login-action@v2
+      with:
+        registry: registry.hub.docker.com
+        username: ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_PASSWORD }}
+
+    - name: Pull cache, build and push image
+
+      # we don't really want per-commit test image we just want to build and push the cache image so CI will be able
+      # to use it and run much faster
+      if: ${{ matrix.image-name != 'test' }}
+      run: |
+        for registry in $(echo ${{ steps.computed_params.outputs.mlrun_docker_registries }} | sed "s/,/ /g"); \
+          do \
+            MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
+            MLRUN_DOCKER_REGISTRY=$registry \
+            MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
+            MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
+            MLRUN_VERSION=${{ steps.computed_params.outputs.mlrun_version }} \
+            MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+            MLRUN_NO_CACHE=${{ steps.docker_cache.outputs.no_cache }} \
+            MLRUN_PUSH_DOCKER_CACHE_IMAGE="true" \
+            MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
+            INCLUDE_PYTHON_VERSION_SUFFIX=${{ matrix.include-suffix }} \
+            make push-${{ matrix.image-name }}; \
+          done;
+
+    - name: Build and push unstable tag
+
+      # we don't need to have unstable tag for the test image
+      # And we don't need to run this when triggered manually (workflow dispatch)
+      if: matrix.image-name != 'test' && github.event_name != 'workflow_dispatch' && github.ref_name == 'development'
+      run: |
+        for registry in "ghcr.io/" "quay.io/" "registry.hub.docker.com/"; \
+          do \
+            MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
+            MLRUN_DOCKER_REGISTRY=$registry \
+            MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
+            MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
+            MLRUN_VERSION=unstable \
+            MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+            MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
+            INCLUDE_PYTHON_VERSION_SUFFIX=${{ matrix.include-suffix }} \
+            make push-${{ matrix.image-name }}; \
+          done;
+    - name: Pull cache, build and push test image
+      # When version is given we're probably in a release process, we don't need the test image in that case
+      if: matrix.image-name == 'test' && github.event.inputs.version == ''
+      run: |
+        MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
+        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
+        MLRUN_VERSION=${{ steps.docker_cache.outputs.tag }} \
+        MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+        MLRUN_PUSH_DOCKER_CACHE_IMAGE=true \
+        MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
+        INCLUDE_PYTHON_VERSION_SUFFIX=${{ matrix.include-suffix }} \
+        make push-${{ matrix.image-name }}

--- a/.github/workflows/build-internal.yaml
+++ b/.github/workflows/build-internal.yaml
@@ -31,27 +31,22 @@ on:
     inputs:
       docker_registries:
         description: 'Comma separated list of docker registries to push images to (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
-        required: true
         default: 'ghcr.io/'
         type: string
       docker_repo:
         description: 'Docker repo to push images to (default: lowercase github repository owner name)'
-        required: false
         default: ''
         type: string
       version:
         description: 'The version to build, without prefix v (e.g. 1.1.0), if not provided version will be <unstable-version-prefix>-<commit-hash>, where <unstable-version-prefix> is taken from automation/version/unstable_version_prefix'
-        required: false
         default: ''
         type: string
       skip_images:
         description: 'Comma separated list of images to skip building, example with all possible images: mlrun,api,base,models,models-gpu,jupyter,test'
-        required: false
         default: ''
         type: string
       build_from_cache:
         description: 'Whether to build images from cache or not. Default: true, set to false only if required because that will cause a significant increase in build time'
-        required: true
         default: 'true'
         type: string
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 # This name is referenced in the release.yaml workflow, if you're changing here - change there
 name: Build
+
 run-name: Building ${{ inputs.version }} ${{ github.ref_name }}
+
+permissions:
+
+  # Allow the action to upload images to ghcr
+  packages: write
 
 on:
   push:
@@ -50,135 +57,14 @@ on:
           - 'false'
 
 jobs:
-  matrix_prep:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: set-matrix
-        uses: ./.github/actions/image-matrix-prep
-        with:
-          skip_images: ${{ github.event.inputs.skip_images }}
-
-  build-images:
-    name: Build and push image - ${{ matrix.image-name }} (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    needs: matrix_prep
-
-    # let's not run this on every fork, change to your fork when developing
+  build-mlrun:
     if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
-
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
-    steps:
-    - uses: actions/checkout@v3
-
-    # since github-actions gives us 14G only, and fills it up with some garbage
-    - name: Freeing up disk space
-      run: |
-        "${GITHUB_WORKSPACE}/automation/scripts/github_workflow_free_space.sh"
-
-    - name: Install curl and jq
-      run: sudo apt-get install curl jq
-    - name: Extract git hash, ref and latest version
-      id: git_info
-      run: |
-        echo "mlrun_commit_hash=$(git rev-parse --short=8 $GITHUB_SHA)"  >> $GITHUB_OUTPUT
-        echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)"  >> $GITHUB_OUTPUT
-    - name: Resolve docker cache tag
-      id: docker_cache
-      run: |
-        export version_suffix=$(echo "$GITHUB_REF_NAME" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.');
-        export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi);
-        export build_from_cache=$(if [ -z "$INPUT_BUILD_FROM_CACHE" ]; then echo "true" ; else echo "$INPUT_BUILD_FROM_CACHE";fi);
-        export no_cache=$(if [ "$build_from_cache" = "false" ]; then echo "true" ; else echo "";fi);
-        echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
-        echo "no_cache=$(echo $no_cache)" >> $GITHUB_OUTPUT
-      env:
-        INPUT_BUILD_FROM_CACHE: ${{ github.event.inputs.build_from_cache }}
-    - name: Set computed versions params
-      id: computed_params
-      run: |
-        echo "mlrun_version=$( \
-          input_mlrun_version=$INPUT_VERSION && \
-          default_mlrun_version=$(echo ${{ steps.git_info.outputs.unstable_version_prefix }}+${{ steps.git_info.outputs.mlrun_commit_hash }}) && \
-          echo ${input_mlrun_version:-`echo $default_mlrun_version`})" >> $GITHUB_OUTPUT
-        echo "mlrun_docker_repo=$( \
-          input_docker_repo=$INPUT_DOCKER_VERSION && \
-          default_docker_repo=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') && \
-          echo ${input_docker_repo:-`echo $default_docker_repo`})" >> $GITHUB_OUTPUT
-        echo "mlrun_docker_registries=$( \
-          input_docker_registries=$INPUT_DOCKER_REGISTRIES && \
-          echo ${input_docker_registries:-ghcr.io/})" >> $GITHUB_OUTPUT
-        echo "mlrun_cache_date=$(date +%s)" >> $GITHUB_OUTPUT
-      env:
-        INPUT_VERSION: ${{ github.event.inputs.version }}
-        INPUT_DOCKER_VERSION: ${{ github.event.inputs.docker_repo }}
-        INPUT_DOCKER_REGISTRIES: ${{ github.event.inputs.docker_registries }}
-    - name: Docker login
-      # all suffixed with "| true" to allow failures if secrets are not defined (fork)
-      run: |
-        echo ${{ secrets.GHCR_DOCKER_REGISTRY_PASSWORD }} | \
-          docker login ghcr.io -u ${{ secrets.GHCR_DOCKER_REGISTRY_USERNAME }} --password-stdin | true
-        echo ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_PASSWORD }} | \
-          docker login registry.hub.docker.com -u ${{ secrets.DOCKER_HUB_DOCKER_REGISTRY_USERNAME }} \
-          --password-stdin | true
-        echo ${{ secrets.QUAY_IO_DOCKER_REGISTRY_PASSWORD }} | \
-          docker login quay.io -u ${{ secrets.QUAY_IO_DOCKER_REGISTRY_USERNAME }} \
-          --password-stdin | true
-
-    - name: Pull cache, build and push image
-
-      # we don't really want per-commit test image we just want to build and push the cache image so CI will be able
-      # to use it and run much faster
-      if: ${{ matrix.image-name != 'test' }}
-      run: |
-        for registry in $(echo ${{ steps.computed_params.outputs.mlrun_docker_registries }} | sed "s/,/ /g"); \
-          do \
-            MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
-            MLRUN_DOCKER_REGISTRY=$registry \
-            MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
-            MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
-            MLRUN_VERSION=${{ steps.computed_params.outputs.mlrun_version }} \
-            MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
-            MLRUN_NO_CACHE=${{ steps.docker_cache.outputs.no_cache }} \
-            MLRUN_PUSH_DOCKER_CACHE_IMAGE="true" \
-            MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
-            INCLUDE_PYTHON_VERSION_SUFFIX=${{ matrix.include-suffix }} \
-            make push-${{ matrix.image-name }}; \
-          done;
-
-    - name: Build and push unstable tag
-
-      # we don't need to have unstable tag for the test image
-      # And we don't need to run this when triggered manually (workflow dispatch)
-      if: matrix.image-name != 'test' && github.event_name != 'workflow_dispatch' && github.ref_name == 'development'
-      run: |
-        for registry in "ghcr.io/" "quay.io/" "registry.hub.docker.com/"; \
-          do \
-            MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
-            MLRUN_DOCKER_REGISTRY=$registry \
-            MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
-            MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
-            MLRUN_VERSION=unstable \
-            MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
-            MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
-            INCLUDE_PYTHON_VERSION_SUFFIX=${{ matrix.include-suffix }} \
-            make push-${{ matrix.image-name }}; \
-          done;
-    - name: Pull cache, build and push test image
-      # When version is given we're probably in a release process, we don't need the test image in that case
-      if: matrix.image-name == 'test' && github.event.inputs.version == ''
-      run: |
-        MLRUN_CACHE_DATE=${{ steps.computed_params.outputs.mlrun_cache_date }} \
-        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
-        MLRUN_DOCKER_CACHE_FROM_REGISTRY=ghcr.io/ \
-        MLRUN_DOCKER_REPO=${{ steps.computed_params.outputs.mlrun_docker_repo }} \
-        MLRUN_VERSION=${{ steps.docker_cache.outputs.tag }} \
-        MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
-        MLRUN_PUSH_DOCKER_CACHE_IMAGE=true \
-        MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
-        INCLUDE_PYTHON_VERSION_SUFFIX=${{ matrix.include-suffix }} \
-        make push-${{ matrix.image-name }}
+    name: Build MLRun
+    uses: ./.github/workflows/build-internal.yaml
+    with:
+      docker_registries: ${{ github.event.inputs.docker_registries }}
+      docker_repo: ${{ github.event.inputs.docker_repo }}
+      version: ${{ needs.prepare-inputs.outputs.version }}
+      skip_images: ${{ github.event.inputs.skip_images }}
+      build_from_cache: ${{ github.event.inputs.build_from_cache }}
+    secrets: inherit

--- a/.github/workflows/periodic-rebuild.yaml
+++ b/.github/workflows/periodic-rebuild.yaml
@@ -21,8 +21,7 @@ on:
 
 jobs:
   re-build-images:
-    # let's not run this on every fork, change to your fork when developing
-    if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'mlrun/mlrun'
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +29,8 @@ jobs:
         branch: ["development","1.3.x"]
     runs-on: ubuntu-latest
     steps:
+
+      # TODO: move to reuseable workflow once all branches have backported with the new workflow
       - name: Re-Build MLRun Image
         if: matrix.repo == 'mlrun'
         uses: convictional/trigger-workflow-and-wait@v1.6.5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,6 +110,9 @@ jobs:
         with:
           python-version: 3.9
           cache: pip
+      - name: Install dependencies
+        run: |
+          pip install -r automation/requirements.txt
       - name: Build & push to pypi
 
         # publishing to pypi is (kind of) irreversible, therefore do it only if both previous steps finished successfully

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
       skip_images: ${{ github.event.inputs.skip_images }}
     secrets: inherit
 
-  # Move to reuseable-workflow too.
+  # TODO: Move to reuseable-workflow too.
   # Requires cross-repo validation for passing github token as secret
   trigger-and-wait-for-ui-image-building:
     name: Trigger build workflow in mlrun/ui and wait to finish
@@ -102,6 +102,8 @@ jobs:
   publish-to-pypi:
     name: Publish package to pypi
     runs-on: ubuntu-latest
+
+    # publishing to pypi is (kind of) irreversible, therefore do it only if both previous steps finished successfully
     needs: [trigger-and-wait-for-ui-image-building, trigger-and-wait-for-mlrun-image-building]
     steps:
       - uses: actions/checkout@v3
@@ -114,8 +116,6 @@ jobs:
         run: |
           pip install -r automation/requirements.txt
       - name: Build & push to pypi
-
-        # publishing to pypi is (kind of) irreversible, therefore do it only if both previous steps finished successfully
         if: github.event.inputs.skip_publish_pypi != 'true'
         run: |
           pip install twine wheel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,12 +87,11 @@ jobs:
   trigger-and-wait-for-ui-image-building:
     name: Trigger build workflow in mlrun/ui and wait to finish
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.inputs.skip_images, 'ui') }}
-
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        if: ${{ !contains(github.event.inputs.skip_images, 'ui') }}
         with:
-          owner: mlrun
+          owner: ${{ github.repository_owner }}
           repo: ui
           github_token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
           workflow_file_name: build.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,16 @@
 #
 
 name: Release
+
 run-name: Releasing ${{ inputs.version }}
+
+permissions:
+
+  # Create release and upload artifact to releases
+  contents: write
+
+  # Allow the action to upload images to ghcr
+  packages: write
 
 on:
   workflow_dispatch:
@@ -63,21 +72,18 @@ on:
           - 'false'
 
 jobs:
+
   trigger-and-wait-for-mlrun-image-building:
     name: Trigger build workflow in mlrun/mlrun and wait to finish
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/build-internal.yaml
+    with:
+      docker_registries: "ghcr.io/,quay.io/,registry.hub.docker.com/"
+      version: ${{ github.event.inputs.version }}
+      skip_images: ${{ github.event.inputs.skip_images }}
+    secrets: inherit
 
-    steps:
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: mlrun
-          repo: mlrun
-          github_token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
-          workflow_file_name: build.yaml
-          ref: ${{ github.ref_name }}
-          wait_interval: 60
-          client_payload: '{"docker_registries": "ghcr.io/,quay.io/,registry.hub.docker.com/", "version": "${{ github.event.inputs.version }}", "skip_images": "${{ github.event.inputs.skip_images }}"}'
-
+  # Move to reuseable-workflow too.
+  # Requires cross-repo validation for passing github token as secret
   trigger-and-wait-for-ui-image-building:
     name: Trigger build workflow in mlrun/ui and wait to finish
     runs-on: ubuntu-latest
@@ -97,8 +103,6 @@ jobs:
   publish-to-pypi:
     name: Publish package to pypi
     runs-on: ubuntu-latest
-    if: github.event.inputs.skip_publish_pypi != 'true'
-    # publishing to pypi is (kind of) irreversible, therefore do it only if both previous steps finished successfully
     needs: [trigger-and-wait-for-ui-image-building, trigger-and-wait-for-mlrun-image-building]
     steps:
       - uses: actions/checkout@v3
@@ -108,6 +112,9 @@ jobs:
           python-version: 3.9
           cache: pip
       - name: Build & push to pypi
+
+        # publishing to pypi is (kind of) irreversible, therefore do it only if both previous steps finished successfully
+        if: github.event.inputs.skip_publish_pypi != 'true'
         run: |
           pip install twine wheel
           export TWINE_USERNAME=${{ secrets.PYPI_USERNAME }}
@@ -119,16 +126,17 @@ jobs:
   create-releases:
     name: Create release & tag v${{ github.event.inputs.version }}
     runs-on: ubuntu-latest
-    if: github.event.inputs.skip_create_tag_release != 'true'
     needs: publish-to-pypi
     steps:
       - uses: ncipollo/release-action@v1
+        if: github.event.inputs.skip_create_tag_release != 'true'
         with:
           tag: v${{ github.event.inputs.version }}
           commit: ${{ github.ref_name }}
-          token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ github.event.inputs.pre_release }}
       - uses: ncipollo/release-action@v1
+        if: github.event.inputs.skip_create_tag_release != 'true'
         with:
           repo: ui
           tag: v${{ github.event.inputs.version }}
@@ -171,7 +179,7 @@ jobs:
         with:
           tag: v${{ github.event.inputs.version }}
           commit: ${{ github.ref_name }}
-          token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           prerelease: ${{ github.event.inputs.pre_release }}
           body: ${{ steps.resolve-release-notes.outputs.body }}
@@ -191,5 +199,5 @@ jobs:
         with:
           allowUpdates: true
           tag: v${{ github.event.inputs.version }}
-          token: ${{ secrets.RELEASE_GITHUB_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: mlrun-tutorials.tar


### PR DESCRIPTION
Reuse workflow for build-internal so that it can be called from build/release and soon periodic. The idea is so use builtins by github and reduce external workflows.

In addition:

- added some fixes and tweaks for release/build to skips parts when needed without failing the entire workflow (e.g.: when skipping pypi, let it continue for create release part).
- use github token generated as per "permission" section to create release / upload container images to ghcr





