### PR TITLE
[CI] Fix backwards compatibility check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ automation/patch_igz/patch_env.yml
 # e.g., when developing for mlrun api, you may use this env to preset envvars.
 # then, when running the api, just feed it with "MLRUN_DEFAULT_ENV_FILE=<absolute-path-to-this-file>"
 hack/mlrun.env
+
+# files generated for openapi spec checks
+mlrun_bc_*.json

--- a/Makefile
+++ b/Makefile
@@ -672,11 +672,12 @@ endif
 ifndef MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH
 	$(error MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH is undefined)
 endif
+	export MLRUN_HTTPDB__DSN='sqlite:////mlrun/db/mlrun.db?check_same_thread=false' && \
 	export MLRUN_OPENAPI_JSON_NAME=mlrun_bc_base_oai.json && \
 	python -m pytest -v --capture=no --disable-warnings --durations=100 $(MLRUN_BC_TESTS_BASE_CODE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	export MLRUN_OPENAPI_JSON_NAME=mlrun_bc_head_oai.json && \
 	python -m pytest -v --capture=no --disable-warnings --durations=100 tests/api/api/test_docs.py::test_save_openapi_json && \
-	docker run --rm -t -v $(MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH):/specs:ro openapitools/openapi-diff:2.0.1 /specs/mlrun_bc_base_oai.json /specs/mlrun_bc_head_oai.json --fail-on-incompatible
+	docker run --rm -t -v $(MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH):/specs:ro openapitools/openapi-diff:latest /specs/mlrun_bc_base_oai.json /specs/mlrun_bc_head_oai.json --fail-on-incompatible
 
 
 .PHONY: release-notes


### PR DESCRIPTION
It uses 2.0.1 which has a bug reporting breaking schema compatibility while it actually doesnt, see https://github.com/mlrun/mlrun/pull/4233 runs for an instance. while I added a field (which is considered BC) it reports non backwards compatibe.
while upgrading the docker container of openapi diff checker, it fixes the issue