### PR TITLE
[Dockerfiles] mlrun/mlrun to use miniconda + opmi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ MLRUN_ML_DOCKER_IMAGE_NAME_PREFIX ?= ml-
 # do not specify the patch version so that we can easily upgrade it when needed - it is determined by the base image
 # mainly used for mlrun, base and models images. mlrun API version >= 1.3.0 should always have python 3.9
 MLRUN_PYTHON_VERSION ?= 3.9
-MLRUN_CONDA_PYTHON_VERSION ?= 39
 MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 23.2.1
@@ -240,7 +239,7 @@ prebake-mlrun-gpu: ## Build prebake mlrun GPU based docker image
 	docker build \
 		--file dockerfiles/gpu/prebaked.Dockerfile \
 		--build-arg CUDA_VER=$(MLRUN_GPU_CUDA_VERSION) \
-		--build-arg MLRUN_ANACONDA_PYTHON_DISTRIBUTION=$(MLRUN_CONDA_PYTHON_VERSION) \
+		--build-arg MLRUN_ANACONDA_PYTHON_DISTRIBUTION=$(MLRUN_ANACONDA_PYTHON_DISTRIBUTION) \
 		--tag $(MLRUN_GPU_PREBAKED_IMAGE_NAME_TAGGED) \
 		.
 

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ mlrun: update-version-file ## Build mlrun docker image
 	$(MLRUN_CACHE_IMAGE_PULL_COMMAND)
 	docker build \
 		--file dockerfiles/mlrun/Dockerfile \
+		--build-arg MLRUN_ANACONDA_PYTHON_DISTRIBUTION=$(MLRUN_ANACONDA_PYTHON_DISTRIBUTION) \
 		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
 		$(MLRUN_IMAGE_DOCKER_CACHE_FROM_FLAG) \

--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -41,12 +41,12 @@ WORKDIR /mlrun
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
 
+# Install MiniConda (Python 3.9):
 ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py39"
-
-# install miniconda
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_23.1.0-1-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \
     rm ~/installconda.sh && \
+    /opt/conda/bin/conda clean -aqy && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc

--- a/dockerfiles/gpu/prebaked.Dockerfile
+++ b/dockerfiles/gpu/prebaked.Dockerfile
@@ -51,7 +51,7 @@ ENV PIP_NO_CACHE_DIR=1
 ENV LD_LIBRARY_PATH /usr/local/cuda-11.7/lib64:$LD_LIBRARY_PATH
 
 # Install Open-MPI:
-ARG OMPI_VERSION=4.1.4
+ARG OMPI_VERSION=4.1.5
 RUN conda install -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \
     conda clean -aqy
 ENV OMPI_ALLOW_RUN_AS_ROOT=1

--- a/dockerfiles/gpu/prebaked.Dockerfile
+++ b/dockerfiles/gpu/prebaked.Dockerfile
@@ -35,14 +35,15 @@ RUN apt update -qqq --fix-missing \
     && rm -rf /var/lib/apt/lists/*
 
 # Install MiniConda (Python 3.9):
-ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="39"
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_23.1.0-1-Linux-x86_64.sh -O ~/installconda.sh && \
+ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py39"
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_23.1.0-1-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \
     rm ~/installconda.sh && \
     /opt/conda/bin/conda clean -aqy && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc
+
 ENV PATH /opt/conda/bin:$PATH
 
 # Setup environment variables:

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -24,6 +24,7 @@ ENV PIP_NO_CACHE_DIR=1
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   gcc \
+  wget \
   git-core \
  && rm -rf /var/lib/apt/lists/*
 
@@ -32,7 +33,7 @@ WORKDIR /mlrun
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
 
-# Install MiniConda (Python 3.9):
+# Install MiniConda:
 ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py39"
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_23.1.0-1-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \
@@ -51,9 +52,13 @@ RUN conda install -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
+# Install Python:
 ARG MLRUN_PIP_VERSION=23.2.1
-RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
+RUN conda config --add channels conda-forge && \
+    conda install python=${MLRUN_PYTHON_VERSION} pip~=${MLRUN_PIP_VERSION} && \
+    conda clean -aqy
 
+# Install MLRun:
 COPY ./dockerfiles/mlrun/requirements.txt ./mlrun-image-requirements.txt
 COPY ./extras-requirements.txt ./extras-requirements.txt
 COPY ./requirements.txt ./

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -46,7 +46,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
 ENV PATH /opt/conda/bin:$PATH
 
 # Install Open-MPI:
-ARG OMPI_VERSION=4.1.4
+ARG OMPI_VERSION=4.1.5
 RUN conda install -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \
     conda clean -aqy
 ENV OMPI_ALLOW_RUN_AS_ROOT=1

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 ARG MLRUN_PYTHON_VERSION=3.9
 
 FROM gcr.io/iguazio/python:${MLRUN_PYTHON_VERSION}-slim
@@ -31,6 +31,25 @@ WORKDIR /mlrun
 
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
+
+# Install MiniConda (Python 3.9):
+ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py39"
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_23.1.0-1-Linux-x86_64.sh -O ~/installconda.sh && \
+    /bin/bash ~/installconda.sh -b -p /opt/conda && \
+    rm ~/installconda.sh && \
+    /opt/conda/bin/conda clean -aqy && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
+
+ENV PATH /opt/conda/bin:$PATH
+
+# Install Open-MPI:
+ARG OMPI_VERSION=4.1.4
+RUN conda install -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \
+    conda clean -aqy
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 ARG MLRUN_PIP_VERSION=23.2.1
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -3,3 +3,4 @@ scipy~=1.0
 scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
+mpi4py~=3.1

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -16,12 +16,10 @@ ARG MLRUN_BASE_IMAGE=mlrun/ml-base:unstable-core
 
 FROM ${MLRUN_BASE_IMAGE}
 
+# Install Open-MPI:
 ARG OMPI_VERSION=4.1.4
-
-# Install Open MPI
 RUN conda install -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \
     conda clean -aqy
-
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 

--- a/dockerfiles/models/Dockerfile
+++ b/dockerfiles/models/Dockerfile
@@ -17,7 +17,7 @@ ARG MLRUN_BASE_IMAGE=mlrun/ml-base:unstable-core
 FROM ${MLRUN_BASE_IMAGE}
 
 # Install Open-MPI:
-ARG OMPI_VERSION=4.1.4
+ARG OMPI_VERSION=4.1.5
 RUN conda install -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \
     conda clean -aqy
 ENV OMPI_ALLOW_RUN_AS_ROOT=1

--- a/tests/system/runtimes/test_mpijob.py
+++ b/tests/system/runtimes/test_mpijob.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pytest
 
 import mlrun
 import tests.system.base

--- a/tests/system/runtimes/test_mpijob.py
+++ b/tests/system/runtimes/test_mpijob.py
@@ -38,13 +38,10 @@ class TestMpiJobRuntime(tests.system.base.TestMLRunSystem):
             project=self.project_name,
             filename=code_path,
             image="mlrun/mlrun",
-            requirements=["mpi4py"],
         )
         mpijob_function.spec.replicas = replicas
 
-        mpijob_run = mpijob_function.run(
-            returns=["reduced_result", "rank_0_result"], auto_build=True
-        )
+        mpijob_run = mpijob_function.run(returns=["reduced_result", "rank_0_result"])
         assert mpijob_run.status.state == RunStates.completed
 
         reduced_result = mpijob_run.status.results["reduced_result"]


### PR DESCRIPTION
As part of the effort to provide a more simplified images and deprecate/remove mlrun/ml-models and mlrun/ml-models-gpu, this PR boost the common image `mlrun/mlrun` with miniconda and opmi ready for use.

note - the image size increases from ~1.5GB to ~2.3GB