### PR TITLE
[Utils] Fix HTTP session retryable error handling 

### DIFF
--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -92,6 +92,7 @@ class ExponentialRetryOverride(ExponentialRetry):
         # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
         ConnectionRefusedError,
         ConnectionAbortedError,
+        ConnectionError,
         # aiohttp exceptions that can be raised during connection establishment
         aiohttp.ClientConnectionError,
         aiohttp.ServerDisconnectedError,
@@ -268,4 +269,7 @@ class _CustomRequestContext(_RequestContext):
             if isinstance(exc, aiohttp.ClientConnectorError):
                 if isinstance(exc.os_error, exc_type):
                     return
-        raise exc
+        if exc.__cause__:
+            return self.verify_exception_type(exc.__cause__)
+        else:
+            raise exc

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -54,6 +54,7 @@ class HTTPSessionWithRetry(requests.Session):
         ConnectionAbortedError,
         ConnectionError,
         # often happens when the server is overloaded and can't handle the load.
+        requests.exceptions.ConnectionError,
         requests.exceptions.ConnectTimeout,
         requests.exceptions.ReadTimeout,
         urllib3.exceptions.ReadTimeoutError,

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -52,6 +52,7 @@ class HTTPSessionWithRetry(requests.Session):
         # "Connection aborted" and "Connection refused" happen when the server doesn't respond at all.
         ConnectionRefusedError,
         ConnectionAbortedError,
+        ConnectionError,
         # often happens when the server is overloaded and can't handle the load.
         requests.exceptions.ConnectTimeout,
         requests.exceptions.ReadTimeout,
@@ -166,12 +167,21 @@ class HTTPSessionWithRetry(requests.Session):
             )
             return False
 
+        def exception_is_retryable(exc, retryable_exceptions):
+            def err_chain(err):
+                while err:
+                    yield err
+                    err = err.__cause__
+
+            return any(
+                isinstance(err_in_chain, retryable_exc)
+                for retryable_exc in retryable_exceptions
+                for err_in_chain in err_chain(exc)
+            )
+
         # only retryable exceptions
-        exception_is_retryable = any(
-            msg in str(exc) for msg in self.HTTP_RETRYABLE_EXCEPTION_STRINGS
-        ) or any(
-            isinstance(exc, retryable_exc)
-            for retryable_exc in self.HTTP_RETRYABLE_EXCEPTIONS
+        exception_is_retryable = exception_is_retryable(
+            exc, self.HTTP_RETRYABLE_EXCEPTIONS
         )
 
         if not exception_is_retryable:

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -56,7 +56,7 @@ def test_api_call_enum_conversion():
     [
         # feature enabled
         ("enabled", Exception, ("some-error",), 1),
-        ("enabled", ConnectionError, ("some-error",), 1),
+        ("enabled", ConnectionError, ("some-error",), 4),
         (
             "enabled",
             ConnectionError,

--- a/tests/utils/test_async_http.py
+++ b/tests/utils/test_async_http.py
@@ -15,6 +15,7 @@
 
 import http.server
 import typing
+from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import aioresponses
@@ -168,3 +169,52 @@ async def test_headers_filtering(
     )
     assert response.headers["y"] == "z", "header should not have been filtered"
     assert "x" not in response.headers, "header with 'None' value was not filtered"
+
+
+def raise_exception():
+    try:
+        raise ConnectionError("This is an ErrorA")
+    except ConnectionError as e1:
+        try:
+            raise Exception from e1
+        except Exception as e2:
+            return e2
+
+
+@pytest.mark.parametrize(
+    "exception,expected",
+    [
+        # Test error cases that occur twice,
+        # and are retryable errors, so we expect no Exception to be raised
+        (ConnectionError("This is an ConnectionErr"), does_not_raise()),
+        (ConnectionRefusedError("This is an ConnectionRefusedErr"), does_not_raise()),
+        (
+            ClientConnectorError(mock.MagicMock(code=500), ConnectionResetError()),
+            does_not_raise(),
+        ),
+        # Test a custom exception with a root cause that is included in our retryable exceptions list,
+        # should not raise an exception
+        (raise_exception(), does_not_raise()),
+        # Test a non-retryable error and ensure it fails immediately and is not retried
+        (TypeError("TypeErr"), pytest.raises(TypeError)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_session_retry(
+    async_client: AsyncClientWithRetry,
+    aioresponses_mock: aioresponses_mock,
+    exception,
+    expected,
+):
+    max_retries = 3
+    for i in range(max_retries - 1):
+        aioresponses_mock.get(
+            "http://localhost:30678",
+            exception=exception,
+        )
+        aioresponses_mock.get(
+            "http://localhost:30678",
+            status=200,
+        )
+    with expected:
+        await async_client.get("http://localhost:30678")

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from mlrun.utils.http import HTTPSessionWithRetry
+
+
+@pytest.fixture
+def http_session():
+    with HTTPSessionWithRetry() as session:
+        yield session
+
+
+def raise_exception():
+    try:
+        raise ConnectionError("This is an ErrorA")
+    except ConnectionError as e1:
+        try:
+            raise Exception from e1
+        except Exception as e2:
+            return e2
+
+
+@pytest.mark.parametrize(
+    "error_to_raise,expected",
+    [
+        # Test ConnectionError and ConnectionRefusedError cases that occur once,
+        # and are retryable errors, so we expect no Exception to be raised
+        ([ConnectionError("This is an ConnectionErr"), True], does_not_raise()),
+        (
+            [ConnectionRefusedError("This is a ConnectionRefusedErr"), True],
+            does_not_raise(),
+        ),
+        # Test a custom exception with a root cause that is included in our retryable exceptions list,
+        # should not raise an exception
+        ([raise_exception(), True], does_not_raise()),
+        # Test a custom exception with a root cause that is included in our retryable exceptions list,
+        # it will be raised 3 times before we expect an error to be raised
+        (raise_exception(), pytest.raises(Exception)),
+        # Test a non-retryable error and ensure it fails immediately and is not retried
+        ([TypeError("TypeErr"), True], pytest.raises(TypeError)),
+    ],
+)
+def test_session_retry(http_session: HTTPSessionWithRetry, error_to_raise, expected):
+    with unittest.mock.patch(
+        "mlrun.utils.http.requests.Session.request", side_effect=error_to_raise
+    ):
+        with expected:
+            http_session.request("GET", "http://localhost:30678")


### PR DESCRIPTION
resolves: [ML-4323](https://jira.iguazeng.com/browse/ML-4323)

The pipeline step failure caused by a ConnectionError. The error was previously categorized as non-retryable, but it should be considered retryable due to its transient nature.
In this PR, Added ConnectionError to the list of retryable exceptions, and implemented a check to see if the error is related to a retryable cause in the exception chain.