### PR TITLE
[Project] Restore init function in spec for BC [1.5.x]

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3334,7 +3334,11 @@ def _init_function_from_dict(
     url, in_context = project.get_item_absolute_path(url)
 
     if "spec" in f:
-        func = new_function(name, runtime=f, tag=tag)
+        if "spec" in f["spec"]:
+            # Maintained for backwards compatibility
+            func = new_function(name, runtime=f["spec"])
+        else:
+            func = new_function(name, runtime=f, tag=tag)
 
     elif not url and has_module:
         func = new_function(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1358,7 +1358,7 @@ def test_init_function_from_dict_backwards_compatability():
                 "image": ".sparkjob-from-github:latest",
                 "build": {
                     "source": "./",
-                    "base_image": "iguazio/spark-app:3.5.5-b697.20231004142246",
+                    "base_image": "iguazio/spark-app:3.5.5-b697",
                     "commands": [],
                     "load_source_on_run": False,
                     "requirements": ["pyspark==3.2.3"],
@@ -1366,12 +1366,7 @@ def test_init_function_from_dict_backwards_compatability():
                 "description": "",
                 "disable_auto_mount": False,
                 "clone_target_dir": "/home/mlrun_code/",
-                "env": [
-                    {"name": "V3IO_API", "value": ""},
-                    {"name": "V3IO_USERNAME", "value": ""},
-                    {"name": "V3IO_ACCESS_KEY", "value": ""},
-                    {"name": "V3IO_FRAMESD", "value": ""},
-                ],
+                "env": [],
                 "replicas": 1,
                 "image_pull_policy": "Always",
                 "priority_class_name": "dummy-class",

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1355,10 +1355,10 @@ def test_init_function_from_dict_backwards_compatability():
             "spec": {
                 "command": "simple_job.py",
                 "args": [],
-                "image": ".mlrun/func-spark-example-func-from-github-admin-sparkjob-from-github:latest",
+                "image": ".sparkjob-from-github:latest",
                 "build": {
                     "source": "./",
-                    "base_image": "datanode-registry.iguazio-platform.app.vmdev81.lab.iguazeng.com:80/iguazio/spark-app:3.5.5-b697.20231004142246",
+                    "base_image": "iguazio/spark-app:3.5.5-b697.20231004142246",
                     "commands": [],
                     "load_source_on_run": False,
                     "requirements": ["pyspark==3.2.3"],
@@ -1371,23 +1371,10 @@ def test_init_function_from_dict_backwards_compatability():
                     {"name": "V3IO_USERNAME", "value": ""},
                     {"name": "V3IO_ACCESS_KEY", "value": ""},
                     {"name": "V3IO_FRAMESD", "value": ""},
-                    {
-                        "name": "CURRENT_NODE_IP",
-                        "valueFrom": {
-                            "fieldRef": {
-                                "apiVersion": "v1",
-                                "fieldPath": "status.hostIP",
-                            }
-                        },
-                    },
-                    {
-                        "name": "IGZ_DATA_CONFIG_FILE",
-                        "value": "/igz/java/conf/v3io.conf",
-                    },
                 ],
                 "replicas": 1,
                 "image_pull_policy": "Always",
-                "priority_class_name": "igz-workload-medium",
+                "priority_class_name": "dummy-class",
                 "preemption_mode": "prevent",
                 "driver_resources": {
                     "requests": {"memory": "512m", "cpu": 1},

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1337,3 +1337,99 @@ def test_project_set_function_with_requirements(requirements, with_requirements_
         assert func.spec.image == image
 
     assert func.spec.build.requirements == expected_requirements
+
+
+def test_init_function_from_dict_backwards_compatability():
+    project_name = "project-name"
+    project = mlrun.new_project(project_name, save=False)
+    func_dict = {
+        "name": "sparkjob-from-github",
+        "spec": {
+            "kind": "spark",
+            "metadata": {
+                "name": "sparkjob-from-github",
+                "tag": "latest",
+                "project": project_name,
+                "categories": [],
+            },
+            "spec": {
+                "command": "simple_job.py",
+                "args": [],
+                "image": ".mlrun/func-spark-example-func-from-github-admin-sparkjob-from-github:latest",
+                "build": {
+                    "source": "./",
+                    "base_image": "datanode-registry.iguazio-platform.app.vmdev81.lab.iguazeng.com:80/iguazio/spark-app:3.5.5-b697.20231004142246",
+                    "commands": [],
+                    "load_source_on_run": False,
+                    "requirements": ["pyspark==3.2.3"],
+                },
+                "description": "",
+                "disable_auto_mount": False,
+                "clone_target_dir": "/home/mlrun_code/",
+                "env": [
+                    {"name": "V3IO_API", "value": ""},
+                    {"name": "V3IO_USERNAME", "value": ""},
+                    {"name": "V3IO_ACCESS_KEY", "value": ""},
+                    {"name": "V3IO_FRAMESD", "value": ""},
+                    {
+                        "name": "CURRENT_NODE_IP",
+                        "valueFrom": {
+                            "fieldRef": {
+                                "apiVersion": "v1",
+                                "fieldPath": "status.hostIP",
+                            }
+                        },
+                    },
+                    {
+                        "name": "IGZ_DATA_CONFIG_FILE",
+                        "value": "/igz/java/conf/v3io.conf",
+                    },
+                ],
+                "replicas": 1,
+                "image_pull_policy": "Always",
+                "priority_class_name": "igz-workload-medium",
+                "preemption_mode": "prevent",
+                "driver_resources": {
+                    "requests": {"memory": "512m", "cpu": 1},
+                    "limits": {"cpu": "1300m"},
+                },
+                "executor_resources": {
+                    "requests": {"memory": "512m", "cpu": 1},
+                    "limits": {"cpu": "1400m"},
+                },
+                "deps": {
+                    "jars": [
+                        "local:///spark/v3io-libs/v3io-hcfs_2.12.jar",
+                        "local:///spark/v3io-libs/v3io-spark3-streaming_2.12.jar",
+                        "local:///spark/v3io-libs/v3io-spark3-object-dataframe_2.12.jar",
+                        "local:///igz/java/libs/scala-library-2.12.14.jar",
+                        "local:///spark/jars/jmx_prometheus_javaagent-0.16.1.jar",
+                    ],
+                    "files": ["local:///igz/java/libs/v3io-pyspark.zip"],
+                },
+                "use_default_image": False,
+                "monitoring": {
+                    "enabled": True,
+                    "exporter_jar": "/spark/jars/jmx_prometheus_javaagent-0.16.1.jar",
+                },
+                "driver_preemption_mode": "prevent",
+                "executor_preemption_mode": "prevent",
+                "affinity": None,
+                "tolerations": None,
+                "security_context": {},
+                "executor_affinity": None,
+                "executor_tolerations": None,
+                "driver_affinity": None,
+                "driver_tolerations": None,
+                "volume_mounts": [],
+                "volumes": [],
+                "driver_volume_mounts": [],
+                "executor_volume_mounts": [],
+            },
+            "verbose": False,
+        },
+    }
+    func = mlrun.projects.project._init_function_from_dict(func_dict, project)
+    assert (
+        deepdiff.DeepDiff(func[1].to_dict(), func_dict["spec"], ignore_order=True) == {}
+    )


### PR DESCRIPTION
We encountered an issue with 1.5.0 where users would sync functions of a project that had a function in an old format of:
~~~
{"name":...
"spec":{
"metadata":{...},
"spec":{...},
}}
~~~
This format can no longer be generated but we still need to support this as we did not migrate it.
This was removed in https://github.com/mlrun/mlrun/pull/4271/files#diff-c972cfb48585c0ee85184b83808a9bf592a0ddd60a07cba789023649354f6cb8L3148