### PR TITLE
[API] Fix workflow bugs (system tests)

### DIFF
--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -33,7 +33,7 @@ import mlrun.api.utils.singletons.db
 import mlrun.api.utils.singletons.project_member
 import mlrun.common.schemas
 import mlrun.projects.pipelines
-from mlrun.api.api.utils import log_and_raise, parse_reference
+from mlrun.api.api.utils import log_and_raise
 from mlrun.utils.helpers import logger
 
 router = fastapi.APIRouter()
@@ -295,13 +295,13 @@ def _update_dict(dict_1: dict, dict_2: dict):
 
 
 @router.get(
-    "/projects/{project}/workflows/{name}/references/{reference}",
+    "/projects/{project}/workflows/{name}/runs/{uid}",
     response_model=mlrun.common.schemas.GetWorkflowResponse,
 )
 async def get_workflow_id(
     project: str,
     name: str,
-    reference: str,
+    uid: str,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request
     ),
@@ -322,14 +322,13 @@ async def get_workflow_id(
 
     :param project:     name of the project
     :param name:        name of the workflow
-    :param reference:   the id of the running job that runs the workflow
+    :param uid:         the id of the running job that runs the workflow
     :param auth_info:   auth info of the request
     :param db_session:  session that manages the current dialog with the database
     :param engine:      pipeline runner, for example: "kfp"
 
     :returns: workflow id
     """
-    _, uid = parse_reference(reference)
     # Check permission READ run:
     await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.run,

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -313,7 +313,8 @@ class WorkflowRunners(
 
         :param project:     MLRun project
         :param source:      the source of the project, needs to be a remote URL that contains the project yaml file.
-        :param load_only:   if we only load the project, the project must be saved.
+        :param load_only:   if we only load the project, it must be saved to ensure we are not running a pipeline
+                            without a project as it's not supported.
 
         :returns: True if the project need to be saved afterward.
         """

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -110,34 +110,16 @@ class WorkflowRunners(
             "schedule": schedule,
         }
 
-        if workflow_request.spec.override:
-            get_scheduler().store_schedule(
-                db_session=db_session,
-                auth_info=auth_info,
-                project=project.metadata.name,
-                name=workflow_spec.name,
-                scheduled_object=scheduled_object,
-                cron_trigger=schedule,
-                labels=runner.metadata.labels,
-                kind=mlrun.common.schemas.ScheduleKinds.job,
-            )
-        else:
-            try:
-                get_scheduler().create_schedule(
-                    db_session=db_session,
-                    auth_info=auth_info,
-                    project=project.metadata.name,
-                    name=workflow_spec.name,
-                    kind=mlrun.common.schemas.ScheduleKinds.job,
-                    scheduled_object=scheduled_object,
-                    cron_trigger=schedule,
-                    labels=runner.metadata.labels,
-                )
-            except mlrun.errors.MLRunConflictError:
-                raise mlrun.errors.MLRunConflictError(
-                    f"There is already a schedule for workflow {workflow_spec.name}."
-                    " If you want to override this schedule use override=True (SDK) or --override-workflow (CLI)"
-                )
+        get_scheduler().store_schedule(
+            db_session=db_session,
+            auth_info=auth_info,
+            project=project.metadata.name,
+            name=workflow_spec.name,
+            scheduled_object=scheduled_object,
+            cron_trigger=schedule,
+            labels=runner.metadata.labels,
+            kind=mlrun.common.schemas.ScheduleKinds.job,
+        )
 
     def _prepare_run_object_for_scheduling(
         self,
@@ -173,6 +155,7 @@ class WorkflowRunners(
                     engine=workflow_spec.engine,
                     local=workflow_spec.run_local,
                     save=save,
+                    subpath=project.spec.subpath,
                 ),
                 handler="mlrun.projects.load_and_run",
                 scrape_metrics=config.scrape_metrics,
@@ -312,6 +295,7 @@ class WorkflowRunners(
                     ttl=workflow_spec.ttl,
                     engine=workflow_spec.engine,
                     local=workflow_spec.run_local,
+                    subpath=project.spec.subpath,
                 )
             )
 
@@ -329,8 +313,7 @@ class WorkflowRunners(
 
         :param project:     MLRun project
         :param source:      the source of the project, needs to be a remote URL that contains the project yaml file.
-        :param load_only:   if we only load the project, it must be saved to ensure we are not running a pipeline
-                            without a project as it's not supported.
+        :param load_only:   if we only load the project, the project must be saved.
 
         :returns: True if the project need to be saved afterward.
         """

--- a/mlrun/common/schemas/workflow.py
+++ b/mlrun/common/schemas/workflow.py
@@ -30,7 +30,6 @@ class WorkflowSpec(pydantic.BaseModel):
     args_schema: typing.Optional[list] = None
     schedule: typing.Union[str, ScheduleCronTrigger] = None
     run_local: typing.Optional[bool] = None
-    override: typing.Optional[bool] = None
     image: typing.Optional[str] = None
 
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3190,7 +3190,7 @@ class HTTPRunDB(RunDBInterface):
             params["engine"] = engine
         response = self.api_call(
             "GET",
-            f"projects/{project}/workflows/{name}/references/{run_id}",
+            f"projects/{project}/workflows/{name}/runs/{run_id}",
             params=params,
         )
         return mlrun.common.schemas.GetWorkflowResponse(**response.json())

--- a/tests/api/api/test_workflows.py
+++ b/tests/api/api/test_workflows.py
@@ -64,14 +64,14 @@ def test_get_workflow_bad_id(db: Session, client: TestClient):
     }
     mlrun.api.crud.Runs().store_run(db, data, right_id, project=PROJECT_NAME)
     good_resp = client.get(
-        f"projects/{PROJECT_NAME}/workflows/{WORKFLOW_NAME}/references/{right_id}"
+        f"projects/{PROJECT_NAME}/workflows/{WORKFLOW_NAME}/runs/{right_id}"
     ).json()
 
     assert (
         good_resp.get("workflow_id", "") == expected_workflow_id
     ), f"response: {good_resp}"
     bad_resp = client.get(
-        f"projects/{PROJECT_NAME}/workflows/{WORKFLOW_NAME}/references/{wrong_id}"
+        f"projects/{PROJECT_NAME}/workflows/{WORKFLOW_NAME}/runs/{wrong_id}"
     )
     assert bad_resp.status_code == HTTPStatus.NOT_FOUND
 
@@ -88,7 +88,7 @@ def test_get_workflow_bad_project(db: Session, client: TestClient):
     }
     mlrun.api.crud.Runs().store_run(db, data, run_id, project=PROJECT_NAME)
     resp = client.get(
-        f"projects/{wrong_project_name}/workflows/{WORKFLOW_NAME}/references/{run_id}"
+        f"projects/{wrong_project_name}/workflows/{WORKFLOW_NAME}/runs/{run_id}"
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
     assert f"Run {run_id}:{wrong_project_name} not found" in resp.json()["detail"]


### PR DESCRIPTION
Fixes the following bugs:
1. `parse_reference` - parsed job's uid wrongly (length can be smaller than 40)
2. Using only `store_schedule` and removing deprecated `override` field in `WorkflowSpec`.
3. Passing `subpath` into `load_and_run`.