### PR TITLE
[Feature Store] Fix `feature_set.to_dataframe` when passthrough is True 

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -233,9 +233,6 @@ class CSVSource(BaseSourceDriver):
         time_field=None,
     ):
         reader_args = self.attributes.get("reader_args", {})
-        parse_dates = self._parse_dates or []
-        if time_field and time_field not in parse_dates:
-            parse_dates.append(time_field)
         return mlrun.store_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
@@ -243,7 +240,7 @@ class CSVSource(BaseSourceDriver):
             start_time=start_time or self.start_time,
             end_time=end_time or self.end_time,
             time_column=time_field or self.time_field,
-            parse_dates=parse_dates if parse_dates else None,
+            parse_dates=self._parse_dates,
             chunksize=self.attributes.get("chunksize"),
             **reader_args,
         )

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -234,7 +234,7 @@ class CSVSource(BaseSourceDriver):
     ):
         reader_args = self.attributes.get("reader_args", {})
         parse_dates = self._parse_dates or []
-        if time_field not in parse_dates:
+        if time_field and time_field not in parse_dates:
             parse_dates.append(time_field)
         return mlrun.store_manager.object(url=self.path).as_df(
             columns=columns,

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -233,6 +233,9 @@ class CSVSource(BaseSourceDriver):
         time_field=None,
     ):
         reader_args = self.attributes.get("reader_args", {})
+        parse_dates = self._parse_dates or []
+        if time_field not in parse_dates:
+            parse_dates.append(time_field)
         return mlrun.store_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
@@ -240,7 +243,7 @@ class CSVSource(BaseSourceDriver):
             start_time=start_time or self.start_time,
             end_time=end_time or self.end_time,
             time_column=time_field or self.time_field,
-            parse_dates=self._parse_dates,
+            parse_dates=parse_dates if parse_dates else None,
             chunksize=self.attributes.get("chunksize"),
             **reader_args,
         )

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -942,6 +942,10 @@ class FeatureSet(ModelObj):
                 raise mlrun.errors.MLRunNotFoundError(
                     "passthrough feature set {self.metadata.name} with no source"
                 )
+            print(start_time or pd.Timestamp.min)
+            print(end_time)
+            print(columns)
+
             df = self.spec.source.to_dataframe(
                 columns=columns,
                 start_time=start_time

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -942,15 +942,11 @@ class FeatureSet(ModelObj):
                 raise mlrun.errors.MLRunNotFoundError(
                     "passthrough feature set {self.metadata.name} with no source"
                 )
-            print(start_time or pd.Timestamp.min)
-            print(end_time)
-            print(columns)
-
             df = self.spec.source.to_dataframe(
                 columns=columns,
                 start_time=start_time
                 or pd.Timestamp.min,  # overwrite `source.start_time` when the source is schedule.
-                end_time=end_time,
+                end_time=end_time or pd.Timestamp.now(),
                 time_field=time_column,
                 **kwargs,
             )

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -946,7 +946,7 @@ class FeatureSet(ModelObj):
                 columns=columns,
                 start_time=start_time
                 or pd.Timestamp.min,  # overwrite `source.start_time` when the source is schedule.
-                end_time=end_time or pd.Timestamp.now(),
+                end_time=end_time or pd.Timestamp.max,
                 time_field=time_column,
                 **kwargs,
             )


### PR DESCRIPTION
[ML-4126](https://jira.iguazeng.com/browse/ML-4126)

When preforming time filtering on parquet datasource we have to pass start and end time.