### PR TITLE
[CLI] Get artifacts - change the "tree" column to "workflow/job uid"

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -763,11 +763,12 @@ def get(kind, name, selector, namespace, uid, project, tag, db, extra_args):
             name, project=project, tag=tag, labels=selector
         )
         df = artifacts.to_df()[
-            ["tree", "key", "iter", "kind", "path", "hash", "updated", "uri"]
+            ["key", "iter", "kind", "path", "hash", "updated", "uri", "tree"]
         ]
         df["tree"] = df["tree"].apply(lambda x: f"..{x[-8:]}")
         df["hash"] = df["hash"].apply(lambda x: f"..{x[-6:]}")
         df["updated"] = df["updated"].apply(time_str)
+        df.rename(columns={"tree": "job/workflow uid"}, inplace=True)
         print(tabulate(df, headers="keys"))
 
     elif kind.startswith("func"):


### PR DESCRIPTION
fixes: https://jira.iguazeng.com/browse/ML-2019

in the UI, the artifact has no "tree" column ( and the term "tree" is not mentioned anywhere) , but it is "uid", so changed the CLI to be corresponding to it.