### PR TITLE
[Notifications] Remove notification params from MLRUN_EXEC_CONFIG

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1220,15 +1220,21 @@ class RunObject(RunTemplate):
         return cls(template.spec, template.metadata)
 
     def to_json(self, exclude=None, **kwargs):
+        # Since the `params` attribute within each notification object can be large,
+        # it has the potential to cause errors and is unnecessary for the notification functionality.
+        # Therefore, in this section, we remove the `params` attribute from each notification object.
         if (
             exclude_notifications_params := kwargs.get("exclude_notifications_params")
         ) and exclude_notifications_params:
             if self.spec.notifications:
+                # Extract and remove 'params' from notification
                 extracted_params = []
                 for notification in self.spec.notifications:
                     extracted_params.append(notification.params)
-                    del notification.params  # Remove params from the object
+                    del notification.params
+                # Generate the JSON representation, excluding specified fields
                 json_obj = super().to_json(exclude=exclude)
+                # Restore 'params' back to the notifications
                 for notification, params in zip(
                     self.spec.notifications, extracted_params
                 ):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1227,7 +1227,7 @@ class RunObject(RunTemplate):
             exclude_notifications_params := kwargs.get("exclude_notifications_params")
         ) and exclude_notifications_params:
             if self.spec.notifications:
-                # Extract and remove 'params' from notification
+                # Extract and remove 'params' from each notification
                 extracted_params = []
                 for notification in self.spec.notifications:
                     extracted_params.append(notification.params)

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -33,6 +33,7 @@ import mlrun.common.schemas.notification
 from .utils import (
     dict_to_json,
     dict_to_yaml,
+    exclude_notification_params_from_run_object,
     fill_project_path_template,
     get_artifact_target,
     is_legacy_artifact,
@@ -1198,7 +1199,7 @@ class RunTemplate(ModelObj):
         return self
 
     def to_env(self):
-        environ["MLRUN_EXEC_CONFIG"] = self.to_json()
+        environ["MLRUN_EXEC_CONFIG"] = exclude_notification_params_from_run_object(self)
 
 
 class RunObject(RunTemplate):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -16,6 +16,7 @@ import getpass
 import http
 import re
 import warnings
+from copy import deepcopy
 from base64 import b64encode
 from os import environ
 from typing import Callable, Dict, List, Optional, Union
@@ -403,7 +404,13 @@ class BaseRuntime(ModelObj):
             "MLRUN_DEFAULT_PROJECT": self.metadata.project or config.default_project
         }
         if runobj:
-            runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json()
+            # Since the `params` attribute within each notification object can be large,
+            # it has the potential to cause errors and is unnecessary for the notification functionality.
+            # Therefore, in this section, we remove the `params` attribute from each notification object.
+            runobj_for_exec_config = deepcopy(runobj)
+            for notification in runobj_for_exec_config.spec.notifications:
+                notification.params = {}
+            runtime_env["MLRUN_EXEC_CONFIG"] = runobj_for_exec_config.to_json()
             if runobj.metadata.project:
                 runtime_env["MLRUN_DEFAULT_PROJECT"] = runobj.metadata.project
             if runobj.spec.verbose:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -43,7 +43,6 @@ from ..utils import (
     dict_to_json,
     dict_to_yaml,
     enrich_image_url,
-    exclude_notification_params_from_run_object,
     get_in,
     get_parsed_docker_registry,
     logger,
@@ -404,9 +403,9 @@ class BaseRuntime(ModelObj):
             "MLRUN_DEFAULT_PROJECT": self.metadata.project or config.default_project
         }
         if runobj:
-            runtime_env[
-                "MLRUN_EXEC_CONFIG"
-            ] = exclude_notification_params_from_run_object(runobj)
+            runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json(
+                exclude_notifications_params=True
+            )
             if runobj.metadata.project:
                 runtime_env["MLRUN_DEFAULT_PROJECT"] = runobj.metadata.project
             if runobj.spec.verbose:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -404,9 +404,6 @@ class BaseRuntime(ModelObj):
             "MLRUN_DEFAULT_PROJECT": self.metadata.project or config.default_project
         }
         if runobj:
-            # Since the `params` attribute within each notification object can be large,
-            # it has the potential to cause errors and is unnecessary for the notification functionality.
-            # Therefore, in this section, we remove the `params` attribute from each notification object.
             runtime_env[
                 "MLRUN_EXEC_CONFIG"
             ] = exclude_notification_params_from_run_object(runobj)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -16,7 +16,6 @@ import getpass
 import http
 import re
 import warnings
-from copy import deepcopy
 from base64 import b64encode
 from os import environ
 from typing import Callable, Dict, List, Optional, Union
@@ -44,6 +43,7 @@ from ..utils import (
     dict_to_json,
     dict_to_yaml,
     enrich_image_url,
+    exclude_notification_params_from_run_object,
     get_in,
     get_parsed_docker_registry,
     logger,
@@ -407,10 +407,9 @@ class BaseRuntime(ModelObj):
             # Since the `params` attribute within each notification object can be large,
             # it has the potential to cause errors and is unnecessary for the notification functionality.
             # Therefore, in this section, we remove the `params` attribute from each notification object.
-            runobj_for_exec_config = deepcopy(runobj)
-            for notification in runobj_for_exec_config.spec.notifications:
-                notification.params = {}
-            runtime_env["MLRUN_EXEC_CONFIG"] = runobj_for_exec_config.to_json()
+            runtime_env[
+                "MLRUN_EXEC_CONFIG"
+            ] = exclude_notification_params_from_run_object(runobj)
             if runobj.metadata.project:
                 runtime_env["MLRUN_DEFAULT_PROJECT"] = runobj.metadata.project
             if runobj.spec.verbose:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -197,7 +197,7 @@ def verify_field_regex(
         return False
 
 
-def exclude_notification_params_from_run_object(run_object: mlrun.model.RunTemplate):
+def exclude_notification_params_from_run_object(run_object):
     run_object_json = run_object.to_json()
     for notification in run_object_json.spec.notifications:
         if hasattr(notification, "params"):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -197,6 +197,14 @@ def verify_field_regex(
         return False
 
 
+def exclude_notification_params_from_run_object(run_object: mlrun.model.RunTemplate):
+    run_object_json = run_object.to_json()
+    for notification in run_object_json.spec.notifications:
+        if hasattr(notification, "params"):
+            del notification.params
+    return run_object_json
+
+
 def validate_builder_source(
     source: str, pull_at_runtime: bool = False, workdir: str = None
 ):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -198,11 +198,17 @@ def verify_field_regex(
 
 
 def exclude_notification_params_from_run_object(run_object):
-    run_object_json = run_object.to_json()
-    for notification in run_object_json.spec.notifications:
-        if hasattr(notification, "params"):
-            del notification.params
-    return run_object_json
+    # Since the `params` attribute within each notification object can be large,
+    # it has the potential to cause errors and is unnecessary for the notification functionality.
+    # Therefore, in this section, we remove the `params` attribute from each notification object.
+    run_object_dict = run_object.to_dict()
+    if run_object.spec.notifications:
+        modified_notifications = [
+            {k: v for k, v in notification.items() if k != "params"}
+            for notification in run_object.spec.notifications
+        ]
+        run_object_dict["spec"]["notifications"] = modified_notifications
+    return dict_to_json(run_object_dict)
 
 
 def validate_builder_source(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -197,20 +197,6 @@ def verify_field_regex(
         return False
 
 
-def exclude_notification_params_from_run_object(run_object):
-    # Since the `params` attribute within each notification object can be large,
-    # it has the potential to cause errors and is unnecessary for the notification functionality.
-    # Therefore, in this section, we remove the `params` attribute from each notification object.
-    run_object_dict = run_object.to_dict()
-    if run_object.spec.notifications:
-        modified_notifications = [
-            {k: v for k, v in notification.items() if k != "params"}
-            for notification in run_object.spec.notifications
-        ]
-        run_object_dict["spec"]["notifications"] = modified_notifications
-    return dict_to_json(run_object_dict)
-
-
 def validate_builder_source(
     source: str, pull_at_runtime: bool = False, workdir: str = None
 ):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
+
 import mlrun.common.schemas
 import mlrun.runtimes
 
@@ -20,3 +22,75 @@ def test_enum_yaml_dump():
     function = mlrun.new_function("function-name", kind="job")
     function.status.state = mlrun.common.schemas.FunctionState.ready
     print(function.to_yaml())
+
+
+@pytest.mark.parametrize(
+    "exclude_params,expected_result,is_empty",
+    [
+        (
+            True,
+            (
+                '{"spec": {"outputs": [], "secret_sources": [], "notifications": [{"kind": '
+                '"webhook", "name": "notification-test", "message": "completed", "severity": '
+                '"info", "when": ["completed", "error"], "condition": ""}]}, "metadata": '
+                '{"iteration": 0}, "status": {"state": "created"}}'
+            ),
+            False,
+        ),
+        (
+            False,
+            (
+                '{"spec": {"outputs": [], "secret_sources": [], "notifications": [{"kind": '
+                '"webhook", "name": "notification-test", "message": "completed", "severity": '
+                '"info", "when": ["completed", "error"], "condition": "", "params": {"url": '
+                '"https://url", "method": "PUT", "override_body": "AAAAAAAAAAAAAAAAAAAA"}}]}, '
+                '"metadata": {"iteration": 0}, "status": {"state": "created"}}'
+            ),
+            False,
+        ),
+        (
+            True,
+            (
+                '{"spec": {"outputs": [], "secret_sources": []}, "metadata": {"iteration": '
+                '0}, "status": {"state": "created"}}'
+            ),
+            True,
+        ),
+        (
+            False,
+            (
+                '{"spec": {"outputs": [], "secret_sources": []}, "metadata": {"iteration": '
+                '0}, "status": {"state": "created"}}'
+            ),
+            True,
+        ),
+    ],
+)
+def test_runobject_to_json_with_exclude_params(
+    exclude_params, expected_result, is_empty
+):
+    run_object_to_test = mlrun.model.RunObject()
+    notification = mlrun.model.Notification(
+        kind="webhook",
+        when=["completed", "error"],
+        name="notification-test",
+        message="completed",
+        condition="",
+        severity="info",
+        params={"url": "https://url", "method": "PUT", "override_body": "A" * 20},
+    )
+
+    run_object_to_test.spec.notifications = [] if is_empty else [notification]
+
+    # Call the to_json function with the exclude_notifications_params parameter
+    json_result = run_object_to_test.to_json(
+        exclude_notifications_params=exclude_params
+    )
+
+    # Check if the JSON result matches the expected result
+    assert json_result == expected_result
+
+    # Ensure the 'params' attribute of the notification is set back to the object
+    if not is_empty:
+        for notification in run_object_to_test.spec.notifications:
+            assert notification.params


### PR DESCRIPTION
resolves: [ML-4523](https://jira.iguazeng.com/browse/ML-4523)

The notification params attribute was included in the MLRUN_EXEC_CONFIG of the runtime pod, and when it was large it caused the argument list too long error. It is not necessary or in use, so it can be excluded.