### PR TITLE
[Datastore] Add list and delete APIs for datastore profiles

### DIFF
--- a/mlrun/api/api/endpoints/datastore_profile.py
+++ b/mlrun/api/api/endpoints/datastore_profile.py
@@ -70,6 +70,12 @@ async def store_datastore_profile(
         mlrun.common.schemas.AuthorizationAction.store,
         auth_info,
     )
+
+    # TODO: Although embedding specialized business logic like the handling of sensitive information in secrets
+    # directly within endpoint code is suboptimal, we currently lack a dedicated CRUD object for managing storage
+    # profiles. Creating one solely for this purpose might introduce unnecessary overhead.
+    # When new features are introduced that warrant a CRUD framework, the logic for handling storage
+    # profiles should be relocated there.
     await run_in_threadpool(
         mlrun.api.crud.Secrets().store_project_secrets,
         project_name,

--- a/mlrun/api/api/endpoints/datastore_profile.py
+++ b/mlrun/api/api/endpoints/datastore_profile.py
@@ -26,6 +26,7 @@ import mlrun.api.utils.auth.verifier
 import mlrun.api.utils.singletons.db
 import mlrun.common.schemas
 from mlrun.api.api.utils import log_and_raise
+from mlrun.datastore.datastore_profile import DatastoreProfile as ds
 
 router = APIRouter()
 
@@ -60,6 +61,24 @@ async def store_datastore_profile(
             HTTPStatus.BAD_REQUEST.value,
             reason="The project name provided in the URI does not match the one specified in the DatastoreProfile",
         )
+    project_ds_name_private = ds.generate_secret_key(info.name, project_name)
+
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.secret,
+        project_name,
+        mlrun.common.schemas.SecretProviderName.kubernetes,
+        mlrun.common.schemas.AuthorizationAction.store,
+        auth_info,
+    )
+    await run_in_threadpool(
+        mlrun.api.crud.Secrets().store_project_secrets,
+        project_name,
+        mlrun.common.schemas.SecretsData(
+            provider=mlrun.common.schemas.SecretProviderName.kubernetes,
+            secrets={project_ds_name_private: info.private},
+        ),
+        True,
+    )
 
     await run_in_threadpool(
         mlrun.api.utils.singletons.db.get_db().store_datastore_profile,
@@ -168,6 +187,24 @@ async def delete_datastore_profile(
         mlrun.common.schemas.AuthorizationAction.delete,
         auth_info,
     )
+    await mlrun.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.secret,
+        project_name,
+        mlrun.common.schemas.SecretProviderName.kubernetes,
+        mlrun.common.schemas.AuthorizationAction.delete,
+        auth_info,
+    )
+    project_ds_name_private = ds.generate_secret_key(profile, project_name)
+
+    await run_in_threadpool(
+        mlrun.api.crud.Secrets().delete_project_secret,
+        project_name,
+        mlrun.common.schemas.SecretProviderName.kubernetes,
+        project_ds_name_private,
+        allow_secrets_from_k8s=True,
+        allow_internal_secrets=True,
+    )
+
     return await run_in_threadpool(
         mlrun.api.utils.singletons.db.get_db().delete_datastore_profile,
         db_session,

--- a/mlrun/common/schemas/datastore_profile.py
+++ b/mlrun/common/schemas/datastore_profile.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+import typing
+
 from pydantic import BaseModel
 
 
@@ -20,4 +22,5 @@ class DatastoreProfile(BaseModel):
     name: str
     type: str
     object: str
+    private: typing.Optional[str]
     project: str

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -39,7 +39,7 @@ class DatastoreProfile(pydantic.BaseModel):
     def generate_secret_key(profile_name: str, project: str):
         secret_name_separator = "-__-"
         full_key = (
-            "datastore-profiles"
+            "mlrun.datastore-profiles"
             + secret_name_separator
             + project
             + secret_name_separator

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -48,6 +48,13 @@ class DatastoreProfile(pydantic.BaseModel):
         return full_key
 
 
+class DatastoreProfileBasic(DatastoreProfile):
+    type: str = pydantic.Field("basic")
+    _private_attributes = "private"
+    public: str
+    private: typing.Optional[str] = None
+
+
 class DatastoreProfileRedis(DatastoreProfile):
     type: str = pydantic.Field("redis")
     _private_attributes = ("username", "password")
@@ -130,7 +137,10 @@ class DatastoreProfile2Json(pydantic.BaseModel):
 
         decoded_dict = {k: safe_literal_eval(v) for k, v in decoded_dict.items()}
         datastore_type = decoded_dict.get("type")
-        ds_profile_factory = {"redis": DatastoreProfileRedis}
+        ds_profile_factory = {
+            "redis": DatastoreProfileRedis,
+            "basic": DatastoreProfileBasic,
+        }
         if datastore_type in ds_profile_factory:
             return ds_profile_factory[datastore_type].parse_obj(decoded_dict)
         else:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3314,12 +3314,26 @@ class HTTPRunDB(RunDBInterface):
         return None
 
     def delete_datastore_profile(self, name: str, project: str):
-        pass
+        project = project or config.default_project
+        path = self._path_of("projects", project, "datastore-profiles") + f"/{name}"
+        self.api_call(method="DELETE", path=path)
+        return None
 
     def list_datastore_profiles(
         self, project: str
     ) -> List[mlrun.common.schemas.DatastoreProfile]:
-        pass
+        project = project or config.default_project
+        path = self._path_of("projects", project, "datastore-profiles")
+
+        res = self.api_call(method="GET", path=path)
+        if res:
+            public_wrapper = res.json()
+            datastores = [
+                DatastoreProfile2Json.create_from_json(x["object"])
+                for x in public_wrapper
+            ]
+            return datastores
+        return None
 
     def store_datastore_profile(
         self, profile: mlrun.common.schemas.DatastoreProfile, project: str

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3040,6 +3040,24 @@ class MlrunProject(ModelObj):
             provider=mlrun.common.schemas.SecretProviderName.kubernetes,
         )
 
+    def delete_datastore_profile(self, profile: str):
+        project_ds_name_private = DatastoreProfile.generate_secret_key(
+            profile, self.name
+        )
+        if project_ds_name_private in os.environ:
+            del os.environ[project_ds_name_private]
+        mlrun.db.get_run_db(secrets=self._secrets).delete_datastore_profile(
+            profile, self.name
+        )
+        mlrun.db.get_run_db(secrets=self._secrets).delete_project_secrets(
+            self.name, secrets=[project_ds_name_private]
+        )
+
+    def list_datastore_profiles(self) -> List[DatastoreProfile]:
+        return mlrun.db.get_run_db(secrets=self._secrets).list_datastore_profiles(
+            self.name
+        )
+
     def get_custom_packagers(self) -> typing.List[typing.Tuple[str, bool]]:
         """
         Get the custom packagers registered in the project.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3027,18 +3027,17 @@ class MlrunProject(ModelObj):
         public_body = DatastoreProfile2Json.get_json_public(profile)
         # set project public data to DB
         public_profile = mlrun.common.schemas.DatastoreProfile(
-            name=profile.name, type=profile.type, object=public_body, project=self.name
+            name=profile.name,
+            type=profile.type,
+            object=public_body,
+            private=private_body,
+            project=self.name,
         )
         mlrun.db.get_run_db(secrets=self._secrets).store_datastore_profile(
             public_profile, self.name
         )
         # Set local environment variable
         environ[project_ds_name_private] = private_body
-        # set project secret
-        self.set_secrets(
-            secrets={project_ds_name_private: private_body},
-            provider=mlrun.common.schemas.SecretProviderName.kubernetes,
-        )
 
     def delete_datastore_profile(self, profile: str):
         project_ds_name_private = DatastoreProfile.generate_secret_key(
@@ -3048,9 +3047,6 @@ class MlrunProject(ModelObj):
             del os.environ[project_ds_name_private]
         mlrun.db.get_run_db(secrets=self._secrets).delete_datastore_profile(
             profile, self.name
-        )
-        mlrun.db.get_run_db(secrets=self._secrets).delete_project_secrets(
-            self.name, secrets=[project_ds_name_private]
         )
 
     def list_datastore_profiles(self) -> List[DatastoreProfile]:

--- a/tests/api/api/test_datastore_profiles.py
+++ b/tests/api/api/test_datastore_profiles.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 import mlrun.artifacts
 import mlrun.common.schemas
+from tests.api.conftest import K8sSecretsMock
 
 project = "prj"
 datastore = {
@@ -27,6 +28,7 @@ datastore = {
     "name": "ds",
     "type": "nosql",
     "object": "http://some_url_example/pp",
+    "private": None,
 }
 legacy_api_projects_path = "projects"
 api_datastore_path = f"/api/v1/projects/{project}/datastore-profiles"
@@ -44,7 +46,9 @@ def _create_project(client: TestClient, project_name: str = project):
     return resp
 
 
-def test_datastore_profile_create_ok(db: Session, client: TestClient):
+def test_datastore_profile_create_ok(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     _create_project(client)
     resp = client.put(
         api_datastore_path,
@@ -61,7 +65,9 @@ def test_datastore_profile_create_ok(db: Session, client: TestClient):
     assert json.loads(resp._content) == expected_return
 
 
-def test_datastore_profile_update_ok(db: Session, client: TestClient):
+def test_datastore_profile_update_ok(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     _create_project(client)
     resp = client.put(
         api_datastore_path,
@@ -85,7 +91,9 @@ def test_datastore_profile_update_ok(db: Session, client: TestClient):
     assert json.loads(resp._content) == expected_return
 
 
-def test_datastore_profile_create_fail(db: Session, client: TestClient):
+def test_datastore_profile_create_fail(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     # No project created
     resp = client.put(
         api_datastore_path,
@@ -102,7 +110,9 @@ def test_datastore_profile_create_fail(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY.value
 
 
-def test_datastore_profile_get_fail(db: Session, client: TestClient):
+def test_datastore_profile_get_fail(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     # No project created
     resp = client.get(
         api_datastore_path + "/" + datastore["name"],
@@ -121,7 +131,9 @@ def test_datastore_profile_get_fail(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.NOT_FOUND.value
 
 
-def test_datastore_profile_delete_wrong_project(db: Session, client: TestClient):
+def test_datastore_profile_delete_wrong_project(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     # No project created
     resp = client.delete(
         api_datastore_path + "/" + datastore["name"],
@@ -129,7 +141,9 @@ def test_datastore_profile_delete_wrong_project(db: Session, client: TestClient)
     assert resp.status_code == HTTPStatus.NOT_FOUND.value
 
 
-def test_datastore_profile_delete_not_exist(db: Session, client: TestClient):
+def test_datastore_profile_delete_not_exist(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     # Not existing profile
     _create_project(client)
     resp = client.delete(
@@ -138,7 +152,9 @@ def test_datastore_profile_delete_not_exist(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.NOT_FOUND.value
 
 
-def test_datastore_profile_delete(db: Session, client: TestClient):
+def test_datastore_profile_delete(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     # Not existing profile
     _create_project(client)
 
@@ -168,7 +184,9 @@ def test_datastore_profile_delete(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.NOT_FOUND.value
 
 
-def test_datastore_profile_list(db: Session, client: TestClient):
+def test_datastore_profile_list(
+    db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock
+):
     # No project created
     resp = client.get(
         api_datastore_path,

--- a/tests/system/datastore/test_datastore_profiles.py
+++ b/tests/system/datastore/test_datastore_profiles.py
@@ -1,0 +1,54 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+import mlrun
+from mlrun.datastore.datastore_profile import DatastoreProfileBasic
+from tests.system.base import TestMLRunSystem
+
+
+# Marked as enterprise because of v3io mount and pipelines
+@TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestDatastoreProfile(TestMLRunSystem):
+    project_name = "dsprofiles-system-test-project"
+
+    def custom_setup(self):
+        pass
+
+    def test_datastore_profile_list(self):
+        project = mlrun.get_or_create_project(self.project_name)
+
+        profile1 = DatastoreProfileBasic(name="dsname1", public="http://1.1.1.1:1234")
+        profile2 = DatastoreProfileBasic(name="dsname2", public="http://2.2.2.2:1234")
+
+        project.register_datastore_profile(profile1)
+        project.register_datastore_profile(profile2)
+        profiles = project.list_datastore_profiles()
+        assert profiles == [profile1, profile2]
+
+    def test_datastore_profile_delete(self):
+        project = mlrun.get_or_create_project(self.project_name)
+
+        profile1 = DatastoreProfileBasic(name="dsname1", public="http://1.1.1.1:1234")
+        profile2 = DatastoreProfileBasic(name="dsname2", public="http://2.2.2.2:1234")
+
+        project.register_datastore_profile(profile1)
+        project.register_datastore_profile(profile2)
+
+        project.delete_datastore_profile("dsname1")
+        profiles = project.list_datastore_profiles()
+        assert profiles == [profile2]


### PR DESCRIPTION
[ML-4463 ](https://jira.iguazeng.com/browse/ML-4463), [ML-4467](https://jira.iguazeng.com/browse/ML-4467)
Adding two interfaces to MlrunProject class:  **list_datastore_pfofiles**() and **delete_datastore_profile**()
