### PR TITLE
[Builder] Clone GitHub repository to `/home/mlrun_code` instead of `/tmp`

### DIFF
--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -14,7 +14,6 @@
 import os.path
 import pathlib
 import re
-import tempfile
 import textwrap
 import typing
 from base64 import b64decode, b64encode
@@ -495,12 +494,10 @@ def build_image(
         not runtime.spec.clone_target_dir
         or not os.path.isabs(runtime.spec.clone_target_dir)
     ):
-        # use a temp dir for permissions and set it as the workdir
-        tmpdir = tempfile.mkdtemp()
         relative_workdir = runtime.spec.clone_target_dir or ""
         relative_workdir = relative_workdir.removeprefix("./")
 
-        runtime.spec.clone_target_dir = path.join(tmpdir, "mlrun", relative_workdir)
+        runtime.spec.clone_target_dir = path.join("/home", relative_workdir)
 
     dock = make_dockerfile(
         base_image,

--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -497,7 +497,7 @@ def build_image(
         relative_workdir = runtime.spec.clone_target_dir or ""
         relative_workdir = relative_workdir.removeprefix("./")
 
-        runtime.spec.clone_target_dir = path.join("/home", relative_workdir)
+        runtime.spec.clone_target_dir = path.join("/home/mlrun_code", relative_workdir)
 
     dock = make_dockerfile(
         base_image,

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -806,10 +806,10 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
 @pytest.mark.parametrize(
     "clone_target_dir,expected_workdir",
     [
-        (None, r"WORKDIR /home"),
-        ("", r"WORKDIR /home"),
-        ("./path/to/code", r"WORKDIR /home/path/to/code"),
-        ("rel_path", r"WORKDIR /home/rel_path"),
+        (None, r"WORKDIR /home/mlrun_code"),
+        ("", r"WORKDIR /home/mlrun_code"),
+        ("./path/to/code", r"WORKDIR /home/mlrun_code/path/to/code"),
+        ("rel_path", r"WORKDIR /home/mlrun_code/rel_path"),
         ("/some/workdir", r"WORKDIR /some/workdir"),
     ],
 )
@@ -897,11 +897,15 @@ def test_builder_source(monkeypatch, source, expectation):
                 _, expected_source = os.path.split(source)
 
             if source.endswith(".zip"):
-                expected_output_re = re.compile(rf"COPY {expected_source} /home/source")
+                expected_output_re = re.compile(
+                    rf"COPY {expected_source} /home/mlrun_code/source"
+                )
                 expected_line_index = 3
 
             else:
-                expected_output_re = re.compile(rf"ADD {expected_source} /home")
+                expected_output_re = re.compile(
+                    rf"ADD {expected_source} /home/mlrun_code"
+                )
                 expected_line_index = 2
 
             assert expected_output_re.match(

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -806,11 +806,11 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
 @pytest.mark.parametrize(
     "clone_target_dir,expected_workdir",
     [
-        (None, r"WORKDIR .*\/tmp.*\/mlrun"),
-        ("", r"WORKDIR .*\/tmp.*\/mlrun"),
-        ("./path/to/code", r"WORKDIR .*\/tmp.*\/mlrun\/path\/to\/code"),
-        ("rel_path", r"WORKDIR .*\/tmp.*\/mlrun\/rel_path"),
-        ("/some/workdir", r"WORKDIR \/some\/workdir"),
+        (None, r"WORKDIR /home"),
+        ("", r"WORKDIR /home"),
+        ("./path/to/code", r"WORKDIR /home/path/to/code"),
+        ("rel_path", r"WORKDIR /home/rel_path"),
+        ("/some/workdir", r"WORKDIR /some/workdir"),
     ],
 )
 def test_builder_workdir(monkeypatch, clone_target_dir, expected_workdir):
@@ -897,15 +897,11 @@ def test_builder_source(monkeypatch, source, expectation):
                 _, expected_source = os.path.split(source)
 
             if source.endswith(".zip"):
-                expected_output_re = re.compile(
-                    rf"COPY {expected_source} .*/tmp.*/mlrun/source"
-                )
+                expected_output_re = re.compile(rf"COPY {expected_source} /home/source")
                 expected_line_index = 3
 
             else:
-                expected_output_re = re.compile(
-                    rf"ADD {expected_source} .*/tmp.*/mlrun"
-                )
+                expected_output_re = re.compile(rf"ADD {expected_source} /home")
                 expected_line_index = 2
 
             assert expected_output_re.match(

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -806,11 +806,11 @@ def test_kaniko_pod_spec_user_service_account_enrichment(monkeypatch):
 @pytest.mark.parametrize(
     "clone_target_dir,expected_workdir",
     [
-        (None, r"WORKDIR /home/mlrun_code"),
-        ("", r"WORKDIR /home/mlrun_code"),
-        ("./path/to/code", r"WORKDIR /home/mlrun_code/path/to/code"),
-        ("rel_path", r"WORKDIR /home/mlrun_code/rel_path"),
-        ("/some/workdir", r"WORKDIR /some/workdir"),
+        (None, "WORKDIR /home/mlrun_code"),
+        ("", "WORKDIR /home/mlrun_code"),
+        ("./path/to/code", "WORKDIR /home/mlrun_code/path/to/code"),
+        ("rel_path", "WORKDIR /home/mlrun_code/rel_path"),
+        ("/some/workdir", "WORKDIR /some/workdir"),
     ],
 )
 def test_builder_workdir(monkeypatch, clone_target_dir, expected_workdir):


### PR DESCRIPTION
Second attempt at [ML-4741](https://jira.iguazeng.com/browse/ML-4741) after reverting #4434.