### PR TITLE
[Pipelines] Delete Kubeflow experiments along with its related MLRun project

### DIFF
--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -161,9 +161,11 @@ class Projects(
         )
         if mlrun.mlconf.resolve_kfp_url():
             logger.debug("Removing KFP pipelines runs for project", project=name)
-            mlrun.api.crud.pipelines.Pipelines().delete_pipelines_runs(
+            pipelines = mlrun.api.crud.pipelines.Pipelines()
+            pipelines.delete_pipelines_runs(
                 db_session=session, project=name
             )
+            pipelines.delete_experiments(project=name)
 
         # log collector service will delete the logs, so we don't need to do it here
         if (

--- a/mlrun/api/crud/projects.py
+++ b/mlrun/api/crud/projects.py
@@ -162,9 +162,7 @@ class Projects(
         if mlrun.mlconf.resolve_kfp_url():
             logger.debug("Removing KFP pipelines runs for project", project=name)
             pipelines = mlrun.api.crud.pipelines.Pipelines()
-            pipelines.delete_pipelines_runs(
-                db_session=session, project=name
-            )
+            pipelines.delete_pipelines_runs(db_session=session, project=name)
             pipelines.delete_experiments(project=name)
 
         # log collector service will delete the logs, so we don't need to do it here


### PR DESCRIPTION
[ML-4163](https://jira.iguazeng.com/browse/ML-4163)

When a project is deleted with the cascading strategy, Kubeflow experiments related to said project must also be deleted alongside other resources.

For now, however, clearing Kubeflow Executions and Artifacts is blocked by a lack of API support on the [ML Metadata (MLMD)](https://github.com/google/ml-metadata/) database, that is leveraged by Kubeflow to store information about machine learning workloads on MySQL. 

We have the option of clearing such metadata by connecting to the MySQL database directly, but that might lead to some data consistency issues. If this is an avenue that interests us, let me know and I'll prepare a strategy for it.