### PR TITLE
[Model Monitoring] Add an evidently app to the system test

### DIFF
--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -53,7 +53,7 @@ class ModelMonitoringApplicationResult:
     result_value: float
     result_kind: mlrun.common.schemas.model_monitoring.constants.ResultKindApp
     result_status: mlrun.common.schemas.model_monitoring.constants.ResultStatusApp
-    result_extra_data: dict
+    result_extra_data: dict = dataclasses.field(default_factory=dict)
 
     def to_dict(self):
         """

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -52,5 +52,4 @@ class DemoMonitoringApp(ModelMonitoringApplication):
             result_value=2.15,
             result_kind=ResultKindApp.data_drift,
             result_status=ResultStatusApp.detected,
-            result_extra_data={},
         )

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -43,7 +43,9 @@ class DemoMonitoringApp(ModelMonitoringApplication):
         endpoint_id: str,
         output_stream_uri: str,
     ) -> ModelMonitoringApplicationResult:
+        self.context.logger.info("Running demo app")
         assert len(sample_df) == EXPECTED_EVENTS_COUNT
+        self.context.logger.info("Asserted sample_df length")
         return ModelMonitoringApplicationResult(
             self.name,
             endpoint_id,

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -1,0 +1,131 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+import pandas as pd
+from sklearn.datasets import load_iris
+
+from mlrun.common.schemas.model_monitoring.constants import (
+    ResultKindApp,
+    ResultStatusApp,
+)
+from mlrun.model_monitoring.application import ModelMonitoringApplicationResult
+from mlrun.model_monitoring.evidently_application import (
+    _HAS_EVIDENTLY,
+    EvidentlyModelMonitoringApplication,
+)
+
+if _HAS_EVIDENTLY:
+    from evidently.metrics import (
+        ColumnDriftMetric,
+        ColumnSummaryMetric,
+        DatasetDriftMetric,
+        DatasetMissingValuesMetric,
+    )
+    from evidently.report import Report
+    from evidently.test_preset import DataDriftTestPreset
+    from evidently.test_suite import TestSuite
+
+
+class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplication):
+    name = "evidently-app-test"
+
+    def run_application(
+        self,
+        application_name: str,
+        sample_df_stats: pd.DataFrame,
+        feature_stats: pd.DataFrame,
+        sample_df: pd.DataFrame,
+        schedule_time: pd.Timestamp,
+        latest_request: pd.Timestamp,
+        endpoint_id: str,
+        output_stream_uri: str,
+    ) -> ModelMonitoringApplicationResult:
+        iris = load_iris()
+        self.train_set = pd.DataFrame(
+            iris.data,
+            columns=[
+                "sepal_length_cm",
+                "sepal_width_cm",
+                "petal_length_cm",
+                "petal_width_cm",
+            ],
+        )
+
+        sample_df = sample_df[
+            ["sepal_length_cm", "sepal_width_cm", "petal_length_cm", "petal_width_cm"]
+        ]
+
+        data_drift_report = self.create_report(sample_df, schedule_time)
+        self.evidently_workspace.add_report(
+            self.evidently_project_id, data_drift_report
+        )
+        data_drift_test_suite = self.create_test_suite(sample_df, schedule_time)
+        self.evidently_workspace.add_test_suite(
+            self.evidently_project_id, data_drift_test_suite
+        )
+
+        self.log_evidently_object(data_drift_report, f"report_{str(schedule_time)}")
+        self.log_evidently_object(data_drift_test_suite, f"suite_{str(schedule_time)}")
+        self.log_project_dashboard(None, schedule_time + datetime.timedelta(minutes=1))
+
+        return ModelMonitoringApplicationResult(
+            self.name,
+            endpoint_id,
+            schedule_time,
+            result_name="data_drift_test",
+            result_value=0.5,
+            result_kind=ResultKindApp.data_drift,
+            result_status=ResultStatusApp.detected,
+        )
+
+    def create_report(
+        self, sample_df: pd.DataFrame, schedule_time: pd.Timestamp
+    ) -> "Report":
+        metrics = [
+            DatasetDriftMetric(),
+            DatasetMissingValuesMetric(),
+        ]
+        for col_name in [
+            "sepal_length_cm",
+            "sepal_width_cm",
+            "petal_length_cm",
+            "petal_width_cm",
+        ]:
+            metrics.extend(
+                [
+                    ColumnDriftMetric(column_name=col_name, stattest="wasserstein"),
+                    ColumnSummaryMetric(column_name=col_name),
+                ]
+            )
+
+        data_drift_report = Report(
+            metrics=metrics,
+            timestamp=schedule_time,
+        )
+
+        data_drift_report.run(reference_data=self.train_set, current_data=sample_df)
+        return data_drift_report
+
+    def create_test_suite(
+        self, sample_df: pd.DataFrame, schedule_time: pd.Timestamp
+    ) -> "TestSuite":
+        data_drift_test_suite = TestSuite(
+            tests=[DataDriftTestPreset()],
+            timestamp=schedule_time,
+        )
+
+        data_drift_test_suite.run(reference_data=self.train_set, current_data=sample_df)
+        return data_drift_test_suite

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -50,7 +50,7 @@ class _AppData:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem):
-    project_name = "test-monitoring-app-flow" + str(24)  # <-- +1
+    project_name = "test-monitoring-app-flow" + str(35)  # <-- +1
     # project_name = "test-monitoring-app-flow"
 
     @classmethod
@@ -84,12 +84,13 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         )
 
     def _set_monitoring_apps(self) -> None:
-        for app_data in self.apps_data[:1]:
+        for app_data in self.apps_data:
             self.project.set_model_monitoring_application(
                 func=app_data.abs_path,
                 application_class=app_data.class_.__name__,
                 name=app_data.class_.name,
-                image="mlrun/mlrun",
+                image="jonathandaniel503/mlrun:app-sys-tst",  # DONTTRACK
+                requirements=app_data.requirements,
                 **app_data.kwargs,
             )
 
@@ -115,7 +116,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             cls.model_name,
             model_path=f"store://models/{cls.project_name}/{cls.model_name}:latest",
         )
-        image = "mlrun/mlrun:1.6.0-rc1"  # DONTTRACK
+        image = "jonathandaniel503/mlrun:app-sys-tst"  # DONTTRACK
         serving_fn.set_tracking(
             tracking_policy=TrackingPolicy(
                 default_batch_intervals=f"*/{cls.app_interval} * * * *",
@@ -142,7 +143,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
 
     @classmethod
     def _test_kv_record(cls, ep_id: str) -> None:
-        for app_data in cls.apps_data:
+        for app_data in cls.apps_data[:1]:
             app_name = app_data.class_.name
             resp = ModelMonitoringWriter._get_v3io_client().kv.get(
                 container=cls._v3io_container, table_path=ep_id, key=app_name

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -50,7 +50,8 @@ class _AppData:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem):
-    project_name = "test-monitoring-app-flow"
+    project_name = "test-monitoring-app-flow" + str(24)  # <-- +1
+    # project_name = "test-monitoring-app-flow"
 
     @classmethod
     def custom_setup_class(cls) -> None:
@@ -114,12 +115,18 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             cls.model_name,
             model_path=f"store://models/{cls.project_name}/{cls.model_name}:latest",
         )
+        image = "mlrun/mlrun:1.6.0-rc1"  # DONTTRACK
         serving_fn.set_tracking(
             tracking_policy=TrackingPolicy(
                 default_batch_intervals=f"*/{cls.app_interval} * * * *",
                 application_batch=True,
+                default_batch_image=image,  # DONTTRACK
+                stream_image=image,  # DONTTRACK
             ),
         )
+        serving_fn.spec.image = image  # DONTTRACK
+        serving_fn.spec.build.image = image  # DONTTRACK
+
         serving_fn.deploy()
         return typing.cast(mlrun.runtimes.serving.ServingRuntime, serving_fn)
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -51,8 +51,7 @@ class _AppData:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem):
-    project_name = "test-monitoring-app-flow" + str(49)  # <-- +1
-    # project_name = "test-monitoring-app-flow"
+    project_name = "test-monitoring-app-flow"
 
     @classmethod
     def custom_setup_class(cls) -> None:
@@ -98,7 +97,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
                 func=app_data.abs_path,
                 application_class=app_data.class_.__name__,
                 name=app_data.class_.name,
-                image="jonathandaniel503/mlrun:app-sys-tst",  # DONTTRACK
+                image="mlrun/mlrun",
                 requirements=app_data.requirements,
                 **app_data.kwargs,
             )
@@ -125,17 +124,12 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             cls.model_name,
             model_path=f"store://models/{cls.project_name}/{cls.model_name}:latest",
         )
-        image = "jonathandaniel503/mlrun:app-sys-tst"  # DONTTRACK
         serving_fn.set_tracking(
             tracking_policy=TrackingPolicy(
                 default_batch_intervals=f"*/{cls.app_interval} * * * *",
                 application_batch=True,
-                default_batch_image=image,  # DONTTRACK
-                stream_image=image,  # DONTTRACK
             ),
         )
-        serving_fn.spec.image = image  # DONTTRACK
-        serving_fn.spec.build.image = image  # DONTTRACK
 
         serving_fn.deploy()
         return typing.cast(mlrun.runtimes.serving.ServingRuntime, serving_fn)


### PR DESCRIPTION
Add a new application with [evidently](https://github.com/evidentlyai/evidently) logic (and package) in addition to the dummy application.

It passes locally.

This PR continues the work on [ML-4762](https://jira.iguazeng.com/browse/ML-4762),  https://github.com/mlrun/mlrun/pull/4478.