### PR TITLE
[Model Monitoring] Filter out `None` values when generating feature stats histogram 

### DIFF
--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -119,7 +119,9 @@ class FeatureValues(BaseModel):
                 min=stats["min"],
                 mean=stats["mean"],
                 max=stats["max"],
-                histogram=Histogram(buckets=stats["hist"][1], counts=stats["hist"][0]),
+                histogram=Histogram(buckets=stats["hist"][1], counts=stats["hist"][0])
+                if "hist" in stats
+                else {},
             )
         else:
             return None

--- a/mlrun/data_types/infer.py
+++ b/mlrun/data_types/infer.py
@@ -131,7 +131,7 @@ def get_df_stats(df, options, num_bins=None, sample_size=None):
         ) and pd.api.types.is_numeric_dtype(df[col]):
             # store histogram
             try:
-                hist, bins = np.histogram(df[col], bins=num_bins)
+                hist, bins = np.histogram(df[col].dropna(), bins=num_bins)
                 stats_dict["hist"] = [hist.tolist(), bins.tolist()]
             except Exception:
                 pass

--- a/mlrun/model_monitoring/model_monitoring_batch.py
+++ b/mlrun/model_monitoring/model_monitoring_batch.py
@@ -459,7 +459,10 @@ def calculate_inputs_statistics(
 
     # Recalculate the histograms over the bins that are set in the sample-set of the end point:
     for feature in inputs_statistics.keys():
-        if feature in sample_set_statistics:
+        if (
+            feature in sample_set_statistics
+            and "hist" in sample_set_statistics[feature]
+        ):
             counts, bins = np.histogram(
                 inputs[feature].to_numpy(),
                 bins=sample_set_statistics[feature]["hist"][1],

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -777,6 +777,9 @@ class TestBatchDrift(TestMLRunSystem):
                 ]
             ),
         )
+
+        train_set.loc[train_set["sepal_length_cm"] < 5, ["sepal_length_cm"]] = None
+
         model_name = "sklearn_RandomForestClassifier"
         # Upload the model through the projects API so that it is available to the serving function
         project.log_model(
@@ -830,6 +833,12 @@ class TestBatchDrift(TestMLRunSystem):
         artifacts = context.artifacts
         assert artifacts[0]["metadata"]["key"] == "drift_table_plot"
         assert artifacts[1]["metadata"]["key"] == "features_drift_results"
+
+        # Validate that hist exist for features with nan values records:
+        assert model_endpoint.status.feature_stats["sepal_length_cm"]["count"] < 150
+        assert model_endpoint.status.feature_stats["sepal_width_cm"]["count"] == 150
+        assert model_endpoint.status.feature_stats["petal_length_cm"]["count"] == 150
+        assert model_endpoint.status.feature_stats["petal_width_cm"]["count"] == 150
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured


### PR DESCRIPTION
At the moment, the feature hist stats can't be generated with `None` values. As a result, the drift job analysis won't be able to calculate drift for that certain feature and the feature analysis UI screen is broken.
In this PR, we remove the `None` records from that feature hist (other features stats won't be affected). 