### PR TITLE
[Tests] Fix HTTP Data Store tests

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2866,7 +2866,7 @@ class HTTPRunDB(RunDBInterface):
             import mlrun.common.schemas
 
             # Add a private source as the last one (will be #1 in the list)
-            private_source = mlrun.common.schemas.IndexedHubeSource(
+            private_source = mlrun.common.schemas.IndexedHubSource(
                 order=-1,
                 source=mlrun.common.schemas.HubSource(
                     metadata=mlrun.common.schemas.HubObjectMetadata(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -706,10 +706,10 @@ def extend_hub_uri_if_needed(uri) -> Tuple[str, bool]:
     if "/" in name:
         try:
             source_name, name = name.split("/")
-        except ValueError:
+        except ValueError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Invalid character '/' in function name or source name"
-            )
+            ) from exc
     name = normalize_name(name=name, verbose=False)
     if not source_name:
         # Searching item in all sources

--- a/tests/system/datastore/test_http.py
+++ b/tests/system/datastore/test_http.py
@@ -19,7 +19,10 @@ from tests.system.base import TestMLRunSystem
 
 
 class TestHttpDataStore(TestMLRunSystem):
-    private_repo_function_path = "https://raw.githubusercontent.com/mlrun/private-system-tests/main/support_private_hub_repo/func/function.yaml"
+    private_repo_function_path = (
+        "https://raw.githubusercontent.com/mlrun/private-system-tests/main/"
+        "support_private_hub_repo/func/function.yaml"
+    )
 
     def test_https_auth_token_with_env(self):
         os.environ["HTTPS_AUTH_TOKEN"] = os.environ["MLRUN_SYSTEM_TESTS_GIT_TOKEN"]

--- a/tests/system/datastore/test_http.py
+++ b/tests/system/datastore/test_http.py
@@ -19,23 +19,20 @@ from tests.system.base import TestMLRunSystem
 
 
 class TestHttpDataStore(TestMLRunSystem):
+    private_repo_function_path = "https://raw.githubusercontent.com/mlrun/private-system-tests/main/support_private_hub_repo/func/function.yaml"
+
     def test_https_auth_token_with_env(self):
-        mlrun.mlconf.hub_url = (
-            "https://raw.githubusercontent.com/mlrun/private-system-tests/"
-        )
         os.environ["HTTPS_AUTH_TOKEN"] = os.environ["MLRUN_SYSTEM_TESTS_GIT_TOKEN"]
         func = mlrun.import_function(
-            "hub://support_private_hub_repo/func:main",
+            self.private_repo_function_path,
             secrets=None,
         )
         assert func.metadata.name == "func"
 
     def test_https_auth_token_with_secrets_flag(self):
-        mlrun.mlconf.hub_url = (
-            "https://raw.githubusercontent.com/mlrun/private-system-tests/"
-        )
         secrets = {"HTTPS_AUTH_TOKEN": os.environ["MLRUN_SYSTEM_TESTS_GIT_TOKEN"]}
         func = mlrun.import_function(
-            "hub://support_private_hub_repo/func:main", secrets=secrets
+            self.private_repo_function_path,
+            secrets=secrets,
         )
         assert func.metadata.name == "func"


### PR DESCRIPTION
These tests cannot use the hub since the configuration has changed and creating a new hub requires adhering to a certain file structure. Since the point of the test is to test the data store and not the hub, I changed the url straight to the https url instead of creating an extra hub which will require updating the `private-system-tests` repo to the required structure.