### PR TITLE
[Workflows] Fail if name handler or path were not given

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2511,10 +2511,7 @@ class MlrunProject(ModelObj):
             )
 
         if not name and not workflow_path and not workflow_handler:
-            if self.spec.workflows:
-                name = list(self.spec._workflows.keys())[0]
-            else:
-                raise ValueError("Workflow name or path must be specified")
+            raise ValueError("Workflow name, path, or handler must be specified")
 
         if workflow_path or (workflow_handler and callable(workflow_handler)):
             workflow_spec = WorkflowSpec(path=workflow_path, args=arguments)

--- a/tests/projects/test_local_pipeline.py
+++ b/tests/projects/test_local_pipeline.py
@@ -139,6 +139,16 @@ class TestLocalPipeline(tests.projects.base_pipeline.TestPipeline):
             # expect y = (param1 * 2) + 1 = 15
             assert run_result.output("y") == 15, "unexpected run result"
 
+    def test_run_pipeline_no_workflow(self):
+        mlrun.projects.pipeline_context.clear(with_project=True)
+        self._create_project("localpipe2")
+        self._set_functions()
+
+        with pytest.raises(ValueError):
+            self.project.run(
+                local=True,
+            )
+
     def test_pipeline_args(self):
         mlrun.projects.pipeline_context.clear(with_project=True)
         self._create_project("localpipe3")


### PR DESCRIPTION
instead of running arbitrary workflow, force user to provide which workflow to run
https://jira.iguazeng.com/browse/ML-3169