### PR TITLE
[Model Monitoring] Encode feature statistics data (KV)

### DIFF
--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -535,7 +535,7 @@ class KVModelEndpointStore(ModelEndpointStore):
             ]
 
     @staticmethod
-    def _encode_field(field: typing.Union[str, bytes]) -> typing.Union[bytes]:
+    def _encode_field(field: typing.Union[str, bytes]) -> bytes:
         """Encode a provided field. Mainly used when storing data in the KV table."""
 
         if isinstance(field, str):
@@ -543,7 +543,7 @@ class KVModelEndpointStore(ModelEndpointStore):
         return field
 
     @staticmethod
-    def _decode_field(field: typing.Union[str, bytes]) -> typing.Union[str]:
+    def _decode_field(field: typing.Union[str, bytes]) -> str:
         """Decode a provided field. Mainly used when retrieving data from the KV table."""
 
         if isinstance(field, bytes):

--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -60,7 +60,7 @@ class KVModelEndpointStore(ModelEndpointStore):
         for field in fields_to_encode_decode:
             if field in endpoint:
                 # Encode to binary data
-                endpoint[field] = self._encode_decode_field(endpoint[field])
+                endpoint[field] = self._encode_field(endpoint[field])
 
         self.client.kv.put(
             container=self.container,
@@ -84,7 +84,7 @@ class KVModelEndpointStore(ModelEndpointStore):
         for field in fields_to_encode_decode:
             if field in attributes:
                 # Encode to binary data
-                attributes[field] = self._encode_decode_field(attributes[field])
+                attributes[field] = self._encode_field(attributes[field])
 
         self.client.kv.update(
             container=self.container,
@@ -136,9 +136,7 @@ class KVModelEndpointStore(ModelEndpointStore):
         for field in fields_to_encode_decode:
             if field in endpoint:
                 # Decode binary data
-                endpoint[field] = self._encode_decode_field(
-                    endpoint[field], encode=False
-                )
+                endpoint[field] = self._decode_field(endpoint[field])
 
         if not endpoint:
             raise mlrun.errors.MLRunNotFoundError(f"Endpoint {endpoint_id} not found")
@@ -537,13 +535,17 @@ class KVModelEndpointStore(ModelEndpointStore):
             ]
 
     @staticmethod
-    def _encode_decode_field(
-        field: typing.Union[str, bytes], encode: bool = True
-    ) -> typing.Union[str, bytes]:
-        """Encode or decode a provided field. Mainly used for storing (or retrieving) the data in the KV table"""
+    def _encode_field(field: typing.Union[str, bytes]) -> typing.Union[str, bytes]:
+        """Encode a provided field. Mainly used when storing data in the KV table."""
 
-        if encode and isinstance(field, str):
+        if isinstance(field, str):
             return field.encode("ascii")
-        elif not encode and isinstance(field, bytes):
+        return field
+
+    @staticmethod
+    def _decode_field(field: typing.Union[str, bytes]) -> typing.Union[str, bytes]:
+        """Decode a provided field. Mainly used when retrieving data from the KV table."""
+
+        if isinstance(field, bytes):
             return field.decode()
         return field

--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -27,6 +27,12 @@ from mlrun.utils import logger
 
 from .model_endpoint_store import ModelEndpointStore
 
+# Fields to encode before storing in the KV table or to decode after retrieving
+fields_to_encode_decode = [
+    mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_STATS,
+    mlrun.common.schemas.model_monitoring.EventFieldType.CURRENT_STATS,
+]
+
 
 class KVModelEndpointStore(ModelEndpointStore):
     """
@@ -51,6 +57,11 @@ class KVModelEndpointStore(ModelEndpointStore):
         :param endpoint: model endpoint dictionary that will be written into the DB.
         """
 
+        for field in fields_to_encode_decode:
+            if field in endpoint:
+                # Encode to binary data
+                endpoint[field] = self._encode_decode_field(endpoint[field])
+
         self.client.kv.put(
             container=self.container,
             table_path=self.path,
@@ -69,6 +80,11 @@ class KVModelEndpointStore(ModelEndpointStore):
                            of the attributes dictionary should exist in the KV table.
 
         """
+
+        for field in fields_to_encode_decode:
+            if field in attributes:
+                # Encode to binary data
+                attributes[field] = self._encode_decode_field(attributes[field])
 
         self.client.kv.update(
             container=self.container,
@@ -116,6 +132,13 @@ class KVModelEndpointStore(ModelEndpointStore):
             access_key=self.access_key,
         )
         endpoint = endpoint.output.item
+
+        for field in fields_to_encode_decode:
+            if field in endpoint:
+                # Decode binary data
+                endpoint[field] = self._encode_decode_field(
+                    endpoint[field], encode=False
+                )
 
         if not endpoint:
             raise mlrun.errors.MLRunNotFoundError(f"Endpoint {endpoint_id} not found")
@@ -512,3 +535,15 @@ class KVModelEndpointStore(ModelEndpointStore):
             ] = endpoint[
                 mlrun.common.schemas.model_monitoring.EventFieldType.ENDPOINT_ID
             ]
+
+    @staticmethod
+    def _encode_decode_field(
+        field: typing.Union[str, bytes], encode: bool = True
+    ) -> typing.Union[str, bytes]:
+        """Encode or decode a provided field. Mainly used for storing (or retrieving) the data in the KV table"""
+
+        if encode and isinstance(field, str):
+            return field.encode("ascii")
+        elif not encode and isinstance(field, bytes):
+            return field.decode()
+        return field

--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -535,7 +535,7 @@ class KVModelEndpointStore(ModelEndpointStore):
             ]
 
     @staticmethod
-    def _encode_field(field: typing.Union[str, bytes]) -> typing.Union[str, bytes]:
+    def _encode_field(field: typing.Union[str, bytes]) -> typing.Union[bytes]:
         """Encode a provided field. Mainly used when storing data in the KV table."""
 
         if isinstance(field, str):
@@ -543,7 +543,7 @@ class KVModelEndpointStore(ModelEndpointStore):
         return field
 
     @staticmethod
-    def _decode_field(field: typing.Union[str, bytes]) -> typing.Union[str, bytes]:
+    def _decode_field(field: typing.Union[str, bytes]) -> typing.Union[str]:
         """Decode a provided field. Mainly used when retrieving data from the KV table."""
 
         if isinstance(field, bytes):


### PR DESCRIPTION
When storing a string attribute data under the model endpoint with a huge length, the user might face a v3io-kv string attribute length limitation. 
In this PR we fix that issue by converting the statistics data string (which used to be stored as an attribute of type string) into binary string.

A fix to [ML-4597](https://jira.iguazeng.com/browse/ML-4597). 
