### PR TITLE
[Utils] backwards compatibility for parsing object URI 

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -37,15 +37,16 @@ import pandas
 import semver
 import yaml
 from dateutil import parser
+from deprecated import deprecated
 from pandas._libs.tslibs.timestamps import Timedelta, Timestamp
 from yaml.representer import RepresenterError
 
 import mlrun
+import mlrun.common.helpers
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.regex
 import mlrun.utils.version.version
-from mlrun.common.helpers import parse_versioned_object_uri
 from mlrun.errors import err_to_str
 
 from ..config import config
@@ -61,8 +62,18 @@ LEGAL_TIME_UNITS = ["year", "month", "day", "hour", "minute", "second"]
 DEFAULT_TIME_PARTITIONS = ["year", "month", "day", "hour"]
 DEFAULT_TIME_PARTITIONING_GRANULARITY = "hour"
 
-# This is kept for backwards compatibility - in older versions this method was defined in this file
-parse_versioned_object_uri = parse_versioned_object_uri
+
+# TODO: remove in 1.7.0
+@deprecated(
+    version="1.5.0",
+    reason="'parse_versioned_object_uri' will be removed from this file in 1.7.0, use "
+    "'mlrun.common.helpers.parse_versioned_object_uri' instead",
+    category=FutureWarning,
+)
+def parse_versioned_object_uri(uri: str, default_project: str = ""):
+    return mlrun.common.helpers.parse_versioned_object_uri(
+        uri=uri, default_project=default_project
+    )
 
 
 class StorePrefix:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -45,6 +45,7 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.regex
 import mlrun.utils.version.version
+from mlrun.common.helpers import parse_versioned_object_uri
 from mlrun.errors import err_to_str
 
 from ..config import config
@@ -59,6 +60,9 @@ DB_SCHEMA = "store"
 LEGAL_TIME_UNITS = ["year", "month", "day", "hour", "minute", "second"]
 DEFAULT_TIME_PARTITIONS = ["year", "month", "day", "hour"]
 DEFAULT_TIME_PARTITIONING_GRANULARITY = "hour"
+
+# This is kept for backwards compatibility - in older versions this method was defined in this file
+parse_versioned_object_uri = parse_versioned_object_uri
 
 
 class StorePrefix:


### PR DESCRIPTION
Following #3598 , the function `parse_versioned_object_uri` has been moved from `mlrun/utils/helpers.py` to `mlrun/common/helpers.py` because it is being used by both Client and Server side.
However, to handle backwards compatibility (a fix for https://jira.iguazeng.com/browse/ML-4276), in this PR we add a reference to that function from `mlrun/utils/helpers.py`.