### PR TITLE
[Docs] Add docs for notifications secret_params

### DIFF
--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -80,12 +80,13 @@ In any `run` method you can configure the notifications via their model. For exa
 
 ```python
 notification = mlrun.model.Notification(
-    kind="slack",
+    kind="webhook",
     when=["completed","error"],
     name="notification-1",
     message="completed",
     severity="info",
-    secret_params={"webhook": "<slack webhook url>"}
+    secret_params={"url": "<webhook url>"},
+    params={"method": "GET", "verify_ssl": True},
 )
 function.run(handler=handler, notifications=[notification])
 ```
@@ -94,10 +95,10 @@ function.run(handler=handler, notifications=[notification])
 For pipelines, you configure the notifications on the project notifiers. For example:
 
 ```python
-project.notifiers.add_notification(notification_type="slack",secret_params={"webhook":"<slack webhook url>"})
-project.notifiers.add_notification(notification_type="git", params={"repo": "<repo>", "issue": "<issue>"}, secret_params={"token": "<token>"})
+project.notifiers.add_notification(notification_type="slack",params={"webhook":"<slack webhook url>"})
+project.notifiers.add_notification(notification_type="git", params={"repo": "<repo>", "issue": "<issue>", "token": "<token>"})
 ```
-Instead of passing the webhook in the notification `secret_params`, it is also possible in a Jupyter notebook to use the ` %env` 
+Instead of passing the webhook in the notification `params`, it is also possible in a Jupyter notebook to use the ` %env` 
 magic command:
 ```
 %env SLACK_WEBHOOK=<slack webhook url>
@@ -105,7 +106,7 @@ magic command:
 
 Editing and removing notifications is done similarly with the following methods:
 ```python
-project.notifiers.edit_notification(notification_type="slack",secret_params={"webhook":"<new slack webhook url>"})
+project.notifiers.edit_notification(notification_type="slack",params={"webhook":"<new slack webhook url>"})
 project.notifiers.remove_notification(notification_type="slack")
 ```
 

--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -22,7 +22,8 @@ The notification object's schema is:
 - `name`: str - notification name
 - `message`: str - notification message
 - `severity`: str - notification severity (info, warning, error, debug)
-- `params`: dict - notification parameters (See definitions in [Notification Kinds](#notification-kinds))
+- `params`: dict - notification parameters (See definitions in [Notification Kinds](#notification-params-and-secrets))
+- `secret_params`: dict - secret data notification parameters (See definitions in [Notification Params and Secrets](#notification-kinds))
 - `condition`: str - jinja template for a condition that determines whether the notification is sent or not (See [Notification Conditions](#notification-conditions))
 
 
@@ -38,10 +39,15 @@ These cases are:
 > **Disclaimer:** Local notifications aren't persisted in mlrun API
 
 ## Notification Params and Secrets
-The notification parameters might contain sensitive information (slack webhook, git token, etc.). For this reason, 
-when a notification is created its params are masked in a kubernetes secret. The secret is named 
-`<run-uid>-<notification-id>` (or `<schedule-name>-<notification-id>`) and is created in the namespace where mlrun is 
-installed. In the notification params the secret reference is stored under the `secret` key once masked.
+The notification parameters often contain sensitive information, such as Slack webhooks Git tokens, etc.
+To safeguard this sensitive data, we've implemented a masking process for the notification's `secret_params`.
+When a notification is created, its `secret_params` are automatically masked and stored in a kubernetes secret.
+The naming convention for the secret is `<run-uid>-<notification-id>` (or `<schedule-name>-<notification-id>`).
+This secret is created within the namespace where MLRun is installed.
+Inside the notification's `secret_params`, you'll find a reference to the secret under the `secret` key once it's been masked.
+For non-sensitive notification parameters, you can simply use the `params` parameter, which doesn't go through this masking process.
+It's essential to utilize `secret_params` exclusively for handling sensitive information, ensuring secure data management.
+
 
 ## Notification Kinds
 
@@ -79,7 +85,7 @@ notification = mlrun.model.Notification(
     name="notification-1",
     message="completed",
     severity="info",
-    params={"webhook": "<slack webhook url>"}
+    secret_params={"webhook": "<slack webhook url>"}
 )
 function.run(handler=handler, notifications=[notification])
 ```
@@ -88,10 +94,10 @@ function.run(handler=handler, notifications=[notification])
 For pipelines, you configure the notifications on the project notifiers. For example:
 
 ```python
-project.notifiers.add_notification(notification_type="slack",params={"webhook":"<slack webhook url>"})
-project.notifiers.add_notification(notification_type="git", params={"repo": "<repo>", "issue": "<issue>", "token": "<token>"})
+project.notifiers.add_notification(notification_type="slack",secret_params={"webhook":"<slack webhook url>"})
+project.notifiers.add_notification(notification_type="git", params={"repo": "<repo>", "issue": "<issue>"}, secret_params={"token": "<token>"})
 ```
-Instead of passing the webhook in the notification params, it is also possible in a Jupyter notebook to use the ` %env` 
+Instead of passing the webhook in the notification `secret_params`, it is also possible in a Jupyter notebook to use the ` %env` 
 magic command:
 ```
 %env SLACK_WEBHOOK=<slack webhook url>
@@ -99,7 +105,7 @@ magic command:
 
 Editing and removing notifications is done similarly with the following methods:
 ```python
-project.notifiers.edit_notification(notification_type="slack",params={"webhook":"<new slack webhook url>"})
+project.notifiers.edit_notification(notification_type="slack",secret_params={"webhook":"<new slack webhook url>"})
 project.notifiers.remove_notification(notification_type="slack")
 ```
 
@@ -142,7 +148,7 @@ notification = mlrun.model.Notification(
     name="notification-1",
     message="completed",
     severity="info",
-    params={"webhook": "<slack webhook url>"},
+    secret_params={"webhook": "<slack webhook url>"},
     condition='{{ run["status"]["results"]["drift"] > 0.1 }}'
 )
 ```

--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -41,9 +41,8 @@ These cases are:
 ## Notification Params and Secrets
 The notification parameters often contain sensitive information, such as Slack webhooks Git tokens, etc.
 To safeguard this sensitive data, we've implemented a masking process for the notification's `secret_params`.
-When a notification is created, its `secret_params` are automatically masked and stored in a kubernetes secret.
-The naming convention for the secret is `<run-uid>-<notification-id>` (or `<schedule-name>-<notification-id>`).
-This secret is created within the namespace where MLRun is installed.
+When a notification is created, its `secret_params` are automatically masked and stored in a mlrun project secret.
+The name of the secret is built from the hash of the params themselves (So if multiple notifications use the same secret, it won't waste space in the project secret).
 Inside the notification's `secret_params`, you'll find a reference to the secret under the `secret` key once it's been masked.
 For non-sensitive notification parameters, you can simply use the `params` parameter, which doesn't go through this masking process.
 It's essential to utilize `secret_params` exclusively for handling sensitive information, ensuring secure data management.

--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -40,7 +40,8 @@ These cases are:
 
 ## Notification Params and Secrets
 The notification parameters often contain sensitive information, such as Slack webhooks Git tokens, etc.
-To safeguard this sensitive data, we've implemented a masking process for the notification's `secret_params`.
+To ensure the safety of this sensitive data, the parameters are split into 2 objects - `params` and `secret_params`.
+Either can be used to store any notification parameter. However the `secret_params` will be protected by project secrets.
 When a notification is created, its `secret_params` are automatically masked and stored in a mlrun project secret.
 The name of the secret is built from the hash of the params themselves (So if multiple notifications use the same secret, it won't waste space in the project secret).
 Inside the notification's `secret_params`, you'll find a reference to the secret under the `secret` key once it's been masked.

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -59,7 +59,7 @@ class Notification(pydantic.BaseModel):
     params: typing.Dict[str, typing.Any] = None
     status: NotificationStatus = None
     sent_time: typing.Union[str, datetime.datetime] = None
-    secret_params: typing.Dict[str, typing.Any] = None
+    secret_params: typing.Optional[typing.Dict[str, typing.Any]] = None
 
 
 class SetNotificationRequest(pydantic.BaseModel):

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -59,7 +59,7 @@ class Notification(pydantic.BaseModel):
     params: typing.Dict[str, typing.Any] = None
     status: NotificationStatus = None
     sent_time: typing.Union[str, datetime.datetime] = None
-    secret_params: typing.Optional[typing.Dict[str, typing.Any]] = None
+    secret_params: typing.Dict[str, typing.Any] = None
 
 
 class SetNotificationRequest(pydantic.BaseModel):


### PR DESCRIPTION
Documentation Update for [ML-4498](https://jira.iguazeng.com/browse/ML-4498): Separation of "params" and "secret_params" in notifications.