### PR TITLE
[Tests] Fix KFP pipeline param test

### DIFF
--- a/tests/system/runtimes/assets/my_func.py
+++ b/tests/system/runtimes/assets/my_func.py
@@ -15,5 +15,5 @@
 from mlrun.execution import MLClientCtx
 
 
-def handler(context: MLClientCtx) -> None:
-    context.logger.info("Handler started")
+def handler(context: MLClientCtx, p1: int = 9) -> None:
+    context.logger.info("Handler started", p1=p1)

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -58,7 +58,7 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         mlrun.wait_for_pipeline_completion(run_id, project=self.project_name)
 
     @pytest.mark.enterprise
-    def test_kfp_with_run_pipeline_and_run_function(self):
+    def test_kfp_with_pipeline_param_and_run_function(self):
         code_path = str(self.assets_path / "my_func.py")
         func = mlrun.code_to_function(
             name="func",
@@ -78,14 +78,18 @@ class TestKFP(tests.system.base.TestMLRunSystem):
                 outputs=["mymodel"],
             )
 
+            if str(p1) != "{{pipelineparam:op=;name=p1}}":
+                raise ValueError(f"p1 was expected to be a pipeline param but is {p1}")
+
         arguments = {"p1": 8}
-        run_id = mlrun._run_pipeline(
-            job_pipeline,
-            arguments,
-            experiment="my-job",
-            project=self.project_name,
+        run_id = self.project.run(
+            workflow_handler=job_pipeline,
+            arguments=arguments,
+            name="my-job",
+            watch=True,
         )
 
+        # double check that the pipeline completed successfully
         mlrun.wait_for_pipeline_completion(run_id, project=self.project_name)
 
     def test_kfp_without_image(self):

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -78,8 +78,9 @@ class TestKFP(tests.system.base.TestMLRunSystem):
                 outputs=["mymodel"],
             )
 
-            if str(p1) != "{{pipelineparam:op=;name=p1}}":
-                raise ValueError(f"p1 was expected to be a pipeline param but is {p1}")
+            assert (
+                str(p1) == "{{pipelineparam:op=;name=p1}}"
+            ), f"p1 was expected to be a pipeline param but is {p1}"
 
         arguments = {"p1": 8}
         run_id = self.project.run(


### PR DESCRIPTION
This test used to use `run_pipeline` sdk which was deprecated and removed.
It should use project.run instead of internal methods.