### PR TITLE
[Datastore] Correct the issue where the datastore name is prefixed to the Redis key

### DIFF
--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -24,7 +24,8 @@ import mlrun.datastore
 
 
 def store_path_to_spark(path):
-    if path.startswith("redis://") or path.startswith("rediss://"):
+    schemas = ["redis://", "rediss://", "ds://"]
+    if any(path.startswith(schema) for schema in schemas):
         url = urlparse(path)
         if url.path:
             path = url.path


### PR DESCRIPTION
[ML-4460](https://jira.iguazeng.com/browse/ML-4460)
When saving a Spark dataframe to Redis using a datastore profile, the profile name is mistakenly prefixed to the Redis key.