### PR TITLE
[Notifications] Use Run DB to store run notifications

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -75,7 +75,5 @@ forbidden_modules=
     mlrun.api
 
 ignore_imports =
-    mlrun.utils.notifications.notification_pusher -> mlrun.api.db.session
-    mlrun.utils.notifications.notification_pusher -> mlrun.api.db.base
     mlrun.runtimes.daskjob -> mlrun.api.utils.singletons.k8s
     mlrun.runtimes.utils -> mlrun.api.utils.singletons.k8s

--- a/mlrun/api/crud/notifications.py
+++ b/mlrun/api/crud/notifications.py
@@ -34,13 +34,18 @@ class Notifications(
         notification_objects: typing.List[mlrun.model.Notification],
         run_uid: str,
         project: str = None,
+        mask_params: bool = True,
     ):
         project = project or mlrun.mlconf.default_project
-        notification_objects_to_store = (
-            mlrun.api.api.utils.validate_and_mask_notification_list(
-                notification_objects, run_uid, project
+
+        # we don't mask the notification params when it's a status update as they are already masked
+        notification_objects_to_store = notification_objects
+        if mask_params:
+            notification_objects_to_store = (
+                mlrun.api.api.utils.validate_and_mask_notification_list(
+                    notification_objects, run_uid, project
+                )
             )
-        )
 
         mlrun.api.utils.singletons.db.get_db().store_run_notifications(
             session, notification_objects_to_store, run_uid, project

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -617,7 +617,7 @@ def _push_terminal_run_notifications(db: mlrun.api.db.base.DBInterface, db_sessi
     logger.debug(
         "Got terminal runs with configured notifications", runs_amount=len(runs)
     )
-    mlrun.utils.notifications.NotificationPusher(unmasked_runs).push(db)
+    mlrun.utils.notifications.NotificationPusher(unmasked_runs).push()
 
     _last_notification_push_time = now
 

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -676,6 +676,22 @@ class SQLRunDB(RunDBInterface):
             uid,
         )
 
+    def store_run_notifications(
+        self,
+        notification_objects: List[mlrun.model.Notification],
+        run_uid: str,
+        project: str = None,
+        mask_params: bool = True,
+    ):
+        return self._transform_db_error(
+            mlrun.api.crud.Notifications().store_run_notifications,
+            self.session,
+            notification_objects,
+            run_uid,
+            project,
+            mask_params,
+        )
+
     def list_pipelines(
         self,
         project: str,

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -622,5 +622,14 @@ class RunDBInterface(ABC):
     ):
         pass
 
+    def store_run_notifications(
+        self,
+        notification_objects: typing.List[mlrun.model.Notification],
+        run_uid: str,
+        project: str = None,
+        mask_params: bool = True,
+    ):
+        pass
+
     def watch_log(self, uid, project="", watch=True, offset=0):
         pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3100,6 +3100,20 @@ class HTTPRunDB(RunDBInterface):
             },
         )
 
+    def store_run_notifications(
+        self,
+        notification_objects: typing.List[mlrun.model.Notification],
+        run_uid: str,
+        project: str = None,
+        mask_params: bool = True,
+    ):
+        """
+        For internal use.
+        The notification mechanism may run "locally" for certain runtimes.
+        However, the updates occur in the API so nothing to do here.
+        """
+        pass
+
     def submit_workflow(
         self,
         project: str,


### PR DESCRIPTION
As part of the server-client separation.
I decided not to create a dedicated `update_run_notification` like we have `update_run` and `store_run` separately because:
1. it will essentially do the same thing as `store_run_notification`
2. I don't see a reason to list the notifications and validate they exist (as update logic suggests).

Instead I added the flag to disable masking the notification params.