### PR TITLE
[Schemas][Builder][Kubejob] Remove python 3.7 leftovers

### DIFF
--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -420,10 +420,7 @@ def build_image(
         # use a temp dir for permissions and set it as the workdir
         tmpdir = tempfile.mkdtemp()
         relative_workdir = runtime.spec.clone_target_dir or ""
-        if relative_workdir.startswith("./"):
-            # TODO: use 'removeprefix' when we drop python 3.7 support
-            # relative_workdir.removeprefix("./")
-            relative_workdir = relative_workdir[2:]
+        relative_workdir.removeprefix("./")
 
         runtime.spec.clone_target_dir = path.join(tmpdir, "mlrun", relative_workdir)
 

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -420,7 +420,7 @@ def build_image(
         # use a temp dir for permissions and set it as the workdir
         tmpdir = tempfile.mkdtemp()
         relative_workdir = runtime.spec.clone_target_dir or ""
-        relative_workdir.removeprefix("./")
+        relative_workdir = relative_workdir.removeprefix("./")
 
         runtime.spec.clone_target_dir = path.join(tmpdir, "mlrun", relative_workdir)
 

--- a/mlrun/common/schemas/runs.py
+++ b/mlrun/common/schemas/runs.py
@@ -14,14 +14,8 @@
 
 import typing
 
-# TODO: When we remove support for python 3.7, we can use Literal from the typing package.
-#       Remove the following try/except block with import from typing_extensions.
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 import pydantic
+from typing_extensions import Literal
 
 
 class RunIdentifier(pydantic.BaseModel):

--- a/mlrun/common/schemas/runs.py
+++ b/mlrun/common/schemas/runs.py
@@ -15,10 +15,9 @@
 import typing
 
 import pydantic
-from typing_extensions import Literal
 
 
 class RunIdentifier(pydantic.BaseModel):
-    kind: Literal["run"] = "run"
+    kind: typing.Literal["run"] = "run"
     uid: typing.Optional[str]
     iter: typing.Optional[int]

--- a/mlrun/common/schemas/schedule.py
+++ b/mlrun/common/schemas/schedule.py
@@ -15,14 +15,8 @@
 from datetime import datetime
 from typing import Any, List, Optional, Union
 
-# TODO: When we remove support for python 3.7, we can use Literal from the typing package.
-#       Remove the following try/except block with import from typing_extensions.
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from pydantic import BaseModel
+from typing_extensions import Literal
 
 import mlrun.common.types
 from mlrun.common.schemas.auth import Credentials

--- a/mlrun/common/schemas/schedule.py
+++ b/mlrun/common/schemas/schedule.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 #
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from pydantic import BaseModel
-from typing_extensions import Literal
 
 import mlrun.common.types
 from mlrun.common.schemas.auth import Credentials

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -359,10 +359,8 @@ class KubejobRuntime(KubeResource):
 
         if self.spec.clone_target_dir:
             workdir = workdir or ""
-            if workdir.startswith("./"):
-                # TODO: use 'removeprefix' when we drop python 3.7 support
-                # workdir.removeprefix("./")
-                workdir = workdir[2:]
+            workdir.removeprefix("./")
+
             return os.path.join(self.spec.clone_target_dir, workdir)
 
         return workdir

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -359,7 +359,7 @@ class KubejobRuntime(KubeResource):
 
         if self.spec.clone_target_dir:
             workdir = workdir or ""
-            workdir.removeprefix("./")
+            workdir = workdir.removeprefix("./")
 
             return os.path.join(self.spec.clone_target_dir, workdir)
 


### PR DESCRIPTION
Do some TODOs leftovers from python 3.7 limitations