### PR TITLE
[RemoteRunner] Fix sanitizing workflow spec [1.5.x]

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -787,7 +787,7 @@ class _RemoteRunner(_PipelineRunner):
             # to load the workflow file to.
             # e.g.
             # /path/to/project/workflow.py -> ./workflow.py
-            # /path/to/project/subdir/workflow.py -> ./subdir/workflow.py
+            # /path/to/project/subdir/workflow.py -> ./workflow.py
             if workflow_spec.path:
                 prefix = project.spec.get_code_path()
                 if workflow_spec.path.startswith(prefix):

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -782,6 +782,21 @@ class _RemoteRunner(_PipelineRunner):
                 project_name=project.name,
             )
 
+            # set it relative to project path
+            # as the runner pod will mount and use `load_and_run` which will use the project context
+            # to load the workflow file to.
+            # e.g.
+            # /path/to/project/workflow.py -> ./workflow.py
+            # /path/to/project/subdir/workflow.py -> ./subdir/workflow.py
+            if workflow_spec.path:
+                prefix = project.spec.get_code_path()
+                if workflow_spec.path.startswith(prefix):
+                    workflow_spec.path = workflow_spec.path.removeprefix(prefix)
+                    relative_prefix = "."
+                    if not workflow_spec.path.startswith("/"):
+                        relative_prefix += "/"
+                    workflow_spec.path = f"{relative_prefix}{workflow_spec.path}"
+
             workflow_response = run_db.submit_workflow(
                 project=project.name,
                 name=workflow_name,


### PR DESCRIPTION
When submitting remote workflow, the `load_and_run` initializes the project from a relative path. that means, when client code tries to run a workflow from an absolute path of his local path, the remote runner wont be able to detect the workflow file.
The fix removes the prefix and let the `load_and_run` relatively load the file.

e.g.:
running locally:

```python
import mlrun
project = mlrun.load_project(name="p0",  
                             context='/User/p0', 
                             url="git://github.com/someone/somewhere.git", 
                             clone=True)
```
will end up having a code located locally. to run a workflow, remotely, with a schedule, the client will invoke

```python
project.run(workflow_path="/User/p0/workflow.py", watch=False, schedule="0 */1 * * *")
```

Before the PR it would fail, because the remote pod won't have `/User/p0/workflow.py` path, as the project wont be cloned to that path but "./<project>". and the workflow would be located "./project/workflow.py", thus sanitizing to "./workflow.py" do the trick.


https://jira.iguazeng.com/browse/ML-4679