### PR TITLE
[Dockerfiles] Fix building base image

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -58,7 +58,7 @@ RUN conda config --add channels conda-forge && \
     conda install python=${MLRUN_PYTHON_VERSION} pip~=${MLRUN_PIP_VERSION} && \
     conda clean -aqy
 
-COPY ./dockerfiles/mlrun/requirements.txt ./mlrun-image-requirements.txt
+COPY ./dockerfiles/base/mlrun_requirements.txt ./mlrun-image-requirements.txt
 COPY ./extras-requirements.txt ./extras-requirements.txt
 COPY ./requirements.txt ./
 RUN python -m pip install \

--- a/dockerfiles/base/mlrun_requirements.txt
+++ b/dockerfiles/base/mlrun_requirements.txt
@@ -1,0 +1,9 @@
+# This is a hard copy of dockerfiles/mlrun/requirements.txt file
+# minus the mpi4py dependency which is not supported on base image
+# NOTE: this entire base, common and models would be deleted soon
+# TODO: delete me once we delete models entirely
+matplotlib~=3.5
+scipy~=1.0
+scikit-learn~=1.0
+seaborn~=0.11.0
+scikit-plot~=0.3.7


### PR DESCRIPTION
Base image tried installing mpi4py without having the base requirements for that (opmi) and failed. this PR remove that dependency by a hacky workaround.