### PR TITLE
[HTTPDB] Fix list runs

### DIFF
--- a/mlrun/api/api/endpoints/runs.py
+++ b/mlrun/api/api/endpoints/runs.py
@@ -225,7 +225,6 @@ async def list_runs(
     if (
         not name
         and not uid
-        and not project
         and not labels
         and not state
         and not last
@@ -233,6 +232,9 @@ async def list_runs(
         and not start_time_to
         and not last_update_time_from
         and not last_update_time_to
+        and not partition_by
+        and not partition_sort_by
+        and not iter
     ):
         # default to last week on no filter
         start_time_from = (

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -670,7 +670,6 @@ class HTTPRunDB(RunDBInterface):
         if (
             not name
             and not uid
-            and not project
             and not labels
             and not state
             and not last

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -677,6 +677,9 @@ class HTTPRunDB(RunDBInterface):
             and not start_time_to
             and not last_update_time_from
             and not last_update_time_to
+            and not partition_by
+            and not partition_sort_by
+            and not iter
         ):
             # default to last week on no filter
             start_time_from = datetime.now() - timedelta(days=7)

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -16,7 +16,7 @@ import copy
 import time
 import unittest.mock
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from http import HTTPStatus
 
 from fastapi.testclient import TestClient
@@ -229,11 +229,13 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     # Create runs
     projects = ["run-project-1", "run-project-2", "run-project-3"]
     run_names = ["run-name-1", "run-name-2", "run-name-3"]
+    suffixes = ["first", "second", "third"]
+    iterations = 3
     for project in projects:
         for name in run_names:
-            for suffix in ["first", "second", "third"]:
+            for suffix in suffixes:
                 uid = f"{name}-uid-{suffix}"
-                for iteration in range(3):
+                for iteration in range(iterations):
                     run = {
                         "metadata": {
                             "name": name,
@@ -245,30 +247,42 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
                     mlrun.api.crud.Runs().store_run(db, run, uid, iteration, project)
 
     # basic list, all projects, all iterations so 3 projects * 3 names * 3 uids * 3 iterations = 81
-    runs = _list_and_assert_objects(
+    _list_and_assert_objects(
         client,
-        {},
-        81,
+        params={},
+        expected_number_of_runs=81,
         project="*",
     )
 
-    # basic list, specific project, only iteration 0, so 3 names * 3 uids = 9
-    runs = _list_and_assert_objects(
+    # basic list, specific project, only iteration 0, so 3 names = 3
+    _list_and_assert_objects(
         client,
-        {"iter": False},
-        9,
+        params={"iter": False},
+        expected_number_of_runs=3,
+        project=projects[0],
+    )
+
+    # adding start time from to make sure we get all runs (and not just latest)
+    # basic list, specific project, only iteration 0, so 3 names * 3 uids = 9
+    _list_and_assert_objects(
+        client,
+        params={
+            "iter": False,
+            "start_time_from": datetime.now() - timedelta(days=1),
+        },
+        expected_number_of_runs=9,
         project=projects[0],
     )
 
     # partioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
     runs = _list_and_assert_objects(
         client,
-        {
+        params={
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.created,
             "partition-order": mlrun.common.schemas.OrderType.asc,
         },
-        3,
+        expected_number_of_runs=3,
         project=projects[0],
     )
     # sorted by ascending created so only the first ones created
@@ -278,12 +292,12 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     # partioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
     runs = _list_and_assert_objects(
         client,
-        {
+        params={
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
             "partition-order": mlrun.common.schemas.OrderType.desc,
         },
-        3,
+        expected_number_of_runs=3,
         project=projects[0],
     )
     # sorted by descending updated so only the third ones created
@@ -291,29 +305,29 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
         assert "third" in run["metadata"]["uid"]
 
     # partioned list, specific project, 5 row per partition, so 3 names * 5 row = 15
-    runs = _list_and_assert_objects(
+    _list_and_assert_objects(
         client,
-        {
+        params={
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
             "partition-order": mlrun.common.schemas.OrderType.desc,
             "rows-per-partition": 5,
         },
-        15,
+        expected_number_of_runs=15,
         project=projects[0],
     )
 
     # partitioned list, specific project, 5 rows per partition, max of 2 partitions, so 2 names * 5 rows = 10
     runs = _list_and_assert_objects(
         client,
-        {
+        params={
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
             "partition-order": mlrun.common.schemas.OrderType.desc,
             "rows-per-partition": 5,
             "max-partitions": 2,
         },
-        10,
+        expected_number_of_runs=10,
         project=projects[0],
     )
     for run in runs:
@@ -323,7 +337,7 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
     # Complex query, with partitioning and filtering over iter==0
     runs = _list_and_assert_objects(
         client,
-        {
+        params={
             "iter": False,
             "partition-by": mlrun.common.schemas.RunPartitionByField.name,
             "partition-sort-by": mlrun.common.schemas.SortField.updated,
@@ -331,7 +345,7 @@ def test_list_runs_partition_by(db: Session, client: TestClient) -> None:
             "rows-per-partition": 2,
             "max-partitions": 1,
         },
-        2,
+        expected_number_of_runs=2,
         project=projects[0],
     )
 

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -16,7 +16,7 @@ import copy
 import time
 import unittest.mock
 import uuid
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
 from fastapi.testclient import TestClient

--- a/tests/integration/sdk_api/httpdb/runs/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/runs/test_runs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 import http
 import json
 
@@ -48,13 +49,14 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         projects = ["run-project-1", "run-project-2", "run-project-3"]
         run_names = ["run-name-1", "run-name-2", "run-name-3"]
         suffixes = ["first", "second", "third"]
+        iterations = 3
         for project in projects:
             project_obj = mlrun.new_project(project)
             project_obj.save()
             for name in run_names:
                 for suffix in suffixes:
                     uid = f"{name}-uid-{suffix}"
-                    for iteration in range(3):
+                    for iteration in range(iterations):
                         run = {
                             "metadata": {
                                 "name": name,
@@ -66,17 +68,41 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
                         mlrun.get_run_db().store_run(run, uid, project, iteration)
 
         # basic list, all projects, all iterations so 3 projects * 3 names * 3 uids * 3 iterations = 81
-        runs = _list_and_assert_objects(81, project="*", iter=True)
+        _list_and_assert_objects(
+            expected_number_of_runs=len(projects)
+            * len(run_names)
+            * len(suffixes)
+            * iterations,
+            project="*",
+            iter=True,
+        )
 
         # basic list, specific project, all iterations, so 3 names * 3 uids * 3 iterations = 27
-        runs = _list_and_assert_objects(27, project=projects[0], iter=True)
+        _list_and_assert_objects(
+            expected_number_of_runs=len(run_names) * len(suffixes) * iterations,
+            project=projects[0],
+            iter=True,
+        )
+
+        # basic list, specific project, only iteration 0, so 3 names = 3
+        _list_and_assert_objects(
+            expected_number_of_runs=len(run_names),
+            project=projects[0],
+            iter=False,
+        )
 
         # basic list, specific project, only iteration 0, so 3 names * 3 uids = 9
-        runs = _list_and_assert_objects(9, project=projects[0], iter=False)
+        # using start time from to make sure we get all runs (and not just latest)
+        _list_and_assert_objects(
+            expected_number_of_runs=len(run_names) * len(suffixes),
+            start_time_from=datetime.datetime.now() - datetime.timedelta(days=1),
+            project=projects[0],
+            iter=False,
+        )
 
         # partitioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
         runs = _list_and_assert_objects(
-            3,
+            expected_number_of_runs=len(run_names),
             project=projects[0],
             partition_by=mlrun.common.schemas.RunPartitionByField.name,
             partition_sort_by=mlrun.common.schemas.SortField.created,
@@ -88,7 +114,7 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # partitioned list, specific project, 1 row per partition by default, so 3 names * 1 row = 3
         runs = _list_and_assert_objects(
-            3,
+            expected_number_of_runs=len(run_names),
             project=projects[0],
             partition_by=mlrun.common.schemas.RunPartitionByField.name,
             partition_sort_by=mlrun.common.schemas.SortField.updated,
@@ -99,32 +125,33 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             assert "third" in run["metadata"]["uid"]
 
         # partitioned list, specific project, 5 row per partition, so 3 names * 5 row = 15
-        runs = _list_and_assert_objects(
-            15,
+        rows_per_partition = 5
+        _list_and_assert_objects(
+            expected_number_of_runs=len(run_names) * rows_per_partition,
             project=projects[0],
             partition_by=mlrun.common.schemas.RunPartitionByField.name,
             partition_sort_by=mlrun.common.schemas.SortField.updated,
             partition_order=mlrun.common.schemas.OrderType.desc,
-            rows_per_partition=5,
+            rows_per_partition=rows_per_partition,
             iter=True,
         )
 
         # partitioned list, specific project, 5 rows per partition, max of 2 partitions, so 2 names * 5 rows = 10
-        runs = _list_and_assert_objects(
-            10,
+        _list_and_assert_objects(
+            expected_number_of_runs=10,
             project=projects[0],
             partition_by=mlrun.common.schemas.RunPartitionByField.name,
             partition_sort_by=mlrun.common.schemas.SortField.updated,
             partition_order=mlrun.common.schemas.OrderType.desc,
-            rows_per_partition=5,
+            rows_per_partition=rows_per_partition,
             max_partitions=2,
             iter=True,
         )
 
         # partitioned list, specific project, 4 rows per partition, max of 2 partitions, but only iter=0 so each
         # partition has 3 rows, so 2 * 3 = 6
-        runs = _list_and_assert_objects(
-            6,
+        _list_and_assert_objects(
+            expected_number_of_runs=6,
             project=projects[0],
             partition_by=mlrun.common.schemas.RunPartitionByField.name,
             partition_sort_by=mlrun.common.schemas.SortField.updated,
@@ -137,14 +164,14 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         # Some negative testing - no sort by field
         with pytest.raises(mlrun.errors.MLRunBadRequestError):
             _list_and_assert_objects(
-                0,
+                expected_number_of_runs=0,
                 project=projects[0],
                 partition_by=mlrun.common.schemas.RunPartitionByField.name,
             )
         # An invalid partition-by field - will be failed by fastapi due to schema validation.
         with pytest.raises(mlrun.errors.MLRunHTTPError) as excinfo:
             _list_and_assert_objects(
-                0,
+                expected_number_of_runs=0,
                 project=projects[0],
                 partition_by="key",
                 partition_sort_by=mlrun.common.schemas.SortField.updated,
@@ -156,7 +183,7 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # expecting 3 since we're getting back all iterations for that uid
         _list_and_assert_objects(
-            3,
+            expected_number_of_runs=3,
             project=projects[0],
             uid=f"{run_names[0]}-uid-{suffixes[0]}",
             iter=True,
@@ -164,7 +191,7 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         uid_list = [f"{run_names[0]}-uid-{suffix}" for suffix in suffixes]
         runs = _list_and_assert_objects(
-            len(uid_list),
+            expected_number_of_runs=len(uid_list),
             project=projects[0],
             uid=uid_list,
             iter=False,

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import codecs
+import datetime
 import sys
 import time
 from collections import namedtuple
@@ -272,9 +273,19 @@ def test_runs(create_server):
         run_as_dict["metadata"]["name"] = "run-name"
         db.store_run(run_as_dict, uid, prj)
 
+    # retrieve only the last run as it is partitioned by name
+    # and since there is no other filter, it will return only the last run
     runs = db.list_runs(project=prj)
-    assert len(runs) == count, "bad number of runs"
+    assert len(runs) == 1, "bad number of runs"
 
+    # retrieve all runs
+    runs = db.list_runs(
+        project=prj,
+        start_time_from=datetime.datetime.now() - datetime.timedelta(days=1),
+    )
+    assert len(runs) == 7, "bad number of runs"
+
+    # delete runs in created state
     db.del_runs(project=prj, state="created")
     runs = db.list_runs(project=prj)
     assert not runs, "found runs in after delete"


### PR DESCRIPTION
Project is always set when running from sdk as list runs is a project functionality.
That means, when querying for project runs, it will default to runs lasted 7 days ago.
if desired more than that, then refine the filter by providing specific runs as per list_run parameters.

https://jira.iguazeng.com/browse/ML-4316