### PR TITLE
[Model Monitoring] Fix delete model endpoints resources on CE 

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -544,6 +544,14 @@ class ModelEndpoints:
             data_session=os.getenv("V3IO_ACCESS_KEY")
         )
 
+        # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,
+        # we're using the igz version heuristic
+        if (
+            mlrun.mlconf.model_endpoint_monitoring.store_type
+            == mlrun.common.schemas.model_monitoring.ModelEndpointTarget.V3IO_NOSQL
+            and (not mlrun.mlconf.igz_version or not mlrun.mlconf.v3io_api)
+        ):
+            return
         # Generate a model endpoint store object and get a list of model endpoint dictionaries
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,

--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -544,11 +544,6 @@ class ModelEndpoints:
             data_session=os.getenv("V3IO_ACCESS_KEY")
         )
 
-        # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,
-        # we're using the igz version heuristic
-        if not mlrun.mlconf.igz_version or not mlrun.mlconf.v3io_api:
-            return
-
         # Generate a model endpoint store object and get a list of model endpoint dictionaries
         endpoint_store = get_model_endpoint_store(
             access_key=auth_info.data_session,

--- a/mlrun/common/schemas/model_monitoring/__init__.py
+++ b/mlrun/common/schemas/model_monitoring/__init__.py
@@ -23,6 +23,7 @@ from .constants import (
     EventLiveStats,
     FileTargetKind,
     FunctionURI,
+    ModelEndpointTarget,
     ModelMonitoringMode,
     ModelMonitoringStoreKinds,
     ProjectSecretKeys,


### PR DESCRIPTION
When calling delete project API with `cascade` policy, the model endpoints resources should be deleted as well. During that process, we used to validate that we are deleting these resources only if we are using V3IO in a valid iguazio version. However, to delete the model endpoint resources on a CE environment (which by default stores the model endpoints records under mlrun-db service) we need to modify this condition and apply it only if the model endpoints store type is indeed v3io. 
This PR should also fix a failure in the open source system tests. 

[ML-4565](https://jira.iguazeng.com/browse/ML-4565)