### PR TITLE
[Secrets] Abstract secrets provider, allow in-mem secrets for integration-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -599,6 +599,7 @@ run-api: api ## Run mlrun api (dockerized)
 		--add-host host.docker.internal:host-gateway \
 		--env MLRUN_HTTPDB__DSN=$(MLRUN_HTTPDB__DSN) \
 		--env MLRUN_LOG_LEVEL=$(MLRUN_LOG_LEVEL) \
+		--env MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS=$(MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS) \
 		$(MLRUN_API_IMAGE_NAME_TAGGED)
 
 .PHONY: run-test-db

--- a/mlrun/api/utils/singletons/k8s.py
+++ b/mlrun/api/utils/singletons/k8s.py
@@ -287,7 +287,7 @@ class K8sHelper(mlrun.common.secrets.SecretProviderInterface):
             project=project
         )
 
-    def get_auth_secret_name(self, access_key: str) -> str:
+    def resolve_auth_secret_name(self, access_key: str) -> str:
         hashed_access_key = self._hash_access_key(access_key)
         return mlconfig.config.secret_stores.kubernetes.auth_secret_name.format(
             hashed_access_key=hashed_access_key
@@ -347,7 +347,7 @@ class K8sHelper(mlrun.common.secrets.SecretProviderInterface):
         Store the given access key as a secret in the cluster. The secret name is generated from the access key
         :return: returns the secret name and the action taken against the secret
         """
-        secret_name = self.get_auth_secret_name(access_key)
+        secret_name = self.resolve_auth_secret_name(access_key)
         secret_data = {
             mlrun.common.schemas.AuthSecretData.get_field_secret_key(
                 "username"

--- a/mlrun/api/utils/singletons/k8s.py
+++ b/mlrun/api/utils/singletons/k8s.py
@@ -21,6 +21,7 @@ from kubernetes.client.rest import ApiException
 
 import mlrun.api.runtime_handlers.mpijob
 import mlrun.common.schemas
+import mlrun.common.secrets
 import mlrun.config as mlconfig
 import mlrun.errors
 import mlrun.platforms.iguazio
@@ -49,7 +50,7 @@ class SecretTypes:
     v3io_fuse = "v3io/fuse"
 
 
-class K8sHelper:
+class K8sHelper(mlrun.common.secrets.SecretProviderInterface):
     def __init__(self, namespace=None, silent=False, log=True):
         self.namespace = namespace or mlconfig.config.namespace
         self.config_file = mlconfig.config.kubernetes.kubeconfig_path or None

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -1,0 +1,147 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABC, abstractmethod
+
+import mlrun.common.schemas
+
+
+class SecretProviderInterface(ABC):
+    @abstractmethod
+    def store_auth_secret(
+        self, username: str, access_key: str, namespace=""
+    ) -> (str, mlrun.common.schemas.SecretEventActions):
+        pass
+
+    @abstractmethod
+    def delete_auth_secret(self, secret_ref: str, namespace=""):
+        pass
+
+    @abstractmethod
+    def read_auth_secret(self, secret_name, namespace="", raise_on_not_found=False):
+        pass
+
+    @abstractmethod
+    def store_project_secrets(
+        self, project, secrets, namespace=""
+    ) -> (str, mlrun.common.schemas.SecretEventActions):
+        pass
+
+    @abstractmethod
+    def delete_project_secrets(self, project, secrets, namespace=""):
+        pass
+
+    @abstractmethod
+    def get_project_secret_keys(self, project, namespace="", filter_internal=False):
+        pass
+
+    @abstractmethod
+    def get_project_secret_data(self, project, secret_keys=None, namespace=""):
+        pass
+
+    @abstractmethod
+    def get_secret_data(self, secret_name, namespace=""):
+        pass
+
+
+class InMemorySecretProvider(SecretProviderInterface):
+    def __init__(self):
+        # project -> secret_key -> secret_value
+        self.project_secrets_map = {}
+        # ref -> secret_key -> secret_value
+        self.auth_secrets_map = {}
+        # secret-name -> secret_key -> secret_value
+        self.secrets_map = {}
+
+    @staticmethod
+    def get_auth_secret_name(username: str, access_key: str) -> str:
+        return f"secret-ref-{username}-{access_key}"
+
+    def store_auth_secret(
+        self, username: str, access_key: str, namespace=""
+    ) -> (str, mlrun.common.schemas.SecretEventActions):
+        secret_ref = self.get_auth_secret_name(username, access_key)
+        self.auth_secrets_map.setdefault(secret_ref, {}).update(
+            self._generate_auth_secret_data(username, access_key)
+        )
+        return secret_ref, mlrun.common.schemas.SecretEventActions.created
+
+    @staticmethod
+    def _generate_auth_secret_data(username: str, access_key: str):
+        return {
+            mlrun.common.schemas.AuthSecretData.get_field_secret_key(
+                "username"
+            ): username,
+            mlrun.common.schemas.AuthSecretData.get_field_secret_key(
+                "access_key"
+            ): access_key,
+        }
+
+    def delete_auth_secret(self, secret_ref: str, namespace=""):
+        del self.auth_secrets_map[secret_ref]
+
+    def read_auth_secret(self, secret_name, namespace="", raise_on_not_found=False):
+        secret = self.auth_secrets_map.get(secret_name)
+        if not secret:
+            if raise_on_not_found:
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Secret '{secret_name}' was not found in auth secrets map"
+                )
+
+            return None, None
+        username = secret[
+            mlrun.common.schemas.AuthSecretData.get_field_secret_key("username")
+        ]
+        access_key = secret[
+            mlrun.common.schemas.AuthSecretData.get_field_secret_key("access_key")
+        ]
+        return username, access_key
+
+    def store_project_secrets(
+        self, project, secrets, namespace=""
+    ) -> (str, mlrun.common.schemas.SecretEventActions):
+        self.project_secrets_map.setdefault(project, {}).update(secrets)
+        secret_name = project
+        return secret_name, mlrun.common.schemas.SecretEventActions.created
+
+    def delete_project_secrets(self, project, secrets, namespace=""):
+        if not secrets:
+            self.project_secrets_map.pop(project, None)
+        else:
+            for key in secrets:
+                self.project_secrets_map.get(project, {}).pop(key, None)
+        return "", True
+
+    def get_project_secret_keys(self, project, namespace="", filter_internal=False):
+        secret_keys = list(self.project_secrets_map.get(project, {}).keys())
+        if filter_internal:
+            secret_keys = list(
+                filter(lambda key: not key.startswith("mlrun."), secret_keys)
+            )
+        return secret_keys
+
+    def get_project_secret_data(self, project, secret_keys=None, namespace=""):
+        secrets_data = self.project_secrets_map.get(project, {})
+        return {
+            key: value
+            for key, value in secrets_data.items()
+            if (secret_keys and key in secret_keys) or not secret_keys
+        }
+
+    def store_secret(self, secret_name, secrets: dict):
+        self.secrets_map[secret_name] = secrets
+
+    def get_secret_data(self, secret_name, namespace=""):
+        return self.secrets_map[secret_name]

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -78,17 +78,6 @@ class InMemorySecretProvider(SecretProviderInterface):
         )
         return secret_ref, mlrun.common.schemas.SecretEventActions.created
 
-    @staticmethod
-    def _generate_auth_secret_data(username: str, access_key: str):
-        return {
-            mlrun.common.schemas.AuthSecretData.get_field_secret_key(
-                "username"
-            ): username,
-            mlrun.common.schemas.AuthSecretData.get_field_secret_key(
-                "access_key"
-            ): access_key,
-        }
-
     def delete_auth_secret(self, secret_ref: str, namespace=""):
         del self.auth_secrets_map[secret_ref]
 
@@ -145,3 +134,14 @@ class InMemorySecretProvider(SecretProviderInterface):
 
     def get_secret_data(self, secret_name, namespace=""):
         return self.secrets_map[secret_name]
+
+    @staticmethod
+    def _generate_auth_secret_data(username: str, access_key: str):
+        return {
+            mlrun.common.schemas.AuthSecretData.get_field_secret_key(
+                "username"
+            ): username,
+            mlrun.common.schemas.AuthSecretData.get_field_secret_key(
+                "access_key"
+            ): access_key,
+        }

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -65,14 +65,10 @@ class InMemorySecretProvider(SecretProviderInterface):
         # secret-name -> secret_key -> secret_value
         self.secrets_map = {}
 
-    @staticmethod
-    def get_auth_secret_name(username: str, access_key: str) -> str:
-        return f"secret-ref-{username}-{access_key}"
-
     def store_auth_secret(
         self, username: str, access_key: str, namespace=""
     ) -> (str, mlrun.common.schemas.SecretEventActions):
-        secret_ref = self.get_auth_secret_name(username, access_key)
+        secret_ref = self.resolve_auth_secret_name(username, access_key)
         self.auth_secrets_map.setdefault(secret_ref, {}).update(
             self._generate_auth_secret_data(username, access_key)
         )
@@ -145,3 +141,7 @@ class InMemorySecretProvider(SecretProviderInterface):
                 "access_key"
             ): access_key,
         }
+
+    @staticmethod
+    def resolve_auth_secret_name(username: str, access_key: str) -> str:
+        return f"secret-ref-{username}-{access_key}"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -422,6 +422,9 @@ default_config = {
         "endpoint_store_connection": "",
     },
     "secret_stores": {
+        # Use only in testing scenarios (such as integration tests) to avoid using k8s for secrets (will use in-memory
+        # "secrets")
+        "test_mode_mock_secrets": False,
         "vault": {
             # URLs to access Vault. For example, in a local env (Minikube on Mac) these would be:
             # http://docker.for.mac.localhost:8200

--- a/tests/api/api/test_submit.py
+++ b/tests/api/api/test_submit.py
@@ -141,7 +141,7 @@ def test_submit_job_auto_mount(
 
     resp = client.post("submit_job", json=submit_job_body)
     assert resp
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, access_key)
     expected_env_vars = {
         "V3IO_API": api_url,
         "V3IO_USERNAME": username,
@@ -173,7 +173,7 @@ def test_submit_job_ensure_function_has_auth_set(
     resp = client.post("submit_job", json=submit_job_body)
     assert resp
 
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, access_key)
     expected_env_vars = {
         mlrun.runtimes.constants.FunctionEnvironmentVariables.auth_session: (
             secret_name,

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -509,7 +509,7 @@ def test_ensure_function_has_auth_set(
         )
         == {}
     )
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, access_key)
     assert (
         function.metadata.credentials.access_key
         == f"{mlrun.model.Credentials.secret_reference_prefix}{secret_name}"
@@ -584,7 +584,7 @@ def test_ensure_function_has_auth_set(
     ensure_function_has_auth_set(
         function, mlrun.common.schemas.AuthInfo(username=username)
     )
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, access_key)
     k8s_secrets_mock.assert_auth_secret(secret_name, username, access_key)
     assert (
         DeepDiff(
@@ -692,7 +692,7 @@ def test_mask_v3io_access_key_env_var(
         )
         == {}
     )
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, v3io_access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, v3io_access_key)
     k8s_secrets_mock.assert_auth_secret(secret_name, username, v3io_access_key)
     _assert_env_var_from_secret(
         function,
@@ -869,7 +869,7 @@ def test_mask_v3io_volume_credentials(
         )
         == {}
     )
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, access_key)
     k8s_secrets_mock.assert_auth_secret(secret_name, username, access_key)
     assert "accessKey" not in function.spec.volumes[0]["flexVolume"]["options"]
     assert function.spec.volumes[0]["flexVolume"]["secretRef"]["name"] == secret_name
@@ -894,7 +894,7 @@ def test_mask_v3io_volume_credentials(
         )
         == {}
     )
-    secret_name = k8s_secrets_mock.get_auth_secret_name(username, access_key)
+    secret_name = k8s_secrets_mock.resolve_auth_secret_name(username, access_key)
     k8s_secrets_mock.assert_auth_secret(secret_name, username, access_key)
     assert "accessKey" not in function.spec.volumes[0]["flexVolume"]["options"]
     assert function.spec.volumes[0]["flexVolume"]["secretRef"]["name"] == secret_name

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -811,7 +811,7 @@ async def test_rescheduling_secrets_storing(
     assert jobs[0].args[5].access_key == access_key
     assert jobs[0].args[5].username == username
     k8s_secrets_mock.assert_auth_secret(
-        k8s_secrets_mock.get_auth_secret_name(username, access_key),
+        k8s_secrets_mock.resolve_auth_secret_name(username, access_key),
         username,
         access_key,
     )
@@ -854,7 +854,7 @@ async def test_schedule_crud_secrets_handling(
             cron_trigger,
         )
         _assert_schedule_auth_secrets(
-            k8s_secrets_mock.get_auth_secret_name(username, access_key),
+            k8s_secrets_mock.resolve_auth_secret_name(username, access_key),
             username,
             access_key,
         )
@@ -874,7 +874,7 @@ async def test_schedule_crud_secrets_handling(
         )
 
         _assert_schedule_auth_secrets(
-            k8s_secrets_mock.get_auth_secret_name(username, access_key),
+            k8s_secrets_mock.resolve_auth_secret_name(username, access_key),
             username,
             access_key,
         )
@@ -918,7 +918,7 @@ async def test_schedule_access_key_generation(
     )
     mlrun.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key.assert_called_once()
     _assert_schedule_auth_secrets(
-        k8s_secrets_mock.get_auth_secret_name("", access_key), "", access_key
+        k8s_secrets_mock.resolve_auth_secret_name("", access_key), "", access_key
     )
 
     access_key = "generated-access-key-2"
@@ -936,7 +936,7 @@ async def test_schedule_access_key_generation(
     )
     mlrun.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key.assert_called_once()
     _assert_schedule_auth_secrets(
-        k8s_secrets_mock.get_auth_secret_name("", access_key), "", access_key
+        k8s_secrets_mock.resolve_auth_secret_name("", access_key), "", access_key
     )
 
 
@@ -1021,7 +1021,7 @@ async def test_schedule_convert_from_old_credentials_to_new(
 
     await scheduler.start(db)
     _assert_schedule_auth_secrets(
-        k8s_secrets_mock.get_auth_secret_name(username, access_key),
+        k8s_secrets_mock.resolve_auth_secret_name(username, access_key),
         username,
         access_key,
     )
@@ -1486,7 +1486,7 @@ def _assert_schedule_get_and_list_credentials_enrichment(
         include_credentials=True,
     )
 
-    secret_name = tests.api.conftest.K8sSecretsMock.get_auth_secret_name(
+    secret_name = tests.api.conftest.K8sSecretsMock.resolve_auth_secret_name(
         expected_username, expected_access_key
     )
     secret_ref = mlrun.model.Credentials.secret_reference_prefix + secret_name

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -143,6 +143,7 @@ class TestMLRunIntegration:
                     "MLRUN_VERSION": "0.0.0+unstable",
                     "MLRUN_HTTPDB__DSN": self.db_dsn,
                     "MLRUN_LOG_LEVEL": "DEBUG",
+                    "MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS": "True",
                 }
             ),
             cwd=TestMLRunIntegration.root_path,

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -241,6 +241,18 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         assert project.spec.artifacts == []
         assert project.spec.conda == ""
 
+    def test_set_project_secrets(self):
+        # A basic test verifying that we can access (mocked) project-secrets functionality in integration tests.
+        project_name = "some-project"
+        project_object = mlrun.get_or_create_project(project_name)
+
+        secrets = {"secret1": "value1", "secret2": "value2"}
+        project_object.set_secrets(secrets)
+        secret_keys = (
+            mlrun.get_run_db().list_project_secret_keys(project_name).secret_keys
+        )
+        assert secret_keys == list(secrets.keys())
+
 
 def _assert_projects(expected_project, project):
     assert (


### PR DESCRIPTION
This PR serves 2 purposes:
1. Allow integration tests to cover flows which require project-secrets functionality. We have more and more flows that use this functionality, and these could not be tested in integration tests due to the lack of k8s environment to support them. This PR allows running the MLRun service and the `Secrets` crud using an in-memory implementation for secrets (the same as used until now for unit-tests), enabling these flows
2. This PR introduces a `SecretProviderInterface` abstract class, which allows different implementations for secrets storage in different deployment modes (for example, use files in Docker environments). The default mode is still k8s secrets, of course. The `Secrets` crud for now selects the implementation on initialization based on config. In the future this can be changed to a more complex logic or using dependency injection if needed.

A new simple integration test was added just to verify that the functionality is indeed working.