### PR TITLE
[Runtimes][Dask] Ensure that MLRUN_DBPATH is available for workers

### DIFF
--- a/mlrun/api/runtime_handlers/daskjob.py
+++ b/mlrun/api/runtime_handlers/daskjob.py
@@ -307,6 +307,9 @@ def enrich_dask_cluster(
         or "daskdev/dask:latest"
     )
     env = spec.env
+    env.extend(
+        [{"name": k, "value": v} for k, v in function.generate_runtime_env().items()]
+    )
     namespace = meta.namespace or config.namespace
     if spec.extra_pip:
         env.append(spec.extra_pip)

--- a/mlrun/api/runtime_handlers/daskjob.py
+++ b/mlrun/api/runtime_handlers/daskjob.py
@@ -307,9 +307,7 @@ def enrich_dask_cluster(
         or "daskdev/dask:latest"
     )
     env = spec.env
-    env.extend(
-        [{"name": k, "value": v} for k, v in function.generate_runtime_env().items()]
-    )
+    env.extend(function.generate_runtime_k8s_env())
     namespace = meta.namespace or config.namespace
     if spec.extra_pip:
         env.append(spec.extra_pip)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -374,15 +374,16 @@ class BaseRuntime(ModelObj):
         if task:
             return task.to_dict()
 
-    def _generate_runtime_env(self, runobj: RunObject):
+    def generate_runtime_env(self, runobj: RunObject = None):
         runtime_env = {
-            "MLRUN_EXEC_CONFIG": runobj.to_json(),
-            "MLRUN_DEFAULT_PROJECT": runobj.metadata.project
-            or self.metadata.project
-            or config.default_project,
+            "MLRUN_DEFAULT_PROJECT": self.metadata.project or config.default_project
         }
-        if runobj.spec.verbose:
-            runtime_env["MLRUN_LOG_LEVEL"] = "DEBUG"
+        if runobj:
+            runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json()
+            if runobj.metadata.project:
+                runtime_env["MLRUN_DEFAULT_PROJECT"] = runobj.metadata.project
+            if runobj.spec.verbose:
+                runtime_env["MLRUN_LOG_LEVEL"] = "DEBUG"
         if config.httpdb.api_url:
             runtime_env["MLRUN_DBPATH"] = config.httpdb.api_url
         if self.metadata.namespace or config.namespace:
@@ -416,7 +417,7 @@ class BaseRuntime(ModelObj):
             runspec.spec.function = self._function_uri(hash_key=hash_key)
 
     def _get_cmd_args(self, runobj: RunObject):
-        extra_env = self._generate_runtime_env(runobj)
+        extra_env = self.generate_runtime_env(runobj)
         if self.spec.pythonpath:
             extra_env["PYTHONPATH"] = self.spec.pythonpath
         args = []

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -269,7 +269,10 @@ class BaseRuntime(ModelObj):
         :param runobj: Run context object (RunObject) with run metadata and status
         :return: List of dicts with the structure {"name": "var_name", "value": "var_value"}
         """
-        return [{"name": k, "value": v} for k, v in self._generate_runtime_env(runobj).items()]
+        return [
+            {"name": k, "value": v}
+            for k, v in self._generate_runtime_env(runobj).items()
+        ]
 
     def run(
         self,

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -457,7 +457,9 @@ class DaskCluster(KubejobRuntime):
         handler = runobj.spec.handler
         self._force_handler(handler)
 
-        extra_env = self.generate_runtime_env(runobj)
+        # TODO: investigate if the following instructions could overwrite the environment on any MLRun API Pod
+        # Such action could result on race conditions against other runtimes and MLRun itself
+        extra_env = self._generate_runtime_env(runobj)
         environ.update(extra_env)
 
         context = MLClientCtx.from_dict(

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -457,7 +457,7 @@ class DaskCluster(KubejobRuntime):
         handler = runobj.spec.handler
         self._force_handler(handler)
 
-        extra_env = self._generate_runtime_env(runobj)
+        extra_env = self.generate_runtime_env(runobj)
         environ.update(extra_env)
 
         context = MLClientCtx.from_dict(

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -108,7 +108,7 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
                 self.spec.priority_class_name,
             )
 
-        extra_env = self._generate_runtime_env(runobj)
+        extra_env = self.generate_runtime_env(runobj)
         extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]
         self._update_container(job, "env", extra_env + self.spec.env)
         if self.spec.image_pull_policy:

--- a/mlrun/runtimes/mpijob/v1alpha1.py
+++ b/mlrun/runtimes/mpijob/v1alpha1.py
@@ -108,8 +108,7 @@ class MpiRuntimeV1Alpha1(AbstractMPIJobRuntime):
                 self.spec.priority_class_name,
             )
 
-        extra_env = self.generate_runtime_env(runobj)
-        extra_env = [{"name": k, "value": v} for k, v in extra_env.items()]
+        extra_env = self.generate_runtime_k8s_env(runobj)
         self._update_container(job, "env", extra_env + self.spec.env)
         if self.spec.image_pull_policy:
             self._update_container(job, "imagePullPolicy", self.spec.image_pull_policy)


### PR DESCRIPTION
[ML-3711](https://jira.iguazeng.com/browse/ML-3711)

The traditional process for populating Job pods with MLRun related environment variables doesn't work for Dask pods, since the their scheduler is itself separated from the MLRun API pod and, because of that, it's not aware of such variables.

This PR ensures that the MLRun API pod add the relevant variables to the pod templates used to create both scheduler and worker pods on the Dask runtime.