### PR TITLE
[Model Monitoring] Send a notification when an app reports "detected" status

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -263,7 +263,7 @@ class ResultKindApp(enum.Enum):
     system_performance = 3
 
 
-class ResultStatusApp(enum.Enum):
+class ResultStatusApp(enum.IntEnum):
     """
     Enum for the result status values, detected means that the app detected some problem.
     """


### PR DESCRIPTION
A part of [ML-4394](https://jira.iguazeng.com/browse/ML-4394)

Tested locally and with mocks.
Note that a Slack application and NOT a workflow is expected.

To use this feature, set the webhook secret as an [MLRun secret](https://docs.mlrun.org/en/stable/secrets.html#mlrun-managed-secrets).