### PR TITLE
[API] Fix load-project return `RunObject` instead of `BackgroundTask`

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1137,37 +1137,35 @@ class TestProject(TestMLRunSystem):
         project.set_workflow("main", workflow_path)
 
     @pytest.mark.parametrize(
-        "name, save_secrets, expected_states",
+        "name, save_secrets",
         [
             (
                 "load-project-secrets",
                 True,
-                [
-                    mlrun.common.schemas.BackgroundTaskState.running,
-                    mlrun.common.schemas.BackgroundTaskState.succeeded,
-                ],
             ),
             (
                 "load-project-secrets-1",
                 False,
-                [mlrun.common.schemas.BackgroundTaskState.succeeded],
             ),
         ],
     )
     def test_load_project_remotely_with_secrets(
-        self, name, save_secrets, expected_states
+        self,
+        name,
+        save_secrets,
     ):
         self.custom_project_names_to_delete.append(name)
         db = self._run_db
-        bg_task = db.load_project(
+        state = db.load_project(
             name=name,
             url="git://github.com/mlrun/project-demo.git",
             secrets={"secret1": "1234"},
             save_secrets=save_secrets,
         )
-        assert bg_task.status.state in expected_states
+        assert state == "completed"
 
         secrets = db.list_project_secret_keys(name)
+
         if save_secrets:
             assert "secret1" in secrets.secret_keys
         else:
@@ -1176,12 +1174,12 @@ class TestProject(TestMLRunSystem):
     def test_load_project_remotely_with_secrets_failed(self):
         name = "failed-to-load"
         db = self._run_db
-        bg_task = db.load_project(
+        state = db.load_project(
             name=name,
             url="git://github.com/some/wrong/uri.git",
             secrets={"secret1": "1234"},
             save_secrets=False,
         )
-        assert bg_task.status.state == mlrun.common.schemas.BackgroundTaskState.failed
+        assert state == "error"
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
             db.get_project(name)


### PR DESCRIPTION
The use of `BackgroundTask` in this context was not fully useful since it does not keep in hand the return value and it is impossible to watch jobs in the server side.
In order to keep track of the job state, this endpoint returns now a `RunObject` that is now watched by `run.logs()` in the `httpdb.py`.