### PR TITLE
[Dask] Increase timeouts to handle transient failures

### DIFF
--- a/mlrun/api/runtime_handlers/daskjob.py
+++ b/mlrun/api/runtime_handlers/daskjob.py
@@ -247,11 +247,13 @@ def initialize_dask_cluster(scheduler_pod, worker_pod, function, namespace):
             svc_temp["spec"]["ports"][1]["nodePort"] = spec.node_port
         mlrun.utils.update_in(svc_temp, "spec.type", spec.service_type)
 
-    norm_name = mlrun.utils.normalize_name(meta.name)
     dask.config.set(
         {
             "kubernetes.scheduler-service-template": svc_temp,
-            "kubernetes.name": "mlrun-" + norm_name + "-{uuid}",
+            "kubernetes.name": f"mlrun-{mlrun.utils.normalize_name(meta.name)}-{{uuid}}",
+            # 5 minutes, to resiliently handle delicate/slow k8s clusters
+            "kubernetes.scheduler-service-wait-timeout": 60 * 5,
+            "distributed.comm.timeouts.connect": "300s",
         }
     )
 


### PR DESCRIPTION
default timeout to 5 minutes (and not 30s) to handle delicate/slow gke clusters.
it has been observed on gke such transient errors
<details><summary>Details</summary>
<p>

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/distributed/deploy/spec.py", line 310, in _start
    await super()._start()
  File "/usr/local/lib/python3.9/site-packages/distributed/deploy/cluster.py", line 84, in _start
    comm = await self.scheduler_comm.live_comm()
  File "/usr/local/lib/python3.9/site-packages/distributed/core.py", line 774, in live_comm
    comm = await connect(
  File "/usr/local/lib/python3.9/site-packages/distributed/comm/core.py", line 308, in connect
    raise OSError(
OSError: Timed out trying to connect to tcp://mlrun-klzfq-func-far-15af43d4-a.default-tenant:8786 after 30 s

</p>
</details> 


https://jira.iguazeng.com/browse/ML-4255