### PR TITLE
[Model Monitoring] Use a shared class for the model endpoint tables

### DIFF
--- a/mlrun/model_monitoring/stores/models/__init__.py
+++ b/mlrun/model_monitoring/stores/models/__init__.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
 from .mysql import ModelEndpointsTable as MySQLModelEndpointsTable
 from .sqlite import ModelEndpointsTable as SQLiteModelEndpointsTable
 
 
-def get_model_endpoints_table(connection_string: Optional[str] = None) -> Type:
+def get_model_endpoints_table(
+    connection_string: Optional[str] = None,
+) -> Union[Type[MySQLModelEndpointsTable], Type[SQLiteModelEndpointsTable]]:
     """Return ModelEndpointsTable based on the provided connection string"""
     if connection_string and "mysql:" in connection_string:
         return MySQLModelEndpointsTable

--- a/mlrun/model_monitoring/stores/models/__init__.py
+++ b/mlrun/model_monitoring/stores/models/__init__.py
@@ -11,13 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+from typing import Optional, Type
+
+from .mysql import ModelEndpointsTable as MySQLModelEndpointsTable
+from .sqlite import ModelEndpointsTable as SQLiteModelEndpointsTable
 
 
-def get_ModelEndpointsTable(connection_string: str = None):
+def get_ModelEndpointsTable(connection_string: Optional[str] = None) -> Type:
     """Return ModelEndpointsTable based on the provided connection string"""
-    if "mysql:" in connection_string:
-        from .mysql import ModelEndpointsTable
-    else:
-        from .sqlite import ModelEndpointsTable
-    return ModelEndpointsTable
+    if connection_string and "mysql:" in connection_string:
+        return MySQLModelEndpointsTable
+    return SQLiteModelEndpointsTable

--- a/mlrun/model_monitoring/stores/models/__init__.py
+++ b/mlrun/model_monitoring/stores/models/__init__.py
@@ -18,7 +18,7 @@ from .mysql import ModelEndpointsTable as MySQLModelEndpointsTable
 from .sqlite import ModelEndpointsTable as SQLiteModelEndpointsTable
 
 
-def get_ModelEndpointsTable(connection_string: Optional[str] = None) -> Type:
+def get_model_endpoints_table(connection_string: Optional[str] = None) -> Type:
     """Return ModelEndpointsTable based on the provided connection string"""
     if connection_string and "mysql:" in connection_string:
         return MySQLModelEndpointsTable

--- a/mlrun/model_monitoring/stores/models/base.py
+++ b/mlrun/model_monitoring/stores/models/base.py
@@ -11,8 +11,74 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, String, Text
 
-Base = declarative_base()
+from mlrun.common.schemas.model_monitoring import EventFieldType
+from mlrun.utils.db import BaseModel
+
+
+class ModelEndpointsBaseTable(BaseModel):
+    __tablename__ = EventFieldType.MODEL_ENDPOINTS
+
+    uid = Column(
+        EventFieldType.UID,
+        String(40),
+        primary_key=True,
+    )
+    state = Column(EventFieldType.STATE, String(10))
+    project = Column(EventFieldType.PROJECT, String(40))
+    function_uri = Column(
+        EventFieldType.FUNCTION_URI,
+        String(255),
+    )
+    model = Column(EventFieldType.MODEL, String(255))
+    model_class = Column(
+        EventFieldType.MODEL_CLASS,
+        String(255),
+    )
+    labels = Column(EventFieldType.LABELS, Text)
+    model_uri = Column(EventFieldType.MODEL_URI, String(255))
+    stream_path = Column(EventFieldType.STREAM_PATH, Text)
+    algorithm = Column(
+        EventFieldType.ALGORITHM,
+        String(255),
+    )
+    active = Column(EventFieldType.ACTIVE, Boolean)
+    monitoring_mode = Column(
+        EventFieldType.MONITORING_MODE,
+        String(10),
+    )
+    feature_stats = Column(EventFieldType.FEATURE_STATS, Text)
+    current_stats = Column(EventFieldType.CURRENT_STATS, Text)
+    feature_names = Column(EventFieldType.FEATURE_NAMES, Text)
+    children = Column(EventFieldType.CHILDREN, Text)
+    label_names = Column(EventFieldType.LABEL_NAMES, Text)
+    endpoint_type = Column(
+        EventFieldType.ENDPOINT_TYPE,
+        String(10),
+    )
+    children_uids = Column(EventFieldType.CHILDREN_UIDS, Text)
+    drift_measures = Column(EventFieldType.DRIFT_MEASURES, Text)
+    drift_status = Column(
+        EventFieldType.DRIFT_STATUS,
+        String(40),
+    )
+    monitor_configuration = Column(
+        EventFieldType.MONITOR_CONFIGURATION,
+        Text,
+    )
+    monitoring_feature_set_uri = Column(
+        EventFieldType.FEATURE_SET_URI,
+        String(255),
+    )
+    error_count = Column(EventFieldType.ERROR_COUNT, Integer)
+    metrics = Column(EventFieldType.METRICS, Text)
+    first_request = Column(
+        EventFieldType.FIRST_REQUEST,
+        TIMESTAMP,
+    )
+    last_request = Column(
+        EventFieldType.LAST_REQUEST,
+        TIMESTAMP,
+    )

--- a/mlrun/model_monitoring/stores/models/mysql.py
+++ b/mlrun/model_monitoring/stores/models/mysql.py
@@ -11,108 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+import sqlalchemy.dialects.mysql
+from sqlalchemy import Column
+from sqlalchemy.ext.declarative import declarative_base
+
+from mlrun.common.schemas.model_monitoring import EventFieldType
+
+from .base import ModelEndpointsBaseTable
+
+Base = declarative_base()
 
 
-import sqlalchemy.dialects
-from sqlalchemy import Boolean, Column, Integer, String, Text
-
-import mlrun.common.schemas.model_monitoring
-from mlrun.utils.db import BaseModel
-
-from .base import Base
-
-
-class ModelEndpointsTable(Base, BaseModel):
-    __tablename__ = mlrun.common.schemas.model_monitoring.EventFieldType.MODEL_ENDPOINTS
-
-    uid = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.UID,
-        String(40),
-        primary_key=True,
-    )
-    state = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.STATE, String(10)
-    )
-    project = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.PROJECT, String(40)
-    )
-    function_uri = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FUNCTION_URI,
-        String(255),
-    )
-    model = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MODEL, String(255)
-    )
-    model_class = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MODEL_CLASS,
-        String(255),
-    )
-    labels = Column(mlrun.common.schemas.model_monitoring.EventFieldType.LABELS, Text)
-    model_uri = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MODEL_URI, String(255)
-    )
-    stream_path = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.STREAM_PATH, Text
-    )
-    algorithm = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ALGORITHM,
-        String(255),
-    )
-    active = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ACTIVE, Boolean
-    )
-    monitoring_mode = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MONITORING_MODE,
-        String(10),
-    )
-    feature_stats = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_STATS, Text
-    )
-    current_stats = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.CURRENT_STATS, Text
-    )
-    feature_names = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_NAMES, Text
-    )
-    children = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.CHILDREN, Text
-    )
-    label_names = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.LABEL_NAMES, Text
-    )
-
-    endpoint_type = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_TYPE,
-        String(10),
-    )
-    children_uids = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.CHILDREN_UIDS, Text
-    )
-    drift_measures = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.DRIFT_MEASURES, Text
-    )
-    drift_status = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.DRIFT_STATUS,
-        String(40),
-    )
-    monitor_configuration = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MONITOR_CONFIGURATION,
-        Text,
-    )
-    monitoring_feature_set_uri = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_SET_URI,
-        String(255),
-    )
+class ModelEndpointsTable(Base, ModelEndpointsBaseTable):
     first_request = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FIRST_REQUEST,
+        EventFieldType.FIRST_REQUEST,
         sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3),
     )
     last_request = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.LAST_REQUEST,
+        EventFieldType.LAST_REQUEST,
         sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3),
     )
-    error_count = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ERROR_COUNT, Integer
-    )
-    metrics = Column(mlrun.common.schemas.model_monitoring.EventFieldType.METRICS, Text)

--- a/mlrun/model_monitoring/stores/models/sqlite.py
+++ b/mlrun/model_monitoring/stores/models/sqlite.py
@@ -11,106 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+from sqlalchemy.ext.declarative import declarative_base
+
+from .base import ModelEndpointsBaseTable
+
+Base = declarative_base()
 
 
-from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, String, Text
-
-import mlrun.common.schemas.model_monitoring
-from mlrun.utils.db import BaseModel
-
-from .base import Base
-
-
-class ModelEndpointsTable(Base, BaseModel):
-    __tablename__ = mlrun.common.schemas.model_monitoring.EventFieldType.MODEL_ENDPOINTS
-
-    uid = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.UID,
-        String(40),
-        primary_key=True,
-    )
-    state = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.STATE, String(10)
-    )
-    project = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.PROJECT, String(40)
-    )
-    function_uri = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FUNCTION_URI,
-        String(255),
-    )
-    model = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MODEL, String(255)
-    )
-    model_class = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MODEL_CLASS,
-        String(255),
-    )
-    labels = Column(mlrun.common.schemas.model_monitoring.EventFieldType.LABELS, Text)
-    model_uri = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MODEL_URI, String(255)
-    )
-    stream_path = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.STREAM_PATH, Text
-    )
-    algorithm = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ALGORITHM,
-        String(255),
-    )
-    active = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ACTIVE, Boolean
-    )
-    monitoring_mode = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MONITORING_MODE,
-        String(10),
-    )
-    feature_stats = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_STATS, Text
-    )
-    current_stats = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.CURRENT_STATS, Text
-    )
-    feature_names = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_NAMES, Text
-    )
-    children = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.CHILDREN, Text
-    )
-    label_names = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.LABEL_NAMES, Text
-    )
-    endpoint_type = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_TYPE,
-        String(10),
-    )
-    children_uids = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.CHILDREN_UIDS, Text
-    )
-    drift_measures = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.DRIFT_MEASURES, Text
-    )
-    drift_status = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.DRIFT_STATUS,
-        String(40),
-    )
-    monitor_configuration = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.MONITOR_CONFIGURATION,
-        Text,
-    )
-    monitoring_feature_set_uri = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_SET_URI,
-        String(255),
-    )
-    first_request = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.FIRST_REQUEST,
-        TIMESTAMP,
-    )
-    last_request = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.LAST_REQUEST,
-        TIMESTAMP,
-    )
-    error_count = Column(
-        mlrun.common.schemas.model_monitoring.EventFieldType.ERROR_COUNT, Integer
-    )
-    metrics = Column(mlrun.common.schemas.model_monitoring.EventFieldType.METRICS, Text)
+class ModelEndpointsTable(Base, ModelEndpointsBaseTable):
+    pass

--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -27,7 +27,7 @@ from mlrun.common.db.sql_session import create_session, get_engine
 from mlrun.utils import logger
 
 from .model_endpoint_store import ModelEndpointStore
-from .models import get_ModelEndpointsTable
+from .models import get_model_endpoints_table
 from .models.base import Base
 
 
@@ -69,7 +69,7 @@ class SQLModelEndpointStore(ModelEndpointStore):
         )
 
         self._engine = get_engine(dsn=self.sql_connection_string)
-        self.ModelEndpointsTable = get_ModelEndpointsTable(
+        self.ModelEndpointsTable = get_model_endpoints_table(
             connection_string=self.sql_connection_string
         )
         # Create table if not exist. The `metadata` contains the `ModelEndpointsTable`

--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -28,7 +28,6 @@ from mlrun.utils import logger
 
 from .model_endpoint_store import ModelEndpointStore
 from .models import get_model_endpoints_table
-from .models.base import Base
 
 
 class SQLModelEndpointStore(ModelEndpointStore):
@@ -74,7 +73,7 @@ class SQLModelEndpointStore(ModelEndpointStore):
         )
         # Create table if not exist. The `metadata` contains the `ModelEndpointsTable`
         if not self._engine.has_table(self.table_name):
-            Base.metadata.create_all(bind=self._engine)
+            self.ModelEndpointsTable.metadata.create_all(bind=self._engine)
         self.model_endpoints_table = self.ModelEndpointsTable.__table__
 
     def write_model_endpoint(self, endpoint: typing.Dict[str, typing.Any]):

--- a/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/sql_model_endpoint_store.py
@@ -73,8 +73,12 @@ class SQLModelEndpointStore(ModelEndpointStore):
         )
         # Create table if not exist. The `metadata` contains the `ModelEndpointsTable`
         if not self._engine.has_table(self.table_name):
-            self.ModelEndpointsTable.metadata.create_all(bind=self._engine)
-        self.model_endpoints_table = self.ModelEndpointsTable.__table__
+            self.ModelEndpointsTable.metadata.create_all(  # pyright: ignore[reportGeneralTypeIssues]
+                bind=self._engine
+            )
+        self.model_endpoints_table = (
+            self.ModelEndpointsTable.__table__  # pyright: ignore[reportGeneralTypeIssues]
+        )
 
     def write_model_endpoint(self, endpoint: typing.Dict[str, typing.Any]):
         """


### PR DESCRIPTION
Resolves [ML-4526](https://jira.iguazeng.com/browse/ML-4526).

These tables are used as a replacement for V3IO in CE.
The MySQL and SQLite SQLAlchemy tables have the same fields by design, up to a MySQL specification for two time fields.
This PR refactors the code to remove this duplication without changing the models. This is required for easier extension and addition to more models.

Before this PR:
```mermaid
classDiagram
`base.Base` <|-- `mysql.ModelEndpointsTable`
BaseModel <|-- `mysql.ModelEndpointsTable`
`base.Base` <|-- `sqlite.ModelEndpointsTable`
BaseModel <|-- `sqlite.ModelEndpointsTable`
```
The two classes could not be imported together, therefore the if was inside the `get_ModelEndpointsTable` function.

After this PR:
```mermaid
classDiagram
BaseModel <|-- `base.ModelEndpointsBaseTable`
`base.ModelEndpointsBaseTable` <|-- `sqlite.ModelEndpointsTable`
`base.ModelEndpointsBaseTable` <|-- `mysql.ModelEndpointsTable`
`sqlite.Base` <|-- `sqlite.ModelEndpointsTable`
`mysql.Base` <|-- `mysql.ModelEndpointsTable`
```

Inheriting from different `Base` (`from sqlalchemy.ext.declarative import declarative_base`) allows the two tables to live side by side.

Checked on a CE system:
* The `model_endpoints` table is created in the `mlrun` MySQL database.
* The table is updated with the data.