### PR TITLE
[CI] Ensure ssh client is active prior to running remote commands

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -118,7 +118,7 @@ class SystemTestPreparer:
         self._mysql_user = mysql_user
         self._mysql_password = mysql_password
         self._purge_db = purge_db
-        self._ssh_client = None
+        self._ssh_client: typing.Optional[paramiko.SSHClient] = None
 
         self._env_config = {
             "MLRUN_DBPATH": mlrun_dbpath,
@@ -206,6 +206,10 @@ class SystemTestPreparer:
         suppress_error_strings = suppress_error_strings or []
 
         log_command_location = "locally" if local else "on data cluster"
+
+        # ssh session might not be active if the command reran due retry mechanism on a connection failure
+        if not local:
+            self._ensure_ssh_session_active()
 
         if verbose:
             self._logger.log(
@@ -489,11 +493,12 @@ class SystemTestPreparer:
                 )
                 finished = True
 
-            except Exception:
+            except Exception as exc:
                 self._logger.log(
                     "debug",
                     f"Command {command_name} didn't complete yet, trying again in {interval} seconds",
                     retry_number=retries,
+                    exc=exc,
                 )
                 retries += 1
                 time.sleep(interval)
@@ -763,6 +768,29 @@ class SystemTestPreparer:
             )
 
         return json.loads(out or "{}")
+
+    def _ensure_ssh_session_active(self):
+        self._logger.log("info", "Ensuring ssh session is active")
+        try:
+            self._ssh_client.exec_command("ls > /dev/null")
+        except Exception as exc:
+            self._logger.log("warning", "Failed to execute command", exc=exc)
+            if any(
+                map(
+                    lambda err_msg: err_msg.lower() in str(exc).lower(),
+                    [
+                        "No existing session",
+                        "session not active",
+                        "Unable to connect to",
+                    ],
+                )
+            ):
+                self._logger.log("info", "Reconnecting to remote")
+                self.connect_to_remote()
+                self._logger.log("info", "Reconnected to remote")
+                return
+            raise
+        self._logger.log("info", "SSH session is active")
 
 
 @click.group()

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -774,10 +774,11 @@ class SystemTestPreparer:
         try:
             self._ssh_client.exec_command("ls > /dev/null")
         except Exception as exc:
-            self._logger.log("warning", "Failed to execute command", exc=exc)
+            exc_msg = str(exc)
+            self._logger.log("warning", "Failed to execute command", exc=exc_msg)
             if any(
                 map(
-                    lambda err_msg: err_msg.lower() in str(exc).lower(),
+                    lambda err_msg: err_msg.lower() in exc_msg.lower(),
                     [
                         "No existing session",
                         "session not active",


### PR DESCRIPTION
To avoid transient error we use retry mechanism, a side effect is that the ssh client gets stale during retry and thus we need to establish new ssh connection