### PR TITLE
[Model Monitoring] Secret provider for SQL connection string on API side

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -89,4 +89,3 @@ ignore_imports =
     mlrun.runtimes.mpijob.v1alpha1 -> mlrun.api.db.base
     mlrun.runtimes.sparkjob.abstract -> mlrun.api.db.base
     mlrun.runtimes.utils -> mlrun.api.utils.singletons.k8s
-    mlrun.model_monitoring.helpers -> mlrun.api.crud.secrets

--- a/mlrun/api/crud/model_monitoring/helpers.py
+++ b/mlrun/api/crud/model_monitoring/helpers.py
@@ -127,26 +127,3 @@ def get_stream_path(project: str = None):
     return mlrun.common.model_monitoring.helpers.parse_monitoring_stream_path(
         stream_uri=stream_uri, project=project
     )
-
-
-def get_project_secret_provider(project: str) -> typing.Callable:
-    """Implement secret provider for handle the related project secret on the API side. At the moment, it only supports
-     SQL connection string. If wasn't set, the connection string will be taken from the system configurations.
-
-    :param project: Project name.
-
-    :return: A secret provider function.
-    """
-
-    def _secret_provider(key: str):
-        return (
-            mlrun.api.crud.secrets.Secrets().get_project_secret(
-                project=project,
-                provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
-                allow_secrets_from_k8s=True,
-                secret_key=key,
-            )
-            or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
-        )
-
-    return _secret_provider

--- a/mlrun/api/crud/model_monitoring/helpers.py
+++ b/mlrun/api/crud/model_monitoring/helpers.py
@@ -127,3 +127,31 @@ def get_stream_path(project: str = None):
     return mlrun.common.model_monitoring.helpers.parse_monitoring_stream_path(
         stream_uri=stream_uri, project=project
     )
+
+
+def get_connection_string(key: str = None) -> str:
+    """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
+    configurations.
+
+    :param key: Project secret key that includes the project name along with the endpoint store connection key,
+                separated by '_'.
+
+    :return:    Valid SQL connection string.
+    """
+
+    project = key[
+        : -len(
+            mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION
+        )
+        - 1
+    ]
+
+    return (
+        mlrun.api.crud.secrets.Secrets().get_project_secret(
+            project=project,
+            provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
+            allow_secrets_from_k8s=True,
+            secret_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
+        )
+        or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
+    )

--- a/mlrun/api/crud/model_monitoring/helpers.py
+++ b/mlrun/api/crud/model_monitoring/helpers.py
@@ -129,29 +129,25 @@ def get_stream_path(project: str = None):
     )
 
 
-def get_connection_string(key: str = None) -> str:
+def get_connection_string(project: str = None) -> str:
     """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
     configurations.
 
-    :param key: Project secret key that includes the project name along with the endpoint store connection key,
-                separated by '_'.
+    :param project: Project name
 
-    :return:    Valid SQL connection string.
+    :return: Valid SQL connection string.
     """
 
-    project = key[
-        : -len(
-            mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION
+    def _secret_provider(key):
+        # Replace this code with code that retrieves project secret with project and key
+        return (
+            mlrun.api.crud.secrets.Secrets().get_project_secret(
+                project=project,
+                provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
+                allow_secrets_from_k8s=True,
+                secret_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
+            )
+            or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
         )
-        - 1
-    ]
 
-    return (
-        mlrun.api.crud.secrets.Secrets().get_project_secret(
-            project=project,
-            provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
-            allow_secrets_from_k8s=True,
-            secret_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
-        )
-        or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
-    )
+    return _secret_provider

--- a/mlrun/api/crud/model_monitoring/helpers.py
+++ b/mlrun/api/crud/model_monitoring/helpers.py
@@ -129,23 +129,22 @@ def get_stream_path(project: str = None):
     )
 
 
-def get_connection_string(project: str = None) -> str:
-    """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
-    configurations.
+def get_project_secret_provider(project: str) -> typing.Callable:
+    """Implement secret provider for handle the related project secret on the API side. At the moment, it only supports
+     SQL connection string. If wasn't set, the connection string will be taken from the system configurations.
 
-    :param project: Project name
+    :param project: Project name.
 
-    :return: Valid SQL connection string.
+    :return: A secret provider function.
     """
 
-    def _secret_provider(key):
-        # Replace this code with code that retrieves project secret with project and key
+    def _secret_provider(key: str):
         return (
             mlrun.api.crud.secrets.Secrets().get_project_secret(
                 project=project,
                 provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
                 allow_secrets_from_k8s=True,
-                secret_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
+                secret_key=key,
             )
             or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
         )

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -156,7 +156,7 @@ class ModelEndpoints:
         # Write the new model endpoint
         model_endpoint_store = get_model_endpoint_store(
             project=model_endpoint.metadata.project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
                 project=model_endpoint.metadata.project
             ),
         )
@@ -188,7 +188,7 @@ class ModelEndpoints:
         # Generate a model endpoint store object and apply the update process
         model_endpoint_store = get_model_endpoint_store(
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
                 project=project
             ),
         )
@@ -320,7 +320,7 @@ class ModelEndpoints:
         """
         model_endpoint_store = get_model_endpoint_store(
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
                 project=project
             ),
         )
@@ -373,7 +373,7 @@ class ModelEndpoints:
         model_endpoint_store = get_model_endpoint_store(
             project=project,
             access_key=auth_info.data_session,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
                 project=project
             ),
         )
@@ -470,7 +470,7 @@ class ModelEndpoints:
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
                 project=project
             ),
         )
@@ -543,7 +543,7 @@ class ModelEndpoints:
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,
             project=project_name,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
                 project=project_name
             ),
         )

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -22,6 +22,7 @@ import sqlalchemy.orm
 import mlrun.api.api.utils
 import mlrun.api.crud.model_monitoring.deployment
 import mlrun.api.crud.model_monitoring.helpers
+import mlrun.api.crud.secrets
 import mlrun.api.rundb.sqldb
 import mlrun.artifacts
 import mlrun.common.helpers
@@ -156,7 +157,7 @@ class ModelEndpoints:
         # Write the new model endpoint
         model_endpoint_store = get_model_endpoint_store(
             project=model_endpoint.metadata.project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
+            secret_provider=mlrun.api.crud.secrets.get_project_secret_provider(
                 project=model_endpoint.metadata.project
             ),
         )
@@ -188,7 +189,7 @@ class ModelEndpoints:
         # Generate a model endpoint store object and apply the update process
         model_endpoint_store = get_model_endpoint_store(
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
+            secret_provider=mlrun.api.crud.secrets.get_project_secret_provider(
                 project=project
             ),
         )
@@ -320,7 +321,7 @@ class ModelEndpoints:
         """
         model_endpoint_store = get_model_endpoint_store(
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
+            secret_provider=mlrun.api.crud.secrets.get_project_secret_provider(
                 project=project
             ),
         )
@@ -373,7 +374,7 @@ class ModelEndpoints:
         model_endpoint_store = get_model_endpoint_store(
             project=project,
             access_key=auth_info.data_session,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
+            secret_provider=mlrun.api.crud.secrets.get_project_secret_provider(
                 project=project
             ),
         )
@@ -470,7 +471,7 @@ class ModelEndpoints:
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
+            secret_provider=mlrun.api.crud.secrets.get_project_secret_provider(
                 project=project
             ),
         )
@@ -543,7 +544,7 @@ class ModelEndpoints:
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,
             project=project_name,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_project_secret_provider(
+            secret_provider=mlrun.api.crud.secrets.get_project_secret_provider(
                 project=project_name
             ),
         )

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -156,6 +156,7 @@ class ModelEndpoints:
         # Write the new model endpoint
         model_endpoint_store = get_model_endpoint_store(
             project=model_endpoint.metadata.project,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
         )
         model_endpoint_store.write_model_endpoint(endpoint=model_endpoint.flat_dict())
 
@@ -185,6 +186,7 @@ class ModelEndpoints:
         # Generate a model endpoint store object and apply the update process
         model_endpoint_store = get_model_endpoint_store(
             project=project,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
         )
         model_endpoint_store.update_model_endpoint(
             endpoint_id=endpoint_id, attributes=attributes
@@ -314,6 +316,7 @@ class ModelEndpoints:
         """
         model_endpoint_store = get_model_endpoint_store(
             project=project,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
         )
 
         model_endpoint_store.delete_model_endpoint(endpoint_id=endpoint_id)
@@ -362,7 +365,9 @@ class ModelEndpoints:
 
         # Generate a model endpoint store object and get the model endpoint record as a dictionary
         model_endpoint_store = get_model_endpoint_store(
-            project=project, access_key=auth_info.data_session
+            project=project,
+            access_key=auth_info.data_session,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
         )
 
         model_endpoint_record = model_endpoint_store.get_model_endpoint(
@@ -455,7 +460,9 @@ class ModelEndpoints:
 
         # Generate a model endpoint store object and get a list of model endpoint dictionaries
         endpoint_store = get_model_endpoint_store(
-            access_key=auth_info.data_session, project=project
+            access_key=auth_info.data_session,
+            project=project,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
         )
 
         endpoint_dictionary_list = endpoint_store.list_model_endpoints(
@@ -524,7 +531,9 @@ class ModelEndpoints:
 
         # Generate a model endpoint store object and get a list of model endpoint dictionaries
         endpoint_store = get_model_endpoint_store(
-            access_key=auth_info.data_session, project=project_name
+            access_key=auth_info.data_session,
+            project=project_name,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
         )
         endpoints = endpoint_store.list_model_endpoints()
 

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -156,7 +156,9 @@ class ModelEndpoints:
         # Write the new model endpoint
         model_endpoint_store = get_model_endpoint_store(
             project=model_endpoint.metadata.project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+                project=model_endpoint.metadata.project
+            ),
         )
         model_endpoint_store.write_model_endpoint(endpoint=model_endpoint.flat_dict())
 
@@ -186,7 +188,9 @@ class ModelEndpoints:
         # Generate a model endpoint store object and apply the update process
         model_endpoint_store = get_model_endpoint_store(
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+                project=project
+            ),
         )
         model_endpoint_store.update_model_endpoint(
             endpoint_id=endpoint_id, attributes=attributes
@@ -316,7 +320,9 @@ class ModelEndpoints:
         """
         model_endpoint_store = get_model_endpoint_store(
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+                project=project
+            ),
         )
 
         model_endpoint_store.delete_model_endpoint(endpoint_id=endpoint_id)
@@ -367,7 +373,9 @@ class ModelEndpoints:
         model_endpoint_store = get_model_endpoint_store(
             project=project,
             access_key=auth_info.data_session,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+                project=project
+            ),
         )
 
         model_endpoint_record = model_endpoint_store.get_model_endpoint(
@@ -462,7 +470,9 @@ class ModelEndpoints:
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,
             project=project,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+                project=project
+            ),
         )
 
         endpoint_dictionary_list = endpoint_store.list_model_endpoints(
@@ -533,7 +543,9 @@ class ModelEndpoints:
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,
             project=project_name,
-            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string,
+            secret_provider=mlrun.api.crud.model_monitoring.helpers.get_connection_string(
+                project=project_name
+            ),
         )
         endpoints = endpoint_store.list_model_endpoints()
 

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -543,7 +543,7 @@ def get_project_secret_provider(project: str) -> typing.Callable:
     :return: A secret provider function.
     """
 
-    def _secret_provider(key: str):
+    def secret_provider(key: str):
         return mlrun.api.crud.secrets.Secrets().get_project_secret(
             project=project,
             provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
@@ -551,4 +551,4 @@ def get_project_secret_provider(project: str) -> typing.Callable:
             secret_key=key,
         )
 
-    return _secret_provider
+    return secret_provider

--- a/mlrun/api/crud/secrets.py
+++ b/mlrun/api/crud/secrets.py
@@ -17,9 +17,11 @@ import json
 import typing
 import uuid
 
+import mlrun.api
 import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.events.events_factory as events_factory
 import mlrun.api.utils.singletons.k8s
+import mlrun.common
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.helpers
@@ -531,3 +533,22 @@ class Secrets(
     @staticmethod
     def _generate_uuid() -> str:
         return str(uuid.uuid4())
+
+
+def get_project_secret_provider(project: str) -> typing.Callable:
+    """Implement secret provider for handle the related project secret on the API side.
+
+    :param project: Project name.
+
+    :return: A secret provider function.
+    """
+
+    def _secret_provider(key: str):
+        return mlrun.api.crud.secrets.Secrets().get_project_secret(
+            project=project,
+            provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
+            allow_secrets_from_k8s=True,
+            secret_key=key,
+        )
+
+    return _secret_provider

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -14,9 +14,10 @@
 #
 
 
+import typing
+
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
-from mlrun.config import is_running_as_api
 
 
 def get_stream_path(project: str = None):
@@ -35,31 +36,34 @@ def get_stream_path(project: str = None):
     )
 
 
-def get_connection_string(project: str = None):
-    """Get endpoint store connection string from the project secret.
-    If wasn't set, take it from the system configurations"""
+def get_connection_string(
+    project: str = None, secret_provider: typing.Callable = None
+) -> str:
+    """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
+    configurations.
 
-    if is_running_as_api():
-        # Running on API server side
-        import mlrun.api.crud.secrets
-        import mlrun.common.schemas
+    :param project:         Project name.
+    :param secret_provider: An optional secret provider which in this case is a callable function that handles the
+                            connection string secret in the API side.
 
-        return (
-            mlrun.api.crud.secrets.Secrets().get_project_secret(
-                project=project,
-                provider=mlrun.common.schemas.secret.SecretProviderName.kubernetes,
-                allow_secrets_from_k8s=True,
-                secret_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
-            )
-            or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
-        )
-    else:
-        # Running on stream server side
-        import mlrun
+    :return:                Valid SQL connection string.
 
+    """
+
+    if secret_provider:
+        # Running on API side - use secret provider to get the connection string secret
         return (
             mlrun.get_secret_or_env(
-                mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION
+                key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
+                secret_provider=secret_provider,
+                prefix=project,
             )
             or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
         )
+
+    return (
+        mlrun.get_secret_or_env(
+            key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
+        )
+        or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
+    )

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -36,13 +36,10 @@ def get_stream_path(project: str = None):
     )
 
 
-def get_connection_string(
-    project: str = None, secret_provider: typing.Callable = None
-) -> str:
+def get_connection_string(secret_provider: typing.Callable = None) -> str:
     """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
     configurations.
 
-    :param project:         Project name.
     :param secret_provider: An optional secret provider which in this case is a callable function that handles the
                             connection string secret in the API side.
 
@@ -50,20 +47,10 @@ def get_connection_string(
 
     """
 
-    if secret_provider:
-        # Running on API side - use secret provider to get the connection string secret
-        return (
-            mlrun.get_secret_or_env(
-                key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
-                secret_provider=secret_provider,
-                prefix=project,
-            )
-            or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
-        )
-
     return (
         mlrun.get_secret_or_env(
             key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION,
+            secret_provider=secret_provider,
         )
         or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
     )

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -40,8 +40,7 @@ def get_connection_string(secret_provider: typing.Callable = None) -> str:
     """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
     configurations.
 
-    :param secret_provider: An optional secret provider which in this case is a callable function that handles the
-                            connection string secret in the API side.
+    :param secret_provider: An optional secret provider to get the connection string secret.
 
     :return:                Valid SQL connection string.
 

--- a/mlrun/model_monitoring/stores/__init__.py
+++ b/mlrun/model_monitoring/stores/__init__.py
@@ -17,6 +17,7 @@
 import enum
 import typing
 
+import mlrun.common.schemas.secret
 import mlrun.errors
 
 from .model_endpoint_store import ModelEndpointStore
@@ -33,6 +34,7 @@ class ModelEndpointStoreType(enum.Enum):
         project: str,
         access_key: str = None,
         endpoint_store_connection: str = None,
+        secret_provider: typing.Callable = None,
     ) -> ModelEndpointStore:
         """
         Return a ModelEndpointStore object based on the provided enum value.
@@ -46,6 +48,8 @@ class ModelEndpointStoreType(enum.Enum):
                                           e.g. A root user with password 1234, tries to connect a schema called
                                           mlrun within a local MySQL DB instance:
                                           'mysql+pymysql://root:1234@localhost:3306/mlrun'.
+        :param secret_provider:           An optional secret provider which in this case is a callable function that
+                                          handles the connection string secret in the API side.
 
         :return: `ModelEndpointStore` object.
 
@@ -61,15 +65,13 @@ class ModelEndpointStoreType(enum.Enum):
 
         # Assuming SQL store target if store type is not KV.
         # Update these lines once there are more than two store target types.
-        from mlrun.model_monitoring.helpers import get_connection_string
 
-        sql_connection_string = endpoint_store_connection or get_connection_string(
-            project=project
-        )
         from .sql_model_endpoint_store import SQLModelEndpointStore
 
         return SQLModelEndpointStore(
-            project=project, sql_connection_string=sql_connection_string
+            project=project,
+            sql_connection_string=endpoint_store_connection,
+            secret_provider=secret_provider,
         )
 
     @classmethod
@@ -84,13 +86,17 @@ class ModelEndpointStoreType(enum.Enum):
 
 
 def get_model_endpoint_store(
-    project: str, access_key: str = None
+    project: str,
+    access_key: str = None,
+    secret_provider: typing.Callable = None,
 ) -> ModelEndpointStore:
     """
     Getting the DB target type based on mlrun.config.model_endpoint_monitoring.store_type.
 
-    :param project:    The name of the project.
-    :param access_key: Access key with permission to the DB table.
+    :param project:         The name of the project.
+    :param access_key:      Access key with permission to the DB table.
+    :param secret_provider: An optional secret provider which in this case is a callable function that handles the
+                            connection string secret in the API side.
 
     :return: `ModelEndpointStore` object. Using this object, the user can apply different operations on the
              model endpoint record such as write, update, get and delete.
@@ -102,4 +108,6 @@ def get_model_endpoint_store(
     )
 
     # Convert into model endpoint store target object
-    return model_endpoint_store_type.to_endpoint_store(project, access_key)
+    return model_endpoint_store_type.to_endpoint_store(
+        project=project, access_key=access_key, secret_provider=secret_provider
+    )

--- a/mlrun/model_monitoring/stores/__init__.py
+++ b/mlrun/model_monitoring/stores/__init__.py
@@ -48,8 +48,7 @@ class ModelEndpointStoreType(enum.Enum):
                                           e.g. A root user with password 1234, tries to connect a schema called
                                           mlrun within a local MySQL DB instance:
                                           'mysql+pymysql://root:1234@localhost:3306/mlrun'.
-        :param secret_provider:           An optional secret provider which in this case is a callable function that
-                                          handles the connection string secret in the API side.
+        :param secret_provider:           An optional secret provider to get the connection string secret.
 
         :return: `ModelEndpointStore` object.
 
@@ -95,8 +94,7 @@ def get_model_endpoint_store(
 
     :param project:         The name of the project.
     :param access_key:      Access key with permission to the DB table.
-    :param secret_provider: An optional secret provider which in this case is a callable function that handles the
-                            connection string secret in the API side.
+    :param secret_provider: An optional secret provider to get the connection string secret.
 
     :return: `ModelEndpointStore` object. Using this object, the user can apply different operations on the
              model endpoint record such as write, update, get and delete.

--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -61,7 +61,7 @@ class SQLModelEndpointStore(ModelEndpointStore):
         self.sql_connection_string = (
             sql_connection_string
             or mlrun.model_monitoring.helpers.get_connection_string(
-                project=self.project, secret_provider=secret_provider
+                secret_provider=secret_provider
             )
         )
 

--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -45,12 +45,15 @@ class SQLModelEndpointStore(ModelEndpointStore):
         self,
         project: str,
         sql_connection_string: str = None,
+        secret_provider: typing.Callable = None,
     ):
         """
         Initialize SQL store target object.
 
         :param project:               The name of the project.
         :param sql_connection_string: Valid connection string or a path to SQL database with model endpoints table.
+        :param secret_provider:       An optional secret provider which in this case is a callable function that
+                                      handles the connection string secret in the API side.
         """
 
         super().__init__(project=project)
@@ -58,7 +61,7 @@ class SQLModelEndpointStore(ModelEndpointStore):
         self.sql_connection_string = (
             sql_connection_string
             or mlrun.model_monitoring.helpers.get_connection_string(
-                project=self.project
+                project=self.project, secret_provider=secret_provider
             )
         )
 

--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -52,8 +52,7 @@ class SQLModelEndpointStore(ModelEndpointStore):
 
         :param project:               The name of the project.
         :param sql_connection_string: Valid connection string or a path to SQL database with model endpoints table.
-        :param secret_provider:       An optional secret provider which in this case is a callable function that
-                                      handles the connection string secret in the API side.
+        :param secret_provider:       An optional secret provider to get the connection string secret.
         """
 
         super().__init__(project=project)


### PR DESCRIPTION
The main goal of this PR is to remove the unnecessary import from MLRun API (`import mlrun.api.crud.secrets`) when calling `get_connection_string()` from the client side. In this PR, we add a secret provider to the `get_connection_string` function that handles the call from the API side. This secret provider is actually a new callable function that can be found under `mlrun.api.crud.secrets.py`. 

A related JIRA: https://jira.iguazeng.com/browse/ML-4240