### PR TITLE
[k8s] Sanitize label's values to ensure k8s compatibility

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -538,7 +538,7 @@ default_config = {
     "workflows": {
         "default_workflow_runner_name": "workflow-runner-{}",
         # Default timeout seconds for retrieving workflow id after execution:
-        "timeouts": {"local": 120, "kfp": 30},
+        "timeouts": {"local": 120, "kfp": 30, "remote": 30},
     },
     "log_collector": {
         "address": "localhost:8282",

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 import typing
 
 import kubernetes.client
@@ -119,3 +120,14 @@ def generate_preemptible_tolerations() -> typing.List[kubernetes.client.V1Tolera
             )
         )
     return toleration_objects
+
+
+def sanitize_label_value(value: str) -> str:
+    """
+    Kubernetes label values must be sanitized before they're sent to the API
+    Refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+
+    :param value: arbitrary string that needs to sanitized for usage on k8s labels
+    :return:      string fully compliant with k8s label value expectations
+    """
+    return re.sub(r"([^a-zA-Z0-9_.-]|^[^a-zA-Z0-9]|[^a-zA-Z0-9]$)", "-", value[:63])

--- a/server/api/api/endpoints/workflows.py
+++ b/server/api/api/endpoints/workflows.py
@@ -32,6 +32,7 @@ import server.api.utils.auth.verifier
 import server.api.utils.clients.chief
 import server.api.utils.singletons.db
 import server.api.utils.singletons.project_member
+from mlrun.k8s_utils import sanitize_label_value
 from mlrun.utils.helpers import logger
 from server.api.api.utils import log_and_raise
 
@@ -172,15 +173,17 @@ async def submit_workflow(
     workflow_runner.metadata.labels.update(
         {
             "job-type": "workflow-runner",
-            "workflow": workflow_request.spec.name,
+            "workflow": sanitize_label_value(workflow_request.spec.name),
         }
     )
     if client_version is not None:
-        workflow_runner.metadata.labels["mlrun/client_version"] = client_version
+        workflow_runner.metadata.labels["mlrun/client_version"] = sanitize_label_value(
+            client_version
+        )
     if client_python_version is not None:
         workflow_runner.metadata.labels[
             "mlrun/client_python_version"
-        ] = client_python_version
+        ] = sanitize_label_value(client_python_version)
     try:
         if workflow_spec.schedule:
             await run_in_threadpool(

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+from mlrun.k8s_utils import sanitize_label_value
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("my-value", "my-value"),
+        ("foo%bar", "foo-bar"),
+        (
+            "very{long}[string](value)#with#\several\|illegal|;characters;'present'",
+            "very-long--string--value--with--several--illegal--characters--p",
+        ),
+        ("0.0.0+unstable", "0.0.0-unstable"),
+    ],
+)
+def test_sanitize_label_value(value: str, expected: str):
+    assert sanitize_label_value(value) == expected

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -23,7 +23,7 @@ from mlrun.k8s_utils import sanitize_label_value
         ("my-value", "my-value"),
         ("foo%bar", "foo-bar"),
         (
-            "very{long}[string](value)#with#\several\|illegal|;characters;'present'",
+            "very{long}[string](value)#with#$several$|illegal|;characters;'present'",
             "very-long--string--value--with--several--illegal--characters--p",
         ),
         ("0.0.0+unstable", "0.0.0-unstable"),


### PR DESCRIPTION
[ML-4730](https://jira.iguazeng.com/browse/ML-4730)

When a remote runner is used to run a pipeline, its labels are also sent to the Kubernetes API, so the values used must comply to k8s' character standards. 

Refer to the following error to better understand what happens when such standards are disregarded:
https://github.com/mlrun/mlrun/actions/runs/6434045624/job/17473081675
```
Error:  :x: Workflow main run failed!, error: 400 Client Error: Bad Request for url: https://mlrun-api.default-tenant.app.mlrun-system-tests-2.iguazio-cd1.com/api/v1/projects/source-project/workflows/main/submit: details: {'reason': 'Workflow failed', 'workflow_name': 'main', 'workflow_action': 'run', 'error': '(422)\nReason: Unprocessable Entity\nHTTP response headers: HTTPHeaderDict({\'Audit-Id\': \'584d8ca4-c7b6-48e6-b7fa-008737d36d91\', \'Cache-Control\': \'no-cache, private\', \'Content-Type\': \'application/json\', \'X-Kubernetes-Pf-Flowschema-Uid\': \'99adf1f2-2bd3-4d09-a5cd-df5797914700\', \'X-Kubernetes-Pf-Prioritylevel-Uid\': \'2ef46983-2374-4711-8647-fd3048f25fbf\', \'Date\': \'Fri, 06 Oct 2023 19:45:31 GMT\', \'Content-Length\': \'926\'})\nHTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod \\"workflow-runner-main-prn5w\\" is invalid: metadata.labels: Invalid value: \\"1.5.0+dc138ead\\": a valid label must be an empty string or consist of alphanumeric characters, \'-\', \'_\' or \'.\', and must start and end with an alphanumeric character (e.g. \'MyValue\',  or \'my_value\',  or \'12345\', regex used for validation is \'(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?\')","reason":"Invalid","details":{"name":"workflow-runner-main-prn5w","kind":"Pod","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \\"1.5.0+dc138ead\\": a valid label must be an empty string or consist of alphanumeric characters, \'-\', \'_\' or \'.\', and must start and end with an alphanumeric character (e.g. \'MyValue\',  or \'my_value\',  or \'12345\', regex used for validation is \'(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?\')","field":"metadata.labels"}]},"code":422}\n\n'}
```