### PR TITLE
[Model Monitoring] Add retry on model endpoint metrics assertion in system tests

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -291,12 +291,12 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         mlrun.utils.helpers.retry_until_successful(
             3,
             10,
-            mlrun.utils.logger,
+            self._logger,
             False,
-            self._check_model_endpoint_metrics,
+            self._assert_model_endpoint_metrics,
         )
 
-    def _check_model_endpoint_metrics(self):
+    def _assert_model_endpoint_metrics(self):
 
         endpoints_list = mlrun.get_run_db().list_model_endpoints(
             self.project_name, metrics=["predictions_per_second"]
@@ -582,7 +582,7 @@ class TestVotingModelMonitoring(TestMLRunSystem):
         mlrun.utils.helpers.retry_until_successful(
             2,
             20,
-            mlrun.utils.logger,
+            self._logger,
             False,
             self._check_monitoring_building_state,
             base_runtime=base_runtime,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -287,6 +287,9 @@ class TestBasicModelMonitoring(TestMLRunSystem):
             )
             sleep(choice([0.01, 0.04]))
 
+        # Wait for model endpoint stats to be updated
+        sleep(10)
+
         # Test metrics
         endpoints_list = mlrun.get_run_db().list_model_endpoints(
             self.project_name, metrics=["predictions_per_second"]
@@ -294,6 +297,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         assert len(endpoints_list) == 1
 
         endpoint = endpoints_list[0]
+        self._logger.debug("Model endpoint metrics", endpoint.status.metrics)
         assert len(endpoint.status.metrics) > 0
 
         assert endpoint.status.metrics["generic"]["predictions_count_5m"] == 101


### PR DESCRIPTION
Following model monitoring system test failures that are related to the model endpoint feature stats (e.g. https://github.com/mlrun/mlrun/actions/runs/6078927221/job/16491351301#:~:text=%3E%20%20%20%20%20%20%20assert%20endpoint,KeyError%3A%20%27predictions_count_5m%27 & https://github.com/mlrun/mlrun/actions/runs/6006655462/job/16292184281#:~:text=assert%20endpoint.status,assert%2091.0%20%3D%3D%20101, in this PR we add a sleep time of 10sec before retrieving the endpoint record from the database. 
