### PR TITLE
[Notifications] Add Webhook notification type

### DIFF
--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -57,6 +57,12 @@ Currently, the supported notification kinds and their params are as follows:
                      If using merge request, the issue will be ignored, and vice versa.
   - `server`: The git server to which to send the notification.
   - `gitlab`: (bool) Whether the git server is gitlab or not.
+- `webhook`:
+  - `url`: The webhook url to which to send the notification.
+  - `method`: The http method to use when sending the notification (GET, POST, PUT, etc...).
+  - `headers`: (dict) The http headers to send with the notification.
+  - `override_body`: (dict) The body to send with the notification. If not specified, the body will be a dict with the 
+                     `name`, `message`, `severity`, and the `runs` list of the completed runs.
 - `console` (no params, local only)
 - `ipython` (no params, local only)
 

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -25,6 +25,7 @@ class NotificationKind(mlrun.common.types.StrEnum):
     git = "git"
     ipython = "ipython"
     slack = "slack"
+    webhook = "webhook"
 
 
 class NotificationSeverity(mlrun.common.types.StrEnum):

--- a/mlrun/utils/notifications/notification/__init__.py
+++ b/mlrun/utils/notifications/notification/__init__.py
@@ -22,6 +22,7 @@ from .console import ConsoleNotification
 from .git import GitNotification
 from .ipython import IPythonNotification
 from .slack import SlackNotification
+from .webhook import WebhookNotification
 
 
 class NotificationTypes(str, enum.Enum):
@@ -29,6 +30,7 @@ class NotificationTypes(str, enum.Enum):
     git = NotificationKind.git.value
     ipython = NotificationKind.ipython.value
     slack = NotificationKind.slack.value
+    webhook = NotificationKind.webhook.value
 
     def get_notification(self) -> typing.Type[NotificationBase]:
         return {
@@ -36,6 +38,7 @@ class NotificationTypes(str, enum.Enum):
             self.git: GitNotification,
             self.ipython: IPythonNotification,
             self.slack: SlackNotification,
+            self.webhook: WebhookNotification,
         }.get(self)
 
     def inverse_dependencies(self) -> typing.List[str]:
@@ -56,5 +59,6 @@ class NotificationTypes(str, enum.Enum):
                 cls.git,
                 cls.ipython,
                 cls.slack,
+                cls.webhook,
             ]
         )

--- a/mlrun/utils/notifications/notification/webhook.py
+++ b/mlrun/utils/notifications/notification/webhook.py
@@ -1,0 +1,61 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+import aiohttp
+
+import mlrun.common.schemas
+import mlrun.lists
+import mlrun.utils.helpers
+
+from .base import NotificationBase
+
+
+class WebhookNotification(NotificationBase):
+    """
+    API/Client notification for sending run statuses in a http request
+    """
+
+    async def push(
+        self,
+        message: str,
+        severity: typing.Union[
+            mlrun.common.schemas.NotificationSeverity, str
+        ] = mlrun.common.schemas.NotificationSeverity.INFO,
+        runs: typing.Union[mlrun.lists.RunList, list] = None,
+        custom_html: str = None,
+    ):
+        url = self.params.get("url", None)
+        method = self.params.get("method", "post").lower()
+        headers = self.params.get("headers", {})
+        override_body = self.params.get("override_body", None)
+
+        request_body = {
+            "message": message,
+            "severity": severity,
+            "runs": runs,
+        }
+
+        if custom_html:
+            request_body["custom_html"] = custom_html
+
+        if override_body:
+            request_body = override_body
+
+        async with aiohttp.ClientSession() as session:
+            response = await getattr(session, method)(
+                url, headers=headers, json=request_body
+            )
+            response.raise_for_status()


### PR DESCRIPTION
Add Webhook notification implementation to the notification mechanism.

Users will be able to supply in notification params:
- `url`: The webhook url to which to send the notification.
- `method`: The http method to use when sending the notification (GET, POST, PUT, etc...).
- `headers`: (dict) The http headers to send with the notification.
- `override_body`: (dict) The body to send with the notification. If not specified, the body will be a dict with the `name`, `message`, `severity`, and the `runs` 