### PR TITLE
[Model Monitoring] Fix parsing of default http target

### DIFF
--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -65,5 +65,7 @@ def parse_monitoring_stream_path(stream_uri: str, project: str):
 
     elif stream_uri.startswith("v3io://") and mlrun.mlconf.is_ce_mode():
         # V3IO is not supported in CE mode, generating a default http stream path
-        stream_uri = mlrun.mlconf.model_endpoint_monitoring.default_http_sink
+        stream_uri = mlrun.mlconf.model_endpoint_monitoring.default_http_sink.format(
+            project=project
+        )
     return stream_uri

--- a/tests/model_monitoring/test_target_path.py
+++ b/tests/model_monitoring/test_target_path.py
@@ -63,6 +63,13 @@ def test_get_stream_path():
         stream_path == f"v3io:///users/pipelines/{TEST_PROJECT}/model-endpoints/stream"
     )
 
+    mlrun.mlconf.ce.mode = "full"
+    stream_path = mlrun.model_monitoring.get_stream_path(project=TEST_PROJECT)
+    assert (
+        stream_path
+        == f"http://nuclio-{TEST_PROJECT}-model-monitoring-stream.mlrun.svc.cluster.local:8080"
+    )
+
     # kafka stream path from env
     os.environ["STREAM_PATH"] = "kafka://some_kafka_bootstrap_servers:8080"
     stream_path = mlrun.model_monitoring.get_stream_path(project=TEST_PROJECT)


### PR DESCRIPTION
When calling `parse_monitoring_stream_path()` on MLRun CE deployment that has no `kafka` stream, we use the default http path of the monitoring stream function as the main endpoint for the monitoring events. This default value can be found under `mlrun.mlconf.model_endpoint_monitoring.default_http_sink`:
`http://nuclio-{project}-model-monitoring-stream.mlrun.svc.cluster.local:8080`


This PR fix the parsing function of that http value in which we enrich the project name within the http path. 