### PR TITLE
[SDK] Return deprecated ops missing from change-log

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -17,6 +17,7 @@ import json
 import pathlib
 import socket
 import traceback
+import warnings
 from ast import literal_eval
 from base64 import b64decode, b64encode
 from os import environ, path, remove
@@ -591,6 +592,13 @@ def build(
     default="",
     help="path/url of function yaml or function " "yaml or db://<project>/<name>[:tag]",
 )
+# TODO: Remove in 1.6.0
+@click.option(
+    "--dashboard",
+    "-d",
+    default="",
+    help="Deprecated. Keep empty to allow auto-detect by MLRun API",
+)
 @click.option("--project", "-p", default="", help="project name")
 @click.option("--model", "-m", multiple=True, help="model name and path (name=path)")
 @click.option("--kind", "-k", default=None, help="runtime sub kind")
@@ -609,6 +617,7 @@ def deploy(
     spec,
     source,
     func_url,
+    dashboard,
     project,
     model,
     tag,
@@ -668,6 +677,14 @@ def deploy(
         for k, v in list2dict(env).items():
             function.set_env(k, v)
     function.verbose = verbose
+
+    if dashboard:
+        warnings.warn(
+            "'--dashboard' is deprecated in 1.3.0, and will be removed in 1.6.0, "
+            "Keep '--dashboard' value empty to allow auto-detection by MLRun API.",
+            # TODO: Remove in 1.6.0
+            FutureWarning,
+        )
 
     try:
         addr = function.deploy(project=project, tag=tag)
@@ -1004,6 +1021,13 @@ def logs(uid, project, offset, db, watch):
     "https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron."
     "For using the pre-defined workflow's schedule, set --schedule 'true'",
 )
+# TODO: Remove in 1.6.0
+@click.option(
+    "--overwrite-schedule",
+    "-os",
+    is_flag=True,
+    help="Overwrite a schedule when submitting a new one with the same name.",
+)
 @click.option(
     "--save-secrets",
     is_flag=True,
@@ -1043,6 +1067,7 @@ def project(
     timeout,
     schedule,
     notifications,
+    overwrite_schedule,
     save_secrets,
     save,
 ):
@@ -1132,6 +1157,7 @@ def project(
                 local=local,
                 schedule=schedule,
                 timeout=timeout,
+                overwrite=overwrite_schedule,
             )
         except Exception as err:
             print(traceback.format_exc())

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1026,7 +1026,8 @@ def logs(uid, project, offset, db, watch):
     "--overwrite-schedule",
     "-os",
     is_flag=True,
-    help="Overwrite a schedule when submitting a new one with the same name.",
+    help="Deprecated (Saving schedules is now an upsert opertaion)."
+         " Overwrite a schedule when submitting a new one with the same name.",
 )
 @click.option(
     "--save-secrets",

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1027,7 +1027,7 @@ def logs(uid, project, offset, db, watch):
     "-os",
     is_flag=True,
     help="Deprecated (Saving schedules is now an upsert opertaion)."
-         " Overwrite a schedule when submitting a new one with the same name.",
+    " Overwrite a schedule when submitting a new one with the same name.",
 )
 @click.option(
     "--save-secrets",

--- a/mlrun/lists.py
+++ b/mlrun/lists.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
 from copy import copy
 from typing import List
 
@@ -217,6 +218,16 @@ class ArtifactList(list):
 
     def to_objects(self) -> List[Artifact]:
         """return as a list of artifact objects"""
+        return [dict_to_artifact(artifact) for artifact in self]
+
+    def objects(self) -> List[Artifact]:
+        """return as a list of artifact objects"""
+        warnings.warn(
+            "'objects' is deprecated in 1.3.0 and will be removed in 1.6.0. "
+            "Use 'to_objects' instead.",
+            # TODO: remove in 1.6.0
+            FutureWarning,
+        )
         return [dict_to_artifact(artifact) for artifact in self]
 
     def dataitems(self) -> List["mlrun.DataItem"]:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -19,6 +19,7 @@ import tempfile
 import traceback
 import typing
 import uuid
+import warnings
 
 import kfp.compiler
 from kfp import dsl
@@ -76,18 +77,28 @@ class WorkflowSpec(mlrun.model.ModelObj):
         args=None,
         name=None,
         handler=None,
+        # TODO: deprecated, remove in 1.6.0
+        ttl=None,
         args_schema: dict = None,
         schedule: typing.Union[str, mlrun.common.schemas.ScheduleCronTrigger] = None,
         cleanup_ttl: int = None,
         image: str = None,
     ):
+        if ttl:
+            warnings.warn(
+                "'ttl' is deprecated, use 'cleanup_ttl' instead. "
+                "This will be removed in 1.6.0",
+                # TODO: Remove this in 1.6.0
+                FutureWarning,
+            )
         self.engine = engine
         self.code = code
         self.path = path
         self.args = args
         self.name = name
         self.handler = handler
-        self.cleanup_ttl = cleanup_ttl
+        self.ttl = cleanup_ttl or ttl
+        self.cleanup_ttl = cleanup_ttl or ttl
         self.args_schema = args_schema
         self.run_local = False
         self._tmp_path = None
@@ -550,7 +561,7 @@ class _KFPRunner(_PipelineRunner):
 
         conf = new_pipe_metadata(
             artifact_path=artifact_path,
-            cleanup_ttl=workflow_spec.cleanup_ttl,
+            cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl,
         )
         compiler.Compiler().compile(pipeline, target, pipeline_conf=conf)
         workflow_spec.clear_tmp()
@@ -583,7 +594,7 @@ class _KFPRunner(_PipelineRunner):
             experiment=name or workflow_spec.name,
             namespace=namespace,
             artifact_path=artifact_path,
-            cleanup_ttl=workflow_spec.cleanup_ttl,
+            cleanup_ttl=workflow_spec.cleanup_ttl or workflow_spec.ttl,
         )
         project.notifiers.push_pipeline_start_message(
             project.metadata.name,
@@ -883,6 +894,8 @@ def load_and_run(
     namespace: str = None,
     sync: bool = False,
     dirty: bool = False,
+    # TODO: deprecated, remove in 1.6.0
+    ttl: int = None,
     engine: str = None,
     local: bool = None,
     schedule: typing.Union[str, mlrun.common.schemas.ScheduleCronTrigger] = None,
@@ -910,6 +923,8 @@ def load_and_run(
     :param namespace:           kubernetes namespace if other than default
     :param sync:                force functions sync before run
     :param dirty:               allow running the workflow when the git repo is dirty
+    :param ttl:                 pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                                workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
     :param engine:              workflow engine running the workflow.
                                 supported values are 'kfp' (default) or 'local'
     :param local:               run local pipeline with local functions (set local=True in function.run())
@@ -918,6 +933,14 @@ def load_and_run(
                                 workflow and all its resources are deleted)
     :param load_only:           for just loading the project, inner use.
     """
+    if ttl:
+        warnings.warn(
+            "'ttl' is deprecated, use 'cleanup_ttl' instead. "
+            "This will be removed in 1.6.0",
+            # TODO: Remove this in 1.6.0
+            FutureWarning,
+        )
+
     try:
         project = mlrun.load_project(
             context=f"./{project_name}",
@@ -969,7 +992,7 @@ def load_and_run(
         sync=sync,
         watch=False,  # Required for fetching the workflow_id
         dirty=dirty,
-        cleanup_ttl=cleanup_ttl,
+        cleanup_ttl=cleanup_ttl or ttl,
         engine=engine,
         local=local,
     )

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2208,12 +2208,16 @@ class MlrunProject(ModelObj):
         sync: bool = False,
         watch: bool = False,
         dirty: bool = False,
+        # TODO: deprecated, remove in 1.6.0
+        ttl: int = None,
         engine: str = None,
         local: bool = None,
         schedule: typing.Union[
             str, mlrun.common.schemas.ScheduleCronTrigger, bool
         ] = None,
         timeout: int = None,
+        # TODO: deprecated, remove in 1.6.0
+        overwrite: bool = False,
         source: str = None,
         cleanup_ttl: int = None,
     ) -> _PipelineRunStatus:
@@ -2233,6 +2237,8 @@ class MlrunProject(ModelObj):
         :param sync:      force functions sync before run
         :param watch:     wait for pipeline completion
         :param dirty:     allow running the workflow when the git repo is dirty
+        :param ttl:       pipeline cleanup ttl in secs (time to wait after workflow completion, at which point the
+                          workflow and all its resources are deleted) (deprecated, use cleanup_ttl instead)
         :param engine:    workflow engine running the workflow.
                           supported values are 'kfp' (default), 'local' or 'remote'.
                           for setting engine for remote running use 'remote:local' or 'remote:kfp'.
@@ -2243,6 +2249,8 @@ class MlrunProject(ModelObj):
                           https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
                           for using the pre-defined workflow's schedule, set `schedule=True`
         :param timeout:   timeout in seconds to wait for pipeline completion (watch will be activated)
+        :param overwrite: (deprecated) replacing the schedule of the same workflow (under the same name) if exists
+                          with the new one.
         :param source:    remote source to use instead of the actual `project.spec.source` (used when engine is remote).
                           for other engines the source is to validate that the code is up-to-date
         :param cleanup_ttl:
@@ -2250,6 +2258,22 @@ class MlrunProject(ModelObj):
                           workflow and all its resources are deleted)
         :returns: run id
         """
+
+        if ttl:
+            warnings.warn(
+                "'ttl' is deprecated, use 'cleanup_ttl' instead. "
+                "This will be removed in 1.6.0",
+                # TODO: Remove this in 1.6.0
+                FutureWarning,
+            )
+
+        if overwrite:
+            warnings.warn(
+                "'overwrite' is deprecated, running a schedule is now an upsert operation. "
+                "This will be removed in 1.6.0",
+                # TODO: Remove this in 1.6.0
+                FutureWarning,
+            )
 
         arguments = arguments or {}
         need_repo = self.spec._need_repo()
@@ -2283,7 +2307,9 @@ class MlrunProject(ModelObj):
         else:
             workflow_spec = self.spec._workflows[name].copy()
             workflow_spec.merge_args(arguments)
-        workflow_spec.cleanup_ttl = cleanup_ttl or workflow_spec.cleanup_ttl
+        workflow_spec.cleanup_ttl = (
+            cleanup_ttl or ttl or workflow_spec.cleanup_ttl or workflow_spec.ttl
+        )
         workflow_spec.run_local = local
 
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -558,8 +558,9 @@ class RemoteRuntime(KubeResource):
             self.metadata.tag = tag
 
         if dashboard:
+            # TODO: remove in 1.6.0
             warnings.warn(
-                "'dashboard' parameter is no longer supported on client side, "
+                "'dashboard' parameter is no longer supported on client side, and will be removed in 1.6.0."
                 "it is being configured through the MLRun API.",
             )
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -812,6 +812,18 @@ def new_pipe_metadata(
     return conf
 
 
+# TODO: remove in 1.6.0
+@deprecated(
+    version="1.3.0",
+    reason="'new_pipe_meta' will be removed in 1.6.0",
+    category=FutureWarning,
+)
+def new_pipe_meta(artifact_path=None, ttl=None, *args):
+    return new_pipe_metadata(
+        artifact_path=artifact_path, cleanup_ttl=ttl, op_transformers=args
+    )
+
+
 def _convert_python_package_version_to_image_tag(version: typing.Optional[str]):
     return (
         version.replace("+", "-").replace("0.0.0-", "") if version is not None else None


### PR DESCRIPTION
Returning methods/flags that were deprecated in 1.3.0 but were not documented. They will be removed in 1.6.0

SDK:
1. new_pipe_meta
2. objects methods from artifacts list
3. ttl param from pipeline

CLI:
1. dashboard (nuclio/deploy)
2. overwrite schedule (project)

Related to https://github.com/mlrun/mlrun/pull/3971