### PR TITLE
[Feature Store] Add default feature set target to ClientSpec

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -173,7 +173,8 @@ jobs:
             --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
             --set mlrun.api.extraEnvKeyValue.MLRUN_LOG_LEVEL="DEBUG" \
             --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__SCHEDULING__MIN_ALLOWED_INTERVAL="0 seconds"' \
-            --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS="100"
+            --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS="100" \ 
+            --set mlrun.api.extraEnvKeyValue.MLRUN_FEATURE_STORE__DEFAULT_TARGETS="parquet"
 
     - name: Prepare system tests env
       run: |

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -173,8 +173,7 @@ jobs:
             --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ steps.computed_params.outputs.mlrun_docker_registry }}" \
             --set mlrun.api.extraEnvKeyValue.MLRUN_LOG_LEVEL="DEBUG" \
             --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__SCHEDULING__MIN_ALLOWED_INTERVAL="0 seconds"' \
-            --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS="100" \ 
-            --set mlrun.api.extraEnvKeyValue.MLRUN_FEATURE_STORE__DEFAULT_TARGETS="parquet"
+            --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS="100"
 
     - name: Prepare system tests env
       run: |

--- a/mlrun/api/crud/client_spec.py
+++ b/mlrun/api/crud/client_spec.py
@@ -101,6 +101,9 @@ class ClientSpec(
             feature_store_data_prefixes=self._get_config_value_if_not_default(
                 "feature_store.data_prefixes"
             ),
+            feature_store_default_targets=self._get_config_value_if_not_default(
+                "feature_store.default_targets"
+            ),
             model_endpoint_monitoring_store_type=self._get_config_value_if_not_default(
                 "model_endpoint_monitoring.store_type"
             ),

--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -29,6 +29,7 @@ class ClientSpec(pydantic.BaseModel):
     ui_url: typing.Optional[str]
     artifact_path: typing.Optional[str]
     feature_store_data_prefixes: typing.Optional[typing.Dict[str, str]]
+    feature_store_default_targets: typing.Optional[typing.List[str]]
     spark_app_image: typing.Optional[str]
     spark_app_image_tag: typing.Optional[str]
     spark_history_server_path: typing.Optional[str]

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -451,6 +451,10 @@ class HTTPRunDB(RunDBInterface):
                     setattr(
                         config.feature_store.data_prefixes, prefix, server_prefix_value
                     )
+            config.model_endpoint_monitoring.endpoint_store_connection = (
+                server_cfg.get("feature_store_default_targets")
+                or config.feature_store.default_targets
+            )
 
         except Exception as exc:
             logger.warning(

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -58,7 +58,6 @@ def test_client_spec(
     )
 
     feature_set_default_targets = ["parquet", "csv"]
-
     mlrun.mlconf.feature_store.default_targets = feature_set_default_targets
 
     tolerations = [

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -130,8 +130,7 @@ def test_client_spec(
     assert response_body["ce_mode"] == response_body["ce"]["mode"] == ce_mode
     assert response_body["ce"]["release"] == ce_release
 
-    assert response_body['feature_store_default_targets'] == feature_set_default_targets
-
+    assert response_body["feature_store_default_targets"] == feature_set_default_targets
 
 
 def test_client_spec_response_based_on_client_version(

--- a/tests/api/api/test_client_spec.py
+++ b/tests/api/api/test_client_spec.py
@@ -57,6 +57,10 @@ def test_client_spec(
         feature_store_data_prefix_redisnosql
     )
 
+    feature_set_default_targets = ["parquet", "csv"]
+
+    mlrun.mlconf.feature_store.default_targets = feature_set_default_targets
+
     tolerations = [
         kubernetes.client.V1Toleration(
             effect="NoSchedule",
@@ -125,6 +129,9 @@ def test_client_spec(
     )
     assert response_body["ce_mode"] == response_body["ce"]["mode"] == ce_mode
     assert response_body["ce"]["release"] == ce_release
+
+    assert response_body['feature_store_default_targets'] == feature_set_default_targets
+
 
 
 def test_client_spec_response_based_on_client_version(


### PR DESCRIPTION
By default, the default feature store target is both v3io nosql and parquet. In this PR we expose the default feature store target as a clientspec argument. 

Related JIRA - https://jira.iguazeng.com/browse/ML-4577