### PR TITLE
[Model Monitoring] Validate the app parquet length

### DIFF
--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -23,6 +23,8 @@ from mlrun.model_monitoring.application import (
     ModelMonitoringApplicationResult,
 )
 
+EXPECTED_EVENTS_COUNT = 5
+
 
 class DemoMonitoringApp(ModelMonitoringApplication):
     name = "monitoring-test"
@@ -38,7 +40,7 @@ class DemoMonitoringApp(ModelMonitoringApplication):
         endpoint_id: str,
         output_stream_uri: str,
     ) -> ModelMonitoringApplicationResult:
-        assert not sample_df.empty
+        assert len(sample_df) == EXPECTED_EVENTS_COUNT
         return ModelMonitoringApplicationResult(
             self.name,
             endpoint_id,

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -38,6 +38,7 @@ class DemoMonitoringApp(ModelMonitoringApplication):
         endpoint_id: str,
         output_stream_uri: str,
     ) -> ModelMonitoringApplicationResult:
+        assert not sample_df.empty
         return ModelMonitoringApplicationResult(
             self.name,
             endpoint_id,

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -27,7 +27,7 @@ from mlrun.model_monitoring import TrackingPolicy
 from mlrun.model_monitoring.writer import _TSDB_BE, _TSDB_TABLE, ModelMonitoringWriter
 from tests.system.base import TestMLRunSystem
 
-from .assets.application import DemoMonitoringApp
+from .assets.application import EXPECTED_EVENTS_COUNT, DemoMonitoringApp
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured
@@ -38,6 +38,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
     @classmethod
     def custom_setup_class(cls) -> None:
         cls.max_events = 5
+        assert cls.max_events == EXPECTED_EVENTS_COUNT
 
         cls.model_name = "classification"
         cls.num_features = 4


### PR DESCRIPTION
This df is read directly from the application parquet, see:
https://github.com/mlrun/mlrun/blob/c672e81d368dfd4b0e7d57dc56b0a6759ab6a8c1/mlrun/model_monitoring/batch_application.py#L441-L445

This new assertion makes sure (indirectly) that the parquet is created for the application and can be read.

To test locally with the updated mlrun/mlrun images, use this branch:
https://github.com/jond01/mlrun/tree/tests/check-parquet-in-dummy-app-check
https://github.com/jond01/mlrun/commit/f83302f1d815cf5378582d32ceaf1e2cffd0f0fc

I tested the application locally with failures, and the e2e test failed as expected.

~~There's no concrete assertion on `len(df)`, although it's currently 5, as such an assertion will make the test more susceptible to external changes.~~

This PR continues the work on [ML-4762](https://jira.iguazeng.com/browse/ML-4762), which started in https://github.com/mlrun/mlrun/pull/4473.