### PR TITLE
[Launcher] Enrich with auth info from server side

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -76,7 +76,6 @@ forbidden_modules=
     mlrun.api
 
 ignore_imports =
-    mlrun.feature_store.ingestion -> mlrun.api.api.utils
     mlrun.utils.notifications.notification_pusher -> mlrun.api.db.session
     mlrun.utils.notifications.notification_pusher -> mlrun.api.db.base
     mlrun.runtimes.base -> mlrun.api.crud

--- a/.importlinter
+++ b/.importlinter
@@ -76,7 +76,6 @@ forbidden_modules=
     mlrun.api
 
 ignore_imports =
-    mlrun.feature_store.feature_set -> mlrun.api.api.utils
     mlrun.feature_store.ingestion -> mlrun.api.api.utils
     mlrun.utils.notifications.notification_pusher -> mlrun.api.db.session
     mlrun.utils.notifications.notification_pusher -> mlrun.api.db.base

--- a/mlrun/api/api/endpoints/feature_store.py
+++ b/mlrun/api/api/endpoints/feature_store.py
@@ -408,10 +408,6 @@ async def ingest_feature_set(
             mlrun.common.schemas.AuthorizationAction.read,
             auth_info,
         )
-    # Need to override the default rundb since we're in the server.
-    # this is done so further down the flow when running the function created for ingestion we won't access the httpdb
-    # but rather "understand" that we are running on server side and call the DB.
-    await run_in_threadpool(feature_set._override_run_db, db_session)
 
     if ingest_parameters.targets:
         data_targets = [

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -706,9 +706,14 @@ def _build_function(
             reason=f"runtime error: {err_to_str(err)}",
         )
     try:
+        # connect to run db
         run_db = get_run_db_instance(db_session)
         fn.set_db_connection(run_db)
-        mlrun.api.launcher.ServerSideLauncher.enrich_runtime(runtime=fn)
+
+        # enrich runtime with project defaults
+        launcher = mlrun.api.launcher.ServerSideLauncher()
+        launcher.enrich_runtime(runtime=fn)
+
         fn.save(versioned=False)
         if fn.kind in RuntimeKinds.nuclio_runtimes():
             mlrun.api.api.utils.apply_enrichment_and_validation_on_function(

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -291,7 +291,6 @@ class ModelEndpoints:
         driver.update_resource_status("created")
 
         # Save the new feature set
-        feature_set._override_run_db(db_session)
         feature_set.save()
         logger.info(
             "Monitoring feature set created",

--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 from typing import Dict, List, Optional, Union
 
+from dependency_injector import containers, providers
+
+import mlrun.api.api.utils
 import mlrun.api.crud
 import mlrun.common.db.sql_session
 import mlrun.common.schemas.schedule
@@ -27,18 +30,20 @@ import mlrun.utils
 import mlrun.utils.regex
 
 
-def initialize_launcher():
-    """Set the factory custom launcher to the server side launcher"""
-    mlrun.launcher.factory.LauncherFactory().set_launcher(ServerSideLauncher)
-
-
 class ServerSideLauncher(launcher.BaseLauncher):
-    def __init__(self, local: bool = False, **kwargs):
+    def __init__(
+        self,
+        local: bool = False,
+        auth_info: Optional[mlrun.common.schemas.AuthInfo] = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         if local:
             raise mlrun.errors.MLRunInternalServerError(
                 "Launch of local run inside the server is not allowed"
             )
+
+        self._auth_info = auth_info
 
     def launch(
         self,
@@ -158,15 +163,21 @@ class ServerSideLauncher(launcher.BaseLauncher):
 
         return self._wrap_run_result(runtime, result, run, err=last_err)
 
-    @staticmethod
     def enrich_runtime(
-        runtime: "mlrun.runtimes.base.BaseRuntime", project_name: Optional[str] = ""
+        self,
+        runtime: "mlrun.runtimes.base.BaseRuntime",
+        project_name: Optional[str] = "",
     ):
         """
         Enrich the runtime object with the project spec and metadata.
         This is done only on the server side, since it's the source of truth for the project, and we want to keep the
         client side enrichment as minimal as possible.
         """
+        if self._auth_info:
+            mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
+                runtime, self._auth_info
+            )
+
         # ensure the runtime has a project before we enrich it with the project's spec
         runtime.metadata.project = (
             project_name
@@ -207,3 +218,9 @@ class ServerSideLauncher(launcher.BaseLauncher):
                 struct, runtime.metadata.name, runtime.metadata.project, versioned=True
             )
             run.spec.function = runtime._function_uri(hash_key=hash_key)
+
+
+# Once this file is imported it will set the container server side launcher
+@containers.override(mlrun.launcher.factory.LauncherContainer)
+class ServerSideLauncherContainer(containers.DeclarativeContainer):
+    server_side_launcher = providers.Factory(ServerSideLauncher)

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -36,7 +36,6 @@ import mlrun.utils.version
 from mlrun.api.api.api import api_router
 from mlrun.api.db.session import close_session, create_session
 from mlrun.api.initial_data import init_data
-from mlrun.api.launcher import initialize_launcher
 from mlrun.api.middlewares import init_middlewares
 from mlrun.api.utils.periodic import (
     cancel_all_periodic_functions,
@@ -141,7 +140,6 @@ async def startup_event():
 
     initialize_logs_dir()
     initialize_db()
-    initialize_launcher()
 
     if (
         config.httpdb.clusterization.worker.sync_with_chief.mode

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -418,16 +418,6 @@ class FeatureSet(ModelObj):
             fullname += ":" + self._metadata.tag
         return fullname
 
-    def _override_run_db(
-        self,
-        session,
-    ):
-        # Import here, since this method only runs in API context. If this import was global, client would need
-        # API requirements and would fail.
-        from ..api.api.utils import get_run_db_instance
-
-        self._run_db = get_run_db_instance(session)
-
     def _get_run_db(self):
         if self._run_db:
             return self._run_db

--- a/mlrun/feature_store/ingestion.py
+++ b/mlrun/feature_store/ingestion.py
@@ -278,17 +278,12 @@ def run_ingestion_job(name, featureset, run_config, schedule=None, spark_service
     # when running in server side we want to set the function db connection to the actual DB and not to use the httpdb
     function.set_db_connection(featureset._get_run_db())
 
-    # when running on server side there are multiple enrichments and validations to be applied on a function,
-    # auth_info is an attribute which is been added only on server side.
-    if run_config.auth_info:
-        # using from to not conflict with other mlrun imports
-        from mlrun.api.api.utils import apply_enrichment_and_validation_on_function
-
-        # apply_enrichment_and_validation_on_function is a server side function we don't want to import it on client
-        apply_enrichment_and_validation_on_function(function, run_config.auth_info)
-
     run = function.run(
-        task, schedule=schedule, local=run_config.local, watch=run_config.watch
+        task,
+        schedule=schedule,
+        local=run_config.local,
+        watch=run_config.watch,
+        auth_info=run_config.auth_info,
     )
     if run_config.watch:
         featureset.reload()

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -74,9 +74,9 @@ class BaseLauncher(abc.ABC):
         """run the function from the server/client[local/remote]"""
         pass
 
-    @staticmethod
     @abc.abstractmethod
     def enrich_runtime(
+        self,
         runtime: "mlrun.runtimes.base.BaseRuntime",
         project_name: Optional[str] = "",
     ):

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -31,9 +31,10 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
     Abstract class for common code between client launchers
     """
 
-    @staticmethod
     def enrich_runtime(
-        runtime: "mlrun.runtimes.base.BaseRuntime", project_name: Optional[str] = ""
+        self,
+        runtime: "mlrun.runtimes.base.BaseRuntime",
+        project_name: Optional[str] = "",
     ):
         runtime.try_auto_mount_based_on_config()
         runtime._fill_credentials()

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -295,6 +295,7 @@ class BaseRuntime(ModelObj):
         param_file_secrets: Optional[Dict[str, str]] = None,
         notifications: Optional[List[mlrun.model.Notification]] = None,
         returns: Optional[List[Union[str, Dict[str, str]]]] = None,
+        **kwargs,
     ) -> RunObject:
         """
         Run a local or remote task.
@@ -342,7 +343,7 @@ class BaseRuntime(ModelObj):
         :return: Run context object (RunObject) with run metadata, results and status
         """
         launcher = mlrun.launcher.factory.LauncherFactory().create_launcher(
-            self._is_remote, local=local
+            self._is_remote, local=local, **kwargs
         )
         return launcher.launch(
             runtime=self,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -34,6 +34,7 @@ import mlrun.api.utils.singletons.project_member
 import mlrun.api.utils.singletons.scheduler
 import mlrun.common.schemas
 import mlrun.db.factory
+import mlrun.launcher.factory
 from mlrun import mlconf
 from mlrun.api.initial_data import init_data
 from mlrun.api.main import BASE_VERSIONED_API_PREFIX, app
@@ -53,12 +54,18 @@ def api_config_test():
 
     mlrun.api.utils.runtimes.nuclio.cached_nuclio_version = None
 
-    mlrun.api.launcher.initialize_launcher()
+    mlrun.config._is_running_as_api = True
 
     # we need to override the run db container manually because we run all unit tests in the same process in CI
     # so API is imported even when it's not needed
     rundb_factory = mlrun.db.factory.RunDBFactory()
     rundb_factory._rundb_container.override(mlrun.api.rundb.sqldb.SQLRunDBContainer)
+
+    # same for the launcher container
+    launcher_factory = mlrun.launcher.factory.LauncherFactory()
+    launcher_factory._launcher_container.override(
+        mlrun.api.launcher.ServerSideLauncherContainer
+    )
 
 
 @pytest.fixture()

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -34,6 +34,7 @@ import mlrun.datastore
 import mlrun.db
 import mlrun.db.factory
 import mlrun.k8s_utils
+import mlrun.launcher.factory
 import mlrun.projects.project
 import mlrun.utils
 import mlrun.utils.singleton
@@ -94,9 +95,11 @@ def config_test_base():
     mlrun.mlconf.default_project = "default"
     mlrun.projects.project.pipeline_context.set(None)
 
-    # reset run db overrides
+    # reset factory container overrides
     rundb_factory = mlrun.db.factory.RunDBFactory()
     rundb_factory._rundb_container.reset_override()
+    launcher_factory = mlrun.launcher.factory.LauncherFactory()
+    launcher_factory._launcher_container.reset_override()
 
 
 @pytest.fixture


### PR DESCRIPTION
1. Use dependency injector to inject the server side launcher
2. Accept auth info in server side launcher via kwargs so that it will not be visible for users in the SDK
3. Apply enrichment and validation of API if auth info is set
https://jira.iguazeng.com/browse/ML-3802