### PR TITLE
[frontend-spec] Fix Redis' default path for the Feature Store

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -453,7 +453,7 @@ default_config = {
         "data_prefixes": {
             "default": "v3io:///projects/{project}/FeatureStore/{name}/{kind}",
             "nosql": "v3io:///projects/{project}/FeatureStore/{name}/{kind}",
-            "redisnosql": "redis:///projects/{project}/FeatureStore/{name}/{kind}",
+            "redisnosql": "redis:///{hostIP}:{port}/projects/{project}/FeatureStore/{name}/{kind}",
         },
         "default_targets": "parquet,nosql",
         "default_job_image": "mlrun/mlrun",


### PR DESCRIPTION
Redis' default path configuration must take into account the hostIP and serving port of the available deployment.

See [ML-4359](https://jira.iguazeng.com/browse/ML-4359) for details.
