### PR TITLE
[API] Redact unmasked run notifications param

### DIFF
--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -34,6 +34,7 @@ from fastapi.concurrency import run_in_threadpool
 from kubernetes.client.rest import ApiException
 from sqlalchemy.orm import Session
 
+import mlrun.api.api.utils
 import mlrun.api.crud.model_monitoring.deployment
 import mlrun.api.crud.runtimes.nuclio.function
 import mlrun.api.db.session
@@ -47,7 +48,6 @@ import mlrun.common.model_monitoring
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
 from mlrun.api.api import deps
-from mlrun.api.api.utils import get_run_db_instance, log_and_raise, log_path
 from mlrun.api.crud.secrets import Secrets, SecretsClientType
 from mlrun.api.utils.builder import build_runtime
 from mlrun.api.utils.singletons.scheduler import get_scheduler
@@ -97,7 +97,9 @@ async def store_function(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
+        mlrun.api.api.utils.log_and_raise(
+            HTTPStatus.BAD_REQUEST.value, reason="bad JSON body"
+        )
 
     logger.debug("Storing function", project=project, name=name, tag=tag)
     hash_key = await run_in_threadpool(
@@ -265,7 +267,9 @@ async def build_function(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
+        mlrun.api.api.utils.log_and_raise(
+            HTTPStatus.BAD_REQUEST.value, reason="bad JSON body"
+        )
 
     logger.info("Building function", data=data)
     function = data.get("function")
@@ -347,7 +351,9 @@ async def start_function(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
+        mlrun.api.api.utils.log_and_raise(
+            HTTPStatus.BAD_REQUEST.value, reason="bad JSON body"
+        )
 
     logger.info("Got request to start function", body=data)
 
@@ -388,7 +394,9 @@ async def function_status(
     try:
         data = await request.json()
     except ValueError:
-        log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
+        mlrun.api.api.utils.log_and_raise(
+            HTTPStatus.BAD_REQUEST.value, reason="bad JSON body"
+        )
 
     resp = await _get_function_status(data, auth_info)
     return {
@@ -422,7 +430,9 @@ async def build_status(
         mlrun.api.crud.Functions().get_function, db_session, name, project, tag
     )
     if not fn:
-        log_and_raise(HTTPStatus.NOT_FOUND.value, name=name, project=project, tag=tag)
+        mlrun.api.api.utils.log_and_raise(
+            HTTPStatus.NOT_FOUND.value, name=name, project=project, tag=tag
+        )
 
     # nuclio deploy status
     if fn.get("kind") in RuntimeKinds.nuclio_runtimes():
@@ -484,7 +494,7 @@ def _handle_job_deploy_status(
         )
 
     # read from log file
-    log_file = log_path(project, f"build_{name}__{tag or 'latest'}")
+    log_file = mlrun.api.api.utils.log_path(project, f"build_{name}__{tag or 'latest'}")
     if (
         function_state in mlrun.common.schemas.FunctionState.terminal_states()
         and log_file.exists()
@@ -701,13 +711,13 @@ def _build_function(
         fn = new_function(runtime=function)
     except Exception as err:
         logger.error(traceback.format_exc())
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason=f"runtime error: {err_to_str(err)}",
         )
     try:
         # connect to run db
-        run_db = get_run_db_instance(db_session)
+        run_db = mlrun.api.api.utils.get_run_db_instance(db_session)
         fn.set_db_connection(run_db)
 
         is_nuclio_runtime = fn.kind in RuntimeKinds.nuclio_runtimes()
@@ -784,7 +794,7 @@ def _build_function(
             # deploy only start the process, the get status API is used to check readiness
             ready = False
         else:
-            log_file = log_path(
+            log_file = mlrun.api.api.utils.log_path(
                 fn.metadata.project,
                 f"build_{fn.metadata.name}__{fn.metadata.tag or 'latest'}",
             )
@@ -806,7 +816,7 @@ def _build_function(
         logger.info("Resolved function", fn=fn.to_yaml())
     except Exception as err:
         logger.error(traceback.format_exc())
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason=f"runtime error: {err_to_str(err)}",
         )
@@ -816,7 +826,7 @@ def _build_function(
 def _parse_start_function_body(db_session, data):
     url = data.get("functionUrl")
     if not url:
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason="runtime error: functionUrl not specified",
         )
@@ -826,7 +836,7 @@ def _parse_start_function_body(db_session, data):
         db_session, name, project, tag, hash_key
     )
     if not runtime:
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason=f"runtime error: function {url} not found",
         )
@@ -843,7 +853,7 @@ def _start_function(
     db_session = mlrun.api.db.session.create_session()
     try:
         try:
-            run_db = get_run_db_instance(db_session)
+            run_db = mlrun.api.api.utils.get_run_db_instance(db_session)
             function.set_db_connection(run_db)
             mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
                 function,
@@ -860,7 +870,7 @@ def _start_function(
 
         except Exception as err:
             logger.error(traceback.format_exc())
-            log_and_raise(
+            mlrun.api.api.utils.log_and_raise(
                 HTTPStatus.BAD_REQUEST.value,
                 reason=f"Runtime error: {err_to_str(err)}",
             )
@@ -873,7 +883,7 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
     selector = data.get("selector")
     kind = data.get("kind")
     if not selector or not kind:
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason="Runtime error: selector or runtime kind not specified",
         )
@@ -900,7 +910,7 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
 
     except Exception as err:
         logger.error(traceback.format_exc())
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason=f"Runtime error: {err_to_str(err)}",
         )

--- a/mlrun/api/api/endpoints/functions.py
+++ b/mlrun/api/api/endpoints/functions.py
@@ -852,7 +852,7 @@ def _start_function(
 ):
     db_session = mlrun.api.db.session.create_session()
     try:
-        run_db = get_run_db_instance(db_session)
+        run_db = mlrun.api.api.utils.get_run_db_instance(db_session)
         function.set_db_connection(run_db)
         mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
             function,
@@ -869,7 +869,7 @@ def _start_function(
 
     except Exception as err:
         logger.error(traceback.format_exc())
-        log_and_raise(
+        mlrun.api.api.utils.log_and_raise(
             HTTPStatus.BAD_REQUEST.value,
             reason=f"Runtime error: {err_to_str(err)}",
         )

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -27,6 +27,7 @@ from fastapi import HTTPException
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
+import mlrun.api.constants
 import mlrun.api.crud
 import mlrun.api.db.base
 import mlrun.api.utils.auth.verifier
@@ -202,12 +203,12 @@ async def submit_run(
 
 def apply_enrichment_and_validation_on_task(task):
     # Conceal notification config params from the task object with secrets
-    mask_notification_params_on_task(task, "conceal")
+    mask_notification_params_on_task(task, mlrun.api.constants.MaskOperations.CONCEAL)
 
 
 def mask_notification_params_on_task(
     task: dict,
-    action: str,
+    action: mlrun.api.constants.MaskOperations,
 ):
     """
     Mask notification config params from the task object
@@ -232,8 +233,8 @@ def _notification_params_mask_op(
     action,
 ) -> typing.Callable[[str, str, mlrun.model.Notification], mlrun.model.Notification]:
     return {
-        "conceal": _conceal_notification_params_with_secret,
-        "redact": _redact_notification_params,
+        mlrun.api.constants.MaskOperations.CONCEAL: _conceal_notification_params_with_secret,
+        mlrun.api.constants.MaskOperations.REDACT: _redact_notification_params,
     }[action]
 
 

--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -211,15 +211,19 @@ def notification_params_mask_op(
 
 def apply_enrichment_and_validation_on_task(task):
     # Conceal notification config params from the task object with secrets
-    mask_notification_params_on_task(task, notification_params_mask_op("conceal"))
+    mask_notification_params_on_task(task, "conceal")
 
 
 def mask_notification_params_on_task(
     task: dict,
-    mask_op: typing.Callable[
-        [str, str, mlrun.model.Notification], mlrun.model.Notification
-    ],
-) -> dict:
+    action: str,
+):
+    """
+    Mask notification config params from the task object
+    :param task:    The task object to mask
+    :param action:  The masking operation to perform on the notification config params (conceal/redact)
+    """
+    mask_op = notification_params_mask_op(action)
     run_uid = get_in(task, "metadata.uid")
     project = get_in(task, "metadata.project")
     notifications = task.get("spec", {}).get("notifications", [])

--- a/mlrun/api/constants.py
+++ b/mlrun/api/constants.py
@@ -14,8 +14,15 @@
 #
 from enum import Enum
 
+from mlrun.common.types import StrEnum
+
 
 class LogSources(Enum):
     AUTO = "auto"
     PERSISTENCY = "persistency"
     K8S = "k8s"
+
+
+class MaskOperations(StrEnum):
+    CONCEAL = "conceal"
+    REDACT = "redact"

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -17,6 +17,7 @@ import typing
 import sqlalchemy.orm
 
 import mlrun.api.api.utils
+import mlrun.api.constants
 import mlrun.api.utils.projects.remotes.follower
 import mlrun.api.utils.singletons.db
 import mlrun.api.utils.singletons.project_member
@@ -45,7 +46,9 @@ class Runs(
 
         # Some runtimes do not use the submit job flow, so their notifications are not masked.
         # Redact notification params if not concealed with a secret
-        mlrun.api.api.utils.mask_notification_params_on_task(data, "redact")
+        mlrun.api.api.utils.mask_notification_params_on_task(
+            data, mlrun.api.constants.MaskOperations.REDACT
+        )
 
         mlrun.api.utils.singletons.db.get_db().store_run(
             db_session,

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -43,7 +43,12 @@ class Runs(
     ):
         project = project or mlrun.mlconf.default_project
 
-        mlrun.api.api.utils.mask_notification_params_on_task(data)
+        # Some runtimes do not use the submit job flow, so their notifications are not masked.
+        # Redact notification params if not concealed with a secret
+        mlrun.api.api.utils.mask_notification_params_on_task(
+            data, mlrun.api.api.utils.notification_params_mask_op("redact")
+        )
+
         mlrun.api.utils.singletons.db.get_db().store_run(
             db_session,
             data,

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -45,9 +45,7 @@ class Runs(
 
         # Some runtimes do not use the submit job flow, so their notifications are not masked.
         # Redact notification params if not concealed with a secret
-        mlrun.api.api.utils.mask_notification_params_on_task(
-            data, mlrun.api.api.utils.notification_params_mask_op("redact")
-        )
+        mlrun.api.api.utils.mask_notification_params_on_task(data, "redact")
 
         mlrun.api.utils.singletons.db.get_db().store_run(
             db_session,

--- a/mlrun/api/crud/runs.py
+++ b/mlrun/api/crud/runs.py
@@ -16,6 +16,7 @@ import typing
 
 import sqlalchemy.orm
 
+import mlrun.api.api.utils
 import mlrun.api.utils.projects.remotes.follower
 import mlrun.api.utils.singletons.db
 import mlrun.api.utils.singletons.project_member
@@ -41,6 +42,8 @@ class Runs(
         project: str = mlrun.mlconf.default_project,
     ):
         project = project or mlrun.mlconf.default_project
+
+        mlrun.api.api.utils.mask_notification_params_on_task(data)
         mlrun.api.utils.singletons.db.get_db().store_run(
             db_session,
             data,

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -17,13 +17,9 @@ from typing import Dict
 
 from sqlalchemy.orm import Session
 
+import mlrun.api.api.utils
 import mlrun.common.schemas
 import mlrun.utils.singleton
-from mlrun.api.api.utils import (
-    apply_enrichment_and_validation_on_function,
-    get_run_db_instance,
-    get_scheduler,
-)
 from mlrun.config import config
 from mlrun.model import Credentials, RunMetadata, RunObject, RunSpec
 from mlrun.utils import fill_project_path_template
@@ -60,12 +56,12 @@ class WorkflowRunners(
             image=image,
         )
 
-        runner.set_db_connection(get_run_db_instance(db_session))
+        runner.set_db_connection(mlrun.api.api.utils.get_run_db_instance(db_session))
 
         # Enrichment and validation requires access key
         runner.metadata.credentials.access_key = Credentials.generate_access_key
 
-        apply_enrichment_and_validation_on_function(
+        mlrun.api.api.utils.apply_enrichment_and_validation_on_function(
             function=runner,
             auth_info=auth_info,
         )
@@ -111,7 +107,7 @@ class WorkflowRunners(
             "schedule": schedule,
         }
 
-        get_scheduler().store_schedule(
+        mlrun.api.api.utils.get_scheduler().store_schedule(
             db_session=db_session,
             auth_info=auth_info,
             project=project.metadata.name,

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -178,22 +178,6 @@ class RuntimeKinds(object):
         return False
 
     @staticmethod
-    def is_watchable(kind):
-        """
-        Returns True if the runtime kind is watchable, False otherwise.
-        Runtimes that are not watchable are blocking, meaning that the run() method will not return until the runtime
-        is completed.
-        """
-        # "" or None counted as local
-        if not kind:
-            return False
-        return kind not in [
-            RuntimeKinds.local,
-            RuntimeKinds.handler,
-            RuntimeKinds.dask,
-        ]
-
-    @staticmethod
     def requires_absolute_artifacts_path(kind):
         """
         Returns True if the runtime kind requires absolute artifacts' path (i.e. is local), False otherwise.

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -19,6 +19,7 @@ import uuid
 from datetime import datetime, timezone
 from http import HTTPStatus
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -448,7 +449,7 @@ def test_delete_runs_without_permissions(db: Session, client: TestClient):
     assert len(runs) == 1
 
 
-def test_store_run_masking(db: Session, client: TestClient, k8s_secrets_mock) -> None:
+def test_store_run_masking(db: Session, client: TestClient, k8s_secrets_mock):
     unmasked_notifications = [
         {
             "condition": "",
@@ -464,9 +465,7 @@ def test_store_run_masking(db: Session, client: TestClient, k8s_secrets_mock) ->
     ]
 
     masked_notifications = copy.deepcopy(unmasked_notifications)
-    masked_notifications[0]["params"] = {
-        "secret": "mlrun.notifications.1234567890.notification-1"
-    }
+    masked_notifications[0]["params"]["webhook"] = "REDACTED"
 
     expected_response_params = {
         "spec.notifications": masked_notifications,

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -19,7 +19,6 @@ import uuid
 from datetime import datetime, timezone
 from http import HTTPStatus
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import copy
 import time
 import unittest.mock
 import uuid
@@ -445,6 +446,53 @@ def test_delete_runs_without_permissions(db: Session, client: TestClient):
     assert response.status_code == HTTPStatus.UNAUTHORIZED.value
     runs = mlrun.api.crud.Runs().list_runs(db, project=project)
     assert len(runs) == 1
+
+
+def test_store_run_masking(db: Session, client: TestClient, k8s_secrets_mock) -> None:
+    unmasked_notifications = [
+        {
+            "condition": "",
+            "kind": "slack",
+            "message": "completed",
+            "name": "notification-1",
+            "params": {
+                "webhook": "https://hooks.slack.com/services/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"
+            },
+            "severity": "info",
+            "when": ["error"],
+        }
+    ]
+
+    masked_notifications = copy.deepcopy(unmasked_notifications)
+    masked_notifications[0]["params"] = {
+        "secret": "mlrun.notifications.1234567890.notification-1"
+    }
+
+    expected_response_params = {
+        "spec.notifications": masked_notifications,
+    }
+
+    uid = "1234567890"
+    project = "test-store-run-masking"
+    unmasked_run = {
+        "metadata": {
+            "name": "unmasked-run",
+            "project": project,
+            "uid": uid,
+        },
+        "spec": {
+            "notifications": unmasked_notifications,
+        },
+    }
+
+    mlrun.api.crud.Runs().store_run(db, unmasked_run, uid, project=project)
+    resp = client.get(f"run/{project}/{uid}")
+    assert resp.status_code == HTTPStatus.OK.value
+
+    response_body = resp.json()["data"]
+    for param, expected_value in expected_response_params.items():
+        value = mlrun.utils.get_in(response_body, param)
+        assert value == expected_value
 
 
 def _store_run(db, uid, project="some-project"):

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -24,6 +24,7 @@ import pytest
 import tabulate
 
 import mlrun.api.api.utils
+import mlrun.api.constants
 import mlrun.api.crud
 import mlrun.common.schemas.notification
 import mlrun.utils.notifications
@@ -426,7 +427,9 @@ def test_notification_params_masking_on_run(monkeypatch):
             ]
         },
     }
-    mlrun.api.api.utils.mask_notification_params_on_task(run, "conceal")
+    mlrun.api.api.utils.mask_notification_params_on_task(
+        run, mlrun.api.constants.MaskOperations.CONCEAL
+    )
     assert "sensitive" not in run["spec"]["notifications"][0]["params"]
     assert "secret" in run["spec"]["notifications"][0]["params"]
     assert (

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -426,7 +426,7 @@ def test_notification_params_masking_on_run(monkeypatch):
             ]
         },
     }
-    mlrun.api.api.utils.mask_notification_params_on_task(run)
+    mlrun.api.api.utils.mask_notification_params_on_task(run, "conceal")
     assert "sensitive" not in run["spec"]["notifications"][0]["params"]
     assert "secret" in run["spec"]["notifications"][0]["params"]
     assert (


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4427
For local, handler, dask runs we push notifications from the client which means that the notifications params are not masked by the server and we save them in the run object. This ensures that if the notifications params were not concealed, we redact them.