### PR TITLE
[Client] Support non-blocking project creation

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2295,7 +2295,9 @@ class HTTPRunDB(RunDBInterface):
         error_message = f"Failed creating project {project_name}"
         response = self.api_call(
             "POST",
-            "projects",
+            # do not wait for project to reach terminal state synchronously.
+            # let it start and wait for it to reach terminal state asynchronously
+            "projects?wait-for-completion=false",
             error_message,
             body=dict_to_json(project),
         )
@@ -2319,7 +2321,7 @@ class HTTPRunDB(RunDBInterface):
 
         return mlrun.utils.helpers.retry_until_successful(
             self._wait_for_project_terminal_state_retry_interval,
-            120,
+            180,
             logger,
             False,
             _verify_project_in_terminal_state,

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -53,7 +53,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError,
             match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix()}"
-            r"\/projects: Failed creating project some_p"
+            r"\/projects(.*): Failed creating project some_p"
             r"roject details: MLRunInvalidArgumentError\(\"Field \'project\.metadata\.name\' is malformed"
             rf"\. {invalid_project_name} does not match required pattern: (.*)\"\)",
         ):


### PR DESCRIPTION
no need to hold the request and wait for mlrun api with project. let the project creation be a background job while sampling mlrun api

https://jira.iguazeng.com/browse/IG-22046