### PR TITLE
[Runtimes] Add databricks to runtime_with_handlers

### DIFF
--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -120,6 +120,7 @@ class RuntimeKinds(object):
             RuntimeKinds.spark,
             RuntimeKinds.remotespark,
             RuntimeKinds.mpijob,
+            RuntimeKinds.databricks,
         ]
 
     @staticmethod


### PR DESCRIPTION
Add `databricks` to `runtime_with_handlers`.

[ML-4402](https://jira.iguazeng.com/browse/ML-4402)