### PR TITLE
[Tests] Fix system tests

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -86,8 +86,8 @@ class TestMLRunSystem:
         self._run_db = get_run_db()
 
         if not self._skip_set_environment():
-            set_environment(project=self.project_name)
             self.project = mlrun.get_or_create_project(self.project_name, "./")
+            set_environment()
 
         self.custom_setup()
 


### PR DESCRIPTION
Deprecated parameter `project` was removed in #3971, causing system test setup to fail.