### PR TITLE
[Hub] Update default hub on data init

### DIFF
--- a/mlrun/api/db/base.py
+++ b/mlrun/api/db/base.py
@@ -582,7 +582,9 @@ class DBInterface(ABC):
     def delete_hub_source(self, session, name):
         pass
 
-    def get_hub_source(self, session, name) -> mlrun.common.schemas.IndexedHubSource:
+    def get_hub_source(
+        self, session, name=None, index=None
+    ) -> mlrun.common.schemas.IndexedHubSource:
         pass
 
     def store_background_task(

--- a/mlrun/api/db/sqldb/db.py
+++ b/mlrun/api/db/sqldb/db.py
@@ -3600,12 +3600,20 @@ class SQLDB(DBInterface):
             session, source_record, move_to=None, move_from=current_order
         )
 
-    def get_hub_source(self, session, name) -> mlrun.common.schemas.IndexedHubSource:
-        source_record = self._query(session, HubSource, name=name).one_or_none()
+    def get_hub_source(
+        self, session, name=None, index=None, raise_on_not_found=True
+    ) -> typing.Optional[mlrun.common.schemas.IndexedHubSource]:
+        source_record = self._query(
+            session, HubSource, name=name, index=index
+        ).one_or_none()
         if not source_record:
-            raise mlrun.errors.MLRunNotFoundError(
-                f"Hub source not found. name = {name}"
-            )
+            log_method = logger.warning if raise_on_not_found else logger.debug
+            message = f"Hub source not found. name = {name}"
+            log_method(message)
+            if raise_on_not_found:
+                raise mlrun.errors.MLRunNotFoundError(message)
+
+            return None
 
         return self._transform_hub_source_record_to_schema(source_record)
 

--- a/mlrun/api/initial_data.py
+++ b/mlrun/api/initial_data.py
@@ -544,42 +544,47 @@ def _perform_version_4_data_migrations(
 def _add_default_hub_source_if_needed(
     db: mlrun.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
 ):
-    hub_source = (
-        db_session.query(mlrun.api.db.sqldb.models.HubSource)
-        .filter(
-            mlrun.api.db.sqldb.models.HubSource.index
-            == mlrun.common.schemas.hub.last_source_index
-        )
-        .one_or_none()
+    default_hub_source = mlrun.common.schemas.HubSource.generate_default_source()
+    # hub_source will be None if the configuration has hub.default_source.create=False
+    if not default_hub_source:
+        logger.info("Not adding default hub source, per configuration")
+        return
+
+    hub_source = db.get_hub_source(
+        db_session,
+        index=mlrun.common.schemas.hub.last_source_index,
+        raise_on_not_found=False,
     )
 
-    if not hub_source:
-        _update_default_hub_source(db, db_session)
+    # update the default hub if configured url has changed
+    if not hub_source or hub_source.source.spec.path != default_hub_source.spec.path:
+        _update_default_hub_source(db, db_session, default_hub_source)
 
 
 def _update_default_hub_source(
     db: mlrun.api.db.sqldb.db.SQLDB,
     db_session: sqlalchemy.orm.Session,
+    hub_source: mlrun.common.schemas.hub.HubSource = None,
 ):
     """
     Updates default hub source in db.
     """
-    hub_source = mlrun.common.schemas.HubSource.generate_default_source()
-    # hub_source will be None if the configuration has hub.default_source.create=False
-    if hub_source:
-        _delete_default_hub_source(db_session)
-        logger.info("Adding default hub source")
-        # Not using db.store_hub_source() since it doesn't allow changing the default hub source.
-        hub_record = db._transform_hub_source_schema_to_record(
-            mlrun.common.schemas.IndexedHubSource(
-                index=mlrun.common.schemas.hub.last_source_index,
-                source=hub_source,
-            )
-        )
-        db_session.add(hub_record)
-        db_session.commit()
-    else:
+    hub_source = hub_source or mlrun.common.schemas.HubSource.generate_default_source()
+    if not hub_source:
         logger.info("Not adding default hub source, per configuration")
+        return
+
+    _delete_default_hub_source(db_session)
+    logger.info("Adding default hub source")
+    # Not using db.store_hub_source() since it doesn't allow changing the default hub source.
+    hub_record = db._transform_hub_source_schema_to_record(
+        mlrun.common.schemas.IndexedHubSource(
+            index=mlrun.common.schemas.hub.last_source_index,
+            source=hub_source,
+        )
+    )
+    db_session.add(hub_record)
+    db_session.commit()
 
 
 def _delete_default_hub_source(db_session: sqlalchemy.orm.Session):

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -177,6 +177,7 @@ async def move_api_to_online():
         config.httpdb.clusterization.role
         == mlrun.common.schemas.ClusterizationRole.chief
     ):
+        mlrun.api.initial_data.update_default_configuration_data()
         # runs cleanup/monitoring is not needed if we're not inside kubernetes cluster
         if get_k8s_helper(silent=True).is_running_inside_kubernetes_cluster():
             _start_periodic_cleanup()

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -26,6 +26,7 @@ import mlrun.api.initial_data
 import mlrun.api.utils.singletons.db
 import mlrun.common.db.sql_session
 import mlrun.common.schemas
+from mlrun.config import config
 
 
 def test_add_data_version_empty_db():
@@ -146,6 +147,44 @@ def test_resolve_current_data_version_before_and_after_projects(table_exists, db
     )
     assert mlrun.api.initial_data._resolve_current_data_version(db, db_session) == 1
     mlrun.api.initial_data.latest_data_version = original_latest_data_version
+
+
+def test_add_default_hub_source_if_needed():
+    db, db_session = _initialize_db_without_migrations()
+
+    # Start with no hub source
+    hub_source = db.get_hub_source(
+        db_session,
+        index=mlrun.common.schemas.hub.last_source_index,
+        raise_on_not_found=False,
+    )
+    assert hub_source is None
+
+    # Create the default hub source
+    mlrun.api.initial_data._add_default_hub_source_if_needed(db, db_session)
+    hub_source = db.get_hub_source(
+        db_session,
+        index=mlrun.common.schemas.hub.last_source_index,
+        raise_on_not_found=False,
+    )
+    assert hub_source.source.spec.path == config.hub.default_source.url
+
+    # Change the config and make sure the hub source is updated
+    config.hub.default_source.url = "http://some-other-url"
+    mlrun.api.initial_data._add_default_hub_source_if_needed(db, db_session)
+    hub_source = db.get_hub_source(
+        db_session,
+        index=mlrun.common.schemas.hub.last_source_index,
+        raise_on_not_found=False,
+    )
+    assert hub_source.source.spec.path == config.hub.default_source.url
+
+    # Make sure the hub source is not updated if it already exists
+    with unittest.mock.patch(
+        "mlrun.api.initial_data._update_default_hub_source"
+    ) as update_default_hub_source:
+        mlrun.api.initial_data._add_default_hub_source_if_needed(db, db_session)
+        assert update_default_hub_source.call_count == 0
 
 
 def _initialize_db_without_migrations() -> (

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -165,7 +165,6 @@ def test_add_default_hub_source_if_needed():
     hub_source = db.get_hub_source(
         db_session,
         index=mlrun.common.schemas.hub.last_source_index,
-        raise_on_not_found=False,
     )
     assert hub_source.source.spec.path == config.hub.default_source.url
 
@@ -175,7 +174,6 @@ def test_add_default_hub_source_if_needed():
     hub_source = db.get_hub_source(
         db_session,
         index=mlrun.common.schemas.hub.last_source_index,
-        raise_on_not_found=False,
     )
     assert hub_source.source.spec.path == config.hub.default_source.url
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4396
Update of default hub source on api online event if configuration was changed.
Removed updating hub source on migrations as api online event is triggered after migrations.
This is to allow changing the default hub source once it was set. In mlrun 1.5.0 we changed the hub source but the change would not take effect prior to this fix as we would not change the DB entry if it existed before.