### PR TITLE
Revert "[Builder] Clone GitHub repository to a directory other than `/tmp`"

### DIFF
--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -14,6 +14,7 @@
 import os.path
 import pathlib
 import re
+import tempfile
 import textwrap
 import typing
 from base64 import b64decode, b64encode
@@ -494,10 +495,12 @@ def build_image(
         not runtime.spec.clone_target_dir
         or not os.path.isabs(runtime.spec.clone_target_dir)
     ):
+        # use a temp dir for permissions and set it as the workdir
+        tmpdir = tempfile.mkdtemp()
         relative_workdir = runtime.spec.clone_target_dir or ""
         relative_workdir = relative_workdir.removeprefix("./")
 
-        runtime.spec.clone_target_dir = path.join("~", relative_workdir)
+        runtime.spec.clone_target_dir = path.join(tmpdir, "mlrun", relative_workdir)
 
     dock = make_dockerfile(
         base_image,

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -806,10 +806,10 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
 @pytest.mark.parametrize(
     "clone_target_dir,expected_workdir",
     [
-        (None, r"WORKDIR ~\/"),
-        ("", r"WORKDIR ~\/"),
-        ("./path/to/code", r"WORKDIR ~\/path\/to\/code"),
-        ("rel_path", r"WORKDIR ~\/rel_path"),
+        (None, r"WORKDIR .*\/tmp.*\/mlrun"),
+        ("", r"WORKDIR .*\/tmp.*\/mlrun"),
+        ("./path/to/code", r"WORKDIR .*\/tmp.*\/mlrun\/path\/to\/code"),
+        ("rel_path", r"WORKDIR .*\/tmp.*\/mlrun\/rel_path"),
         ("/some/workdir", r"WORKDIR \/some\/workdir"),
     ],
 )
@@ -897,11 +897,15 @@ def test_builder_source(monkeypatch, source, expectation):
                 _, expected_source = os.path.split(source)
 
             if source.endswith(".zip"):
-                expected_output_re = re.compile(rf"COPY {expected_source} ~/source")
+                expected_output_re = re.compile(
+                    rf"COPY {expected_source} .*/tmp.*/mlrun/source"
+                )
                 expected_line_index = 3
 
             else:
-                expected_output_re = re.compile(rf"ADD {expected_source} ~")
+                expected_output_re = re.compile(
+                    rf"ADD {expected_source} .*/tmp.*/mlrun"
+                )
                 expected_line_index = 2
 
             assert expected_output_re.match(


### PR DESCRIPTION
Reverts mlrun/mlrun#4434

Need to redo this in a way that won't break `projects/test_project.py::TestProject::test_run_git_build`.