### PR TITLE
[Datastore] Fix reading parquet directory when using datastore profiles

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -285,7 +285,14 @@ class DataStore:
         if file_system:
             if self.supports_isdir() and file_system.isdir(file_url) or df_module == dd:
                 storage_options = self.get_storage_options()
-                if storage_options:
+                if url.startswith("ds://"):
+                    parsed_url = urllib.parse.urlparse(url)
+                    url = parsed_url.path[1:]
+                    # Pass the underlying file system
+                    kwargs["filesystem"] = file_system
+                elif storage_options:
+                    # If it's a datastore profile,
+                    # the storage_options are already incorporated into the filesystem object.
                     kwargs["storage_options"] = storage_options
                 df = reader(url, **kwargs)
             else:

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -291,8 +291,6 @@ class DataStore:
                     # Pass the underlying file system
                     kwargs["filesystem"] = file_system
                 elif storage_options:
-                    # If it's a datastore profile,
-                    # the storage_options are already incorporated into the filesystem object.
                     kwargs["storage_options"] = storage_options
                 df = reader(url, **kwargs)
             else:

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -205,6 +205,8 @@ class TestAwsS3:
 
     def test_directory(self, use_datastore_profile):
         param = self.s3["ds"] if use_datastore_profile else self.s3["s3"]
+        for p in credential_params:
+            os.environ[p] = config["env"][p]
         parquet_dir = f"/parquets{uuid.uuid4()}"
         parquets_url = param["bucket_path"] + parquet_dir
         #  generate dfs

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -14,10 +14,14 @@
 #
 import os
 import random
+import tempfile
+import uuid
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import yaml
+from pandas.testing import assert_frame_equal
 
 import mlrun
 import mlrun.errors
@@ -198,3 +202,35 @@ class TestAwsS3:
         # cleanup
         for param in params:
             os.environ.pop(param)
+
+    def test_directory(self, use_datastore_profile):
+        param = self.s3["ds"] if use_datastore_profile else self.s3["s3"]
+        parquet_dir = f"/parquets{uuid.uuid4()}"
+        parquets_url = param["bucket_path"] + parquet_dir
+        #  generate dfs
+        # Define data for the first DataFrame
+        data1 = {"Column1": [1, 2, 3], "Column2": ["A", "B", "C"]}
+
+        # Define data for the second DataFrame
+        data2 = {"Column1": [4, 5, 6], "Column2": ["X", "Y", "Z"]}
+
+        # Create the DataFrames
+        df1 = pd.DataFrame(data1)
+        df2 = pd.DataFrame(data2)
+        temp_file1 = tempfile.mktemp(suffix=".parquet")
+        temp_file2 = tempfile.mktemp(suffix=".parquet")
+        # Save DataFrames as Parquet files
+        df1.to_parquet(temp_file1, index=False)
+        df2.to_parquet(temp_file2, index=False)
+        #  upload
+        dt1 = mlrun.run.get_dataitem(parquets_url + "/df1.parquet")
+        dt2 = mlrun.run.get_dataitem(parquets_url + "/df2.parquet")
+        dt1.upload(src_path=temp_file1)
+        dt2.upload(src_path=temp_file2)
+        dt1.as_df()
+        dt2.as_df()
+        dt_dir = mlrun.run.get_dataitem(parquets_url)
+        tested_df = dt_dir.as_df(format="parquet")
+
+        expected_df = pd.concat([df1, df2], ignore_index=True)
+        assert_frame_equal(tested_df, expected_df)

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -219,20 +219,22 @@ class TestAwsS3:
         # Create the DataFrames
         df1 = pd.DataFrame(data1)
         df2 = pd.DataFrame(data2)
-        temp_file1 = tempfile.mktemp(suffix=".parquet")
-        temp_file2 = tempfile.mktemp(suffix=".parquet")
-        # Save DataFrames as Parquet files
-        df1.to_parquet(temp_file1, index=False)
-        df2.to_parquet(temp_file2, index=False)
-        #  upload
-        dt1 = mlrun.run.get_dataitem(parquets_url + "/df1.parquet")
-        dt2 = mlrun.run.get_dataitem(parquets_url + "/df2.parquet")
-        dt1.upload(src_path=temp_file1)
-        dt2.upload(src_path=temp_file2)
-        dt1.as_df()
-        dt2.as_df()
-        dt_dir = mlrun.run.get_dataitem(parquets_url)
-        tested_df = dt_dir.as_df(format="parquet")
-
-        expected_df = pd.concat([df1, df2], ignore_index=True)
-        assert_frame_equal(tested_df, expected_df)
+        with tempfile.NamedTemporaryFile(
+            suffix=".parquet", delete=True
+        ) as temp_file1, tempfile.NamedTemporaryFile(
+            suffix=".parquet", delete=True
+        ) as temp_file2:
+            # Save DataFrames as Parquet files
+            df1.to_parquet(temp_file1.name, index=False)
+            df2.to_parquet(temp_file2.name, index=False)
+            #  upload
+            dt1 = mlrun.run.get_dataitem(parquets_url + "/df1.parquet")
+            dt2 = mlrun.run.get_dataitem(parquets_url + "/df2.parquet")
+            dt1.upload(src_path=temp_file1.name)
+            dt2.upload(src_path=temp_file2.name)
+            dt1.as_df()
+            dt2.as_df()
+            dt_dir = mlrun.run.get_dataitem(parquets_url)
+            tested_df = dt_dir.as_df(format="parquet")
+            expected_df = pd.concat([df1, df2], ignore_index=True)
+            assert_frame_equal(tested_df, expected_df)


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4751
When a datastore profile directory (as opposed to a single file) is utilized to read a pandas dataframe, the appropriate filesystem is already determined and set up. However, it remains unused. This is because, while pandas attempts to create a new instance of the filesystem, mlrun doesn't forward the filesystem to pandas. As a result, pandas encounters an error due to its unfamiliarity with the 'ds://' schema. This PR rectifies this by providing the pre-established filesystem to the pandas parquet reader and removing the 'ds://prfofile' prefix from the directory URL