### PR TITLE
[Feature Store] Drop columns according to the user `drop_columns` param when reading the result df with `RemoteVectorResponse`  [1.5.x]

### DIFF
--- a/mlrun/feature_store/retrieval/job.py
+++ b/mlrun/feature_store/retrieval/job.py
@@ -133,16 +133,17 @@ def run_merge_job(
         watch=run_config.watch,
     )
     logger.info(f"feature vector merge job started, run id = {run.uid()}")
-    return RemoteVectorResponse(vector, run, with_indexes)
+    return RemoteVectorResponse(vector, run, with_indexes, drop_columns)
 
 
 class RemoteVectorResponse:
     """get_offline_features response object"""
 
-    def __init__(self, vector, run, with_indexes=False):
+    def __init__(self, vector, run, with_indexes=False, drop_columns=None):
         self.run = run
         self.vector = vector
         self.with_indexes = with_indexes or self.vector.spec.with_indexes
+        self.drop_columns = drop_columns
 
     @property
     def status(self):
@@ -168,6 +169,9 @@ class RemoteVectorResponse:
                 columns += self.vector.status.index_keys
                 if self.vector.status.timestamp_key is not None:
                     columns.insert(0, self.vector.status.timestamp_key)
+            if self.drop_columns:
+                for drop_col in self.drop_columns:
+                    columns.remove(drop_col)
 
         file_format = kwargs.get("format")
         if not file_format:

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -1423,6 +1423,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         target_df = target.as_df()
         target_df.set_index(key, drop=True, inplace=True)
         assert resp_df.equals(target_df)
+        assert "department" not in resp_df
 
     # ML-2802, ML-3397
     @pytest.mark.parametrize(

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -1380,6 +1380,50 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         resp_df.reset_index(drop=True, inplace=True)
         assert resp_df[["bad", "department"]].equals(expected_df)
 
+    def test_get_offline_features_with_drop_columns(self):
+        key = "patient_id"
+        measurements = fstore.FeatureSet(
+            "measurements",
+            entities=[fstore.Entity(key)],
+            engine="spark",
+        )
+        source = ParquetSource("myparquet", path=self.get_pq_source_path())
+        self.set_targets(measurements)
+        fstore.ingest(
+            measurements,
+            source,
+            spark_context=self.spark_service,
+            run_config=fstore.RunConfig(local=self.run_local),
+        )
+        assert measurements.status.targets[0].run_id is not None
+        fv_name = "measurements-fv"
+        features = [
+            "measurements.bad",
+            "measurements.department",
+        ]
+        my_fv = fstore.FeatureVector(
+            fv_name,
+            features,
+        )
+        my_fv.spec.with_indexes = True
+        my_fv.save()
+        target = ParquetTarget(
+            "mytarget", path=f"{self.output_dir()}-get_offline_features"
+        )
+        resp = fstore.get_offline_features(
+            fv_name,
+            target=target,
+            engine="spark",
+            drop_columns=["department"],
+            run_config=fstore.RunConfig(local=self.run_local, kind="remote-spark"),
+            spark_service=self.spark_service,
+        )
+
+        resp_df = resp.to_dataframe()
+        target_df = target.as_df()
+        target_df.set_index(key, drop=True, inplace=True)
+        assert resp_df.equals(target_df)
+
     # ML-2802, ML-3397
     @pytest.mark.parametrize(
         ["target_type", "passthrough"],


### PR DESCRIPTION
 (#4424)

(cherry picked from commit d2459ba924fcabd696dff8140941058b05d00353)