### PR TITLE
[Spark] Fix masking of errors in spark graph [1.4.x]

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -896,10 +896,11 @@ def _ingest_with_spark(
         if featureset.spec.graph and featureset.spec.graph.steps:
             df = run_spark_graph(df, featureset, namespace, spark)
 
-        df.persist()
-
         if isinstance(df, Response) and df.status_code != 0:
             mlrun.errors.raise_for_status_code(df.status_code, df.body.split(": ")[1])
+
+        df.persist()
+
         _infer_from_static_df(df, featureset, options=infer_options)
 
         key_columns = list(featureset.spec.entities.keys())

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -1659,8 +1659,13 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         )
         source = ParquetSource("myparquet", path=self.get_pq_source_path())
         targets = [CSVTarget(name="csv", path=csv_path_spark)]
+        error_type = (
+            mlrun.errors.MLRunBadRequestError
+            if self.run_local
+            else mlrun.runtimes.utils.RunError
+        )
         with pytest.raises(
-            mlrun.runtimes.utils.RunError,
+            error_type,
             match="^MapValues - mapping that changes column type must change all values accordingly,"
             " which is not the case for column 'hr_is_error'$",
         ):


### PR DESCRIPTION
Backport of #3919.

The real error is masked by this subsequent error:
```
mlrun.runtimes.utils.RunError: 'Response' object has no attribute 'persist'
```