### PR TITLE
[SQLRunDB] Fix abuse of sessions

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -47,7 +47,7 @@ import mlrun.common.model_monitoring
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
 from mlrun.api.api import deps
-from mlrun.api.api.utils import get_run_db_instance, log_and_raise, log_path
+from mlrun.api.api.utils import log_and_raise, log_path
 from mlrun.api.crud.secrets import Secrets, SecretsClientType
 from mlrun.api.utils.builder import build_runtime
 from mlrun.api.utils.singletons.scheduler import get_scheduler
@@ -706,9 +706,6 @@ def _build_function(
             reason=f"runtime error: {err_to_str(err)}",
         )
     try:
-        # connect to run db
-        run_db = get_run_db_instance(db_session)
-        fn.set_db_connection(run_db)
 
         # enrich runtime with project defaults
         launcher = mlrun.api.launcher.ServerSideLauncher()
@@ -841,32 +838,26 @@ def _start_function(
     client_version: str = None,
     client_python_version: str = None,
 ):
-    db_session = mlrun.api.db.session.create_session()
     try:
-        try:
-            run_db = get_run_db_instance(db_session)
-            function.set_db_connection(run_db)
-            mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
-                function,
-                auth_info,
-            )
+        mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
+            function,
+            auth_info,
+        )
 
-            mlrun.api.crud.Functions().start_function(
-                function, client_version, client_python_version
-            )
-            logger.info("Fn:\n %s", function.to_yaml())
+        mlrun.api.crud.Functions().start_function(
+            function, client_version, client_python_version
+        )
+        logger.info("Fn:\n %s", function.to_yaml())
 
-        except mlrun.errors.MLRunBadRequestError:
-            raise
+    except mlrun.errors.MLRunBadRequestError:
+        raise
 
-        except Exception as err:
-            logger.error(traceback.format_exc())
-            log_and_raise(
-                HTTPStatus.BAD_REQUEST.value,
-                reason=f"Runtime error: {err_to_str(err)}",
-            )
-    finally:
-        mlrun.api.db.session.close_session(db_session)
+    except Exception as err:
+        logger.error(traceback.format_exc())
+        log_and_raise(
+            HTTPStatus.BAD_REQUEST.value,
+            reason=f"Runtime error: {err_to_str(err)}",
+        )
 
 
 async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):

--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -388,7 +388,6 @@ async def load_project(
         mlrun.api.crud.WorkflowRunners().create_runner,
         run_name=f"load-{name}",
         project=name,
-        db_session=db_session,
         auth_info=auth_info,
         image=mlrun.mlconf.default_base_image,
     )

--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -141,7 +141,6 @@ async def submit_workflow(
             workflow_spec.name
         ),
         project=project.metadata.name,
-        db_session=db_session,
         auth_info=auth_info,
         image=workflow_spec.image
         or project.spec.default_image

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -36,8 +36,6 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.pod
 import mlrun.utils.helpers
-from mlrun.api.db.sqldb.db import SQLDB
-from mlrun.api.rundb.sqldb import SQLRunDB
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.logs_dir import get_logs_dir
 from mlrun.api.utils.singletons.scheduler import get_scheduler
@@ -128,18 +126,6 @@ def get_secrets(
     return {
         "V3IO_ACCESS_KEY": auth_info.data_session,
     }
-
-
-def get_run_db_instance(
-    db_session: Session,
-):
-    db = get_db()
-    if isinstance(db, SQLDB):
-        run_db = SQLRunDB(db.dsn, db_session)
-    else:
-        run_db = db.db
-    run_db.connect()
-    return run_db
 
 
 def parse_submit_run_body(data):
@@ -880,8 +866,6 @@ def submit_run_sync(
     try:
         fn, task = _generate_function_and_task_from_submit_run_body(db_session, data)
 
-        run_db = get_run_db_instance(db_session)
-        fn.set_db_connection(run_db)
         logger.info("Submitting run", function=fn.to_dict(), task=task)
         schedule = data.get("schedule")
         if schedule:

--- a/mlrun/api/crud/model_monitoring/deployment.py
+++ b/mlrun/api/crud/model_monitoring/deployment.py
@@ -216,7 +216,6 @@ class MonitoringDeployment:
             fn = self._get_model_monitoring_batch_function(
                 project=project,
                 model_monitoring_access_key=model_monitoring_access_key,
-                db_session=db_session,
                 auth_info=auth_info,
                 tracking_policy=tracking_policy,
             )
@@ -320,7 +319,6 @@ class MonitoringDeployment:
         self,
         project: str,
         model_monitoring_access_key: str,
-        db_session: sqlalchemy.orm.Session,
         auth_info: mlrun.common.schemas.AuthInfo,
         tracking_policy: mlrun.model_monitoring.tracking_policy.TrackingPolicy,
     ):
@@ -347,7 +345,6 @@ class MonitoringDeployment:
             image=tracking_policy.default_batch_image,
             handler="handler",
         )
-        function.set_db_connection(mlrun.api.api.utils.get_run_db_instance(db_session))
 
         # Set the project to the job function
         function.metadata.project = project

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -93,7 +93,7 @@ class ModelEndpoints:
             logger.info(
                 "Getting model object, inferring column names and collecting feature stats"
             )
-            run_db = mlrun.api.api.utils.get_run_db_instance(db_session)
+            run_db = mlrun.get_run_db()
             model_obj: mlrun.artifacts.ModelArtifact = (
                 mlrun.datastore.store_resources.get_store_resource(
                     model_endpoint.spec.model_uri, db=run_db

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -18,10 +18,10 @@ from typing import Dict
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+import mlrun.db
 import mlrun.utils.singleton
 from mlrun.api.api.utils import (
     apply_enrichment_and_validation_on_function,
-    get_run_db_instance,
     get_scheduler,
 )
 from mlrun.config import config
@@ -35,7 +35,6 @@ class WorkflowRunners(
     def create_runner(
         run_name: str,
         project: str,
-        db_session: Session,
         auth_info: mlrun.common.schemas.AuthInfo,
         image: str,
     ) -> mlrun.run.KubejobRuntime:
@@ -58,8 +57,6 @@ class WorkflowRunners(
             # For preventing deployment:
             image=image,
         )
-
-        runner.set_db_connection(get_run_db_instance(db_session))
 
         # Enrichment and validation requires access key
         runner.metadata.credentials.access_key = Credentials.generate_access_key

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -334,13 +334,7 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_schedule(self, data):
-        session = create_session()
-        try:
-            return self._create_session_and_transform_db_error(
-                self.db.store_schedule, session, data
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(self.db.store_schedule, data)
 
     def list_schedules(self):
         return self._create_session_and_transform_db_error(self.db.list_schedules)
@@ -543,17 +537,12 @@ class SQLRunDB(RunDBInterface):
         )
 
     def create_feature_vector(self, feature_vector, project="", versioned=True):
-        session = create_session()
-        try:
-            return self._create_session_and_transform_db_error(
-                mlrun.api.crud.FeatureStore().create_feature_vector,
-                session,
-                project,
-                feature_vector,
-                versioned,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().create_feature_vector,
+            project,
+            feature_vector,
+            versioned,
+        )
 
     def get_feature_vector(
         self, name: str, project: str = "", tag: str = None, uid: str = None

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -68,48 +68,33 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_run(self, struct, uid, project="", iter=0):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Runs().store_run,
-                session,
-                struct,
-                uid,
-                iter,
-                project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Runs().store_run,
+            struct,
+            uid,
+            iter,
+            project,
+        )
 
     def update_run(self, updates: dict, uid, project="", iter=0):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Runs().update_run,
-                session,
-                project,
-                uid,
-                iter,
-                updates,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Runs().update_run,
+            project,
+            uid,
+            iter,
+            updates,
+        )
 
     def abort_run(self, uid, project="", iter=0, timeout=45):
         raise NotImplementedError()
 
     def read_run(self, uid, project=None, iter=None):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Runs().get_run,
-                session,
-                uid,
-                iter,
-                project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Runs().get_run,
+            uid,
+            iter,
+            project,
+        )
 
     def list_runs(
         self,
@@ -134,92 +119,65 @@ class SQLRunDB(RunDBInterface):
         max_partitions: int = 0,
         with_notifications: bool = False,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Runs().list_runs,
-                db_session=session,
-                name=name,
-                uid=uid,
-                project=project,
-                labels=labels,
-                states=mlrun.utils.helpers.as_list(state)
-                if state is not None
-                else None,
-                sort=sort,
-                last=last,
-                iter=iter,
-                start_time_from=start_time_from,
-                start_time_to=start_time_to,
-                last_update_time_from=last_update_time_from,
-                last_update_time_to=last_update_time_to,
-                partition_by=partition_by,
-                rows_per_partition=rows_per_partition,
-                partition_sort_by=partition_sort_by,
-                partition_order=partition_order,
-                max_partitions=max_partitions,
-                with_notifications=with_notifications,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Runs().list_runs,
+            name=name,
+            uid=uid,
+            project=project,
+            labels=labels,
+            states=mlrun.utils.helpers.as_list(state) if state is not None else None,
+            sort=sort,
+            last=last,
+            iter=iter,
+            start_time_from=start_time_from,
+            start_time_to=start_time_to,
+            last_update_time_from=last_update_time_from,
+            last_update_time_to=last_update_time_to,
+            partition_by=partition_by,
+            rows_per_partition=rows_per_partition,
+            partition_sort_by=partition_sort_by,
+            partition_order=partition_order,
+            max_partitions=max_partitions,
+            with_notifications=with_notifications,
+        )
 
     def del_run(self, uid, project=None, iter=None):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Runs().delete_run,
-                session,
-                uid,
-                iter,
-                project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Runs().delete_run,
+            uid,
+            iter,
+            project,
+        )
 
     def del_runs(self, name=None, project=None, labels=None, state=None, days_ago=0):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Runs().delete_runs,
-                session,
-                name,
-                project,
-                labels,
-                state,
-                days_ago,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Runs().delete_runs,
+            name,
+            project,
+            labels,
+            state,
+            days_ago,
+        )
 
     def store_artifact(self, key, artifact, uid, iter=None, tag="", project=""):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Artifacts().store_artifact,
-                session,
-                key,
-                artifact,
-                uid,
-                iter,
-                tag,
-                project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Artifacts().store_artifact,
+            key,
+            artifact,
+            uid,
+            iter,
+            tag,
+            project,
+        )
 
     def read_artifact(self, key, tag="", iter=None, project=""):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Artifacts().get_artifact,
-                session,
-                key,
-                tag,
-                iter,
-                project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Artifacts().get_artifact,
+            key,
+            tag,
+            iter,
+            project,
+        )
 
     def list_artifacts(
         self,
@@ -237,119 +195,80 @@ class SQLRunDB(RunDBInterface):
         if category and isinstance(category, str):
             category = mlrun.common.schemas.ArtifactCategories(category)
 
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Artifacts().list_artifacts,
-                session,
-                project,
-                name,
-                tag,
-                labels,
-                since,
-                until,
-                iter=iter,
-                best_iteration=best_iteration,
-                kind=kind,
-                category=category,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Artifacts().list_artifacts,
+            project,
+            name,
+            tag,
+            labels,
+            since,
+            until,
+            iter=iter,
+            best_iteration=best_iteration,
+            kind=kind,
+            category=category,
+        )
 
     def del_artifact(self, key, tag="", project=""):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Artifacts().delete_artifact,
-                session,
-                key,
-                tag,
-                project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Artifacts().delete_artifact,
+            key,
+            tag,
+            project,
+        )
 
     def del_artifacts(self, name="", project="", tag="", labels=None):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Artifacts().delete_artifacts,
-                session,
-                project,
-                name,
-                tag,
-                labels,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Artifacts().delete_artifacts,
+            project,
+            name,
+            tag,
+            labels,
+        )
 
     def store_function(self, function, name, project="", tag="", versioned=False):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Functions().store_function,
-                session,
-                function,
-                name,
-                project,
-                tag,
-                versioned,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Functions().store_function,
+            function,
+            name,
+            project,
+            tag,
+            versioned,
+        )
 
     def get_function(self, name, project="", tag="", hash_key=""):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Functions().get_function,
-                session,
-                name,
-                project,
-                tag,
-                hash_key,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Functions().get_function,
+            name,
+            project,
+            tag,
+            hash_key,
+        )
 
     def delete_function(self, name: str, project: str = ""):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Functions().delete_function,
-                session,
-                project,
-                name,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Functions().delete_function,
+            project,
+            name,
+        )
 
     def list_functions(self, name=None, project=None, tag=None, labels=None):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Functions().list_functions,
-                db_session=session,
-                project=project,
-                name=name,
-                tag=tag,
-                labels=labels,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Functions().list_functions,
+            project=project,
+            name=name,
+            tag=tag,
+            labels=labels,
+        )
 
     def list_artifact_tags(
         self,
         project=None,
         category: Union[str, mlrun.common.schemas.ArtifactCategories] = None,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                self.db.list_artifact_tags, session, project
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            self.db.list_artifact_tags, project
+        )
 
     def tag_objects(
         self,
@@ -358,26 +277,20 @@ class SQLRunDB(RunDBInterface):
         tag_objects: mlrun.common.schemas.TagObjects,
         replace: bool = False,
     ):
-        session = create_session()
-        try:
-            if replace:
-                return self._transform_db_error(
-                    mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
-                    session,
-                    project,
-                    tag_name,
-                    tag_objects,
-                )
-
-            return self._transform_db_error(
-                mlrun.api.crud.Tags().append_tag_to_objects,
-                session,
+        if replace:
+            return self._create_session_and_transform_db_error(
+                mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
                 project,
                 tag_name,
                 tag_objects,
             )
-        finally:
-            session.close()
+
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Tags().append_tag_to_objects,
+            project,
+            tag_name,
+            tag_objects,
+        )
 
     def delete_objects_tag(
         self,
@@ -385,17 +298,12 @@ class SQLRunDB(RunDBInterface):
         tag_name: str,
         tag_objects: mlrun.common.schemas.TagObjects,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Tags().delete_tag_from_objects,
-                session,
-                project,
-                tag_name,
-                tag_objects,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Tags().delete_tag_from_objects,
+            project,
+            tag_name,
+            tag_objects,
+        )
 
     def tag_artifacts(
         self,
@@ -428,16 +336,14 @@ class SQLRunDB(RunDBInterface):
     def store_schedule(self, data):
         session = create_session()
         try:
-            return self._transform_db_error(self.db.store_schedule, session, data)
+            return self._create_session_and_transform_db_error(
+                self.db.store_schedule, session, data
+            )
         finally:
             session.close()
 
     def list_schedules(self):
-        session = create_session()
-        try:
-            return self._transform_db_error(self.db.list_schedules, session)
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(self.db.list_schedules)
 
     def store_project(
         self,
@@ -447,16 +353,11 @@ class SQLRunDB(RunDBInterface):
         if isinstance(project, dict):
             project = mlrun.common.schemas.Project(**project)
 
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Projects().store_project,
-                session,
-                name=name,
-                project=project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Projects().store_project,
+            name=name,
+            project=project,
+        )
 
     def patch_project(
         self,
@@ -464,60 +365,40 @@ class SQLRunDB(RunDBInterface):
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
     ) -> mlrun.common.schemas.Project:
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Projects().patch_project,
-                session,
-                name=name,
-                project=project,
-                patch_mode=patch_mode,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Projects().patch_project,
+            name=name,
+            project=project,
+            patch_mode=patch_mode,
+        )
 
     def create_project(
         self,
         project: mlrun.common.schemas.Project,
     ) -> mlrun.common.schemas.Project:
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Projects().create_project,
-                session,
-                project=project,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Projects().create_project,
+            project=project,
+        )
 
     def delete_project(
         self,
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Projects().delete_project,
-                session,
-                name=name,
-                deletion_strategy=deletion_strategy,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Projects().delete_project,
+            name=name,
+            deletion_strategy=deletion_strategy,
+        )
 
     def get_project(
         self, name: str = None, project_id: int = None
     ) -> mlrun.common.schemas.Project:
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Projects().get_project,
-                session,
-                name=name,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Projects().get_project,
+            name=name,
+        )
 
     def list_projects(
         self,
@@ -526,54 +407,32 @@ class SQLRunDB(RunDBInterface):
         labels: List[str] = None,
         state: mlrun.common.schemas.ProjectState = None,
     ) -> mlrun.common.schemas.ProjectsOutput:
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Projects().list_projects,
-                session,
-                owner=owner,
-                format_=format_,
-                labels=labels,
-                state=state,
-            )
-        finally:
-            session.close()
-
-    @staticmethod
-    def _transform_db_error(func, *args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except DBError as exc:
-            raise mlrun.db.RunDBError(exc.args) from exc
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Projects().list_projects,
+            owner=owner,
+            format_=format_,
+            labels=labels,
+            state=state,
+        )
 
     def create_feature_set(self, feature_set, project="", versioned=True):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().create_feature_set,
-                session,
-                project,
-                feature_set,
-                versioned,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().create_feature_set,
+            project,
+            feature_set,
+            versioned,
+        )
 
     def get_feature_set(
         self, name: str, project: str = "", tag: str = None, uid: str = None
     ):
-        session = create_session()
-        try:
-            feature_set = self._transform_db_error(
-                mlrun.api.crud.FeatureStore().get_feature_set,
-                session,
-                project,
-                name,
-                tag,
-                uid,
-            )
-        finally:
-            session.close()
+        feature_set = self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().get_feature_set,
+            project,
+            name,
+            tag,
+            uid,
+        )
         return feature_set.dict()
 
     def list_features(
@@ -584,19 +443,14 @@ class SQLRunDB(RunDBInterface):
         entities: List[str] = None,
         labels: List[str] = None,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().list_features,
-                session,
-                project,
-                name,
-                tag,
-                entities,
-                labels,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().list_features,
+            project,
+            name,
+            tag,
+            entities,
+            labels,
+        )
 
     def list_entities(
         self,
@@ -605,18 +459,13 @@ class SQLRunDB(RunDBInterface):
         tag: str = None,
         labels: List[str] = None,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().list_entities,
-                session,
-                project,
-                name,
-                tag,
-                labels,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().list_entities,
+            project,
+            name,
+            tag,
+            labels,
+        )
 
     def list_feature_sets(
         self,
@@ -632,25 +481,20 @@ class SQLRunDB(RunDBInterface):
         partition_sort_by: mlrun.common.schemas.SortField = None,
         partition_order: mlrun.common.schemas.OrderType = mlrun.common.schemas.OrderType.desc,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().list_feature_sets,
-                session,
-                project,
-                name,
-                tag,
-                state,
-                entities,
-                features,
-                labels,
-                partition_by,
-                rows_per_partition,
-                partition_sort_by,
-                partition_order,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().list_feature_sets,
+            project,
+            name,
+            tag,
+            state,
+            entities,
+            features,
+            labels,
+            partition_by,
+            rows_per_partition,
+            partition_sort_by,
+            partition_order,
+        )
 
     def store_feature_set(
         self,
@@ -666,57 +510,42 @@ class SQLRunDB(RunDBInterface):
 
         name = name or feature_set.metadata.name
         project = project or feature_set.metadata.project
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().store_feature_set,
-                session,
-                project,
-                name,
-                feature_set,
-                tag,
-                uid,
-                versioned,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().store_feature_set,
+            project,
+            name,
+            feature_set,
+            tag,
+            uid,
+            versioned,
+        )
 
     def patch_feature_set(
         self, name, feature_set, project="", tag=None, uid=None, patch_mode="replace"
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().patch_feature_set,
-                session,
-                project,
-                name,
-                feature_set,
-                tag,
-                uid,
-                patch_mode,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().patch_feature_set,
+            project,
+            name,
+            feature_set,
+            tag,
+            uid,
+            patch_mode,
+        )
 
     def delete_feature_set(self, name, project="", tag=None, uid=None):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().delete_feature_set,
-                session,
-                project,
-                name,
-                tag,
-                uid,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().delete_feature_set,
+            project,
+            name,
+            tag,
+            uid,
+        )
 
     def create_feature_vector(self, feature_vector, project="", versioned=True):
         session = create_session()
         try:
-            return self._transform_db_error(
+            return self._create_session_and_transform_db_error(
                 mlrun.api.crud.FeatureStore().create_feature_vector,
                 session,
                 project,
@@ -729,18 +558,13 @@ class SQLRunDB(RunDBInterface):
     def get_feature_vector(
         self, name: str, project: str = "", tag: str = None, uid: str = None
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().get_feature_vector,
-                session,
-                project,
-                name,
-                tag,
-                uid,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().get_feature_vector,
+            project,
+            name,
+            tag,
+            uid,
+        )
 
     def list_feature_vectors(
         self,
@@ -754,23 +578,18 @@ class SQLRunDB(RunDBInterface):
         partition_sort_by: mlrun.common.schemas.SortField = None,
         partition_order: mlrun.common.schemas.OrderType = mlrun.common.schemas.OrderType.desc,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().list_feature_vectors,
-                session,
-                project,
-                name,
-                tag,
-                state,
-                labels,
-                partition_by,
-                rows_per_partition,
-                partition_sort_by,
-                partition_order,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().list_feature_vectors,
+            project,
+            name,
+            tag,
+            state,
+            labels,
+            partition_by,
+            rows_per_partition,
+            partition_sort_by,
+            partition_order,
+        )
 
     def store_feature_vector(
         self,
@@ -781,20 +600,15 @@ class SQLRunDB(RunDBInterface):
         uid=None,
         versioned=True,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().store_feature_vector,
-                session,
-                project,
-                name,
-                feature_vector,
-                tag,
-                uid,
-                versioned,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().store_feature_vector,
+            project,
+            name,
+            feature_vector,
+            tag,
+            uid,
+            versioned,
+        )
 
     def patch_feature_vector(
         self,
@@ -805,34 +619,24 @@ class SQLRunDB(RunDBInterface):
         uid=None,
         patch_mode="replace",
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().patch_feature_vector,
-                session,
-                project,
-                name,
-                feature_vector_update,
-                tag,
-                uid,
-                patch_mode,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().patch_feature_vector,
+            project,
+            name,
+            feature_vector_update,
+            tag,
+            uid,
+            patch_mode,
+        )
 
     def delete_feature_vector(self, name, project="", tag=None, uid=None):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.FeatureStore().delete_feature_vector,
-                session,
-                project,
-                name,
-                tag,
-                uid,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.FeatureStore().delete_feature_vector,
+            project,
+            name,
+            tag,
+            uid,
+        )
 
     def store_run_notifications(
         self,
@@ -841,18 +645,13 @@ class SQLRunDB(RunDBInterface):
         project: str = None,
         mask_params: bool = True,
     ):
-        session = create_session()
-        try:
-            return self._transform_db_error(
-                mlrun.api.crud.Notifications().store_run_notifications,
-                session,
-                notification_objects,
-                run_uid,
-                project,
-                mask_params,
-            )
-        finally:
-            session.close()
+        return self._create_session_and_transform_db_error(
+            mlrun.api.crud.Notifications().store_run_notifications,
+            notification_objects,
+            run_uid,
+            project,
+            mask_params,
+        )
 
     def function_status(self, project, name, kind, selector):
         """Retrieve status of a function being executed remotely (relevant to ``dask`` functions).
@@ -1068,6 +867,20 @@ class SQLRunDB(RunDBInterface):
         self, profile: mlrun.common.schemas.DatastoreProfile, project: str
     ):
         raise NotImplementedError()
+
+    def _create_session_and_transform_db_error(self, func, *args, **kwargs):
+        session = create_session()
+        try:
+            return self._transform_db_error(func, session, *args, **kwargs)
+        finally:
+            session.close()
+
+    @staticmethod
+    def _transform_db_error(func, *args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except DBError as exc:
+            raise mlrun.db.RunDBError(exc.args) from exc
 
 
 # Once this file is imported it will override the default RunDB implementation (RunDBContainer)

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -39,15 +39,11 @@ class SQLRunDB(RunDBInterface):
     def __init__(
         self,
         dsn,
-        session=None,
     ):
-        self.session = session
         self.dsn = dsn
         self.db = None
 
     def connect(self, secrets=None):
-        if not self.session:
-            self.session = create_session()
         self.db = SQLDB(self.dsn)
         return self
 
@@ -72,36 +68,48 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_run(self, struct, uid, project="", iter=0):
-        return self._transform_db_error(
-            mlrun.api.crud.Runs().store_run,
-            self.session,
-            struct,
-            uid,
-            iter,
-            project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Runs().store_run,
+                session,
+                struct,
+                uid,
+                iter,
+                project,
+            )
+        finally:
+            session.close()
 
     def update_run(self, updates: dict, uid, project="", iter=0):
-        return self._transform_db_error(
-            mlrun.api.crud.Runs().update_run,
-            self.session,
-            project,
-            uid,
-            iter,
-            updates,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Runs().update_run,
+                session,
+                project,
+                uid,
+                iter,
+                updates,
+            )
+        finally:
+            session.close()
 
     def abort_run(self, uid, project="", iter=0, timeout=45):
         raise NotImplementedError()
 
     def read_run(self, uid, project=None, iter=None):
-        return self._transform_db_error(
-            mlrun.api.crud.Runs().get_run,
-            self.session,
-            uid,
-            iter,
-            project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Runs().get_run,
+                session,
+                uid,
+                iter,
+                project,
+            )
+        finally:
+            session.close()
 
     def list_runs(
         self,
@@ -126,70 +134,92 @@ class SQLRunDB(RunDBInterface):
         max_partitions: int = 0,
         with_notifications: bool = False,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.Runs().list_runs,
-            db_session=self.session,
-            name=name,
-            uid=uid,
-            project=project,
-            labels=labels,
-            states=mlrun.utils.helpers.as_list(state) if state is not None else None,
-            sort=sort,
-            last=last,
-            iter=iter,
-            start_time_from=start_time_from,
-            start_time_to=start_time_to,
-            last_update_time_from=last_update_time_from,
-            last_update_time_to=last_update_time_to,
-            partition_by=partition_by,
-            rows_per_partition=rows_per_partition,
-            partition_sort_by=partition_sort_by,
-            partition_order=partition_order,
-            max_partitions=max_partitions,
-            with_notifications=with_notifications,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Runs().list_runs,
+                db_session=session,
+                name=name,
+                uid=uid,
+                project=project,
+                labels=labels,
+                states=mlrun.utils.helpers.as_list(state)
+                if state is not None
+                else None,
+                sort=sort,
+                last=last,
+                iter=iter,
+                start_time_from=start_time_from,
+                start_time_to=start_time_to,
+                last_update_time_from=last_update_time_from,
+                last_update_time_to=last_update_time_to,
+                partition_by=partition_by,
+                rows_per_partition=rows_per_partition,
+                partition_sort_by=partition_sort_by,
+                partition_order=partition_order,
+                max_partitions=max_partitions,
+                with_notifications=with_notifications,
+            )
+        finally:
+            session.close()
 
     def del_run(self, uid, project=None, iter=None):
-        return self._transform_db_error(
-            mlrun.api.crud.Runs().delete_run,
-            self.session,
-            uid,
-            iter,
-            project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Runs().delete_run,
+                session,
+                uid,
+                iter,
+                project,
+            )
+        finally:
+            session.close()
 
     def del_runs(self, name=None, project=None, labels=None, state=None, days_ago=0):
-        return self._transform_db_error(
-            mlrun.api.crud.Runs().delete_runs,
-            self.session,
-            name,
-            project,
-            labels,
-            state,
-            days_ago,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Runs().delete_runs,
+                session,
+                name,
+                project,
+                labels,
+                state,
+                days_ago,
+            )
+        finally:
+            session.close()
 
     def store_artifact(self, key, artifact, uid, iter=None, tag="", project=""):
-        return self._transform_db_error(
-            mlrun.api.crud.Artifacts().store_artifact,
-            self.session,
-            key,
-            artifact,
-            uid,
-            iter,
-            tag,
-            project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Artifacts().store_artifact,
+                session,
+                key,
+                artifact,
+                uid,
+                iter,
+                tag,
+                project,
+            )
+        finally:
+            session.close()
 
     def read_artifact(self, key, tag="", iter=None, project=""):
-        return self._transform_db_error(
-            mlrun.api.crud.Artifacts().get_artifact,
-            self.session,
-            key,
-            tag,
-            iter,
-            project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Artifacts().get_artifact,
+                session,
+                key,
+                tag,
+                iter,
+                project,
+            )
+        finally:
+            session.close()
 
     def list_artifacts(
         self,
@@ -207,87 +237,119 @@ class SQLRunDB(RunDBInterface):
         if category and isinstance(category, str):
             category = mlrun.common.schemas.ArtifactCategories(category)
 
-        return self._transform_db_error(
-            mlrun.api.crud.Artifacts().list_artifacts,
-            self.session,
-            project,
-            name,
-            tag,
-            labels,
-            since,
-            until,
-            iter=iter,
-            best_iteration=best_iteration,
-            kind=kind,
-            category=category,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Artifacts().list_artifacts,
+                session,
+                project,
+                name,
+                tag,
+                labels,
+                since,
+                until,
+                iter=iter,
+                best_iteration=best_iteration,
+                kind=kind,
+                category=category,
+            )
+        finally:
+            session.close()
 
     def del_artifact(self, key, tag="", project=""):
-        return self._transform_db_error(
-            mlrun.api.crud.Artifacts().delete_artifact,
-            self.session,
-            key,
-            tag,
-            project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Artifacts().delete_artifact,
+                session,
+                key,
+                tag,
+                project,
+            )
+        finally:
+            session.close()
 
     def del_artifacts(self, name="", project="", tag="", labels=None):
-        return self._transform_db_error(
-            mlrun.api.crud.Artifacts().delete_artifacts,
-            self.session,
-            project,
-            name,
-            tag,
-            labels,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Artifacts().delete_artifacts,
+                session,
+                project,
+                name,
+                tag,
+                labels,
+            )
+        finally:
+            session.close()
 
     def store_function(self, function, name, project="", tag="", versioned=False):
-        return self._transform_db_error(
-            mlrun.api.crud.Functions().store_function,
-            self.session,
-            function,
-            name,
-            project,
-            tag,
-            versioned,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Functions().store_function,
+                session,
+                function,
+                name,
+                project,
+                tag,
+                versioned,
+            )
+        finally:
+            session.close()
 
     def get_function(self, name, project="", tag="", hash_key=""):
-        return self._transform_db_error(
-            mlrun.api.crud.Functions().get_function,
-            self.session,
-            name,
-            project,
-            tag,
-            hash_key,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Functions().get_function,
+                session,
+                name,
+                project,
+                tag,
+                hash_key,
+            )
+        finally:
+            session.close()
 
     def delete_function(self, name: str, project: str = ""):
-        return self._transform_db_error(
-            mlrun.api.crud.Functions().delete_function,
-            self.session,
-            project,
-            name,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Functions().delete_function,
+                session,
+                project,
+                name,
+            )
+        finally:
+            session.close()
 
     def list_functions(self, name=None, project=None, tag=None, labels=None):
-        return self._transform_db_error(
-            mlrun.api.crud.Functions().list_functions,
-            db_session=self.session,
-            project=project,
-            name=name,
-            tag=tag,
-            labels=labels,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Functions().list_functions,
+                db_session=session,
+                project=project,
+                name=name,
+                tag=tag,
+                labels=labels,
+            )
+        finally:
+            session.close()
 
     def list_artifact_tags(
         self,
         project=None,
         category: Union[str, mlrun.common.schemas.ArtifactCategories] = None,
     ):
-        return self._transform_db_error(
-            self.db.list_artifact_tags, self.session, project
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                self.db.list_artifact_tags, session, project
+            )
+        finally:
+            session.close()
 
     def tag_objects(
         self,
@@ -296,22 +358,26 @@ class SQLRunDB(RunDBInterface):
         tag_objects: mlrun.common.schemas.TagObjects,
         replace: bool = False,
     ):
-        if replace:
+        session = create_session()
+        try:
+            if replace:
+                return self._transform_db_error(
+                    mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
+                    session,
+                    project,
+                    tag_name,
+                    tag_objects,
+                )
+
             return self._transform_db_error(
-                mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
-                self.session,
+                mlrun.api.crud.Tags().append_tag_to_objects,
+                session,
                 project,
                 tag_name,
                 tag_objects,
             )
-
-        return self._transform_db_error(
-            mlrun.api.crud.Tags().append_tag_to_objects,
-            self.session,
-            project,
-            tag_name,
-            tag_objects,
-        )
+        finally:
+            session.close()
 
     def delete_objects_tag(
         self,
@@ -319,13 +385,17 @@ class SQLRunDB(RunDBInterface):
         tag_name: str,
         tag_objects: mlrun.common.schemas.TagObjects,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.Tags().delete_tag_from_objects,
-            self.session,
-            project,
-            tag_name,
-            tag_objects,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Tags().delete_tag_from_objects,
+                session,
+                project,
+                tag_name,
+                tag_objects,
+            )
+        finally:
+            session.close()
 
     def tag_artifacts(
         self,
@@ -356,10 +426,18 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_schedule(self, data):
-        return self._transform_db_error(self.db.store_schedule, self.session, data)
+        session = create_session()
+        try:
+            return self._transform_db_error(self.db.store_schedule, session, data)
+        finally:
+            session.close()
 
     def list_schedules(self):
-        return self._transform_db_error(self.db.list_schedules, self.session)
+        session = create_session()
+        try:
+            return self._transform_db_error(self.db.list_schedules, session)
+        finally:
+            session.close()
 
     def store_project(
         self,
@@ -369,12 +447,16 @@ class SQLRunDB(RunDBInterface):
         if isinstance(project, dict):
             project = mlrun.common.schemas.Project(**project)
 
-        return self._transform_db_error(
-            mlrun.api.crud.Projects().store_project,
-            self.session,
-            name=name,
-            project=project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Projects().store_project,
+                session,
+                name=name,
+                project=project,
+            )
+        finally:
+            session.close()
 
     def patch_project(
         self,
@@ -382,44 +464,60 @@ class SQLRunDB(RunDBInterface):
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
     ) -> mlrun.common.schemas.Project:
-        return self._transform_db_error(
-            mlrun.api.crud.Projects().patch_project,
-            self.session,
-            name=name,
-            project=project,
-            patch_mode=patch_mode,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Projects().patch_project,
+                session,
+                name=name,
+                project=project,
+                patch_mode=patch_mode,
+            )
+        finally:
+            session.close()
 
     def create_project(
         self,
         project: mlrun.common.schemas.Project,
     ) -> mlrun.common.schemas.Project:
-        return self._transform_db_error(
-            mlrun.api.crud.Projects().create_project,
-            self.session,
-            project=project,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Projects().create_project,
+                session,
+                project=project,
+            )
+        finally:
+            session.close()
 
     def delete_project(
         self,
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.Projects().delete_project,
-            self.session,
-            name=name,
-            deletion_strategy=deletion_strategy,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Projects().delete_project,
+                session,
+                name=name,
+                deletion_strategy=deletion_strategy,
+            )
+        finally:
+            session.close()
 
     def get_project(
         self, name: str = None, project_id: int = None
     ) -> mlrun.common.schemas.Project:
-        return self._transform_db_error(
-            mlrun.api.crud.Projects().get_project,
-            self.session,
-            name=name,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Projects().get_project,
+                session,
+                name=name,
+            )
+        finally:
+            session.close()
 
     def list_projects(
         self,
@@ -428,14 +526,18 @@ class SQLRunDB(RunDBInterface):
         labels: List[str] = None,
         state: mlrun.common.schemas.ProjectState = None,
     ) -> mlrun.common.schemas.ProjectsOutput:
-        return self._transform_db_error(
-            mlrun.api.crud.Projects().list_projects,
-            self.session,
-            owner=owner,
-            format_=format_,
-            labels=labels,
-            state=state,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Projects().list_projects,
+                session,
+                owner=owner,
+                format_=format_,
+                labels=labels,
+                state=state,
+            )
+        finally:
+            session.close()
 
     @staticmethod
     def _transform_db_error(func, *args, **kwargs):
@@ -445,25 +547,33 @@ class SQLRunDB(RunDBInterface):
             raise mlrun.db.RunDBError(exc.args) from exc
 
     def create_feature_set(self, feature_set, project="", versioned=True):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().create_feature_set,
-            self.session,
-            project,
-            feature_set,
-            versioned,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().create_feature_set,
+                session,
+                project,
+                feature_set,
+                versioned,
+            )
+        finally:
+            session.close()
 
     def get_feature_set(
         self, name: str, project: str = "", tag: str = None, uid: str = None
     ):
-        feature_set = self._transform_db_error(
-            mlrun.api.crud.FeatureStore().get_feature_set,
-            self.session,
-            project,
-            name,
-            tag,
-            uid,
-        )
+        session = create_session()
+        try:
+            feature_set = self._transform_db_error(
+                mlrun.api.crud.FeatureStore().get_feature_set,
+                session,
+                project,
+                name,
+                tag,
+                uid,
+            )
+        finally:
+            session.close()
         return feature_set.dict()
 
     def list_features(
@@ -474,15 +584,19 @@ class SQLRunDB(RunDBInterface):
         entities: List[str] = None,
         labels: List[str] = None,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().list_features,
-            self.session,
-            project,
-            name,
-            tag,
-            entities,
-            labels,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().list_features,
+                session,
+                project,
+                name,
+                tag,
+                entities,
+                labels,
+            )
+        finally:
+            session.close()
 
     def list_entities(
         self,
@@ -491,14 +605,18 @@ class SQLRunDB(RunDBInterface):
         tag: str = None,
         labels: List[str] = None,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().list_entities,
-            self.session,
-            project,
-            name,
-            tag,
-            labels,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().list_entities,
+                session,
+                project,
+                name,
+                tag,
+                labels,
+            )
+        finally:
+            session.close()
 
     def list_feature_sets(
         self,
@@ -514,21 +632,25 @@ class SQLRunDB(RunDBInterface):
         partition_sort_by: mlrun.common.schemas.SortField = None,
         partition_order: mlrun.common.schemas.OrderType = mlrun.common.schemas.OrderType.desc,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().list_feature_sets,
-            self.session,
-            project,
-            name,
-            tag,
-            state,
-            entities,
-            features,
-            labels,
-            partition_by,
-            rows_per_partition,
-            partition_sort_by,
-            partition_order,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().list_feature_sets,
+                session,
+                project,
+                name,
+                tag,
+                state,
+                entities,
+                features,
+                labels,
+                partition_by,
+                rows_per_partition,
+                partition_sort_by,
+                partition_order,
+            )
+        finally:
+            session.close()
 
     def store_feature_set(
         self,
@@ -544,61 +666,81 @@ class SQLRunDB(RunDBInterface):
 
         name = name or feature_set.metadata.name
         project = project or feature_set.metadata.project
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().store_feature_set,
-            self.session,
-            project,
-            name,
-            feature_set,
-            tag,
-            uid,
-            versioned,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().store_feature_set,
+                session,
+                project,
+                name,
+                feature_set,
+                tag,
+                uid,
+                versioned,
+            )
+        finally:
+            session.close()
 
     def patch_feature_set(
         self, name, feature_set, project="", tag=None, uid=None, patch_mode="replace"
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().patch_feature_set,
-            self.session,
-            project,
-            name,
-            feature_set,
-            tag,
-            uid,
-            patch_mode,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().patch_feature_set,
+                session,
+                project,
+                name,
+                feature_set,
+                tag,
+                uid,
+                patch_mode,
+            )
+        finally:
+            session.close()
 
     def delete_feature_set(self, name, project="", tag=None, uid=None):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().delete_feature_set,
-            self.session,
-            project,
-            name,
-            tag,
-            uid,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().delete_feature_set,
+                session,
+                project,
+                name,
+                tag,
+                uid,
+            )
+        finally:
+            session.close()
 
     def create_feature_vector(self, feature_vector, project="", versioned=True):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().create_feature_vector,
-            self.session,
-            project,
-            feature_vector,
-            versioned,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().create_feature_vector,
+                session,
+                project,
+                feature_vector,
+                versioned,
+            )
+        finally:
+            session.close()
 
     def get_feature_vector(
         self, name: str, project: str = "", tag: str = None, uid: str = None
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().get_feature_vector,
-            self.session,
-            project,
-            name,
-            tag,
-            uid,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().get_feature_vector,
+                session,
+                project,
+                name,
+                tag,
+                uid,
+            )
+        finally:
+            session.close()
 
     def list_feature_vectors(
         self,
@@ -612,19 +754,23 @@ class SQLRunDB(RunDBInterface):
         partition_sort_by: mlrun.common.schemas.SortField = None,
         partition_order: mlrun.common.schemas.OrderType = mlrun.common.schemas.OrderType.desc,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().list_feature_vectors,
-            self.session,
-            project,
-            name,
-            tag,
-            state,
-            labels,
-            partition_by,
-            rows_per_partition,
-            partition_sort_by,
-            partition_order,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().list_feature_vectors,
+                session,
+                project,
+                name,
+                tag,
+                state,
+                labels,
+                partition_by,
+                rows_per_partition,
+                partition_sort_by,
+                partition_order,
+            )
+        finally:
+            session.close()
 
     def store_feature_vector(
         self,
@@ -635,16 +781,20 @@ class SQLRunDB(RunDBInterface):
         uid=None,
         versioned=True,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().store_feature_vector,
-            self.session,
-            project,
-            name,
-            feature_vector,
-            tag,
-            uid,
-            versioned,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().store_feature_vector,
+                session,
+                project,
+                name,
+                feature_vector,
+                tag,
+                uid,
+                versioned,
+            )
+        finally:
+            session.close()
 
     def patch_feature_vector(
         self,
@@ -655,26 +805,34 @@ class SQLRunDB(RunDBInterface):
         uid=None,
         patch_mode="replace",
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().patch_feature_vector,
-            self.session,
-            project,
-            name,
-            feature_vector_update,
-            tag,
-            uid,
-            patch_mode,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().patch_feature_vector,
+                session,
+                project,
+                name,
+                feature_vector_update,
+                tag,
+                uid,
+                patch_mode,
+            )
+        finally:
+            session.close()
 
     def delete_feature_vector(self, name, project="", tag=None, uid=None):
-        return self._transform_db_error(
-            mlrun.api.crud.FeatureStore().delete_feature_vector,
-            self.session,
-            project,
-            name,
-            tag,
-            uid,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.FeatureStore().delete_feature_vector,
+                session,
+                project,
+                name,
+                tag,
+                uid,
+            )
+        finally:
+            session.close()
 
     def store_run_notifications(
         self,
@@ -683,14 +841,18 @@ class SQLRunDB(RunDBInterface):
         project: str = None,
         mask_params: bool = True,
     ):
-        return self._transform_db_error(
-            mlrun.api.crud.Notifications().store_run_notifications,
-            self.session,
-            notification_objects,
-            run_uid,
-            project,
-            mask_params,
-        )
+        session = create_session()
+        try:
+            return self._transform_db_error(
+                mlrun.api.crud.Notifications().store_run_notifications,
+                session,
+                notification_objects,
+                run_uid,
+                project,
+                mask_params,
+            )
+        finally:
+            session.close()
 
     def function_status(self, project, name, kind, selector):
         """Retrieve status of a function being executed remotely (relevant to ``dask`` functions).

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -111,7 +111,7 @@ class HTTPRunDB(RunDBInterface):
 
     def __init__(self, url):
         self.server_version = ""
-        self.session = None
+        self._session = None
         self._wait_for_project_terminal_state_retry_interval = 3
         self._wait_for_background_task_terminal_state_retry_interval = 3
         self._wait_for_project_deletion_interval = 3
@@ -244,12 +244,12 @@ class HTTPRunDB(RunDBInterface):
                         dict_[key] = dict_[key].value
 
         # if the method is POST, we need to update the session with the appropriate retry policy
-        if not self.session or method == "POST":
+        if not self._session or method == "POST":
             retry_on_post = self._is_retry_on_post_allowed(method, path)
-            self.session = self._init_session(retry_on_post)
+            self._session = self._init_session(retry_on_post)
 
         try:
-            response = self.session.request(
+            response = self._session.request(
                 method, url, timeout=timeout, verify=False, **kw
             )
         except requests.RequestException as exc:

--- a/tests/api/test_rundb.py
+++ b/tests/api/test_rundb.py
@@ -25,7 +25,7 @@ import mlrun.errors
 from mlrun.api.initial_data import init_data
 from mlrun.api.rundb import sqldb
 from mlrun.api.utils.singletons.db import initialize_db
-from mlrun.common.db.sql_session import _init_engine, create_session
+from mlrun.common.db.sql_session import _init_engine
 from mlrun.config import config
 from mlrun.db.base import RunDBInterface
 from tests.conftest import new_run, run_now

--- a/tests/api/test_rundb.py
+++ b/tests/api/test_rundb.py
@@ -47,8 +47,7 @@ def db(request):
         _init_engine(dsn=dsn)
         init_data()
         initialize_db()
-        db_session = create_session()
-        db = sqldb.SQLRunDB(dsn, session=db_session)
+        db = sqldb.SQLRunDB(dsn)
     else:
         assert False, f"unknown db type - {request.param}"
 

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -35,7 +35,7 @@ class SomeEnumClass(str, enum.Enum):
 
 def test_api_call_enum_conversion():
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
-    db.session = unittest.mock.Mock()
+    db._session = unittest.mock.Mock()
 
     # ensure not exploding when no headers/params
     db.api_call("GET", "some-path")
@@ -47,7 +47,7 @@ def test_api_call_enum_conversion():
         params={"enum-value": SomeEnumClass.value2, "string-value": "value"},
     )
     for dict_key in ["headers", "params"]:
-        for value in db.session.request.call_args_list[1][1][dict_key].values():
+        for value in db._session.request.call_args_list[1][1][dict_key].values():
             assert type(value) == str
 
 
@@ -221,7 +221,7 @@ def test_retriable_post_requests(path, call_amount):
     mlrun.config.config.httpdb.retry_api_call_on_exception = "enabled"
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
     # init the session to make sure it will be reinitialized when needed
-    db.session = db._init_session(False)
+    db._session = db._init_session(False)
     original_request = requests.Session.request
     requests.Session.request = unittest.mock.Mock()
     requests.Session.request.side_effect = ConnectionRefusedError(
@@ -285,8 +285,8 @@ def test_watch_logs_continue():
         f"https://wherever.com/api/v1/log/{project}/{run_uid}",
         content=callback,
     )
-    db.session = db._init_session()
-    db.session.mount("https://", adapter)
+    db._session = db._init_session()
+    db._session.mount("https://", adapter)
     mlrun.mlconf.httpdb.logs.pull_logs_default_interval = 0.1
     with unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as newprint:
         db.watch_log(run_uid, project=project)


### PR DESCRIPTION
Since the SQLRunDB is effectively a singleton (the factory holds its instance) we encountered the following errors:
1. We cannot use the session in multithreading until we move to async engine.
2. If a session query fails and not rolled back the session dies and can't be use anymore.
3. Keeping an open connection to the DB is occupying it and we see queries wait forever when the API is idle.

Here we create a new session for each operation (the session is not used from outside of the run db) and we make sure to close it when operation is done.
We still have other places where we create sessions in the API and we access the db layer (SQLDB) directly and we can improve this  mechanism but this should fix the issues we see for now.