### PR TITLE
[Kaniko] Fix kaniko pod env not initialized in ECR flow

### DIFF
--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -335,8 +335,7 @@ def configure_kaniko_ecr_init_container(
     )
     init_container_env = {}
 
-    if kpod.env is None:
-        kpod.env = []
+    kpod.env = kpod.env or []
 
     if assume_instance_role:
 

--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -335,6 +335,9 @@ def configure_kaniko_ecr_init_container(
     )
     init_container_env = {}
 
+    if kpod.env is None:
+        kpod.env = []
+
     if assume_instance_role:
 
         # assume instance role has permissions to register and store a container image


### PR DESCRIPTION
If `builder_env` or `projects_secrets` are empty, the kaniko pod envs are set as None.
Later, if an ECR registry is configured, some other env vars are appended although the pod envs can still be None.

Fixes https://jira.iguazeng.com/browse/ML-4459