### PR TITLE
[Model Monitoring] Remove drift analysis from `get_or_create_model_endpoint()`

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -74,8 +74,8 @@ class EventFieldType:
     FEATURE_SET_URI = "monitoring_feature_set_uri"
     ALGORITHM = "algorithm"
     VALUE = "value"
-    DRIFT_DETECTED = "drift_detected"
-    POSSIBLE_DRIFT = "possible_drift"
+    DRIFT_DETECTED_THRESHOLD = "drift_detected_threshold"
+    POSSIBLE_DRIFT_THRESHOLD = "possible_drift_threshold"
 
 
 class EventLiveStats:

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -74,6 +74,8 @@ class EventFieldType:
     FEATURE_SET_URI = "monitoring_feature_set_uri"
     ALGORITHM = "algorithm"
     VALUE = "value"
+    DRIFT_DETECTED = "drift_detected"
+    POSSIBLE_DRIFT = "possible_drift"
 
 
 class EventLiveStats:

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -140,7 +140,7 @@ def record_results(
     endpoint_id: str = "",
     function_name: str = "",
     context: mlrun.MLClientCtx = None,
-    df_to_target: pd.DataFrame = None,
+    infer_results_df: pd.DataFrame = None,
     sample_set_statistics: typing.Dict[str, typing.Any] = None,
     monitoring_mode: ModelMonitoringMode = ModelMonitoringMode.enabled,
     drift_threshold: float = 0.7,
@@ -169,8 +169,9 @@ def record_results(
                                      function URI.
     :param context:                  MLRun context. Note that the context is required for logging the artifacts
                                      following the batch drift job.
-    :param df_to_target:             DataFrame that will be stored under the model endpoint parquet target. This
-                                     DataFrame will be used by the scheduled monitoring batch drift job.
+    :param infer_results_df:         DataFrame that will be stored under the model endpoint parquet target. Will be
+                                     used for doing the drift analysis. Please make sure that the dataframe includes
+                                     both feature names and label columns.
     :param sample_set_statistics:    Dictionary of sample set statistics that will be used as a reference data for
                                      the current model endpoint.
     :param monitoring_mode:          If enabled, apply model monitoring features on the provided endpoint id. Enabled
@@ -205,12 +206,12 @@ def record_results(
         patch_if_exist=True,
     )
 
-    if df_to_target is not None:
+    if infer_results_df is not None:
         # Write the monitoring parquet to the relevant model endpoint context
         write_monitoring_df(
             feature_set_uri=model_endpoint.status.monitoring_feature_set_uri,
             endpoint_id=model_endpoint.metadata.uid,
-            df_to_target=df_to_target,
+            df_to_target=infer_results_df,
         )
 
     if trigger_monitoring_job:

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -39,8 +39,8 @@ DatasetType = typing.Union[
 
 def get_or_create_model_endpoint(
     project: str,
-    model_path: str,
-    model_endpoint_name: str,
+    model_path: str = "",
+    model_endpoint_name: str = "",
     endpoint_id: str = "",
     function_name: str = "",
     context: mlrun.MLClientCtx = None,
@@ -222,6 +222,10 @@ def record_results(
             db_session=db,
         )
 
+        if not sample_set_statistics:
+            # Take reference data from the model endpoint stored stats
+            sample_set_statistics = model_endpoint.status.feature_stats
+
         perform_drift_analysis(
             project=project,
             context=context,
@@ -343,7 +347,8 @@ def _generate_model_endpoint(
     model_endpoint.spec.monitoring_mode = monitoring_mode
     model_endpoint.status.first_request = datetime.datetime.now()
     model_endpoint.status.last_request = datetime.datetime.now()
-    model_endpoint.status.feature_stats = sample_set_statistics
+    if sample_set_statistics:
+        model_endpoint.status.feature_stats = sample_set_statistics
 
     db_session.create_model_endpoint(
         project=project, endpoint_id=endpoint_id, model_endpoint=model_endpoint

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -44,8 +44,108 @@ def get_or_create_model_endpoint(
     model_name: str,
     function_name: str = "",
     context: mlrun.MLClientCtx = None,
+    sample_set_statistics: typing.Dict[str, typing.Any] = None,
+    drift_threshold: float = 0.7,
+    possible_drift_threshold: float = 0.5,
+    monitoring_mode: typing.Optional[
+        mlrun.common.schemas.model_monitoring.ModelMonitoringMode
+    ] = mlrun.common.schemas.model_monitoring.ModelMonitoringMode.disabled,
+    db_session=None,
+    patch_if_exist: bool = False,
+) -> ModelEndpoint:
+    """
+    Get a single model endpoint object. If not exist, generate a new model endpoint with the provided parameters. Note
+    that in case of generating a new model endpoint, by default the monitoring features are disabled. To enable these
+    features, set `monitoring_mode=enabled`.
+
+    :param project:                  Project name.
+    :param endpoint_id:              Model endpoint unique ID. If not exist in DB, will generate a new record based
+                                     on the provided `endpoint_id`.
+    :param model_path:               The model store path.
+    :param model_name:               If a new model endpoint is created, the model name will be presented under this
+                                     endpoint.
+    :param function_name:            If a new model endpoint is created, use this function name for generating the
+                                     function URI.
+    :param context:                  MLRun context. If `function_name` not provided, use the context to generate the
+                                     full function hash.
+    :param sample_set_statistics:    Dictionary of sample set statistics that will be used as a reference data for
+                                     the new model endpoint.
+    :param drift_threshold:          The threshold of which to mark drifts. Defaulted to 0.7.
+    :param possible_drift_threshold: The threshold of which to mark possible drifts. Defaulted to 0.5.
+    :param monitoring_mode:          If enabled, apply model monitoring features on the provided endpoint id.
+    :param db_session:               A runtime session that manages the current dialog with the database.
+    :param patch_if_exist:           If true and the model endpoint record is already exist, update it with the
+                                     provided values.
+
+
+    :return: A ModelEndpoint object
+    """
+
+    if not endpoint_id:
+        # Generate a new model endpoint id based on the project name and model name
+        endpoint_id = hashlib.sha1(
+            f"{project}_{model_name}".encode("utf-8")
+        ).hexdigest()
+    if not db_session:
+        # Generate a runtime database
+        db_session = mlrun.get_run_db()
+    try:
+        model_endpoint = db_session.get_model_endpoint(
+            project=project, endpoint_id=endpoint_id
+        )
+        if patch_if_exist:
+            # Update provided values
+            attributes_to_update = {
+                mlrun.common.schemas.model_monitoring.EventFieldType.LAST_REQUEST: datetime.datetime.now(),
+                mlrun.common.schemas.model_monitoring.EventFieldType.DRIFT_DETECTED: drift_threshold,
+                mlrun.common.schemas.model_monitoring.EventFieldType.POSSIBLE_DRIFT: possible_drift_threshold,
+                mlrun.common.schemas.model_monitoring.EventFieldType.MONITORING_MODE: monitoring_mode,
+            }
+            if sample_set_statistics:
+                attributes_to_update[
+                    mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_STATS
+                ] = json.dumps(sample_set_statistics)
+
+            db_session.patch_model_endpoint(
+                project=project,
+                endpoint_id=endpoint_id,
+                attributes=attributes_to_update,
+            )
+            # Get the updated model endpoint object
+            model_endpoint = db_session.get_model_endpoint(
+                project=project, endpoint_id=endpoint_id
+            )
+
+    except mlrun.errors.MLRunNotFoundError:
+        # Create a new model endpoint with the provided details
+        model_endpoint = _generate_model_endpoint(
+            project=project,
+            db_session=db_session,
+            endpoint_id=endpoint_id,
+            model_path=model_path,
+            model_name=model_name,
+            function_name=function_name,
+            context=context,
+            sample_set_statistics=sample_set_statistics,
+            drift_threshold=drift_threshold,
+            possible_drift_threshold=possible_drift_threshold,
+            monitoring_mode=monitoring_mode,
+        )
+    return model_endpoint
+
+
+def record_results(
+    project: str,
+    endpoint_id: str,
+    model_path: str,
+    model_name: str,
+    function_name: str = "",
+    context: mlrun.MLClientCtx = None,
     df_to_target: pd.DataFrame = None,
     sample_set_statistics: typing.Dict[str, typing.Any] = None,
+    monitoring_mode: typing.Optional[
+        mlrun.common.schemas.model_monitoring.ModelMonitoringMode
+    ] = mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled,
     drift_threshold: float = 0.7,
     possible_drift_threshold: float = 0.5,
     inf_capping: float = 10.0,
@@ -55,11 +155,11 @@ def get_or_create_model_endpoint(
 ) -> ModelEndpoint:
     """
     Write a provided inference dataset to model endpoint parquet target. If not exist, generate a new model endpoint
-    record and use the provided sample set statistics as feature stats that will be later for the drift analysis.
-    To manually trigger the monitoring batch job, you have to set `trigger_monitoring_job=True` and then the batch
-    job will immediately perform drift analysis between the sample set statistics stored in the model to the current
-    input data. The drift rule is the value per-feature mean of the TVD and Hellinger scores according to the
-    thresholds configures here.
+    record and use the provided sample set statistics as feature stats that will be used later for the drift analysis.
+    To manually trigger the monitoring batch job, set `trigger_monitoring_job=True` and then the batch
+    job will immediately perform drift analysis between the sample set statistics stored in the model and the new
+    input data (along with the outputs). The drift rule is the value per-feature mean of the TVD and Hellinger scores
+    according to the provided thresholds.
 
     :param project:                  Project name.
     :param endpoint_id:              Model endpoint unique ID. If not exist in DB, will generate a new record based
@@ -75,6 +175,8 @@ def get_or_create_model_endpoint(
                                      DataFrame will be used by the scheduled monitoring batch drift job.
     :param sample_set_statistics:    Dictionary of sample set statistics that will be used as a reference data for
                                      the current model endpoint.
+    :param monitoring_mode:          If enabled, apply model monitoring features on the provided endpoint id. Enabled
+                                     by default.
     :param drift_threshold:          The threshold of which to mark drifts. Defaulted to 0.7.
     :param possible_drift_threshold: The threshold of which to mark possible drifts. Defaulted to 0.5.
     :param inf_capping:              The value to set for when it reached infinity. Defaulted to 10.0.
@@ -85,61 +187,29 @@ def get_or_create_model_endpoint(
 
     :return: A ModelEndpoint object
     """
-
-    if not endpoint_id:
-        # Generate a new model endpoint id based on the project name and model name
-        endpoint_id = hashlib.sha1(
-            f"{project}_{model_name}".encode("utf-8")
-        ).hexdigest()
-
     db = mlrun.get_run_db()
-    try:
-        model_endpoint = db.get_model_endpoint(project=project, endpoint_id=endpoint_id)
 
-        # Update last request
-        attributes_to_update = {
-            mlrun.common.schemas.model_monitoring.EventFieldType.LAST_REQUEST: datetime.datetime.now(),
-        }
-
-        db.patch_model_endpoint(
-            project=project, endpoint_id=endpoint_id, attributes=attributes_to_update
-        )
-
-    except mlrun.errors.MLRunNotFoundError:
-        # Create a new model endpoint with the provided details
-        model_endpoint = _generate_model_endpoint(
-            project=project,
-            db_session=db,
-            endpoint_id=endpoint_id,
-            model_path=model_path,
-            model_name=model_name,
-            function_name=function_name,
-            context=context,
-            sample_set_statistics=sample_set_statistics,
-            drift_threshold=drift_threshold,
-            possible_drift_threshold=possible_drift_threshold,
-        )
+    model_endpoint = get_or_create_model_endpoint(
+        project=project,
+        endpoint_id=endpoint_id,
+        model_path=model_path,
+        model_name=model_name,
+        function_name=function_name,
+        context=context,
+        sample_set_statistics=sample_set_statistics,
+        drift_threshold=drift_threshold,
+        possible_drift_threshold=possible_drift_threshold,
+        monitoring_mode=monitoring_mode,
+        db_session=db,
+        patch_if_exist=True,
+    )
 
     if df_to_target is not None:
-        # Write the parquet file through feature set ingestion process
-        monitoring_feature_set = mlrun.feature_store.get_feature_set(
-            uri=model_endpoint.status.monitoring_feature_set_uri
-        )
-
-        # Modify the DataFrame to the required structure that will be used later by the monitoring batch job
-        df_to_target[
-            mlrun.common.schemas.model_monitoring.EventFieldType.TIMESTAMP
-        ] = datetime.datetime.now()
-        df_to_target[
-            mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_ID
-        ] = endpoint_id
-        df_to_target.set_index(
-            mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_ID,
-            inplace=True,
-        )
-
-        mlrun.feature_store.ingest(
-            featureset=monitoring_feature_set, source=df_to_target, overwrite=False
+        # Write the monitoring parquet to the relevant model endpoint context
+        write_monitoring_df(
+            feature_set_uri=model_endpoint.status.monitoring_feature_set_uri,
+            endpoint_id=model_endpoint.metadata.uid,
+            df_to_target=df_to_target,
         )
 
     if trigger_monitoring_job:
@@ -147,7 +217,8 @@ def get_or_create_model_endpoint(
         trigger_drift_batch_job(
             project=project,
             default_batch_image=default_batch_image,
-            model_endpoints_ids=[endpoint_id],
+            model_endpoints_ids=[model_endpoint.metadata.uid],
+            db_session=db,
         )
 
         perform_drift_analysis(
@@ -158,11 +229,63 @@ def get_or_create_model_endpoint(
             possible_drift_threshold=possible_drift_threshold,
             inf_capping=inf_capping,
             artifacts_tag=artifacts_tag,
-            endpoint_id=endpoint_id,
+            endpoint_id=model_endpoint.metadata.uid,
             db_session=db,
         )
 
     return model_endpoint
+
+
+def write_monitoring_df(
+    endpoint_id: str,
+    df_to_target: pd.DataFrame,
+    monitoring_feature_set: mlrun.feature_store.FeatureSet = None,
+    feature_set_uri: str = "",
+):
+    """Write monitoring dataframe to the parquet target of the current model endpoint. The dataframe will be written
+    using feature set ingest process. Please make sure that you provide either a valid monitoring feature set (with
+    parquet target) or a valid monitoring feature set uri.
+
+    :param endpoint_id:             Model endpoint unique ID.
+    :param df_to_target:            DataFrame that will be stored under the model endpoint parquet target.
+    :param monitoring_feature_set:  A `mlrun.feature_store.FeatureSet` object corresponding to the provided endpoint_id.
+    :param feature_set_uri:         if monitoring_feature_set not provided, use the feature_set_uri value to get the
+                                    relevant `mlrun.feature_store.FeatureSet`.
+    """
+
+    if not monitoring_feature_set:
+        if not feature_set_uri:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Please provide either a valid monitoring feature set object or a monitoring feature set uri"
+            )
+
+        monitoring_feature_set = mlrun.feature_store.get_feature_set(
+            uri=feature_set_uri
+        )
+
+    # Modify the DataFrame to the required structure that will be used later by the monitoring batch job
+    if (
+        mlrun.common.schemas.model_monitoring.EventFieldType.TIMESTAMP
+        not in df_to_target.columns
+    ):
+        # Initialize timestamp column with the current time
+        df_to_target[
+            mlrun.common.schemas.model_monitoring.EventFieldType.TIMESTAMP
+        ] = datetime.datetime.now()
+
+    # `endpoint_id` is the monitoring feature set entity and therefore it should be defined as the df index before
+    # the ingest process
+    df_to_target[
+        mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_ID
+    ] = endpoint_id
+    df_to_target.set_index(
+        mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_ID,
+        inplace=True,
+    )
+
+    mlrun.feature_store.ingest(
+        featureset=monitoring_feature_set, source=df_to_target, overwrite=False
+    )
 
 
 def _generate_model_endpoint(
@@ -176,6 +299,9 @@ def _generate_model_endpoint(
     sample_set_statistics: typing.Dict[str, typing.Any],
     drift_threshold: float,
     possible_drift_threshold: float,
+    monitoring_mode: typing.Optional[
+        mlrun.common.schemas.model_monitoring.ModelMonitoringMode
+    ] = mlrun.common.schemas.model_monitoring.ModelMonitoringMode.disabled,
 ) -> ModelEndpoint:
     """
     Write a new model endpoint record.
@@ -222,11 +348,7 @@ def _generate_model_endpoint(
         "possible_drift"
     ] = possible_drift_threshold
 
-    model_endpoint.spec.monitoring_mode = (
-        mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled.value
-        if sample_set_statistics
-        else mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled.disabled
-    )
+    model_endpoint.spec.monitoring_mode = monitoring_mode
     model_endpoint.status.first_request = datetime.datetime.now()
     model_endpoint.status.last_request = datetime.datetime.now()
     model_endpoint.status.feature_stats = sample_set_statistics
@@ -243,6 +365,7 @@ def trigger_drift_batch_job(
     default_batch_image="mlrun/mlrun",
     model_endpoints_ids: typing.List[str] = None,
     batch_intervals_dict: typing.Dict[str, float] = None,
+    db_session=None,
 ):
     """
     Run model monitoring drift analysis job. If not exists, the monitoring batch function will be registered through
@@ -253,17 +376,20 @@ def trigger_drift_batch_job(
     :param model_endpoints_ids:  List of model endpoints to include in the current run.
     :param batch_intervals_dict: Batch interval range (days, hours, minutes). By default, the batch interval is
                                  configured to run through the last hour.
+    :param db_session:           A runtime session that manages the current dialog with the database.
 
     """
     if not model_endpoints_ids:
         raise mlrun.errors.MLRunNotFoundError(
             "No model endpoints provided",
         )
-
-    db = mlrun.get_run_db()
+    if not db_session:
+        db_session = mlrun.get_run_db()
 
     # Register the monitoring batch job (do nothing if already exist) and get the job function as a dictionary
-    batch_function_dict: typing.Dict[str, typing.Any] = db.deploy_monitoring_batch_job(
+    batch_function_dict: typing.Dict[
+        str, typing.Any
+    ] = db_session.deploy_monitoring_batch_job(
         project=project,
         default_batch_image=default_batch_image,
     )
@@ -411,30 +537,32 @@ def read_dataset_as_dataframe(
 
 def perform_drift_analysis(
     project: str,
+    endpoint_id: str,
     context: mlrun.MLClientCtx,
     sample_set_statistics: dict,
     drift_threshold: float,
     possible_drift_threshold: float,
     inf_capping: float,
-    db_session,
     artifacts_tag: str = "",
-    endpoint_id: str = "",
+    db_session=None,
 ):
     """
     Calculate drift per feature and produce the drift table artifact for logging post prediction. Note that most of
     the calculations were already made through the monitoring batch job.
 
     :param project:                  Project name.
-    :param context:                  MLRun context. Will be used for getting the project name and to log the artifacts.
+    :param endpoint_id:              Model endpoint unique ID.
+    :param context:                  MLRun context. Will log the artifacts.
     :param sample_set_statistics:    The statistics of the sample set logged along a model.
     :param drift_threshold:          The threshold of which to mark drifts.
     :param possible_drift_threshold: The threshold of which to mark possible drifts.
     :param inf_capping:              The value to set for when it reached infinity.
-    :param db_session:               A session that manages the current dialog with the database.
     :param artifacts_tag:            Tag to use for all the artifacts resulted from the function.
-    :param endpoint_id:              Model endpoint unique ID.
+    :param db_session:               A runtime session that manages the current dialog with the database.
 
     """
+    if not db_session:
+        db_session = mlrun.get_run_db()
 
     model_endpoint = db_session.get_model_endpoint(
         project=project, endpoint_id=endpoint_id
@@ -505,7 +633,7 @@ def _log_drift_artifacts(
     2 - Drift result per feature in a JSON format
     3 - Results of the total drift analysis
 
-    :param context:             MLRun context. Will be used for getting the project name and to log the artifacts.
+    :param context:             MLRun context. Will log the artifacts.
     :param html_plot:           Path to the html file of the plot.
     :param metrics_per_feature: Dictionary in which the key is a feature name and the value is the drift numerical
                                 result.

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -96,8 +96,8 @@ def get_or_create_model_endpoint(
             # Update provided values
             attributes_to_update = {
                 EventFieldType.LAST_REQUEST: datetime.datetime.now(),
-                EventFieldType.DRIFT_DETECTED: drift_threshold,
-                EventFieldType.POSSIBLE_DRIFT: possible_drift_threshold,
+                EventFieldType.DRIFT_DETECTED_THRESHOLD: drift_threshold,
+                EventFieldType.POSSIBLE_DRIFT_THRESHOLD: possible_drift_threshold,
                 EventFieldType.MONITORING_MODE: monitoring_mode,
             }
             if sample_set_statistics:
@@ -339,9 +339,11 @@ def _generate_model_endpoint(
     model_endpoint.spec.model_uri = model_path
     model_endpoint.spec.model = model_endpoint_name
     model_endpoint.spec.model_class = "drift-analysis"
-    model_endpoint.spec.monitor_configuration["drift_detected"] = drift_threshold
     model_endpoint.spec.monitor_configuration[
-        "possible_drift"
+        EventFieldType.DRIFT_DETECTED_THRESHOLD
+    ] = drift_threshold
+    model_endpoint.spec.monitor_configuration[
+        EventFieldType.POSSIBLE_DRIFT_THRESHOLD
     ] = possible_drift_threshold
 
     model_endpoint.spec.monitoring_mode = monitoring_mode

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -253,7 +253,7 @@ def write_monitoring_df(
     set (with parquet target) or a valid monitoring feature set uri.
 
     :param endpoint_id:             Model endpoint unique ID.
-    :param infer_results_df:            DataFrame that will be stored under the model endpoint parquet target.
+    :param infer_results_df:        DataFrame that will be stored under the model endpoint parquet target.
     :param monitoring_feature_set:  A `mlrun.feature_store.FeatureSet` object corresponding to the provided endpoint_id.
     :param feature_set_uri:         if monitoring_feature_set not provided, use the feature_set_uri value to get the
                                     relevant `mlrun.feature_store.FeatureSet`.

--- a/mlrun/model_monitoring/model_monitoring_batch.py
+++ b/mlrun/model_monitoring/model_monitoring_batch.py
@@ -754,11 +754,24 @@ class BatchProcessor:
                 )
                 or {}
             )
+
+            # For backwards compatibility first check if the old drift thresholds
+            # (both `possible drift and `drift_detected`) keys exist in the monitor configuration dict
+            # TODO: Remove the first get in 1.7.0
             possible_drift = monitor_configuration.get(
-                "possible_drift", self.default_possible_drift_threshold
+                "possible_drift",
+                monitor_configuration.get(
+                    mlrun.common.schemas.model_monitoring.EventFieldType.POSSIBLE_DRIFT_THRESHOLD,
+                    self.default_possible_drift_threshold,
+                ),
             )
+
             drift_detected = monitor_configuration.get(
-                "drift_detected", self.default_drift_detected_threshold
+                "drift_detected",
+                monitor_configuration.get(
+                    mlrun.common.schemas.model_monitoring.EventFieldType.DRIFT_DETECTED_THRESHOLD,
+                    self.default_drift_detected_threshold,
+                ),
             )
 
             # Check for possible drift based on the results of the statistical metrics defined above:

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -21,6 +21,7 @@ from time import monotonic, sleep
 from typing import Optional
 
 import fsspec
+import numpy as np
 import pandas as pd
 import pytest
 import v3iofs
@@ -29,6 +30,7 @@ from sklearn.datasets import load_diabetes, load_iris
 import mlrun.artifacts.model
 import mlrun.common.schemas.model_monitoring
 import mlrun.feature_store
+import mlrun.model_monitoring.api
 import mlrun.serving.routers
 from mlrun.errors import MLRunNotFoundError
 from mlrun.model import BaseMetadata
@@ -740,6 +742,92 @@ class TestVotingModelMonitoring(TestMLRunSystem):
         assert fields_dict["function_uri"] == "string"
         assert fields_dict["endpoint_type"] == "string"
         assert fields_dict["active"] == "boolean"
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestBatchDrift(TestMLRunSystem):
+    """Record monitoring parquet results and trigger the monitoring batch drift job analysis. This flow tests
+    the monitoring process of the batch infer job function that can be imported from the functions hub."""
+
+    project_name = "pr-batch-drift"
+
+    def test_batch_drift(self):
+        # Main validations:
+        # 1 - Generate new model endpoint record through get_or_create_model_endpoint() within MLRun SDK
+        # 2 - Write monitoring parquet result to the relevant context
+        # 3 - Register and trigger monitoring batch drift job
+        # 4 - Log monitoring artifacts
+
+        # Generate project and context (context will be used for logging the artifacts)
+        project = mlrun.get_run_db().get_project(self.project_name)
+        context = mlrun.get_or_create_ctx(name="batch-drift-context")
+
+        # Log a model artifact
+        iris = load_iris()
+        train_set = pd.DataFrame(
+            data=np.c_[iris["data"], iris["target"]],
+            columns=(
+                [
+                    "sepal_length_cm",
+                    "sepal_width_cm",
+                    "petal_length_cm",
+                    "petal_width_cm",
+                    "p0",
+                ]
+            ),
+        )
+        model_name = "sklearn_RandomForestClassifier"
+        # Upload the model through the projects API so that it is available to the serving function
+        project.log_model(
+            model_name,
+            model_dir=os.path.relpath(self.assets_path),
+            model_file="model.pkl",
+            training_set=train_set,
+            artifact_path=f"v3io:///projects/{project.metadata.name}",
+            label_column="p0",
+        )
+
+        # Generate a dataframe that will be writen as a monitoring parquet
+        # This dataframe is basically replacing the result set that is being generated through the batch infer function
+        df_to_target = pd.DataFrame(
+            {
+                "sepal_length_cm": [-500, -500],
+                "sepal_width_cm": [-500, -500],
+                "petal_length_cm": [-500, -500],
+                "petal_width_cm": [-500, -500],
+                "p0": [0, 0],
+            }
+        )
+        df_to_target[mlrun.common.schemas.EventFieldType.TIMESTAMP] = datetime.utcnow()
+
+        # Record results and trigger the monitoring batch job
+        endpoint_id = "123123123123"
+        mlrun.model_monitoring.api.record_results(
+            project=project.metadata.name,
+            endpoint_id=endpoint_id,
+            model_path=project.get_artifact_uri(
+                key=model_name, category="model", tag="latest"
+            ),
+            model_endpoint_name="batch-drift-test",
+            function_name="batch-drift-function",
+            context=context,
+            df_to_target=df_to_target,
+            trigger_monitoring_job=True,
+        )
+
+        # Test the drift results
+        model_endpoint = mlrun.model_monitoring.api.get_or_create_model_endpoint(
+            project=project.metadata.name, endpoint_id=endpoint_id
+        )
+        assert model_endpoint.status.feature_stats
+        assert model_endpoint.status.current_stats
+        assert model_endpoint.status.drift_status == "DRIFT_DETECTED"
+
+        # Validate that the artifacts were logged under the generated context
+        artifacts = context.artifacts
+        assert artifacts[0]["metadata"]["key"] == "drift_table_plot"
+        assert artifacts[1]["metadata"]["key"] == "features_drift_results"
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -790,7 +790,7 @@ class TestBatchDrift(TestMLRunSystem):
 
         # Generate a dataframe that will be writen as a monitoring parquet
         # This dataframe is basically replacing the result set that is being generated through the batch infer function
-        df_to_target = pd.DataFrame(
+        infer_results_df = pd.DataFrame(
             {
                 "sepal_length_cm": [-500, -500],
                 "sepal_width_cm": [-500, -500],
@@ -799,7 +799,9 @@ class TestBatchDrift(TestMLRunSystem):
                 "p0": [0, 0],
             }
         )
-        df_to_target[mlrun.common.schemas.EventFieldType.TIMESTAMP] = datetime.utcnow()
+        infer_results_df[
+            mlrun.common.schemas.EventFieldType.TIMESTAMP
+        ] = datetime.utcnow()
 
         # Record results and trigger the monitoring batch job
         endpoint_id = "123123123123"
@@ -812,7 +814,7 @@ class TestBatchDrift(TestMLRunSystem):
             model_endpoint_name="batch-drift-test",
             function_name="batch-drift-function",
             context=context,
-            df_to_target=df_to_target,
+            infer_results_df=infer_results_df,
             trigger_monitoring_job=True,
         )
 


### PR DESCRIPTION
After exposing the new `get_or_create_model_endpoint()` in MLRun SDK (https://github.com/mlrun/mlrun/pull/4020), in this PR we would like to remove the drift analysis process from `get_or_create_model_endpoint()`.
As for the batch inference job, instead of calling `get_or_create_model_endpoint()`, it will use a new SDK function called `record_results()` which wraps both `get_or_create_model_endpoint()` function and the drift analysis process.

A related JIRA ticket: https://jira.iguazeng.com/browse/ML-4443