### PR TITLE
[Notifications] Remove notification params from MLRUN_EXEC_CONFIG 

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -403,7 +403,9 @@ class BaseRuntime(ModelObj):
             "MLRUN_DEFAULT_PROJECT": self.metadata.project or config.default_project
         }
         if runobj:
-            runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json()
+            runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json(
+                exclude_notifications_params=True
+            )
             if runobj.metadata.project:
                 runtime_env["MLRUN_DEFAULT_PROJECT"] = runobj.metadata.project
             if runobj.spec.verbose:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
+
 import mlrun.common.schemas
 import mlrun.runtimes
 
@@ -20,3 +22,75 @@ def test_enum_yaml_dump():
     function = mlrun.new_function("function-name", kind="job")
     function.status.state = mlrun.common.schemas.FunctionState.ready
     print(function.to_yaml())
+
+
+@pytest.mark.parametrize(
+    "exclude_params,expected_result,is_empty",
+    [
+        (
+            True,
+            (
+                '{"spec": {"outputs": [], "secret_sources": [], "notifications": [{"kind": '
+                '"webhook", "name": "notification-test", "message": "completed", "severity": '
+                '"info", "when": ["completed", "error"], "condition": ""}]}, "metadata": '
+                '{"iteration": 0}, "status": {"state": "created"}}'
+            ),
+            False,
+        ),
+        (
+            False,
+            (
+                '{"spec": {"outputs": [], "secret_sources": [], "notifications": [{"kind": '
+                '"webhook", "name": "notification-test", "message": "completed", "severity": '
+                '"info", "when": ["completed", "error"], "condition": "", "params": {"url": '
+                '"https://url", "method": "PUT", "override_body": "AAAAAAAAAAAAAAAAAAAA"}}]}, '
+                '"metadata": {"iteration": 0}, "status": {"state": "created"}}'
+            ),
+            False,
+        ),
+        (
+            True,
+            (
+                '{"spec": {"outputs": [], "secret_sources": []}, "metadata": {"iteration": '
+                '0}, "status": {"state": "created"}}'
+            ),
+            True,
+        ),
+        (
+            False,
+            (
+                '{"spec": {"outputs": [], "secret_sources": []}, "metadata": {"iteration": '
+                '0}, "status": {"state": "created"}}'
+            ),
+            True,
+        ),
+    ],
+)
+def test_runobject_to_json_with_exclude_params(
+    exclude_params, expected_result, is_empty
+):
+    run_object_to_test = mlrun.model.RunObject()
+    notification = mlrun.model.Notification(
+        kind="webhook",
+        when=["completed", "error"],
+        name="notification-test",
+        message="completed",
+        condition="",
+        severity="info",
+        params={"url": "https://url", "method": "PUT", "override_body": "A" * 20},
+    )
+
+    run_object_to_test.spec.notifications = [] if is_empty else [notification]
+
+    # Call the to_json function with the exclude_notifications_params parameter
+    json_result = run_object_to_test.to_json(
+        exclude_notifications_params=exclude_params
+    )
+
+    # Check if the JSON result matches the expected result
+    assert json_result == expected_result
+
+    # Ensure the 'params' attribute of the notification is set back to the object
+    if not is_empty:
+        for notification in run_object_to_test.spec.notifications:
+            assert notification.params


### PR DESCRIPTION
resolves: [ML-4523](https://jira.iguazeng.com/browse/ML-4523)

The notification params attribute was included in the MLRUN_EXEC_CONFIG of the runtime pod, and when it was large it caused the argument list too long error. It is not necessary or in use, so it can be excluded.