### PR TITLE
[Model Monitoring] Add `endpoint_store_connection` to client spec

### DIFF
--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -104,6 +104,9 @@ class ClientSpec(
             model_endpoint_monitoring_store_type=self._get_config_value_if_not_default(
                 "model_endpoint_monitoring.store_type"
             ),
+            model_endpoint_monitoring_endpoint_store_connection=self._get_config_value_if_not_default(
+                "model_endpoint_monitoring.endpoint_store_connection"
+            ),
             packagers=self._get_config_value_if_not_default("packagers"),
         )
 

--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -57,6 +57,7 @@ class ClientSpec(pydantic.BaseModel):
     redis_type: typing.Optional[str]
     sql_url: typing.Optional[str]
     model_endpoint_monitoring_store_type: typing.Optional[str]
+    model_endpoint_monitoring_endpoint_store_connection: typing.Optional[str]
     # ce_mode is deprecated, we will use the full ce config instead and ce_mode will be removed in 1.6.0
     ce_mode: typing.Optional[str]
     ce: typing.Optional[dict]

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -440,6 +440,10 @@ class HTTPRunDB(RunDBInterface):
                 server_cfg.get("model_endpoint_monitoring_store_type")
                 or config.model_endpoint_monitoring.store_type
             )
+            config.model_endpoint_monitoring.endpoint_store_connection = (
+                server_cfg.get("model_endpoint_monitoring_endpoint_store_connection")
+                or config.model_endpoint_monitoring.endpoint_store_connection
+            )
             config.packagers = server_cfg.get("packagers") or config.packagers
             server_data_prefixes = server_cfg.get("feature_store_data_prefixes") or {}
             for prefix in ["default", "nosql", "redisnosql"]:


### PR DESCRIPTION
Following https://github.com/v3io/helm-charts/pull/996 & https://github.com/mlrun/ce/pull/78, the model monitoring DB is generated under the existing `mlrun-db` service (as a default behaviour in the CE). 

In this PR, we add the field `endpoint_store_connection` to the client spec which be default will be enriched with the new model monitoring DB. 

A related JIRA ticket - https://jira.iguazeng.com/browse/CEML-106