### PR TITLE
[Model Monitoring] Fix generating `function_uri` when calling `get_or_create_model_endpoint`

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -415,8 +415,8 @@ def _generate_model_endpoint(
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Please provide either a function name or a valid MLRun context"
             )
-        # Get the function hash from the provided context
-        (_, _, _, function_name,) = mlrun.common.helpers.parse_versioned_object_uri(
+        # Get the function name from the provided context
+        (_, function_name, _, _,) = mlrun.common.helpers.parse_versioned_object_uri(
             context.to_dict()["spec"]["function"]
         )
 

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -405,22 +405,17 @@ def _generate_model_endpoint(
 
     :return `mlrun.model_monitoring.model_endpoint.ModelEndpoint` object.
     """
-
     model_endpoint = ModelEndpoint()
     model_endpoint.metadata.project = project
     model_endpoint.metadata.uid = endpoint_id
-
-    if not function_name:
-        if not context:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "Please provide either a function name or a valid MLRun context"
-            )
-        # Get the function name from the provided context
-        (_, function_name, _, _,) = mlrun.common.helpers.parse_versioned_object_uri(
-            context.to_dict()["spec"]["function"]
+    if function_name:
+        model_endpoint.spec.function_uri = project + "/" + function_name
+    elif not context:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Please provide either a function name or a valid MLRun context"
         )
-
-    model_endpoint.spec.function_uri = project + "/" + function_name
+    else:
+        model_endpoint.spec.function_uri = context.to_dict()["spec"]["function"]
     model_endpoint.spec.model_uri = model_path
     model_endpoint.spec.model = model_endpoint_name
     model_endpoint.spec.model_class = "drift-analysis"

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -857,6 +857,12 @@ class TestBatchDrift(TestMLRunSystem):
             == f"store://models/{project.metadata.name}/{model_name}:latest"
         )
 
+        # Validate that function_uri is based on project and function name
+        assert (
+            model_endpoint.spec.function_uri
+            == f"{project.metadata.name}/batch-drift-function"
+        )
+
 
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise


### PR DESCRIPTION
When generating a new model endpoint using `get_or_create_model_endpoint` the function URI format is based on `<project>/<function hash>` which is invalid - the uri must contain the function name in it.

In this PR we fix that issue and generate the function uri based on `<project>/<function name>`. 

Related JIRA: https://jira.iguazeng.com/browse/ML-4630