### PR TITLE
[Model Monitoring] Enable prometheus stack installation in CE system tests

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -169,7 +169,6 @@ jobs:
             --minikube \
             --namespace=${NAMESPACE} \
             --registry-secret-name="" \
-            --disable-prometheus-stack \
             --sqlite /mlrun/db/mlrun.db \
             --override-mlrun-api-image="${{ steps.computed_params.outputs.mlrun_docker_registry }}${{ steps.computed_params.outputs.mlrun_docker_repo }}/mlrun-api:${{ steps.computed_params.outputs.mlrun_docker_tag }}" \
             --override-mlrun-ui-image="ghcr.io/mlrun/mlrun-ui:${{ steps.computed_params.outputs.mlrun_ui_version }}" \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -153,11 +153,8 @@ jobs:
 
     - name: Install MLRun CE helm chart
       run: |
-        # TODO: There are a couple of modifications to the helm chart that we are doing right now:
-        #       1. The grafana prometheus stack is disabled as there are currently no system tests checking its
-        #          functionality. Once the model monitoring feature is complete and we have system tests for it, we
-        #          can enable it.
-        #       2. The mlrun DB is set as the old SQLite db. There is a bug in github workers when trying to run a mysql
+        # TODO: There is a modification to the helm chart that we are doing right now:
+        #          The mlrun DB is set as the old SQLite db. There is a bug in github workers when trying to run a mysql
         #          server pod in minikube installed on the worker, the mysql pod crashes. There isn't much information
         #          about this issue online as this isn't how github expect you to use mysql in workflows - the worker
         #          has a mysql server installed directly on it and should be enabled and used as the DB. So we might

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -41,7 +41,6 @@ from tests.system.base import TestMLRunSystem
 
 # Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
-@pytest.mark.enterprise
 class TestModelEndpointsOperations(TestMLRunSystem):
     """Applying basic model endpoint CRUD operations through MLRun API"""
 
@@ -318,7 +317,6 @@ class TestBasicModelMonitoring(TestMLRunSystem):
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
-@pytest.mark.enterprise
 class TestModelMonitoringRegression(TestMLRunSystem):
     """Train, deploy and apply monitoring on a regression model"""
 


### PR DESCRIPTION
Following the completion of implementing model monitoring features in the CE, in this PR we remove the flag that disabled the installation of the Prometheus stack as part of the CE system tests.