### PR TITLE
[Migrations] Set PYTHONPATH to root

### DIFF
--- a/automation/scripts/create_migration_mysql.sh
+++ b/automation/scripts/create_migration_mysql.sh
@@ -55,6 +55,7 @@ while ! docker exec migration-db mysql --user=root --password=pass -e "status" >
 	times=$(( times + 1 ))
 done
 
+export PYTHONPATH=$ROOT_DIR
 
 alembic -c "${ROOT_DIR}/server/api/alembic_mysql.ini" upgrade head
 alembic -c "${ROOT_DIR}/server/api/alembic_mysql.ini" revision --autogenerate -m "${MLRUN_MIGRATION_MESSAGE}"

--- a/automation/scripts/create_migration_sqlite.sh
+++ b/automation/scripts/create_migration_sqlite.sh
@@ -33,5 +33,7 @@ export MLRUN_HTTPDB__DSN="sqlite:///${ROOT_DIR}/server/api/migrations_sqlite/mlr
 
 cleanup
 
+export PYTHONPATH=$ROOT_DIR
+
 alembic -c "${ROOT_DIR}/server/api/alembic.ini" upgrade head
 alembic -c "${ROOT_DIR}/server/api/alembic.ini" revision --autogenerate -m "${MLRUN_MIGRATION_MESSAGE}"


### PR DESCRIPTION
In order for the alembic script to find mlrun and server modules.