### PR TITLE
[Project] Set function to function spec only once

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2053,7 +2053,7 @@ class MlrunProject(ModelObj):
 
     def _set_function(
         self,
-        name: str,
+        resolved_function_name: str,
         tag: str,
         function_object: mlrun.runtimes.BaseRuntime,
         func: dict,
@@ -2062,10 +2062,12 @@ class MlrunProject(ModelObj):
         # if the name contains the tag we only update the tagged entry
         # if the name doesn't contain the tag (or was not specified) we update both the tagged and untagged entries
         # for consistency
-        if tag and not name.endswith(f":{tag}"):
-            self.spec.set_function(f"{name}:{tag}", function_object, func)
+        if tag and not resolved_function_name.endswith(f":{tag}"):
+            self.spec.set_function(
+                f"{resolved_function_name}:{tag}", function_object, func
+            )
 
-        self.spec.set_function(name, function_object, func)
+        self.spec.set_function(resolved_function_name, function_object, func)
 
     def remove_function(self, name):
         """remove a function from a project

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1849,7 +1849,7 @@ class MlrunProject(ModelObj):
         elif isinstance(func, str) and isinstance(handler, str):
             kind = "nuclio"
 
-        resolved_name, tag, function_object, func = self._resolved_function(
+        resolved_function_name, tag, function_object, func = self._resolved_function(
             func,
             name,
             kind,
@@ -1875,7 +1875,7 @@ class MlrunProject(ModelObj):
         )
 
         # save to project spec
-        self._set_function(name, tag, function_object, func)
+        self._set_function(resolved_function_name, tag, function_object, func)
 
         return function_object
 
@@ -1947,7 +1947,7 @@ class MlrunProject(ModelObj):
             requirements_file,
         )
 
-        self._set_function(name, tag, function_object, func)
+        self._set_function(resolved_function_name, tag, function_object, func)
         return function_object
 
     def _resolved_function(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2042,11 +2042,12 @@ class MlrunProject(ModelObj):
         # if the name doesn't contain the tag (or was not specified) we update both the tagged and untagged entries
         # for consistency
         name = name or resolved_function_name
-        if tag and not name.endswith(f":{tag}"):
-            self.spec.set_function(f"{name}:{tag}", function_object, func)
 
-        self.spec.set_function(name, function_object, func)
-        return name, function_object, func
+        return (
+            f"{name}:{tag}" if tag and not name.endswith(f":{tag}") else name,
+            function_object,
+            func,
+        )
 
     def remove_function(self, name):
         """remove a function from a project

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1849,7 +1849,7 @@ class MlrunProject(ModelObj):
         elif isinstance(func, str) and isinstance(handler, str):
             kind = "nuclio"
 
-        resolved_function_name, function_object, func = self._resolved_function(
+        resolved_name, tag, function_object, func = self._resolved_function(
             func,
             name,
             kind,
@@ -1875,7 +1875,7 @@ class MlrunProject(ModelObj):
         )
 
         # save to project spec
-        self.spec.set_function(resolved_function_name, function_object, func)
+        self._set_function(name, tag, function_object, func)
 
         return function_object
 
@@ -1935,7 +1935,7 @@ class MlrunProject(ModelObj):
 
         :returns: function object
         """
-        resolved_function_name, function_object, func = self._resolved_function(
+        resolved_function_name, tag, function_object, func = self._resolved_function(
             func,
             name,
             kind,
@@ -1946,7 +1946,8 @@ class MlrunProject(ModelObj):
             requirements,
             requirements_file,
         )
-        self.spec.set_function(resolved_function_name, function_object, func)
+
+        self._set_function(name, tag, function_object, func)
         return function_object
 
     def _resolved_function(
@@ -2044,10 +2045,27 @@ class MlrunProject(ModelObj):
         name = name or resolved_function_name
 
         return (
-            f"{name}:{tag}" if tag and not name.endswith(f":{tag}") else name,
+            name,
+            tag,
             function_object,
             func,
         )
+
+    def _set_function(
+        self,
+        name: str,
+        tag: str,
+        function_object: mlrun.runtimes.BaseRuntime,
+        func: dict,
+    ):
+        # resolved_function_name is the name without the tag or the actual function name if it was not specified
+        # if the name contains the tag we only update the tagged entry
+        # if the name doesn't contain the tag (or was not specified) we update both the tagged and untagged entries
+        # for consistency
+        if tag and not name.endswith(f":{tag}"):
+            self.spec.set_function(f"{name}:{tag}", function_object, func)
+
+        self.spec.set_function(name, function_object, func)
 
     def remove_function(self, name):
         """remove a function from a project

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2039,9 +2039,6 @@ class MlrunProject(ModelObj):
 
         function_object.metadata.tag = tag or function_object.metadata.tag or "latest"
         # resolved_function_name is the name without the tag or the actual function name if it was not specified
-        # if the name contains the tag we only update the tagged entry
-        # if the name doesn't contain the tag (or was not specified) we update both the tagged and untagged entries
-        # for consistency
         name = name or resolved_function_name
 
         return (
@@ -2053,21 +2050,18 @@ class MlrunProject(ModelObj):
 
     def _set_function(
         self,
-        resolved_function_name: str,
+        name: str,
         tag: str,
         function_object: mlrun.runtimes.BaseRuntime,
         func: dict,
     ):
-        # resolved_function_name is the name without the tag or the actual function name if it was not specified
         # if the name contains the tag we only update the tagged entry
         # if the name doesn't contain the tag (or was not specified) we update both the tagged and untagged entries
         # for consistency
-        if tag and not resolved_function_name.endswith(f":{tag}"):
-            self.spec.set_function(
-                f"{resolved_function_name}:{tag}", function_object, func
-            )
+        if tag and not name.endswith(f":{tag}"):
+            self.spec.set_function(f"{name}:{tag}", function_object, func)
 
-        self.spec.set_function(resolved_function_name, function_object, func)
+        self.spec.set_function(name, function_object, func)
 
     def remove_function(self, name):
         """remove a function from a project


### PR DESCRIPTION
Add `_set_function` method  - this method should be used in mm_app\function flows, for setting a function to the project. 