### PR TITLE
[Runtimes] Fix - propagate databricks job errors

### DIFF
--- a/mlrun/runtimes/databricks/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks/databricks_wrapper.py
@@ -19,9 +19,9 @@ import uuid
 from base64 import b64decode
 
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import OperationFailed
 from databricks.sdk.service.compute import ClusterSpec
 from databricks.sdk.service.jobs import Run, SparkPythonTask, SubmitTask
-from databricks.sdk.errors import OperationFailed
 
 import mlrun
 from mlrun.errors import MLRunRuntimeError
@@ -93,7 +93,7 @@ def run_mlrun_databricks_job(
             # TODO handle rerun tasks - so we can not take the first task in tasks list.
             task_run_id = workspace.jobs.get_run(run_id=waiter.run_id).tasks[0].run_id
             error_dict = workspace.jobs.get_run_output(task_run_id).as_dict()
-            error_trace = error_dict.pop('error_trace')
+            error_trace = error_dict.pop("error_trace")
             custom_error = "error information and metadata:\n"
             custom_error += json.dumps(error_dict, indent=1)
             custom_error += "\nerror trace from databricks:\n"

--- a/mlrun/runtimes/databricks/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks/databricks_wrapper.py
@@ -93,6 +93,7 @@ def run_mlrun_databricks_job(
             )
         except OperationFailed:
             # TODO handle rerun tasks - so we can not take the first task in tasks list.
+            #  will be fixed at ML-4406.
             task_run_id = workspace.jobs.get_run(run_id=waiter.run_id).tasks[0].run_id
             error_dict = workspace.jobs.get_run_output(task_run_id).as_dict()
             error_trace = error_dict.pop("error_trace", "")

--- a/mlrun/runtimes/databricks/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks/databricks_wrapper.py
@@ -21,8 +21,10 @@ from base64 import b64decode
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service.compute import ClusterSpec
 from databricks.sdk.service.jobs import Run, SparkPythonTask, SubmitTask
+from databricks.sdk.errors import OperationFailed
 
 import mlrun
+from mlrun.errors import MLRunRuntimeError
 
 
 def run_mlrun_databricks_job(
@@ -67,6 +69,7 @@ def run_mlrun_databricks_job(
                 node_type_id=workspace.clusters.select_node_type(local_disk=True),
                 num_workers=mlrun_internal_number_of_workers,
             )
+
         waiter = workspace.jobs.submit(
             run_name=f"py-sdk-run-{mlrun_databricks_job_id}",
             tasks=[
@@ -81,10 +84,21 @@ def run_mlrun_databricks_job(
             ],
         )
         logger.info(f"starting to poll: {waiter.run_id}")
-        run = waiter.result(
-            timeout=datetime.timedelta(minutes=mlrun_internal_timeout_minutes),
-            callback=print_status,
-        )
+        try:
+            run = waiter.result(
+                timeout=datetime.timedelta(minutes=mlrun_internal_timeout_minutes),
+                callback=print_status,
+            )
+        except OperationFailed:
+            # TODO handle rerun tasks - so we can not take the first task in tasks list.
+            task_run_id = workspace.jobs.get_run(run_id=waiter.run_id).tasks[0].run_id
+            error_dict = workspace.jobs.get_run_output(task_run_id).as_dict()
+            error_trace = error_dict.pop('error_trace')
+            custom_error = "error information and metadata:\n"
+            custom_error += json.dumps(error_dict, indent=1)
+            custom_error += "\nerror trace from databricks:\n"
+            custom_error += error_trace
+            raise MLRunRuntimeError(custom_error)
 
         run_output = workspace.jobs.get_run_output(run.tasks[0].run_id)
         context.log_result("databricks_runtime_task", run_output.as_dict())

--- a/mlrun/runtimes/databricks/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks/databricks_wrapper.py
@@ -93,10 +93,10 @@ def run_mlrun_databricks_job(
             # TODO handle rerun tasks - so we can not take the first task in tasks list.
             task_run_id = workspace.jobs.get_run(run_id=waiter.run_id).tasks[0].run_id
             error_dict = workspace.jobs.get_run_output(task_run_id).as_dict()
-            error_trace = error_dict.pop("error_trace")
+            error_trace = error_dict.pop("error_trace", "")
             custom_error = "error information and metadata:\n"
             custom_error += json.dumps(error_dict, indent=1)
-            custom_error += "\nerror trace from databricks:\n"
+            custom_error += "\nerror trace from databricks:\n" if error_trace else ""
             custom_error += error_trace
             raise MLRunRuntimeError(custom_error)
 

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -119,7 +119,7 @@ def import_mlrun():
 
         self._add_databricks_env(function=function, is_cluster_id_required=True)
         with pytest.raises(RunError) as error:
-            run = function.run(
+            function.run(
                 handler="import_mlrun",
                 project="databricks-proj",
             )

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -119,7 +119,7 @@ def print_kwargs(**kwargs):
                 == "kwargs: {'param1': 'value1', 'param2': 'value2'}\n"
             )
 
-    def test_fail_in_databricks(self):
+    def test_failure_in_databricks(self):
         code = """
 
 def import_mlrun():

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -21,6 +21,7 @@ import yaml
 import mlrun
 import tests.system.base
 from mlrun.runtimes.function_reference import FunctionReference
+from mlrun.runtimes.utils import RunError
 from tests.datastore.databricks_utils import is_databricks_configured
 
 here = Path(__file__).absolute().parent
@@ -72,7 +73,7 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
 
 def print_kwargs(**kwargs):
     print(f"kwargs: {kwargs}")
-        """
+"""
 
         function_ref = FunctionReference(
             kind="databricks",
@@ -99,6 +100,32 @@ def print_kwargs(**kwargs):
             run.status.results["databricks_runtime_task"]["logs"]
             == "kwargs: {'param1': 'value1', 'param2': 'value2'}\n"
         )
+
+    def test_fail_in_databricks(self):
+        code = """
+
+def import_mlrun():
+    import mlrun
+"""
+
+        function_ref = FunctionReference(
+            kind="databricks",
+            code=code,
+            image="mlrun/mlrun",
+            name="databricks-fails-test",
+        )
+
+        function = function_ref.to_function()
+
+        self._add_databricks_env(function=function, is_cluster_id_required=True)
+        with pytest.raises(RunError) as error:
+            run = function.run(
+                handler="import_mlrun",
+                project="databricks-proj",
+            )
+        lines = str(error.value).splitlines()
+        assert "No module named 'mlrun'" in lines[2]
+        assert "No module named 'mlrun'" in lines[-1]
 
     def test_kwargs_from_file(self):
         code_path = str(self.assets_path / "databricks_function_print_kwargs.py")


### PR DESCRIPTION
1) Capture errors that occur within the `Databricks environment`, raise them to make the real error message accessible to the user.
2) Provide additional information such as the `trace`, `metadata`, and other relevant details.
3) Test that demonstrates this usage.

[ML-4403](https://jira.iguazeng.com/browse/ML-4403)