### PR TITLE
[Model Monitoring] Add edge bins for actual data outside of the expected distribution

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -26,6 +26,7 @@ import mlrun.api.crud.secrets
 import mlrun.api.rundb.sqldb
 import mlrun.artifacts
 import mlrun.common.helpers
+import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring
 import mlrun.feature_store
 from mlrun.model_monitoring.stores import get_model_endpoint_store
@@ -104,6 +105,11 @@ class ModelEndpoints:
             if not model_endpoint.status.feature_stats and hasattr(
                 model_obj, "feature_stats"
             ):
+                mlrun.common.model_monitoring.helpers.pad_features_hist(
+                    mlrun.common.model_monitoring.helpers.FeatureStats(
+                        model_obj.spec.feature_stats
+                    )
+                )
                 model_endpoint.status.feature_stats = model_obj.spec.feature_stats
             # Get labels from model object if not found in model endpoint object
             if not model_endpoint.spec.label_names and model_obj.spec.outputs:

--- a/mlrun/model_monitoring/model_monitoring_batch.py
+++ b/mlrun/model_monitoring/model_monitoring_batch.py
@@ -468,6 +468,13 @@ def calculate_inputs_statistics(
                 counts.tolist(),
                 bins.tolist(),
             ]
+        elif "hist" in inputs_statistics[feature]:
+            # Comply with the other common features' histogram length
+            mlrun.common.model_monitoring.helpers.pad_hist(
+                mlrun.common.model_monitoring.helpers.Histogram(
+                    inputs_statistics[feature]["hist"]
+                )
+            )
 
     return inputs_statistics
 

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -1,0 +1,72 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+import pytest
+
+from mlrun.common.model_monitoring.helpers import (
+    _MAX_FLOAT,
+    FeatureStats,
+    Histogram,
+    pad_features_hist,
+)
+
+
+class _HistLen(typing.NamedTuple):
+    counts_len: int
+    edges_len: int
+
+
+@pytest.fixture
+def feature_stats() -> FeatureStats:
+    return FeatureStats(
+        {
+            "feat0": {"hist": [[0, 1], [1.1, 2.2, 3.3]]},
+            "feat1": {
+                "key": "val",
+                "hist": [[4, 2, 0, 2, 0], [-5, 5, 6, 100, 101, 222]],
+            },
+        }
+    )
+
+
+@pytest.fixture
+def orig_feature_stats_hist_data(feature_stats: FeatureStats) -> dict[str, _HistLen]:
+    data: dict[str, _HistLen] = {}
+    for feat_name, feat in feature_stats.items():
+        hist = feat["hist"]
+        data[feat_name] = _HistLen(counts_len=len(hist[0]), edges_len=len(hist[1]))
+    return data
+
+
+def _check_padded_hist_spec(hist: Histogram, orig_data: _HistLen) -> None:
+    counts = hist[0]
+    edges = hist[1]
+    edges_len = len(edges)
+    counts_len = len(counts)
+    assert edges_len == counts_len + 1
+    assert counts_len == orig_data.counts_len + 2
+    assert edges_len == orig_data.edges_len + 2
+    assert counts[0] == counts[-1] == 0
+    assert (-edges[0]) == edges[-1] == _MAX_FLOAT
+
+
+def test_pad_features_hist(
+    feature_stats: FeatureStats,
+    orig_feature_stats_hist_data: dict[str, _HistLen],
+) -> None:
+    pad_features_hist(feature_stats)
+    for feat_name, feat in feature_stats.items():
+        _check_padded_hist_spec(feat["hist"], orig_feature_stats_hist_data[feat_name])


### PR DESCRIPTION
Resolves [ML-4219](https://jira.iguazeng.com/browse/ML-4219).
This PR indirectly fixes the metrics calculation and UI view when the actual data lies outside of the train range.

- Add the `pad_features_hist` function
- Replace `float("inf")` with `sys.float_info.max` for valid DB storage.
- Use the +/-inf padding in `create_model_endpoint`

Tests:
- Unit in this PR
- Manual system patching (EE)

The UI:
![image](https://github.com/mlrun/mlrun/assets/36337649/b9201e64-3fee-4f38-9a1f-7367cb357eab) ![image](https://github.com/mlrun/mlrun/assets/36337649/8128e220-9a3c-476e-9e07-38ad72999e57)

![image](https://github.com/mlrun/mlrun/assets/36337649/0e035068-80a0-4417-ad47-eb3f9d3181c9) ![image](https://github.com/mlrun/mlrun/assets/36337649/47d4078f-37ca-4eda-863b-e5980b0ce4a4)

There's a small issue - the edge bins ±inf aren't presented correctly: [ML-4445](https://jira.iguazeng.com/browse/ML-4445).