### PR TITLE
[Model Monitoring] Fix histogram padding when model object has no feature stats

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -65,8 +65,9 @@ class ModelEndpoints:
             db_session=db_session, model_endpoint=model_endpoint
         )
 
+    @classmethod
     def create_model_endpoint(
-        self,
+        cls,
         db_session: sqlalchemy.orm.Session,
         model_endpoint: mlrun.common.schemas.ModelEndpoint,
     ) -> mlrun.common.schemas.ModelEndpoint:
@@ -129,7 +130,7 @@ class ModelEndpoints:
                 model_endpoint.spec.monitoring_mode
                 == mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled.value
             ):
-                monitoring_feature_set = self.create_monitoring_feature_set(
+                monitoring_feature_set = cls.create_monitoring_feature_set(
                     model_endpoint, model_obj, db_session, run_db
                 )
                 # Link model endpoint object to feature set URI
@@ -144,13 +145,13 @@ class ModelEndpoints:
             logger.info("Feature stats found, cleaning feature names")
             if model_endpoint.spec.feature_names:
                 # Validate that the length of feature_stats is equal to the length of feature_names and label_names
-                self._validate_length_features_and_labels(model_endpoint=model_endpoint)
+                cls._validate_length_features_and_labels(model_endpoint=model_endpoint)
 
                 # Clean feature names in both feature_stats and feature_names
             (
                 model_endpoint.status.feature_stats,
                 model_endpoint.spec.feature_names,
-            ) = self._adjust_feature_names_and_stats(model_endpoint=model_endpoint)
+            ) = cls._adjust_feature_names_and_stats(model_endpoint=model_endpoint)
 
             logger.info(
                 "Done preparing feature names and stats",

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -105,11 +105,12 @@ class ModelEndpoints:
             if not model_endpoint.status.feature_stats and hasattr(
                 model_obj, "feature_stats"
             ):
-                mlrun.common.model_monitoring.helpers.pad_features_hist(
-                    mlrun.common.model_monitoring.helpers.FeatureStats(
-                        model_obj.spec.feature_stats
+                if model_obj.spec.feature_stats:
+                    mlrun.common.model_monitoring.helpers.pad_features_hist(
+                        mlrun.common.model_monitoring.helpers.FeatureStats(
+                            model_obj.spec.feature_stats
+                        )
                     )
-                )
                 model_endpoint.status.feature_stats = model_obj.spec.feature_stats
             # Get labels from model object if not found in model endpoint object
             if not model_endpoint.spec.label_names and model_obj.spec.outputs:

--- a/tests/api/crud/model_monitoring/test_model_endpoints.py
+++ b/tests/api/crud/model_monitoring/test_model_endpoints.py
@@ -1,0 +1,61 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterator
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.orm import Session as DBSession
+
+import mlrun.common.schemas
+from mlrun.api.crud.model_monitoring.model_endpoints import ModelEndpoints
+from mlrun.artifacts import ModelArtifact
+
+
+@pytest.fixture
+def db_session() -> DBSession:
+    return Mock(spec=DBSession)
+
+
+@pytest.fixture
+def model_endpoint() -> mlrun.common.schemas.ModelEndpoint:
+    return mlrun.common.schemas.ModelEndpoint(
+        spec=mlrun.common.schemas.model_monitoring.ModelEndpointSpec(
+            model_uri="some_fake_uri"
+        )
+    )
+
+
+@pytest.fixture
+def _patch_external_resources() -> Iterator[None]:
+    with patch("mlrun.api.api.utils.get_run_db_instance", autospec=True):
+        with patch(
+            "mlrun.datastore.store_resources.get_store_resource",
+            return_value=ModelArtifact(),
+        ):
+            with patch(
+                "mlrun.api.crud.model_monitoring.model_endpoints.get_model_endpoint_store",
+                autospec=True,
+            ):
+                yield
+
+
+@pytest.mark.usefixtures("_patch_external_resources")
+def test_create_with_empty_feature_stats(
+    db_session: DBSession,
+    model_endpoint: mlrun.common.schemas.ModelEndpoint,
+) -> None:
+    ModelEndpoints.create_model_endpoint(
+        db_session=db_session, model_endpoint=model_endpoint
+    )


### PR DESCRIPTION
Fix [ML-4499](https://jira.iguazeng.com/browse/ML-4499) (caused thanks to myself in #4124).

- Add the fix line - check for `feature_stats` existence in the model object first.
- Add a test with mocks for external resources. It fails before the fix and passes after.
- Make the method a class method.