### PR TITLE
[Iguazio] Filter projects being deleted

### DIFF
--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -362,7 +362,7 @@ class Client(
 
         # avoid getting projects that are in the process of being deleted
         # this is done to avoid race condition between deleting the project flow and sync mechanism
-        params["filter[operational_status]"] = f"[$ne]deleting"
+        params["filter[operational_status]"] = "[$ne]deleting"
 
         response = self._send_request_to_api(
             "GET",

--- a/mlrun/api/utils/clients/iguazio.py
+++ b/mlrun/api/utils/clients/iguazio.py
@@ -352,13 +352,17 @@ class Client(
         params = {}
         if updated_after is not None:
             time_string = updated_after.isoformat().split("+")[0]
-            params = {"filter[updated_at]": f"[$gt]{time_string}Z"}
+            params["filter[updated_at]"] = f"[$gt]{time_string}Z"
         if page_size is None:
             page_size = (
                 mlrun.mlconf.httpdb.projects.iguazio_list_projects_default_page_size
             )
         if page_size is not None:
             params["page[size]"] = int(page_size)
+
+        # avoid getting projects that are in the process of being deleted
+        # this is done to avoid race condition between deleting the project flow and sync mechanism
+        params["filter[operational_status]"] = f"[$ne]deleting"
 
         response = self._send_request_to_api(
             "GET",

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -419,6 +419,7 @@ async def test_list_project_with_updated_after(
                     mlrun.mlconf.httpdb.projects.iguazio_list_projects_default_page_size
                 )
             ],
+            "filter[operational_status]": ["[$ne]deleting"],
         }
         context.status_code = http.HTTPStatus.OK.value
         _verify_project_request_headers(request.headers, session)


### PR DESCRIPTION
Observed during delete project flow, the sync mechanism kicked in and tried to sync (aka update) a project being deleted, which took the db lock and held it for too long. this PR filters out project being deleted to simplify sync mechanism

https://jira.iguazeng.com/browse/ML-4502