### PR TITLE
[Tests] Add fixture to change the working directory for tests

### DIFF
--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
+import os
 import shutil
 import unittest
 from datetime import datetime
@@ -163,6 +165,27 @@ def running_as_api():
     mlrun.config.is_running_as_api = unittest.mock.Mock(return_value=True)
     yield
     mlrun.config.is_running_as_api = old_is_running_as_api
+
+
+@pytest.fixture()
+def chdir_to_test_location(request):
+    """
+    Fixture to change the working directory for tests,
+    It allows seamless access to files relative to the test file.
+
+    Because the working directory inside the dockerized test is '/mlrun',
+    this fixture allows to automatically modify the cwd to the test file directory,
+    to ensure the workflow files are located,
+    and modify it back after the test case for other tests
+
+    """
+    original_working_dir = os.getcwd()
+    test_file_path = os.path.abspath(inspect.getfile(request.function))
+    os.chdir(os.path.dirname(test_file_path))
+
+    yield
+
+    os.chdir(original_working_dir)
 
 
 @pytest.fixture

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -180,7 +180,7 @@ def chdir_to_test_location(request):
 
     """
     original_working_dir = os.getcwd()
-    test_file_path = os.path.abspath(inspect.getfile(request.function))
+    test_file_path = os.path.dirname(inspect.getfile(request.function))
     os.chdir(os.path.dirname(test_file_path))
 
     yield

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -941,23 +941,12 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
         ),
     ],
 )
-def test_set_workflow_with_invalid_path(workflow_path, exception):
+def test_set_workflow_with_invalid_path(
+    chdir_to_test_location, workflow_path, exception
+):
     proj = mlrun.new_project("proj", save=False)
-
-    # TODO: make this a fixture
-    # because the working directory inside the dockerized test is '/mlrun'
-    # modify cwd to the current file's dir to ensure the workflow files are located
-    # modify it back after the test case for other tests
-    tests_working_dir = os.getcwd()
-
-    current_file_abspath = os.path.abspath(__file__)
-    current_dirname = os.path.dirname(current_file_abspath)
-    os.chdir(current_dirname)
-
     with exception:
         proj.set_workflow("main", workflow_path)
-
-    os.chdir(tests_working_dir)
 
 
 def test_project_ops():


### PR DESCRIPTION
Add chdir_to_test_location fixture,
It allows seamless access to files relative to the test file.

