### PR TITLE
[Datastore] Keep private data as user secrets instead of mlrun internal

### DIFF
--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -37,9 +37,9 @@ class DatastoreProfile(pydantic.BaseModel):
 
     @staticmethod
     def generate_secret_key(profile_name: str, project: str):
-        secret_name_separator = "-__-"
+        secret_name_separator = "."
         full_key = (
-            "mlrun.datastore-profiles"
+            "datastore-profiles"
             + secret_name_separator
             + project
             + secret_name_separator


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4521
Storing private data from the datastore as internal k8s secrets in MLRun prevents these secrets from being mounted to the pods. This, in turn, prevents the pods from accessing datastore profiles. To address this, we transition the private data to regular user secrets, which are also visible in the UI.