### PR TITLE
[Datastore] Fix dbfs preview

### DIFF
--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -82,9 +82,10 @@ class DatabricksFileSystemDisableCache(DatabricksFileSystem):
 # dbfs objects will be represented with the following URL: dbfs://<path>
 class DBFSStore(DataStore):
     def __init__(self, parent, schema, name, endpoint="", secrets: dict = None):
-        if not endpoint:
-            endpoint = mlrun.get_secret_or_env("DATABRICKS_HOST")
         super().__init__(parent, name, schema, endpoint, secrets=secrets)
+        if not endpoint:
+            endpoint = self._get_secret_or_env("DATABRICKS_HOST")
+        self.endpoint = endpoint
         self.get_filesystem(silent=False)
 
     def get_filesystem(self, silent=True):
@@ -96,7 +97,7 @@ class DBFSStore(DataStore):
     def get_storage_options(self):
         return dict(
             token=self._get_secret_or_env("DATABRICKS_TOKEN"),
-            instance=mlrun.get_secret_or_env("DATABRICKS_HOST"),
+            instance=self._get_secret_or_env("DATABRICKS_HOST"),
         )
 
     def _verify_filesystem_and_key(self, key: str):
@@ -111,12 +112,12 @@ class DBFSStore(DataStore):
 
     def get(self, key: str, size=None, offset=0) -> bytes:
         self._verify_filesystem_and_key(key)
-        if size is not None and size < 0:
-            raise mlrun.errors.MLRunInvalidArgumentError("size cannot be negative")
-        if offset is None:
-            raise mlrun.errors.MLRunInvalidArgumentError("offset cannot be None")
+        if size is not None and size <= 0:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "size cannot be negative or zero"
+            )
         start = offset or None
-        end = offset + size if size else None
+        end = offset + size if size is not None else None
         return self._filesystem.cat_file(key, start=start, end=end)
 
     def put(self, key, data, append=False):

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -112,12 +112,12 @@ class DBFSStore(DataStore):
 
     def get(self, key: str, size=None, offset=0) -> bytes:
         self._verify_filesystem_and_key(key)
-        if size is not None and size <= 0:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "size cannot be negative or zero"
-            )
+        if size is not None and size < 0:
+            raise mlrun.errors.MLRunInvalidArgumentError("size cannot be negative")
+        if offset is None:
+            raise mlrun.errors.MLRunInvalidArgumentError("offset cannot be None")
         start = offset or None
-        end = offset + size if size is not None else None
+        end = offset + size if size else None
         return self._filesystem.cat_file(key, start=start, end=end)
 
     def put(self, key, data, append=False):


### PR DESCRIPTION
In Dbfs fix the method that use to get secrets.
Instead of `mlrun.get_secret_or_env`,now  __init__ using datastore get_secret method, called `_get_secret_or_env`.

[ML-4381](https://jira.iguazeng.com/browse/ML-4381)