### PR TITLE
[Datastore] Introducing the API for creating client temporary datastore profiles

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 
 import mlrun
 import mlrun.errors
+from mlrun.datastore.datastore_profile import TemporaryClientDatastoreProfiles
 from mlrun.errors import err_to_str
 
 from ..utils import DB_SCHEMA, run_keys
@@ -188,10 +189,13 @@ class StoreManager:
 
         if schema == "ds":
             profile_name = endpoint
-            project_name = urlparse(url).username or mlrun.mlconf.default_project
-            datastore = mlrun.db.get_run_db(
-                secrets=self._secrets
-            ).get_datastore_profile(profile_name, project_name)
+            datastore = TemporaryClientDatastoreProfiles().get(profile_name)
+            if not datastore:
+                project_name = urlparse(url).username or mlrun.mlconf.default_project
+                datastore = mlrun.db.get_run_db(
+                    secrets=self._secrets
+                ).get_datastore_profile(profile_name, project_name)
+
             datastore_type = datastore.type
 
         if schema == "memory":

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -48,6 +48,17 @@ class DatastoreProfile(pydantic.BaseModel):
         return full_key
 
 
+class TemporaryClientDatastoreProfiles(metaclass=mlrun.utils.singleton.Singleton):
+    def __init__(self):
+        self._data = {}  # Initialize the dictionary
+
+    def add(self, profile: DatastoreProfile):
+        self._data[profile.name] = profile
+
+    def get(self, key):
+        return self._data.get(key, None)
+
+
 class DatastoreProfileBasic(DatastoreProfile):
     type: str = pydantic.Field("basic")
     _private_attributes = "private"
@@ -162,6 +173,10 @@ def datastore_profile_read(url):
 
     profile_name = parsed_url.hostname
     project_name = parsed_url.username or mlrun.mlconf.default_project
+    datastore = TemporaryClientDatastoreProfiles().get(profile_name)
+    if datastore:
+        return datastore
+
     public_profile = mlrun.db.get_run_db().get_datastore_profile(
         profile_name, project_name
     )
@@ -180,3 +195,7 @@ def datastore_profile_read(url):
         private_json=private_body,
     )
     return datastore
+
+
+def register_temporary_client_datastore_profile(profile: DatastoreProfile):
+    TemporaryClientDatastoreProfiles().add(profile)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3039,6 +3039,11 @@ class MlrunProject(ModelObj):
             profile, self.name
         )
 
+    def get_datastore_profile(self, profile: str) -> DatastoreProfile:
+        return mlrun.db.get_run_db(secrets=self._secrets).get_datastore_profile(
+            profile, self.name
+        )
+
     def list_datastore_profiles(self) -> List[DatastoreProfile]:
         return mlrun.db.get_run_db(secrets=self._secrets).list_datastore_profiles(
             self.name

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3020,13 +3020,10 @@ class MlrunProject(ModelObj):
         )
 
     def register_datastore_profile(self, profile: DatastoreProfile):
-        project_ds_name_private = DatastoreProfile.generate_secret_key(
-            profile.name, self.name
-        )
         private_body = DatastoreProfile2Json.get_json_private(profile)
         public_body = DatastoreProfile2Json.get_json_public(profile)
-        # set project public data to DB
-        public_profile = mlrun.common.schemas.DatastoreProfile(
+        # send project data to DB
+        profile = mlrun.common.schemas.DatastoreProfile(
             name=profile.name,
             type=profile.type,
             object=public_body,
@@ -3034,17 +3031,10 @@ class MlrunProject(ModelObj):
             project=self.name,
         )
         mlrun.db.get_run_db(secrets=self._secrets).store_datastore_profile(
-            public_profile, self.name
-        )
-        # Set local environment variable
-        environ[project_ds_name_private] = private_body
-
-    def delete_datastore_profile(self, profile: str):
-        project_ds_name_private = DatastoreProfile.generate_secret_key(
             profile, self.name
         )
-        if project_ds_name_private in os.environ:
-            del os.environ[project_ds_name_private]
+
+    def delete_datastore_profile(self, profile: str):
         mlrun.db.get_run_db(secrets=self._secrets).delete_datastore_profile(
             profile, self.name
         )

--- a/tests/system/datastore/test_datastore_profiles.py
+++ b/tests/system/datastore/test_datastore_profiles.py
@@ -29,6 +29,15 @@ class TestDatastoreProfile(TestMLRunSystem):
     def custom_setup(self):
         pass
 
+    def test_datastore_profile_get(self):
+        project = mlrun.get_or_create_project(self.project_name)
+
+        profile1 = DatastoreProfileBasic(name="dsname1", public="http://1.1.1.1:1234")
+
+        project.register_datastore_profile(profile1)
+        profile = project.get_datastore_profile("dsname1")
+        assert profile == profile1
+
     def test_datastore_profile_list(self):
         project = mlrun.get_or_create_project(self.project_name)
 

--- a/tests/system/datastore/test_redis.py
+++ b/tests/system/datastore/test_redis.py
@@ -17,7 +17,10 @@ import os
 import pytest
 
 import mlrun.datastore
-from mlrun.datastore.datastore_profile import DatastoreProfileRedis
+from mlrun.datastore.datastore_profile import (
+    DatastoreProfileRedis,
+    register_temporary_client_datastore_profile,
+)
 from tests.system.base import TestMLRunSystem
 
 redis_endpoints = ["redis://", "redis://localhost:6379"]
@@ -73,13 +76,11 @@ class TestRedisDataStore(TestMLRunSystem):
         expected = "abcde" * 100
         with open("temp_upload", "w") as f:
             f.write(expected)
-        project = mlrun.get_or_create_project(name="my-project", context="./")
-
         if use_datastore_profile:
             profile = DatastoreProfileRedis(
                 name="dsname", endpoint_url=mlrun.mlconf.redis.url
             )
-            project.register_datastore_profile(profile)
+            register_temporary_client_datastore_profile(profile)
             redis_path = f"ds://dsname/{redis_object}"
         else:
             redis_path = f"redis:///{redis_object}"

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -40,7 +40,10 @@ import mlrun.feature_store as fstore
 import tests.conftest
 from mlrun.config import config
 from mlrun.data_types.data_types import InferOptions, ValueType
-from mlrun.datastore.datastore_profile import DatastoreProfileRedis
+from mlrun.datastore.datastore_profile import (
+    DatastoreProfileRedis,
+    register_temporary_client_datastore_profile,
+)
 from mlrun.datastore.sources import (
     CSVSource,
     DataFrameSource,
@@ -2198,11 +2201,10 @@ class TestFeatureStore(TestMLRunSystem):
             path=path,
         )
         if target_redis.startswith("ds://"):
-            project = mlrun.get_or_create_project(self.project_name)
             profile = DatastoreProfileRedis(
                 name=target_redis[len("ds://") :], endpoint_url=mlrun.mlconf.redis.url
             )
-            project.register_datastore_profile(profile)
+            register_temporary_client_datastore_profile(profile)
 
         targets = [
             CSVTarget(),


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4461
To clarify the access policy for datastore profiles, we've established a distinct separation between profile access from pods and from clients. Profiles registered using `project.register_datastore_profile()` are exclusively accessible from pods, while those registered via `register_temporary_client_datastore_profile()` can only be accessed by clients.