### PR TITLE
[Projects] Fix Project Sync Fails on Malformed Project

### DIFF
--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -356,7 +356,7 @@ class Member(
                         logger.warning(
                             "Failed to delete project from DB, continuing...",
                             name=project_to_remove,
-                            exc=exc,
+                            exc=err_to_str(exc),
                         )
             if latest_updated_at:
 

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -346,11 +346,18 @@ class Member(
                         "Found project in the DB that is not in leader. Removing",
                         name=project_to_remove,
                     )
-                    mlrun.api.crud.Projects().delete_project(
-                        db_session,
-                        project_to_remove,
-                        mlrun.common.schemas.DeletionStrategy.cascading,
-                    )
+                    try:
+                        mlrun.api.crud.Projects().delete_project(
+                            db_session,
+                            project_to_remove,
+                            mlrun.common.schemas.DeletionStrategy.cascading,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to delete project from DB, continuing...",
+                            name=project_to_remove,
+                            exc=exc,
+                        )
             if latest_updated_at:
 
                 # sanity and defensive programming - if the leader returned a latest_updated_at that is older


### PR DESCRIPTION
If for any reason the project isn't deleted (from a bug, malformed data, etc...)
We want to best-effort the procedure and delete as many projects as possible and log warnings for the projects that weren't deleted.