### PR TITLE
[API] Support cross-project query for list-schedules using `*` as project name

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2975,7 +2975,7 @@ class MlrunProject(ModelObj):
                         used. If not set, the `mlconf.default_project_image_name` value will be used
         :param set_as_default: set `image` to be the project's default image (default False)
         :param with_mlrun:      add the current mlrun package to the container build
-        :param skip_deployed:   skip the build if we already have the image specified built
+        :param skip_deployed:   *Deprecated* parameter is ignored
         :param base_image:      base image name/path (commands and source code will be added to it)
         :param commands:        list of docker build (RUN) commands e.g. ['pip install pandas']
         :param secret_name:     k8s secret for accessing the docker registry
@@ -2992,6 +2992,14 @@ class MlrunProject(ModelObj):
             e.g. extra_args="--skip-tls-verify --build-arg A=val"r
         :param force_build:
         """
+
+        if skip_deployed:
+            warnings.warn(
+                "The 'skip_deployed' parameter is deprecated and will be removed in 1.7.0. "
+                "This parameter is ignored.",
+                # TODO: remove in 1.7.0
+                FutureWarning,
+            )
 
         self.build_config(
             image=image,
@@ -3016,7 +3024,6 @@ class MlrunProject(ModelObj):
             commands=build.commands,
             secret_name=build.secret,
             requirements=build.requirements,
-            skip_deployed=skip_deployed,
             overwrite_build_params=overwrite_build_params,
             mlrun_version_specifier=mlrun_version_specifier,
             builder_env=builder_env,

--- a/server/api/api/endpoints/schedules.py
+++ b/server/api/api/endpoints/schedules.py
@@ -147,11 +147,13 @@ async def list_schedules(
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
-    await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
-        project,
-        mlrun.common.schemas.AuthorizationAction.read,
-        auth_info,
-    )
+    if project != "*":
+        await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+            project,
+            mlrun.common.schemas.AuthorizationAction.read,
+            auth_info,
+        )
+
     schedules = await run_in_threadpool(
         get_scheduler().list_schedules,
         db_session,

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1373,7 +1373,9 @@ class SQLDB(DBInterface):
         kind: mlrun.common.schemas.ScheduleKinds = None,
     ) -> List[mlrun.common.schemas.ScheduleRecord]:
         logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
-        query = self._query(session, Schedule, project=project, kind=kind)
+        query = self._query(session, Schedule, kind=kind)
+        if project != "*":
+            query = query.filter(Schedule.project == project)
         if name is not None:
             query = query.filter(generate_query_predicate_for_name(Schedule.name, name))
         labels = label_set(labels)

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1374,7 +1374,7 @@ class SQLDB(DBInterface):
     ) -> List[mlrun.common.schemas.ScheduleRecord]:
         logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
         query = self._query(session, Schedule, kind=kind)
-        if project != "*":
+        if project and project != "*":
             query = query.filter(Schedule.project == project)
         if name is not None:
             query = query.filter(generate_query_predicate_for_name(Schedule.name, name))

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -95,7 +95,7 @@ def test_list_schedules(
         )
 
     # Validate multi-project query
-    resp = client.get(f"projects/*/schedules", params={"labels": "label1"})
+    resp = client.get("projects/*/schedules", params={"labels": "label1"})
     assert resp.status_code == http.HTTPStatus.OK.value, "status"
     result = resp.json()["schedules"]
     assert len(result) == len(project_names)


### PR DESCRIPTION
For the MLRun cross-project monitoring capability, the list-schedules API (`GET /projects/{project}/schedules`) now supports providing `*` as project-name, returning schedules across all projects. This is consistent with the support we already have in the list-runs and list-pipelines APIs.
Of course, the results are filtered according to user permissions as defined in the OPA manifest - this code was already in place.

Addresses [ML-4878](https://jira.iguazeng.com/browse/ML-4878)