### PR TITLE
[Package] Fix for inherited types unpacking

### DIFF
--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -269,7 +269,7 @@ class Packager(ABC, metaclass=_PackagerMeta):
         it matches, it looks for the artifact type in the list returned from `get_supported_artifact_types`.
 
         :param data_item:     The input data item to check if unpackable.
-        :param type_hint:     The type hint of the input to unpack.
+        :param type_hint:     The type hint of the input to unpack (the object type to be unpacked).
         :param artifact_type: The artifact type to unpack the object as.
 
         :return: True if unpackable and False otherwise.
@@ -277,8 +277,8 @@ class Packager(ABC, metaclass=_PackagerMeta):
         # Check type (ellipses means any type):
         if cls.PACKABLE_OBJECT_TYPE is not ...:
             if not TypeHintUtils.is_matching(
-                object_type=cls.PACKABLE_OBJECT_TYPE,
-                type_hint=type_hint,
+                object_type=type_hint,  # The type hint is the expected object type the MLRun function wants.
+                type_hint=cls.PACKABLE_OBJECT_TYPE,
                 reduce_type_hint=False,
             ):
                 return False

--- a/tests/package/test_usage.py
+++ b/tests/package/test_usage.py
@@ -14,7 +14,7 @@
 #
 import os
 import tempfile
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -24,6 +24,9 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OrdinalEncoder
 
 import mlrun
+from mlrun import DataItem
+from mlrun.package import DefaultPackager
+from tests.package.usage_assets import BaseClass, InheritingClass
 
 RETURNS_LOG_HINTS = [
     "my_array",
@@ -257,6 +260,114 @@ def test_parse_inputs_from_mlrun_function(rundb_mock):
         params={
             "my_int": log_artifacts_and_results_run.outputs["my_int"],
             "my_str": log_artifacts_and_results_run.outputs["my_str"],
+        },
+        artifact_path=artifact_path.name,
+        local=True,
+    )
+
+    # Clean the test outputs:
+    artifact_path.cleanup()
+
+
+class BaseClassPackager(DefaultPackager):
+    PACKABLE_OBJECT_TYPE = BaseClass
+    PACK_SUBCLASSES = True
+
+    @classmethod
+    def unpack_object(
+        cls,
+        data_item: DataItem,
+        pickle_module_name: str = "cloudpickle",
+        object_module_name: str = None,
+        python_version: str = None,
+        pickle_module_version: str = None,
+        object_module_version: str = None,
+    ) -> Any:
+        base_class = super().unpack_object(
+            data_item=data_item,
+            pickle_module_name=pickle_module_name,
+            object_module_name=object_module_name,
+            python_version=python_version,
+            pickle_module_version=pickle_module_version,
+            object_module_version=object_module_version,
+        )
+
+        # To make sure this packager unpacked the object and not the default packager, we reduce a by 1 (it will be
+        # asserted in the unpacking functions):
+        base_class.a -= 1
+
+        return base_class
+
+
+def func_to_pack_base_class(a: int, b: str = None) -> BaseClass:
+    if b:
+        return InheritingClass(a=a, b=b)
+    return BaseClass(a=a)
+
+
+def func_to_unpack_base_class(base_class: BaseClass, a: int, b: str = None):
+    assert isinstance(base_class, BaseClass)
+    assert base_class.a == a - 1
+
+
+def func_to_unpack_inheriting_class(base_class: InheritingClass, a: int, b: str = None):
+    assert isinstance(base_class, InheritingClass)
+    assert base_class.b == b
+    assert base_class.a == a - 1
+
+
+@pytest.mark.parametrize("a, b", [(10, None), (1, "a test")])
+def test_subclasses_packing_and_unpacking(rundb_mock, a: int, b: str):
+    """
+    Run the `func_to_pack_base_class` and `func_to_unpack_base_class` functions with MLRun to see the custom `BaseClass`
+    packager is packing and unpacking subclasses successfully.
+
+    :param rundb_mock: A runDB mock fixture.
+    :param a:          The `a` value for the `BaseClass` init method.
+    :param b:          The `b` value for the `InheritingClass` init method. None will mark the test to initialize a
+                       `BaseClass`.
+    """
+    # Get the project:
+    project = mlrun.get_or_create_project("default")
+
+    # Add the custom packager for `BaseClass`:
+    project.add_custom_packager(
+        packager="tests.package.test_usage.BaseClassPackager", is_mandatory=True
+    )
+
+    # Create the function:
+    mlrun_function = project.set_function(
+        func=__file__, name="test_func", kind="job", image="mlrun/mlrun"
+    )
+    artifact_path = tempfile.TemporaryDirectory()
+
+    # Run the packing function:
+    pack_run = mlrun_function.run(
+        handler="func_to_pack_base_class",
+        params={"a": a, "b": b},
+        returns=["base_class"],
+        artifact_path=artifact_path.name,
+        local=True,
+    )
+
+    # Make sure the `BaseClassPackager` packed the object:
+    unpacking_instructions = pack_run.status.artifacts[0]["spec"][
+        "unpackaging_instructions"
+    ]
+    assert unpacking_instructions["packager_name"] == BaseClassPackager.__name__
+    assert unpacking_instructions["object_type"] == (
+        f"{InheritingClass.__module__}.{InheritingClass.__name__}"
+        if b
+        else f"{BaseClass.__module__}.{BaseClass.__name__}"
+    )
+
+    # Run the unpacking function:
+    mlrun_function.run(
+        handler="func_to_unpack_inheriting_class" if b else "func_to_unpack_base_class",
+        inputs={"base_class": pack_run.outputs["base_class"]},
+        params={
+            "a": a,
+            "b": b,
         },
         artifact_path=artifact_path.name,
         local=True,

--- a/tests/package/usage_assets.py
+++ b/tests/package/usage_assets.py
@@ -1,0 +1,9 @@
+class BaseClass:
+    def __init__(self, a: int):
+        self.a = a
+
+
+class InheritingClass(BaseClass):
+    def __init__(self, a: int, b: str):
+        super().__init__(a=a)
+        self.b = b

--- a/tests/package/usage_assets.py
+++ b/tests/package/usage_assets.py
@@ -1,3 +1,19 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 class BaseClass:
     def __init__(self, a: int):
         self.a = a


### PR DESCRIPTION
Fixed a minor edge case for when user would type hint an inheriting class a packager with `PACK_SUBCLASSES=True` should catch. A test is added.