### PR TITLE
[Feature Store] Revert the order of the columns in the return Dataframe when running `get_offline_features` in remote [1.5.x]

### DIFF
--- a/mlrun/feature_store/retrieval/job.py
+++ b/mlrun/feature_store/retrieval/job.py
@@ -167,7 +167,7 @@ class RemoteVectorResponse:
             if self.with_indexes:
                 columns += self.vector.status.index_keys
                 if self.vector.status.timestamp_key is not None:
-                    columns.append(self.vector.status.timestamp_key)
+                    columns.insert(0, self.vector.status.timestamp_key)
 
         file_format = kwargs.get("format")
         if not file_format:


### PR DESCRIPTION
(#4405)

(cherry picked from commit 937e9e6f81211b8489b26ba0ba0f6986c69e74d6)