### PR TITLE
[Package] Improved docs and minor edge case fixes

### DIFF
--- a/tests/package/test_packagers_manager.py
+++ b/tests/package/test_packagers_manager.py
@@ -52,14 +52,20 @@ class PackagerA(Packager):
         return ["result"]
 
     @classmethod
-    def is_packable(cls, obj: Any, artifact_type: str = None) -> bool:
+    def is_packable(
+        cls, obj: Any, artifact_type: str = None, configurations: dict = None
+    ) -> bool:
         return type(obj) is cls.PACKABLE_OBJECT_TYPE and artifact_type == "result"
 
     @classmethod
     def pack(
-        cls, obj: str, artifact_type: str = None, configurations: dict = None
+        cls,
+        obj: str,
+        key: str = None,
+        artifact_type: str = None,
+        configurations: dict = None,
     ) -> dict:
-        return {f"{configurations['key']}_from_PackagerA": obj}
+        return {f"{key}_from_PackagerA": obj}
 
     @classmethod
     def unpack(
@@ -155,9 +161,13 @@ class PackagerC(PackagerA):
 
     @classmethod
     def pack(
-        cls, obj: float, artifact_type: str = None, configurations: dict = None
+        cls,
+        obj: float,
+        key: str = None,
+        artifact_type: str = None,
+        configurations: dict = None,
     ) -> dict:
-        return {configurations["key"]: round(obj, configurations["n_round"])}
+        return {key: round(obj, configurations["n_round"])}
 
     @classmethod
     def unpack(


### PR DESCRIPTION
* The packagers generated docs include priority and default artifact types:

![image](https://github.com/mlrun/mlrun/assets/83535508/9428c920-2633-42db-b86f-7cd2bcd99a51)

* `DefaultPackager` and `Packager` got links to methods in their class doc string.
* Log hint configurations now propagate into the `get_default_packing_artifact_type` method to enrich logic of some packagers (see `NumPyNdArrayListPackager` and `NumPyNdArrayDictPackager` for example).
* Handled an edge case that caused empty lists and dictionary with `file` artifact type were saved in `npz` format due to missing configurations in logic.
* Handled an edge case where user would give a local file as `inputs` running with `local=True` and the packager would delete it at the end of the run because `DataItem.local()` would not download it to temp but simply return the actual path to the file. The correct way to run this scenario is of course to use `params` and not `inputs` but now it is handled anyway.
* Added `key` as a mandatory argument (extracted out from the configurations) - better design.