### PR TITLE
[Model Monitoring ] Update `_MODEL_MONITORING_COMMON_PATH` according to mlrun server split

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -33,7 +33,9 @@ from mlrun.utils import logger
 from server.api.api import deps
 from server.api.crud.model_monitoring.helpers import Seconds, seconds2minutes
 
-_MODEL_MONITORING_COMMON_PATH = pathlib.Path(__file__).parents[4] / "mlrun" / "model_monitoring"
+_MODEL_MONITORING_COMMON_PATH = (
+    pathlib.Path(__file__).parents[4] / "mlrun" / "model_monitoring"
+)
 _STREAM_PROCESSING_FUNCTION_PATH = (
     _MODEL_MONITORING_COMMON_PATH / "stream_processing.py"
 )

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -33,7 +33,7 @@ from mlrun.utils import logger
 from server.api.api import deps
 from server.api.crud.model_monitoring.helpers import Seconds, seconds2minutes
 
-_MODEL_MONITORING_COMMON_PATH = pathlib.Path(__file__).parents[3] / "model_monitoring"
+_MODEL_MONITORING_COMMON_PATH = pathlib.Path(__file__).parents[4] / "mlrun" / "model_monitoring"
 _STREAM_PROCESSING_FUNCTION_PATH = (
     _MODEL_MONITORING_COMMON_PATH / "stream_processing.py"
 )


### PR DESCRIPTION
Fix `_MODEL_MONITORING_COMMON_PATH` for the model monitoring job deployment.