### PR TITLE
[Model Monitoring] Fix drift result dictionary calculation when the value is 0

### DIFF
--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -356,7 +356,12 @@ class VirtualDrift:
             # Calculate the feature's drift mean:
             tvd = results[TotalVarianceDistance.NAME]
             hellinger = results[HellingerDistance.NAME]
-            if not tvd or not hellinger:
+            if tvd is None or hellinger is None:
+                logger.warning(
+                    "Can't calculate drift for this feature because at least one of the required"
+                    "statistical metrics is missing",
+                    feature=feature,
+                )
                 continue
             metrics_results_dictionary = (tvd + hellinger) / 2
             # Decision rule for drift detection:

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -361,6 +361,8 @@ class VirtualDrift:
                     "Can't calculate drift for this feature because at least one of the required"
                     "statistical metrics is missing",
                     feature=feature,
+                    tvd=tvd,
+                    hellinger=hellinger,
                 )
                 continue
             metrics_results_dictionary = (tvd + hellinger) / 2


### PR DESCRIPTION
When the statistical metric result (e.g. hellinger distance) is 0 it means that the reference data distribution and the new data distribution are basically the same data. 
In this PR we fix an issue in which we don't skip a 0 value when calculating the drift result dictionary for each feature. Instead, we only skip the calculation if the expected metric doesn't exist. In this case, we will log a warning message. 
Related JIRA: https://jira.iguazeng.com/browse/ML-4691