### PR TITLE
[Datastore] Fix issue when parquet target path is directory but the parquet isn't partitioned  [1.5.x]

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -544,11 +544,7 @@ class BaseStoreTarget(DataTargetBase):
                             break
                 # Partitioning will be performed on timestamp_key and then on self.partition_cols
                 # (We might want to give the user control on this order as additional functionality)
-                partition_cols = (
-                    partition_cols + (self.partition_cols or [])
-                    if partition_cols
-                    else self.partition_cols
-                )
+                partition_cols += self.partition_cols or []
             storage_options = self._get_store().get_storage_options()
             self._write_dataframe(
                 target_df,


### PR DESCRIPTION
Cherry-picked from #4292 development PR.

First introduced in #4287.