### PR TITLE
[HTTPDB] Change `list_projects` default format to name only

### DIFF
--- a/mlrun/api/rundb/sqldb.py
+++ b/mlrun/api/rundb/sqldb.py
@@ -426,7 +426,7 @@ class SQLRunDB(RunDBInterface):
     def list_projects(
         self,
         owner: str = None,
-        format_: mlrun.common.schemas.ProjectsFormat = mlrun.common.schemas.ProjectsFormat.full,
+        format_: mlrun.common.schemas.ProjectsFormat = mlrun.common.schemas.ProjectsFormat.name_only,
         labels: List[str] = None,
         state: mlrun.common.schemas.ProjectState = None,
     ) -> mlrun.common.schemas.ProjectsOutput:

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -257,7 +257,7 @@ class RunDBInterface(ABC):
     def list_projects(
         self,
         owner: str = None,
-        format_: mlrun.common.schemas.ProjectsFormat = mlrun.common.schemas.ProjectsFormat.full,
+        format_: mlrun.common.schemas.ProjectsFormat = mlrun.common.schemas.ProjectsFormat.name_only,
         labels: List[str] = None,
         state: mlrun.common.schemas.ProjectState = None,
     ) -> mlrun.common.schemas.ProjectsOutput:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2179,7 +2179,7 @@ class HTTPRunDB(RunDBInterface):
         owner: str = None,
         format_: Union[
             str, mlrun.common.schemas.ProjectsFormat
-        ] = mlrun.common.schemas.ProjectsFormat.full,
+        ] = mlrun.common.schemas.ProjectsFormat.name_only,
         labels: List[str] = None,
         state: Union[str, mlrun.common.schemas.ProjectState] = None,
     ) -> List[Union[mlrun.projects.MlrunProject, str]]:
@@ -2188,9 +2188,9 @@ class HTTPRunDB(RunDBInterface):
         :param owner: List only projects belonging to this specific owner.
         :param format_: Format of the results. Possible values are:
 
-            - ``full`` (default value) - Return full project objects.
+            - ``name_only`` (default value) - Return just the names of the projects.
             - ``minimal`` - Return minimal project objects (minimization happens in the BE).
-            - ``name_only`` - Return just the names of the projects.
+            - ``full``  - Return full project objects.
 
         :param labels: Filter by labels attached to the project.
         :param state: Filter by project's state. Can be either ``online`` or ``archived``.

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -193,7 +193,7 @@ class NopDB(RunDBInterface):
     def list_projects(
         self,
         owner: str = None,
-        format_: mlrun.common.schemas.ProjectsFormat = mlrun.common.schemas.ProjectsFormat.full,
+        format_: mlrun.common.schemas.ProjectsFormat = mlrun.common.schemas.ProjectsFormat.name_only,
         labels: List[str] = None,
         state: mlrun.common.schemas.ProjectState = None,
     ) -> mlrun.common.schemas.ProjectsOutput:

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -29,7 +29,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         mlrun.new_project(project_name)
         projects = mlrun.get_run_db().list_projects()
         assert len(projects) == 1
-        assert projects[0].metadata.name == project_name
+        assert projects[0] == project_name
 
     def test_create_project_failure_already_exists(self):
         project_name = "some-project"
@@ -107,7 +107,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
                 project=project.metadata.name,
             )
 
-        projects = db.list_projects()
+        projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
 
@@ -138,7 +138,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         old_creation_time = projects[0].metadata.created
 
         mlrun.new_project(project_name, overwrite=True)
-        projects = db.list_projects()
+        projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
 
@@ -153,7 +153,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         mlrun.new_project(project_name)
         db = mlrun.get_run_db()
 
-        projects = db.list_projects()
+        projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
 
@@ -163,7 +163,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # overwrite empty project
         mlrun.new_project(project_name, overwrite=True)
-        projects = db.list_projects()
+        projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
 
@@ -177,7 +177,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
         mlrun.new_project(project_name)
         db = mlrun.get_run_db()
 
-        projects = db.list_projects()
+        projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
         old_creation_time = projects[0].metadata.created
@@ -187,7 +187,7 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
             mlrun.new_project(project_name, from_template="bla", overwrite=True)
 
         # ensure project was not deleted
-        projects = db.list_projects()
+        projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
         assert len(projects) == 1
         assert projects[0].metadata.name == project_name
         assert projects[0].metadata.created == old_creation_time

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -759,7 +759,7 @@ def test_project_sql_db_roundtrip(create_server):
     _assert_projects(project, patched_project)
     get_project = db.get_project(project_name)
     _assert_projects(project, get_project)
-    list_projects = db.list_projects()
+    list_projects = db.list_projects(format_=mlrun.common.schemas.ProjectsFormat.full)
     _assert_projects(project, list_projects[0])
 
 


### PR DESCRIPTION
Breaking change - changing list project to return project names only to reduce load on api needlessly