### PR TITLE
[Function Docs] Fix return type parsing + `kwargs`/`varargs` detection fix

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1456,12 +1456,23 @@ class EntrypointParam(ModelObj):
 
 
 class FunctionEntrypoint(ModelObj):
-    def __init__(self, name="", doc="", parameters=None, outputs=None, lineno=-1):
+    def __init__(
+        self,
+        name="",
+        doc="",
+        parameters=None,
+        outputs=None,
+        lineno=-1,
+        has_varargs=None,
+        has_kwargs=None,
+    ):
         self.name = name
         self.doc = doc
         self.parameters = [] if parameters is None else parameters
         self.outputs = [] if outputs is None else outputs
         self.lineno = lineno
+        self.has_varargs = has_varargs
+        self.has_kwargs = has_kwargs
 
 
 def new_task(

--- a/mlrun/runtimes/funcdoc.py
+++ b/mlrun/runtimes/funcdoc.py
@@ -21,9 +21,9 @@ from deprecated import deprecated
 from mlrun.model import FunctionEntrypoint
 
 
-def type_name(ann):
+def type_name(ann, empty_is_none=False):
     if ann is inspect.Signature.empty:
-        return ""
+        return None if empty_is_none else ""
     return getattr(ann, "__name__", str(ann))
 
 
@@ -87,7 +87,9 @@ def func_info(fn) -> dict:
         name=fn.__name__,
         doc=doc,
         params=[inspect_param(p) for p in sig.parameters.values()],
-        returns=param_dict(type=type_name(sig.return_annotation)),
+        returns=param_dict(
+            type=type_name(sig.return_annotation, empty_is_none=True), default=None
+        ),
         lineno=func_lineno(fn),
     )
 

--- a/mlrun/runtimes/funcdoc.py
+++ b/mlrun/runtimes/funcdoc.py
@@ -183,7 +183,9 @@ def parse_rst(docstring: str):
 
 def ast_func_info(func: ast.FunctionDef):
     doc = ast.get_docstring(func) or ""
-    rtype = getattr(func.returns, "id", "")
+    rtype = None
+    if func.returns:
+        rtype = ast.unparse(func.returns)
     params = [ast_param_dict(p) for p in func.args.args]
     # adds info about *args and **kwargs to the function doc
     has_varargs = func.args.vararg is not None
@@ -197,7 +199,7 @@ def ast_func_info(func: ast.FunctionDef):
         name=func.name,
         doc=doc,
         params=params,
-        returns=param_dict(type=rtype),
+        returns=param_dict(type=rtype, default=None) if rtype else None,
         lineno=func.lineno,
         has_varargs=has_varargs,
         has_kwargs=has_kwargs,
@@ -297,6 +299,8 @@ def as_func(handler):
         parameters=[clean(p) for p in handler["params"]],
         outputs=[ret] if ret else None,
         lineno=handler["lineno"],
+        has_varargs=handler["has_varargs"],
+        has_kwargs=handler["has_kwargs"],
     ).to_dict()
 
 

--- a/mlrun/runtimes/funcdoc.py
+++ b/mlrun/runtimes/funcdoc.py
@@ -199,7 +199,7 @@ def ast_func_info(func: ast.FunctionDef):
         name=func.name,
         doc=doc,
         params=params,
-        returns=param_dict(type=rtype, default=None) if rtype else None,
+        returns=param_dict(type=rtype, default=None),
         lineno=func.lineno,
         has_varargs=has_varargs,
         has_kwargs=has_kwargs,

--- a/tests/runtimes/info_cases.yml
+++ b/tests/runtimes/info_cases.yml
@@ -23,7 +23,6 @@
         name: ""
         type: int
         doc: ""
-        default: ""
       params:
         - name: n
           type: int
@@ -40,9 +39,8 @@
       doc: ""
       return:
         name: ""
-        type: ""
+        type: null
         doc: ""
-        default: ""
       params:
         - name: n
           type: ""
@@ -67,7 +65,6 @@
         name: ""
         type: int
         doc: a number
-        default: ""
       params:
         - name: n
           type: int
@@ -87,7 +84,6 @@
         name: ""
         type: int
         doc: ""
-        default: ""
       params:
         - name: n
           type: int
@@ -116,9 +112,8 @@
       doc: Open a file/object archive into a target directory
       return:
         name: ""
-        type: ""
+        type: null
         doc: "content dir"
-        default: ""
       params:
         - name: context
           type: ""

--- a/tests/runtimes/test_funcdoc.py
+++ b/tests/runtimes/test_funcdoc.py
@@ -302,7 +302,4 @@ def test_annotate_mod():
 def test_return_types(func_code, expected_return_type):
     fn: ast.FunctionDef = ast.parse(dedent(func_code)).body[0]
     func_info = funcdoc.ast_func_info(fn)
-    if expected_return_type:
-        assert func_info["return"]["type"] == expected_return_type
-    else:
-        assert func_info["return"] is None
+    assert func_info["return"]["type"] == expected_return_type

--- a/tests/runtimes/test_funcdoc.py
+++ b/tests/runtimes/test_funcdoc.py
@@ -98,7 +98,7 @@ find_handlers_expected = [
     {
         "name": "inc",
         "doc": "",
-        "return": funcdoc.param_dict(),
+        "return": funcdoc.param_dict(type=None, default=None),
         "params": [funcdoc.param_dict("n", default=None)],
         "lineno": 6,
         "has_varargs": False,


### PR DESCRIPTION
Two fixes are included in this PR that are related to the function code parsing done by `code_to_function`:

1.  In #3528 new indications were added whether the handler is receiving `**kwargs` or `*vargs`. This is useful for the UI to know whether the user is allowed to add extra parameters except those that are documented. However, this improvement was not complete since the resulting dict is going through a `FunctionEntrypoint` class which serializes it to dict and this class has no notion of those new parameters. Therefore, these were omitted from the parsed entrypoint.
2. The return type hint was parsed in a weird way which didn't really provide any result. Changed this to use `ast.unparse` which returns the AST node to a textual form. Also this now distinguishes between no type hint at all (would put `type: None` in the result, translating to yaml `null`) and a `-> None` hint (would put `type: "None"` that would mean the return is indeed `None`).