### PR TITLE
[Automation] Fix check for suppressed errors

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -235,7 +235,7 @@ class SystemTestPreparer:
                 )
             if exit_status != 0 and not suppress_errors:
                 for suppress_error_string in suppress_error_strings:
-                    if suppress_error_string in stderr:
+                    if suppress_error_string in str(stderr):
                         self._logger.log(
                             "warning",
                             "Suppressing error",


### PR DESCRIPTION
stderr is bytes
```
  File "/home/runner/work/mlrun/mlrun/automation/system_test/prepare.py", line 238, in _run_command
    if suppress_error_string in stderr:
TypeError: a bytes-like object is required, not 'str'
```