### PR TITLE
[Projects] Fix Projects Sync Deleting Projects not found in leader

### DIFF
--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -360,10 +360,12 @@ class Member(
         logger.info("Performing full sync")
         leader_project_names = [project.metadata.name for project in leader_projects]
         projects_to_archive = {
-            project.metadata.name: project
-            for project in db_projects.projects
-            if project.metadata.name not in leader_project_names
+            project.metadata.name: project for project in db_projects.projects
         }
+        for project_name in leader_project_names:
+            if project_name in projects_to_archive:
+                del projects_to_archive[project_name]
+
         for project_to_archive in projects_to_archive:
             logger.info(
                 "Found project in the DB that is not in leader. Archiving...",
@@ -380,7 +382,7 @@ class Member(
                 )
             except Exception as exc:
                 logger.warning(
-                    "Failed to delete project from DB, continuing...",
+                    "Failed to archive project from DB, continuing...",
                     name=project_to_archive,
                     exc=err_to_str(exc),
                 )

--- a/mlrun/api/utils/projects/follower.py
+++ b/mlrun/api/utils/projects/follower.py
@@ -301,6 +301,24 @@ class Member(
         :param full_sync: when set to true, in addition to syncing project creation/updates from the leader, we will
         also sync deletions that may occur without updating us the follower
         """
+        db_session = mlrun.api.db.session.create_session()
+
+        try:
+            leader_projects, latest_updated_at = self._list_projects_from_leader()
+            db_projects = mlrun.api.crud.Projects().list_projects(db_session)
+
+            self._store_projects_from_leader(db_session, db_projects, leader_projects)
+
+            if full_sync:
+                self._archive_projects_missing_from_leader(
+                    db_session, db_projects, leader_projects
+                )
+
+            self._update_latest_synced_datetime(latest_updated_at)
+        finally:
+            mlrun.api.db.session.close_session(db_session)
+
+    def _list_projects_from_leader(self):
         try:
             leader_projects, latest_updated_at = self._leader_client.list_projects(
                 self._sync_session, self._synced_until_datetime
@@ -312,62 +330,70 @@ class Member(
             leader_projects, latest_updated_at = self._leader_client.list_projects(
                 self._sync_session
             )
+        return leader_projects, latest_updated_at
 
-        db_session = mlrun.api.db.session.create_session()
-        try:
-            db_projects = mlrun.api.crud.Projects().list_projects(
-                db_session, format_=mlrun.common.schemas.ProjectsFormat.name_only
+    def _store_projects_from_leader(self, db_session, db_projects, leader_projects):
+
+        db_projects_names = [project.metadata.name for project in db_projects.projects]
+
+        # Don't add projects in non-terminal state if they didn't exist before to prevent race conditions
+        filtered_projects = []
+        for leader_project in leader_projects:
+            if (
+                leader_project.status.state
+                not in mlrun.common.schemas.ProjectState.terminal_states()
+                and leader_project.metadata.name not in db_projects_names
+            ):
+                continue
+            filtered_projects.append(leader_project)
+
+        for project in filtered_projects:
+            # if a project was previously archived, it's state will be overriden by the leader
+            # and returned to normal here.
+            mlrun.api.crud.Projects().store_project(
+                db_session, project.metadata.name, project
             )
-            # Don't add projects in non terminal state if they didn't exist before to prevent race conditions
-            filtered_projects = []
-            for leader_project in leader_projects:
-                if (
-                    leader_project.status.state
-                    not in mlrun.common.schemas.ProjectState.terminal_states()
-                    and leader_project.metadata.name not in db_projects.projects
-                ):
-                    continue
-                filtered_projects.append(leader_project)
 
-            for project in filtered_projects:
-                mlrun.api.crud.Projects().store_project(
-                    db_session, project.metadata.name, project
+    def _archive_projects_missing_from_leader(
+        self, db_session, db_projects, leader_projects
+    ):
+        logger.info("Performing full sync")
+        leader_project_names = [project.metadata.name for project in leader_projects]
+        projects_to_archive = {
+            project.metadata.name: project
+            for project in db_projects.projects
+            if project.metadata.name not in leader_project_names
+        }
+        for project_to_archive in projects_to_archive:
+            logger.info(
+                "Found project in the DB that is not in leader. Archiving...",
+                name=project_to_archive,
+            )
+            try:
+                projects_to_archive[
+                    project_to_archive
+                ].status.state = mlrun.common.schemas.ProjectState.archived
+                mlrun.api.crud.Projects().patch_project(
+                    db_session,
+                    project_to_archive,
+                    projects_to_archive[project_to_archive].dict(),
                 )
-            if full_sync:
-                logger.info("Performing full sync")
-                leader_project_names = [
-                    project.metadata.name for project in leader_projects
-                ]
-                projects_to_remove = list(
-                    set(db_projects.projects).difference(leader_project_names)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to delete project from DB, continuing...",
+                    name=project_to_archive,
+                    exc=err_to_str(exc),
                 )
-                for project_to_remove in projects_to_remove:
-                    logger.info(
-                        "Found project in the DB that is not in leader. Removing",
-                        name=project_to_remove,
-                    )
-                    try:
-                        mlrun.api.crud.Projects().delete_project(
-                            db_session,
-                            project_to_remove,
-                            mlrun.common.schemas.DeletionStrategy.cascading,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "Failed to delete project from DB, continuing...",
-                            name=project_to_remove,
-                            exc=err_to_str(exc),
-                        )
-            if latest_updated_at:
 
-                # sanity and defensive programming - if the leader returned a latest_updated_at that is older
-                # than the epoch, we'll set it to the epoch
-                epoch = pytz.UTC.localize(datetime.datetime.utcfromtimestamp(0))
-                if latest_updated_at < epoch:
-                    latest_updated_at = epoch
-                self._synced_until_datetime = latest_updated_at
-        finally:
-            mlrun.api.db.session.close_session(db_session)
+    def _update_latest_synced_datetime(self, latest_updated_at):
+        if latest_updated_at:
+
+            # sanity and defensive programming - if the leader returned a latest_updated_at that is older
+            # than the epoch, we'll set it to the epoch
+            epoch = pytz.UTC.localize(datetime.datetime.utcfromtimestamp(0))
+            if latest_updated_at < epoch:
+                latest_updated_at = epoch
+            self._synced_until_datetime = latest_updated_at
 
     def _is_request_from_leader(
         self, projects_role: typing.Optional[mlrun.common.schemas.ProjectsRole]

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -128,9 +128,6 @@ def test_sync_projects(
     )
 
     # ensure after full sync project that is not in leader is archived
-    mlrun.api.crud.Projects().delete_project_resources = unittest.mock.Mock(
-        return_value=None
-    )
     project_only_in_db.status.state = mlrun.common.schemas.ProjectState.archived
     projects_follower._sync_projects(full_sync=True)
     _assert_list_projects(

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -84,14 +84,21 @@ def test_sync_projects(
         state=mlrun.common.schemas.ProjectState.offline,
     )
     project_only_in_db = _generate_project(name="only-in-db")
+    project_will_be_unarchived = _generate_project(
+        name="project-will-be-unarchived",
+        state=mlrun.common.schemas.ProjectState.archived,
+    )
     for _project in [
         project_nothing_changed,
         project_in_creation,
         project_will_be_offline,
         project_only_in_db,
         project_will_be_in_deleting,
+        project_will_be_unarchived,
     ]:
         projects_follower.create_project(db, _project)
+
+    project_will_be_unarchived.status.state = mlrun.common.schemas.ProjectState.online
     nop_leader_list_projects_mock = unittest.mock.Mock(
         return_value=(
             [
@@ -100,6 +107,7 @@ def test_sync_projects(
                 project_in_deletion,
                 project_offline,
                 project_moved_to_deletion,
+                project_will_be_unarchived,
             ],
             None,
         )
@@ -115,13 +123,15 @@ def test_sync_projects(
             project_offline,
             project_only_in_db,
             project_moved_to_deletion,
+            project_will_be_unarchived,
         ],
     )
 
-    # ensure after full sync project that is not in leader is removed
+    # ensure after full sync project that is not in leader is archived
     mlrun.api.crud.Projects().delete_project_resources = unittest.mock.Mock(
         return_value=None
     )
+    project_only_in_db.status.state = mlrun.common.schemas.ProjectState.archived
     projects_follower._sync_projects(full_sync=True)
     _assert_list_projects(
         db,
@@ -130,7 +140,9 @@ def test_sync_projects(
             project_nothing_changed,
             project_in_creation,
             project_offline,
+            project_only_in_db,
             project_moved_to_deletion,
+            project_will_be_unarchived,
         ],
     )
 


### PR DESCRIPTION
We realise that deleting the projects immediately if not found in the leader can cause data-loss if the project wasn't returned from the leader due to some transient issue.
Instead, we now archive the project instead of deleting it. This way, if the project does come back from the leader, it will be automatically unarchived and returned to normal.
If the project indeed was deleted from the leader and is in an archived state in mlrun, it is possible to create a new project with the same name, and this will link up the newly created project in the leader with the archived one in mlrun and effectively unarchive it.