### PR TITLE
[API] Pass auth info to launcher in submit job flow

### DIFF
--- a/mlrun/api/launcher.py
+++ b/mlrun/api/launcher.py
@@ -35,14 +35,13 @@ import mlrun.api.api.utils  # isort:skip
 class ServerSideLauncher(launcher.BaseLauncher):
     def __init__(
         self,
-        is_remote: bool,
         local: bool = False,
         auth_info: Optional[mlrun.common.schemas.AuthInfo] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        if not is_remote or local:
-            raise mlrun.errors.MLRunInternalServerError(
+        if local:
+            raise mlrun.errors.MLRunPreconditionFailedError(
                 "Launch of local run inside the server is not allowed"
             )
 

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -28,6 +28,7 @@ from apscheduler.triggers.cron import CronTrigger as APSchedulerCronTrigger
 from sqlalchemy.orm import Session
 
 import mlrun.api.api.utils
+import mlrun.api.crud
 import mlrun.api.utils.auth.verifier
 import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.helpers
@@ -461,8 +462,6 @@ class Scheduler:
         auth_info: mlrun.common.schemas.AuthInfo,
         kind: mlrun.common.schemas.ScheduleKinds,
     ):
-        import mlrun.api.crud
-
         if (
             kind not in mlrun.common.schemas.ScheduleKinds.local_kinds()
             and mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required()
@@ -496,9 +495,6 @@ class Scheduler:
         self,
         auth_info: mlrun.common.schemas.AuthInfo,
     ) -> str:
-        # import here to avoid circular imports
-        import mlrun.api.crud
-
         if mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required():
             # sanity
             if not auth_info.access_key:
@@ -527,9 +523,6 @@ class Scheduler:
         project: str,
         name: str,
     ):
-        # import here to avoid circular imports
-        import mlrun.api.crud
-
         if mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required():
             # sanity
             if not auth_info.access_key:
@@ -577,9 +570,6 @@ class Scheduler:
         project: str,
         name: str,
     ):
-        # import here to avoid circular imports
-        import mlrun.api.crud
-
         if mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required():
             access_key_secret_key = (
                 mlrun.api.crud.Secrets().generate_client_project_secret_key(
@@ -622,8 +612,6 @@ class Scheduler:
     def _get_schedule_secrets(
         self, project: str, name: str, include_username: bool = True
     ) -> typing.Tuple[typing.Optional[str], typing.Optional[str]]:
-        # import here to avoid circular imports
-        import mlrun.api.crud
 
         schedule_access_key_secret_key = (
             mlrun.api.crud.Secrets().generate_client_project_secret_key(
@@ -785,7 +773,6 @@ class Scheduler:
         *args,
         **kwargs,
     ):
-
         try:
             return self._scheduler.modify_job(
                 job_id,
@@ -806,9 +793,6 @@ class Scheduler:
         for db_schedule in db_schedules:
             # don't let one failure fail the rest
             try:
-                # import here to avoid circular imports
-                import mlrun.api.crud
-
                 access_key = None
                 username = None
                 need_to_update_credentials = False
@@ -1085,11 +1069,6 @@ class Scheduler:
         schedule_concurrency_limit,
         auth_info,
     ):
-
-        # import here to avoid circular imports
-        import mlrun.api.crud
-        from mlrun.api.api.utils import submit_run_sync
-
         db_session = None
 
         try:
@@ -1149,7 +1128,9 @@ class Scheduler:
                     schedule_name,
                 )
 
-            _, _, _, response = submit_run_sync(db_session, auth_info, scheduled_object)
+            _, _, _, response = mlrun.api.api.utils.submit_run_sync(
+                db_session, auth_info, scheduled_object
+            )
 
             run_metadata = response["data"]["metadata"]
             run_uri = RunObject.create_uri(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -32,7 +32,9 @@ import mlrun.api.crud
 import mlrun.api.utils.auth.verifier
 import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.helpers
+import mlrun.api.utils.singletons.project_member
 import mlrun.common.schemas
+import mlrun.common.schemas.constants
 import mlrun.errors
 from mlrun.api.db.session import close_session, create_session
 from mlrun.api.utils.singletons.db import get_db
@@ -1102,9 +1104,6 @@ class Scheduler:
                 not auth_info.access_key
                 and mlrun.api.utils.auth.verifier.AuthVerifier().is_jobs_auth_required()
             ):
-                # import here to avoid circular imports
-                import mlrun.api.utils.auth
-                import mlrun.api.utils.singletons.project_member
 
                 logger.info(
                     "Schedule missing auth info which is required. Trying to fill from project owner",

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -34,7 +34,6 @@ import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.helpers
 import mlrun.api.utils.singletons.project_member
 import mlrun.common.schemas
-import mlrun.common.schemas.constants
 import mlrun.errors
 from mlrun.api.db.session import close_session, create_session
 from mlrun.api.utils.singletons.db import get_db

--- a/mlrun/launcher/factory.py
+++ b/mlrun/launcher/factory.py
@@ -41,7 +41,7 @@ class LauncherFactory(
         :return:            The appropriate launcher for the specified run.
         """
         if mlrun.config.is_running_as_api():
-            return self._launcher_container.server_side_launcher(**kwargs)
+            return self._launcher_container.server_side_launcher(is_remote, **kwargs)
 
         local = kwargs.get("local", False)
         if is_remote and not local:

--- a/mlrun/launcher/factory.py
+++ b/mlrun/launcher/factory.py
@@ -41,7 +41,7 @@ class LauncherFactory(
         :return:            The appropriate launcher for the specified run.
         """
         if mlrun.config.is_running_as_api():
-            return self._launcher_container.server_side_launcher(is_remote, **kwargs)
+            return self._launcher_container.server_side_launcher(**kwargs)
 
         local = kwargs.get("local", False)
         if is_remote and not local:

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -242,7 +242,7 @@ def test_generate_function_and_task_from_submit_run_body_body_override_values(
         },
     }
     parsed_function_object, task = _generate_function_and_task_from_submit_run_body(
-        db, mlrun.common.schemas.AuthInfo(), submit_job_body
+        db, submit_job_body
     )
     assert parsed_function_object.metadata.name == function_name
     assert parsed_function_object.metadata.project == project
@@ -343,7 +343,7 @@ def test_generate_function_and_task_from_submit_run_with_preemptible_nodes_and_t
         ),
     )
     parsed_function_object, task = _generate_function_and_task_from_submit_run_body(
-        db, mlrun.common.schemas.AuthInfo(), submit_job_body
+        db, submit_job_body
     )
     assert (
         parsed_function_object.spec.preemption_mode
@@ -372,7 +372,7 @@ def test_generate_function_and_task_from_submit_run_with_preemptible_nodes_and_t
         "function": {"spec": {"preemption_mode": "constrain"}},
     }
     parsed_function_object, task = _generate_function_and_task_from_submit_run_body(
-        db, mlrun.common.schemas.AuthInfo(), submit_job_body
+        db, submit_job_body
     )
     expected_affinity = kubernetes.client.V1Affinity(
         node_affinity=kubernetes.client.V1NodeAffinity(
@@ -407,7 +407,7 @@ def test_generate_function_and_task_from_submit_run_body_keep_resources(
         "function": {"spec": {"resources": {"limits": {}, "requests": {}}}},
     }
     parsed_function_object, task = _generate_function_and_task_from_submit_run_body(
-        db, mlrun.common.schemas.AuthInfo(), submit_job_body
+        db, submit_job_body
     )
     assert parsed_function_object.metadata.name == function_name
     assert parsed_function_object.metadata.project == PROJECT
@@ -448,7 +448,7 @@ def test_generate_function_and_task_from_submit_run_body_keep_credentials(
         "function": {"metadata": {"credentials": None}},
     }
     parsed_function_object, task = _generate_function_and_task_from_submit_run_body(
-        db, mlrun.common.schemas.AuthInfo(), submit_job_body
+        db, submit_job_body
     )
     assert parsed_function_object.metadata.name == function_name
     assert parsed_function_object.metadata.project == project
@@ -1187,7 +1187,7 @@ def test_generate_function_and_task_from_submit_run_body_imported_function_proje
         "function": {"spec": {"resources": {"limits": {}, "requests": {}}}},
     }
     parsed_function_object, task = _generate_function_and_task_from_submit_run_body(
-        db, mlrun.common.schemas.AuthInfo(), submit_job_body
+        db, submit_job_body
     )
     assert parsed_function_object.metadata.project == PROJECT
 

--- a/tests/api/test_launcher.py
+++ b/tests/api/test_launcher.py
@@ -29,10 +29,10 @@ import mlrun.launcher.factory
     "is_remote, local, expectation",
     [
         (True, False, does_not_raise()),
-        (False, False, does_not_raise()),
+        (False, False, pytest.raises(mlrun.errors.MLRunPreconditionFailedError)),
         # local run is not allowed when running as API
-        (True, True, pytest.raises(mlrun.errors.MLRunInternalServerError)),
-        (False, True, pytest.raises(mlrun.errors.MLRunInternalServerError)),
+        (True, True, pytest.raises(mlrun.errors.MLRunPreconditionFailedError)),
+        (False, True, pytest.raises(mlrun.errors.MLRunPreconditionFailedError)),
     ],
 )
 def test_create_server_side_launcher(is_remote, local, expectation):

--- a/tests/api/test_launcher.py
+++ b/tests/api/test_launcher.py
@@ -29,7 +29,7 @@ import mlrun.launcher.factory
     "is_remote, local, expectation",
     [
         (True, False, does_not_raise()),
-        (False, False, pytest.raises(mlrun.errors.MLRunPreconditionFailedError)),
+        (False, False, does_not_raise()),
         # local run is not allowed when running as API
         (True, True, pytest.raises(mlrun.errors.MLRunPreconditionFailedError)),
         (False, True, pytest.raises(mlrun.errors.MLRunPreconditionFailedError)),


### PR DESCRIPTION
When the server side launcher receives the auth info it will enrich and validate the runtime with `mlrun.api.api.utils.apply_enrichment_and_validation_on_function`
This will enable using the auth info in https://github.com/mlrun/mlrun/pull/4008
Note that for schedules which also use the submit job endpoint, the auth info is stores in the `submit_run_wrapper` closure and then passed again to the submit job flow to trigger the run.