### PR TITLE
[Config] Move Pytest's config to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ profile = "black"
 multi_line_output = 3
 extend_skip_glob = ["*venv*", "server/api/proto"]
 
+[tool.pytest.ini_options]
+addopts = "-v -rf --disable-warnings"
+python_files = [
+    "tests/*/test_*.py",
+    "tests/test_*.py",
+]
+
 [tool.importlinter]
 root_packages = [
     "mlrun",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [aliases]
 test = pytest
-
-[tool:pytest]
-addopts = -v -rf --disable-warnings
-python_files = tests/*/test_*.py tests/test_*.py


### PR DESCRIPTION
Resolves [ML-4824](https://jira.iguazeng.com/browse/ML-4824).

See:
- https://docs.pytest.org/en/7.4.x/reference/customize.html#pyproject-toml
- https://docs.pytest.org/en/7.4.x/reference/reference.html#confval-python_files

Keep the `setup.cfg` file for now, as the "aliases" option might be used somewhere.

To verify it works - you may run a test and see the printed "configfile". For example:
```sh
pytest tests/model_monitoring/test_metrics.py
```
prints
```text
====================== test session starts ======================
...
configfile: pyproject.toml
...
```

Before this change, it was: `configfile: setup.cfg`.