### PR TITLE
[Model Monitoring] Validate `model_uri` prefix

### DIFF
--- a/mlrun/api/crud/model_monitoring/model_endpoints.py
+++ b/mlrun/api/crud/model_monitoring/model_endpoints.py
@@ -72,6 +72,12 @@ class ModelEndpoints:
                 )
             )
 
+            mlrun.utils.helpers.verify_field_of_type(
+                field_name="model_endpoint.spec.model_uri",
+                field_value=model_obj,
+                expected_type=mlrun.artifacts.ModelArtifact,
+            )
+
             # Get stats from model object if not found in model endpoint object
             if not model_endpoint.status.feature_stats and hasattr(
                 model_obj, "feature_stats"

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -114,9 +114,11 @@ class ModelEndpointSpec(ObjectSpec):
     @validator("model_uri")
     def validate_model_uri(cls, model_uri):
         """Validate that the model uri includes the required prefix"""
-        prefix, _ = mlrun.datastore.parse_store_uri(model_uri)
-        if prefix and prefix != "models":
-            return model_uri.replace(prefix, "models", 1)
+        prefix, uri = mlrun.datastore.parse_store_uri(model_uri)
+        if prefix and prefix != mlrun.utils.helpers.StorePrefix.Model:
+            return mlrun.datastore.get_store_uri(
+                mlrun.utils.helpers.StorePrefix.Model, uri
+            )
         return model_uri
 
 

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -111,6 +111,14 @@ class ModelEndpointSpec(ObjectSpec):
             ),
         }
 
+    @validator("model_uri")
+    def validate_model_uri(cls, model_uri):
+        """Validate that the model uri includes the required prefix"""
+        prefix, _ = mlrun.datastore.parse_store_uri(model_uri)
+        if prefix and prefix != "models":
+            return model_uri.replace(prefix, "models", 1)
+        return model_uri
+
 
 class Histogram(BaseModel):
     buckets: List[float]

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -846,6 +846,8 @@ class TestBatchDrift(TestMLRunSystem):
         assert model_endpoint.status.current_stats
         assert model_endpoint.status.drift_status == "DRIFT_DETECTED"
 
+        assert model_endpoint.spec.model_uri == 'store://models/pr-batch-drift/sklearn_RandomForestClassifier:latest'
+
         # Validate that the artifacts were logged under the generated context
         artifacts = context.artifacts
         assert artifacts[0]["metadata"]["key"] == "drift_table_plot"

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -846,7 +846,7 @@ class TestBatchDrift(TestMLRunSystem):
         assert model_endpoint.status.current_stats
         assert model_endpoint.status.drift_status == "DRIFT_DETECTED"
 
-        assert model_endpoint.spec.model_uri == 'store://models/pr-batch-drift/sklearn_RandomForestClassifier:latest'
+        assert model_endpoint.spec.model_uri == f"store://models/{project.metadata.name}/{model_name}:latest"
 
         # Validate that the artifacts were logged under the generated context
         artifacts = context.artifacts

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -846,12 +846,16 @@ class TestBatchDrift(TestMLRunSystem):
         assert model_endpoint.status.current_stats
         assert model_endpoint.status.drift_status == "DRIFT_DETECTED"
 
-        assert model_endpoint.spec.model_uri == f"store://models/{project.metadata.name}/{model_name}:latest"
-
         # Validate that the artifacts were logged under the generated context
         artifacts = context.artifacts
         assert artifacts[0]["metadata"]["key"] == "drift_table_plot"
         assert artifacts[1]["metadata"]["key"] == "features_drift_results"
+
+        # Validate that model_uri is based on models prefix
+        assert (
+            model_endpoint.spec.model_uri
+            == f"store://models/{project.metadata.name}/{model_name}:latest"
+        )
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured


### PR DESCRIPTION
Verify that the `model_endpoint.spec.model_uri` value represents a store uri of `models`. In addition, we also verify that during the model endpoint deployment the `model_uri` does represent a valid `ModelArtifact` object. 

Related JIRA: https://jira.iguazeng.com/browse/ML-4611