### PR TITLE
[Tests] Fix `MLRUN_IGUAZIO_API_URL` env template example

### DIFF
--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -21,7 +21,7 @@ MLRUN_DBPATH:
 # The webapi https_direct url - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com:8444
 V3IO_API:
 
-# Iguazio API URL - e.g. https://default-tenant.app.hedingber-28-1.iguazio-cd2.com
+# Iguazio API URL - e.g. https://default-tenant.data.hedingber-28-1.iguazio-cd2.com
 MLRUN_IGUAZIO_API_URL:
 
 # The framesd url - e.g. https://framesd.default-tenant.app.hedingber-28-1.iguazio-cd2.com


### PR DESCRIPTION
some zebo endpoints are not accessible from the app ingress