### PR TITLE
[Spark] Fix monitor runs ui url update

### DIFF
--- a/mlrun/api/runtime_handlers/base.py
+++ b/mlrun/api/runtime_handlers/base.py
@@ -960,8 +960,8 @@ class BaseRuntimeHandler(ABC):
                 _,
                 run_state,
             ) = self._resolve_pod_status_info(db, db_session, runtime_resource)
-        self._update_ui_url(db, db_session, project, uid, runtime_resource, run)
-        _, updated_run_state = self._ensure_run_state(
+
+        _, updated_run_state, run = self._ensure_run_state(
             db,
             db_session,
             project,
@@ -971,6 +971,11 @@ class BaseRuntimeHandler(ABC):
             run,
             search_run=False,
         )
+
+        # Update the ui URL after ensured run state because it also ensures that a run exists
+        # (A runtime resource might exist before the run is created)
+        self._update_ui_url(db, db_session, project, uid, runtime_resource, run)
+
         if updated_run_state in RunStates.terminal_states():
             self._ensure_run_logs_collected(db, db_session, project, uid)
 
@@ -1141,7 +1146,7 @@ class BaseRuntimeHandler(ABC):
         run_state: str,
         run: Dict = None,
         search_run: bool = True,
-    ) -> Tuple[bool, str]:
+    ) -> Tuple[bool, str, dict]:
         if run is None:
             run = {}
         if search_run:
@@ -1160,10 +1165,13 @@ class BaseRuntimeHandler(ABC):
             run = {"metadata": {"project": project, "name": name, "uid": uid}}
         db_run_state = run.get("status", {}).get("state")
         if db_run_state:
+
             if db_run_state == run_state:
-                return False, run_state
-            # if the current run state is terminal and different than the desired - log
+                return False, run_state, run
+
+            # if the current run state is terminal and different from the desired - log
             if db_run_state in RunStates.terminal_states():
+
                 # This can happen when the SDK running in the user's Run updates the Run's state to terminal, but
                 # before it exits, when the runtime resource is still running, the API monitoring (here) is executed
                 if run_state not in RunStates.terminal_states():
@@ -1186,7 +1194,7 @@ class BaseRuntimeHandler(ABC):
                                 now=now,
                                 debounce_period=debounce_period,
                             )
-                            return False, run_state
+                            return False, run_state, run
 
                 logger.warning(
                     "Run record has terminal state but monitoring found different state on runtime resource. Changing",
@@ -1201,7 +1209,7 @@ class BaseRuntimeHandler(ABC):
         run.setdefault("status", {})["last_update"] = now_date().isoformat()
         db.store_run(db_session, run, uid, project)
 
-        return True, run_state
+        return True, run_state, run
 
     @staticmethod
     def _resolve_runtime_resource_run(runtime_resource: Dict) -> Tuple[str, str, str]:

--- a/mlrun/api/runtime_handlers/sparkjob.py
+++ b/mlrun/api/runtime_handlers/sparkjob.py
@@ -71,6 +71,9 @@ class SparkRuntimeHandler(BaseRuntimeHandler):
         crd_object,
         run: Dict = None,
     ):
+        if run is None:
+            return
+
         app_state = (
             crd_object.get("status", {}).get("applicationState", {}).get("state")
         )

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -32,22 +32,23 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self.kind = RuntimeKinds.spark
         self.runtime_handler = get_runtime_handler(RuntimeKinds.spark)
         self.runtime_handler.wait_for_deletion_interval = 0
+        self._ui_url = "http://spark-ui-url:4040"
 
         # initializing them here to save space in tests
         self.running_crd_dict = self._generate_sparkjob_crd(
             self.project,
             self.run_uid,
-            self._get_running_crd_status(),
+            self._get_running_crd_status(self._ui_url),
         )
         self.completed_crd_dict = self._generate_sparkjob_crd(
             self.project,
             self.run_uid,
-            self._get_completed_crd_status(),
+            self._get_completed_crd_status(self._ui_url),
         )
         self.failed_crd_dict = self._generate_sparkjob_crd(
             self.project,
             self.run_uid,
-            self._get_failed_crd_status(),
+            self._get_failed_crd_status(self._ui_url),
         )
 
         executor_pod_labels = {
@@ -342,6 +343,21 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.driver_pod.metadata.name,
         )
 
+    @pytest.mark.asyncio
+    async def test_monitor_run_update_ui_url(self, db: Session, client: TestClient):
+        _db = get_db()
+        _db.del_run(db, self.run_uid, self.project)
+
+        list_namespaced_crds_calls = [
+            [self.running_crd_dict],
+        ]
+        self._mock_list_namespaced_crds(list_namespaced_crds_calls)
+        self.runtime_handler.monitor_runs(_db, db)
+
+        run = get_db().read_run(db, self.run_uid, self.project)
+        assert run["status"]["state"] == RunStates.running
+        assert run["status"]["ui_url"] == self._ui_url
+
     def _generate_get_logger_pods_label_selector(self, runtime_handler):
         logger_pods_label_selector = super()._generate_get_logger_pods_label_selector(
             runtime_handler
@@ -377,21 +393,30 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         return crd_dict
 
     @staticmethod
-    def _get_running_crd_status():
+    def _get_running_crd_status(driver_ui_url=None):
         return {
             "applicationState": {"state": "RUNNING"},
+            "driverInfo": {
+                "webUIIngressAddress": driver_ui_url,
+            },
         }
 
     @staticmethod
-    def _get_completed_crd_status(timestamp=None):
+    def _get_completed_crd_status(timestamp=None, driver_ui_url=None):
         return {
             "terminationTime": timestamp or "2020-10-05T21:17:11Z",
             "applicationState": {"state": "COMPLETED"},
+            "driverInfo": {
+                "webUIIngressAddress": driver_ui_url,
+            },
         }
 
     @staticmethod
-    def _get_failed_crd_status():
+    def _get_failed_crd_status(driver_ui_url=None):
         return {
             "terminationTime": "2020-10-05T21:17:11Z",
             "applicationState": {"state": "FAILED"},
+            "driverInfo": {
+                "webUIIngressAddress": driver_ui_url,
+            },
         }

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -345,14 +345,14 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
 
     @pytest.mark.asyncio
     async def test_monitor_run_update_ui_url(self, db: Session, client: TestClient):
-        _db = get_db()
-        _db.del_run(db, self.run_uid, self.project)
+        db_instance = get_db()
+        db_instance.del_run(db, self.run_uid, self.project)
 
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        self.runtime_handler.monitor_runs(_db, db)
+        self.runtime_handler.monitor_runs(db_instance, db)
 
         run = get_db().read_run(db, self.run_uid, self.project)
         assert run["status"]["state"] == RunStates.running


### PR DESCRIPTION
It is possible that the runtime resource was created before the run was.
Therefore, we need to ensure that the run exists before updating the ui url.
Related to https://jira.iguazeng.com/browse/ML-4440 where we saw:
```
[warning] Failed monitoring runtime resource. Continuing: {'runtime_resource_name': 'cyxgqaqu-ingest-ee41a830', 'project_name': 'upgrade-ixfloyub', 'namespace': 'default-tenant', 'exc': \"'NoneType' object has no attribute 'get'\", 'traceback': 'Traceback (most recent call last):\\n  File \"/mlrun/mlrun/api/runtime_handlers/base.py\", line 200, in monitor_runs\\n    self._monitor_runtime_resource(\\n  File \"/mlrun/mlrun/api/runtime_handlers/base.py\", line 963, in _monitor_runtime_resource\\n    self._update_ui_url(db, db_session, project, uid, runtime_resource, run)\\n  File \"/mlrun/mlrun/api/runtime_handlers/sparkjob.py\", line 85, in _update_ui_url\\n    db_ui_url = run.get(\"status\", {}).get(\"ui_url\")\\nAttributeError: \\'NoneType\\' object has no attribute \\'get\\'\\n'}\n","stream":"stdout","time":"2023-08-17T17:03:44.890277696Z"}
```