### PR TITLE
[Tests] Use the default number of 10K events to test the app framework

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -420,7 +420,7 @@ default_config = {
         "default_http_sink": "http://nuclio-{project}-model-monitoring-stream.mlrun.svc.cluster.local:8080",
         "default_http_sink_app": "http://nuclio-{project}-{application_name}.mlrun.svc.cluster.local:8080",
         "batch_processing_function_branch": "master",
-        "parquet_batching_max_events": 10000,
+        "parquet_batching_max_events": 10_000,
         "parquet_batching_timeout_secs": timedelta(minutes=30).total_seconds(),
         # See mlrun.model_monitoring.stores.ModelEndpointStoreType for available options
         "store_type": "v3io-nosql",

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -14,6 +14,7 @@
 
 import pandas as pd
 
+import mlrun
 from mlrun.common.schemas.model_monitoring.constants import (
     ResultKindApp,
     ResultStatusApp,
@@ -23,7 +24,9 @@ from mlrun.model_monitoring.application import (
     ModelMonitoringApplicationResult,
 )
 
-EXPECTED_EVENTS_COUNT = 5
+EXPECTED_EVENTS_COUNT = (
+    mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events
+)
 
 
 class DemoMonitoringApp(ModelMonitoringApplication):

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -43,13 +43,6 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         cls.model_name = "classification"
         cls.num_features = 4
 
-        cls._orig_parquet_batching_max_events = (
-            mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events
-        )
-        mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events = (
-            cls.max_events
-        )
-
         cls.app_interval: int = 1  # every 1 minute
 
         cls.app_name = DemoMonitoringApp.name
@@ -60,12 +53,6 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         cls._kv_storage = ModelMonitoringWriter._get_v3io_client().kv
         cls._tsdb_storage = ModelMonitoringWriter._get_v3io_frames_client(
             cls._v3io_container
-        )
-
-    @classmethod
-    def custom_teardown_class(cls) -> None:
-        mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events = (
-            cls._orig_parquet_batching_max_events
         )
 
     def _log_model(self) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -33,7 +33,7 @@ from .assets.application import EXPECTED_EVENTS_COUNT, DemoMonitoringApp
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem):
-    project_name = "test-monitoring-app-flow"
+    project_name = "app-tst-" + str(4)
 
     @classmethod
     def custom_setup_class(cls) -> None:
@@ -79,12 +79,17 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             cls.model_name,
             model_path=f"store://models/{cls.project_name}/{cls.model_name}:latest",
         )
+        image = "jonathandaniel503/mlrun:app-sys-tst"
         serving_fn.set_tracking(
             tracking_policy=TrackingPolicy(
                 default_batch_intervals=f"*/{cls.app_interval} * * * *",
                 application_batch=True,
+                default_batch_image=image,
+                stream_image=image,
             ),
         )
+        serving_fn.spec.image = image  # DONTTRACK
+        serving_fn.spec.build.image = image  # DONTTRACK
         serving_fn.deploy()
         return typing.cast(mlrun.runtimes.serving.ServingRuntime, serving_fn)
 
@@ -128,7 +133,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             func=str((Path(__file__).parent / "assets/application.py").absolute()),
             application_class="DemoMonitoringApp",
             name=self.app_name,
-            image="mlrun/mlrun",
+            image="jonathandaniel503/mlrun:app-sys-tst",
         )
         self._log_model()
         self.serving_fn = self._deploy_model_serving()

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -37,7 +37,9 @@ class TestMonitoringAppFlow(TestMLRunSystem):
 
     @classmethod
     def custom_setup_class(cls) -> None:
-        cls.max_events = 5
+        cls.max_events = typing.cast(
+            int, mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events
+        )
         assert cls.max_events == EXPECTED_EVENTS_COUNT
 
         cls.model_name = "classification"

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -33,7 +33,7 @@ from .assets.application import EXPECTED_EVENTS_COUNT, DemoMonitoringApp
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem):
-    project_name = "app-tst-" + str(4)
+    project_name = "test-monitoring-app-flow"
 
     @classmethod
     def custom_setup_class(cls) -> None:
@@ -79,17 +79,12 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             cls.model_name,
             model_path=f"store://models/{cls.project_name}/{cls.model_name}:latest",
         )
-        image = "jonathandaniel503/mlrun:app-sys-tst"
         serving_fn.set_tracking(
             tracking_policy=TrackingPolicy(
                 default_batch_intervals=f"*/{cls.app_interval} * * * *",
                 application_batch=True,
-                default_batch_image=image,
-                stream_image=image,
             ),
         )
-        serving_fn.spec.image = image  # DONTTRACK
-        serving_fn.spec.build.image = image  # DONTTRACK
         serving_fn.deploy()
         return typing.cast(mlrun.runtimes.serving.ServingRuntime, serving_fn)
 
@@ -133,7 +128,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             func=str((Path(__file__).parent / "assets/application.py").absolute()),
             application_class="DemoMonitoringApp",
             name=self.app_name,
-            image="jonathandaniel503/mlrun:app-sys-tst",
+            image="mlrun/mlrun",
         )
         self._log_model()
         self.serving_fn = self._deploy_model_serving()


### PR DESCRIPTION
Before this change, the monitoring stream pod wouldn't write the parquet because of "not enough" events. This can be mediated on the server side by applying the following config map:
```yml
apiVersion: v1
data:
 MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS: "5"
kind: ConfigMap
metadata:
 name: mlrun-override-env
 namespace: default-tenant
```
to the mlrun-api pods.

The parquet is written after sending the 10K events to the model endpoint, and the test passes without an additional configuration. The extra time it takes for the test to finish is negligible.

This PR continues #4473 and together with #4498 completes [ML-4762](https://jira.iguazeng.com/browse/ML-4762).

(See [ML-4889](https://jira.iguazeng.com/browse/ML-4889) for solving the client-server config issue.)