### PR TITLE
[Workflow] Fix running preloaded workflow [1.5.x]

### DIFF
--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -220,7 +220,7 @@ def _is_requested_schedule(
         return workflow_spec.schedule is not None
 
     project_workflow = _get_workflow_by_name(project, name)
-    return bool(project_workflow.get("schedule"))
+    return bool(project_workflow.get("schedule")) if project_workflow else False
 
 
 def _get_workflow_by_name(
@@ -232,14 +232,11 @@ def _get_workflow_by_name(
     :param project:     MLRun project
     :param name:        workflow name
 
-    :return: workflow as a dict if project has the workflow, otherwise raises a bad request exception
+    :return: workflow as a dict if project has the workflow
     """
     for workflow in project.spec.workflows:
         if workflow["name"] == name:
             return workflow
-    log_and_raise(
-        reason=f"workflow {name} not found in project",
-    )
 
 
 def _fill_workflow_missing_fields_from_project(
@@ -260,6 +257,8 @@ def _fill_workflow_missing_fields_from_project(
     """
     # Verifying workflow exists in project:
     workflow = _get_workflow_by_name(project, workflow_name)
+    if not workflow:
+        workflow = {}
 
     if spec:
         # Merge between the workflow spec provided in the request with existing

--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -267,7 +267,7 @@ def _fill_workflow_missing_fields_from_project(
         workflow = copy.deepcopy(workflow)
         workflow = _update_dict(workflow, spec.dict())
 
-    if not workflow["name"]:
+    if "name" not in workflow:
         log_and_raise(
             reason=f"workflow name {workflow_name} is not found"
             if not workflow

--- a/mlrun/api/api/endpoints/workflows.py
+++ b/mlrun/api/api/endpoints/workflows.py
@@ -269,7 +269,7 @@ def _fill_workflow_missing_fields_from_project(
 
     if "name" not in workflow:
         log_and_raise(
-            reason=f"workflow name {workflow_name} is not found"
+            reason=f"workflow {workflow_name} not found in project"
             if not workflow
             else "workflow spec is invalid",
         )

--- a/mlrun/api/crud/workflows.py
+++ b/mlrun/api/crud/workflows.py
@@ -52,7 +52,6 @@ class WorkflowRunners(
             name=run_name,
             project=project,
             kind=mlrun.runtimes.RuntimeKinds.job,
-            # For preventing deployment:
             image=image,
         )
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3254,6 +3254,7 @@ class HTTPRunDB(RunDBInterface):
         else:
             req["spec"] = workflow_spec
         req["spec"]["image"] = image
+        req["spec"]["name"] = name
         response = self.api_call(
             "POST",
             f"projects/{project}/workflows/{name}/submit",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3254,9 +3254,11 @@ class HTTPRunDB(RunDBInterface):
         }
         if isinstance(
             workflow_spec,
-            (mlrun.common.schemas.WorkflowSpec, mlrun.projects.pipelines.WorkflowSpec),
+            mlrun.common.schemas.WorkflowSpec,
         ):
             req["spec"] = workflow_spec.dict()
+        elif isinstance(workflow_spec, mlrun.projects.pipelines.WorkflowSpec):
+            req["spec"] = workflow_spec.to_dict()
         else:
             req["spec"] = workflow_spec
         req["spec"]["image"] = image

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3240,6 +3240,11 @@ class HTTPRunDB(RunDBInterface):
             if hasattr(workflow_spec, "image")
             else workflow_spec.get("image", None)
         )
+        workflow_name = name or (
+            workflow_spec.name
+            if hasattr(workflow_spec, "name")
+            else workflow_spec.get("name", None)
+        )
         req = {
             "arguments": arguments,
             "artifact_path": artifact_path,
@@ -3247,17 +3252,18 @@ class HTTPRunDB(RunDBInterface):
             "run_name": run_name,
             "namespace": namespace,
         }
-        if isinstance(workflow_spec, mlrun.common.schemas.WorkflowSpec):
+        if isinstance(
+            workflow_spec,
+            (mlrun.common.schemas.WorkflowSpec, mlrun.projects.pipelines.WorkflowSpec),
+        ):
             req["spec"] = workflow_spec.dict()
-        elif isinstance(workflow_spec, mlrun.projects.pipelines.WorkflowSpec):
-            req["spec"] = workflow_spec.to_dict()
         else:
             req["spec"] = workflow_spec
         req["spec"]["image"] = image
-        req["spec"]["name"] = workflow_spec.get("name", name)
+        req["spec"]["name"] = workflow_name
         response = self.api_call(
             "POST",
-            f"projects/{project}/workflows/{name}/submit",
+            f"projects/{project}/workflows/{workflow_name}/submit",
             json=req,
         )
         return mlrun.common.schemas.WorkflowResponse(**response.json())

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3254,7 +3254,7 @@ class HTTPRunDB(RunDBInterface):
         else:
             req["spec"] = workflow_spec
         req["spec"]["image"] = image
-        req["spec"]["name"] = name
+        req["spec"]["name"] = workflow_spec.get("name", name)
         response = self.api_call(
             "POST",
             f"projects/{project}/workflows/{name}/submit",


### PR DESCRIPTION
In case client want to run a workflow without explicitly set the workflow, do not force locating the workflow on project spec but simply runs it. the idea is to support backwards compatibility to the way we submitted workflows before 1.5.x.


https://jira.iguazeng.com/browse/ML-4679