### PR TITLE
[Tests] Fix a model monitoring system test

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -568,12 +568,7 @@ class TestVotingModelMonitoring(TestMLRunSystem):
 
         # validate monitoring feature set features and target
         m_fs = fs_list[0]
-        assert list(m_fs.spec.features.keys()) == [
-            "sepal_length_cm",
-            "sepal_width_cm",
-            "petal_length_cm",
-            "petal_width_cm",
-        ]
+        assert list(m_fs.spec.features.keys()) == columns + ["label"]
         assert m_fs.status.to_dict()["targets"][0]["kind"] == "parquet"
 
         # checking that stream processing and batch monitoring were successfully deployed


### PR DESCRIPTION
Following the MM apps framework, the extra columns in the data are marked as "labels".
This should fix the following error:
https://github.com/mlrun/mlrun/actions/runs/6238236180/job/16936024769#step:6:2699

I ran it locally and it passed.
(`columns` is defined in L505.)