### PR TITLE
[Dask] Move resource methods to API

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -75,5 +75,4 @@ forbidden_modules=
     mlrun.api
 
 ignore_imports =
-    mlrun.runtimes.daskjob -> mlrun.api.utils.singletons.k8s
     mlrun.runtimes.utils -> mlrun.api.utils.singletons.k8s

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -870,13 +870,13 @@ def _start_function(
 
 
 async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
-    logger.info(f"function_status:\n{data}")
+    logger.info(f"Getting function status:\n{data}")
     selector = data.get("selector")
     kind = data.get("kind")
     if not selector or not kind:
         log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
-            reason="runtime error: selector or runtime kind not specified",
+            reason="Runtime error: selector or runtime kind not specified",
         )
     project, name = data.get("project"), data.get("name")
 
@@ -889,11 +889,12 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
     )
 
     try:
-        resp = mlrun.api.crud.Functions().get_function_status(
+        status = mlrun.api.crud.Functions().get_function_status(
             kind,
             selector,
         )
-        logger.info("Status: %s", resp)
+        logger.info("Got function status", status=status)
+        return status
 
     except mlrun.errors.MLRunBadRequestError:
         raise

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -57,7 +57,7 @@ from mlrun.config import config
 from mlrun.errors import MLRunRuntimeError, err_to_str
 from mlrun.model_monitoring.tracking_policy import TrackingPolicy
 from mlrun.run import new_function
-from mlrun.runtimes import RuntimeKinds, ServingRuntime, runtime_resources_map
+from mlrun.runtimes import RuntimeKinds, ServingRuntime
 from mlrun.runtimes.utils import get_item_name
 from mlrun.utils import get_in, logger, update_in
 
@@ -843,12 +843,6 @@ def _start_function(
 ):
     db_session = mlrun.api.db.session.create_session()
     try:
-        resource = runtime_resources_map.get(function.kind)
-        if "start" not in resource:
-            log_and_raise(
-                HTTPStatus.BAD_REQUEST.value,
-                reason="runtime error: 'start' not supported by this runtime",
-            )
         try:
             run_db = get_run_db_instance(db_session)
             function.set_db_connection(run_db)
@@ -857,19 +851,19 @@ def _start_function(
                 auth_info,
             )
 
-            #  resp = resource["start"](fn)  # TODO: handle resp?
-            resource["start"](
-                function,
-                client_version=client_version,
-                client_python_version=client_python_version,
+            mlrun.api.crud.Functions().start_function(
+                function, client_version, client_python_version
             )
-            function.save(versioned=False)
             logger.info("Fn:\n %s", function.to_yaml())
+
+        except mlrun.errors.MLRunBadRequestError:
+            raise
+
         except Exception as err:
             logger.error(traceback.format_exc())
             log_and_raise(
                 HTTPStatus.BAD_REQUEST.value,
-                reason=f"runtime error: {err_to_str(err)}",
+                reason=f"Runtime error: {err_to_str(err)}",
             )
     finally:
         mlrun.api.db.session.close_session(db_session)
@@ -885,10 +879,6 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
             reason="runtime error: selector or runtime kind not specified",
         )
     project, name = data.get("project"), data.get("name")
-    # Only after 0.6.6 the client start sending the project and name, as long as 0.6.6 is a valid version we'll need
-    # to try and resolve them from the selector. TODO: remove this when 0.6.6 is not relevant anymore
-    if not project or not name:
-        project, name, _ = mlrun.runtimes.utils.parse_function_selector(selector)
 
     await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.function,
@@ -898,21 +888,21 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
         auth_info,
     )
 
-    resource = runtime_resources_map.get(kind)
-    if "status" not in resource:
-        log_and_raise(
-            HTTPStatus.BAD_REQUEST.value,
-            reason="runtime error: 'status' not supported by this runtime",
-        )
-
     try:
-        resp = resource["status"](selector)
-        logger.info("status: %s", resp)
+        resp = mlrun.api.crud.Functions().get_function_status(
+            kind,
+            selector,
+        )
+        logger.info("Status: %s", resp)
+
+    except mlrun.errors.MLRunBadRequestError:
+        raise
+
     except Exception as err:
         logger.error(traceback.format_exc())
         log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
-            reason=f"runtime error: {err_to_str(err)}",
+            reason=f"Runtime error: {err_to_str(err)}",
         )
 
 

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -692,6 +692,34 @@ class SQLRunDB(RunDBInterface):
             mask_params,
         )
 
+    def function_status(self, project, name, kind, selector):
+        """Retrieve status of a function being executed remotely (relevant to ``dask`` functions).
+
+        :param project:     The project of the function, not needed here.
+        :param name:        The name of the function, not needed here.
+        :param kind:        The kind of the function, currently ``dask`` is supported.
+        :param selector:    Selector clause to be applied to the Kubernetes status query to filter the results.
+        """
+        return self._transform_db_error(
+            mlrun.api.crud.Functions().get_function_status,
+            kind,
+            selector,
+        )
+
+    def start_function(
+        self, func_url: str = None, function: "mlrun.runtimes.BaseRuntime" = None
+    ):
+        """Execute a function remotely, Used for ``dask`` functions.
+
+        :param func_url: URL to the function to be executed.
+        :param function: The function object to start.
+        :returns: A BackgroundTask object, with details on execution process and its status.
+        """
+        return self._transform_db_error(
+            mlrun.api.crud.Functions().start_function,
+            function,
+        )
+
     def list_pipelines(
         self,
         project: str,

--- a/mlrun/api/runtime_handlers/__init__.py
+++ b/mlrun/api/runtime_handlers/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 from mlrun.api.runtime_handlers.base import BaseRuntimeHandler
-from mlrun.api.runtime_handlers.daskjob import DaskRuntimeHandler
+from mlrun.api.runtime_handlers.daskjob import DaskRuntimeHandler, get_dask_resource
 from mlrun.api.runtime_handlers.kubejob import KubeRuntimeHandler
 from mlrun.api.runtime_handlers.mpijob import (
     MpiV1Alpha1RuntimeHandler,
@@ -24,6 +24,7 @@ from mlrun.api.runtime_handlers.sparkjob import SparkRuntimeHandler
 from mlrun.runtimes import MPIJobCRDVersions, RuntimeKinds, resolve_mpijob_crd_version
 
 runtime_handler_instances_cache = {}
+runtime_resources_map = {RuntimeKinds.dask: get_dask_resource()}
 
 
 def get_runtime_handler(kind: str) -> BaseRuntimeHandler:

--- a/mlrun/api/runtime_handlers/daskjob.py
+++ b/mlrun/api/runtime_handlers/daskjob.py
@@ -21,14 +21,24 @@ from sqlalchemy.orm import Session
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.k8s_utils
+import mlrun.runtimes
+import mlrun.runtimes.pod
 import mlrun.utils
 import mlrun.utils.regex
 from mlrun.api.db.base import DBInterface
 from mlrun.api.runtime_handlers.base import BaseRuntimeHandler
 from mlrun.config import config
 from mlrun.runtimes.base import RuntimeClassMode
-from mlrun.runtimes.utils import get_k8s
+from mlrun.runtimes.utils import get_k8s, get_resource_labels
 from mlrun.utils import logger
+
+
+def get_dask_resource():
+    return {
+        "scope": "function",
+        "start": deploy_function,
+        "status": get_obj_status,
+    }
 
 
 class DaskRuntimeHandler(BaseRuntimeHandler):
@@ -207,3 +217,188 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
                 # ignore error if service is already removed
                 if exc.status != 404:
                     raise
+
+
+def deploy_function(
+    function: mlrun.runtimes.DaskCluster,
+    secrets=None,
+    client_version: str = None,
+    client_python_version: str = None,
+):
+    _validate_dask_related_libraries_installed()
+
+    scheduler_pod, worker_pod, function, namespace = enrich_dask_cluster(
+        function, secrets, client_version, client_python_version
+    )
+    return initialize_dask_cluster(scheduler_pod, worker_pod, function, namespace)
+
+
+def initialize_dask_cluster(scheduler_pod, worker_pod, function, namespace):
+    import dask
+    import dask_kubernetes
+
+    spec, meta = function.spec, function.metadata
+
+    svc_temp = dask.config.get("kubernetes.scheduler-service-template")
+    if spec.service_type or spec.node_port:
+        if spec.node_port:
+            spec.service_type = "NodePort"
+            svc_temp["spec"]["ports"][1]["nodePort"] = spec.node_port
+        mlrun.utils.update_in(svc_temp, "spec.type", spec.service_type)
+
+    norm_name = mlrun.utils.normalize_name(meta.name)
+    dask.config.set(
+        {
+            "kubernetes.scheduler-service-template": svc_temp,
+            "kubernetes.name": "mlrun-" + norm_name + "-{uuid}",
+        }
+    )
+
+    cluster = dask_kubernetes.KubeCluster(
+        worker_pod,
+        scheduler_pod_template=scheduler_pod,
+        deploy_mode="remote",
+        namespace=namespace,
+        idle_timeout=spec.scheduler_timeout,
+    )
+
+    logger.info(f"cluster {cluster.name} started at {cluster.scheduler_address}")
+
+    function.status.scheduler_address = cluster.scheduler_address
+    function.status.cluster_name = cluster.name
+    if spec.service_type == "NodePort":
+        ports = cluster.scheduler.service.spec.ports
+        function.status.node_ports = {
+            "scheduler": ports[0].node_port,
+            "dashboard": ports[1].node_port,
+        }
+
+    if spec.replicas:
+        cluster.scale(spec.replicas)
+    else:
+        cluster.adapt(minimum=spec.min_replicas, maximum=spec.max_replicas)
+
+    return cluster
+
+
+def enrich_dask_cluster(
+    function, secrets, client_version: str = None, client_python_version: str = None
+):
+    from dask.distributed import Client, default_client  # noqa: F401
+    from dask_kubernetes import KubeCluster, make_pod_spec  # noqa: F401
+    from kubernetes import client
+
+    # Is it possible that the function will not have a project at this point?
+    if function.metadata.project:
+        function._add_secrets_to_spec_before_running(project=function.metadata.project)
+
+    spec = function.spec
+    meta = function.metadata
+    spec.remote = True
+
+    image = (
+        function.full_image_path(
+            client_version=client_version, client_python_version=client_python_version
+        )
+        # TODO: we might never enter here, since running a function requires defining an image
+        or "daskdev/dask:latest"
+    )
+    env = spec.env
+    namespace = meta.namespace or config.namespace
+    if spec.extra_pip:
+        env.append(spec.extra_pip)
+
+    pod_labels = get_resource_labels(function, scrape_metrics=config.scrape_metrics)
+    # TODO: 'dask-worker' is deprecated, new dask CLI was introduced in 2022.10.0.
+    #  Upgrade when we drop python 3.7 support and use 'dask worker' instead
+    worker_args = ["dask-worker", "--nthreads", str(spec.nthreads)]
+    memory_limit = spec.worker_resources.get("limits", {}).get("memory")
+    if memory_limit:
+        worker_args.extend(["--memory-limit", str(memory_limit)])
+    if spec.args:
+        worker_args.extend(spec.args)
+    # TODO: 'dask-scheduler' is deprecated, new dask CLI was introduced in 2022.10.0.
+    #  Upgrade when we drop python 3.7 support and use 'dask scheduler' instead
+    scheduler_args = ["dask-scheduler"]
+
+    container_kwargs = {
+        "name": "base",
+        "image": image,
+        "env": env,
+        "image_pull_policy": spec.image_pull_policy,
+        "volume_mounts": spec.volume_mounts,
+    }
+    scheduler_container = client.V1Container(
+        resources=spec.scheduler_resources, args=scheduler_args, **container_kwargs
+    )
+    worker_container = client.V1Container(
+        resources=spec.worker_resources, args=worker_args, **container_kwargs
+    )
+
+    scheduler_pod_spec = mlrun.runtimes.pod.kube_resource_spec_to_pod_spec(
+        spec, scheduler_container
+    )
+    worker_pod_spec = mlrun.runtimes.pod.kube_resource_spec_to_pod_spec(
+        spec, worker_container
+    )
+    for pod_spec in [scheduler_pod_spec, worker_pod_spec]:
+        if spec.image_pull_secret:
+            pod_spec.image_pull_secrets = [
+                client.V1LocalObjectReference(name=spec.image_pull_secret)
+            ]
+
+    scheduler_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(namespace=namespace, labels=pod_labels),
+        # annotations=meta.annotation),
+        spec=scheduler_pod_spec,
+    )
+    worker_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(namespace=namespace, labels=pod_labels),
+        # annotations=meta.annotation),
+        spec=worker_pod_spec,
+    )
+    return scheduler_pod, worker_pod, function, namespace
+
+
+def _validate_dask_related_libraries_installed():
+    try:
+        import dask  # noqa: F401
+        from dask.distributed import Client, default_client  # noqa: F401
+        from dask_kubernetes import KubeCluster, make_pod_spec  # noqa: F401
+        from kubernetes import client  # noqa: F401
+    except ImportError as exc:
+        print(
+            "missing dask or dask_kubernetes, please run "
+            '"pip install dask distributed dask_kubernetes", %s',
+            exc,
+        )
+        raise exc
+
+
+def get_obj_status(selector=None, namespace=None):
+    if selector is None:
+        selector = []
+
+    import mlrun.api.utils.singletons.k8s
+
+    k8s = mlrun.api.utils.singletons.k8s.get_k8s_helper()
+    namespace = namespace or config.namespace
+    selector = ",".join(["dask.org/component=scheduler"] + selector)
+    pods = k8s.list_pods(namespace, selector=selector)
+    status = ""
+    for pod in pods:
+        status = pod.status.phase.lower()
+        if status == "running":
+            cluster = pod.metadata.labels.get("dask.org/cluster-name")
+            logger.info(
+                "Found running dask function",
+                pod_name=pod.metadata.name,
+                cluster=cluster,
+            )
+            return status
+        logger.info(
+            "Found dask function in non ready state",
+            pod_name=pod.metadata.name,
+            status=status,
+        )
+    return status

--- a/mlrun/api/runtime_handlers/daskjob.py
+++ b/mlrun/api/runtime_handlers/daskjob.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional, Union
 from kubernetes.client.rest import ApiException
 from sqlalchemy.orm import Session
 
+import mlrun.api.utils.singletons.k8s
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.k8s_utils
@@ -378,8 +379,6 @@ def _validate_dask_related_libraries_installed():
 def get_obj_status(selector=None, namespace=None):
     if selector is None:
         selector = []
-
-    import mlrun.api.utils.singletons.k8s
 
     k8s = mlrun.api.utils.singletons.k8s.get_k8s_helper()
     namespace = namespace or config.namespace

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -658,3 +658,11 @@ class RunDBInterface(ABC):
         self, profile: mlrun.common.schemas.DatastoreProfile, project: str
     ):
         pass
+
+    def function_status(self, project, name, kind, selector):
+        pass
+
+    def start_function(
+        self, func_url: str = None, function: "mlrun.runtimes.BaseRuntime" = None
+    ):
+        pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1264,10 +1264,13 @@ class HTTPRunDB(RunDBInterface):
             text = resp.content.decode()
         return text, last_log_timestamp
 
-    def remote_start(self, func_url) -> mlrun.common.schemas.BackgroundTask:
+    def start_function(
+        self, func_url: str = None, function: "mlrun.runtimes.BaseRuntime" = None
+    ) -> mlrun.common.schemas.BackgroundTask:
         """Execute a function remotely, Used for ``dask`` functions.
 
         :param func_url: URL to the function to be executed.
+        :param function: The function object to start, not needed here.
         :returns: A BackgroundTask object, with details on execution process and its status.
         """
 
@@ -1312,13 +1315,13 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", path, error_message)
         return mlrun.common.schemas.BackgroundTask(**response.json())
 
-    def remote_status(self, project, name, kind, selector):
+    def function_status(self, project, name, kind, selector):
         """Retrieve status of a function being executed remotely (relevant to ``dask`` functions).
 
-        :param project: The project of the function
-        :param name: The name of the function
-        :param kind: The kind of the function, currently ``dask`` is supported.
-        :param selector: Selector clause to be applied to the Kubernetes status query to filter the results.
+        :param project:     The project of the function
+        :param name:        The name of the function
+        :param kind:        The kind of the function, currently ``dask`` is supported.
+        :param selector:    Selector clause to be applied to the Kubernetes status query to filter the results.
         """
 
         try:

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -32,7 +32,7 @@ from mlrun.runtimes.utils import (
 
 from .base import BaseRuntime, RunError, RuntimeClassMode  # noqa
 from .constants import MPIJobCRDVersions
-from .daskjob import DaskCluster, get_dask_resource  # noqa
+from .daskjob import DaskCluster  # noqa
 from .function import RemoteRuntime
 from .kubejob import KubejobRuntime  # noqa
 from .local import HandlerRuntime, LocalRuntime  # noqa
@@ -207,9 +207,6 @@ class RuntimeKinds(object):
         ]:
             return True
         return False
-
-
-runtime_resources_map = {RuntimeKinds.dask: get_dask_resource()}
 
 
 def get_runtime_class(kind: str):

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -28,20 +28,12 @@ from ..config import config
 from ..execution import MLClientCtx
 from ..model import RunObject
 from ..render import ipython_display
-from ..utils import logger, normalize_name, update_in
+from ..utils import logger
 from .base import FunctionStatus
 from .kubejob import KubejobRuntime
 from .local import exec_from_params, load_module
-from .pod import KubeResourceSpec, kube_resource_spec_to_pod_spec
-from .utils import RunError, get_func_selector, get_resource_labels, log_std
-
-
-def get_dask_resource():
-    return {
-        "scope": "function",
-        "start": deploy_function,
-        "status": get_obj_status,
-    }
+from .pod import KubeResourceSpec
+from .utils import RunError, get_func_selector, log_std
 
 
 class DaskSpec(KubeResourceSpec):
@@ -242,50 +234,50 @@ class DaskCluster(KubejobRuntime):
         return False
 
     def _start(self, watch=True):
-        if self._is_remote_api():
-            self.try_auto_mount_based_on_config()
-            self._fill_credentials()
-            db = self._get_db()
-            if not self.is_deployed():
-                raise RunError(
-                    "function image is not built/ready, use .deploy()"
-                    " method first, or set base dask image (daskdev/dask:latest)"
-                )
+        db = self._get_db()
+        if not self._is_remote_api():
+            self._cluster = db.start_function(self)
+            return
 
-            self.save(versioned=False)
-            background_task = db.remote_start(self._function_uri())
-            if watch:
-                now = datetime.datetime.utcnow()
-                timeout = now + datetime.timedelta(minutes=10)
-                while now < timeout:
-                    background_task = db.get_project_background_task(
-                        background_task.metadata.project, background_task.metadata.name
-                    )
+        self.try_auto_mount_based_on_config()
+        self._fill_credentials()
+        if not self.is_deployed():
+            raise RunError(
+                "Function image is not built/ready, use .deploy()"
+                " method first, or set base dask image (daskdev/dask:latest)"
+            )
+
+        self.save(versioned=False)
+        background_task = db.start_function(self._function_uri())
+        if watch:
+            now = datetime.datetime.utcnow()
+            timeout = now + datetime.timedelta(minutes=10)
+            while now < timeout:
+                background_task = db.get_project_background_task(
+                    background_task.metadata.project, background_task.metadata.name
+                )
+                if (
+                    background_task.status.state
+                    in mlrun.common.schemas.BackgroundTaskState.terminal_states()
+                ):
                     if (
                         background_task.status.state
-                        in mlrun.common.schemas.BackgroundTaskState.terminal_states()
+                        == mlrun.common.schemas.BackgroundTaskState.failed
                     ):
-                        if (
-                            background_task.status.state
-                            == mlrun.common.schemas.BackgroundTaskState.failed
-                        ):
-                            raise mlrun.errors.MLRunRuntimeError(
-                                "Failed bringing up dask cluster"
-                            )
-                        else:
-                            function = db.get_function(
-                                self.metadata.name,
-                                self.metadata.project,
-                                self.metadata.tag,
-                            )
-                            if function and function.get("status"):
-                                self.status = function.get("status")
-                            return
-                    time.sleep(5)
-                    now = datetime.datetime.utcnow()
-        else:
-            self._cluster = deploy_function(self)
-            self.save(versioned=False)
+                        raise mlrun.errors.MLRunRuntimeError(
+                            "Failed bringing up dask cluster"
+                        )
+                    else:
+                        function = db.get_function(
+                            self.metadata.name,
+                            self.metadata.project,
+                            self.metadata.tag,
+                        )
+                        if function and function.get("status"):
+                            self.status = function.get("status")
+                        return
+                time.sleep(5)
+                now = datetime.datetime.utcnow()
 
     def close(self, running=True):
         from dask.distributed import default_client
@@ -301,13 +293,8 @@ class DaskCluster(KubejobRuntime):
     def get_status(self):
         meta = self.metadata
         selector = get_func_selector(meta.project, meta.name, meta.tag)
-        if self._is_remote_api():
-            db = self._get_db()
-            return db.remote_status(meta.project, meta.name, self.kind, selector)
-
-        status = get_obj_status(selector)
-        print(status)
-        return status
+        db = self._get_db()
+        return db.function_status(meta.project, meta.name, self.kind, selector)
 
     def cluster(self):
         return self._cluster
@@ -491,180 +478,3 @@ class DaskCluster(KubejobRuntime):
         sout, serr = exec_from_params(handler, runobj, context)
         log_std(self._db_conn, runobj, sout, serr, skip=self.is_child, show=False)
         return context.to_dict()
-
-
-def deploy_function(
-    function: DaskCluster,
-    secrets=None,
-    client_version: str = None,
-    client_python_version: str = None,
-):
-    _validate_dask_related_libraries_installed()
-
-    scheduler_pod, worker_pod, function, namespace = enrich_dask_cluster(
-        function, secrets, client_version, client_python_version
-    )
-    return initialize_dask_cluster(scheduler_pod, worker_pod, function, namespace)
-
-
-def initialize_dask_cluster(scheduler_pod, worker_pod, function, namespace):
-    import dask
-    import dask_kubernetes
-
-    spec, meta = function.spec, function.metadata
-
-    svc_temp = dask.config.get("kubernetes.scheduler-service-template")
-    if spec.service_type or spec.node_port:
-        if spec.node_port:
-            spec.service_type = "NodePort"
-            svc_temp["spec"]["ports"][1]["nodePort"] = spec.node_port
-        update_in(svc_temp, "spec.type", spec.service_type)
-
-    norm_name = normalize_name(meta.name)
-    dask.config.set(
-        {
-            "kubernetes.scheduler-service-template": svc_temp,
-            "kubernetes.name": "mlrun-" + norm_name + "-{uuid}",
-        }
-    )
-
-    cluster = dask_kubernetes.KubeCluster(
-        worker_pod,
-        scheduler_pod_template=scheduler_pod,
-        deploy_mode="remote",
-        namespace=namespace,
-        idle_timeout=spec.scheduler_timeout,
-    )
-
-    logger.info(f"cluster {cluster.name} started at {cluster.scheduler_address}")
-
-    function.status.scheduler_address = cluster.scheduler_address
-    function.status.cluster_name = cluster.name
-    if spec.service_type == "NodePort":
-        ports = cluster.scheduler.service.spec.ports
-        function.status.node_ports = {
-            "scheduler": ports[0].node_port,
-            "dashboard": ports[1].node_port,
-        }
-
-    if spec.replicas:
-        cluster.scale(spec.replicas)
-    else:
-        cluster.adapt(minimum=spec.min_replicas, maximum=spec.max_replicas)
-
-    return cluster
-
-
-def enrich_dask_cluster(
-    function, secrets, client_version: str = None, client_python_version: str = None
-):
-    from dask.distributed import Client, default_client  # noqa: F401
-    from dask_kubernetes import KubeCluster, make_pod_spec  # noqa: F401
-    from kubernetes import client
-
-    # Is it possible that the function will not have a project at this point?
-    if function.metadata.project:
-        function._add_secrets_to_spec_before_running(project=function.metadata.project)
-
-    spec = function.spec
-    meta = function.metadata
-    spec.remote = True
-
-    image = (
-        function.full_image_path(
-            client_version=client_version, client_python_version=client_python_version
-        )
-        # TODO: we might never enter here, since running a function requires defining an image
-        or "daskdev/dask:latest"
-    )
-    env = spec.env
-    namespace = meta.namespace or config.namespace
-    if spec.extra_pip:
-        env.append(spec.extra_pip)
-
-    pod_labels = get_resource_labels(function, scrape_metrics=config.scrape_metrics)
-    # TODO: 'dask-worker' is deprecated, new dask CLI was introduced in 2022.10.0.
-    #  Upgrade when we drop python 3.7 support and use 'dask worker' instead
-    worker_args = ["dask-worker", "--nthreads", str(spec.nthreads)]
-    memory_limit = spec.worker_resources.get("limits", {}).get("memory")
-    if memory_limit:
-        worker_args.extend(["--memory-limit", str(memory_limit)])
-    if spec.args:
-        worker_args.extend(spec.args)
-    # TODO: 'dask-scheduler' is deprecated, new dask CLI was introduced in 2022.10.0.
-    #  Upgrade when we drop python 3.7 support and use 'dask scheduler' instead
-    scheduler_args = ["dask-scheduler"]
-
-    container_kwargs = {
-        "name": "base",
-        "image": image,
-        "env": env,
-        "image_pull_policy": spec.image_pull_policy,
-        "volume_mounts": spec.volume_mounts,
-    }
-    scheduler_container = client.V1Container(
-        resources=spec.scheduler_resources, args=scheduler_args, **container_kwargs
-    )
-    worker_container = client.V1Container(
-        resources=spec.worker_resources, args=worker_args, **container_kwargs
-    )
-
-    scheduler_pod_spec = kube_resource_spec_to_pod_spec(spec, scheduler_container)
-    worker_pod_spec = kube_resource_spec_to_pod_spec(spec, worker_container)
-    for pod_spec in [scheduler_pod_spec, worker_pod_spec]:
-        if spec.image_pull_secret:
-            pod_spec.image_pull_secrets = [
-                client.V1LocalObjectReference(name=spec.image_pull_secret)
-            ]
-
-    scheduler_pod = client.V1Pod(
-        metadata=client.V1ObjectMeta(namespace=namespace, labels=pod_labels),
-        # annotations=meta.annotation),
-        spec=scheduler_pod_spec,
-    )
-    worker_pod = client.V1Pod(
-        metadata=client.V1ObjectMeta(namespace=namespace, labels=pod_labels),
-        # annotations=meta.annotation),
-        spec=worker_pod_spec,
-    )
-    return scheduler_pod, worker_pod, function, namespace
-
-
-def _validate_dask_related_libraries_installed():
-    try:
-        import dask  # noqa: F401
-        from dask.distributed import Client, default_client  # noqa: F401
-        from dask_kubernetes import KubeCluster, make_pod_spec  # noqa: F401
-        from kubernetes import client  # noqa: F401
-    except ImportError as exc:
-        print(
-            "missing dask or dask_kubernetes, please run "
-            '"pip install dask distributed dask_kubernetes", %s',
-            exc,
-        )
-        raise exc
-
-
-def get_obj_status(selector=None, namespace=None):
-    if selector is None:
-        selector = []
-
-    import mlrun.api.utils.singletons.k8s
-
-    k8s = mlrun.api.utils.singletons.k8s.get_k8s_helper()
-    namespace = namespace or config.namespace
-    selector = ",".join(["dask.org/component=scheduler"] + selector)
-    pods = k8s.list_pods(namespace, selector=selector)
-    status = ""
-    for pod in pods:
-        status = pod.status.phase.lower()
-        if status == "running":
-            cluster = pod.metadata.labels.get("dask.org/cluster-name")
-            logger.info(
-                f"found running dask function {pod.metadata.name}, cluster={cluster}"
-            )
-            return status
-        logger.info(
-            f"found dask function {pod.metadata.name} in non ready state ({status})"
-        )
-    return status

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -236,7 +236,7 @@ class DaskCluster(KubejobRuntime):
     def _start(self, watch=True):
         db = self._get_db()
         if not self._is_remote_api():
-            self._cluster = db.start_function(self)
+            self._cluster = db.start_function(function=self)
             return
 
         self.try_auto_mount_based_on_config()
@@ -248,7 +248,7 @@ class DaskCluster(KubejobRuntime):
             )
 
         self.save(versioned=False)
-        background_task = db.start_function(self._function_uri())
+        background_task = db.start_function(func_url=self._function_uri())
         if watch:
             now = datetime.datetime.utcnow()
             timeout = now + datetime.timedelta(minutes=10)


### PR DESCRIPTION
Part of client-server separation.
Moving the "start" and "status" methods to the API.
Using the run db abstraction to execute the logic from common code.