### PR TITLE
[DB] Fix submit job not using specific db session

### DIFF
--- a/mlrun/api/api/utils.py
+++ b/mlrun/api/api/utils.py
@@ -175,7 +175,7 @@ def _generate_function_and_task_from_submit_run_body(db_session: Session, data):
     else:
         if "://" in function_url:
             project_name = task.get("metadata", {}).get("project")
-            hub_function = function_url.startswith(mlrun.utils.hub_prefix)
+            hub_function = False
             db = mlrun.api.api.utils.get_run_db_instance(db_session)
             if function_url.startswith(mlrun.utils.db_prefix):
                 url = function_url.removeprefix(mlrun.utils.db_prefix)
@@ -183,7 +183,7 @@ def _generate_function_and_task_from_submit_run_body(db_session: Session, data):
                 runtime = db.get_function(name, _project_name, tag, hash_key)
                 if not runtime:
                     raise mlrun.errors.MLRunNotFoundError(
-                        f"function {name}:{tag} not found in the DB",
+                        f"Function {name}:{tag} not found in the DB",
                     )
             else:
                 url, hub_function = extend_hub_uri_if_needed(function_url, db=db)

--- a/mlrun/db/factory.py
+++ b/mlrun/db/factory.py
@@ -28,7 +28,9 @@ class RunDBFactory(
         self._last_db_url = None
         self._rundb_container = RunDBContainer()
 
-    def create_run_db(self, url="", secrets=None, force_reconnect=False):
+    def create_run_db(
+        self, url="", secrets=None, force_reconnect=False
+    ) -> mlrun.db.RunDBInterface:
         """Returns the runtime database"""
         if not url:
             url = mlrun.db.get_or_set_dburl("./")

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -24,6 +24,10 @@ from .pipelines import enrich_function_object, pipeline_context
 
 def _get_engine_and_function(function, project=None):
     is_function_object = not isinstance(function, str)
+    if not is_function_object and not function:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "function name (str) or object must be specified"
+        )
     project = project or pipeline_context.project
     if not is_function_object:
         if function.startswith(hub_prefix):

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -528,8 +528,8 @@ def import_function_to_dict(url, secrets=None):
                 raise ValueError("exec path (spec.command) must be relative")
             url = url[: url.rfind("/") + 1] + code_file
             code = get_object(url, secrets)
-            if path.dirname(code_file):
-                makedirs(path.dirname(code_file), exist_ok=True)
+            if code_dir := path.dirname(code_file):
+                makedirs(code_dir, exist_ok=True)
             with open(code_file, "wb") as fp:
                 fp.write(code)
         elif cmd:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -56,6 +56,7 @@ yaml.Dumper.ignore_aliases = lambda *args: True
 _missing = object()
 
 hub_prefix = "hub://"
+db_prefix = "db://"
 DB_SCHEMA = "store"
 
 LEGAL_TIME_UNITS = ["year", "month", "day", "hour", "minute", "second"]
@@ -698,11 +699,12 @@ def generate_artifact_uri(project, key, tag=None, iter=None):
     return artifact_uri
 
 
-def extend_hub_uri_if_needed(uri) -> Tuple[str, bool]:
+def extend_hub_uri_if_needed(uri, db=None) -> Tuple[str, bool]:
     """
     Retrieve the full uri of the item's yaml in the hub.
 
     :param uri: structure: "hub://[<source>/]<item-name>[:<tag>]"
+    :param db: DB interface
 
     :return: A tuple of:
                [0] = Extended URI of item
@@ -712,7 +714,10 @@ def extend_hub_uri_if_needed(uri) -> Tuple[str, bool]:
     if not is_hub_uri:
         return uri, is_hub_uri
 
-    db = mlrun.get_run_db()
+    # for backward compatibility
+    if not db:
+        db = mlrun.get_run_db()
+
     name = uri.removeprefix(hub_prefix)
     tag = "latest"
     source_name = ""


### PR DESCRIPTION
Fix submit function from hub due to reused session that have race condition between others using it (singleton-issue). injecting db session given by fastapi instead solves it

https://jira.iguazeng.com/browse/ML-4733