### PR TITLE
[Model Monitoring] Implement apps writer (EE)

### DIFF
--- a/mlrun/api/crud/model_monitoring/deployment.py
+++ b/mlrun/api/crud/model_monitoring/deployment.py
@@ -675,7 +675,7 @@ class MonitoringDeployment:
 
         # Create writer monitoring serving graph
         graph = function.set_topology("flow")
-        graph.to(ModelMonitoringWriter(name="king")).respond()  # writer
+        graph.to(ModelMonitoringWriter(project=project)).respond()  # writer
 
         # Set the project to the serving function
         function.metadata.project = project

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -28,6 +28,7 @@ from mlrun.serving.utils import StepToDict
 from mlrun.utils import logger
 
 _TSDB_BE = "tsdb"
+_TSDB_RATE = "1/s"
 RawEvent = dict[str, Any]
 AppResultEvent = NewType("AppResultEvent", RawEvent)
 
@@ -74,6 +75,7 @@ class ModelMonitoringWriter(StepToDict):
             backend=_TSDB_BE,
             table=self._TSDB_TABLE,
             if_exists=IGNORE,
+            rate=_TSDB_RATE,
         )
 
     def _update_kv_db(self, event: AppResultEvent) -> None:

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -30,6 +30,7 @@ from mlrun.utils import logger
 
 _TSDB_BE = "tsdb"
 _TSDB_RATE = "1/s"
+_TSDB_TABLE = "app-results"
 RawEvent = dict[str, Any]
 AppResultEvent = NewType("AppResultEvent", RawEvent)
 
@@ -52,7 +53,6 @@ class ModelMonitoringWriter(StepToDict):
     """
 
     kind = "monitoring_application_stream_pusher"
-    _TSDB_TABLE = "app-results"
 
     def __init__(self, project: str) -> None:
         self.project = project
@@ -74,7 +74,7 @@ class ModelMonitoringWriter(StepToDict):
     def _create_tsdb_table(self) -> None:
         self._tsdb_client.create(
             backend=_TSDB_BE,
-            table=self._TSDB_TABLE,
+            table=_TSDB_TABLE,
             if_exists=IGNORE,
             rate=_TSDB_RATE,
         )
@@ -100,7 +100,7 @@ class ModelMonitoringWriter(StepToDict):
         try:
             self._tsdb_client.write(
                 backend=_TSDB_BE,
-                table=self._TSDB_TABLE,
+                table=_TSDB_TABLE,
                 dfs=pd.DataFrame.from_records([event]),
                 index_cols=[
                     WriterEvent.SCHEDULE_TIME,
@@ -108,12 +108,12 @@ class ModelMonitoringWriter(StepToDict):
                     WriterEvent.APPLICATION_NAME,
                 ],
             )
-            logger.info("Updated V3IO TSDB successfully", table=self._TSDB_TABLE)
+            logger.info("Updated V3IO TSDB successfully", table=_TSDB_TABLE)
         except V3IOFramesError as err:
             logger.warn(
                 "Could not write drift measures to TSDB",
                 err=err,
-                table=self._TSDB_TABLE,
+                table=_TSDB_TABLE,
                 event=event,
             )
 

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -61,10 +61,11 @@ class ModelMonitoringWriter(StepToDict):
         self._create_tsdb_table()
 
     def _get_v3io_client(self) -> V3IOClient:
-        return mlrun.utils.v3io_clients.get_v3io_client()
+        return mlrun.utils.v3io_clients.get_v3io_client(endpoint=mlrun.mlconf.v3io_api)
 
     def _get_v3io_frames_client(self) -> V3IOFramesClient:
         return mlrun.utils.v3io_clients.get_frames_client(
+            address=mlrun.mlconf.v3io_framesd,
             container=self._v3io_container,
         )
 

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -64,6 +64,7 @@ class ModelMonitoringWriter(StepToDict):
 
     def __init__(self, project: str) -> None:
         self.project = project
+        self.name = project  # required for the deployment process
         self._kv_db = self._get_kv_db()
 
         self._v3io_access_key = os.getenv(_V3IO_ACCESS_KEY_NAME)

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -33,16 +33,6 @@ _V3IO_ACCESS_KEY_NAME = "V3IO_ACCESS_KEY"
 RawEvent = dict[str, Any]
 AppResultEvent = NewType("AppResultEvent", RawEvent)
 
-_KEY_SEP = "_"
-
-
-def application_result_key(endpoint_id: str, app_name: str) -> str:
-    """
-    Combine an endpoint ID and a monitoring application name into a
-    unique key for the KV storage.
-    """
-    return f"{endpoint_id}{_KEY_SEP}{app_name}"
-
 
 class _WriterEventError:
     pass

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -11,27 +11,107 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-import mlrun.common.schemas
+
+import os
+from typing import Any, NewType, Tuple
+
+import pandas as pd
+from v3io_frames.client import ClientBase
+from v3io_frames.errors import Error as V3IOFramesError
+
+import mlrun.common.model_monitoring
+import mlrun.model_monitoring
+import mlrun.utils.v3io_clients
+from mlrun.common.schemas.model_monitoring import FileTargetKind
+from mlrun.common.schemas.model_monitoring.constants import WriterEvent
 from mlrun.serving.utils import StepToDict
+from mlrun.utils import logger
+
+_V3IO_ACCESS_KEY_NAME = "V3IO_ACCESS_KEY"
+
+RawEvent = dict[str, Any]
+AppResultEvent = NewType("AppResultEvent", RawEvent)
 
 
 class ModelMonitoringWriter(StepToDict):
-    """DEMO WRITER TODO"""
+    """
+    Write monitoring app events to V3IO KV storage
+    """
 
     kind = "monitoring_application_stream_pusher"
 
     def __init__(self, project: str) -> None:
         self.project = project
+        self._kv_db = self._get_kv_db()
 
-    def do(self, event):
+        self._v3io_access_key = os.getenv(_V3IO_ACCESS_KEY_NAME)
+        self._tsdb_path, self._frames_client = self._get_v3io_frames_client()
 
-        print(
-            f"endpoint_uid ={event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.ENDPOINT_ID]}, \n"
-            f"app_name = {event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.APPLICATION_NAME]}, \n"
-            f"schedule_time = {event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.SCHEDULE_TIME]}, \n"
-            f"result_name ={event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.RESULT_NAME]}, \n"
-            f"result_value ={event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.RESULT_VALUE]}, \n"
-            f"my_name = {self.project}."
+    def _get_kv_db(self) -> mlrun.model_monitoring.stores.ModelEndpointStore:
+        return mlrun.model_monitoring.get_model_endpoint_store(project=self.project)
+
+    def _get_v3io_frames_client(self) -> Tuple[str, ClientBase]:
+        tsdb_path = mlrun.mlconf.get_model_monitoring_file_target_path(
+            project=self.project,
+            kind=FileTargetKind.EVENTS,
         )
-        return event
+        (
+            _,
+            tsdb_container,
+            _,
+        ) = mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
+            tsdb_path
+        )
+        return tsdb_path, mlrun.utils.v3io_clients.get_frames_client(
+            address=mlrun.mlconf.v3io_framesd,
+            container=tsdb_container,
+            token=self._v3io_access_key,
+        )
+
+    def _update_kv_db(self, event: AppResultEvent) -> None:
+        event = AppResultEvent(event.copy())
+        endpoint_id = event.pop(WriterEvent.ENDPOINT_ID)
+        self._kv_db.update_model_endpoint(endpoint_id=endpoint_id, attributes=event)
+
+    def _update_tsdb(self, event: AppResultEvent) -> None:
+        try:
+            self._frames_client.write(
+                backend="tsdb",
+                table=self._tsdb_path,
+                dfs=pd.DataFrame.from_records([event]),
+                index_cols=[
+                    WriterEvent.SCHEDULE_TIME,
+                    WriterEvent.ENDPOINT_ID,
+                    WriterEvent.APPLICATION_NAME,
+                ],
+            )
+        except V3IOFramesError as err:
+            logger.warn(
+                "Could not write drift measures to TSDB",
+                err=err,
+                tsdb_path=self._tsdb_path,
+                endpoint=event[WriterEvent.ENDPOINT_ID],
+            )
+
+    @staticmethod
+    def _reconstruct_event(event: RawEvent) -> AppResultEvent:
+        return AppResultEvent(
+            {
+                key: event[key]
+                for key in (
+                    WriterEvent.ENDPOINT_ID,
+                    WriterEvent.SCHEDULE_TIME,
+                    WriterEvent.APPLICATION_NAME,
+                    WriterEvent.RESULT_NAME,
+                    WriterEvent.RESULT_KIND,
+                    WriterEvent.RESULT_VALUE,
+                    WriterEvent.RESULT_STATUS,
+                    WriterEvent.RESULT_EXTRA_DATA,
+                )
+            }
+        )
+
+    def do(self, event: RawEvent) -> None:
+        event = self._reconstruct_event(event)
+        self._update_tsdb(event)
+        self._update_kv_db(event)

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -72,6 +72,7 @@ class ModelMonitoringWriter(StepToDict):
         event = AppResultEvent(event.copy())
         endpoint_id = event.pop(WriterEvent.ENDPOINT_ID)
         self._kv_db.update_model_endpoint(endpoint_id=endpoint_id, attributes=event)
+        logger.debug("Updated V3IO KV successfully", key=endpoint_id)
 
     def _update_tsdb(self, event: AppResultEvent) -> None:
         try:
@@ -85,6 +86,7 @@ class ModelMonitoringWriter(StepToDict):
                     WriterEvent.APPLICATION_NAME,
                 ],
             )
+            logger.debug("Updated V3IO TSDB successfully")
         except V3IOFramesError as err:
             logger.warn(
                 "Could not write drift measures to TSDB",
@@ -113,5 +115,7 @@ class ModelMonitoringWriter(StepToDict):
 
     def do(self, event: RawEvent) -> None:
         event = self._reconstruct_event(event)
+        logger.debug("Starting to write event", event=event)
         self._update_tsdb(event)
         self._update_kv_db(event)
+        logger.debug("Completed event DB writes")

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -31,8 +31,8 @@ from mlrun.utils import logger
 _TSDB_BE = "tsdb"
 _TSDB_RATE = "1/s"
 _TSDB_TABLE = "app-results"
-RawEvent = dict[str, Any]
-AppResultEvent = NewType("AppResultEvent", RawEvent)
+_RawEvent = dict[str, Any]
+_AppResultEvent = NewType("_AppResultEvent", _RawEvent)
 
 
 class _WriterEventError:
@@ -79,8 +79,8 @@ class ModelMonitoringWriter(StepToDict):
             rate=_TSDB_RATE,
         )
 
-    def _update_kv_db(self, event: AppResultEvent) -> None:
-        event = AppResultEvent(event.copy())
+    def _update_kv_db(self, event: _AppResultEvent) -> None:
+        event = _AppResultEvent(event.copy())
         endpoint_id = event.pop(WriterEvent.ENDPOINT_ID)
         app_name = event.pop(WriterEvent.APPLICATION_NAME)
         self._kv_client.put(
@@ -91,8 +91,8 @@ class ModelMonitoringWriter(StepToDict):
         )
         logger.info("Updated V3IO KV successfully", key=app_name)
 
-    def _update_tsdb(self, event: AppResultEvent) -> None:
-        event = AppResultEvent(event.copy())
+    def _update_tsdb(self, event: _AppResultEvent) -> None:
+        event = _AppResultEvent(event.copy())
         event[WriterEvent.SCHEDULE_TIME] = pd.to_datetime(
             event[WriterEvent.SCHEDULE_TIME],
             format=EventFieldType.TIME_FORMAT,
@@ -118,9 +118,9 @@ class ModelMonitoringWriter(StepToDict):
             )
 
     @staticmethod
-    def _reconstruct_event(event: RawEvent) -> AppResultEvent:
+    def _reconstruct_event(event: _RawEvent) -> _AppResultEvent:
         try:
-            return AppResultEvent(
+            return _AppResultEvent(
                 {
                     key: event[key]
                     for key in (
@@ -145,7 +145,7 @@ class ModelMonitoringWriter(StepToDict):
                 f"The event is of type: {type(event)}, expected a dictionary"
             ) from err
 
-    def do(self, event: RawEvent) -> None:
+    def do(self, event: _RawEvent) -> None:
         event = self._reconstruct_event(event)
         logger.info("Starting to write event", event=event)
         self._update_tsdb(event)

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -57,7 +57,7 @@ class ModelMonitoringWriter(StepToDict):
     def __init__(self, project: str) -> None:
         self.project = project
         self.name = project  # required for the deployment process
-        self._v3io_container = f"users/pipelines/project/{self.name}/monitoring-apps"
+        self._v3io_container = f"users/pipelines/{self.name}/monitoring-apps"
         self._kv_client = self._get_v3io_client().kv
         self._tsdb_client = self._get_v3io_frames_client()
         self._create_tsdb_table()

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -119,6 +119,10 @@ class ModelMonitoringWriter(StepToDict):
 
     @staticmethod
     def _reconstruct_event(event: _RawEvent) -> _AppResultEvent:
+        """
+        Modify the raw event into the expected monitoring application event
+        schema as defined in `mlrun.common.schemas.model_monitoring.constants.WriterEvent`
+        """
         try:
             return _AppResultEvent(
                 {

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -21,8 +21,8 @@ class ModelMonitoringWriter(StepToDict):
 
     kind = "monitoring_application_stream_pusher"
 
-    def __init__(self, name: str = None):
-        self.name = name or "king"
+    def __init__(self, project: str) -> None:
+        self.project = project
 
     def do(self, event):
 
@@ -32,6 +32,6 @@ class ModelMonitoringWriter(StepToDict):
             f"schedule_time = {event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.SCHEDULE_TIME]}, \n"
             f"result_name ={event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.RESULT_NAME]}, \n"
             f"result_value ={event[mlrun.common.schemas.model_monitoring.constants.WriterEvent.RESULT_VALUE]}, \n"
-            f"my_name = {self.name}."
+            f"my_name = {self.project}."
         )
         return event

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -88,7 +88,7 @@ class ModelMonitoringWriter(StepToDict):
             key=app_name,
             attributes=event,
         )
-        logger.debug("Updated V3IO KV successfully", key=app_name)
+        logger.info("Updated V3IO KV successfully", key=app_name)
 
     def _update_tsdb(self, event: AppResultEvent) -> None:
         try:
@@ -102,7 +102,7 @@ class ModelMonitoringWriter(StepToDict):
                     WriterEvent.APPLICATION_NAME,
                 ],
             )
-            logger.debug("Updated V3IO TSDB successfully", table=self._TSDB_TABLE)
+            logger.info("Updated V3IO TSDB successfully", table=self._TSDB_TABLE)
         except V3IOFramesError as err:
             logger.warn(
                 "Could not write drift measures to TSDB",
@@ -141,7 +141,7 @@ class ModelMonitoringWriter(StepToDict):
 
     def do(self, event: RawEvent) -> None:
         event = self._reconstruct_event(event)
-        logger.debug("Starting to write event", event=event)
+        logger.info("Starting to write event", event=event)
         self._update_tsdb(event)
         self._update_kv_db(event)
-        logger.debug("Completed event DB writes")
+        logger.info("Completed event DB writes")

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Type
+from uuid import UUID
+
+import pytest
+
+from mlrun.model_monitoring.writer import (
+    ModelMonitoringWriter,
+    RawEvent,
+    WriterEvent,
+    _WriterEventTypeError,
+    _WriterEventValueError,
+    application_result_key,
+)
+
+
+@pytest.mark.parametrize("endpoint_ids", [[UUID(int=4), "flsdkl2210kd"], ["justepid"]])
+@pytest.mark.parametrize("app_names", [["app_1", "app_2"]])
+def test_unique_kv_keys(endpoint_ids: list[str], app_names: list[str]) -> None:
+    keys = [
+        application_result_key(endpoint_id=ep_id, app_name=app_name)
+        for ep_id in endpoint_ids
+        for app_name in app_names
+    ]
+    assert len(set(keys)) == len(keys), "Some keys are not unique"
+
+
+@pytest.mark.parametrize(
+    ("event", "exception"),
+    [
+        ("key1:val1,key2:val2", _WriterEventTypeError),
+        ({WriterEvent.ENDPOINT_ID: "ep2211"}, _WriterEventValueError),
+    ],
+)
+def test_reconstruct_event_error(event: RawEvent, exception: Type[Exception]) -> None:
+    with pytest.raises(exception):
+        ModelMonitoringWriter._reconstruct_event(event)

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -18,8 +18,8 @@ import pytest
 
 from mlrun.model_monitoring.writer import (
     ModelMonitoringWriter,
-    RawEvent,
     WriterEvent,
+    _RawEvent,
     _WriterEventTypeError,
     _WriterEventValueError,
 )
@@ -32,6 +32,6 @@ from mlrun.model_monitoring.writer import (
         ({WriterEvent.ENDPOINT_ID: "ep2211"}, _WriterEventValueError),
     ],
 )
-def test_reconstruct_event_error(event: RawEvent, exception: Type[Exception]) -> None:
+def test_reconstruct_event_error(event: _RawEvent, exception: Type[Exception]) -> None:
     with pytest.raises(exception):
         ModelMonitoringWriter._reconstruct_event(event)

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Type
-from uuid import UUID
 
 import pytest
 
@@ -23,19 +22,7 @@ from mlrun.model_monitoring.writer import (
     WriterEvent,
     _WriterEventTypeError,
     _WriterEventValueError,
-    application_result_key,
 )
-
-
-@pytest.mark.parametrize("endpoint_ids", [[UUID(int=4), "flsdkl2210kd"], ["justepid"]])
-@pytest.mark.parametrize("app_names", [["app_1", "app_2"]])
-def test_unique_kv_keys(endpoint_ids: list[str], app_names: list[str]) -> None:
-    keys = [
-        application_result_key(endpoint_id=ep_id, app_name=app_name)
-        for ep_id in endpoint_ids
-        for app_name in app_names
-    ]
-    assert len(set(keys)) == len(keys), "Some keys are not unique"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Related ticket: [ML-4394](https://jira.iguazeng.com/browse/ML-4394)

Write app events to V3IO storage (EE):
- KV (need to add more keys)
- TSDB: index by
  - scheduled time
  - endpoint ID
  - application name

The CE edition will follow this PR.

Tests:
- Manual full-flow on EE
- Automatic for some core functionalities