### PR TITLE
[Model Monitoring] Add MM applications dashboard to Grafana

### DIFF
--- a/docs/monitoring/dashboards/model-monitoring-applications.json
+++ b/docs/monitoring/dashboards/model-monitoring-applications.json
@@ -1,0 +1,1029 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 11,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "title": "Model Monitoring - Overview",
+      "type": "link",
+      "url": "d/g0M4uh0Mz/model-monitoring-overview"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Details",
+      "type": "link",
+      "url": "d/AohIXhAMk/model-monitoring-details"
+    },
+      {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "title": "Model Monitoring - Performance",
+      "type": "link",
+      "url": "/d/9CazA-UGz/model-monitoring-performance"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "iguazio"
+      },
+      "description": "Pie chart that represents each type of drift result in the selected application.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "displayLabels": [
+          "percent",
+          "name"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": false,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.15",
+      "targets": [
+        {
+          "datasource": "iguazio",
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;container=users;table=pipelines/$PROJECT/monitoring-apps/app-results;filter=application_name ==\"$APPLICATION\";",
+          "type": "table"
+        }
+      ],
+      "title": "# Drift Status by Category",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "application_name": true,
+              "endpoint_id": true,
+              "result_kind": true,
+              "result_name": true,
+              "result_status": false,
+              "result_value": true,
+              "time": true
+            },
+            "indexByName": {
+              "application_name": 0,
+              "endpoint_id": 1,
+              "result_kind": 2,
+              "result_name": 3,
+              "result_status": 5,
+              "result_value": 4,
+              "time": 6
+            },
+            "renameByName": {
+              "result_kind": "",
+              "result_name": "",
+              "result_status": "Latest Status",
+              "result_value": "",
+              "time": ""
+            }
+          }
+        },
+        {
+          "id": "histogram",
+          "options": {
+            "combine": false,
+            "fields": {}
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "BucketMax": true,
+              "BucketMin": false
+            },
+            "indexByName": {},
+            "renameByName": {
+              "BucketMax": "",
+              "BucketMin": "Status",
+              "Latest Status": "Count"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "string",
+                "targetField": "Status"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": []
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "0": "Stable",
+              "1": "Potential Detection",
+              "2": "Detected",
+              "-1": "Irrelevant"
+            }
+          }
+        }
+      ],
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "iguazio"
+      },
+      "description": "Average drift result value of the provided application in the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 7,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "9.2.15",
+      "targets": [
+        {
+          "datasource": "iguazio",
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;container=users;table=pipelines/$PROJECT/monitoring-apps/app-results;filter= application_name ==\"$APPLICATION\";",
+          "type": "table"
+        }
+      ],
+      "title": "Average Drift Value Result",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "application_name": true,
+              "endpoint_id": true,
+              "result_kind": true,
+              "result_name": true,
+              "result_status": true,
+              "result_value": false,
+              "time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "result_name": "",
+              "result_status": "",
+              "result_value": "Drift Value",
+              "time": ""
+            }
+          }
+        }
+      ],
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "iguazio"
+      },
+      "description": "Latest calculated results according to the selected time range. ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Name"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Kind"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "index": 0,
+                        "text": "Data Drift"
+                      },
+                      "1": {
+                        "index": 1,
+                        "text": "Concept Drift"
+                      },
+                      "2": {
+                        "index": 2,
+                        "text": "Model Performance"
+                      },
+                      "3": {
+                        "index": 3,
+                        "text": "System Performance"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "color"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "Stable"
+                      },
+                      "1": {
+                        "color": "orange",
+                        "index": 2,
+                        "text": "Potential Detection"
+                      },
+                      "2": {
+                        "color": "red",
+                        "index": 3,
+                        "text": "Detected"
+                      },
+                      "-1": {
+                        "color": "text",
+                        "index": 0,
+                        "text": "Irrelevant"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 15,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/.*/",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "9.2.15",
+      "targets": [
+        {
+          "datasource": "iguazio",
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;container=users;table=pipelines/$PROJECT/monitoring-apps/app-results;;filter= application_name ==\"$APPLICATION\";",
+          "type": "table"
+        }
+      ],
+      "title": "Latest Result",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "application_name": true,
+              "endpoint_id": true,
+              "result_kind": false,
+              "result_name": false,
+              "result_value": false,
+              "time": true
+            },
+            "indexByName": {
+              "application_name": 0,
+              "endpoint_id": 1,
+              "result_kind": 2,
+              "result_name": 3,
+              "result_status": 5,
+              "result_value": 4,
+              "time": 6
+            },
+            "renameByName": {
+              "result_kind": "Kind",
+              "result_name": "Name",
+              "result_status": "Status",
+              "result_value": "Value",
+              "time": ""
+            }
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "iguazio",
+      "description": "Table summary of the application results including the schedule time, the metric name,  metric kind, result status, and result numerical value. ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Kind"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "index": 0,
+                        "text": "Data Drift"
+                      },
+                      "1": {
+                        "index": 1,
+                        "text": "Concept Drift"
+                      },
+                      "2": {
+                        "index": 2,
+                        "text": "Model Performance"
+                      },
+                      "3": {
+                        "index": 3,
+                        "text": "System Performance"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "Stable"
+                      },
+                      "1": {
+                        "color": "orange",
+                        "index": 2,
+                        "text": "Potential Detection"
+                      },
+                      "2": {
+                        "color": "red",
+                        "index": 3,
+                        "text": "Detected"
+                      },
+                      "-1": {
+                        "color": "text",
+                        "index": 0,
+                        "text": "Irrelevant"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 0,
+        "y": 9
+      },
+      "id": 14,
+      "options": {
+        "footer": {
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "9.2.15",
+      "targets": [
+        {
+          "datasource": "iguazio",
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;container=users;table=pipelines/$PROJECT/monitoring-apps/app-results;;filter= application_name ==\"$APPLICATION\";",
+          "type": "table"
+        }
+      ],
+      "title": "Application Summary",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "application_name": true,
+              "endpoint_id": true,
+              "result_extra_data": true,
+              "schedule_time": false
+            },
+            "indexByName": {
+              "application_name": 5,
+              "endpoint_id": 6,
+              "result_kind": 2,
+              "result_name": 1,
+              "result_status": 3,
+              "result_value": 4,
+              "time": 0
+            },
+            "renameByName": {
+              "endpoint_id": "",
+              "result_kind": "Kind",
+              "result_name": "Name",
+              "result_status": "Status",
+              "result_value": "Value",
+              "schedule_time": "Time",
+              "time": "Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "iguazio",
+      "description": "Metric result value by time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Value",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 3,
+            "pointSize": 12,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 13,
+        "x": 11,
+        "y": 9
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.15",
+      "targets": [
+        {
+          "datasource": "iguazio",
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;container=users;table=pipelines/$PROJECT/monitoring-apps/app-results;;filter= application_name ==\"$APPLICATION\";",
+          "type": "table"
+        }
+      ],
+      "title": "Result Value by Time",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "application_name": true,
+              "endpoint_id": true,
+              "result_kind": true,
+              "result_name": true,
+              "result_status": true,
+              "result_value": false,
+              "time": false
+            },
+            "indexByName": {},
+            "renameByName": {
+              "result_name": "",
+              "result_status": "",
+              "result_value": "Result Value",
+              "time": "Time"
+            }
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "iguazio",
+      "description": "Drift status by time. Using this chart you can detect different types of drifts by time such as gradual drift or incremental drift. To learn more about different types of drifts, check out Iguazio tutorials:\nhttps://www.iguazio.com/glossary/model-monitoring/\n \nNote that when the result doesn't represent drift (\"irrelevant\"), the value is filtered from this chart. ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 3,
+            "pointSize": 12,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1.8
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Drift Status"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Stable"
+                      },
+                      "1": {
+                        "color": "orange",
+                        "index": 1,
+                        "text": "Potential Detection"
+                      },
+                      "2": {
+                        "color": "red",
+                        "index": 2,
+                        "text": "Detected"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.15",
+      "targets": [
+        {
+          "datasource": "iguazio",
+          "rawQuery": true,
+          "refId": "A",
+          "target": "backend=tsdb;container=users;table=pipelines/$PROJECT/monitoring-apps/app-results;;filter= application_name ==\"$APPLICATION\";",
+          "type": "table"
+        }
+      ],
+      "title": "Drift Detection History",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "application_name": true,
+              "endpoint_id": true,
+              "result_kind": true,
+              "result_name": true,
+              "result_value": true,
+              "time": false
+            },
+            "indexByName": {},
+            "renameByName": {
+              "result_name": "",
+              "result_status": "Drift Status",
+              "result_value": "Drift Value",
+              "time": "Time"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": -1
+                  }
+                },
+                "fieldName": "Drift Status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": "model-monitoring",
+        "definition": "target_endpoint=list_projects",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Project",
+        "multi": false,
+        "name": "PROJECT",
+        "options": [],
+        "query": "target_endpoint=list_projects",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": "iguazio",
+        "definition": "backend=kv;container=users;table=pipelines/$PROJECT/model-endpoints/endpoints;fields=uid;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Model Endpoint",
+        "multi": false,
+        "name": "MODELENDPOINT",
+        "options": [],
+        "query": "backend=kv;container=users;table=pipelines/$PROJECT/model-endpoints/endpoints;fields=uid;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {},
+        "datasource": "iguazio",
+        "definition": "backend=kv;container=users;table=pipelines/$PROJECT/monitoring-apps/$MODELENDPOINT;fields=__name;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Application Name",
+        "multi": false,
+        "name": "APPLICATION",
+        "options": [],
+        "query": "backend=kv;container=users;table=pipelines/$PROJECT/monitoring-apps/$MODELENDPOINT;fields=__name;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Model Monitoring - Applications",
+  "uid": "gVrVlU7Iz",
+  "version": 7,
+  "weekStart": ""
+}

--- a/docs/monitoring/dashboards/model-monitoring-details.json
+++ b/docs/monitoring/dashboards/model-monitoring-details.json
@@ -44,6 +44,16 @@
       "title": "Model Monitoring - Overview",
       "type": "link",
       "url": "d/g0M4uh0Mz/model-monitoring-overview"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Applications",
+      "type": "link",
+      "url": "d/gVrVlU7Iz/model-monitoring-applications"
     }
   ],
   "liveNow": false,

--- a/docs/monitoring/dashboards/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/model-monitoring-overview.json
@@ -44,6 +44,16 @@
       "title": "Model Monitoring - Details",
       "type": "link",
       "url": "d/AohIXhAMk/model-monitoring-details"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Applications",
+      "type": "link",
+      "url": "d/gVrVlU7Iz/model-monitoring-applications"
     }
   ],
   "liveNow": false,

--- a/docs/monitoring/dashboards/model-monitoring-performance.json
+++ b/docs/monitoring/dashboards/model-monitoring-performance.json
@@ -45,6 +45,16 @@
       "title": "Model Monitoring - Details",
       "type": "link",
       "url": "d/AohIXhAMk/model-monitoring-details"
+    },
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Model Monitoring - Applications",
+      "type": "link",
+      "url": "d/gVrVlU7Iz/model-monitoring-applications"
     }
   ],
   "liveNow": false,

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from typing import Any, NewType
 
 import pandas as pd
@@ -25,11 +24,7 @@ import mlrun.common.model_monitoring
 import mlrun.model_monitoring
 import mlrun.utils.v3io_clients
 from mlrun.common.schemas.model_monitoring import EventFieldType
-from mlrun.common.schemas.model_monitoring.constants import (
-    ProjectSecretKeys,
-    ResultStatusApp,
-    WriterEvent,
-)
+from mlrun.common.schemas.model_monitoring.constants import ResultStatusApp, WriterEvent
 from mlrun.common.schemas.notification import NotificationKind, NotificationSeverity
 from mlrun.serving.utils import StepToDict
 from mlrun.utils import logger
@@ -156,8 +151,6 @@ class ModelMonitoringWriter(StepToDict):
             self._generate_kv_schema(endpoint_id)
         logger.info("Updated V3IO KV successfully", key=app_name)
 
-
-
     def _generate_kv_schema(self, endpoint_id: str):
         """Generate V3IO KV schema file which will be used by the model monitoring applications dashboard in Grafana."""
         fields = [
@@ -167,7 +160,11 @@ class ModelMonitoringWriter(StepToDict):
             {"name": WriterEvent.RESULT_KIND, "type": "double", "nullable": False},
             {"name": WriterEvent.RESULT_VALUE, "type": "double", "nullable": False},
             {"name": WriterEvent.RESULT_STATUS, "type": "double", "nullable": False},
-            {"name": WriterEvent.RESULT_EXTRA_DATA, "type": "string", "nullable": False},
+            {
+                "name": WriterEvent.RESULT_EXTRA_DATA,
+                "type": "string",
+                "nullable": False,
+            },
         ]
         res = self._kv_client.create_schema(
             container=self._v3io_container,
@@ -180,9 +177,10 @@ class ModelMonitoringWriter(StepToDict):
                 f"Couldn't infer schema for endpoint {endpoint_id} which is required for Grafana dashboards"
             )
         else:
-            logger.info("Generated V3IO KV schema successfully", endpoint_id=endpoint_id)
+            logger.info(
+                "Generated V3IO KV schema successfully", endpoint_id=endpoint_id
+            )
             self._kv_schemas.append(endpoint_id)
-
 
     def _update_tsdb(self, event: _AppResultEvent) -> None:
         event = _AppResultEvent(event.copy())

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -115,6 +115,7 @@ class ModelMonitoringWriter(StepToDict):
             notification_types=[NotificationKind.slack]
         )
         self._create_tsdb_table()
+        self._kv_schemas = []
 
     @staticmethod
     def get_v3io_container(project_name: str) -> str:
@@ -124,7 +125,6 @@ class ModelMonitoringWriter(StepToDict):
     def _get_v3io_client() -> V3IOClient:
         return mlrun.utils.v3io_clients.get_v3io_client(
             endpoint=mlrun.mlconf.v3io_api,
-            access_key=os.getenv(ProjectSecretKeys.ACCESS_KEY),
         )
 
     @staticmethod
@@ -132,7 +132,6 @@ class ModelMonitoringWriter(StepToDict):
         return mlrun.utils.v3io_clients.get_frames_client(
             address=mlrun.mlconf.v3io_framesd,
             container=v3io_container,
-            token=os.getenv(ProjectSecretKeys.ACCESS_KEY, ""),
         )
 
     def _create_tsdb_table(self) -> None:
@@ -153,7 +152,37 @@ class ModelMonitoringWriter(StepToDict):
             key=app_name,
             attributes=event,
         )
+        if endpoint_id not in self._kv_schemas:
+            self._generate_kv_schema(endpoint_id)
         logger.info("Updated V3IO KV successfully", key=app_name)
+
+
+
+    def _generate_kv_schema(self, endpoint_id: str):
+        """Generate V3IO KV schema file which will be used by the model monitoring applications dashboard in Grafana."""
+        fields = [
+            {"name": WriterEvent.APPLICATION_NAME, "type": "string", "nullable": False},
+            {"name": WriterEvent.SCHEDULE_TIME, "type": "string", "nullable": False},
+            {"name": WriterEvent.RESULT_NAME, "type": "string", "nullable": False},
+            {"name": WriterEvent.RESULT_KIND, "type": "double", "nullable": False},
+            {"name": WriterEvent.RESULT_VALUE, "type": "double", "nullable": False},
+            {"name": WriterEvent.RESULT_STATUS, "type": "double", "nullable": False},
+            {"name": WriterEvent.RESULT_EXTRA_DATA, "type": "string", "nullable": False},
+        ]
+        res = self._kv_client.create_schema(
+            container=self._v3io_container,
+            table_path=endpoint_id,
+            key=WriterEvent.APPLICATION_NAME,
+            fields=fields,
+        )
+        if res.status_code != 200:
+            raise mlrun.errors.MLRunBadRequestError(
+                f"Couldn't infer schema for endpoint {endpoint_id} which is required for Grafana dashboards"
+            )
+        else:
+            logger.info("Generated V3IO KV schema successfully", endpoint_id=endpoint_id)
+            self._kv_schemas.append(endpoint_id)
+
 
     def _update_tsdb(self, event: _AppResultEvent) -> None:
         event = _AppResultEvent(event.copy())


### PR DESCRIPTION
In this PR:
- Generate V3IO KV Schema file under `users/pipelines/{project_name}/monitoring-apps/{endpoint_id}`. 
- Add a new Grafana dashboard called `Model Monitoring - Applications`. The new Grafana dashboard includes charts and KPIs that are relevant to a specific monitoring application (under a specific model endpoint). Most of the presented stats are taken from the V3IO TSDB. 

A dashboard example:

![image](https://github.com/mlrun/mlrun/assets/101177563/7cae8e59-38e7-4980-be5f-98a5b5752068)

