### PR TITLE
[Project] Fix set tagged function

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1879,10 +1879,11 @@ class MlrunProject(ModelObj):
         else:
             raise ValueError("func must be a function url or object")
 
-        # if function name was not explicitly provided,
-        # we use the resolved name (from the function object) and add the tag
-        if tag and not name and ":" not in resolved_function_name:
-            resolved_function_name = f"{resolved_function_name}:{tag}"
+        if tag and not resolved_function_name.endswith(f":{tag}"):
+            # Update the tagged key as well for consistency
+            self.spec.set_function(
+                f"{resolved_function_name}:{tag}", function_object, func
+            )
 
         self.spec.set_function(resolved_function_name, function_object, func)
         return function_object

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -616,6 +616,26 @@ def test_set_function_with_tagged_key():
     assert func.metadata.tag == tag_v2
 
 
+def test_set_function_update_code():
+    project = mlrun.new_project("set-func-update-code", save=False)
+    for i in range(2):
+        func = project.set_function(
+            func=str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
+            name="handler",
+            kind="job",
+            image="mlrun/mlrun",
+            handler="myhandler",
+            tag="v1",
+        )
+
+        assert id(func) == id(
+            project.get_function("handler")
+        ), f"Function of index {i} was not set correctly"
+        assert id(func) == id(
+            project.get_function("handler:v1")
+        ), f"Function of index {i} was not set and tagged correctly"
+
+
 def test_set_function_with_relative_path(context):
     project = mlrun.new_project("inline", context=str(assets_path()), save=False)
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-3739
Previously, we would not update the tagged function in the project's function objects.
This introduced inconsistencies with the DB in case a function was saved to the DB with the tag but was set in the project with a name and a tag separately. Getting such function from the project would return the old object and not the latest one set.