### PR TITLE
[DB] Fix `_commit` logs to support multiple object classes

### DIFF
--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -2865,34 +2865,50 @@ class SQLDB(DBInterface):
         def _try_commit_obj():
             try:
                 session.commit()
-            except SQLAlchemyError as err:
+            except SQLAlchemyError as sql_err:
                 session.rollback()
                 classes = list(set([object_.__class__.__name__ for object_ in objects]))
-                if "database is locked" in str(err):
+
+                # if the database is locked, we raise a retryable error
+                if "database is locked" in str(sql_err):
                     logger.warning(
-                        "Database is locked. Retrying", classes=classes, err=str(err)
+                        "Database is locked. Retrying",
+                        classes_to_commit=classes,
+                        err=str(sql_err),
                     )
                     raise mlrun.errors.MLRunRuntimeError(
                         "Failed committing changes, database is locked"
-                    ) from err
+                    ) from sql_err
+
+                # the error is not retryable, so we try to identify weather there was a conflict or not
+                # either way - we wrap the error with a fatal error so the retry mechanism will stop
                 logger.warning(
                     "Failed committing changes to DB",
                     classes=classes,
-                    err=err_to_str(err),
+                    err=err_to_str(sql_err),
                 )
                 if not ignore:
+                    # get the identifiers of the objects that failed to commit, for logging purposes
                     identifiers = ",".join(
                         object_.get_identifier_string() for object_ in objects
                     )
-                    # We want to retry only when database is locked so for any other scenario escalate to fatal failure
+
+                    mlrun_error = mlrun.errors.MLRunRuntimeError(
+                        f"Failed committing changes to DB. classes={classes} objects={identifiers}"
+                    )
+
+                    # check if the error is a conflict error
+                    if any([message in str(sql_err) for message in conflict_messages]):
+                        mlrun_error = mlrun.errors.MLRunConflictError(
+                            f"Conflict - at least one of the objects already exists: {identifiers}"
+                        )
+
+                    # we want to keep the exception stack trace, but we also want the retry mechanism to stop
+                    # so, we raise a new indicative exception from the original sql exception (this keeps
+                    # the stack trace intact), and then wrap it with a fatal error (which stops the retry mechanism).
+                    # Note - this way, the exception is raised from this code section, and not from the retry function.
                     try:
-                        if any([message in str(err) for message in conflict_messages]):
-                            raise mlrun.errors.MLRunConflictError(
-                                f"Conflict - at least one of the objects already exists: {identifiers}"
-                            ) from err
-                        raise mlrun.errors.MLRunRuntimeError(
-                            f"Failed committing changes to DB. classes={classes} objects={identifiers}"
-                        ) from err
+                        raise mlrun_error from sql_err
                     except (
                         mlrun.errors.MLRunRuntimeError,
                         mlrun.errors.MLRunConflictError,

--- a/mlrun/api/db/sqldb/models/models_mysql.py
+++ b/mlrun/api/db/sqldb/models/models_mysql.py
@@ -263,6 +263,9 @@ with warnings.catch_warnings():
         state = Column(String(255, collation=SQLCollationUtil.collation()))
         timeout = Column(Integer)
 
+        def get_identifier_string(self) -> str:
+            return f"{self.project}/{self.name}"
+
     class Schedule(Base, mlrun.utils.db.BaseModel):
         __tablename__ = "schedules_v2"
         __table_args__ = (UniqueConstraint("project", "name", name="_schedules_v2_uc"),)
@@ -321,6 +324,9 @@ with warnings.catch_warnings():
 
         id = Column(Integer, primary_key=True)
         name = Column(String(255, collation=SQLCollationUtil.collation()))
+
+        def get_identifier_string(self) -> str:
+            return f"{self.name}"
 
     class Project(Base, mlrun.utils.db.BaseModel):
         __tablename__ = "projects"
@@ -512,6 +518,9 @@ with warnings.catch_warnings():
             sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3),
             default=datetime.now(timezone.utc),
         )
+
+        def get_identifier_string(self) -> str:
+            return f"{self.version}"
 
 
 # Must be after all table definitions

--- a/mlrun/api/db/sqldb/models/models_mysql.py
+++ b/mlrun/api/db/sqldb/models/models_mysql.py
@@ -52,6 +52,9 @@ def make_label(table):
         value = Column(String(255, collation=SQLCollationUtil.collation()))
         parent = Column(Integer, ForeignKey(f"{table}.id"))
 
+        def get_identifier_string(self) -> str:
+            return f"{self.__tablename__}/{self.parent}/{self.name}/{self.value}"
+
     return Label
 
 
@@ -84,6 +87,9 @@ def make_tag_v2(table):
         name = Column(String(255, collation=SQLCollationUtil.collation()))
         obj_id = Column(Integer, ForeignKey(f"{table}.id"))
         obj_name = Column(String(255, collation=SQLCollationUtil.collation()))
+
+        def get_identifier_string(self) -> str:
+            return f"{self.__tablename__}/{self.project}/{self.name}"
 
     return Tag
 

--- a/mlrun/api/db/sqldb/models/models_mysql.py
+++ b/mlrun/api/db/sqldb/models/models_mysql.py
@@ -53,7 +53,7 @@ def make_label(table):
         parent = Column(Integer, ForeignKey(f"{table}.id"))
 
         def get_identifier_string(self) -> str:
-            return f"{self.__tablename__}/{self.parent}/{self.name}/{self.value}"
+            return f"{self.parent}/{self.name}/{self.value}"
 
     return Label
 
@@ -89,7 +89,7 @@ def make_tag_v2(table):
         obj_name = Column(String(255, collation=SQLCollationUtil.collation()))
 
         def get_identifier_string(self) -> str:
-            return f"{self.__tablename__}/{self.project}/{self.name}"
+            return f"{self.project}/{self.name}"
 
     return Tag
 

--- a/mlrun/api/db/sqldb/models/models_sqlite.py
+++ b/mlrun/api/db/sqldb/models/models_sqlite.py
@@ -53,6 +53,9 @@ def make_label(table):
         value = Column(String(255, collation=SQLCollationUtil.collation()))
         parent = Column(Integer, ForeignKey(f"{table}.id"))
 
+        def get_identifier_string(self) -> str:
+            return f"{self.parent}/{self.name}/{self.value}"
+
     return Label
 
 
@@ -88,6 +91,9 @@ def make_tag_v2(table):
             String(255, collation=SQLCollationUtil.collation()),
             ForeignKey(f"{table}.name"),
         )
+
+        def get_identifier_string(self) -> str:
+            return f"{self.project}/{self.name}"
 
     return Tag
 
@@ -241,6 +247,9 @@ with warnings.catch_warnings():
         state = Column(String(255, collation=SQLCollationUtil.collation()))
         timeout = Column(Integer)
 
+        def get_identifier_string(self) -> str:
+            return f"{self.project}/{self.name}"
+
     class Schedule(Base, mlrun.utils.db.BaseModel):
         __tablename__ = "schedules_v2"
         __table_args__ = (UniqueConstraint("project", "name", name="_schedules_v2_uc"),)
@@ -300,6 +309,9 @@ with warnings.catch_warnings():
         id = Column(Integer, primary_key=True)
         name = Column(String(255, collation=SQLCollationUtil.collation()))
 
+        def get_identifier_string(self) -> str:
+            return f"{self.name}"
+
     class Project(Base, mlrun.utils.db.BaseModel):
         __tablename__ = "projects"
         # For now since we use project name a lot
@@ -346,7 +358,7 @@ with warnings.catch_warnings():
         labels = relationship(Label, cascade="all, delete-orphan")
 
         def get_identifier_string(self) -> str:
-            return f"{self.project}/{self.name}"
+            return f"{self.feature_set_id}/{self.name}"
 
     class Entity(Base, mlrun.utils.db.BaseModel):
         __tablename__ = "entities"
@@ -462,6 +474,9 @@ with warnings.catch_warnings():
         id = Column(Integer, primary_key=True)
         version = Column(String(255, collation=SQLCollationUtil.collation()))
         created = Column(TIMESTAMP, default=datetime.now(timezone.utc))
+
+        def get_identifier_string(self) -> str:
+            return f"{self.version}"
 
 
 # Must be after all table definitions

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -411,7 +411,7 @@ async def test_create_schedule_failure_already_exists(
 
     with pytest.raises(
         mlrun.errors.MLRunConflictError,
-        match=rf"Conflict - Schedule already exists: {project}/{schedule_name}",
+        match=rf"Conflict - at least one of the objects already exists: {project}/{schedule_name}",
     ):
         scheduler.create_schedule(
             db,


### PR DESCRIPTION
The db's `_commit` function is a helper function that gets multiple objects and tries to commit them to the db.
It's advantage is that it is retrying the commit if it fails, with some logs which depend on the failures.

Before this PR this function assumed all given objects are of the same class for logging purposes, which might not be the issue.
Now, the logs log all of the classes given in the objects.
Also, since it is using the db schema's `get_identifier_string`, I added this method to the classes that were missing it.