### PR TITLE
[Model Monitoring] Add default drift thresholds under `model_endpoint.spec.monitor_configuration`

### DIFF
--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -18,7 +18,7 @@ import json
 import typing
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.main import Extra
 
 import mlrun.common.model_monitoring
@@ -99,6 +99,17 @@ class ModelEndpointSpec(ObjectSpec):
             flattened_dictionary=endpoint_dict,
             json_parse_values=json_parse_values,
         )
+
+    @validator("monitor_configuration")
+    def set_name(cls, monitor_configuration):
+        return monitor_configuration or {
+            EventFieldType.DRIFT_DETECTED_THRESHOLD: (
+                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.drift_detected
+            ),
+            EventFieldType.POSSIBLE_DRIFT_THRESHOLD: (
+                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.possible_drift
+            ),
+        }
 
 
 class Histogram(BaseModel):

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -88,6 +88,16 @@ class TestModelEndpointsOperations(TestMLRunSystem):
 
         assert endpoint_before_update.status.state == "null"
 
+        # Check default drift thresholds
+        assert endpoint_before_update.spec.monitor_configuration == {
+            mlrun.common.schemas.EventFieldType.DRIFT_DETECTED_THRESHOLD: (
+                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.drift_detected
+            ),
+            mlrun.common.schemas.EventFieldType.POSSIBLE_DRIFT_THRESHOLD: (
+                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.possible_drift
+            ),
+        }
+
         updated_state = "testing...testing...1 2 1 2"
         drift_status = "DRIFT_DETECTED"
         current_stats = {


### PR DESCRIPTION
If not provided, drift thresholds will be filled according to `mlrun.mlconf.
model_endpoint_monitoring.drift_thresholds`. The values will be stored under `model_endpoint.spect.monitor_configuration`.

Related JIRA - https://jira.iguazeng.com/browse/ML-4592