### PR TITLE
[Automation] Remove tty flag from delete db command

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -629,7 +629,7 @@ class SystemTestPreparer:
                 "exec",
                 "-n",
                 self.Constants.namespace,
-                "-it",
+                "-i",
                 mlrun_db_pod_name_cmd,
                 "--",
                 drop_db_cmd,


### PR DESCRIPTION
We are getting connection reset errors quite often recently:
```
2023-07-29 16:18:03,995 - automation - INFO - Deleting mlrun db pod: {'mlrun_db_pod_name_cmd': 'mlrun-db-74b8db68c6-4qj5p'}
Socket exception: Connection reset by peer (104)
2023-07-29 16:22:45,852 - automation - ERROR - Failed running command on data cluster: {'error': 'Command failed with exit status: -1', 'stdout': '', 'stderr': b'Defaulted container "mlrun-db" out of: mlrun-db, init-mysql (init)\nUnable to use a TTY - input is not a terminal or the right kind of file\n', 'exit_status': -1}
```
Hopefully this will fix it because clearly it's a script and is not interactive