### PR TITLE
[Requirements] Bump v3io-frames to 0.10.7 [1.5.x]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pydantic~=1.10, >=1.10.8
 # blacklist 3.8.12 due to a bug not being able to collect traceback of exceptions
 orjson~=3.3, <3.8.12
 mergedeep~=1.3
-v3io-frames~=0.10.4
+v3io-frames~=0.10.7
 semver~=3.0
 dask~=2021.11.2
 distributed~=2021.11.2


### PR DESCRIPTION
Backport of #4289.

[IG-21969](https://jira.iguazeng.com/browse/IG-21969)