### PR TITLE
[Datastore] Fix issue when parquet target path is directory but the parquet isn't partitioned

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -554,7 +554,7 @@ class BaseStoreTarget(DataTargetBase):
                 target_df,
                 self.storage_options or storage_options,
                 target_path,
-                partition_cols=partition_cols,
+                partition_cols=partition_cols or [],
                 **kwargs,
             )
             try:

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -544,11 +544,7 @@ class BaseStoreTarget(DataTargetBase):
                             break
                 # Partitioning will be performed on timestamp_key and then on self.partition_cols
                 # (We might want to give the user control on this order as additional functionality)
-                partition_cols = (
-                    partition_cols + (self.partition_cols or [])
-                    if partition_cols
-                    else self.partition_cols
-                ) or []
+                partition_cols += self.partition_cols or []
             storage_options = self._get_store().get_storage_options()
             self._write_dataframe(
                 target_df,

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -548,13 +548,13 @@ class BaseStoreTarget(DataTargetBase):
                     partition_cols + (self.partition_cols or [])
                     if partition_cols
                     else self.partition_cols
-                )
+                ) or []
             storage_options = self._get_store().get_storage_options()
             self._write_dataframe(
                 target_df,
                 self.storage_options or storage_options,
                 target_path,
-                partition_cols=partition_cols or [],
+                partition_cols=partition_cols,
                 **kwargs,
             )
             try:


### PR DESCRIPTION
Fix `feature_store/test_feature_store.py::TestFeatureStore::test_pandas_write_parquet` - Failed after #4216