### PR TITLE
[Model Monitoring] Fix predictions and latency calculations in monitoring stream graph

### DIFF
--- a/mlrun/model_monitoring/stream_processing_fs.py
+++ b/mlrun/model_monitoring/stream_processing_fs.py
@@ -50,19 +50,15 @@ class EventStreamProcessor:
         parquet_target: str,
         sample_window: int = 10,
         parquet_batching_timeout_secs: int = 30 * 60,  # Default 30 minutes
-        aggregate_count_windows: typing.Optional[typing.List[str]] = None,
-        aggregate_count_period: str = "30s",
-        aggregate_avg_windows: typing.Optional[typing.List[str]] = None,
-        aggregate_avg_period: str = "30s",
+        aggregate_windows: typing.Optional[typing.List[str]] = None,
+        aggregate_period: str = "30s",
         model_monitoring_access_key: str = None,
     ):
         # General configurations, mainly used for the storey steps in the future serving graph
         self.project = project
         self.sample_window = sample_window
-        self.aggregate_count_windows = aggregate_count_windows or ["5m", "1h"]
-        self.aggregate_count_period = aggregate_count_period
-        self.aggregate_avg_windows = aggregate_avg_windows or ["5m", "1h"]
-        self.aggregate_avg_period = aggregate_avg_period
+        self.aggregate_windows = aggregate_windows or ["5m", "1h"]
+        self.aggregate_period = aggregate_period
 
         # Parquet path and configurations
         self.parquet_path = parquet_target
@@ -202,38 +198,34 @@ class EventStreamProcessor:
 
         # Step 5 - Calculate number of predictions and average latency
         def apply_storey_aggregations():
-            # Step 5.1 - Calculate number of predictions for each window (5 min and 1 hour by default)
-            graph.add_step(
-                class_name="storey.AggregateByKey",
-                aggregates=[
-                    {
-                        "name": EventFieldType.PREDICTIONS,
-                        "column": EventFieldType.ENDPOINT_ID,
-                        "operations": ["count"],
-                        "windows": self.aggregate_count_windows,
-                        "period": self.aggregate_count_period,
-                    }
-                ],
-                name=EventFieldType.PREDICTIONS,
-                after="MapFeatureNames",
-                step_name="Aggregates",
-                table=".",
-            )
-            # Step 5.2 - Calculate average latency time for each window (5 min and 1 hour by default)
+            # Step 5.1 - Calculate number of predictions and average latency for each window (5 min and 1 hour)
             graph.add_step(
                 class_name="storey.AggregateByKey",
                 aggregates=[
                     {
                         "name": EventFieldType.LATENCY,
                         "column": EventFieldType.LATENCY,
-                        "operations": ["avg"],
-                        "windows": self.aggregate_avg_windows,
-                        "period": self.aggregate_avg_period,
+                        "operations": ["count", "avg"],
+                        "windows": self.aggregate_windows,
+                        "period": self.aggregate_period,
                     }
                 ],
                 name=EventFieldType.LATENCY,
-                after=EventFieldType.PREDICTIONS,
+                after="MapFeatureNames",
+                step_name="Aggregates",
                 table=".",
+                key_field=EventFieldType.ENDPOINT_ID,
+            )
+
+            # Step 5.2 - Rename the latency counter field to prediction counter
+            graph.add_step(
+                class_name="storey.Rename",
+                mapping={
+                    "latency_count_5m": EventLiveStats.PREDICTIONS_COUNT_5M,
+                    "latency_count_1h": EventLiveStats.PREDICTIONS_COUNT_1H,
+                },
+                name="Rename",
+                after=EventFieldType.LATENCY,
             )
 
         apply_storey_aggregations()
@@ -243,7 +235,7 @@ class EventStreamProcessor:
             graph.add_step(
                 "storey.steps.SampleWindow",
                 name="sample",
-                after=EventFieldType.LATENCY,
+                after="Rename",
                 window_size=self.sample_window,
                 key=EventFieldType.ENDPOINT_ID,
             )

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -239,7 +239,6 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         # 1 - a single model endpoint is created
         # 2 - stream metrics are recorded as expected under the model endpoint
 
-        simulation_time = 90  # 90 seconds
         # Deploy Model Servers
         project = mlrun.get_run_db().get_project(self.project_name)
 
@@ -284,13 +283,13 @@ class TestBasicModelMonitoring(TestMLRunSystem):
 
         # Simulating valid requests
         iris_data = iris["data"].tolist()
-        t_end = monotonic() + simulation_time
-        while monotonic() < t_end:
+
+        for i in range(102):
             data_point = choice(iris_data)
             serving_fn.invoke(
                 f"v2/models/{model_name}/infer", json.dumps({"inputs": [data_point]})
             )
-            sleep(uniform(0.2, 1.1))
+            sleep(choice([0.01, 0.04]))
 
         # Test metrics
         endpoints_list = mlrun.get_run_db().list_model_endpoints(
@@ -300,6 +299,8 @@ class TestBasicModelMonitoring(TestMLRunSystem):
 
         endpoint = endpoints_list[0]
         assert len(endpoint.status.metrics) > 0
+
+        assert endpoint.status.metrics["generic"]["predictions_count_5m"] == 101
 
         predictions_per_second = endpoint.status.metrics["real_time"][
             "predictions_per_second"


### PR DESCRIPTION
In the monitoring stream graph we have 2 `AggregateByKey` steps: one for predictions counter and one for average latency. When applying `AggregateByKey` step, we need to provide a table path for persistence of aggregations. In our case, we have used the same table for the 2 step, which have led to wrong calculations - https://jira.iguazeng.com/browse/ML-4114.

In this PR, we fix that issue by reducing the 2 steps into a single step in which we calculate both predictions and average latency in the same window and period of time. Therefore, we can still use a single table for the calculations and avoid unexpected results. 

In addition, we had to add a new "Rename" step to change the name of the new resulted fields to the required values (`latency_count_1h` -> `predictions_count_1h` & `latency_count_5m` -> `predictions_count_5m`).

