### PR TITLE
[Function Docs] Fix wrongly reporting default param values when parsing function entrypoint

### DIFF
--- a/mlrun/runtimes/funcdoc.py
+++ b/mlrun/runtimes/funcdoc.py
@@ -16,6 +16,8 @@ import ast
 import inspect
 import re
 
+from deprecated import deprecated
+
 from mlrun.model import FunctionEntrypoint
 
 
@@ -27,7 +29,7 @@ def type_name(ann):
 
 def inspect_default(value):
     if value is inspect.Signature.empty:
-        return ""
+        return None
     return repr(value)
 
 
@@ -41,12 +43,14 @@ def inspect_param(param: inspect.Parameter) -> dict:
 # We're using dict and not classes (here and in func_dict) since this goes
 # directly to YAML
 def param_dict(name="", type="", doc="", default=""):
-    return {
-        "default": default,
+    return_value = {
         "doc": doc,
         "name": name,
         "type": type,
     }
+    if default is not None:
+        return_value["default"] = default
+    return return_value
 
 
 def func_dict(
@@ -69,6 +73,12 @@ def func_dict(
     }
 
 
+# TODO: remove in 1.7.0
+@deprecated(
+    version="1.5.0",
+    reason="'func_info' is deprecated and will be removed in 1.7.0, use 'ast_func_info' instead",
+    category=FutureWarning,
+)
 def func_info(fn) -> dict:
     sig = inspect.signature(fn)
     doc = inspect.getdoc(fn) or ""
@@ -204,7 +214,6 @@ def ast_param_dict(param: ast.arg) -> dict:
         "name": param.arg,
         "type": ann_type(param.annotation) if param.annotation else "",
         "doc": "",
-        "default": "",
     }
 
 

--- a/tests/runtimes/info_cases.yml
+++ b/tests/runtimes/info_cases.yml
@@ -28,7 +28,6 @@
         - name: n
           type: int
           doc: ""
-          default: ""
       lineno: 1
       has_varargs: false
       has_kwargs: false
@@ -48,7 +47,6 @@
         - name: n
           type: ""
           doc: ""
-          default: ""
       lineno: 1
       has_varargs: false
       has_kwargs: false
@@ -74,7 +72,6 @@
         - name: n
           type: int
           doc: number to increment
-          default: ""
       lineno: 1
       has_varargs: false
       has_kwargs: false
@@ -95,7 +92,6 @@
         - name: n
           type: int
           doc: ""
-          default: ""
         - name: delta
           type: int
           doc: ""
@@ -127,7 +123,6 @@
         - name: context
           type: ""
           doc: ""
-          default: ""
         - name: target_dir
           type: str
           doc: "target directory"

--- a/tests/runtimes/test_funcdoc.py
+++ b/tests/runtimes/test_funcdoc.py
@@ -99,7 +99,7 @@ find_handlers_expected = [
         "name": "inc",
         "doc": "",
         "return": funcdoc.param_dict(),
-        "params": [funcdoc.param_dict("n")],
+        "params": [funcdoc.param_dict("n", default=None)],
         "lineno": 6,
         "has_varargs": False,
         "has_kwargs": False,


### PR DESCRIPTION
When MLRun parses function signature as part of the `code_to_function` flow, the `ast_func_info` function parses the function source code. When parsing the function parameters it adds an empty default value even if there is no default at all. Meaning, there's no difference between these two functions:
```
def f1(n: str):
    ...

def f2(n: str = ""):
    ...
```

Both of these functions will produce the same entrypoint where the `n` parameter will have a `"default": ""` value.
This means that the UI, for example, cannot distinguish between a mandatory parameter (such as in `f1`) and a parameter that can be skipped since it has a default (like in `f2`).

This PR fixes this, such that if no default value exists, there will not be a `default` entry for the parameter.

Also as part of this I'm deprecating the `func_info` function, which I could find no usage of anywhere. I still fixed it, but it should be removed if it's of no use whatsoever.

Fixes [ML-4643](https://jira.iguazeng.com/browse/ML-4643)