### PR TITLE
[Datastore] Fix sqlalchemy dynamic import in `SQLTarget`   

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1691,9 +1691,7 @@ class SQLTarget(BaseStoreTarget):
             import sqlalchemy
 
         except (ModuleNotFoundError, ImportError) as exc:
-            raise mlrun.errors.MLRunMissingDependencyError(
-                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
-            ) from exc
+            self._raise_import_error(exc)
 
         db_path, table_name, _, _, _, _ = self._parse_url()
         engine = sqlalchemy.create_engine(db_path)
@@ -1725,9 +1723,7 @@ class SQLTarget(BaseStoreTarget):
             import sqlalchemy
 
         except (ModuleNotFoundError, ImportError) as exc:
-            raise mlrun.errors.MLRunMissingDependencyError(
-                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
-            ) from exc
+            self._raise_import_error(exc)
 
         self._create_sql_table()
 
@@ -1773,9 +1769,7 @@ class SQLTarget(BaseStoreTarget):
             import sqlalchemy
 
         except (ModuleNotFoundError, ImportError) as exc:
-            raise mlrun.errors.MLRunMissingDependencyError(
-                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
-            ) from exc
+            self._raise_import_error(exc)
 
         try:
             primary_key = ast.literal_eval(primary_key)
@@ -1820,6 +1814,11 @@ class SQLTarget(BaseStoreTarget):
                     f"//@{str(create_according_to_data)}//@{if_exists}//@{primary_key}//@{create_table}"
                 )
                 conn.close()
+
+    def _raise_import_error(self, exc):
+        raise mlrun.errors.MLRunMissingDependencyError(
+            "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
+        ) from exc
 
 
 kind_to_driver = {

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1686,12 +1686,11 @@ class SQLTarget(BaseStoreTarget):
         time_column=None,
         **kwargs,
     ):
-        # Validate sqlalchemy (not installed by default):
         try:
             import sqlalchemy
 
         except (ModuleNotFoundError, ImportError) as exc:
-            self._raise_import_error(exc)
+            self._raise_sqlalchemy_import_error(exc)
 
         db_path, table_name, _, _, _, _ = self._parse_url()
         engine = sqlalchemy.create_engine(db_path)
@@ -1718,12 +1717,11 @@ class SQLTarget(BaseStoreTarget):
     def write_dataframe(
         self, df, key_column=None, timestamp_key=None, chunk_id=0, **kwargs
     ):
-        # Validate sqlalchemy (not installed by default):
         try:
             import sqlalchemy
 
         except (ModuleNotFoundError, ImportError) as exc:
-            self._raise_import_error(exc)
+            self._raise_sqlalchemy_import_error(exc)
 
         self._create_sql_table()
 
@@ -1764,12 +1762,11 @@ class SQLTarget(BaseStoreTarget):
             primary_key,
             create_table,
         ) = self._parse_url()
-        # Validate sqlalchemy (not installed by default):
         try:
             import sqlalchemy
 
         except (ModuleNotFoundError, ImportError) as exc:
-            self._raise_import_error(exc)
+            self._raise_sqlalchemy_import_error(exc)
 
         try:
             primary_key = ast.literal_eval(primary_key)
@@ -1815,7 +1812,8 @@ class SQLTarget(BaseStoreTarget):
                 )
                 conn.close()
 
-    def _raise_import_error(self, exc):
+    @staticmethod
+    def _raise_sqlalchemy_import_error(exc):
         raise mlrun.errors.MLRunMissingDependencyError(
             "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
         ) from exc

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1580,15 +1580,6 @@ class SQLTarget(BaseStoreTarget):
         :param parse_dates :    all the field to be parsed as timestamp.
         """
 
-        # Validate sqlalchemy (not installed by default):
-        try:
-            import sqlalchemy
-
-        except (ModuleNotFoundError, ImportError) as exc:
-            raise mlrun.errors.MLRunMissingDependencyError(
-                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
-            ) from exc
-
         create_according_to_data = False  # TODO: open for user
         if time_fields:
             warnings.warn(
@@ -1695,7 +1686,14 @@ class SQLTarget(BaseStoreTarget):
         time_column=None,
         **kwargs,
     ):
-        import sqlalchemy
+        # Validate sqlalchemy (not installed by default):
+        try:
+            import sqlalchemy
+
+        except (ModuleNotFoundError, ImportError) as exc:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
+            ) from exc
 
         db_path, table_name, _, _, _, _ = self._parse_url()
         engine = sqlalchemy.create_engine(db_path)
@@ -1722,7 +1720,14 @@ class SQLTarget(BaseStoreTarget):
     def write_dataframe(
         self, df, key_column=None, timestamp_key=None, chunk_id=0, **kwargs
     ):
-        import sqlalchemy
+        # Validate sqlalchemy (not installed by default):
+        try:
+            import sqlalchemy
+
+        except (ModuleNotFoundError, ImportError) as exc:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
+            ) from exc
 
         self._create_sql_table()
 
@@ -1763,7 +1768,14 @@ class SQLTarget(BaseStoreTarget):
             primary_key,
             create_table,
         ) = self._parse_url()
-        import sqlalchemy
+        # Validate sqlalchemy (not installed by default):
+        try:
+            import sqlalchemy
+
+        except (ModuleNotFoundError, ImportError) as exc:
+            raise mlrun.errors.MLRunMissingDependencyError(
+                "Using 'SQLTarget' requires sqlalchemy package. Use pip install mlrun[sqlalchemy] to install it."
+            ) from exc
 
         try:
             primary_key = ast.literal_eval(primary_key)


### PR DESCRIPTION
[ML-4586](https://jira.iguazeng.com/browse/ML-4586)
first introduce in #4212,  we cant save sqlalchemy as attribute of an instance.
about the dynamic import - if module is already loaded then it won't be loaded again. you will just get a reference to it.