### PR TITLE
[Tests] Use Hypothesis to test zero distance between the same distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/
 .ipynb_checkpoints
 .pytest_cache/
+.hypothesis/
 .vscode/
 .bin
 build

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+__pycache__/
 .aws-secrets
 .idea/
 .ipynb_checkpoints

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ aioresponses~=0.7
 requests-mock~=1.8
 httpx~=0.23.0
 deepdiff~=6.5
+hypothesis[numpy]~=6.87
 # needed for system tests
 matplotlib~=3.5
 graphviz~=0.20.0

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -96,7 +96,13 @@ class HellingerDistance(HistogramDistanceMetric, metric_name="hellinger"):
 
         :returns: Hellinger Distance
         """
-        return np.sqrt(1 - np.sum(np.sqrt(self.distrib_u * self.distrib_t)))
+        return np.sqrt(
+            max(
+                1 - np.sum(np.sqrt(self.distrib_u * self.distrib_t)),
+                0,  # numerical errors may produce small negative numbers, e.g. -1e-16.
+                # However, Cauchy-Schwarz inequality assures this number is in the range [0, 1]
+            )
+        )
 
 
 class KullbackLeiblerDivergence(HistogramDistanceMetric, metric_name="kld"):

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -47,6 +47,8 @@ class HistogramDistanceMetric(abc.ABC):
 
     :args distrib_t: array of distribution t (usually the latest dataset distribution)
     :args distrib_u: array of distribution u (usually the sample dataset distribution)
+
+    Each distribution must contain nonnegative floats that sum up to 1.0.
     """
 
     distrib_t: np.ndarray

--- a/tests/model_monitoring/test_metrics.py
+++ b/tests/model_monitoring/test_metrics.py
@@ -17,6 +17,9 @@ from typing import Type
 
 import numpy as np
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 
 from mlrun.model_monitoring.batch import (
     HellingerDistance,
@@ -31,30 +34,34 @@ from mlrun.model_monitoring.batch import (
     itertools.chain(
         [
             (
-                [
-                    0.07101131,
-                    0.25138296,
-                    0.03700347,
-                    0.06843929,
-                    0.11482246,
-                    0.1339393,
-                    0.0503426,
-                    0.05639414,
-                    0.13406714,
-                    0.08259733,
-                ],
-                [
-                    0.17719221,
-                    0.0949423,
-                    0.02982267,
-                    0.19927063,
-                    0.19288318,
-                    0.00137802,
-                    0.07398598,
-                    0.05829106,
-                    0.06771774,
-                    0.10451622,
-                ],
+                np.array(
+                    [
+                        0.07101131,
+                        0.25138296,
+                        0.03700347,
+                        0.06843929,
+                        0.11482246,
+                        0.1339393,
+                        0.0503426,
+                        0.05639414,
+                        0.13406714,
+                        0.08259733,
+                    ]
+                ),
+                np.array(
+                    [
+                        0.17719221,
+                        0.0949423,
+                        0.02982267,
+                        0.19927063,
+                        0.19288318,
+                        0.00137802,
+                        0.07398598,
+                        0.05829106,
+                        0.06771774,
+                        0.10451622,
+                    ]
+                ),
                 class_,
                 result,
             )
@@ -66,8 +73,8 @@ from mlrun.model_monitoring.batch import (
         ],
         [
             (
-                [0.0, 0.16666667, 0.33333333, 0.5],
-                [0.5, 0.33333333, 0.16666667, 0.0],
+                np.array([0.0, 0.16666667, 0.33333333, 0.5]),
+                np.array([0.5, 0.33333333, 0.16666667, 0.0]),
                 class_,
                 result,
             )
@@ -81,26 +88,39 @@ from mlrun.model_monitoring.batch import (
 )
 def test_histogram_metric_calculation(
     metric_class: Type[HistogramDistanceMetric],
-    distrib_u: list[float],
-    distrib_t: list[float],
+    distrib_u: np.ndarray,
+    distrib_t: np.ndarray,
     expected_result: float,
 ) -> None:
-    distrib_u, distrib_t = np.asarray(distrib_u), np.asarray(distrib_t)
     assert np.isclose(
         metric_class(distrib_t=distrib_t, distrib_u=distrib_u).compute(),
         expected_result,
     )
 
 
+def _norm_arr(arr: np.ndarray) -> np.ndarray:
+    arr_sum = arr.sum()
+    if not arr_sum:
+        return np.array([1])
+    return arr_sum / arr_sum.sum()
+
+
 @pytest.mark.parametrize(
-    ("distrib", "metric_class"),
-    itertools.product(
-        [[1], [0.5, 0.5], [0.2, 0, 0.1, 0.09, 0, 0.61]],
-        HistogramDistanceMetric.__subclasses__(),
-    ),
+    "metric_class",
+    HistogramDistanceMetric.__subclasses__(),
+)
+@given(
+    distrib=st.builds(
+        _norm_arr,
+        arrays(
+            dtype=np.float64,
+            elements=st.floats(min_value=0, max_value=1),
+            shape=st.integers(min_value=1, max_value=500),
+        ),
+    )
 )
 def test_same_distrib_gives_zero_distance(
-    distrib: list[float], metric_class: Type[HistogramDistanceMetric]
+    distrib: np.ndarray, metric_class: Type[HistogramDistanceMetric]
 ) -> None:
     return test_histogram_metric_calculation(
         metric_class=metric_class,

--- a/tests/model_monitoring/test_metrics.py
+++ b/tests/model_monitoring/test_metrics.py
@@ -91,10 +91,12 @@ def test_histogram_metric_calculation(
     distrib_u: np.ndarray,
     distrib_t: np.ndarray,
     expected_result: float,
+    atol: float = 1e-8,
 ) -> None:
     assert np.isclose(
         metric_class(distrib_t=distrib_t, distrib_u=distrib_u).compute(),
         expected_result,
+        atol=atol,
     )
 
 
@@ -127,4 +129,5 @@ def test_same_distrib_gives_zero_distance(
         distrib_t=distrib,
         distrib_u=distrib,
         expected_result=0,
+        atol=1e-7,
     )

--- a/tests/model_monitoring/test_metrics.py
+++ b/tests/model_monitoring/test_metrics.py
@@ -102,7 +102,7 @@ def _norm_arr(arr: np.ndarray) -> np.ndarray:
     arr_sum = arr.sum()
     if not arr_sum:
         return np.array([1])
-    return arr_sum / arr_sum.sum()
+    return arr / arr_sum.sum()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[Hypothesis](https://hypothesis.readthedocs.io/en/latest/) is a Python library that generates test data according to general requirements instead of hard-coded examples. It's a property-based testing (PBT) framework that integrates well with Pytest.

I added it to the dev requirements and used it in our test.
This test is an excellent example of the power of Hypothesis - it replaced the several chosen distribution arrays with a general formula to create them, thus covering more cases.

Resolves [ML-4647](https://jira.iguazeng.com/browse/ML-4647).

Note:
* By default, Hypothesis generates 100 examples: https://hypothesis.readthedocs.io/en/latest/settings.html#hypothesis.settings.max_examples
   In this case, the tests are fast, so it's not a problem. It can be customized per-test.
* Failures can be reproduced: https://hypothesis.readthedocs.io/en/latest/reproducing.html
   For example:
   ![image](https://github.com/mlrun/mlrun/assets/36337649/8f4d786e-196e-416b-99bd-308ef6136c0c)
* The above failure was real and fixed in 85c23ee92182075de54868fb7d92142137f079fc.
   Hypothesis found an issue that occurs because of NumPy's numerical precision in the Hellinger metric.