### PR TITLE
[Model Monitoring] Fix different dataset types when reading a dataset as a DataFrame

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -549,6 +549,7 @@ def get_sample_set_statistics(
 
 def read_dataset_as_dataframe(
     dataset: DatasetType,
+    feature_columns: typing.Union[str, typing.List[str]] = None,
     label_columns: typing.Union[str, typing.List[str]] = None,
     drop_columns: typing.Union[str, typing.List[str], int, typing.List[int]] = None,
 ) -> typing.Tuple[pd.DataFrame, typing.List[str]]:
@@ -556,12 +557,14 @@ def read_dataset_as_dataframe(
     Parse the given dataset into a DataFrame and drop the columns accordingly. In addition, the label columns will be
     parsed and validated as well.
 
-    :param dataset:       The dataset to train the model on.
-                          Can be either a list of lists, dict, URI or a FeatureVector.
-    :param label_columns: The target label(s) of the column(s) in the dataset. for Regression or
-                          Classification tasks.
-    :param drop_columns:  ``str`` / ``int`` or a list of ``str`` / ``int`` that represent the column names / indices to
-                          drop.
+    :param dataset:         The dataset to train the model on.
+                            Can be either a list of lists, dict, URI or a FeatureVector.
+    :param feature_columns: List of feature columns that will be used to build the dataframe when dataset is from
+                            type list or numpy array.
+    :param label_columns:   The target label(s) of the column(s) in the dataset. for Regression or
+                            Classification tasks.
+    :param drop_columns:    ``str`` / ``int`` or a list of ``str`` / ``int`` that represent the column names / indices
+                            to drop.
 
     :returns: A tuple of:
               [0] = The parsed dataset as a DataFrame
@@ -575,42 +578,42 @@ def read_dataset_as_dataframe(
             drop_columns = [drop_columns]
 
     # Check if the dataset is in fact a Feature Vector:
-    if (
-        dataset.meta
-        and dataset.meta.kind == mlrun.common.schemas.ObjectKind.feature_vector
-    ):
+    if isinstance(dataset, mlrun.feature_store.FeatureVector):
         # Try to get the label columns if not provided:
         if label_columns is None:
-            label_columns = dataset.meta.status.label_column
+            label_columns = dataset.status.label_column
         # Get the features and parse to DataFrame:
         dataset = mlrun.feature_store.get_offline_features(
-            dataset.meta.uri, drop_columns=drop_columns
+            dataset.uri, drop_columns=drop_columns
         ).to_dataframe()
+
+    elif isinstance(dataset, (list, np.ndarray)):
+        if not feature_columns:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Feature columns list must be provided when dataset input as from type list or numpy array"
+            )
+        # Parse the list / numpy array into a DataFrame:
+        dataset = pd.DataFrame(dataset, columns=feature_columns)
+        # Validate the `drop_columns` is given as integers:
+        if drop_columns and not all(isinstance(col, int) for col in drop_columns):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "`drop_columns` must be an integer / list of integers if provided as a list."
+            )
+    elif isinstance(dataset, mlrun.DataItem):
+        # Turn the DataITem to DataFrame:
+        dataset = dataset.as_df()
     else:
-        # Parse to DataFrame according to the dataset's type:
-        if isinstance(dataset, (list, np.ndarray)):
-            # Parse the list / numpy array into a DataFrame:
+        # Parse the object (should be a pd.DataFrame / pd.Series, dictionary) into a DataFrame:
+        try:
             dataset = pd.DataFrame(dataset)
-            # Validate the `drop_columns` is given as integers:
-            if drop_columns and not all(isinstance(col, int) for col in drop_columns):
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "`drop_columns` must be an integer / list of integers if provided as a list."
-                )
-        elif isinstance(dataset, mlrun.DataItem):
-            # Turn the DataITem to DataFrame:
-            dataset = dataset.as_df()
-        else:
-            # Parse the object (should be a pd.DataFrame / pd.Series, dictionary) into a DataFrame:
-            try:
-                dataset = pd.DataFrame(dataset)
-            except ValueError as e:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Could not parse the given dataset of type {type(dataset)} into a pandas DataFrame. "
-                    f"Received the following error: {e}"
-                )
-        # Drop columns if needed:
-        if drop_columns:
-            dataset.drop(drop_columns, axis=1, inplace=True)
+        except ValueError as e:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Could not parse the given dataset of type {type(dataset)} into a pandas DataFrame. "
+                f"Received the following error: {e}"
+            )
+    # Drop columns if needed:
+    if drop_columns:
+        dataset.drop(drop_columns, axis=1, inplace=True)
 
     # Turn the `label_columns` into a list by default:
     if label_columns is None:

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -557,7 +557,7 @@ def read_dataset_as_dataframe(
     Parse the given dataset into a DataFrame and drop the columns accordingly. In addition, the label columns will be
     parsed and validated as well.
 
-    :param dataset:         The dataset to train the model on.
+    :param dataset:         A dataset that will be converted into a DataFrame.
                             Can be either a list of lists, dict, URI or a FeatureVector.
     :param feature_columns: List of feature columns that will be used to build the dataframe when dataset is from
                             type list or numpy array.

--- a/tests/model_monitoring/test_monitoring_api.py
+++ b/tests/model_monitoring/test_monitoring_api.py
@@ -17,7 +17,7 @@ import mlrun.model_monitoring.api
 
 def test_read_dataset_as_dataframe():
     # Test list with feature columns
-    dataset = [[5.8, 2.8, 5.1, 2.4, 1.0], [6.0, 2.2, 4.0, 1.0, 2.0]]
+    dataset = [[5.8, 2.8, 5.1, 2.4], [6.0, 2.2, 4.0, 1.0]]
     feature_columns = ["feature_1", "feature_2", "feature_3", "feature_4"]
 
     df, _ = mlrun.model_monitoring.api.read_dataset_as_dataframe(

--- a/tests/model_monitoring/test_monitoring_api.py
+++ b/tests/model_monitoring/test_monitoring_api.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mlrun.model_monitoring.api
+
+
+def test_read_dataset_as_dataframe():
+    # Test list with feature columns
+    dataset = [[5.8, 2.8, 5.1, 2.4, 1.0], [6.0, 2.2, 4.0, 1.0, 2.0]]
+    feature_columns = ["feature_1", "feature_2", "feature_3", "feature_4"]
+
+    df, _ = mlrun.model_monitoring.api.read_dataset_as_dataframe(
+        dataset=dataset,
+        feature_columns=feature_columns,
+    )
+    assert list(df.columns) == feature_columns
+    assert df["feature_1"].to_list() == [dataset[0][0], dataset[1][0]]
+
+    # Test dictionary
+    dataset_dict = {}
+    for i in range(len(feature_columns)):
+        dataset_dict[feature_columns[i]] = [dataset[0][i], dataset[1][i]]
+    df, _ = mlrun.model_monitoring.api.read_dataset_as_dataframe(
+        dataset=dataset_dict, drop_columns="feature_2"
+    )
+    feature_columns.remove("feature_2")
+    assert list(df.columns) == feature_columns


### PR DESCRIPTION
This PR fix a bug in which the dataset is not provided as a `DateItem` object when calling `read_dataset_as_dataframe()` (part of the `batch-infer-v2` flow). 
In addition, we also add a new parameter called `feature_columns` that can be either received by the user or taken from the model artifact inputs. Note that these feature columns are being used when the provided dataset is from type list or numpy array.
A related JIRA - https://jira.iguazeng.com/browse/ML-4477
A similar fix for the `batch-infer-v1` (`read_dataset_as_dataframe` in this case defined within `mlrun/function` repo) - https://github.com/mlrun/functions/pull/662/