### PR TITLE
[HTTPDB] Add retriable invalid chunks exceptions

### DIFF
--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -58,6 +58,9 @@ class HTTPSessionWithRetry(requests.Session):
         requests.exceptions.ConnectTimeout,
         requests.exceptions.ReadTimeout,
         urllib3.exceptions.ReadTimeoutError,
+        # may occur when connection breaks during the request.
+        requests.exceptions.ChunkedEncodingError,
+        urllib3.exceptions.InvalidChunkLength,
     ]
 
     def __init__(


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4532
We saw in this bug that the client request for run logs is being thrown due to timeout error.
Prior to the request we see logs of connection closed in the middle of sending a response which may corrupt the connection buffers. Hopefully if we retry it will create a new connection with new buffers.