### PR TITLE
[FeatureStore] Fix format target path as artifact path

### DIFF
--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -24,9 +24,9 @@ from mlrun.api.api.utils import (
     get_run_db_instance,
     get_scheduler,
 )
-from  mlrun.utils import fill_project_path_template
 from mlrun.config import config
 from mlrun.model import Credentials, RunMetadata, RunObject, RunSpec
+from mlrun.utils import fill_project_path_template
 
 
 class WorkflowRunners(
@@ -162,9 +162,12 @@ class WorkflowRunners(
                 ),
                 handler="mlrun.projects.load_and_run",
                 scrape_metrics=config.scrape_metrics,
-                output_path=fill_project_path_template((
-                    workflow_request.artifact_path or config.artifact_path
-                ).replace("{{run.uid}}", meta_uid),project.metadata.name),
+                output_path=fill_project_path_template(
+                    (workflow_request.artifact_path or config.artifact_path).replace(
+                        "{{run.uid}}", meta_uid
+                    ),
+                    project.metadata.name,
+                ),
             ),
             metadata=RunMetadata(
                 uid=meta_uid, name=workflow_spec.name, project=project.metadata.name

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -24,6 +24,7 @@ from mlrun.api.api.utils import (
     get_run_db_instance,
     get_scheduler,
 )
+from  mlrun.utils import fill_project_path_template
 from mlrun.config import config
 from mlrun.model import Credentials, RunMetadata, RunObject, RunSpec
 
@@ -161,9 +162,9 @@ class WorkflowRunners(
                 ),
                 handler="mlrun.projects.load_and_run",
                 scrape_metrics=config.scrape_metrics,
-                output_path=(
+                output_path=fill_project_path_template((
                     workflow_request.artifact_path or config.artifact_path
-                ).replace("{{run.uid}}", meta_uid),
+                ).replace("{{run.uid}}", meta_uid),project.metadata.name),
             ),
             metadata=RunMetadata(
                 uid=meta_uid, name=workflow_spec.name, project=project.metadata.name

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1010,7 +1010,7 @@ class Config:
             if artifact_path[-1] != "/":
                 artifact_path += "/"
 
-            return mlrun.utils.helpers.fill_artifact_path_template(
+            return mlrun.utils.helpers.fill_project_path_template(
                 artifact_path=artifact_path + file_path, project=project
             )
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -601,7 +601,11 @@ class BaseStoreTarget(DataTargetBase):
     def get_target_path(self):
         path_object = self._target_path_object
         project_name = self._resource.metadata.project if self._resource else None
-        return path_object.get_absolute_path(project_name=project_name) if path_object else None
+        return (
+            path_object.get_absolute_path(project_name=project_name)
+            if path_object
+            else None
+        )
 
     def get_target_path_with_credentials(self):
         return self.get_target_path()

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -600,7 +600,8 @@ class BaseStoreTarget(DataTargetBase):
 
     def get_target_path(self):
         path_object = self._target_path_object
-        return path_object.get_absolute_path() if path_object else None
+        project_name = self._resource.metadata.project if self._resource else None
+        return path_object.get_absolute_path(project_name=project_name) if path_object else None
 
     def get_target_path_with_credentials(self):
         return self.get_target_path()

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -970,7 +970,10 @@ def _ingest_with_spark(
                 max_time = source.start_time
             for target in featureset.status.targets:
                 featureset.status.update_last_written_for_target(
-                    target.get_path().get_absolute_path(project_name=featureset.metadata.project), max_time
+                    target.get_path().get_absolute_path(
+                        project_name=featureset.metadata.project
+                    ),
+                    max_time,
                 )
 
         _post_ingestion(mlrun_context, featureset, spark)

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -970,7 +970,7 @@ def _ingest_with_spark(
                 max_time = source.start_time
             for target in featureset.status.targets:
                 featureset.status.update_last_written_for_target(
-                    target.get_path().get_absolute_path(), max_time
+                    target.get_path().get_absolute_path(project_name=featureset.metadata.project), max_time
                 )
 
         _post_ingestion(mlrun_context, featureset, spark)

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -432,7 +432,7 @@ class FeatureSet(ModelObj):
             target = get_online_target(self, name)
 
         if target:
-            return target.get_path().get_absolute_path()
+            return target.get_path().get_absolute_path(project_name=self.metadata.project)
 
     def set_targets(
         self,

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -432,7 +432,9 @@ class FeatureSet(ModelObj):
             target = get_online_target(self, name)
 
         if target:
-            return target.get_path().get_absolute_path(project_name=self.metadata.project)
+            return target.get_path().get_absolute_path(
+                project_name=self.metadata.project
+            )
 
     def set_targets(
         self,

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -329,7 +329,7 @@ class BaseLauncher(abc.ABC):
 
         if run.spec.output_path:
             run.spec.output_path = run.spec.output_path.replace("{{run.uid}}", meta.uid)
-            run.spec.output_path = mlrun.utils.helpers.fill_artifact_path_template(
+            run.spec.output_path = mlrun.utils.helpers.fill_project_path_template(
                 run.spec.output_path, run.metadata.project
             )
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1587,10 +1587,8 @@ class TargetPathObject:
         path = fill_artifact_path_template(
             artifact_path=self.full_path_template,
             project=project_name,
-            )
-        return (
-            path.format(run_id=self.run_id) if self.run_id else path
         )
+        return path.format(run_id=self.run_id) if self.run_id else path
 
 
 class DataSource(ModelObj):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -34,7 +34,7 @@ from .utils import (
     dict_to_yaml,
     get_artifact_target,
     is_legacy_artifact,
-    logger,
+    logger, fill_artifact_path_template,
 )
 
 # Changing {run_id} will break and will not be backward compatible.
@@ -1581,10 +1581,9 @@ class TargetPathObject:
         return self.full_path_template
 
     def get_absolute_path(self):
-        if self.run_id:
-            return self.full_path_template.format(run_id=self.run_id)
-        else:
-            return self.full_path_template
+        formatted_path = fill_artifact_path_template(artifact_path=self.full_path_template,
+                                                     project=mlrun.get_current_project().name)
+        return formatted_path.format(run_id=self.run_id) if self.run_id else formatted_path
 
 
 class DataSource(ModelObj):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1582,7 +1582,6 @@ class TargetPathObject:
         return self.full_path_template
 
     def get_absolute_path(self, project_name=None):
-
         path = fill_project_path_template(
             artifact_path=self.full_path_template,
             project=project_name,

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -32,9 +32,10 @@ import mlrun.common.schemas.notification
 from .utils import (
     dict_to_json,
     dict_to_yaml,
+    fill_artifact_path_template,
     get_artifact_target,
     is_legacy_artifact,
-    logger, fill_artifact_path_template,
+    logger,
 )
 
 # Changing {run_id} will break and will not be backward compatible.
@@ -1581,9 +1582,13 @@ class TargetPathObject:
         return self.full_path_template
 
     def get_absolute_path(self):
-        formatted_path = fill_artifact_path_template(artifact_path=self.full_path_template,
-                                                     project=mlrun.get_current_project().name)
-        return formatted_path.format(run_id=self.run_id) if self.run_id else formatted_path
+        formatted_path = fill_artifact_path_template(
+            artifact_path=self.full_path_template,
+            project=mlrun.get_current_project().name,
+        )
+        return (
+            formatted_path.format(run_id=self.run_id) if self.run_id else formatted_path
+        )
 
 
 class DataSource(ModelObj):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1582,9 +1582,7 @@ class TargetPathObject:
         return self.full_path_template
 
     def get_absolute_path(self, project_name=None):
-        # if not project_name:
-        #     project = mlrun.get_current_project(silent=True)
-        #     project_name = project.name if project else None
+
         path = fill_project_path_template(
             artifact_path=self.full_path_template,
             project=project_name,

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1582,12 +1582,14 @@ class TargetPathObject:
         return self.full_path_template
 
     def get_absolute_path(self):
-        formatted_path = fill_artifact_path_template(
+        project = mlrun.get_current_project(silent=True)
+        project_name = project.name if project else None
+        path = fill_artifact_path_template(
             artifact_path=self.full_path_template,
-            project=mlrun.get_current_project().name,
-        )
+            project=project_name,
+            )
         return (
-            formatted_path.format(run_id=self.run_id) if self.run_id else formatted_path
+            path.format(run_id=self.run_id) if self.run_id else path
         )
 
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1581,9 +1581,10 @@ class TargetPathObject:
     def get_templated_path(self):
         return self.full_path_template
 
-    def get_absolute_path(self):
-        project = mlrun.get_current_project(silent=True)
-        project_name = project.name if project else None
+    def get_absolute_path(self, project_name=None):
+        # if not project_name:
+        #     project = mlrun.get_current_project(silent=True)
+        #     project_name = project.name if project else None
         path = fill_artifact_path_template(
             artifact_path=self.full_path_template,
             project=project_name,

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -32,7 +32,7 @@ import mlrun.common.schemas.notification
 from .utils import (
     dict_to_json,
     dict_to_yaml,
-    fill_artifact_path_template,
+    fill_project_path_template,
     get_artifact_target,
     is_legacy_artifact,
     logger,
@@ -1585,7 +1585,7 @@ class TargetPathObject:
         # if not project_name:
         #     project = mlrun.get_current_project(silent=True)
         #     project_name = project.name if project else None
-        path = fill_artifact_path_template(
+        path = fill_project_path_template(
             artifact_path=self.full_path_template,
             project=project_name,
         )

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1356,7 +1356,7 @@ class MlrunProject(ModelObj):
     def register_artifacts(self):
         """register the artifacts in the MLRun DB (under this project)"""
         artifact_manager = self._get_artifact_manager()
-        artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
+        artifact_path = mlrun.utils.helpers.fill_project_path_template(
             self.spec.artifact_path or mlrun.mlconf.artifact_path, self.metadata.name
         )
         # TODO: To correctly maintain the list of artifacts from an exported project,
@@ -1476,7 +1476,7 @@ class MlrunProject(ModelObj):
         artifact_path = extend_artifact_path(
             artifact_path, self.spec.artifact_path or mlrun.mlconf.artifact_path
         )
-        artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
+        artifact_path = mlrun.utils.helpers.fill_project_path_template(
             artifact_path, self.metadata.name
         )
         producer = ArtifactProducer(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -420,7 +420,7 @@ def get_or_create_ctx(
     if not newspec:
         newspec = {}
         if upload_artifacts:
-            artifact_path = mlrun.utils.helpers.fill_artifact_path_template(
+            artifact_path = mlrun.utils.helpers.fill_project_path_template(
                 mlconf.artifact_path, project or mlconf.default_project
             )
             update_in(newspec, ["spec", run_keys.output_path], artifact_path)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1269,7 +1269,7 @@ def calculate_dataframe_hash(dataframe: pandas.DataFrame):
     return hashlib.sha1(pandas.util.hash_pandas_object(dataframe).values).hexdigest()
 
 
-def fill_artifact_path_template(artifact_path, project):
+def fill_project_path_template(artifact_path, project):
     # Supporting {{project}} is new, in certain setup configuration the default artifact path has the old
     # {{run.project}} so we're supporting it too for backwards compatibility
     if artifact_path and (

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -596,7 +596,7 @@ class TestFeatureStore(TestMLRunSystem):
     def test_ingest_with_format_run_project(self, local):
         first_data = pd.read_csv("/Users/Tomer_Mamia/Downloads/first_data.csv")
         feature_set_1 = fstore.FeatureSet(
-            name=f"fs_run_project_format_local_{local}",
+            name=f"fs-run_project-format-local-{local}",
             entities=["entity"],
             timestamp_key="time",
         )

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -614,8 +614,13 @@ class TestFeatureStore(TestMLRunSystem):
             )
         else:
             fstore.ingest(featureset=feature_set_1, source=first_data)
-        target_dir_path = os.path.dirname(os.path.dirname(feature_set_1.get_target_path()))
-        assert artifact_path.replace("{{run.project}}", self.project_name) == target_dir_path
+        target_dir_path = os.path.dirname(
+            os.path.dirname(feature_set_1.get_target_path())
+        )
+        assert (
+            artifact_path.replace("{{run.project}}", self.project_name)
+            == target_dir_path
+        )
 
     def test_feature_set_db(self):
         name = "stocks_test"

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -606,14 +606,12 @@ class TestFeatureStore(TestMLRunSystem):
         ]
         feature_set.set_targets(targets=targets, with_defaults=False)
         feature_set.plot(with_targets=True)
-        if local:
-            fstore.ingest(
-                featureset=feature_set,
-                source=first_data,
-                run_config=fstore.RunConfig(local=local),
-            )
-        else:
-            fstore.ingest(featureset=feature_set, source=first_data)
+        config_kwargs = {'run_config': fstore.RunConfig(local=True)} if local else {}
+        fstore.ingest(
+            featureset=feature_set,
+            source=first_data,
+            **config_kwargs,
+        )
         target_dir_path = os.path.dirname(
             os.path.dirname(feature_set.get_target_path())
         )

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -190,7 +190,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         self._logger.info(f"stocks spec: {stocks_set.to_yaml()}")
         assert (
-                stocks_set.spec.features["name"].description == "some name"
+            stocks_set.spec.features["name"].description == "some name"
         ), "description was not set"
         assert len(df) == len(stocks), "dataframe size doesnt match"
         assert stocks_set.status.stats["exchange"], "stats not created"
@@ -241,12 +241,12 @@ class TestFeatureStore(TestMLRunSystem):
         assert quotes_set.status.stats.get("asks1_sum_1h"), "stats not created"
 
     def _get_offline_vector(
-            self,
-            features,
-            features_size,
-            entity_timestamp_column,
-            engine=None,
-            join_graph=None,
+        self,
+        features,
+        features_size,
+        entity_timestamp_column,
+        engine=None,
+        join_graph=None,
     ):
         vector = fstore.FeatureVector(
             "myvector",
@@ -267,10 +267,10 @@ class TestFeatureStore(TestMLRunSystem):
             features
         ), "unexpected num of requested features"
         assert (
-                len(vector.status.features) == features_size
+            len(vector.status.features) == features_size
         ), "unexpected num of returned features"
         assert (
-                len(vector.status.stats) == features_size
+            len(vector.status.stats) == features_size
         ), "unexpected num of feature stats"
         assert vector.status.label_column == "xx", "unexpected label_column name"
 
@@ -304,7 +304,7 @@ class TestFeatureStore(TestMLRunSystem):
             # check that passing a dict (without list) works
             resp = svc.get({"ticker": "GOOG"})
             assert (
-                    resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
+                resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
 
             try:
@@ -322,11 +322,11 @@ class TestFeatureStore(TestMLRunSystem):
             resp = svc.get([{"ticker": "GOOG"}, {"ticker": "MSFT"}])
             resp = svc.get([{"ticker": "AAPL"}])
             assert (
-                    resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
+                resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
             resp2 = svc.get([{"ticker": "AAPL"}], as_list=True)
             assert (
-                    len(resp2[0]) == features_size - 1
+                len(resp2[0]) == features_size - 1
             ), "unexpected online vector size"  # -1 label
 
     @pytest.mark.parametrize("entity_timestamp_column", [None, "time"])
@@ -348,7 +348,7 @@ class TestFeatureStore(TestMLRunSystem):
             "stocks.*",
         ]
         features_size = (
-                len(features) + 1 + 1
+            len(features) + 1 + 1
         )  # (*) returns 2 features, label adds 1 feature
 
         join_graph = None
@@ -460,13 +460,13 @@ class TestFeatureStore(TestMLRunSystem):
             (f"v3io:///bigdata/{project_name}/gof_wt.parquet", False),  # single file
             (f"v3io:///bigdata/{project_name}/gof_wt/", False),  # directory
             (
-                    f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
-                    True,
+                f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
+                True,
             ),  # with run_id
         ],
     )
     def test_different_target_paths_for_get_offline_features(
-            self, target_path, should_raise_error
+        self, target_path, should_raise_error
     ):
         stocks = pd.DataFrame(
             {
@@ -504,7 +504,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_storey_engines(
-            self, should_succeed, is_parquet, is_partitioned, target_path
+        self, should_succeed, is_parquet, is_partitioned, target_path
     ):
         fset = FeatureSet("fsname", entities=[Entity("ticker")], engine="storey")
         target = (
@@ -536,7 +536,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_pandas_engines(
-            self, should_succeed, is_parquet, is_partitioned, target_path, chunks
+        self, should_succeed, is_parquet, is_partitioned, target_path, chunks
     ):
         source = CSVSource(
             "mycsv", path=os.path.relpath(str(self.assets_path / "testdata.csv"))
@@ -586,23 +586,32 @@ class TestFeatureStore(TestMLRunSystem):
         )
 
         assert fset.status.targets[
-                   0
-               ].get_path().get_absolute_path() == fset.get_target_path("parquet")
+            0
+        ].get_path().get_absolute_path() == fset.get_target_path("parquet")
         assert fset.status.targets[
-                   1
-               ].get_path().get_absolute_path() == fset.get_target_path("nosql")
+            1
+        ].get_path().get_absolute_path() == fset.get_target_path("nosql")
 
     @pytest.mark.parametrize("local", [True, False])
     def test_ingest_with_format_run_project(self, local):
-        first_data = pd.read_csv('/Users/Tomer_Mamia/Downloads/first_data.csv')
-        feature_set_1 = fstore.FeatureSet(name=f'fs_run_project_format_local_{local}', entities=['entity'],
-                                          timestamp_key='time')
+        first_data = pd.read_csv("/Users/Tomer_Mamia/Downloads/first_data.csv")
+        feature_set_1 = fstore.FeatureSet(
+            name=f"fs_run_project_format_local_{local}",
+            entities=["entity"],
+            timestamp_key="time",
+        )
         artifact_path = mlrun.mlconf.artifact_path
-        targets = [CSVTarget(name='labels', path=os.path.join(artifact_path, 'file.csv'))]
+        targets = [
+            CSVTarget(name="labels", path=os.path.join(artifact_path, "file.csv"))
+        ]
         feature_set_1.set_targets(targets=targets, with_defaults=False)
         feature_set_1.plot(with_targets=True)
         if local:
-            fstore.ingest(featureset=feature_set_1, source=first_data, run_config=fstore.RunConfig(local=local))
+            fstore.ingest(
+                featureset=feature_set_1,
+                source=first_data,
+                run_config=fstore.RunConfig(local=local),
+            )
         else:
             fstore.ingest(featureset=feature_set_1, source=first_data)
         assert "{{run.project}}" not in feature_set_1.get_target_path()
@@ -861,7 +870,7 @@ class TestFeatureStore(TestMLRunSystem):
     @pytest.mark.parametrize("partition_cols", [None, ["department"]])
     @pytest.mark.parametrize("time_partitioning_granularity", [None, "day"])
     def test_ingest_partitioned_by_key_and_time(
-            self, key_bucketing_number, partition_cols, time_partitioning_granularity
+        self, key_bucketing_number, partition_cols, time_partitioning_granularity
     ):
         name = f"measurements_{uuid.uuid4()}"
         key = "patient_id"
@@ -900,7 +909,7 @@ class TestFeatureStore(TestMLRunSystem):
         file_system = fsspec.filesystem("v3io")
         path = measurements.get_target_path("parquet")
         dataset = pq.ParquetDataset(
-            path if major_pyarrow_version < 11 else path[len("v3io://"):],
+            path if major_pyarrow_version < 11 else path[len("v3io://") :],
             filesystem=file_system,
         )
         if major_pyarrow_version < 11:
@@ -916,12 +925,12 @@ class TestFeatureStore(TestMLRunSystem):
             expected_partitions = [f"hash{key_bucketing_number}_key"]
         expected_partitions += partition_cols or []
         if all(
-                value is None
-                for value in [
-                    key_bucketing_number,
-                    partition_cols,
-                    time_partitioning_granularity,
-                ]
+            value is None
+            for value in [
+                key_bucketing_number,
+                partition_cols,
+                time_partitioning_granularity,
+            ]
         ):
             time_partitioning_granularity = (
                 mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
@@ -1632,7 +1641,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         vector = fstore.FeatureVector("my-vec", features)
         with fstore.get_online_feature_service(
-                vector, fixed_window_type=fixed_window_type
+            vector, fixed_window_type=fixed_window_type
         ) as svc:
             resp = svc.get([{"first_name": "moshe"}])
             if fixed_window_type == FixedWindowType.CurrentOpenWindow:
@@ -2181,7 +2190,7 @@ class TestFeatureStore(TestMLRunSystem):
         if target_redis.startswith("ds://"):
             project = mlrun.get_or_create_project(self.project_name)
             profile = DatastoreProfileRedis(
-                name=target_redis[len("ds://"):], endpoint_url=mlrun.mlconf.redis.url
+                name=target_redis[len("ds://") :], endpoint_url=mlrun.mlconf.redis.url
             )
             project.register_datastore_profile(profile)
 
@@ -2223,7 +2232,7 @@ class TestFeatureStore(TestMLRunSystem):
 
                 # strip protocol
                 if "//" in api:
-                    api = api[api.find("//") + 2:]
+                    api = api[api.find("//") + 2 :]
 
                 # strip port
                 if ":" in api:
@@ -2750,8 +2759,8 @@ class TestFeatureStore(TestMLRunSystem):
         vector.save()
 
         with fstore.get_online_feature_service(
-                vector.uri if pass_vector_as_uri else vector,
-                impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4},
+            vector.uri if pass_vector_as_uri else vector,
+            impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4},
         ) as svc:
             print(svc.vector.status.to_yaml())
 
@@ -2868,7 +2877,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_deploy_ingestion_service_with_different_targets(
-            self, targets, feature_set_targets, expected_target_names
+        self, targets, feature_set_targets, expected_target_names
     ):
         fset_name = "dis-set"
         fset = FeatureSet(
@@ -3269,7 +3278,7 @@ class TestFeatureStore(TestMLRunSystem):
             request_url, json=request_body, headers=headers, verify=False
         )
         assert (
-                response.status_code == 200
+            response.status_code == 200
         ), f"Failed to patch feature vector: {response}"
 
         service = fstore.get_online_feature_service(vector_name)
@@ -4177,8 +4186,8 @@ class TestFeatureStore(TestMLRunSystem):
         )
         key_as_set = {key}
         with pytest.raises(
-                mlrun.errors.MLRunInvalidArgumentError,
-                match=f"^DropFeatures can only drop features, not entities: {key_as_set}$",
+            mlrun.errors.MLRunInvalidArgumentError,
+            match=f"^DropFeatures can only drop features, not entities: {key_as_set}$",
         ):
             fstore.ingest(measurements, source)
 
@@ -4190,31 +4199,31 @@ class TestFeatureStore(TestMLRunSystem):
         "source_class, target_class, local_file_name, reader, reader_kwargs, drop_index",
         [
             (
-                    CSVSource,
-                    CSVTarget,
-                    "testdata_short.csv",
-                    pd.read_csv,
-                    {"parse_dates": ["date_of_birth"]},
-                    False,
+                CSVSource,
+                CSVTarget,
+                "testdata_short.csv",
+                pd.read_csv,
+                {"parse_dates": ["date_of_birth"]},
+                False,
             ),
             (
-                    ParquetSource,
-                    ParquetTarget,
-                    "testdata_short.parquet",
-                    pd.read_parquet,
-                    {},
-                    True,
+                ParquetSource,
+                ParquetTarget,
+                "testdata_short.parquet",
+                pd.read_parquet,
+                {},
+                True,
             ),
         ],
     )
     def test_ingest_with_dbfs(
-            self,
-            source_class,
-            target_class,
-            local_file_name,
-            reader,
-            reader_kwargs,
-            drop_index,
+        self,
+        source_class,
+        target_class,
+        local_file_name,
+        reader,
+        reader_kwargs,
+        drop_index,
     ):
         local_source_path = os.path.relpath(str(self.assets_path / local_file_name))
         drop_column = "number"
@@ -4404,8 +4413,8 @@ class TestFeatureStore(TestMLRunSystem):
             assert res_df.columns == ["val"]
         else:
             with pytest.raises(
-                    mlrun.errors.MLRunInvalidArgumentError,
-                    match="Feature set `fs1` does not have a column named `bad_ts` to filter on.",
+                mlrun.errors.MLRunInvalidArgumentError,
+                match="Feature set `fs1` does not have a column named `bad_ts` to filter on.",
             ):
                 fstore.get_offline_features(
                     vec,
@@ -4445,8 +4454,8 @@ class TestFeatureStore(TestMLRunSystem):
         vector.save()
 
         with pytest.raises(
-                mlrun.errors.MLRunRuntimeError,
-                match="No features found for feature vector 'my-vector'",
+            mlrun.errors.MLRunRuntimeError,
+            match="No features found for feature vector 'my-vector'",
         ):
             fstore.get_online_feature_service(
                 f"store://feature-vectors/{self.project_name}/my-vector:latest"
@@ -4526,11 +4535,11 @@ def verify_target_list_fail(targets, with_defaults=None):
 
 
 def verify_ingest(
-        base_data,
-        keys,
-        infer=False,
-        targets=None,
-        infer_options=fstore.InferOptions.default(),
+    base_data,
+    keys,
+    infer=False,
+    targets=None,
+    infer_options=fstore.InferOptions.default(),
 ):
     if isinstance(keys, str):
         keys = [keys]
@@ -4552,7 +4561,7 @@ def verify_ingest(
 
 
 def prepare_feature_set(
-        name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
+    name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
 ):
     df_source = mlrun.datastore.sources.DataFrameSource(data, entity, timestamp_key)
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -594,32 +594,32 @@ class TestFeatureStore(TestMLRunSystem):
 
     @pytest.mark.parametrize("local", [True, False])
     def test_ingest_with_format_run_project(self, local):
-        first_data = pd.read_csv("/Users/Tomer_Mamia/Downloads/first_data.csv")
-        feature_set_1 = fstore.FeatureSet(
+        first_data = pd.read_csv(os.path.relpath(str(self.assets_path / "testdata.csv")))
+        feature_set = fstore.FeatureSet(
             name=f"fs-run_project-format-local-{local}",
-            entities=["entity"],
-            timestamp_key="time",
+            entities=[Entity('patient_id')],
+            timestamp_key="timestamp",
         )
         artifact_path = mlrun.mlconf.artifact_path
         targets = [
             CSVTarget(name="labels", path=os.path.join(artifact_path, "file.csv"))
         ]
-        feature_set_1.set_targets(targets=targets, with_defaults=False)
-        feature_set_1.plot(with_targets=True)
+        feature_set.set_targets(targets=targets, with_defaults=False)
+        feature_set.plot(with_targets=True)
         if local:
             fstore.ingest(
-                featureset=feature_set_1,
+                featureset=feature_set,
                 source=first_data,
                 run_config=fstore.RunConfig(local=local),
             )
         else:
-            fstore.ingest(featureset=feature_set_1, source=first_data)
+            fstore.ingest(featureset=feature_set, source=first_data)
         target_dir_path = os.path.dirname(
-            os.path.dirname(feature_set_1.get_target_path())
+            os.path.dirname(feature_set.get_target_path())
         )
         assert (
-            artifact_path.replace("{{run.project}}", self.project_name)
-            == target_dir_path
+                artifact_path.replace("{{run.project}}", self.project_name)
+                == target_dir_path
         )
 
     def test_feature_set_db(self):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -594,10 +594,12 @@ class TestFeatureStore(TestMLRunSystem):
 
     @pytest.mark.parametrize("local", [True, False])
     def test_ingest_with_format_run_project(self, local):
-        first_data = pd.read_csv(os.path.relpath(str(self.assets_path / "testdata.csv")))
+        first_data = pd.read_csv(
+            os.path.relpath(str(self.assets_path / "testdata.csv"))
+        )
         feature_set = fstore.FeatureSet(
             name=f"fs-run_project-format-local-{local}",
-            entities=[Entity('patient_id')],
+            entities=[Entity("patient_id")],
             timestamp_key="timestamp",
         )
         artifact_path = mlrun.mlconf.artifact_path
@@ -606,7 +608,7 @@ class TestFeatureStore(TestMLRunSystem):
         ]
         feature_set.set_targets(targets=targets, with_defaults=False)
         feature_set.plot(with_targets=True)
-        config_kwargs = {'run_config': fstore.RunConfig(local=True)} if local else {}
+        config_kwargs = {"run_config": fstore.RunConfig(local=True)} if local else {}
         fstore.ingest(
             featureset=feature_set,
             source=first_data,
@@ -616,8 +618,8 @@ class TestFeatureStore(TestMLRunSystem):
             os.path.dirname(feature_set.get_target_path())
         )
         assert (
-                artifact_path.replace("{{run.project}}", self.project_name)
-                == target_dir_path
+            artifact_path.replace("{{run.project}}", self.project_name)
+            == target_dir_path
         )
 
     def test_feature_set_db(self):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -597,8 +597,10 @@ class TestFeatureStore(TestMLRunSystem):
         source_path = str(self.assets_path / "testdata.csv")
         if not local:
             data = pd.read_csv(source_path)
-            source_path = f"v3io:///projects/{self.project_name}/test_ingest_with_format_run_project/" \
-                          f"{uuid.uuid4()}/source.csv"
+            source_path = (
+                f"v3io:///projects/{self.project_name}/test_ingest_with_format_run_project/"
+                f"{uuid.uuid4()}/source.csv"
+            )
             data.to_csv(source_path)
         source = CSVSource("mycsv", path=source_path)
         feature_set = fstore.FeatureSet(
@@ -621,8 +623,8 @@ class TestFeatureStore(TestMLRunSystem):
             os.path.dirname(feature_set.get_target_path())
         )
         assert (
-                artifact_path.replace("{{run.project}}", self.project_name)
-                == target_dir_path
+            artifact_path.replace("{{run.project}}", self.project_name)
+            == target_dir_path
         )
 
     def test_feature_set_db(self):

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -613,7 +613,6 @@ class TestFeatureStore(TestMLRunSystem):
             CSVTarget(name="labels", path=os.path.join(artifact_path, "file.csv"))
         ]
         feature_set.set_targets(targets=targets, with_defaults=False)
-        feature_set.plot(with_targets=True)
         fstore.ingest(
             featureset=feature_set,
             source=source,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -190,7 +190,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         self._logger.info(f"stocks spec: {stocks_set.to_yaml()}")
         assert (
-            stocks_set.spec.features["name"].description == "some name"
+                stocks_set.spec.features["name"].description == "some name"
         ), "description was not set"
         assert len(df) == len(stocks), "dataframe size doesnt match"
         assert stocks_set.status.stats["exchange"], "stats not created"
@@ -241,12 +241,12 @@ class TestFeatureStore(TestMLRunSystem):
         assert quotes_set.status.stats.get("asks1_sum_1h"), "stats not created"
 
     def _get_offline_vector(
-        self,
-        features,
-        features_size,
-        entity_timestamp_column,
-        engine=None,
-        join_graph=None,
+            self,
+            features,
+            features_size,
+            entity_timestamp_column,
+            engine=None,
+            join_graph=None,
     ):
         vector = fstore.FeatureVector(
             "myvector",
@@ -267,10 +267,10 @@ class TestFeatureStore(TestMLRunSystem):
             features
         ), "unexpected num of requested features"
         assert (
-            len(vector.status.features) == features_size
+                len(vector.status.features) == features_size
         ), "unexpected num of returned features"
         assert (
-            len(vector.status.stats) == features_size
+                len(vector.status.stats) == features_size
         ), "unexpected num of feature stats"
         assert vector.status.label_column == "xx", "unexpected label_column name"
 
@@ -304,7 +304,7 @@ class TestFeatureStore(TestMLRunSystem):
             # check that passing a dict (without list) works
             resp = svc.get({"ticker": "GOOG"})
             assert (
-                resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
+                    resp[0]["name"] == "Alphabet Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
 
             try:
@@ -322,11 +322,11 @@ class TestFeatureStore(TestMLRunSystem):
             resp = svc.get([{"ticker": "GOOG"}, {"ticker": "MSFT"}])
             resp = svc.get([{"ticker": "AAPL"}])
             assert (
-                resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
+                    resp[0]["name"] == "Apple Inc" and resp[0]["exchange"] == "NASDAQ"
             ), "unexpected online result"
             resp2 = svc.get([{"ticker": "AAPL"}], as_list=True)
             assert (
-                len(resp2[0]) == features_size - 1
+                    len(resp2[0]) == features_size - 1
             ), "unexpected online vector size"  # -1 label
 
     @pytest.mark.parametrize("entity_timestamp_column", [None, "time"])
@@ -348,7 +348,7 @@ class TestFeatureStore(TestMLRunSystem):
             "stocks.*",
         ]
         features_size = (
-            len(features) + 1 + 1
+                len(features) + 1 + 1
         )  # (*) returns 2 features, label adds 1 feature
 
         join_graph = None
@@ -460,13 +460,13 @@ class TestFeatureStore(TestMLRunSystem):
             (f"v3io:///bigdata/{project_name}/gof_wt.parquet", False),  # single file
             (f"v3io:///bigdata/{project_name}/gof_wt/", False),  # directory
             (
-                f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
-                True,
+                    f"v3io:///bigdata/{project_name}/{{run_id}}/gof_wt.parquet",
+                    True,
             ),  # with run_id
         ],
     )
     def test_different_target_paths_for_get_offline_features(
-        self, target_path, should_raise_error
+            self, target_path, should_raise_error
     ):
         stocks = pd.DataFrame(
             {
@@ -504,7 +504,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_storey_engines(
-        self, should_succeed, is_parquet, is_partitioned, target_path
+            self, should_succeed, is_parquet, is_partitioned, target_path
     ):
         fset = FeatureSet("fsname", entities=[Entity("ticker")], engine="storey")
         target = (
@@ -536,7 +536,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_different_paths_for_ingest_on_pandas_engines(
-        self, should_succeed, is_parquet, is_partitioned, target_path, chunks
+            self, should_succeed, is_parquet, is_partitioned, target_path, chunks
     ):
         source = CSVSource(
             "mycsv", path=os.path.relpath(str(self.assets_path / "testdata.csv"))
@@ -586,11 +586,26 @@ class TestFeatureStore(TestMLRunSystem):
         )
 
         assert fset.status.targets[
-            0
-        ].get_path().get_absolute_path() == fset.get_target_path("parquet")
+                   0
+               ].get_path().get_absolute_path() == fset.get_target_path("parquet")
         assert fset.status.targets[
-            1
-        ].get_path().get_absolute_path() == fset.get_target_path("nosql")
+                   1
+               ].get_path().get_absolute_path() == fset.get_target_path("nosql")
+
+    @pytest.mark.parametrize("local", [True, False])
+    def test_ingest_with_format_run_project(self, local):
+        first_data = pd.read_csv('/Users/Tomer_Mamia/Downloads/first_data.csv')
+        feature_set_1 = fstore.FeatureSet(name=f'fs_run_project_format_local_{local}', entities=['entity'],
+                                          timestamp_key='time')
+        artifact_path = mlrun.mlconf.artifact_path
+        targets = [CSVTarget(name='labels', path=os.path.join(artifact_path, 'file.csv'))]
+        feature_set_1.set_targets(targets=targets, with_defaults=False)
+        feature_set_1.plot(with_targets=True)
+        if local:
+            fstore.ingest(featureset=feature_set_1, source=first_data, run_config=fstore.RunConfig(local=local))
+        else:
+            fstore.ingest(featureset=feature_set_1, source=first_data)
+        assert "{{run.project}}" not in feature_set_1.get_target_path()
 
     def test_feature_set_db(self):
         name = "stocks_test"
@@ -846,7 +861,7 @@ class TestFeatureStore(TestMLRunSystem):
     @pytest.mark.parametrize("partition_cols", [None, ["department"]])
     @pytest.mark.parametrize("time_partitioning_granularity", [None, "day"])
     def test_ingest_partitioned_by_key_and_time(
-        self, key_bucketing_number, partition_cols, time_partitioning_granularity
+            self, key_bucketing_number, partition_cols, time_partitioning_granularity
     ):
         name = f"measurements_{uuid.uuid4()}"
         key = "patient_id"
@@ -885,7 +900,7 @@ class TestFeatureStore(TestMLRunSystem):
         file_system = fsspec.filesystem("v3io")
         path = measurements.get_target_path("parquet")
         dataset = pq.ParquetDataset(
-            path if major_pyarrow_version < 11 else path[len("v3io://") :],
+            path if major_pyarrow_version < 11 else path[len("v3io://"):],
             filesystem=file_system,
         )
         if major_pyarrow_version < 11:
@@ -901,12 +916,12 @@ class TestFeatureStore(TestMLRunSystem):
             expected_partitions = [f"hash{key_bucketing_number}_key"]
         expected_partitions += partition_cols or []
         if all(
-            value is None
-            for value in [
-                key_bucketing_number,
-                partition_cols,
-                time_partitioning_granularity,
-            ]
+                value is None
+                for value in [
+                    key_bucketing_number,
+                    partition_cols,
+                    time_partitioning_granularity,
+                ]
         ):
             time_partitioning_granularity = (
                 mlrun.utils.helpers.DEFAULT_TIME_PARTITIONING_GRANULARITY
@@ -1617,7 +1632,7 @@ class TestFeatureStore(TestMLRunSystem):
 
         vector = fstore.FeatureVector("my-vec", features)
         with fstore.get_online_feature_service(
-            vector, fixed_window_type=fixed_window_type
+                vector, fixed_window_type=fixed_window_type
         ) as svc:
             resp = svc.get([{"first_name": "moshe"}])
             if fixed_window_type == FixedWindowType.CurrentOpenWindow:
@@ -2166,7 +2181,7 @@ class TestFeatureStore(TestMLRunSystem):
         if target_redis.startswith("ds://"):
             project = mlrun.get_or_create_project(self.project_name)
             profile = DatastoreProfileRedis(
-                name=target_redis[len("ds://") :], endpoint_url=mlrun.mlconf.redis.url
+                name=target_redis[len("ds://"):], endpoint_url=mlrun.mlconf.redis.url
             )
             project.register_datastore_profile(profile)
 
@@ -2208,7 +2223,7 @@ class TestFeatureStore(TestMLRunSystem):
 
                 # strip protocol
                 if "//" in api:
-                    api = api[api.find("//") + 2 :]
+                    api = api[api.find("//") + 2:]
 
                 # strip port
                 if ":" in api:
@@ -2735,8 +2750,8 @@ class TestFeatureStore(TestMLRunSystem):
         vector.save()
 
         with fstore.get_online_feature_service(
-            vector.uri if pass_vector_as_uri else vector,
-            impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4},
+                vector.uri if pass_vector_as_uri else vector,
+                impute_policy={"*": "$max", "data_avg_1h": "$mean", "data2": 4},
         ) as svc:
             print(svc.vector.status.to_yaml())
 
@@ -2853,7 +2868,7 @@ class TestFeatureStore(TestMLRunSystem):
         ],
     )
     def test_deploy_ingestion_service_with_different_targets(
-        self, targets, feature_set_targets, expected_target_names
+            self, targets, feature_set_targets, expected_target_names
     ):
         fset_name = "dis-set"
         fset = FeatureSet(
@@ -3254,7 +3269,7 @@ class TestFeatureStore(TestMLRunSystem):
             request_url, json=request_body, headers=headers, verify=False
         )
         assert (
-            response.status_code == 200
+                response.status_code == 200
         ), f"Failed to patch feature vector: {response}"
 
         service = fstore.get_online_feature_service(vector_name)
@@ -4162,8 +4177,8 @@ class TestFeatureStore(TestMLRunSystem):
         )
         key_as_set = {key}
         with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError,
-            match=f"^DropFeatures can only drop features, not entities: {key_as_set}$",
+                mlrun.errors.MLRunInvalidArgumentError,
+                match=f"^DropFeatures can only drop features, not entities: {key_as_set}$",
         ):
             fstore.ingest(measurements, source)
 
@@ -4175,31 +4190,31 @@ class TestFeatureStore(TestMLRunSystem):
         "source_class, target_class, local_file_name, reader, reader_kwargs, drop_index",
         [
             (
-                CSVSource,
-                CSVTarget,
-                "testdata_short.csv",
-                pd.read_csv,
-                {"parse_dates": ["date_of_birth"]},
-                False,
+                    CSVSource,
+                    CSVTarget,
+                    "testdata_short.csv",
+                    pd.read_csv,
+                    {"parse_dates": ["date_of_birth"]},
+                    False,
             ),
             (
-                ParquetSource,
-                ParquetTarget,
-                "testdata_short.parquet",
-                pd.read_parquet,
-                {},
-                True,
+                    ParquetSource,
+                    ParquetTarget,
+                    "testdata_short.parquet",
+                    pd.read_parquet,
+                    {},
+                    True,
             ),
         ],
     )
     def test_ingest_with_dbfs(
-        self,
-        source_class,
-        target_class,
-        local_file_name,
-        reader,
-        reader_kwargs,
-        drop_index,
+            self,
+            source_class,
+            target_class,
+            local_file_name,
+            reader,
+            reader_kwargs,
+            drop_index,
     ):
         local_source_path = os.path.relpath(str(self.assets_path / local_file_name))
         drop_column = "number"
@@ -4389,8 +4404,8 @@ class TestFeatureStore(TestMLRunSystem):
             assert res_df.columns == ["val"]
         else:
             with pytest.raises(
-                mlrun.errors.MLRunInvalidArgumentError,
-                match="Feature set `fs1` does not have a column named `bad_ts` to filter on.",
+                    mlrun.errors.MLRunInvalidArgumentError,
+                    match="Feature set `fs1` does not have a column named `bad_ts` to filter on.",
             ):
                 fstore.get_offline_features(
                     vec,
@@ -4430,8 +4445,8 @@ class TestFeatureStore(TestMLRunSystem):
         vector.save()
 
         with pytest.raises(
-            mlrun.errors.MLRunRuntimeError,
-            match="No features found for feature vector 'my-vector'",
+                mlrun.errors.MLRunRuntimeError,
+                match="No features found for feature vector 'my-vector'",
         ):
             fstore.get_online_feature_service(
                 f"store://feature-vectors/{self.project_name}/my-vector:latest"
@@ -4511,11 +4526,11 @@ def verify_target_list_fail(targets, with_defaults=None):
 
 
 def verify_ingest(
-    base_data,
-    keys,
-    infer=False,
-    targets=None,
-    infer_options=fstore.InferOptions.default(),
+        base_data,
+        keys,
+        infer=False,
+        targets=None,
+        infer_options=fstore.InferOptions.default(),
 ):
     if isinstance(keys, str):
         keys = [keys]
@@ -4537,7 +4552,7 @@ def verify_ingest(
 
 
 def prepare_feature_set(
-    name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
+        name: str, entity: str, data: pd.DataFrame, timestamp_key=None, targets=None
 ):
     df_source = mlrun.datastore.sources.DataFrameSource(data, entity, timestamp_key)
 

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -614,7 +614,8 @@ class TestFeatureStore(TestMLRunSystem):
             )
         else:
             fstore.ingest(featureset=feature_set_1, source=first_data)
-        assert "{{run.project}}" not in feature_set_1.get_target_path()
+        target_dir_path = os.path.dirname(os.path.dirname(feature_set_1.get_target_path()))
+        assert artifact_path.replace("{{run.project}}", self.project_name) == target_dir_path
 
     def test_feature_set_db(self):
         name = "stocks_test"

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -29,7 +29,7 @@ from mlrun.utils.helpers import (
     StorePrefix,
     enrich_image_url,
     extend_hub_uri_if_needed,
-    fill_artifact_path_template,
+    fill_project_path_template,
     get_parsed_docker_registry,
     get_pretty_types_names,
     get_regex_list_as_string,
@@ -704,12 +704,12 @@ def test_parse_store_uri(uri, expected_output):
         },
     ],
 )
-def test_fill_artifact_path_template(case):
+def test_fill_project_path_template(case):
     if case.get("raise"):
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-            fill_artifact_path_template(case["artifact_path"], case.get("project"))
+            fill_project_path_template(case["artifact_path"], case.get("project"))
     else:
-        filled_artifact_path = fill_artifact_path_template(
+        filled_artifact_path = fill_project_path_template(
             case["artifact_path"], case.get("project")
         )
         assert case["expected_artifact_path"] == filled_artifact_path


### PR DESCRIPTION
In order to format target path as artifact path, add `fill_artifact_path_template `function in `get_absolute_path`.

This function plays a role in obtaining the target path during the `ingestion` process.

[ML-4180](https://jira.iguazeng.com/browse/ML-4180)