### PR TITLE
[MPI] Use dependency injection to resolve the crd version

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -15,8 +15,8 @@
 import mlrun.api.utils.runtimes.nuclio
 import mlrun.common.schemas
 import mlrun.utils.singleton
+from mlrun.api.runtime_handlers.mpijob import resolve_mpijob_crd_version
 from mlrun.config import Config, config, default_config
-from mlrun.runtimes.utils import resolve_mpijob_crd_version
 
 
 class ClientSpec(

--- a/mlrun/api/runtime_handlers/__init__.py
+++ b/mlrun/api/runtime_handlers/__init__.py
@@ -16,12 +16,12 @@ from mlrun.api.runtime_handlers.base import BaseRuntimeHandler
 from mlrun.api.runtime_handlers.daskjob import DaskRuntimeHandler
 from mlrun.api.runtime_handlers.kubejob import KubeRuntimeHandler
 from mlrun.api.runtime_handlers.mpijob import (
-    MpiV1Alpha1RuntimeHandler,
-    MpiV1RuntimeHandler,
+    MpiRuntimeHandlerContainer,
+    resolve_mpijob_crd_version,
 )
 from mlrun.api.runtime_handlers.remotesparkjob import RemoteSparkRuntimeHandler
 from mlrun.api.runtime_handlers.sparkjob import SparkRuntimeHandler
-from mlrun.runtimes import MPIJobCRDVersions, RuntimeKinds, resolve_mpijob_crd_version
+from mlrun.runtimes import RuntimeKinds
 
 runtime_handler_instances_cache = {}
 
@@ -29,13 +29,8 @@ runtime_handler_instances_cache = {}
 def get_runtime_handler(kind: str) -> BaseRuntimeHandler:
     global runtime_handler_instances_cache
     if kind == RuntimeKinds.mpijob:
-        # TODO: split resolve_mpijob_crd_version to client and server side
         mpijob_crd_version = resolve_mpijob_crd_version()
-        crd_version_to_runtime_handler_class = {
-            MPIJobCRDVersions.v1alpha1: MpiV1Alpha1RuntimeHandler,
-            MPIJobCRDVersions.v1: MpiV1RuntimeHandler,
-        }
-        runtime_handler_class = crd_version_to_runtime_handler_class[mpijob_crd_version]
+        runtime_handler_class = MpiRuntimeHandlerContainer.handler_selector()
         if not runtime_handler_instances_cache.setdefault(RuntimeKinds.mpijob, {}).get(
             mpijob_crd_version
         ):

--- a/mlrun/api/runtime_handlers/mpijob.py
+++ b/mlrun/api/runtime_handlers/mpijob.py
@@ -15,12 +15,16 @@
 import typing
 from datetime import datetime
 
+from dependency_injector import containers, providers
 from sqlalchemy.orm import Session
 
+import mlrun.api.utils.singletons.k8s
+import mlrun.k8s_utils
 from mlrun.api.db.base import DBInterface
 from mlrun.api.runtime_handlers import BaseRuntimeHandler
+from mlrun.config import config
 from mlrun.runtimes.base import RuntimeClassMode
-from mlrun.runtimes.constants import MPIJobV1Alpha1States, RunStates
+from mlrun.runtimes.constants import MPIJobCRDVersions, MPIJobV1Alpha1States, RunStates
 from mlrun.runtimes.mpijob import MpiRuntimeV1, MpiRuntimeV1Alpha1
 
 
@@ -145,3 +149,63 @@ class MpiV1RuntimeHandler(BaseRuntimeHandler):
             MpiRuntimeV1.crd_version,
             MpiRuntimeV1.crd_plural,
         )
+
+
+cached_mpijob_crd_version = None
+
+
+# resolve mpijob runtime according to the mpi-operator's supported crd-version
+# if specified on mlrun config set it likewise,
+# if not specified, try resolving it according to the mpi-operator, otherwise set to default
+# since this is a heavy operation (sending requests to k8s/API), and it's unlikely that the crd version
+# will change in any context - cache it
+def resolve_mpijob_crd_version():
+    global cached_mpijob_crd_version
+    if not cached_mpijob_crd_version:
+
+        # config override everything
+        mpijob_crd_version = config.mpijob_crd_version
+
+        if not mpijob_crd_version:
+            in_k8s_cluster = mlrun.k8s_utils.is_running_inside_kubernetes_cluster()
+
+            if in_k8s_cluster:
+                k8s_helper = mlrun.api.utils.singletons.k8s.get_k8s_helper()
+                namespace = k8s_helper.resolve_namespace()
+
+                # try resolving according to mpi-operator that's running
+                res = k8s_helper.list_pods(
+                    namespace=namespace, selector="component=mpi-operator"
+                )
+                if len(res) > 0:
+                    mpi_operator_pod = res[0]
+                    mpijob_crd_version = mpi_operator_pod.metadata.labels.get(
+                        "crd-version"
+                    )
+
+            # backoff to use default if wasn't resolved in API
+            if not mpijob_crd_version:
+                mpijob_crd_version = MPIJobCRDVersions.default()
+
+        if mpijob_crd_version not in MPIJobCRDVersions.all():
+            raise ValueError(
+                f"Unsupported mpijob crd version: {mpijob_crd_version}. "
+                f"Supported versions: {MPIJobCRDVersions.all()}"
+            )
+        cached_mpijob_crd_version = mpijob_crd_version
+
+    return cached_mpijob_crd_version
+
+
+# overrides the way we resolve the mpijob crd version by querying the k8s API
+@containers.override(mlrun.runtimes.mpijob.MpiRuntimeContainer)
+class MpiRuntimeHandlerContainer(containers.DeclarativeContainer):
+    resolver = providers.Callable(
+        resolve_mpijob_crd_version,
+    )
+
+    handler_selector = providers.Selector(
+        resolver,
+        v1=providers.Object(MpiV1RuntimeHandler),
+        v1alpha1=providers.Object(MpiV1Alpha1RuntimeHandler),
+    )

--- a/mlrun/api/runtime_handlers/mpijob.py
+++ b/mlrun/api/runtime_handlers/mpijob.py
@@ -183,9 +183,7 @@ def _resolve_mpijob_crd_version_best_effort():
     if config.mpijob_crd_version:
         return config.mpijob_crd_version
 
-    in_k8s_cluster = mlrun.k8s_utils.is_running_inside_kubernetes_cluster()
-
-    if not in_k8s_cluster:
+    if not mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
         return None
 
     k8s_helper = mlrun.api.utils.singletons.k8s.get_k8s_helper()

--- a/mlrun/api/runtime_handlers/mpijob.py
+++ b/mlrun/api/runtime_handlers/mpijob.py
@@ -154,12 +154,15 @@ class MpiV1RuntimeHandler(BaseRuntimeHandler):
 cached_mpijob_crd_version = None
 
 
-# resolve mpijob runtime according to the mpi-operator's supported crd-version
-# if specified on mlrun config set it likewise,
-# if not specified, try resolving it according to the mpi-operator, otherwise set to default
-# since this is a heavy operation (sending requests to k8s/API), and it's unlikely that the crd version
-# will change in any context - cache it
 def resolve_mpijob_crd_version():
+    """
+    Resolve mpijob runtime according to the mpi-operator's supported crd-version.
+    If specified on mlrun config set it likewise.
+    If not specified, try resolving it according to the mpi-operator, otherwise set to default.
+    Since this is a heavy operation (sending requests to k8s/API), and it's unlikely that the crd version
+    will change in any context - cache it.
+    :return: mpi operator's crd-version
+    """
     global cached_mpijob_crd_version
     if not cached_mpijob_crd_version:
         # try to resolve the crd version with K8s API

--- a/mlrun/api/utils/singletons/k8s.py
+++ b/mlrun/api/utils/singletons/k8s.py
@@ -19,10 +19,12 @@ import typing
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
+import mlrun.api.runtime_handlers.mpijob
 import mlrun.common.schemas
 import mlrun.config as mlconfig
 import mlrun.errors
 import mlrun.platforms.iguazio
+import mlrun.runtimes
 from mlrun.utils import logger
 
 _k8s = None
@@ -219,14 +221,10 @@ class K8sHelper:
         return resp
 
     def get_logger_pods(self, project, uid, run_kind, namespace=""):
-
-        # As this file is imported in mlrun.runtimes, we sadly cannot have this import in the top level imports
-        # as that will create an import loop.
-        # TODO: Fix the import loops already!
-        import mlrun.runtimes
-
         namespace = self.resolve_namespace(namespace)
-        mpijob_crd_version = mlrun.runtimes.utils.resolve_mpijob_crd_version()
+        mpijob_crd_version = (
+            mlrun.api.runtime_handlers.mpijob.resolve_mpijob_crd_version()
+        )
         mpijob_role_label = (
             mlrun.runtimes.constants.MPIJobCRDVersions.role_label_by_version(
                 mpijob_crd_version

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -25,10 +25,7 @@ __all__ = [
     "RemoteSparkRuntime",
 ]
 
-from mlrun.runtimes.utils import (
-    resolve_mpijob_crd_version,
-    resolve_spark_operator_version,
-)
+from mlrun.runtimes.utils import resolve_spark_operator_version
 
 from .base import BaseRuntime, RunError, RuntimeClassMode  # noqa
 from .constants import MPIJobCRDVersions
@@ -36,7 +33,7 @@ from .daskjob import DaskCluster, get_dask_resource  # noqa
 from .function import RemoteRuntime
 from .kubejob import KubejobRuntime  # noqa
 from .local import HandlerRuntime, LocalRuntime  # noqa
-from .mpijob import MpiRuntimeV1, MpiRuntimeV1Alpha1  # noqa
+from .mpijob import MpiRuntimeContainer, MpiRuntimeV1, MpiRuntimeV1Alpha1  # noqa
 from .nuclio import nuclio_init_hook
 from .remotesparkjob import RemoteSparkRuntime
 from .serving import ServingRuntime, new_v2_model_server
@@ -194,7 +191,7 @@ class RuntimeKinds(object):
     @staticmethod
     def requires_absolute_artifacts_path(kind):
         """
-        Returns True if the runtime kind requires absolute artifacts' path (e.i. is local), False otherwise.
+        Returns True if the runtime kind requires absolute artifacts' path (i.e. is local), False otherwise.
         """
         if RuntimeKinds.is_local_runtime(kind):
             return False
@@ -214,12 +211,7 @@ runtime_resources_map = {RuntimeKinds.dask: get_dask_resource()}
 
 def get_runtime_class(kind: str):
     if kind == RuntimeKinds.mpijob:
-        mpijob_crd_version = resolve_mpijob_crd_version()
-        crd_version_to_runtime = {
-            MPIJobCRDVersions.v1alpha1: MpiRuntimeV1Alpha1,
-            MPIJobCRDVersions.v1: MpiRuntimeV1,
-        }
-        return crd_version_to_runtime[mpijob_crd_version]
+        return MpiRuntimeContainer.selector()
 
     if kind == RuntimeKinds.spark:
         return Spark3Runtime

--- a/mlrun/runtimes/mpijob/__init__.py
+++ b/mlrun/runtimes/mpijob/__init__.py
@@ -14,5 +14,34 @@
 
 # flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
+from dependency_injector import containers, providers
+
+from mlrun.config import config
+
+from .. import MPIJobCRDVersions
 from .v1 import MpiRuntimeV1
 from .v1alpha1 import MpiRuntimeV1Alpha1
+
+
+def _resolve_mpijob_crd_version():
+    # config is expected to get enriched from the API through the client-spec
+    return config.mpijob_crd_version or MPIJobCRDVersions.default()
+
+
+class MpiRuntimeContainer(containers.DeclarativeContainer):
+    resolver = providers.Callable(
+        _resolve_mpijob_crd_version,
+    )
+
+    selector = providers.Selector(
+        resolver,
+        v1=providers.Object(MpiRuntimeV1),
+        v1alpha1=providers.Object(MpiRuntimeV1Alpha1),
+    )
+
+    # An empty selector to be overriden by the API
+    handler_selector = providers.Selector(
+        resolver,
+        v1=providers.Object(None),
+        v1alpha1=providers.Object(None),
+    )

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -29,11 +29,9 @@ import mlrun.common.schemas
 import mlrun.utils.regex
 from mlrun.errors import err_to_str
 from mlrun.frameworks.parallel_coordinates import gen_pcp_plot
-from mlrun.runtimes.constants import MPIJobCRDVersions
 
 from ..artifacts import TableArtifact
 from ..config import config, is_running_as_api
-from ..k8s_utils import is_running_inside_kubernetes_cluster
 from ..utils import get_in, helpers, logger, verify_field_regex
 from .generators import selector
 
@@ -57,55 +55,6 @@ class _ContextStore:
 
 
 global_context = _ContextStore()
-
-
-cached_mpijob_crd_version = None
-
-
-# resolve mpijob runtime according to the mpi-operator's supported crd-version
-# if specified on mlrun config set it likewise,
-# if not specified, try resolving it according to the mpi-operator, otherwise set to default
-# since this is a heavy operation (sending requests to k8s/API), and it's unlikely that the crd version
-# will change in any context - cache it
-def resolve_mpijob_crd_version():
-    global cached_mpijob_crd_version
-    if not cached_mpijob_crd_version:
-
-        # config override everything
-        # on client side, expecting it to get enriched from the API through the client-spec
-        mpijob_crd_version = config.mpijob_crd_version
-
-        if not mpijob_crd_version:
-            in_k8s_cluster = is_running_inside_kubernetes_cluster()
-
-            if in_k8s_cluster and is_running_as_api():
-                import mlrun.api.utils.singletons.k8s
-
-                k8s_helper = mlrun.api.utils.singletons.k8s.get_k8s_helper()
-                namespace = k8s_helper.resolve_namespace()
-
-                # try resolving according to mpi-operator that's running
-                res = k8s_helper.list_pods(
-                    namespace=namespace, selector="component=mpi-operator"
-                )
-                if len(res) > 0:
-                    mpi_operator_pod = res[0]
-                    mpijob_crd_version = mpi_operator_pod.metadata.labels.get(
-                        "crd-version"
-                    )
-
-            # backoff to use default if wasn't resolved in API
-            if not mpijob_crd_version:
-                mpijob_crd_version = MPIJobCRDVersions.default()
-
-        if mpijob_crd_version not in MPIJobCRDVersions.all():
-            raise ValueError(
-                f"unsupported mpijob crd version: {mpijob_crd_version}. "
-                f"supported versions: {MPIJobCRDVersions.all()}"
-            )
-        cached_mpijob_crd_version = mpijob_crd_version
-
-    return cached_mpijob_crd_version
 
 
 def resolve_spark_operator_version():

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -53,6 +53,7 @@ def api_config_test():
     mlrun.api.utils.singletons.logs_dir.logs_dir = None
 
     mlrun.api.utils.runtimes.nuclio.cached_nuclio_version = None
+    mlrun.runtimes.utils.cached_mpijob_crd_version = None
 
     mlrun.config._is_running_as_api = True
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -25,6 +25,7 @@ from fastapi.testclient import TestClient
 
 import mlrun.api.launcher
 import mlrun.api.rundb.sqldb
+import mlrun.api.runtime_handlers.mpijob
 import mlrun.api.utils.clients.iguazio
 import mlrun.api.utils.runtimes.nuclio
 import mlrun.api.utils.singletons.db
@@ -53,7 +54,7 @@ def api_config_test():
     mlrun.api.utils.singletons.logs_dir.logs_dir = None
 
     mlrun.api.utils.runtimes.nuclio.cached_nuclio_version = None
-    mlrun.runtimes.utils.cached_mpijob_crd_version = None
+    mlrun.api.runtime_handlers.mpijob.cached_mpijob_crd_version = None
 
     mlrun.config._is_running_as_api = True
 

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -16,6 +16,7 @@ import unittest.mock
 
 import pytest
 
+import mlrun.api.runtime_handlers.mpijob
 import mlrun.api.utils.singletons.k8s
 import mlrun.runtimes
 
@@ -33,7 +34,7 @@ def test_get_logger_pods_label_selector(
     monkeypatch, run_type, mpi_version, extra_selector
 ):
     monkeypatch.setattr(
-        mlrun.runtimes.utils,
+        mlrun.api.runtime_handlers.mpijob,
         "cached_mpijob_crd_version",
         mpi_version or mlrun.runtimes.constants.MPIJobCRDVersions.default(),
     )

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -86,7 +86,6 @@ def config_test_base():
     mlrun.utils.singleton.Singleton._instances = {}
 
     mlrun.runtimes.runtime_handler_instances_cache = {}
-    mlrun.runtimes.utils.cached_mpijob_crd_version = None
 
     # TODO: update this to "sidecar" once the default mode is changed
     mlrun.config.config.log_collector.mode = "legacy"


### PR DESCRIPTION
Part of client-server separation - moved the code that resolves the crd version via k8s query to the API and added a dependency injector container that allows us to override the way we resolve the version.
On the client side it will be enriched by the client-spec endpoint.