### PR TITLE
[Artifacts] Fix register artifacts overrides old artifacts

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1294,11 +1294,13 @@ class MlrunProject(ModelObj):
         artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
             self.spec.artifact_path or mlrun.mlconf.artifact_path, self.metadata.name
         )
+        # TODO: To correctly maintain the list of artifacts from an exported project,
+        #  we need to maintain the different trees that generated them
         producer = ArtifactProducer(
             "project",
             self.metadata.name,
             self.metadata.name,
-            tag=self._get_hexsha() or "latest",
+            tag=self._get_hexsha() or str(uuid.uuid4()),
         )
         for artifact_dict in self.spec.artifacts:
             if _is_imported_artifact(artifact_dict):

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -522,3 +522,18 @@ def test_tag_not_in_model_spec():
 
     assert "tag" not in model_spec, "tag should not be in model spec"
     assert "tag" not in model_spec["metadata"], "tag should not be in metadata"
+
+
+def test_register_artifacts(rundb_mock):
+    project_name = "my-projects"
+    project = mlrun.new_project(project_name)
+    artifact_key = "my-art"
+    artifact_tag = "v1"
+    project.set_artifact(
+        artifact_key,
+        artifact=mlrun.artifacts.Artifact(key=artifact_key, body=b"x=1"),
+        tag=artifact_tag,
+    )
+    project.register_artifacts()
+    artifact = project.get_artifact(artifact_key)
+    assert artifact.tree != "latest"

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -537,7 +537,8 @@ def test_register_artifacts(rundb_mock):
     )
 
     expected_tree = "my_uuid"
-    uuid.uuid4 = unittest.mock.Mock(return_value=expected_tree)
-    project.register_artifacts()
+    with unittest.mock.patch.object(uuid, "uuid4", return_value=expected_tree):
+        project.register_artifacts()
+
     artifact = project.get_artifact(artifact_key)
     assert artifact.tree == expected_tree

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 import typing
 import unittest.mock
+import uuid
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -534,6 +535,9 @@ def test_register_artifacts(rundb_mock):
         artifact=mlrun.artifacts.Artifact(key=artifact_key, body=b"x=1"),
         tag=artifact_tag,
     )
+
+    expected_tree = "my_uuid"
+    uuid.uuid4 = unittest.mock.Mock(return_value=expected_tree)
     project.register_artifacts()
     artifact = project.get_artifact(artifact_key)
-    assert artifact.tree != "latest"
+    assert artifact.tree == expected_tree

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -331,11 +331,14 @@ class RunDBMock:
         return True
 
     def store_project(self, name, project):
-        self._project_name = name
+        return self.create_project(project)
 
+    def create_project(self, project):
         if isinstance(project, dict):
             project = mlrun.projects.MlrunProject.from_dict(project)
         self._project = project
+        self._project_name = project.name
+        return self._project
 
     def get_project(self, name):
         if self._project_name and name == self._project_name:


### PR DESCRIPTION
When exporting a project we use `register_artifact` to save the artifacts which we create a new producer to save them.
Since we use the producer tag "latest" we might be overriding other artifacts with "latest" tree therfeore, we need a uniqe uid.
That being said, this doesn't completely resolve the issue as the exported project may have multiple artifact logged by different runs (different trees) and once we export them they will override each other until we are left with the last logged artifact.
https://jira.iguazeng.com/browse/ML-4074 