### PR TITLE
[API] Fix submit workflow remote engine

### DIFF
--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -155,6 +155,8 @@ class WorkflowRunners(
                     engine=workflow_spec.engine,
                     local=workflow_spec.run_local,
                     save=save,
+                    # save=True modifies the project.yaml (by enrichment) so the local git repo is becoming dirty
+                    dirty=save,
                     subpath=project.spec.subpath,
                 ),
                 handler="mlrun.projects.load_and_run",
@@ -276,6 +278,8 @@ class WorkflowRunners(
                     project_name=project.metadata.name,
                     load_only=load_only,
                     save=save,
+                    # save=True modifies the project.yaml (by enrichment) so the local git repo is becoming dirty
+                    dirty=save,
                 ),
                 handler="mlrun.projects.load_and_run",
             ),

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1495,10 +1495,7 @@ class DeprecationHelper(object):
 
 
 def normalize_workflow_name(name, project_name):
-    workflow_name = (
-        name.lstrip(project_name).lstrip("-") if project_name in name else name
-    )
-    return workflow_name
+    return name.removeprefix(project_name + "-")
 
 
 # run_in threadpool is taken from fastapi to allow us to run sync functions in a threadpool


### PR DESCRIPTION
1. Fix `normalize_name` - use `remove_prefix()` instead of `lsplit()` which can remove unnecessary characters.
2. Use `dirty=True` when `save=True` is applied. 