### PR TITLE
[Serving] Remove overriding of event path for non-http triggers

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -361,8 +361,6 @@ def v2_serving_handler(context, event, get_body=False):
         # Workaround for a Nuclio bug where it sometimes passes b'' instead of None due to dirty memory
         if event.body == b"":
             event.body = None
-    else:
-        event.path = "/"  # fix the issue that non http returns "Unsupported"
 
     return context._server.run(event, context, get_body)
 


### PR DESCRIPTION
[ML-4424](https://jira.iguazeng.com/browse/ML-4424)

This was added in #1179, to work around a nuclio issue that was fixed shortly after in https://github.com/nuclio/nuclio/pull/2285.

It's no longer necessary, and corrupts the topic name. Removing it is necessary for explicit ack to work correctly.