### PR TITLE
[Release] Enhance resolving next version

### DIFF
--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -75,6 +75,7 @@ def main():
         next_version = resolve_next_version(
             args.mode,
             packaging.version.Version(current_version),
+            base_version,
             get_feature_branch_feature_name(),
         )
         print(next_version)
@@ -187,8 +188,20 @@ def get_current_version(
 def resolve_next_version(
     mode: str,
     current_version: packaging.version.Version,
+    base_version: packaging.version.Version,
     feature_name: typing.Optional[str] = None,
 ):
+    if (
+        base_version.major > current_version.major
+        or base_version.minor > current_version.minor
+    ):
+        # the current version is lower, can be because base version was not tagged yet
+        # make current version align with base version
+        suffix = ""
+        if mode == "rc":
+            suffix += "-rc0"
+        current_version = packaging.version.Version(base_version.base_version + suffix)
+
     rc = None
     if current_version.pre and current_version.pre[0] == "rc":
         rc = int(current_version.pre[1])

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -199,6 +199,8 @@ def resolve_next_version(
         # make current version align with base version
         suffix = ""
         if mode == "rc":
+
+            # index 0 because we increment rc later on
             suffix += "-rc0"
         current_version = packaging.version.Version(base_version.base_version + suffix)
 

--- a/tests/automation/version/test_version_file.py
+++ b/tests/automation/version/test_version_file.py
@@ -108,31 +108,44 @@ def test_current_version(git_repo, base_version, tags, expected_current_version)
 
 
 @pytest.mark.parametrize(
-    "bump_type,current_version,feature_name,expected_next_version",
+    "bump_type,current_version,base_version,feature_name,expected_next_version",
     [
-        ("rc", "1.0.0", None, "1.0.1-rc1"),
-        ("rc", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
-        ("rc", "1.0.0-rc1", None, "1.0.0-rc2"),
-        ("rc", "1.0.0-rc1", "ft-test", "1.0.0-rc2+ft-test"),
-        ("rc-grad", "1.0.0-rc1", None, "1.0.0"),
-        ("rc-grad", "1.0.0-rc1", "ft-test", "1.0.0-rc1+ft-test"),
-        ("patch", "1.0.0", None, "1.0.1"),
-        ("patch", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
-        ("patch", "1.0.0-rc1", None, "1.0.1"),
-        ("patch", "1.0.0-rc1", "ft-test", "1.0.1-rc1+ft-test"),
-        ("minor", "1.0.0", None, "1.1.0"),
-        ("minor", "1.0.0", "ft-test", "1.1.0-rc1+ft-test"),
-        ("minor", "1.0.0-rc1", None, "1.1.0"),
-        ("minor", "1.0.0-rc1", "ft-test", "1.1.0-rc1+ft-test"),
-        ("major", "1.0.0", None, "2.0.0"),
-        ("major", "1.0.0", "ft-test", "2.0.0-rc1+ft-test"),
-        ("major", "1.0.0-rc1", None, "2.0.0"),
-        ("major", "1.0.0-rc1", "ft-test", "2.0.0-rc1+ft-test"),
+        # current version is olden than current base version,
+        # the next expected version is derived from the base version
+        ("rc", "1.0.0", "1.1.0", None, "1.1.0-rc1"),
+        ("rc-grad", "1.0.0", "1.1.0", None, "1.1.0"),
+        ("patch", "1.0.0", "1.1.0", None, "1.1.1"),
+        ("minor", "1.0.0", "1.1.0", None, "1.2.0"),
+        ("major", "1.0.0", "1.1.0", None, "2.0.0"),
+        # current+base tagged
+        ("rc", "1.0.0", "1.0.0", None, "1.0.1-rc1"),
+        ("rc", "1.0.0", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
+        ("rc", "1.0.0-rc1", "1.0.0", None, "1.0.0-rc2"),
+        ("rc", "1.0.0-rc1", "1.0.0", "ft-test", "1.0.0-rc2+ft-test"),
+        ("rc-grad", "1.0.0-rc1", "1.0.0", None, "1.0.0"),
+        ("rc-grad", "1.0.0-rc1", "1.0.0", "ft-test", "1.0.0-rc1+ft-test"),
+        ("patch", "1.0.0", "1.0.0", None, "1.0.1"),
+        ("patch", "1.0.0", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
+        ("patch", "1.0.0-rc1", "1.0.0", None, "1.0.1"),
+        ("patch", "1.0.0-rc1", "1.0.0", "ft-test", "1.0.1-rc1+ft-test"),
+        ("minor", "1.0.0", "1.0.0", None, "1.1.0"),
+        ("minor", "1.0.0", "1.0.0", "ft-test", "1.1.0-rc1+ft-test"),
+        ("minor", "1.0.0-rc1", "1.0.0", None, "1.1.0"),
+        ("minor", "1.0.0-rc1", "1.0.0", "ft-test", "1.1.0-rc1+ft-test"),
+        ("major", "1.0.0", "1.0.0", None, "2.0.0"),
+        ("major", "1.0.0", "1.0.0", "ft-test", "2.0.0-rc1+ft-test"),
+        ("major", "1.0.0-rc1", "1.0.0", None, "2.0.0"),
+        ("major", "1.0.0-rc1", "1.0.0", "ft-test", "2.0.0-rc1+ft-test"),
     ],
 )
-def test_next_version(bump_type, current_version, feature_name, expected_next_version):
+def test_next_version(
+    bump_type, current_version, base_version, feature_name, expected_next_version
+):
     next_version = resolve_next_version(
-        bump_type, packaging.version.parse(current_version), feature_name
+        bump_type,
+        packaging.version.parse(current_version),
+        packaging.version.parse(base_version),
+        feature_name,
     )
     assert (
         next_version == expected_next_version


### PR DESCRIPTION
For cases where an rc release was not made yet and we need to trigger one for a new version
before, running with next-version --mode rc -> yields "1.4.0-rc20"
after, yields 1.5.0-rc1 (as expected) because -
current version (aka last version created - 1.4.0-rc19)
base version is 1.5.0 (as per development)

and no release (or rc) was triggered.