### PR TITLE
[Project] Allow for on the fly configuration of Git while pushing and pulling

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2046,11 +2046,11 @@ class MlrunProject(ModelObj):
             raise ValueError("git repo is not set/defined")
         self.save()
 
-        if author_name and author_email:
-            config = repo.config_writer()
-            config.set_value("user", "name", author_name)
-            config.set_value("user", "email", author_email)
-            config.release()
+        with repo.config_writer() as config:
+            if author_name:
+                config.set_value("user", "name", author_name)
+            if author_email:
+                config.set_value("user", "email", author_email)
 
         add = add or []
         add.append("project.yaml")

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2027,9 +2027,9 @@ class MlrunProject(ModelObj):
         :param update:       update files (git add update=True)
         :param remote:       git remote, default to origin
         :param add:          list of files to add
-        :param author_name:  author name to be used on this commit
-        :param author_email: author email to be used on this commit
-        :param secrets:      dict or SecretStore with Git credentials
+        :param author_name:  author's git user name to be used on this commit
+        :param author_email: author's git user email to be used on this commit
+        :param secrets:      dict or SecretsStore with Git credentials e.g. secrets={"GIT_TOKEN": token}
         """
         repo = self.spec.repo
         if not repo:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3140,7 +3140,7 @@ class MlrunProject(ModelObj):
         Enrichment of the remote URL is undone before this method returns
         If no secrets are provided, remote remains untouched
 
-        :param action:  a function or method to be run
+        :param action:  git callback that may require authentication
         :param remote:  git remote to be temporarily enriched with secrets
         :param args:    positional arguments to be passed along to action
         :param kwargs:  keyword arguments to be passed along to action

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1989,8 +1989,8 @@ class MlrunProject(ModelObj):
             remote = remote or "origin"
             self._run_authenticated_git_action(
                 action=self.spec.repo.git.pull,
-                args=[remote, branch or self.spec.repo.active_branch.name],
                 remote=remote,
+                args=[remote, branch or self.spec.repo.active_branch.name],
                 secrets=secrets or {},
             )
         elif url and url.endswith(".tar.gz"):
@@ -2083,8 +2083,8 @@ class MlrunProject(ModelObj):
         remote = remote or "origin"
         self._run_authenticated_git_action(
             action=repo.git.push,
-            args=[remote, branch],
             remote=remote,
+            args=[remote, branch],
             secrets=secrets or {},
         )
 

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -114,7 +114,11 @@ def add_credentials_git_remote_url(url: str, secrets=None) -> Tuple[str, bool]:
         or get_secret("git_password")
         or ""
     )
-    token = get_secret("GITHUB_TOKEN") or get_secret("GIT_TOKEN")
+    token = (
+        get_secret("GITHUB_TOKEN")
+        or get_secret("GITLAB_TOKEN")
+        or get_secret("GIT_TOKEN")
+    )
     if token:
         username, password = get_git_username_password_from_token(token)
 

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -109,10 +109,10 @@ def add_credentials_git_remote_url(url: str, secrets=None) -> Tuple[str, bool]:
 
     username = url_obj.username or get_secret("GIT_USERNAME") or get_secret("git_user")
     password = (
-            url_obj.password
-            or get_secret("GIT_PASSWORD")
-            or get_secret("git_password")
-            or ""
+        url_obj.password
+        or get_secret("GIT_PASSWORD")
+        or get_secret("git_password")
+        or ""
     )
     token = get_secret("GITHUB_TOKEN") or get_secret("GIT_TOKEN")
     if token:

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -18,6 +18,7 @@ import tarfile
 import tempfile
 import zipfile
 from os import path, remove
+from typing import Tuple
 from urllib.parse import urlparse
 
 from git import Repo
@@ -90,12 +91,46 @@ def get_repo_url(repo):
     return url
 
 
-def clone_git(url, context, secrets=None, clone=True):
+def add_credentials_git_remote_url(url: str, secrets=None) -> Tuple[str, bool]:
+    """Enrich a Git remote URL with credential related secrets, if any are available
+    If no secrets are supplied, or if the secrets are insufficient, the original URL is returned
+    Besides the URL, this function also returns a bool indicating if any enrichment was done
 
-    secrets = secrets or {}
+    :param url:     git remote URL to be enriched
+    :param secrets: dict or SecretStore with Git credentials
+
+    :returns: tuple with the final URL and a boolean indicating if any enrichment was done
+    """
 
     def get_secret(key):
         return mlrun.get_secret_or_env(key, secret_provider=secrets)
+
+    url_obj = urlparse(url)
+
+    username = url_obj.username or get_secret("GIT_USERNAME") or get_secret("git_user")
+    password = (
+            url_obj.password
+            or get_secret("GIT_PASSWORD")
+            or get_secret("git_password")
+            or ""
+    )
+    token = get_secret("GITHUB_TOKEN") or get_secret("GIT_TOKEN")
+    if token:
+        username, password = get_git_username_password_from_token(token)
+
+    if username:
+        return f"https://{username}:{password}@{url_obj.hostname}{url_obj.path}", True
+    return url, False
+
+
+def clone_git(url: str, context: str, secrets=None, clone: bool = True):
+    """Clone a remote Git repository in the local context
+
+    :param url:     git remote URL
+    :param context: local directory in which the repository must be stored
+    :param secrets: dict or SecretStore with Git credentials
+    :param clone:   delete all files and folders in "context" if there are any
+    """
 
     url_obj = urlparse(url)
     if not context:
@@ -120,21 +155,10 @@ def clone_git(url, context, secrets=None, clone=True):
     if url_obj.port:
         host += f":{url_obj.port}"
 
-    username = url_obj.username or get_secret("GIT_USERNAME") or get_secret("git_user")
-    password = (
-        url_obj.password
-        or get_secret("GIT_PASSWORD")
-        or get_secret("git_password")
-        or ""
-    )
-    token = get_secret("GITHUB_TOKEN") or get_secret("GIT_TOKEN")
-    if token:
-        username, password = get_git_username_password_from_token(token)
-
     clone_path = f"https://{host}{url_obj.path}"
-    enriched_clone_path = ""
-    if username:
-        enriched_clone_path = f"https://{username}:{password}@{host}{url_obj.path}"
+    final_clone_path, is_path_enriched = add_credentials_git_remote_url(
+        clone_path, secrets=secrets or {}
+    )
 
     branch = None
     tag = None
@@ -149,14 +173,11 @@ def clone_git(url, context, secrets=None, clone=True):
             branch = refs
 
     # when using the CLI and clone path was not enriched, username/password input will be requested via shell
-    repo = Repo.clone_from(
-        enriched_clone_path or clone_path, context, single_branch=True, b=branch
-    )
+    repo = Repo.clone_from(final_clone_path, context, single_branch=True, b=branch)
 
-    if enriched_clone_path:
-
+    if is_path_enriched:
         # override enriched clone path for security reasons
-        repo.remotes[0].set_url(clone_path, enriched_clone_path)
+        repo.remotes[0].set_url(clone_path, final_clone_path)
 
     if tag:
         repo.git.checkout(tag)

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -97,7 +97,7 @@ def add_credentials_git_remote_url(url: str, secrets=None) -> Tuple[str, bool]:
     Besides the URL, this function also returns a bool indicating if any enrichment was done
 
     :param url:     git remote URL to be enriched
-    :param secrets: dict or SecretStore with Git credentials
+    :param secrets: dict or SecretsStore with Git credentials e.g. secrets={"GIT_TOKEN": token}
 
     :returns: tuple with the final URL and a boolean indicating if any enrichment was done
     """
@@ -128,7 +128,7 @@ def clone_git(url: str, context: str, secrets=None, clone: bool = True):
 
     :param url:     git remote URL
     :param context: local directory in which the repository must be stored
-    :param secrets: dict or SecretStore with Git credentials
+    :param secrets: dict or SecretsStore with Git credentials e.g. secrets={"GIT_TOKEN": token}
     :param clone:   delete all files and folders in "context" if there are any
     """
 

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -180,6 +180,26 @@ def mock_failed_get_func(status_code: int):
     return mock_get
 
 
+# Mock class used for tests involving native gitpython functionality
+class GitRepoMock:
+    def __init__(self, remotes: dict):
+        self.remotes = {}
+        for k in remotes:
+            mock = Mock()
+            mock.url = remotes[k]
+            self.remotes[k] = mock
+
+
+@pytest.fixture
+def mock_git_repo():
+    return GitRepoMock(
+        remotes={
+            "origin": "https://git.server/my-repo",
+            "organization": "https://another.git.server/my-repo",
+        }
+    )
+
+
 # Mock class used for client-side runtime tests. This mocks the rundb interface, for running/deploying runtimes
 class RunDBMock:
     def __init__(self):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1147,7 +1147,6 @@ def test_unauthenticated_git_action_with_remote_pristine(mock_git_repo):
     project.spec.repo.remotes["origin"].set_url.assert_not_called()
 
 
-
 def test_get_or_create_project_no_db():
     mlrun.config.config.dbpath = ""
     project_name = "project-name"


### PR DESCRIPTION
[ML-3560](https://jira.iguazeng.com/browse/ML-3560)

SDK users can now provide name, email and credentials directly to the `.push` and `.pull` methods of a project instance instead of running `git config` commands on shell.

When setting name and email with the new strategy, this data is set up only for the current repository (instead of globally). 

Credential information is handled in the same way as in `mlrun.load_project`. In order to achieve this, the existing strategy was abstracted away from `mlrun.utils.clones.clone_git` and now is also leveraged by `mlrun.projects.project.MlrunProject.push` and `mlrun.projects.project.MlrunProject.pull`.