### PR TITLE
[Model Monitoring] Do not write "extra data" in V3IO TSDB

### DIFF
--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -146,6 +146,7 @@ class ModelMonitoringWriter(StepToDict):
             event[WriterEvent.SCHEDULE_TIME],
             format=EventFieldType.TIME_FORMAT,
         )
+        del event[WriterEvent.RESULT_EXTRA_DATA]
         try:
             self._tsdb_client.write(
                 backend=_TSDB_BE,


### PR DESCRIPTION
Resolves [ML-4707](https://jira.iguazeng.com/browse/ML-4707).
The other parts work as expected - in the KV we agreed to have a table per an endpoint ID with the app name as the key.

The Pydantic model of the result will come in a separate PR.