### PR TITLE
[Feature Store] Persist Spark dataframe in ingest to improve performance [1.4.x]

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -896,6 +896,8 @@ def _ingest_with_spark(
         if featureset.spec.graph and featureset.spec.graph.steps:
             df = run_spark_graph(df, featureset, namespace, spark)
 
+        df.persist()
+
         if isinstance(df, Response) and df.status_code != 0:
             mlrun.errors.raise_for_status_code(df.status_code, df.body.split(": ")[1])
         _infer_from_static_df(df, featureset, options=infer_options)


### PR DESCRIPTION
Backport of #3912 with fix from #3919.

[ML-2087](https://jira.iguazeng.com/browse/ML-2087)

Without it, the data is read in by
* [the read operation](https://github.com/mlrun/mlrun/blob/v1.4.0-rc19/mlrun/datastore/sources.py#L101) (for the schema)
* [hasattr(df, "rdd")](https://github.com/mlrun/mlrun/blob/v1.4.0-rc19/mlrun/data_types/__init__.py#L33) (!!) (1)
* [stats calculation](https://github.com/mlrun/mlrun/blob/v1.4.0-rc19/mlrun/data_types/spark.py#L114) (1)
* [get_df_preview_spark](https://github.com/mlrun/mlrun/blob/v1.4.0-rc19/mlrun/data_types/spark.py#L77) (1)
* [Per target (on write)](https://github.com/mlrun/mlrun/blob/v1.4.0-rc19/mlrun/feature_store/api.py#L955) (1)

(1) also runs graph calculations