### PR TITLE
[Builder] Remove env vars from Dockerfile and change behavior for project secrets

### DIFF
--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -45,6 +45,7 @@ def make_dockerfile(
     enriched_group_id: int = None,
     builder_env: typing.List[client.V1EnvVar] = None,
     extra_args: str = "",
+    project_secrets: typing.List[client.V1EnvVar] = None,
 ):
     """
     Generates the content of a Dockerfile for building a container image.
@@ -71,26 +72,21 @@ def make_dockerfile(
     dock = f"FROM {base_image}\n"
 
     builder_env = builder_env or []
+    project_secrets = project_secrets or []
     extra_args = _parse_extra_args_for_dockerfile(extra_args)
 
     # combine a list of all args (including builder_env, project_secrets and extra_args)
     # to add in each of the Dockerfile stages.
-    all_args = [f"{env.name}_ARG" for env in builder_env] + [
-        f"{arg}_ARG" for arg in extra_args
-    ]
+    all_args = (
+        [env.name for env in builder_env]
+        + [arg for arg in extra_args]
+        + [f"{secret.name}=${secret.name}" for secret in project_secrets]
+    )
     args = ""
 
     for arg in all_args:
         args += f"ARG {arg}\n"
     dock += args
-
-    envs = ""
-    for env in builder_env:
-        envs += f"ENV {env.name}=${env.name}_ARG\n"
-
-    for env in extra_args:
-        envs += f"ENV {env}=${env}_ARG\n"
-    dock += envs
 
     if config.is_pip_ca_configured():
         dock += f"COPY ./{pathlib.Path(config.httpdb.builder.pip_ca_path).name} {config.httpdb.builder.pip_ca_path}\n"
@@ -102,7 +98,6 @@ def make_dockerfile(
 
     if source:
         args = args.rstrip("\n")
-        envs = envs.rstrip("\n")
         dock += f"WORKDIR {workdir}\n"
         # 'ADD' command does not extract zip files - add extraction stage to the dockerfile
         if source.endswith(".zip"):
@@ -110,7 +105,6 @@ def make_dockerfile(
             stage_lines = [
                 f"FROM {base_image} AS extractor",
                 args,
-                envs,
                 "RUN apt-get update -qqy && apt install --assume-yes unzip",
                 f"RUN mkdir -p {source_dir}",
                 f"COPY {source} {source_dir}",
@@ -158,6 +152,7 @@ def make_kaniko_pod(
     runtime_spec=None,
     registry=None,
     extra_args="",
+    project_secrets=None,
 ):
     extra_runtime_spec = {}
     if not registry:
@@ -212,7 +207,9 @@ def make_kaniko_pod(
     if verbose:
         args += ["--verbosity", "debug"]
 
-    args = _add_kaniko_args_with_all_build_args(args, builder_env, extra_args)
+    args = _add_kaniko_args_with_all_build_args(
+        args, builder_env, project_secrets, extra_args
+    )
 
     # While requests mainly affect scheduling, setting a limit may prevent Kaniko
     # from finishing successfully (destructive), since we're not allowing to override the default
@@ -236,7 +233,10 @@ def make_kaniko_pod(
         default_pod_spec_attributes=extra_runtime_spec,
         resources=resources,
     )
-    kpod.env = builder_env
+    envs = (
+        builder_env if builder_env else [] + project_secrets if project_secrets else []
+    )
+    kpod.env = envs or None
 
     if config.is_pip_ca_configured():
         items = [
@@ -425,7 +425,7 @@ def build_image(
     )
     username = builder_env.get("V3IO_USERNAME", auth_info.username)
 
-    builder_env = _generate_builder_env(project, builder_env)
+    builder_env, project_secrets = _generate_builder_env(project, builder_env)
 
     parsed_url = urlparse(source)
     source_to_copy = None
@@ -501,6 +501,7 @@ def build_image(
         enriched_group_id=enriched_group_id,
         workdir=runtime.spec.clone_target_dir,
         builder_env=builder_env,
+        project_secrets=project_secrets,
         extra_args=extra_args,
     )
 
@@ -517,6 +518,7 @@ def build_image(
         name=name,
         verbose=verbose,
         builder_env=builder_env,
+        project_secrets=project_secrets,
         runtime_spec=runtime_spec,
         registry=registry,
         extra_args=extra_args,
@@ -760,30 +762,36 @@ def resolve_image_target_and_registry_secret(
 
 def _generate_builder_env(
     project: str, builder_env: typing.Dict
-) -> typing.List[client.V1EnvVar]:
+) -> (typing.List[client.V1EnvVar], typing.List[client.V1EnvVar]):
     k8s = mlrun.api.utils.singletons.k8s.get_k8s_helper(silent=False)
     secret_name = k8s.get_project_secret_name(project)
     existing_secret_keys = k8s.get_project_secret_keys(project, filter_internal=True)
 
     # generate env list from builder env and project secrets
-    env = []
+    project_secrets = []
     for key in existing_secret_keys:
         if key not in builder_env:
             value_from = client.V1EnvVarSource(
                 secret_key_ref=client.V1SecretKeySelector(name=secret_name, key=key)
             )
-            env.append(client.V1EnvVar(name=key, value_from=value_from))
+            project_secrets.append(client.V1EnvVar(name=key, value_from=value_from))
+    env = []
     for key, value in builder_env.items():
         env.append(client.V1EnvVar(name=key, value=value))
-    return env
+    return env, project_secrets
 
 
-def _add_kaniko_args_with_all_build_args(args, builder_env, extra_args):
-
+def _add_kaniko_args_with_all_build_args(
+    args, builder_env, project_secrets, extra_args
+):
     builder_env = builder_env or []
+    project_secrets = project_secrets or []
 
     for env in builder_env:
-        args.extend(["--build-arg", f"{env.name}_ARG={env.value}"])
+        args.extend(["--build-arg", f"{env.name}={env.value}"])
+
+    for secret in project_secrets:
+        args.extend(["--build-arg", f"{secret.name}=${secret.name}"])
 
     # add extra_args to args
     args = _validate_and_merge_args_with_extra_args(args, extra_args)
@@ -960,7 +968,6 @@ def _validate_and_merge_args_with_extra_args(args: list, extra_args: str) -> lis
         if flag == "--build-arg":
             for value in values:
                 key, val = value.split("=")
-                key = f"{key}_ARG"
                 if key not in build_arg_keys:
                     merged_args.extend([flag, f"{key}={val}"])
                     build_arg_keys[key] = val

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -1024,12 +1024,9 @@ def _mock_default_service_account(monkeypatch, service_account):
             ["git+https://${GIT_TOKEN}@github.com/GiladShapira94/new-mlrun.git}"],
             "--build-arg A=b C=d --test",
             [
-                "ARG GIT_TOKEN_ARG",
-                "ARG A_ARG",
-                "ARG C_ARG",
-                "ENV GIT_TOKEN=$GIT_TOKEN_ARG",
-                "ENV A=$A_ARG",
-                "ENV C=$C_ARG",
+                "ARG GIT_TOKEN",
+                "ARG A",
+                "ARG C",
             ],
         ),
         (
@@ -1038,8 +1035,7 @@ def _mock_default_service_account(monkeypatch, service_account):
             ["echo bla"],
             [],
             [
-                "ARG GIT_TOKEN_ARG",
-                "ENV GIT_TOKEN=$GIT_TOKEN_ARG",
+                "ARG GIT_TOKEN",
             ],
         ),
         (
@@ -1051,10 +1047,8 @@ def _mock_default_service_account(monkeypatch, service_account):
             [],
             [],
             [
-                "ARG GIT_TOKEN_ARG",
-                "ARG Test_ARG",
-                "ENV GIT_TOKEN=$GIT_TOKEN_ARG",
-                "ENV Test=$Test_ARG",
+                "ARG GIT_TOKEN",
+                "ARG Test",
             ],
         ),
         (None, "source.zip", [], "", []),
@@ -1100,7 +1094,7 @@ def test_make_dockerfile_with_build_and_extra_args(
         (
             [client.V1EnvVar(name="GIT_TOKEN", value="f1a2b3c4d5e6f7g8h9i")],
             "--build-arg test1=val1",
-            ["test1_ARG=val1"],
+            ["test1=val1"],
         ),
         ([], "", []),
         (
@@ -1109,7 +1103,7 @@ def test_make_dockerfile_with_build_and_extra_args(
                 client.V1EnvVar(name="TEST", value="test"),
             ],
             "--build-arg a=b c=d",
-            ["a_ARG=b", "c_ARG=d"],
+            ["a=b", "c=d"],
         ),
     ],
 )
@@ -1129,9 +1123,7 @@ def test_make_kaniko_pod_command_using_build_args(
             extra_args=extra_args,
         )
 
-    expected_env_vars = [
-        f"{env_var.name}_ARG={env_var.value}" for env_var in builder_env
-    ]
+    expected_env_vars = [f"{env_var.name}={env_var.value}" for env_var in builder_env]
     if extra_args:
         expected_env_vars.extend(parsed_extra_args)
 
@@ -1219,9 +1211,9 @@ def test_validate_extra_args(extra_args, expected):
                 "--arg2",
                 "value2",
                 "--build-arg",
-                "KEY1_ARG=VALUE1",
+                "KEY1=VALUE1",
                 "--build-arg",
-                "KEY2_ARG=VALUE2",
+                "KEY2=VALUE2",
             ],
         ),
         (
@@ -1232,9 +1224,9 @@ def test_validate_extra_args(extra_args, expected):
                 "--arg2",
                 "value2",
                 "--build-arg",
-                "KEY1_ARG=VALUE1",
+                "KEY1=VALUE1",
                 "--build-arg",
-                "KEY2_ARG=new_value2",
+                "KEY2=new_value2",
             ],
         ),
         (
@@ -1244,31 +1236,31 @@ def test_validate_extra_args(extra_args, expected):
                 "--arg1",
                 "value1",
                 "--build-arg",
-                "KEY1_ARG=VALUE1",
+                "KEY1=VALUE1",
                 "--build-arg",
-                "KEY2_ARG=VALUE2",
+                "KEY2=VALUE2",
             ],
         ),
         (
-            ["--arg1", "--build-arg", "KEY1_ARG=VALUE1"],
+            ["--arg1", "--build-arg", "KEY1=VALUE1"],
             "--build-arg KEY2=VALUE2",
             [
                 "--arg1",
                 "--build-arg",
-                "KEY1_ARG=VALUE1",
+                "KEY1=VALUE1",
                 "--build-arg",
-                "KEY2_ARG=VALUE2",
+                "KEY2=VALUE2",
             ],
         ),
         (
             [],
             "--build-arg KEY1=VALUE1",
-            ["--build-arg", "KEY1_ARG=VALUE1"],
+            ["--build-arg", "KEY1=VALUE1"],
         ),
         (
             ["--arg1"],
             "--build-arg KEY1=VALUE1",
-            ["--arg1", "--build-arg", "KEY1_ARG=VALUE1"],
+            ["--arg1", "--build-arg", "KEY1=VALUE1"],
         ),
         (
             [],
@@ -1389,8 +1381,6 @@ def test_matching_args_dockerfile_and_kpod(builder_env, source, extra_args):
     ]
 
     dock_arg_lines = [line for line in dock.splitlines() if line.startswith("ARG")]
-    dock_env_lines = [line for line in dock.splitlines() if line.startswith("ENV")]
     for arg in kpod_build_args:
         arg_key, arg_val = arg.split("=")
         assert f"ARG {arg_key}" in dock_arg_lines
-        assert f"ENV {arg_key.replace('_ARG', '')}=${arg_key}" in dock_env_lines

--- a/tests/system/runtimes/assets/function_with_env_vars.py
+++ b/tests/system/runtimes/assets/function_with_env_vars.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 #
 import datetime
-import os
 
 
-def handler(context, env_vars_names=["ENV_VAR1", "ENV_VAR2"]):
+def handler(context, file_path="/tmp/args.txt"):
     print("started", str(datetime.datetime.now()))
-    for env_var_name in env_vars_names:
-        context.log_result(env_var_name, os.environ.get(env_var_name))
-    context.log_result("finished", str(datetime.datetime.now()))
+    with open(file_path, "r") as file:
+        lines = file.read().split("\n")
+    lines = [line for line in lines if line]
+    context.log_result("results", lines)
     print("finished", str(datetime.datetime.now()))


### PR DESCRIPTION
resolves: [ML-4348](https://jira.iguazeng.com/browse/ML-4348)

We identified that the issue was caused by project secrets arriving as `None` in the Kaniko pod, and consequently, this `None` value propagated into the resulting image. It is not related to the mpi-job.
Upon further consideration, we recognized that including builder envs as persistent environment variables is unnecessary. The better approach here is to keep the builder envs available during the build stage only, and not in the resulting container. This way, it won't carry over and remain present in the final container.
Additionally, we acknowledged that using environment variables for secrets could lead to redundant rebuilds if changes occurred. 

Added in this PR:
- Separation of the builder_env from the project_secrets
- Implementing ARGs only, omitting the need for ENV definitions
- Enhanced security by utilizing '$SECRET_NAME' instead of direct secret inclusion in the Dockerfile
