### PR TITLE
[API] Fix session rollback and multithreading

### DIFF
--- a/mlrun/api/api/endpoints/projects.py
+++ b/mlrun/api/api/endpoints/projects.py
@@ -388,6 +388,7 @@ async def load_project(
         mlrun.api.crud.WorkflowRunners().create_runner,
         run_name=f"load-{name}",
         project=name,
+        db_session=db_session,
         auth_info=auth_info,
         image=mlrun.mlconf.default_base_image,
     )

--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -141,6 +141,7 @@ async def submit_workflow(
             workflow_spec.name
         ),
         project=project.metadata.name,
+        db_session=db_session,
         auth_info=auth_info,
         image=workflow_spec.image
         or project.spec.default_image

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -133,7 +133,7 @@ def get_secrets(
 def get_run_db_instance(
     db_session: Session,
 ):
-    # TODO: getting the run db should be seamlessly created from the run db factory and not require this logic to
+    # TODO: getting the run db should be seamlessly done by the run db factory and not require this logic to
     #  inject the session
     db = get_db()
     if isinstance(db, SQLDB):

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -133,7 +133,7 @@ def get_secrets(
 def get_run_db_instance(
     db_session: Session,
 ):
-    # TODO: getting the run db should be seamlessly done by the run db factory and not require this logic to
+    # TODO: getting the run db should be done seamlessly by the run db factory and not require this logic to
     #  inject the session
     db = get_db()
     if isinstance(db, SQLDB):

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -133,6 +133,8 @@ def get_secrets(
 def get_run_db_instance(
     db_session: Session,
 ):
+    # TODO: getting the run db should be seamlessly created from the run db factory and not require this logic to
+    #  inject the session
     db = get_db()
     if isinstance(db, SQLDB):
         run_db = SQLRunDB(db.dsn, db_session)

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -36,6 +36,8 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.pod
 import mlrun.utils.helpers
+from mlrun.api.db.sqldb.db import SQLDB
+from mlrun.api.rundb.sqldb import SQLRunDB
 from mlrun.api.utils.singletons.db import get_db
 from mlrun.api.utils.singletons.logs_dir import get_logs_dir
 from mlrun.api.utils.singletons.scheduler import get_scheduler
@@ -126,6 +128,18 @@ def get_secrets(
     return {
         "V3IO_ACCESS_KEY": auth_info.data_session,
     }
+
+
+def get_run_db_instance(
+    db_session: Session,
+):
+    db = get_db()
+    if isinstance(db, SQLDB):
+        run_db = SQLRunDB(db.dsn, db_session)
+    else:
+        run_db = db.db
+    run_db.connect()
+    return run_db
 
 
 def parse_submit_run_body(data):
@@ -867,6 +881,8 @@ def submit_run_sync(
     try:
         fn, task = _generate_function_and_task_from_submit_run_body(db_session, data)
 
+        run_db = get_run_db_instance(db_session)
+        fn.set_db_connection(run_db)
         logger.info("Submitting run", function=fn.to_dict(), task=task)
         schedule = data.get("schedule")
         if schedule:

--- a/mlrun/api/crud/model_monitoring/deployment.py
+++ b/mlrun/api/crud/model_monitoring/deployment.py
@@ -216,6 +216,7 @@ class MonitoringDeployment:
             fn = self._get_model_monitoring_batch_function(
                 project=project,
                 model_monitoring_access_key=model_monitoring_access_key,
+                db_session=db_session,
                 auth_info=auth_info,
                 tracking_policy=tracking_policy,
             )
@@ -319,6 +320,7 @@ class MonitoringDeployment:
         self,
         project: str,
         model_monitoring_access_key: str,
+        db_session: sqlalchemy.orm.Session,
         auth_info: mlrun.common.schemas.AuthInfo,
         tracking_policy: mlrun.model_monitoring.tracking_policy.TrackingPolicy,
     ):
@@ -345,6 +347,7 @@ class MonitoringDeployment:
             image=tracking_policy.default_batch_image,
             handler="handler",
         )
+        function.set_db_connection(mlrun.api.api.utils.get_run_db_instance(db_session))
 
         # Set the project to the job function
         function.metadata.project = project

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -93,7 +93,7 @@ class ModelEndpoints:
             logger.info(
                 "Getting model object, inferring column names and collecting feature stats"
             )
-            run_db = mlrun.get_run_db()
+            run_db = mlrun.api.api.utils.get_run_db_instance(db_session)
             model_obj: mlrun.artifacts.ModelArtifact = (
                 mlrun.datastore.store_resources.get_store_resource(
                     model_endpoint.spec.model_uri, db=run_db

--- a/mlrun/api/crud/pipelines.py
+++ b/mlrun/api/crud/pipelines.py
@@ -95,7 +95,7 @@ class Pipelines(
             runs = [run.to_dict() for run in response.runs or []]
             total_size = response.total_size
             next_page_token = response.next_page_token
-        runs = self._format_runs(runs, format_)
+        runs = self._format_runs(db_session, runs, format_)
 
         return total_size, next_page_token, runs
 
@@ -131,6 +131,7 @@ class Pipelines(
 
     def get_pipeline(
         self,
+        db_session: sqlalchemy.orm.Session,
         run_id: str,
         project: typing.Optional[str] = None,
         namespace: typing.Optional[str] = None,
@@ -148,7 +149,9 @@ class Pipelines(
                         raise mlrun.errors.MLRunNotFoundError(
                             f"Pipeline run with id {run_id} is not of project {project}"
                         )
-                run = self._format_run(run, format_, api_run_detail.to_dict())
+                run = self._format_run(
+                    db_session, run, format_, api_run_detail.to_dict()
+                )
         except kfp_server_api.ApiException as exc:
             mlrun.errors.raise_for_status_code(int(exc.status), err_to_str(exc))
         except mlrun.errors.MLRunHTTPStatusError:
@@ -225,16 +228,18 @@ class Pipelines(
 
     def _format_runs(
         self,
+        db_session: sqlalchemy.orm.Session,
         runs: typing.List[dict],
         format_: mlrun.common.schemas.PipelinesFormat = mlrun.common.schemas.PipelinesFormat.metadata_only,
     ) -> typing.List[dict]:
         formatted_runs = []
         for run in runs:
-            formatted_runs.append(self._format_run(run, format_))
+            formatted_runs.append(self._format_run(db_session, run, format_))
         return formatted_runs
 
     def _format_run(
         self,
+        db_session: sqlalchemy.orm.Session,
         run: dict,
         format_: mlrun.common.schemas.PipelinesFormat = mlrun.common.schemas.PipelinesFormat.metadata_only,
         api_run_detail: typing.Optional[dict] = None,
@@ -252,8 +257,9 @@ class Pipelines(
                 raise mlrun.errors.MLRunRuntimeError(
                     "The full kfp api_run_detail object is needed to generate the summary format"
                 )
+            run_db = mlrun.api.api.utils.get_run_db_instance(db_session)
             return mlrun.kfpops.format_summary_from_kfp_run(
-                api_run_detail, run["project"]
+                api_run_detail, run["project"], run_db=run_db
             )
         else:
             raise NotImplementedError(

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -18,10 +18,10 @@ from typing import Dict
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
-import mlrun.db
 import mlrun.utils.singleton
 from mlrun.api.api.utils import (
     apply_enrichment_and_validation_on_function,
+    get_run_db_instance,
     get_scheduler,
 )
 from mlrun.config import config
@@ -35,6 +35,7 @@ class WorkflowRunners(
     def create_runner(
         run_name: str,
         project: str,
+        db_session: Session,
         auth_info: mlrun.common.schemas.AuthInfo,
         image: str,
     ) -> mlrun.run.KubejobRuntime:
@@ -57,6 +58,8 @@ class WorkflowRunners(
             # For preventing deployment:
             image=image,
         )
+
+        runner.set_db_connection(get_run_db_instance(db_session))
 
         # Enrichment and validation requires access key
         runner.metadata.credentials.access_key = Credentials.generate_access_key

--- a/mlrun/api/db/session.py
+++ b/mlrun/api/db/session.py
@@ -28,7 +28,8 @@ def close_session(db_session):
 def run_function_with_new_db_session(func, *args, **kwargs):
     """
     Run a function with a new db session, useful for cuncurrent requests where we can't share a single session.
-    However, any changes made by the new session will not be visible to other sessions until they commit.
+    However, any changes made by the new session will not be visible to old sessions until the old sessions commit
+    due to isolation level.
     """
     session = create_session()
     try:

--- a/mlrun/api/db/session.py
+++ b/mlrun/api/db/session.py
@@ -25,10 +25,14 @@ def close_session(db_session):
     db_session.close()
 
 
-def run_function_with_new_db_session(func):
+def run_function_with_new_db_session(func, *args, **kwargs):
+    """
+    Run a function with a new db session, useful for cuncurrent requests where we can't share a single session.
+    However, any changes made by the new session will not be visible to other sessions until they commit.
+    """
     session = create_session()
     try:
-        result = func(session)
+        result = func(session, *args, **kwargs)
         return result
     finally:
         close_session(session)

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -678,6 +678,8 @@ class SQLRunDB(RunDBInterface):
         project: str = None,
         mask_params: bool = True,
     ):
+        # We run this function with a new session because it may run concurrently.
+        # Older sessions will not be able to see the changes made by this function until they are committed.
         return self._transform_db_error(
             mlrun.api.db.session.run_function_with_new_db_session,
             mlrun.api.crud.Notifications().store_run_notifications,

--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -39,11 +39,15 @@ class SQLRunDB(RunDBInterface):
     def __init__(
         self,
         dsn,
+        session=None,
     ):
+        self.session = session
         self.dsn = dsn
         self.db = None
 
     def connect(self, secrets=None):
+        if not self.session:
+            self.session = create_session()
         self.db = SQLDB(self.dsn)
         return self
 
@@ -68,8 +72,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_run(self, struct, uid, project="", iter=0):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Runs().store_run,
+            self.session,
             struct,
             uid,
             iter,
@@ -77,8 +82,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def update_run(self, updates: dict, uid, project="", iter=0):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Runs().update_run,
+            self.session,
             project,
             uid,
             iter,
@@ -89,8 +95,9 @@ class SQLRunDB(RunDBInterface):
         raise NotImplementedError()
 
     def read_run(self, uid, project=None, iter=None):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Runs().get_run,
+            self.session,
             uid,
             iter,
             project,
@@ -119,8 +126,9 @@ class SQLRunDB(RunDBInterface):
         max_partitions: int = 0,
         with_notifications: bool = False,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Runs().list_runs,
+            db_session=self.session,
             name=name,
             uid=uid,
             project=project,
@@ -142,16 +150,18 @@ class SQLRunDB(RunDBInterface):
         )
 
     def del_run(self, uid, project=None, iter=None):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Runs().delete_run,
+            self.session,
             uid,
             iter,
             project,
         )
 
     def del_runs(self, name=None, project=None, labels=None, state=None, days_ago=0):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Runs().delete_runs,
+            self.session,
             name,
             project,
             labels,
@@ -160,8 +170,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_artifact(self, key, artifact, uid, iter=None, tag="", project=""):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Artifacts().store_artifact,
+            self.session,
             key,
             artifact,
             uid,
@@ -171,8 +182,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def read_artifact(self, key, tag="", iter=None, project=""):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Artifacts().get_artifact,
+            self.session,
             key,
             tag,
             iter,
@@ -195,8 +207,9 @@ class SQLRunDB(RunDBInterface):
         if category and isinstance(category, str):
             category = mlrun.common.schemas.ArtifactCategories(category)
 
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Artifacts().list_artifacts,
+            self.session,
             project,
             name,
             tag,
@@ -210,16 +223,18 @@ class SQLRunDB(RunDBInterface):
         )
 
     def del_artifact(self, key, tag="", project=""):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Artifacts().delete_artifact,
+            self.session,
             key,
             tag,
             project,
         )
 
     def del_artifacts(self, name="", project="", tag="", labels=None):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Artifacts().delete_artifacts,
+            self.session,
             project,
             name,
             tag,
@@ -227,8 +242,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_function(self, function, name, project="", tag="", versioned=False):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Functions().store_function,
+            self.session,
             function,
             name,
             project,
@@ -237,8 +253,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def get_function(self, name, project="", tag="", hash_key=""):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Functions().get_function,
+            self.session,
             name,
             project,
             tag,
@@ -246,15 +263,17 @@ class SQLRunDB(RunDBInterface):
         )
 
     def delete_function(self, name: str, project: str = ""):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Functions().delete_function,
+            self.session,
             project,
             name,
         )
 
     def list_functions(self, name=None, project=None, tag=None, labels=None):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Functions().list_functions,
+            db_session=self.session,
             project=project,
             name=name,
             tag=tag,
@@ -266,8 +285,8 @@ class SQLRunDB(RunDBInterface):
         project=None,
         category: Union[str, mlrun.common.schemas.ArtifactCategories] = None,
     ):
-        return self._create_session_and_transform_db_error(
-            self.db.list_artifact_tags, project
+        return self._transform_db_error(
+            self.db.list_artifact_tags, self.session, project
         )
 
     def tag_objects(
@@ -278,15 +297,17 @@ class SQLRunDB(RunDBInterface):
         replace: bool = False,
     ):
         if replace:
-            return self._create_session_and_transform_db_error(
+            return self._transform_db_error(
                 mlrun.api.crud.Tags().overwrite_object_tags_with_tag,
+                self.session,
                 project,
                 tag_name,
                 tag_objects,
             )
 
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Tags().append_tag_to_objects,
+            self.session,
             project,
             tag_name,
             tag_objects,
@@ -298,8 +319,9 @@ class SQLRunDB(RunDBInterface):
         tag_name: str,
         tag_objects: mlrun.common.schemas.TagObjects,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Tags().delete_tag_from_objects,
+            self.session,
             project,
             tag_name,
             tag_objects,
@@ -334,10 +356,10 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_schedule(self, data):
-        return self._create_session_and_transform_db_error(self.db.store_schedule, data)
+        return self._transform_db_error(self.db.store_schedule, self.session, data)
 
     def list_schedules(self):
-        return self._create_session_and_transform_db_error(self.db.list_schedules)
+        return self._transform_db_error(self.db.list_schedules, self.session)
 
     def store_project(
         self,
@@ -347,8 +369,9 @@ class SQLRunDB(RunDBInterface):
         if isinstance(project, dict):
             project = mlrun.common.schemas.Project(**project)
 
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Projects().store_project,
+            self.session,
             name=name,
             project=project,
         )
@@ -359,8 +382,9 @@ class SQLRunDB(RunDBInterface):
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
     ) -> mlrun.common.schemas.Project:
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Projects().patch_project,
+            self.session,
             name=name,
             project=project,
             patch_mode=patch_mode,
@@ -370,8 +394,9 @@ class SQLRunDB(RunDBInterface):
         self,
         project: mlrun.common.schemas.Project,
     ) -> mlrun.common.schemas.Project:
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Projects().create_project,
+            self.session,
             project=project,
         )
 
@@ -380,8 +405,9 @@ class SQLRunDB(RunDBInterface):
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Projects().delete_project,
+            self.session,
             name=name,
             deletion_strategy=deletion_strategy,
         )
@@ -389,8 +415,9 @@ class SQLRunDB(RunDBInterface):
     def get_project(
         self, name: str = None, project_id: int = None
     ) -> mlrun.common.schemas.Project:
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Projects().get_project,
+            self.session,
             name=name,
         )
 
@@ -401,17 +428,26 @@ class SQLRunDB(RunDBInterface):
         labels: List[str] = None,
         state: mlrun.common.schemas.ProjectState = None,
     ) -> mlrun.common.schemas.ProjectsOutput:
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Projects().list_projects,
+            self.session,
             owner=owner,
             format_=format_,
             labels=labels,
             state=state,
         )
 
+    @staticmethod
+    def _transform_db_error(func, *args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except DBError as exc:
+            raise mlrun.db.RunDBError(exc.args) from exc
+
     def create_feature_set(self, feature_set, project="", versioned=True):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().create_feature_set,
+            self.session,
             project,
             feature_set,
             versioned,
@@ -420,8 +456,9 @@ class SQLRunDB(RunDBInterface):
     def get_feature_set(
         self, name: str, project: str = "", tag: str = None, uid: str = None
     ):
-        feature_set = self._create_session_and_transform_db_error(
+        feature_set = self._transform_db_error(
             mlrun.api.crud.FeatureStore().get_feature_set,
+            self.session,
             project,
             name,
             tag,
@@ -437,8 +474,9 @@ class SQLRunDB(RunDBInterface):
         entities: List[str] = None,
         labels: List[str] = None,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().list_features,
+            self.session,
             project,
             name,
             tag,
@@ -453,8 +491,9 @@ class SQLRunDB(RunDBInterface):
         tag: str = None,
         labels: List[str] = None,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().list_entities,
+            self.session,
             project,
             name,
             tag,
@@ -475,8 +514,9 @@ class SQLRunDB(RunDBInterface):
         partition_sort_by: mlrun.common.schemas.SortField = None,
         partition_order: mlrun.common.schemas.OrderType = mlrun.common.schemas.OrderType.desc,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().list_feature_sets,
+            self.session,
             project,
             name,
             tag,
@@ -504,8 +544,9 @@ class SQLRunDB(RunDBInterface):
 
         name = name or feature_set.metadata.name
         project = project or feature_set.metadata.project
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().store_feature_set,
+            self.session,
             project,
             name,
             feature_set,
@@ -517,8 +558,9 @@ class SQLRunDB(RunDBInterface):
     def patch_feature_set(
         self, name, feature_set, project="", tag=None, uid=None, patch_mode="replace"
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().patch_feature_set,
+            self.session,
             project,
             name,
             feature_set,
@@ -528,8 +570,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def delete_feature_set(self, name, project="", tag=None, uid=None):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().delete_feature_set,
+            self.session,
             project,
             name,
             tag,
@@ -537,8 +580,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def create_feature_vector(self, feature_vector, project="", versioned=True):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().create_feature_vector,
+            self.session,
             project,
             feature_vector,
             versioned,
@@ -547,8 +591,9 @@ class SQLRunDB(RunDBInterface):
     def get_feature_vector(
         self, name: str, project: str = "", tag: str = None, uid: str = None
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().get_feature_vector,
+            self.session,
             project,
             name,
             tag,
@@ -567,8 +612,9 @@ class SQLRunDB(RunDBInterface):
         partition_sort_by: mlrun.common.schemas.SortField = None,
         partition_order: mlrun.common.schemas.OrderType = mlrun.common.schemas.OrderType.desc,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().list_feature_vectors,
+            self.session,
             project,
             name,
             tag,
@@ -589,8 +635,9 @@ class SQLRunDB(RunDBInterface):
         uid=None,
         versioned=True,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().store_feature_vector,
+            self.session,
             project,
             name,
             feature_vector,
@@ -608,8 +655,9 @@ class SQLRunDB(RunDBInterface):
         uid=None,
         patch_mode="replace",
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().patch_feature_vector,
+            self.session,
             project,
             name,
             feature_vector_update,
@@ -619,8 +667,9 @@ class SQLRunDB(RunDBInterface):
         )
 
     def delete_feature_vector(self, name, project="", tag=None, uid=None):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.FeatureStore().delete_feature_vector,
+            self.session,
             project,
             name,
             tag,
@@ -634,8 +683,9 @@ class SQLRunDB(RunDBInterface):
         project: str = None,
         mask_params: bool = True,
     ):
-        return self._create_session_and_transform_db_error(
+        return self._transform_db_error(
             mlrun.api.crud.Notifications().store_run_notifications,
+            self.session,
             notification_objects,
             run_uid,
             project,
@@ -856,20 +906,6 @@ class SQLRunDB(RunDBInterface):
         self, profile: mlrun.common.schemas.DatastoreProfile, project: str
     ):
         raise NotImplementedError()
-
-    def _create_session_and_transform_db_error(self, func, *args, **kwargs):
-        session = create_session()
-        try:
-            return self._transform_db_error(func, session, *args, **kwargs)
-        finally:
-            session.close()
-
-    @staticmethod
-    def _transform_db_error(func, *args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except DBError as exc:
-            raise mlrun.db.RunDBError(exc.args) from exc
 
 
 # Once this file is imported it will override the default RunDB implementation (RunDBContainer)

--- a/mlrun/db/factory.py
+++ b/mlrun/db/factory.py
@@ -54,6 +54,9 @@ class RunDBFactory(
             self._run_db = self._rundb_container.nop(url)
 
         else:
+            # TODO: this practically makes the SQLRunDB a singleton, which mean that its session is shared, needs
+            #  to be refreshed frequently and cannot be used concurrently.
+            #  The SQLRunDB should always get its session from the FastAPI dependency injection.
             self._run_db = self._rundb_container.run_db(url)
 
         self._run_db.connect(secrets=secrets)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -111,7 +111,7 @@ class HTTPRunDB(RunDBInterface):
 
     def __init__(self, url):
         self.server_version = ""
-        self._session = None
+        self.session = None
         self._wait_for_project_terminal_state_retry_interval = 3
         self._wait_for_background_task_terminal_state_retry_interval = 3
         self._wait_for_project_deletion_interval = 3
@@ -244,12 +244,12 @@ class HTTPRunDB(RunDBInterface):
                         dict_[key] = dict_[key].value
 
         # if the method is POST, we need to update the session with the appropriate retry policy
-        if not self._session or method == "POST":
+        if not self.session or method == "POST":
             retry_on_post = self._is_retry_on_post_allowed(method, path)
-            self._session = self._init_session(retry_on_post)
+            self.session = self._init_session(retry_on_post)
 
         try:
-            response = self._session.request(
+            response = self.session.request(
                 method, url, timeout=timeout, verify=False, **kw
             )
         except requests.RequestException as exc:

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -731,16 +731,21 @@ def generate_kfp_dag_and_resolve_project(run, project=None):
     return dag, project, workflow["status"].get("message", "")
 
 
-def format_summary_from_kfp_run(kfp_run, project=None):
+def format_summary_from_kfp_run(
+    kfp_run, project=None, run_db: "mlrun.db.RunDBInterface" = None
+):
     override_project = project if project and project != "*" else None
     dag, project, message = generate_kfp_dag_and_resolve_project(
         kfp_run, override_project
     )
     run_id = get_in(kfp_run, "run.id")
 
+    # run db parameter allows us to use the same db session for the whole flow and avoid session isolation issues
+    if not run_db:
+        run_db = mlrun.db.get_run_db()
+
     # enrich DAG with mlrun run info
-    # TODO: create new session if in API?
-    runs = mlrun.db.get_run_db().list_runs(project=project, labels=f"workflow={run_id}")
+    runs = run_db.list_runs(project=project, labels=f"workflow={run_id}")
 
     for run in runs:
         step = get_in(run, ["metadata", "labels", "mlrun/runner-pod"])

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -739,6 +739,7 @@ def format_summary_from_kfp_run(kfp_run, project=None):
     run_id = get_in(kfp_run, "run.id")
 
     # enrich DAG with mlrun run info
+    # TODO: create new session if in API?
     runs = mlrun.db.get_run_db().list_runs(project=project, labels=f"workflow={run_id}")
 
     for run in runs:

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -55,6 +55,7 @@ def test_list_pipelines_empty_list(
 
 
 def test_list_pipelines_formats(
+    db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,
     kfp_client_mock: kfp.Client,
 ) -> None:
@@ -65,7 +66,9 @@ def test_list_pipelines_formats(
     ]:
         runs = _generate_list_runs_mocks()
         expected_runs = [run.to_dict() for run in runs]
-        expected_runs = mlrun.api.crud.Pipelines()._format_runs(expected_runs, format_)
+        expected_runs = mlrun.api.crud.Pipelines()._format_runs(
+            db, expected_runs, format_
+        )
         _mock_list_runs(kfp_client_mock, runs)
         response = client.get(
             "projects/*/pipelines",
@@ -78,6 +81,7 @@ def test_list_pipelines_formats(
 
 
 def test_get_pipeline_formats(
+    db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,
     kfp_client_mock: kfp.Client,
 ) -> None:
@@ -94,7 +98,7 @@ def test_get_pipeline_formats(
             params={"format": format_},
         )
         expected_run = mlrun.api.crud.Pipelines()._format_run(
-            api_run_detail.to_dict()["run"], format_, api_run_detail.to_dict()
+            db, api_run_detail.to_dict()["run"], format_, api_run_detail.to_dict()
         )
         _assert_get_pipeline_response(expected_run, response)
 
@@ -130,6 +134,7 @@ def test_get_pipeline_no_project_opa_validation(
 
 
 def test_get_pipeline_specific_project(
+    db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,
     kfp_client_mock: kfp.Client,
 ) -> None:
@@ -150,7 +155,7 @@ def test_get_pipeline_specific_project(
             params={"format": format_},
         )
         expected_run = mlrun.api.crud.Pipelines()._format_run(
-            api_run_detail.to_dict()["run"], format_, api_run_detail.to_dict()
+            db, api_run_detail.to_dict()["run"], format_, api_run_detail.to_dict()
         )
         _assert_get_pipeline_response(expected_run, response)
 

--- a/tests/api/test_rundb.py
+++ b/tests/api/test_rundb.py
@@ -25,7 +25,7 @@ import mlrun.errors
 from mlrun.api.initial_data import init_data
 from mlrun.api.rundb import sqldb
 from mlrun.api.utils.singletons.db import initialize_db
-from mlrun.common.db.sql_session import _init_engine
+from mlrun.common.db.sql_session import _init_engine, create_session
 from mlrun.config import config
 from mlrun.db.base import RunDBInterface
 from tests.conftest import new_run, run_now
@@ -47,7 +47,8 @@ def db(request):
         _init_engine(dsn=dsn)
         init_data()
         initialize_db()
-        db = sqldb.SQLRunDB(dsn)
+        db_session = create_session()
+        db = sqldb.SQLRunDB(dsn, session=db_session)
     else:
         assert False, f"unknown db type - {request.param}"
 

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -35,7 +35,7 @@ class SomeEnumClass(str, enum.Enum):
 
 def test_api_call_enum_conversion():
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
-    db._session = unittest.mock.Mock()
+    db.session = unittest.mock.Mock()
 
     # ensure not exploding when no headers/params
     db.api_call("GET", "some-path")
@@ -47,7 +47,7 @@ def test_api_call_enum_conversion():
         params={"enum-value": SomeEnumClass.value2, "string-value": "value"},
     )
     for dict_key in ["headers", "params"]:
-        for value in db._session.request.call_args_list[1][1][dict_key].values():
+        for value in db.session.request.call_args_list[1][1][dict_key].values():
             assert type(value) == str
 
 
@@ -221,7 +221,7 @@ def test_retriable_post_requests(path, call_amount):
     mlrun.config.config.httpdb.retry_api_call_on_exception = "enabled"
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
     # init the session to make sure it will be reinitialized when needed
-    db._session = db._init_session(False)
+    db.session = db._init_session(False)
     original_request = requests.Session.request
     requests.Session.request = unittest.mock.Mock()
     requests.Session.request.side_effect = ConnectionRefusedError(
@@ -285,8 +285,8 @@ def test_watch_logs_continue():
         f"https://wherever.com/api/v1/log/{project}/{run_uid}",
         content=callback,
     )
-    db._session = db._init_session()
-    db._session.mount("https://", adapter)
+    db.session = db._init_session()
+    db.session.mount("https://", adapter)
     mlrun.mlconf.httpdb.logs.pull_logs_default_interval = 0.1
     with unittest.mock.patch("sys.stdout", new_callable=io.StringIO) as newprint:
         db.watch_log(run_uid, project=project)


### PR DESCRIPTION
We decided to revert #4067 due to session isolation issues where if session A would be created from the endpoint dependency injection and session B would create some objects and commits them, session A would not be able to access them.
It is possible to change the isolation level to fix this but it might result in data anomalies.
Here we have to essential fixes that were the initial reasons for the fix:
1. Rollback sessions that result in sqlalchemy errors (A connection issue can corrupt a session and make it unusable until rolled back)
2. Using different sessions for concurrent operations - sessions are not thread safe. This effectively invalidates the previous session as it can't access the committed changes due to isolation level.

However, there is still work required since the run db factory holds the run db object and returns the same object which makes the SQLRunDB a singleton. 
That means that its session is shared, needs to be refreshed frequently and cannot be used concurrently.
The SQLRunDB should always get its session from the FastAPI dependency injection.