### PR TITLE
[Requirements] Add `sqlalchemy~=1.4` to extra requirements

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -73,6 +73,7 @@ def extra_requirements() -> typing.Dict[str, typing.List[str]]:
         ],
         "redis": ["redis~=4.3"],
         "databricks-sdk": ["databricks-sdk~=0.3.0"],
+        "sqlalchemy": ["sqlalchemy~=1.4"],
     }
 
     # see above why we are excluding google-cloud

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,6 +4,3 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
-# sqlalchemy and pymysql versions should be aligned with mlrun-api due to common use with the model monitoring database
-sqlalchemy~=1.4
-pymysql~=1.0

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,5 +4,6 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
-# pymysql version should be aligned with mlrun-api due to common use with the model monitoring database
+# sqlalchemy and pymysql versions should be aligned with mlrun-api due to common use with the model monitoring database
+sqlalchemy~=1.4
 pymysql~=1.0

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,6 +4,3 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
-# sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
-sqlalchemy~=1.4
-pymysql~=1.0

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,3 +4,5 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
+# pymysql version should be aligned with mlrun-api due to common use with the model monitoring database
+pymysql~=1.0

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,4 +4,5 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
+# pymysql version should be aligned with mlrun-api due to common use with the model monitoring database
 pymysql~=1.0

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
+pymysql~=1.0

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -4,3 +4,6 @@ scikit-learn~=1.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1
+# sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
+sqlalchemy~=1.4
+pymysql~=1.0

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -34,3 +34,6 @@ avro~=1.11
 redis~=4.3
 graphviz~=0.20.0
 databricks-sdk~=0.3.0
+# sqlalchemy and pymysql versions should be aligned with mlrun-api due to common use with the model monitoring database
+sqlalchemy~=1.4
+pymysql~=1.0

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -36,4 +36,3 @@ graphviz~=0.20.0
 databricks-sdk~=0.3.0
 # sqlalchemy and pymysql versions should be aligned with mlrun-api due to common use with the model monitoring database
 sqlalchemy~=1.4
-pymysql~=1.0

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -34,5 +34,5 @@ avro~=1.11
 redis~=4.3
 graphviz~=0.20.0
 databricks-sdk~=0.3.0
-# sqlalchemy and pymysql versions should be aligned with mlrun-api due to common use with the model monitoring database
+# sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
 sqlalchemy~=1.4

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1585,10 +1585,10 @@ class SQLTarget(BaseStoreTarget):
             import sqlalchemy
 
             self.sqlalchemy = sqlalchemy
-        except (ModuleNotFoundError, ImportError):
+        except (ModuleNotFoundError, ImportError) as exc:
             raise mlrun.errors.MLRunMissingDependencyError(
                 "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
-            )
+            ) from exc
 
         create_according_to_data = False  # TODO: open for user
         if time_fields:

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import pandas as pd
-import sqlalchemy
 
 import mlrun
 import mlrun.utils.helpers
@@ -1580,6 +1579,17 @@ class SQLTarget(BaseStoreTarget):
         :param varchar_len :    the defalut len of the all the varchar column (using if needed to create the table).
         :param parse_dates :    all the field to be parsed as timestamp.
         """
+
+        # Validate sqlalchemy (not installed by default):
+        try:
+            import sqlalchemy
+
+            self.sqlalchemy = sqlalchemy
+        except (ModuleNotFoundError, ImportError) as Error:
+            raise Error(
+                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
+            )
+
         create_according_to_data = False  # TODO: open for user
         if time_fields:
             warnings.warn(
@@ -1687,7 +1697,7 @@ class SQLTarget(BaseStoreTarget):
         **kwargs,
     ):
         db_path, table_name, _, _, _, _ = self._parse_url()
-        engine = sqlalchemy.create_engine(db_path)
+        engine = self.sqlalchemy.create_engine(db_path)
         parse_dates: Optional[List[str]] = self.attributes.get("parse_dates")
         with engine.connect() as conn:
             query, parse_dates = _generate_sql_query_with_time_filter(
@@ -1725,7 +1735,7 @@ class SQLTarget(BaseStoreTarget):
                 _,
             ) = self._parse_url()
             create_according_to_data = bool(create_according_to_data)
-            engine = sqlalchemy.create_engine(
+            engine = self.sqlalchemy.create_engine(
                 db_path,
             )
             connection = engine.connect()
@@ -1755,23 +1765,23 @@ class SQLTarget(BaseStoreTarget):
             primary_key_for_check = primary_key
         except Exception:
             primary_key_for_check = [primary_key]
-        engine = sqlalchemy.create_engine(db_path)
+        engine = self.sqlalchemy.create_engine(db_path)
         with engine.connect() as conn:
-            metadata = sqlalchemy.MetaData()
+            metadata = self.sqlalchemy.MetaData()
             table_exists = engine.dialect.has_table(conn, table_name)
             if not table_exists and not create_table:
                 raise ValueError(f"Table named {table_name} is not exist")
 
             elif not table_exists and create_table:
                 TYPE_TO_SQL_TYPE = {
-                    int: sqlalchemy.Integer,
-                    str: sqlalchemy.String(self.attributes.get("varchar_len")),
-                    datetime.datetime: sqlalchemy.dialects.mysql.DATETIME(fsp=6),
-                    pd.Timestamp: sqlalchemy.dialects.mysql.DATETIME(fsp=6),
-                    bool: sqlalchemy.Boolean,
-                    float: sqlalchemy.Float,
-                    datetime.timedelta: sqlalchemy.Interval,
-                    pd.Timedelta: sqlalchemy.Interval,
+                    int: self.sqlalchemy.Integer,
+                    str: self.sqlalchemy.String(self.attributes.get("varchar_len")),
+                    datetime.datetime: self.sqlalchemy.dialects.mysql.DATETIME(fsp=6),
+                    pd.Timestamp: self.sqlalchemy.dialects.mysql.DATETIME(fsp=6),
+                    bool: self.sqlalchemy.Boolean,
+                    float: self.sqlalchemy.Float,
+                    datetime.timedelta: self.sqlalchemy.Interval,
+                    pd.Timedelta: self.sqlalchemy.Interval,
                 }
                 # creat new table with the given name
                 columns = []
@@ -1780,12 +1790,12 @@ class SQLTarget(BaseStoreTarget):
                     if col_type is None:
                         raise TypeError(f"{col_type} unsupported type")
                     columns.append(
-                        sqlalchemy.Column(
+                        self.sqlalchemy.Column(
                             col, col_type, primary_key=(col in primary_key_for_check)
                         )
                     )
 
-                sqlalchemy.Table(table_name, metadata, *columns)
+                self.sqlalchemy.Table(table_name, metadata, *columns)
                 metadata.create_all(engine)
                 if_exists = "append"
                 self.path = (

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1585,8 +1585,8 @@ class SQLTarget(BaseStoreTarget):
             import sqlalchemy
 
             self.sqlalchemy = sqlalchemy
-        except (ModuleNotFoundError, ImportError) as Error:
-            raise Error(
+        except (ModuleNotFoundError, ImportError):
+            raise mlrun.errors.MLRunMissingDependencyError(
                 "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
             )
 

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -151,8 +151,8 @@ def _generate_sql_query_with_time_filter(
     # Validate sqlalchemy (not installed by default):
     try:
         import sqlalchemy
-    except (ModuleNotFoundError, ImportError) as Error:
-        raise Error(
+    except (ModuleNotFoundError, ImportError):
+        raise mlrun.errors.MLRunMissingDependencyError(
             "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
         )
     table = sqlalchemy.Table(

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -151,10 +151,10 @@ def _generate_sql_query_with_time_filter(
     # Validate sqlalchemy (not installed by default):
     try:
         import sqlalchemy
-    except (ModuleNotFoundError, ImportError):
+    except (ModuleNotFoundError, ImportError) as exc:
         raise mlrun.errors.MLRunMissingDependencyError(
             "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
-        )
+        ) from exc
     table = sqlalchemy.Table(
         table_name,
         sqlalchemy.MetaData(),

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -142,7 +142,7 @@ def select_columns_generator(
 
 def _generate_sql_query_with_time_filter(
     table_name: str,
-    engine,
+    engine: "sqlalchemy.engine.Engine",  # noqa: F821,
     time_column: str,
     parse_dates: typing.List[str],
     start_time: pd.Timestamp,

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -18,7 +18,6 @@ import typing
 from urllib.parse import parse_qs, urlparse
 
 import pandas as pd
-import sqlalchemy
 
 import mlrun.datastore
 
@@ -143,12 +142,19 @@ def select_columns_generator(
 
 def _generate_sql_query_with_time_filter(
     table_name: str,
-    engine: sqlalchemy.engine.Engine,
+    engine,
     time_column: str,
     parse_dates: typing.List[str],
     start_time: pd.Timestamp,
     end_time: pd.Timestamp,
 ):
+    # Validate sqlalchemy (not installed by default):
+    try:
+        import sqlalchemy
+    except (ModuleNotFoundError, ImportError) as Error:
+        raise Error(
+            "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
+        )
     table = sqlalchemy.Table(
         table_name,
         sqlalchemy.MetaData(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,4 +55,3 @@ jinja2~=3.1
 anyio~=3.5
 # sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
 sqlalchemy~=1.4
-pymysql~=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,5 +53,3 @@ setuptools~=65.5
 deprecated~=1.2
 jinja2~=3.1
 anyio~=3.5
-# sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
-sqlalchemy~=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,6 @@ setuptools~=65.5
 deprecated~=1.2
 jinja2~=3.1
 anyio~=3.5
+# sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
+sqlalchemy~=1.4
+pymysql~=1.0


### PR DESCRIPTION
The model monitoring database is being used by both MLRun API and the model monitoring functions that are not part of MLRun api service (e.g. model monitoring stream pod or model monitoring batch job function). The default image of the monitoring functions is `mlrun/mlrun` but following https://github.com/mlrun/mlrun/pull/4096 the default `sqlalchemy` version is not limited and installed with the newest version (`>2.0`). As a result, the monitoring functions are using `sqlalchemy>2.0` while mlrun api is using `sqlalchemy~=1.4`.
In this PR we fix this conflict by setting the default `sqlalchemy` to `1.4` in MLRun dockerfile as well. 
[ML-4553](https://jira.iguazeng.com/browse/ML-4553)