### PR TITLE
[Scheduler] Store schedule improvements

### DIFF
--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -115,10 +115,10 @@ class WorkflowRunners(
             auth_info=auth_info,
             project=project.metadata.name,
             name=workflow_spec.name,
+            kind=mlrun.common.schemas.ScheduleKinds.job,
             scheduled_object=scheduled_object,
             cron_trigger=schedule,
             labels=runner.metadata.labels,
-            kind=mlrun.common.schemas.ScheduleKinds.job,
         )
 
     def _prepare_run_object_for_scheduling(

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -358,7 +358,7 @@ class Scheduler:
             concurrency_limit=concurrency_limit,
         )
 
-        # we differentiate between update and create because it changes our communication with the apscheduler
+        # we differentiate between update and create because it changes our communication with the scheduler
         if is_update:
             updated_schedule = self._transform_and_enrich_db_schedule(
                 db_session, db_schedule

--- a/mlrun/api/utils/scheduler.py
+++ b/mlrun/api/utils/scheduler.py
@@ -386,6 +386,7 @@ class Scheduler:
             )
 
         self.update_schedule_next_run_time(db_session, name, project, job)
+        return is_update
 
     def _remove_schedule_scheduler_resources(self, db_session: Session, project, name):
         self._remove_schedule_from_scheduler(project, name)

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -1557,12 +1557,12 @@ def _assert_schedule_secrets(
 
 def _assert_schedule(
     schedule: mlrun.common.schemas.ScheduleOutput,
-    project,
-    name,
-    kind,
-    cron_trigger,
-    next_run_time,
-    labels,
+    project: str,
+    name: str,
+    kind: mlrun.common.schemas.ScheduleKinds,
+    cron_trigger: typing.Union[str, mlrun.common.schemas.ScheduleCronTrigger],
+    next_run_time: typing.Optional[datetime] = None,
+    labels: dict = None,
     concurrency_limit: int = None,
 ):
     assert schedule.name == name

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -123,7 +123,11 @@ async def test_not_skipping_delayed_schedules(db: Session, scheduler: Scheduler)
 
 
 @pytest.mark.asyncio
-async def test_create_schedule(db: Session, scheduler: Scheduler):
+@pytest.mark.parametrize(
+    "store",
+    [False, True],
+)
+async def test_create_schedule(db: Session, scheduler: Scheduler, store: bool):
     global call_counter
     call_counter = 0
 
@@ -137,15 +141,27 @@ async def test_create_schedule(db: Session, scheduler: Scheduler):
     )
     schedule_name = "schedule-name"
     project = config.default_project
-    scheduler.create_schedule(
-        db,
-        mlrun.common.schemas.AuthInfo(),
-        project,
-        schedule_name,
-        mlrun.common.schemas.ScheduleKinds.local_function,
-        bump_counter,
-        cron_trigger,
-    )
+    if store:
+        scheduler.store_schedule(
+            db_session=db,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            project=project,
+            name=schedule_name,
+            kind=mlrun.common.schemas.ScheduleKinds.local_function,
+            scheduled_object=bump_counter,
+            cron_trigger=cron_trigger,
+        )
+
+    else:
+        scheduler.create_schedule(
+            db_session=db,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            project=project,
+            name=schedule_name,
+            kind=mlrun.common.schemas.ScheduleKinds.local_function,
+            scheduled_object=bump_counter,
+            cron_trigger=cron_trigger,
+        )
 
     # The trigger is defined with `second="*/1"` meaning it runs on round seconds,
     # but executing the actual functional code - bumping the counter - happens a few microseconds afterwards.
@@ -505,6 +521,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
         cron_trigger,
         None,
         labels_1,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     labels_2 = {
@@ -534,6 +551,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
         cron_trigger_2,
         year_datetime,
         labels_2,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     schedules = scheduler.list_schedules(db)
@@ -546,6 +564,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
         cron_trigger,
         None,
         labels_1,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
     _assert_schedule(
         schedules.schedules[1],
@@ -555,6 +574,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
         cron_trigger_2,
         year_datetime,
         labels_2,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     schedules = scheduler.list_schedules(db, labels="label3=value3")
@@ -567,6 +587,7 @@ async def test_get_schedule(db: Session, scheduler: Scheduler):
         cron_trigger_2,
         year_datetime,
         labels_2,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
 
@@ -1059,6 +1080,7 @@ async def test_update_schedule(
         inactive_cron_trigger,
         None,
         labels_1,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     # update labels
@@ -1079,6 +1101,7 @@ async def test_update_schedule(
         inactive_cron_trigger,
         None,
         labels_2,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     # update nothing
@@ -1098,6 +1121,7 @@ async def test_update_schedule(
         inactive_cron_trigger,
         None,
         labels_2,
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     # update labels to empty dict
@@ -1118,6 +1142,7 @@ async def test_update_schedule(
         inactive_cron_trigger,
         None,
         {},
+        config.httpdb.scheduling.default_concurrency_limit,
     )
 
     # update it so it runs
@@ -1158,6 +1183,7 @@ async def test_update_schedule(
         cron_trigger,
         next_run_time,
         {},
+        config.httpdb.scheduling.default_concurrency_limit,
     )
     time_to_sleep = (
         end_date - datetime.now()
@@ -1377,6 +1403,74 @@ async def test_schedule_job_next_run_time(
     assert len(runs) == 2
 
 
+@pytest.mark.asyncio
+def test_store_schedule(db: Session, scheduler: Scheduler):
+    labels_1 = {
+        "label1": "value1",
+        "label2": "value2",
+    }
+    inactive_cron_trigger_1 = mlrun.common.schemas.ScheduleCronTrigger(year="1999")
+    schedule_name = "store-schedule-test"
+    project_name = config.default_project
+
+    scheduled_object = _create_mlrun_function_and_matching_scheduled_object(
+        db, project_name
+    )
+    runs = get_db().list_runs(db, project=project_name)
+    assert len(runs) == 0
+    scheduler.store_schedule(
+        db,
+        mlrun.common.schemas.AuthInfo(),
+        project_name,
+        schedule_name,
+        mlrun.common.schemas.ScheduleKinds.job,
+        scheduled_object,
+        inactive_cron_trigger_1,
+        labels=labels_1,
+    )
+
+    schedule = scheduler.get_schedule(db, project_name, schedule_name)
+    _assert_schedule(
+        schedule,
+        project_name,
+        schedule_name,
+        mlrun.common.schemas.ScheduleKinds.job,
+        inactive_cron_trigger_1,
+        None,
+        labels_1,
+        config.httpdb.scheduling.default_concurrency_limit,
+    )
+
+    # update labels, concurrency limit and cron trigger
+    labels_2 = {
+        "label3": "value3",
+        "label4": "value4",
+    }
+    concurrency_limit = 10
+    inactive_cron_trigger_2 = mlrun.common.schemas.ScheduleCronTrigger(year="2000")
+    scheduler.store_schedule(
+        db,
+        mlrun.common.schemas.AuthInfo(),
+        project=project_name,
+        name=schedule_name,
+        cron_trigger=inactive_cron_trigger_2,
+        labels=labels_2,
+        concurrency_limit=concurrency_limit,
+    )
+    schedule = scheduler.get_schedule(db, project_name, schedule_name)
+
+    _assert_schedule(
+        schedule,
+        project_name,
+        schedule_name,
+        mlrun.common.schemas.ScheduleKinds.job,
+        inactive_cron_trigger_2,
+        None,
+        labels_2,
+        concurrency_limit,
+    )
+
+
 def _assert_schedule_get_and_list_credentials_enrichment(
     db: Session,
     scheduler: Scheduler,
@@ -1469,6 +1563,7 @@ def _assert_schedule(
     cron_trigger,
     next_run_time,
     labels,
+    concurrency_limit: int = None,
 ):
     assert schedule.name == name
     assert schedule.project == project
@@ -1477,6 +1572,7 @@ def _assert_schedule(
     assert schedule.cron_trigger == cron_trigger
     assert schedule.creation_time is not None
     assert DeepDiff(schedule.labels, labels, ignore_order=True) == {}
+    assert schedule.concurrency_limit == concurrency_limit
 
 
 def _create_do_nothing_schedule(


### PR DESCRIPTION
This PR adds the following fixes/improvements:
1. Use store schedule flow in submit job instead of update or create if not found.
2. Enriches with default concurrency limit if not specified (single point `_create_schedule_db_record`) 
3. Fixes type hints, `Schedule` is the model to commit to the db, `ScheduleRecord` is the schema returned from the db layer.
4. Adds store schedule unit tests