### PR TITLE
[Model] Fix model file parsing

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -949,7 +949,6 @@ def upload_extra_data(
     """upload extra data to the artifact store"""
     if not extra_data:
         return
-    # TODO: change to use `artifact.spec` when removing legacy artifacts
     target_path = artifact.target_path
     for key, item in extra_data.items():
 
@@ -970,7 +969,7 @@ def upload_extra_data(
                 os.path.join(artifact.src_path, item) if artifact.src_path else item
             )
             if not os.path.isfile(src_path):
-                raise ValueError(f"extra data file {src_path} not found")
+                raise ValueError(f"Extra data file {src_path} not found")
 
             if target_path:
                 target = os.path.join(target_path, item)

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -140,7 +140,8 @@ class ModelArtifact(Artifact):
     ):
 
         super().__init__(key, body, format=format, target_path=target_path, **kwargs)
-        if model_file and "://" in model_file:
+        model_file = str(model_file or "")
+        if model_file and "/" in model_file:
             model_dir = path.dirname(model_file)
             model_file = path.basename(model_file)
 
@@ -289,42 +290,15 @@ class ModelArtifact(Artifact):
         # if mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash outputs True and the user
         # didn't pass target_path explicitly, then target_path will be calculated right before uploading the artifact
         # using `resolve_<body/file>_target_hash_path`
-        target_model_path = (
-            path.join(self.spec.target_path, self.spec.model_file)
-            if self.spec.target_path
-            else None
+        target_model_path = None
+        if self.spec.target_path:
+            target_model_path = path.join(
+                self.spec.target_path, path.basename(self.spec.model_file)
+            )
+
+        target_model_path = self._upload_body_or_file(
+            artifact_path, target_model_path=target_model_path
         )
-        body = self.spec.get_body()
-        if body:
-            if not target_model_path:
-                (
-                    self.metadata.hash,
-                    target_model_path,
-                ) = self.resolve_body_target_hash_path(
-                    body=body, artifact_path=artifact_path
-                )
-            self._upload_body(
-                body, target=target_model_path, artifact_path=artifact_path
-            )
-        else:
-            src_model_path = _get_src_path(self, self.spec.model_file)
-            if not path.isfile(src_model_path):
-                raise ValueError(f"model file {src_model_path} not found")
-
-            if not target_model_path:
-                (
-                    self.metadata.hash,
-                    target_model_path,
-                ) = self.resolve_file_target_hash_path(
-                    source_path=src_model_path, artifact_path=artifact_path
-                )
-
-            self._upload_file(
-                src_model_path,
-                target_path=target_model_path,
-                artifact_path=artifact_path,
-            )
-
         upload_extra_data(
             artifact=self, extra_data=self.spec.extra_data, artifact_path=artifact_path
         )
@@ -341,7 +315,7 @@ class ModelArtifact(Artifact):
                 body=spec_body, artifact_path=artifact_path
             )
 
-            # if mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash outputs True, then target_path will be
+            # if mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash outputs True, then target_path
             # will point to the artifact path which is where the model and all its extra data are stored
             self.spec.target_path = (
                 artifact_path + "/"
@@ -351,12 +325,52 @@ class ModelArtifact(Artifact):
             # unlike in extra_data, which stores for each key the path to the file, in target_path we store the
             # target path dir, and because we generated the target path of the model from the artifact hash,
             # the model_file doesn't represent the actual target file name of the model, so we need to update it
-            self.spec.model_target_file = target_model_path.split("/")[-1]
+            self.spec.model_target_file = path.basename(target_model_path)
 
         spec_target_path = spec_target_path or path.join(
-            self.spec.target_path, model_spec_filename
+            self.spec.target_path, path.basename(model_spec_filename)
         )
         store_manager.object(url=spec_target_path).put(spec_body)
+
+    def _upload_body_or_file(
+        self,
+        artifact_path: str,
+        target_model_path: str = None,
+    ):
+
+        body = self.spec.get_body()
+        if body:
+            if not target_model_path:
+                (
+                    self.metadata.hash,
+                    target_model_path,
+                ) = self.resolve_body_target_hash_path(
+                    body=body, artifact_path=artifact_path
+                )
+            self._upload_body(
+                body, target=target_model_path, artifact_path=artifact_path
+            )
+
+        else:
+            src_model_path = _get_src_path(self, self.spec.model_file)
+            if not path.isfile(src_model_path):
+                raise ValueError(f"Model file {src_model_path} not found")
+
+            if not target_model_path:
+                (
+                    self.metadata.hash,
+                    target_model_path,
+                ) = self.resolve_file_target_hash_path(
+                    source_path=src_model_path, artifact_path=artifact_path
+                )
+
+            self._upload_file(
+                src_model_path,
+                target_path=target_model_path,
+                artifact_path=artifact_path,
+            )
+
+        return target_model_path
 
     def _get_file_body(self):
         body = self.spec.get_body()

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -328,7 +328,7 @@ class ModelArtifact(Artifact):
             self.spec.model_target_file = path.basename(target_model_path)
 
         spec_target_path = spec_target_path or path.join(
-            self.spec.target_path, path.basename(model_spec_filename)
+            self.spec.target_path, model_spec_filename
         )
         store_manager.object(url=spec_target_path).put(spec_body)
 

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import pathlib
 import typing
 import unittest.mock
@@ -20,7 +19,6 @@ import uuid
 from contextlib import nullcontext as does_not_raise
 
 import pytest
-import yaml
 
 import mlrun
 import mlrun.artifacts
@@ -493,36 +491,6 @@ def test_inline_body():
     )
     assert artifact.spec.get_body() == "123"
     assert artifact.metadata.key == "y"
-
-
-def test_tag_not_in_model_spec():
-    model_name = "my-model"
-    tag = "some-tag"
-    project_name = "model-spec-test"
-    artifact_path = results_dir / project_name
-
-    # create a project and log a model
-    project = mlrun.new_project(project_name, save=False)
-    project.log_model(
-        model_name,
-        body="model body",
-        model_file="trained_model.pkl",
-        tag=tag,
-        artifact_path=artifact_path,
-        upload=True,
-    )
-
-    # list the artifact path dir and verify the model spec file exists
-    model_path = artifact_path / model_name
-    files = os.listdir(model_path)
-    assert mlrun.artifacts.model.model_spec_filename in files
-
-    # open the model spec file and verify the tag is not there
-    with open(model_path / mlrun.artifacts.model.model_spec_filename) as f:
-        model_spec = yaml.load(f, Loader=yaml.FullLoader)
-
-    assert "tag" not in model_spec, "tag should not be in model spec"
-    assert "tag" not in model_spec["metadata"], "tag should not be in metadata"
 
 
 def test_register_artifacts(rundb_mock):

--- a/tests/artifacts/test_model.py
+++ b/tests/artifacts/test_model.py
@@ -1,0 +1,80 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import pathlib
+
+import pytest
+import yaml
+
+import mlrun
+import mlrun.artifacts
+from tests import conftest
+
+results_dir = (pathlib.Path(conftest.results) / "artifacts").absolute()
+model_file = pathlib.Path(__file__).parent / "assets" / "model.pkl"
+
+
+@pytest.mark.parametrize(
+    "generate_target_path_from_artifact_hash, expected_model_target_file",
+    [(True, "da39a3ee5e6b4b0d3255bfef95601890afd80709"), (False, None)],
+)
+def test_model_target_paths(
+    generate_target_path_from_artifact_hash, expected_model_target_file
+):
+    mlrun.config.config.artifacts.generate_target_path_from_artifact_hash = (
+        generate_target_path_from_artifact_hash
+    )
+    project_name = "model-target-path-test"
+    artifact_path = results_dir / project_name
+    model_key = "model"
+    model = mlrun.artifacts.ModelArtifact(key=model_key, model_file=model_file)
+
+    context = mlrun.get_or_create_ctx("test")
+    # we use log artifact and not log model as it should handle models as well
+    model = context.log_artifact(model, artifact_path=artifact_path)
+
+    assert model.target_path.startswith(str(artifact_path))
+    assert model.model_file == os.path.basename(model_file)
+    assert model.model_target_file == expected_model_target_file
+
+
+def test_tag_not_in_model_spec():
+    model_name = "my-model"
+    tag = "some-tag"
+    project_name = "model-spec-test"
+    artifact_path = results_dir / project_name
+
+    # create a project and log a model
+    project = mlrun.new_project(project_name, save=False)
+    project.log_model(
+        model_name,
+        body="model body",
+        model_file="trained_model.pkl",
+        tag=tag,
+        artifact_path=artifact_path,
+        upload=True,
+    )
+
+    # list the artifact path dir and verify the model spec file exists
+    model_path = artifact_path / model_name
+    files = os.listdir(model_path)
+    assert mlrun.artifacts.model.model_spec_filename in files
+
+    # open the model spec file and verify the tag is not there
+    with open(model_path / mlrun.artifacts.model.model_spec_filename) as f:
+        model_spec = yaml.load(f, Loader=yaml.FullLoader)
+
+    assert "tag" not in model_spec, "tag should not be in model spec"
+    assert "tag" not in model_spec["metadata"], "tag should not be in metadata"


### PR DESCRIPTION
We encountered a user that passed a full path as the `model_file` parameter to the model artifact.
This caused issues as we assume that the model_file is always just the filename.
Instead, we can help the user by splitting the path to model_dir and model_file and not assume that model_file is just the base name.