### PR TITLE
[Log Collector] Limit consecutive start log requests on failed runs

### DIFF
--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import asyncio
+import collections
 import concurrent.futures
 import datetime
 import traceback
@@ -70,7 +71,7 @@ _last_notification_push_time: datetime.datetime = None
 # This is a dictionary which holds the number of consecutive start log requests for each run uid.
 # We use this dictionary to make sure that we don't get stuck in an endless loop of trying to collect logs for a runs
 # that keep failing start logs requests.
-_run_uid_start_log_request_counters: typing.Dict[str, int] = {}
+_run_uid_start_log_request_counters: collections.Counter = collections.Counter()
 
 
 app = fastapi.FastAPI(
@@ -357,7 +358,7 @@ async def _start_log_and_update_runs(
     # each result contains either run_uid or None
     # if it's None it means something went wrong, and we should skip it
     # if it's run_uid it means we requested logs collection for it and we should update it's requested_logs field
-    results = await asyncio.gather(*start_logs_for_runs)
+    results = await asyncio.gather(*start_logs_for_runs, return_exceptions=True)
     successful_run_uids = [result for result in results if result]
 
     # distinct the runs uids

--- a/mlrun/api/main.py
+++ b/mlrun/api/main.py
@@ -68,9 +68,8 @@ BASE_VERSIONED_API_PREFIX = f"{API_PREFIX}/v1"
 _last_notification_push_time: datetime.datetime = None
 
 # This is a dictionary which holds the number of consecutive start log requests for each run uid.
-# The key is the run uid and the value is the number of consecutive start log requests for that run.
-# We use this dictionary to make sure that we don't get stuck in an endless loop of trying to collect logs for a run
-# which keeps failing.
+# We use this dictionary to make sure that we don't get stuck in an endless loop of trying to collect logs for a runs
+# that keep failing start logs requests.
 _run_uid_start_log_request_counters: typing.Dict[str, int] = {}
 
 
@@ -321,7 +320,7 @@ async def _start_log_and_update_runs(
     # the max number of consecutive start log requests for a run before we mark it as requested logs collection
     # basically represents the grace period before the run's resources are deleted
     max_consecutive_start_log_requests = int(
-        int(config.runtime_resources_deletion_grace_period)
+        int(config.log_collector.failed_runs_grace_period)
         / int(config.log_collector.periodic_start_log_interval)
     )
 
@@ -380,7 +379,7 @@ async def _start_log_and_update_runs(
 
         # remove the counters for the runs we updated
         for run_uid in runs_to_mark_as_requested_logs:
-            del _run_uid_start_log_request_counters[run_uid]
+            _run_uid_start_log_request_counters.pop(run_uid, None)
 
 
 async def _start_log_for_run(

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -550,6 +550,7 @@ default_config = {
         "mode": "legacy",
         # interval for collecting and sending runs which require their logs to be collected
         "periodic_start_log_interval": 10,
+        "failed_runs_grace_period": 3600,
         "verbose": True,
         # the number of workers which will be used to trigger the start log collection
         "concurrent_start_logs_workers": 15,

--- a/tests/api/test_collect_runs_logs.py
+++ b/tests/api/test_collect_runs_logs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import time
 import unittest.mock
 
 import deepdiff
@@ -23,6 +24,7 @@ import mlrun.api.crud
 import mlrun.api.main
 import mlrun.api.utils.clients.log_collector
 import mlrun.api.utils.singletons.db
+import mlrun.config
 from tests.api.utils.clients.test_log_collector import BaseLogCollectorResponse
 
 
@@ -164,6 +166,163 @@ class TestCollectRunSLogs:
                 ignore_order=True,
             )
             == {}
+        )
+
+    @pytest.mark.asyncio
+    async def test_collect_logs_for_old_runs_on_startup(
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+    ):
+        log_collector = mlrun.api.utils.clients.log_collector.LogCollectorClient()
+
+        project_name = "some-project"
+        new_uid = "new_uid"
+        old_uid = "old_uid"
+
+        # create first run
+        _create_new_run(
+            db,
+            project_name,
+            uid=old_uid,
+            name=old_uid,
+            kind="job",
+            state=mlrun.runtimes.constants.RunStates.completed,
+        )
+
+        # sleep for 5 seconds to make sure the runs are not created at the same time
+        time.sleep(5)
+
+        # create second run
+        _create_new_run(
+            db,
+            project_name,
+            uid=new_uid,
+            name=new_uid,
+            kind="job",
+            state=mlrun.runtimes.constants.RunStates.completed,
+        )
+
+        # verify that we have 2 runs
+        runs = mlrun.api.utils.singletons.db.get_db().list_distinct_runs_uids(
+            db,
+            requested_logs_modes=[False],
+            only_uids=False,
+        )
+        assert len(runs) == 2
+
+        # change mlrun config so that the old run will be considered as old
+        previous_grace_period = (
+            mlrun.config.config.runtime_resources_deletion_grace_period
+        )
+        mlrun.config.config.runtime_resources_deletion_grace_period = 2
+
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=BaseLogCollectorResponse(True, "")
+        )
+        mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs = (
+            unittest.mock.Mock()
+        )
+
+        await mlrun.api.main._verify_log_collection_started_on_startup(
+            self.start_log_limit
+        )
+
+        assert (
+            mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs.call_count
+            == 1
+        )
+        assert (
+            deepdiff.DeepDiff(
+                mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs.call_args[
+                    1
+                ][
+                    "uids"
+                ],
+                [new_uid],
+                ignore_order=True,
+            )
+            == {}
+        )
+
+        # restore mlrun config
+        mlrun.config.config.runtime_resources_deletion_grace_period = (
+            previous_grace_period
+        )
+
+    @pytest.mark.asyncio
+    async def test_collect_logs_consecutive_failures(
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+    ):
+        log_collector = mlrun.api.utils.clients.log_collector.LogCollectorClient()
+
+        project_name = "some-project"
+        success_uid = "success_uid"
+        failure_uid = "failure_uid"
+
+        for run_uid in [success_uid, failure_uid]:
+            _create_new_run(
+                db,
+                project_name,
+                uid=run_uid,
+                name=run_uid,
+                kind="job",
+                state=mlrun.runtimes.constants.RunStates.completed,
+            )
+
+        # verify that we have 2 runs
+        runs = mlrun.api.utils.singletons.db.get_db().list_distinct_runs_uids(
+            db,
+            requested_logs_modes=[False],
+            only_uids=False,
+        )
+        assert len(runs) == 2
+
+        # change the max_consecutive_start_log_requests to 2, as per the following calculation:
+        # max_consecutive_start_log_requests = int(
+        #     config.runtime_resources_deletion_grace_period
+        #     / config.log_collector.periodic_start_log_interval
+        # )
+        previous_runtime_resources_deletion_grace_period = (
+            mlrun.config.config.runtime_resources_deletion_grace_period
+        )
+        mlrun.config.config.runtime_resources_deletion_grace_period = 20
+
+        log_collector._call = unittest.mock.AsyncMock(
+            side_effect=[
+                # failure response for the first call (failure_uid)
+                BaseLogCollectorResponse(False, "some error"),
+                # success response for the second call (success_uid)
+                BaseLogCollectorResponse(True, ""),
+                # failure response for the third call (failure_uid)
+                BaseLogCollectorResponse(False, "some error"),
+            ]
+        )
+        mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs = (
+            unittest.mock.Mock()
+        )
+
+        for i in range(2):
+            await mlrun.api.main._initiate_logs_collection(self.start_log_limit)
+
+        assert (
+            mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs.call_count
+            == 2
+        )
+        # verify that `failure_uid` is also updated in the second call
+        assert (
+            failure_uid
+            in mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs.call_args[
+                1
+            ][
+                "uids"
+            ]
+        )
+
+        mlrun.config.config.runtime_resources_deletion_grace_period = (
+            previous_runtime_resources_deletion_grace_period
         )
 
     @pytest.mark.asyncio

--- a/tests/api/test_collect_runs_logs.py
+++ b/tests/api/test_collect_runs_logs.py
@@ -298,13 +298,14 @@ class TestCollectRunSLogs:
                 BaseLogCollectorResponse(True, ""),
                 # failure response for the third call (failure_uid)
                 BaseLogCollectorResponse(False, "some error"),
+                BaseLogCollectorResponse(False, "some error"),
             ]
         )
         mlrun.api.utils.singletons.db.get_db().update_runs_requested_logs = (
             unittest.mock.Mock()
         )
 
-        for i in range(2):
+        for i in range(3):
             await mlrun.api.main._initiate_logs_collection(self.start_log_limit)
 
         assert (


### PR DESCRIPTION
The api periodically calls start_log for runs that do not have logs requested.

There is an issue where runs in failed terminated states, which their resources have already been deleted, are still returned in the query for runs with `requested_logs=True`. 
Since there are no resources, the Log Collector always fails to find the runs' pods and returns an error, keeping the runs `requested_logs` field as `False`.

Thus - the api and the log collector sidecar are stuck in an endless loop trying to collect logs for these old runs.

To fix this, this PR adds a limit to the number of consecutive `start_logs` requests. 
The maximum number calculated as the run resource deletion grace period divided by the start log interval, meaning that once the grace period ends the runs are marked as `requested_logs = True` and the loop ends.