### PR TITLE
[Workflows] Minor tweaks

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -52,7 +52,7 @@ def get_workflow_engine(engine_kind, local=False):
         elif engine_kind == "remote":
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "cannot run a remote pipeline locally using `kind='remote'` and `local=True`. "
-                "in order to run a local pipeline remotely, please use `engine='remote: local'` instead"
+                "in order to run a local pipeline remotely, please use `engine='remote:local'` instead"
             )
         return _LocalRunner
     if not engine_kind or engine_kind == "kfp":

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1265,7 +1265,7 @@ class MlrunProject(ModelObj):
         :param name:          name of the workflow
         :param workflow_path: url/path for the workflow file
         :param embed:         add the workflow code into the project.yaml
-        :param engine:        workflow processing engine ("kfp" or "local")
+        :param engine:        workflow processing engine ("kfp", "local", "remote" or "remote:local")
         :param args_schema:   list of arg schema definitions (:py:class`~mlrun.model.EntrypointParam`)
         :param handler:       workflow function handler
         :param schedule:      ScheduleCronTrigger class instance or a standard crontab expression string
@@ -1285,8 +1285,9 @@ class MlrunProject(ModelObj):
                 f"Invalid 'workflow_path': '{workflow_path}'. Please provide a valid URL/path to a file."
             )
 
-        if image and engine not in ["remote"]:
-            logger.warning("Image is only relevant for remote workflows, ignoring it")
+        # engine could be "remote" or "remote:local"
+        if image and ((engine and "remote" in engine) or schedule):
+            logger.warning("Image is only relevant for 'remote' engine, ignoring it")
 
         if embed:
             if (
@@ -2496,6 +2497,8 @@ class MlrunProject(ModelObj):
         inner_engine = None
         if engine and engine.startswith("remote"):
             if ":" in engine:
+
+                # inner could be either kfp or local
                 engine, inner_engine = engine.split(":")
         elif workflow_spec.schedule:
             inner_engine = engine


### PR DESCRIPTION
added reference to remote and remote:local in docstring,  fixed warning not raised for remote:local and when no engine but schedule (which defaults to remote) is selected.

https://jira.iguazeng.com/browse/ML-4721
https://jira.iguazeng.com/browse/ML-4722