### PR TITLE
[API] Change MLRun REST API URLs to conform with the best-practice

### DIFF
--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -16,6 +16,7 @@ import mimetypes
 from http import HTTPStatus
 
 import fastapi
+from deprecated import deprecated
 from fastapi.concurrency import run_in_threadpool
 
 import mlrun.api.api.deps
@@ -31,6 +32,12 @@ from mlrun.utils import logger
 router = fastapi.APIRouter()
 
 
+# TODO: Remove in 1.7.0
+@deprecated(
+    version="1.5.0",
+    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
+    category=FutureWarning,
+)
 @router.get("/files")
 def get_files(
     schema: str = "",
@@ -45,6 +52,12 @@ def get_files(
     return _get_files(schema, objpath, user, size, offset, auth_info)
 
 
+# TODO: Remove in 1.7.0
+@deprecated(
+    version="1.5.0",
+    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
+    category=FutureWarning,
+)
 @router.get("/projects/{project}/files")
 async def get_files_with_project_secrets(
     project: str,
@@ -73,6 +86,12 @@ async def get_files_with_project_secrets(
     )
 
 
+# TODO: Remove in 1.7.0
+@deprecated(
+    version="1.5.0",
+    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
+    category=FutureWarning,
+)
 @router.get("/filestat")
 def get_filestat(
     schema: str = "",
@@ -85,6 +104,12 @@ def get_filestat(
     return _get_filestat(schema, path, user, auth_info)
 
 
+# TODO: Remove in 1.7.0
+@deprecated(
+    version="1.5.0",
+    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
+    category=FutureWarning,
+)
 @router.get("/projects/{project}/filestat")
 async def get_filestat_with_project_secrets(
     project: str,

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -16,7 +16,6 @@ import mimetypes
 from http import HTTPStatus
 
 import fastapi
-from deprecated import deprecated
 from fastapi.concurrency import run_in_threadpool
 
 import mlrun.api.api.deps
@@ -33,12 +32,12 @@ router = fastapi.APIRouter()
 
 
 # TODO: Remove in 1.7.0
-@deprecated(
-    version="1.5.0",
-    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
-    category=FutureWarning,
+@router.get(
+    "/files",
+    deprecated=True,
+    description="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead"
+    "use /projects/{project}/runs/{uid} instead",
 )
-@router.get("/files")
 def get_files(
     schema: str = "",
     objpath: str = fastapi.Query("", alias="path"),
@@ -52,12 +51,6 @@ def get_files(
     return _get_files(schema, objpath, user, size, offset, auth_info)
 
 
-# TODO: Remove in 1.7.0
-@deprecated(
-    version="1.5.0",
-    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
-    category=FutureWarning,
-)
 @router.get("/projects/{project}/files")
 async def get_files_with_project_secrets(
     project: str,
@@ -87,12 +80,12 @@ async def get_files_with_project_secrets(
 
 
 # TODO: Remove in 1.7.0
-@deprecated(
-    version="1.5.0",
-    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
-    category=FutureWarning,
+@router.get(
+    "/filestat",
+    deprecated=True,
+    description="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead"
+    "use /projects/{project}/runs/{uid} instead",
 )
-@router.get("/filestat")
 def get_filestat(
     schema: str = "",
     path: str = "",
@@ -104,12 +97,6 @@ def get_filestat(
     return _get_filestat(schema, path, user, auth_info)
 
 
-# TODO: Remove in 1.7.0
-@deprecated(
-    version="1.5.0",
-    reason="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead, 'mount_v3io' instead",
-    category=FutureWarning,
-)
 @router.get("/projects/{project}/filestat")
 async def get_filestat_with_project_secrets(
     project: str,

--- a/mlrun/api/api/endpoints/logs.py
+++ b/mlrun/api/api/endpoints/logs.py
@@ -21,10 +21,16 @@ import mlrun.api.crud
 import mlrun.api.utils.auth.verifier
 import mlrun.common.schemas
 
-router = fastapi.APIRouter(prefix="/projects/{project}/logs")
+router = fastapi.APIRouter()
 
 
-@router.post("/{uid}")
+@router.post(
+    "/log/{project}/{uid}",
+    deprecated=True,
+    description="/log/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/logs/{uid} instead",
+)
+@router.post("/projects/{project}/logs/{uid}")
 async def store_log(
     request: fastapi.Request,
     project: str,
@@ -52,7 +58,13 @@ async def store_log(
     return {}
 
 
-@router.get("/{uid}")
+@router.get(
+    "/log/{project}/{uid}",
+    deprecated=True,
+    description="/log/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/logs/{uid} instead",
+)
+@router.get("/projects/{project}/logs/{uid}")
 async def get_log(
     project: str,
     uid: str,

--- a/mlrun/api/api/endpoints/logs.py
+++ b/mlrun/api/api/endpoints/logs.py
@@ -24,6 +24,7 @@ import mlrun.common.schemas
 router = fastapi.APIRouter()
 
 
+# TODO: remove /log/{project}/{uid} in 1.7.0
 @router.post(
     "/log/{project}/{uid}",
     deprecated=True,
@@ -58,6 +59,7 @@ async def store_log(
     return {}
 
 
+# TODO: remove /log/{project}/{uid} in 1.7.0
 @router.get(
     "/log/{project}/{uid}",
     deprecated=True,

--- a/mlrun/api/api/endpoints/logs.py
+++ b/mlrun/api/api/endpoints/logs.py
@@ -21,7 +21,7 @@ import mlrun.api.crud
 import mlrun.api.utils.auth.verifier
 import mlrun.common.schemas
 
-router = fastapi.APIRouter(prefix="/log/{project}")
+router = fastapi.APIRouter(prefix="/projects/{project}/logs")
 
 
 @router.post("/{uid}")

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -28,7 +28,7 @@ from mlrun.api.api import deps
 from mlrun.api.api.utils import log_and_raise
 from mlrun.utils.helpers import datetime_from_iso
 
-router = APIRouter(prefix="/projects/{project}/runs")
+router = APIRouter()
 
 
 # TODO: remove /run/{project}/{uid} in 1.7.0
@@ -38,7 +38,7 @@ router = APIRouter(prefix="/projects/{project}/runs")
     description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
     "use /projects/{project}/runs/{uid} instead",
 )
-@router.post("/{uid}")
+@router.post("/projects/{project}/runs/{uid}")
 async def store_run(
     request: Request,
     project: str,
@@ -84,7 +84,7 @@ async def store_run(
     description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
     "use /projects/{project}/runs/{uid} instead",
 )
-@router.patch("/{uid}")
+@router.patch("/projects/{project}/runs/{uid}")
 async def update_run(
     request: Request,
     project: str,
@@ -124,7 +124,7 @@ async def update_run(
     description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
     "use /projects/{project}/runs/{uid} instead",
 )
-@router.get("/{uid}")
+@router.get("/projects/{project}/runs/{uid}")
 async def get_run(
     project: str,
     uid: str,
@@ -154,7 +154,7 @@ async def get_run(
     description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
     "use /projects/{project}/runs/{uid} instead",
 )
-@router.delete("/{uid}")
+@router.delete("/projects/{project}/runs/{uid}")
 async def delete_run(
     project: str,
     uid: str,
@@ -186,7 +186,7 @@ async def delete_run(
     description="/runs is deprecated in 1.5.0 and will be removed in 1.7.0, "
     "use /projects/{project}/runs/{uid} instead",
 )
-@router.get("")
+@router.get("/projects/{project}/runs")
 async def list_runs(
     project: str = None,
     name: str = None,
@@ -264,7 +264,7 @@ async def list_runs(
     description="/runs is deprecated in 1.5.0 and will be removed in 1.7.0, "
     "use /projects/{project}/runs/{uid} instead",
 )
-@router.delete("")
+@router.delete("/projects/{project}/runs")
 async def delete_runs(
     project: str = None,
     name: str = None,
@@ -328,7 +328,7 @@ async def delete_runs(
 
 
 @router.put(
-    "/{uid}/notifications",
+    "/projects/{project}/runs/{uid}/notifications",
     status_code=HTTPStatus.OK.value,
 )
 async def set_run_notifications(

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -31,6 +31,7 @@ from mlrun.utils.helpers import datetime_from_iso
 router = APIRouter(prefix="/projects/{project}/runs")
 
 
+# TODO: remove /run/{project}/{uid} in 1.7.0
 @router.post(
     "/run/{project}/{uid}",
     deprecated=True,
@@ -76,6 +77,7 @@ async def store_run(
     return {}
 
 
+# TODO: remove /run/{project}/{uid} in 1.7.0
 @router.patch(
     "/run/{project}/{uid}",
     deprecated=True,
@@ -115,6 +117,7 @@ async def update_run(
     return {}
 
 
+# TODO: remove /run/{project}/{uid} in 1.7.0
 @router.get(
     "/run/{project}/{uid}",
     deprecated=True,
@@ -144,6 +147,7 @@ async def get_run(
     }
 
 
+# TODO: remove /run/{project}/{uid} in 1.7.0
 @router.delete(
     "/run/{project}/{uid}",
     deprecated=True,
@@ -175,6 +179,7 @@ async def delete_run(
     return {}
 
 
+# TODO: remove /runs in 1.7.0
 @router.get(
     "/runs",
     deprecated=True,
@@ -252,6 +257,7 @@ async def list_runs(
     }
 
 
+# TODO: remove /runs in 1.7.0
 @router.delete(
     "/runs",
     deprecated=True,

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -28,10 +28,10 @@ from mlrun.api.api import deps
 from mlrun.api.api.utils import log_and_raise
 from mlrun.utils.helpers import datetime_from_iso
 
-router = APIRouter()
+router = APIRouter(prefix="/projects/{project}/runs")
 
 
-@router.post("/run/{project}/{uid}")
+@router.post("/{uid}")
 async def store_run(
     request: Request,
     project: str,
@@ -70,7 +70,7 @@ async def store_run(
     return {}
 
 
-@router.patch("/run/{project}/{uid}")
+@router.patch("/{uid}")
 async def update_run(
     request: Request,
     project: str,
@@ -103,7 +103,7 @@ async def update_run(
     return {}
 
 
-@router.get("/run/{project}/{uid}")
+@router.get("/{uid}")
 async def get_run(
     project: str,
     uid: str,
@@ -126,7 +126,7 @@ async def get_run(
     }
 
 
-@router.delete("/run/{project}/{uid}")
+@router.delete("/{uid}")
 async def delete_run(
     project: str,
     uid: str,
@@ -151,7 +151,7 @@ async def delete_run(
     return {}
 
 
-@router.get("/runs")
+@router.get("")
 async def list_runs(
     project: str = None,
     name: str = None,
@@ -222,7 +222,7 @@ async def list_runs(
     }
 
 
-@router.delete("/runs")
+@router.delete("")
 async def delete_runs(
     project: str = None,
     name: str = None,
@@ -286,7 +286,7 @@ async def delete_runs(
 
 
 @router.put(
-    "/projects/{project}/runs/{uid}/notifications",
+    "/{uid}/notifications",
     status_code=HTTPStatus.OK.value,
 )
 async def set_run_notifications(

--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -31,6 +31,12 @@ from mlrun.utils.helpers import datetime_from_iso
 router = APIRouter(prefix="/projects/{project}/runs")
 
 
+@router.post(
+    "/run/{project}/{uid}",
+    deprecated=True,
+    description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/runs/{uid} instead",
+)
 @router.post("/{uid}")
 async def store_run(
     request: Request,
@@ -70,6 +76,12 @@ async def store_run(
     return {}
 
 
+@router.patch(
+    "/run/{project}/{uid}",
+    deprecated=True,
+    description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/runs/{uid} instead",
+)
 @router.patch("/{uid}")
 async def update_run(
     request: Request,
@@ -103,6 +115,12 @@ async def update_run(
     return {}
 
 
+@router.get(
+    "/run/{project}/{uid}",
+    deprecated=True,
+    description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/runs/{uid} instead",
+)
 @router.get("/{uid}")
 async def get_run(
     project: str,
@@ -126,6 +144,12 @@ async def get_run(
     }
 
 
+@router.delete(
+    "/run/{project}/{uid}",
+    deprecated=True,
+    description="/run/{project}/{uid} is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/runs/{uid} instead",
+)
 @router.delete("/{uid}")
 async def delete_run(
     project: str,
@@ -151,6 +175,12 @@ async def delete_run(
     return {}
 
 
+@router.get(
+    "/runs",
+    deprecated=True,
+    description="/runs is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/runs/{uid} instead",
+)
 @router.get("")
 async def list_runs(
     project: str = None,
@@ -222,6 +252,12 @@ async def list_runs(
     }
 
 
+@router.delete(
+    "/runs",
+    deprecated=True,
+    description="/runs is deprecated in 1.5.0 and will be removed in 1.7.0, "
+    "use /projects/{project}/runs/{uid} instead",
+)
 @router.delete("")
 async def delete_runs(
     project: str = None,

--- a/tests/api/api/test_files.py
+++ b/tests/api/api/test_files.py
@@ -27,6 +27,7 @@ from tests.common_fixtures import (  # noqa: F401
 )
 
 
+# TODO: remove in 1.7.0
 @pytest.mark.usefixtures("patch_file_forbidden")
 def test_files_forbidden(db: Session, client: TestClient) -> None:
     validate_files_status_code(client, HTTPStatus.FORBIDDEN.value)

--- a/tests/api/api/test_files.py
+++ b/tests/api/api/test_files.py
@@ -27,7 +27,6 @@ from tests.common_fixtures import (  # noqa: F401
 )
 
 
-# TODO: remove in 1.7.0
 @pytest.mark.usefixtures("patch_file_forbidden")
 def test_files_forbidden(db: Session, client: TestClient) -> None:
     validate_files_status_code(client, HTTPStatus.FORBIDDEN.value)
@@ -39,13 +38,13 @@ def test_files_not_found(db: Session, client: TestClient) -> None:
 
 
 def validate_files_status_code(client: TestClient, status_code: int):
-    resp = client.get("files?schema=v3io&path=mybucket/files.txt")
+    resp = client.get("projects/{project}/files?schema=v3io&path=mybucket/files.txt")
     assert resp.status_code == status_code
 
-    resp = client.get("files?schema=v3io&path=mybucket/")
+    resp = client.get("projects/{project}/files?schema=v3io&path=mybucket/")
     assert resp.status_code == status_code
 
-    resp = client.get("filestat?schema=v3io&path=mybucket/files.txt")
+    resp = client.get("projects/{project}/filestat?schema=v3io&path=mybucket/files.txt")
     assert resp.status_code == status_code
 
 

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -31,7 +31,7 @@ from mlrun.api.utils.singletons.db import get_db
 from mlrun.config import config
 
 API_V1 = "/api/v1"
-RUNS_API_V1 = f"{API_V1}/runs"
+RUNS_API_V1 = f"{API_V1}" + "/projects/{project}/runs"
 
 
 def test_run_with_nan_in_body(db: Session, client: TestClient) -> None:
@@ -246,27 +246,29 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     # basic list, all projects, all iterations so 3 projects * 3 names * 3 uids * 3 iterations = 81
     runs = _list_and_assert_objects(
         client,
-        {"project": "*"},
+        {},
         81,
+        project="*",
     )
 
     # basic list, specific project, only iteration 0, so 3 names * 3 uids = 9
     runs = _list_and_assert_objects(
         client,
-        {"project": projects[0], "iter": False},
+        {"iter": False},
         9,
+        project=projects[0],
     )
 
     # partioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
     runs = _list_and_assert_objects(
         client,
         {
-            "project": projects[0],
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.created,
             "partition-order": mlrun.common.schemas.OrderType.asc,
         },
         3,
+        project=projects[0],
     )
     # sorted by ascending created so only the first ones created
     for run in runs:
@@ -276,12 +278,12 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     runs = _list_and_assert_objects(
         client,
         {
-            "project": projects[0],
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
             "partition-order": mlrun.common.schemas.OrderType.desc,
         },
         3,
+        project=projects[0],
     )
     # sorted by descending updated so only the third ones created
     for run in runs:
@@ -291,20 +293,19 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     runs = _list_and_assert_objects(
         client,
         {
-            "project": projects[0],
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
             "partition-order": mlrun.common.schemas.OrderType.desc,
             "rows-per-partition": 5,
         },
         15,
+        project=projects[0],
     )
 
     # partitioned list, specific project, 5 rows per partition, max of 2 partitions, so 2 names * 5 rows = 10
     runs = _list_and_assert_objects(
         client,
         {
-            "project": projects[0],
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
             "partition-order": mlrun.common.schemas.OrderType.desc,
@@ -312,6 +313,7 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
             "max-partitions": 2,
         },
         10,
+        project=projects[0],
     )
     for run in runs:
         # Partitions are ordered from latest updated to oldest, which means that 3,2 must be here.
@@ -321,7 +323,6 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     runs = _list_and_assert_objects(
         client,
         {
-            "project": projects[0],
             "iter": False,
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
@@ -330,16 +331,21 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
             "max-partitions": 1,
         },
         2,
+        project=projects[0],
     )
 
     for run in runs:
         assert run["metadata"]["name"] == "run-name-3" and run["metadata"]["iter"] == 0
 
     # Some negative testing - no sort by field
-    response = client.get(f"{RUNS_API_V1}?partition-by=name")
+    response = client.get(
+        f"{RUNS_API_V1.format(project=projects[0])}?partition-by=name"
+    )
     assert response.status_code == HTTPStatus.BAD_REQUEST.value
     # An invalid partition-by field - will be failed by fastapi due to schema validation.
-    response = client.get(f"{RUNS_API_V1}?partition-by=key&partition-sort-by=name")
+    response = client.get(
+        f"{RUNS_API_V1.format(project=projects[0])}?partition-by=key&partition-sort-by=name"
+    )
     assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY.value
 
 
@@ -362,10 +368,10 @@ def test_list_runs_single_and_multiple_uids(db: Session, client: TestClient):
     runs = _list_and_assert_objects(
         client,
         {
-            "project": project,
             "uid": "uid_1",
         },
         1,
+        project=project,
     )
     assert runs[0]["metadata"]["uid"] == "uid_1"
 
@@ -373,11 +379,11 @@ def test_list_runs_single_and_multiple_uids(db: Session, client: TestClient):
     runs = _list_and_assert_objects(
         client,
         {
-            "project": project,
             "uid": uid_list,
         },
         # One fictive uid
         len(uid_list) - 1,
+        project=project,
     )
 
     expected_uids = set(uid_list)
@@ -396,7 +402,7 @@ def test_delete_runs_with_permissions(db: Session, client: TestClient):
     _store_run(db, uid="some-uid", project=project)
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 1
-    response = client.delete(f"{RUNS_API_V1}?project={project}")
+    response = client.delete(RUNS_API_V1.format(project="*"))
     assert response.status_code == HTTPStatus.OK.value
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 0
@@ -407,7 +413,7 @@ def test_delete_runs_with_permissions(db: Session, client: TestClient):
     _store_run(db, uid=None, project=second_project)
     all_runs = mlrun.api.crud.Runs().list_runs(db, project="*")
     assert len(all_runs) == 2
-    response = client.delete(f"{RUNS_API_V1}?project=*")
+    response = client.delete(RUNS_API_V1.format(project="*"))
     assert response.status_code == HTTPStatus.OK.value
     runs = mlrun.api.crud.Runs().list_runs(db, project="*")
     assert len(runs) == 0
@@ -422,20 +428,20 @@ def test_delete_runs_without_permissions(db: Session, client: TestClient):
     project = "some-project"
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 0
-    response = client.delete(f"{RUNS_API_V1}?project={project}")
+    response = client.delete(RUNS_API_V1.format(project=project))
     assert response.status_code == HTTPStatus.UNAUTHORIZED.value
 
     # try delete runs with no permission to project (project contains runs)
     _store_run(db, uid="some-uid", project=project)
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 1
-    response = client.delete(f"{RUNS_API_V1}?project={project}")
+    response = client.delete(RUNS_API_V1.format(project=project))
     assert response.status_code == HTTPStatus.UNAUTHORIZED.value
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 1
 
     # try delete runs from all projects with no permissions
-    response = client.delete(f"{RUNS_API_V1}?project=*")
+    response = client.delete(RUNS_API_V1.format(project="*"))
     assert response.status_code == HTTPStatus.UNAUTHORIZED.value
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 1
@@ -451,8 +457,10 @@ def _store_run(db, uid, project="some-project"):
     return mlrun.api.crud.Runs().store_run(db, run_with_nan_float, uid, project=project)
 
 
-def _list_and_assert_objects(client: TestClient, params, expected_number_of_runs: int):
-    response = client.get(RUNS_API_V1, params=params)
+def _list_and_assert_objects(
+    client: TestClient, params, expected_number_of_runs: int, project: str
+):
+    response = client.get(RUNS_API_V1.format(project=project), params=params)
     assert response.status_code == HTTPStatus.OK.value, response.text
 
     runs = response.json()["runs"]

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -31,7 +31,7 @@ from mlrun.api.utils.singletons.db import get_db
 from mlrun.config import config
 
 API_V1 = "/api/v1"
-RUNS_API_V1 = f"{API_V1}" + "/projects/{project}/runs"
+RUNS_API_V1 = f"{API_V1}/projects/{{project}}/runs"
 
 
 def test_run_with_nan_in_body(db: Session, client: TestClient) -> None:


### PR DESCRIPTION
resolves: [ML-4100](https://jira.iguazeng.com/browse/ML-4100)

- `/files` and `/filestat` - deprecate these APIs
- GET/POST `/log/{project}/{uid}` -> GET/POST `/projects/{project}/logs/{uid}`
- GET/POST/PATCH/DELETE `/run/{project}/{uid}` -> GET/POST `/projects/{project}/runs/{uid}`
- GET/DELETE `/runs` -> GET/DELETE` /projects/{project}/runs `