### PR TITLE
[Model Monitoring] Set application filename

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1786,7 +1786,7 @@ class MlrunProject(ModelObj):
 
     def set_model_monitoring_application(
         self,
-        func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,
+        func: typing.Union[str, mlrun.runtimes.BaseRuntime, None] = None,
         application_class: typing.Union[str, ModelMonitoringApplication] = None,
         name: str = None,
         image: str = None,
@@ -1824,7 +1824,10 @@ class MlrunProject(ModelObj):
         kind = None
         if (isinstance(func, str) or func is None) and application_class is not None:
             kind = "serving"
+            if func is None:
+                func = ""
             func = mlrun.code_to_function(
+                filename=func,
                 name=name,
                 project=self.metadata.name,
                 tag=tag,
@@ -1996,7 +1999,6 @@ class MlrunProject(ModelObj):
             )
 
         if isinstance(func, str):
-
             # in hub or db functions name defaults to the function name
             if not name and not (func.startswith("db://") or func.startswith("hub://")):
                 raise ValueError("Function name must be specified")
@@ -2529,7 +2531,6 @@ class MlrunProject(ModelObj):
         inner_engine = None
         if engine and engine.startswith("remote"):
             if ":" in engine:
-
                 # inner could be either kfp or local
                 engine, inner_engine = engine.split(":")
         elif workflow_spec.schedule:
@@ -2612,7 +2613,6 @@ class MlrunProject(ModelObj):
         )
         # clear only if the context path exists and not relative
         if self.spec.context and os.path.isabs(self.spec.context):
-
             # if a subpath is defined, will empty the subdir instead of the entire context
             if self.spec.subpath:
                 path_to_clear = path.join(self.spec.context, self.spec.subpath)


### PR DESCRIPTION
Allow defining an application from a file, not only from a Jupyter notebook.
Fixes [ML-4783](https://jira.iguazeng.com/browse/ML-4783).