### PR TITLE
[Runtimes] Add handler and empty kinds to abortable runtimes

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -683,7 +683,6 @@ def _process_runtime(command, runtime, kind):
     if not runtime:
         runtime = {}
     update_in(runtime, "spec.command", command)
-    runtime["kind"] = kind
     if kind != RuntimeKinds.remote:
         if command:
             update_in(runtime, "spec.command", command)

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -132,6 +132,8 @@ class RuntimeKinds(object):
             RuntimeKinds.mpijob,
             RuntimeKinds.databricks,
             RuntimeKinds.local,
+            RuntimeKinds.handler,
+            "",
         ]
 
     @staticmethod

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -66,7 +66,7 @@ def test_create_local_function_for_execution():
     assert runtime.metadata.project == "default"
     assert runtime.metadata.name == "test"
     assert run.spec.handler == handler
-    assert runtime.kind == ""
+    assert runtime.kind == "local"
     assert runtime._is_run_local
 
 
@@ -91,7 +91,7 @@ def test_create_local_function_for_execution_with_enrichment():
     assert runtime.metadata.name == "other_name"
     assert runtime.spec.workdir == "some_workdir"
     assert run.spec.handler == "handler_v2"
-    assert runtime.kind == ""
+    assert runtime.kind == "local"
     assert runtime._is_run_local
     assert runtime.spec.allow_empty_resources
 

--- a/tests/run/test_run_local.py
+++ b/tests/run/test_run_local.py
@@ -121,7 +121,7 @@ def test_force_run_local():
     result = mlrun.run_function(fn, base_task=spec, workdir=out_path)
     print(result.to_yaml())
     verify_state(result)
-    assert not result.metadata.labels["kind"]
+    assert result.metadata.labels["kind"] == "local"
 
     mlrun.mlconf.force_run_local = old_force
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4579
empty kind is considered local or handler