### PR TITLE
[API] Fix deprecation message for `files` and `filestat` APIs

### DIFF
--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -35,7 +35,7 @@ router = fastapi.APIRouter()
 @router.get(
     "/files",
     deprecated=True,
-    description="'files' and 'filestat' will be removed in 1.7.0, "
+    description="'/files' and '/filestat' will be removed in 1.7.0, "
     "use /projects/{project}/files instead.",
 )
 def get_files(
@@ -83,7 +83,7 @@ async def get_files_with_project_secrets(
 @router.get(
     "/filestat",
     deprecated=True,
-    description="'files' and 'filestat' will be removed in 1.7.0, "
+    description="'/files' and '/filestat' will be removed in 1.7.0, "
     "use /projects/{project}/filestat instead.",
 )
 def get_filestat(

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -35,7 +35,7 @@ router = fastapi.APIRouter()
 @router.get(
     "/files",
     deprecated=True,
-    description="'file' and 'filestat' will be removed in 1.7.0, "
+    description="'files' and 'filestat' will be removed in 1.7.0, "
     "use /projects/{project}/files instead",
 )
 def get_files(
@@ -83,7 +83,7 @@ async def get_files_with_project_secrets(
 @router.get(
     "/filestat",
     deprecated=True,
-    description="'file' and 'filestat' will be removed in 1.7.0, "
+    description="'files' and 'filestat' will be removed in 1.7.0, "
     "use /projects/{project}/filestat instead.",
 )
 def get_filestat(

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -35,8 +35,8 @@ router = fastapi.APIRouter()
 @router.get(
     "/files",
     deprecated=True,
-    description="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead"
-    "use /projects/{project}/runs/{uid} instead",
+    description="'file' and 'filestat' will be removed in 1.7.0, "
+    "use /projects/{project}/files instead",
 )
 def get_files(
     schema: str = "",
@@ -83,8 +83,8 @@ async def get_files_with_project_secrets(
 @router.get(
     "/filestat",
     deprecated=True,
-    description="'file' and 'filestat' will be removed in 1.7.0, you can use project's API instead"
-    "use /projects/{project}/runs/{uid} instead",
+    description="'file' and 'filestat' will be removed in 1.7.0, "
+    "use /projects/{project}/filestat instead.",
 )
 def get_filestat(
     schema: str = "",

--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -36,7 +36,7 @@ router = fastapi.APIRouter()
     "/files",
     deprecated=True,
     description="'files' and 'filestat' will be removed in 1.7.0, "
-    "use /projects/{project}/files instead",
+    "use /projects/{project}/files instead.",
 )
 def get_files(
     schema: str = "",


### PR DESCRIPTION
Fix deprecation message that was wrongly copy-pasted.