### PR TITLE
[Docs] Fix helm repo add mlrun-ce command

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -69,7 +69,7 @@ kubectl create namespace mlrun
 Add the Community Edition helm chart repo:
 
 ```bash
-helm repo add mlrun https://mlrun.github.io/ce
+helm repo add mlrun-ce https://mlrun.github.io/ce
 ```
 
 Run the following command to ensure that the repo is installed and available:


### PR DESCRIPTION
The repo name should be mlrun-ce as mentioned in the next installation steps