### PR TITLE
[Datastore] Fix dbfs zero size handling

### DIFF
--- a/mlrun/api/api/endpoints/files.py
+++ b/mlrun/api/api/endpoints/files.py
@@ -42,7 +42,7 @@ def get_files(
     schema: str = "",
     objpath: str = fastapi.Query("", alias="path"),
     user: str = "",
-    size: int = 0,
+    size: int = None,
     offset: int = 0,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         mlrun.api.api.deps.authenticate_request

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -112,9 +112,7 @@ class DBFSStore(DataStore):
     def get(self, key: str, size=None, offset=0) -> bytes:
         self._verify_filesystem_and_key(key)
         if size is not None and size < 0:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "size cannot be negative"
-            )
+            raise mlrun.errors.MLRunInvalidArgumentError("size cannot be negative")
         start = offset or None
         end = offset + size if size is not None else None
         return self._filesystem.cat_file(key, start=start, end=end)

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -111,9 +111,9 @@ class DBFSStore(DataStore):
 
     def get(self, key: str, size=None, offset=0) -> bytes:
         self._verify_filesystem_and_key(key)
-        if size is not None and size <= 0:
+        if size is not None and size < 0:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "size cannot be negative or zero"
+                "size cannot be negative"
             )
         start = offset or None
         end = offset + size if size is not None else None

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -113,6 +113,8 @@ class DBFSStore(DataStore):
         self._verify_filesystem_and_key(key)
         if size is not None and size < 0:
             raise mlrun.errors.MLRunInvalidArgumentError("size cannot be negative")
+        if offset is None:
+            raise mlrun.errors.MLRunInvalidArgumentError("offset cannot be None")
         start = offset or None
         end = offset + size if size else None
         return self._filesystem.cat_file(key, start=start, end=end)

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -114,7 +114,7 @@ class DBFSStore(DataStore):
         if size is not None and size < 0:
             raise mlrun.errors.MLRunInvalidArgumentError("size cannot be negative")
         start = offset or None
-        end = offset + size if size is not None else None
+        end = offset + size if size else None
         return self._filesystem.cat_file(key, start=start, end=end)
 
     def put(self, key, data, append=False):

--- a/tests/integration/test_dbfs_store/test_dbfs_store.py
+++ b/tests/integration/test_dbfs_store/test_dbfs_store.py
@@ -98,6 +98,8 @@ class TestDBFSStore:
 
             response = data_item.get(offset=20)
             assert response.decode() == self.test_string[20:]
+            response = data_item.get(offset=20, size=10)
+            assert response.decode() == self.test_string[20:30]
 
         finally:
             if use_secrets_as_parameters:

--- a/tests/integration/test_dbfs_store/test_dbfs_store.py
+++ b/tests/integration/test_dbfs_store/test_dbfs_store.py
@@ -98,6 +98,8 @@ class TestDBFSStore:
 
             response = data_item.get(offset=20)
             assert response.decode() == self.test_string[20:]
+            response = data_item.get(offset=20, size=0)
+            assert response.decode() == self.test_string[20:]
             response = data_item.get(offset=20, size=10)
             assert response.decode() == self.test_string[20:30]
 

--- a/tests/integration/test_dbfs_store/test_dbfs_store.py
+++ b/tests/integration/test_dbfs_store/test_dbfs_store.py
@@ -98,6 +98,8 @@ class TestDBFSStore:
 
             response = data_item.get(offset=20)
             assert response.decode() == self.test_string[20:]
+            response = data_item.get(size=20)
+            assert response.decode() == self.test_string[:20]
             response = data_item.get(offset=20, size=0)
             assert response.decode() == self.test_string[20:]
             response = data_item.get(offset=20, size=10)


### PR DESCRIPTION
In datastore default `size` is None.
This PR change default `size` from zero  to `None` also in the API.
Nevertheless, the DBFS has been modified to handle zero size.

[ML-4351](https://jira.iguazeng.com/browse/ML-4351)