### PR TITLE
[Notifications] Fix Getting Git notification issue from GitHub event file

### DIFF
--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -114,11 +114,11 @@ class GitNotification(NotificationBase):
                 with open(os.environ["GITHUB_EVENT_PATH"]) as fp:
                     data = fp.read()
                     event = json.loads(data)
-                    if "issue" not in event:
+                    if "number" not in event:
                         raise mlrun.errors.MLRunInvalidArgumentError(
                             f"issue not found in github actions event\ndata={data}"
                         )
-                    issue = event["issue"].get("number")
+                    issue = event["number"]
             headers = {
                 "Accept": "application/vnd.github.v3+json",
                 "Authorization": f"token {token}",


### PR DESCRIPTION
Fixes - https://jira.iguazeng.com/browse/ML-4145
It seems like the way the GitHub event file is structured now is changed, and we need to change it now to use the `number` attribute in the json on the top level and not under `issue`.