### PR TITLE
[Frameworks] Raise exception when no framework has been defined

### DIFF
--- a/mlrun/frameworks/auto_mlrun/auto_mlrun.py
+++ b/mlrun/frameworks/auto_mlrun/auto_mlrun.py
@@ -297,6 +297,11 @@ class AutoMLRun:
                     f"The model path provided: '{model_path}' is not of a model artifact (store uri) so the framework "
                     f"attribute must be specified."
                 )
+            elif "framework" not in model_artifact.labels:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"No framework defined for the provided model: '{model_path}'. Please log the model again with "
+                    f"the required framework."
+                )
             # Return the framework and the collected files and artifacts:
             return (
                 model_artifact.labels["framework"],


### PR DESCRIPTION
If the user has logged the model without providing a valid framework (either through an argument or through the model uri), he will get an error when calling `AutoMLRun.load_model()`. At the moment, the error is not clear enough. In this PR, we raise an exception about the missing framework and asking the user the log again his model, this time with a valid framework value. 

A related JIRA - https://jira.iguazeng.com/browse/ML-4289?