### PR TITLE
[Model Monitoring] Remove deprecated `create_or_patch` model endpoint API

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -15,7 +15,6 @@
 
 import os
 import typing
-import warnings
 
 import sqlalchemy.orm
 
@@ -35,35 +34,6 @@ from mlrun.utils import logger
 
 class ModelEndpoints:
     """Provide different methods for handling model endpoints such as listing, writing and deleting"""
-
-    def create_or_patch(
-        self,
-        db_session: sqlalchemy.orm.Session,
-        access_key: str,
-        model_endpoint: mlrun.common.schemas.ModelEndpoint,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
-    ) -> mlrun.common.schemas.ModelEndpoint:
-        # TODO: deprecated in 1.3.0, remove in 1.5.0.
-        warnings.warn(
-            "This is deprecated in 1.3.0, and will be removed in 1.5.0."
-            "Please use create_model_endpoint() for create or patch_model_endpoint() for update",
-            FutureWarning,
-        )
-        """
-        Either create or updates the record of a given `ModelEndpoint` object.
-        Leaving here for backwards compatibility, remove in 1.5.0.
-
-        :param db_session:             A session that manages the current dialog with the database
-        :param access_key:             Access key with permission to write to KV table
-        :param model_endpoint:         Model endpoint object to update
-        :param auth_info:              The auth info of the request
-
-        :return: `ModelEndpoint` object.
-        """
-
-        return self.create_model_endpoint(
-            db_session=db_session, model_endpoint=model_endpoint
-        )
 
     @classmethod
     def create_model_endpoint(

--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -16,7 +16,6 @@
 import json
 import os
 import typing
-import warnings
 
 import v3io.dataplane
 import v3io_frames
@@ -468,17 +467,12 @@ class KVModelEndpointStore(ModelEndpointStore):
         """
         Replace default null values for `error_count` and `metrics` for users that logged a model endpoint before 1.3.0.
         In addition, this function also validates that the key name of the endpoint unique id is `uid` and not
-         `endpoint_id` that has been used before 1.3.0.
+        `endpoint_id` that has been used before 1.3.0.
 
         Leaving here for backwards compatibility which related to the model endpoint schema.
 
         :param endpoint: An endpoint flattened dictionary.
         """
-        warnings.warn(
-            "This will be deprecated in 1.3.0, and will be removed in 1.5.0",
-            # TODO: In 1.3.0 do changes in examples & demos In 1.5.0 remove
-            FutureWarning,
-        )
 
         # Validate default value for `error_count`
         # For backwards compatibility reasons, we validate that the model endpoint includes the `error_count` key


### PR DESCRIPTION
- `create_or_patch` model endpoint API is no longer supported.
- the deprecation warning message on validating KV schema fields has been removed. We will keep validating these fields in order to support users that created their model endpoints before `1.3.0`. 