### PR TITLE
[Audit] Refine audit event descriptions

### DIFF
--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -191,7 +191,11 @@ class Projects(
             )
             events_client = events_factory.EventsFactory().get_events_client()
             events_client.emit(
-                events_client.generate_project_secret_deleted_event(name, secret_name)
+                events_client.generate_project_secret_event(
+                    name,
+                    secret_name,
+                    action=mlrun.common.schemas.SecretEventActions.deleted,
+                )
             )
 
     def get_project(

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -167,7 +167,7 @@ class Secrets(
         )
 
         events_client = events_factory.EventsFactory().get_events_client()
-        event = events_client.generate_project_auth_secret_event(
+        event = events_client.generate_auth_secret_event(
             username=secret.username,
             secret_name=auth_secret_name,
             action=mlrun.common.schemas.SecretEventActions.created

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -326,9 +326,7 @@ class Client(
         """
         return True
 
-    def emit_manual_event(
-        self, access_key: str, event: igz_mgmt.schemas.manual_events.ManualEventSchema
-    ):
+    def emit_manual_event(self, access_key: str, event: igz_mgmt.Event):
         """
         Emit a manual event to Iguazio
         """

--- a/mlrun/api/utils/events/base.py
+++ b/mlrun/api/utils/events/base.py
@@ -23,31 +23,19 @@ class BaseEventClient:
     def emit(self, event):
         pass
 
-    def generate_project_auth_secret_event(
+    def generate_auth_secret_event(
         self,
         username: str,
         secret_name: str,
         action: mlrun.common.schemas.AuthSecretEventActions,
     ):
         """
-        Generate a project auth secret event
+        Generate an auth secret event
         :param username:  username
         :param secret_name:  secret name
         :param action: preformed action
         :return: event object to emit
         """
-        pass
-
-    @abc.abstractmethod
-    def generate_project_auth_secret_created_event(
-        self, username: str, secret_name: str
-    ):
-        pass
-
-    @abc.abstractmethod
-    def generate_project_auth_secret_updated_event(
-        self, username: str, secret_name: str
-    ):
         pass
 
     @abc.abstractmethod
@@ -66,20 +54,4 @@ class BaseEventClient:
         :param action: preformed action
         :return: event object to emit
         """
-        pass
-
-    @abc.abstractmethod
-    def generate_project_secret_created_event(
-        self, project: str, secret_name: str, secret_keys: typing.List[str]
-    ):
-        pass
-
-    @abc.abstractmethod
-    def generate_project_secret_updated_event(
-        self, project: str, secret_name: str, secret_keys: typing.List[str]
-    ):
-        pass
-
-    @abc.abstractmethod
-    def generate_project_secret_deleted_event(self, project: str, secret_name: str):
         pass

--- a/mlrun/api/utils/events/nop.py
+++ b/mlrun/api/utils/events/nop.py
@@ -22,29 +22,19 @@ class NopClient(mlrun.api.utils.events.base.BaseEventClient):
     def emit(self, event):
         return
 
-    def generate_project_auth_secret_event(
+    def generate_auth_secret_event(
         self,
         username: str,
         secret_name: str,
         action: mlrun.common.schemas.AuthSecretEventActions,
     ):
         """
-        Generate a project auth secret event
+        Generate an auth secret event
         :param username:  username
         :param secret_name:  secret name
         :param action: preformed action
         :return: event object to emit
         """
-        return
-
-    def generate_project_auth_secret_created_event(
-        self, username: str, secret_name: str
-    ):
-        return
-
-    def generate_project_auth_secret_updated_event(
-        self, username: str, secret_name: str
-    ):
         return
 
     def generate_project_secret_event(
@@ -62,16 +52,4 @@ class NopClient(mlrun.api.utils.events.base.BaseEventClient):
         :param action: preformed action
         :return: event object to emit
         """
-
-    def generate_project_secret_created_event(
-        self, project: str, secret_name: str, secret_keys: typing.List[str]
-    ):
-        return
-
-    def generate_project_secret_updated_event(
-        self, project: str, secret_name: str, secret_keys: typing.List[str]
-    ):
-        return
-
-    def generate_project_secret_deleted_event(self, project: str, secret_name: str):
-        return
+        pass

--- a/tests/system/api/test_secrets.py
+++ b/tests/system/api/test_secrets.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 import pathlib
+import typing
+import uuid
 from http import HTTPStatus
 
 import deepdiff
+import igz_mgmt
 import pytest
 
+import mlrun.api.utils.events.iguazio
 import mlrun.common.schemas
 import mlrun.errors
 from tests.system.base import TestMLRunSystem
@@ -26,6 +31,47 @@ from tests.system.base import TestMLRunSystem
 @TestMLRunSystem.skip_test_if_env_not_configured
 class TestKubernetesProjectSecrets(TestMLRunSystem):
     project_name = "db-system-test-project"
+
+    @pytest.mark.enterprise
+    def test_audit_secret(self):
+        secret_key = str(uuid.uuid4())
+        secrets = {secret_key: "JustMySecret"}
+
+        # ensure no project secrets
+        self._run_db.delete_project_secrets(self.project_name, provider="kubernetes")
+
+        # create secret
+        now = datetime.datetime.utcnow()
+        project = self._run_db.get_project(self.project_name)
+        project.set_secrets(secrets=secrets)
+
+        self._ensure_audit_events(
+            mlrun.api.utils.events.iguazio.PROJECT_SECRET_CREATED,
+            now,
+            "secret_keys",
+            secret_key,
+        )
+
+        now = datetime.datetime.utcnow()
+        another_secret_key = str(uuid.uuid4())
+        secrets.update({another_secret_key: "one"})
+        project.set_secrets(secrets=secrets)
+        self._ensure_audit_events(
+            mlrun.api.utils.events.iguazio.PROJECT_SECRET_UPDATED,
+            now,
+            "secret_keys",
+            another_secret_key,
+        )
+
+        # delete secrets
+        now = datetime.datetime.utcnow()
+        self._run_db.delete_project_secrets(self.project_name, provider="kubernetes")
+        self._ensure_audit_events(
+            mlrun.api.utils.events.iguazio.PROJECT_SECRET_DELETED,
+            now,
+            "project_name",
+            self.project_name,
+        )
 
     def test_k8s_project_secrets_using_api(self):
         secrets = {"secret1": "value1", "secret2": "value2"}
@@ -201,3 +247,46 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
 
         # Cleanup secrets
         self._run_db.delete_project_secrets(self.project_name, provider="kubernetes")
+
+    def _ensure_audit_events(
+        self,
+        event_kind: str,
+        since_time: datetime.datetime,
+        parameter_text_name: str,
+        parameter_text_value: str,
+    ):
+        actual_event = None
+        for event in self._get_audit_events(event_kind, since_time):
+            if not event.parameters_text:
+                continue
+            for parameter_text in event.parameters_text:
+                if (
+                    parameter_text.name == parameter_text_name
+                    and parameter_text_value in parameter_text.value
+                ):
+                    actual_event = event
+                    break
+        assert actual_event is not None, "Failed to find the audit event"
+
+    def _get_audit_events(
+        self, event_kind: str, since_time: datetime.datetime
+    ) -> typing.List[igz_mgmt.AuditEvent]:
+        def _get_audit_events():
+            audit_events = igz_mgmt.AuditEvent.list(
+                self._igz_mgmt_client,
+                filter_by={
+                    "source": "mlrun-api",
+                    "kind": event_kind,
+                    "timestamp_iso8601": f"[$ge]{since_time.isoformat()}Z",
+                },
+            )
+            assert len(audit_events) > 0
+            return audit_events
+
+        return mlrun.utils.retry_until_successful(
+            3,
+            60 * 3,
+            self._logger,
+            True,
+            _get_audit_events,
+        )

--- a/tests/system/api/test_secrets.py
+++ b/tests/system/api/test_secrets.py
@@ -274,7 +274,7 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
             self._logger.info(
                 "Trying to get audit events",
                 event_kind=event_kind,
-                since_time=since_time,
+                since_time=since_time.isoformat(),
             )
             audit_events = igz_mgmt.AuditEvent.list(
                 self._igz_mgmt_client,

--- a/tests/system/api/test_secrets.py
+++ b/tests/system/api/test_secrets.py
@@ -33,7 +33,7 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
     project_name = "db-system-test-project"
 
     @pytest.mark.enterprise
-    def test_audit_secret(self):
+    def test_audit_project_secret_events(self):
         secret_key = str(uuid.uuid4())
         secrets = {secret_key: "JustMySecret"}
 
@@ -42,8 +42,7 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
 
         # create secret
         now = datetime.datetime.utcnow()
-        project = self._run_db.get_project(self.project_name)
-        project.set_secrets(secrets=secrets)
+        self.project.set_secrets(secrets=secrets)
 
         self._ensure_audit_events(
             mlrun.api.utils.events.iguazio.PROJECT_SECRET_CREATED,
@@ -55,7 +54,7 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
         now = datetime.datetime.utcnow()
         another_secret_key = str(uuid.uuid4())
         secrets.update({another_secret_key: "one"})
-        project.set_secrets(secrets=secrets)
+        self.project.set_secrets(secrets=secrets)
         self._ensure_audit_events(
             mlrun.api.utils.events.iguazio.PROJECT_SECRET_UPDATED,
             now,

--- a/tests/system/api/test_secrets.py
+++ b/tests/system/api/test_secrets.py
@@ -271,6 +271,11 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
         self, event_kind: str, since_time: datetime.datetime
     ) -> typing.List[igz_mgmt.AuditEvent]:
         def _get_audit_events():
+            self._logger.info(
+                "Trying to get audit events",
+                event_kind=event_kind,
+                since_time=since_time,
+            )
             audit_events = igz_mgmt.AuditEvent.list(
                 self._igz_mgmt_client,
                 filter_by={
@@ -282,9 +287,10 @@ class TestKubernetesProjectSecrets(TestMLRunSystem):
             assert len(audit_events) > 0
             return audit_events
 
+        # wait for 30 seconds for the audit events to be available
         return mlrun.utils.retry_until_successful(
             3,
-            60 * 3,
+            10 * 3,
             self._logger,
             True,
             _get_audit_events,

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -43,6 +43,7 @@ class TestMLRunSystem:
         "V3IO_FRAMESD",
         "V3IO_USERNAME",
         "V3IO_ACCESS_KEY",
+        "MLRUN_IGUAZIO_API_URL",
         "MLRUN_SYSTEM_TESTS_DEFAULT_SPARK_SERVICE",
     ]
 
@@ -59,10 +60,13 @@ class TestMLRunSystem:
         cls._run_db = get_run_db()
         cls.custom_setup_class()
         cls._logger = logger.get_child(cls.__name__.lower())
-        cls._igz_mgmt_client = igz_mgmt.Client(
-            endpoint=os.environ["MLRUN_IGUAZIO_API_URL"],
-            access_key=os.environ["V3IO_ACCESS_KEY"],
-        )
+        cls.project: typing.Optional[mlrun.projects.MlrunProject] = None
+
+        if "MLRUN_IGUAZIO_API_URL" in env:
+            cls._igz_mgmt_client = igz_mgmt.Client(
+                endpoint=env["MLRUN_IGUAZIO_API_URL"],
+                access_key=env["V3IO_ACCESS_KEY"],
+            )
 
         # the dbpath is already configured on the test startup before this stage
         # so even though we set the env var, we still need to directly configure

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -17,6 +17,7 @@ import pathlib
 import sys
 import typing
 
+import igz_mgmt
 import pytest
 import yaml
 from deepdiff import DeepDiff
@@ -58,6 +59,10 @@ class TestMLRunSystem:
         cls._run_db = get_run_db()
         cls.custom_setup_class()
         cls._logger = logger.get_child(cls.__name__.lower())
+        cls._igz_mgmt_client = igz_mgmt.Client(
+            endpoint=os.environ["MLRUN_IGUAZIO_API_URL"],
+            access_key=os.environ["V3IO_ACCESS_KEY"],
+        )
 
         # the dbpath is already configured on the test startup before this stage
         # so even though we set the env var, we still need to directly configure

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -21,6 +21,9 @@ MLRUN_DBPATH:
 # The webapi https_direct url - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com:8444
 V3IO_API:
 
+# Iguazio API URL - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com
+MLRUN_IGUAZIO_API_URL:
+
 # The framesd url - e.g. https://framesd.default-tenant.app.hedingber-28-1.iguazio-cd2.com
 V3IO_FRAMESD:
 


### PR DESCRIPTION
Remove the secret name from project secret audit events as its name is opaque and says nothing to end user.


https://jira.iguazeng.com/browse/ML-4140


In addition

- Removed specific "generate_*" functions from base, as it has nothing to do with implementation when there is a factory method for that, given an "action"
- Update from latest sdk where RequestManualEvent is simply an Event
- Added system test to cover create/update/delete project secret flow
- Added parameters text, to expose the information in a json-manner


events:
<img width="1051" alt="Screenshot 2023-07-05 at 23 57 20" src="https://github.com/mlrun/mlrun/assets/6547459/d9f4b5eb-d225-4e31-bae0-31b032d2a079">


deleted inspection:
<img width="339" alt="Screenshot 2023-07-05 at 23 57 35" src="https://github.com/mlrun/mlrun/assets/6547459/a7409aa1-7dfd-41a5-9b39-64de93b5a37e">

updated inspection: (key is uuid4 generated by test)
<img width="319" alt="Screenshot 2023-07-05 at 23 58 25" src="https://github.com/mlrun/mlrun/assets/6547459/bea7d64c-210e-462c-bb6c-5fc6cbcda26f">

created inspections:
<img width="322" alt="Screenshot 2023-07-05 at 23 58 58" src="https://github.com/mlrun/mlrun/assets/6547459/8789c0b9-5ed0-4dd3-b9ea-0a11ad952384">
