### PR TITLE
[Tests] Pass Pytest flags on the Arguments field of Pycharm configuration

### DIFF
--- a/.run/Unit tests.run.xml
+++ b/.run/Unit tests.run.xml
@@ -4,7 +4,7 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <option name="SDK_HOME" value="" />
-    <option name="WORKING_DIRECTORY" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
@@ -20,8 +20,8 @@
       </ENTRIES>
     </EXTENSION>
     <option name="_new_keywords" value="&quot;&quot;" />
-    <option name="_new_parameters" value="&quot; -v --capture\u003dno --disable-warnings --durations\u003d100 --ignore\u003dtests/integration --ignore\u003dtests/system --ignore\u003dtests/rundb/test_httpdb.py -rf tests&quot;" />
-    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_parameters" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;-v --capture\u003dno --disable-warnings --durations\u003d100 --ignore\u003dtests/integration --ignore\u003dtests/system --ignore\u003dtests/rundb/test_httpdb.py -rf tests&quot;" />
     <option name="_new_target" value="&quot;$PROJECT_DIR$/tests&quot;" />
     <option name="_new_targetType" value="&quot;PATH&quot;" />
     <method v="2" />


### PR DESCRIPTION
Currently, the configuration flags intended for launching Pytest on Pycharm are stored on the "Parameters" field. However, that field is intended for test parameters and not for CLI arguments, so these flags end up not being received by Pytest in the intended manner.

One of the side effects of this distinction is the amount of tests compiled for execution. When the configuration flags are stored on the "Parameters" field, Pycharm detects 3302 tests for execution. But when we move the flags to the "Additional Arguments" field, the `--ignore` flags are sent to the CLI and the compiled amount of tests is reduced to 2730.

This PR makes the necessary changes on Pycharm's run configuration so that such flags are passed to Pytest as expected. 