### PR TITLE
[Data types] Fix warnings on `ingest` when pandas>=2

### DIFF
--- a/mlrun/data_types/infer.py
+++ b/mlrun/data_types/infer.py
@@ -52,7 +52,7 @@ def infer_schema_from_df(
             entities[name] = {"name": name, "value_type": value_type}
 
     # remove index column if no name provided
-    if not df.index.name and df.index.is_numeric():
+    if not df.index.name and pd.api.types.is_numeric_dtype(df):
         df = df.reset_index().drop("index", axis=1)
 
     schema = pyarrow.Schema.from_pandas(df)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pandas>=1.2, <3
 # used as a the engine for parquet files by pandas
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)
 # <12 to prevent bugs due to major upgrading
-pyarrow>=10.0, <12
+pyarrow>=10.0, <13
 pyyaml~=5.1
 requests~=2.31
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
@@ -33,7 +33,7 @@ semver~=3.0
 dependency-injector~=4.41
 fsspec>=2023.1,<2023.7
 v3iofs~=0.1.15
-storey~=1.6.2
+storey~=1.6.3
 inflection~=0.5.0
 python-dotenv~=0.17.0
 # older version of setuptools contains vulnerabilities, see `GHSA-r9hx-vwmv-q579`, so we limit to 65.5 and above

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numpy>=1.16.5, <1.23.0
 pandas>=1.2, <3
 # used as a the engine for parquet files by pandas
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)
-# <12 to prevent bugs due to major upgrading
+# <13 to prevent bugs due to major upgrading
 pyarrow>=10.0, <13
 pyyaml~=5.1
 requests~=2.31

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -98,7 +98,7 @@ def test_requirement_specifiers_convention():
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "kfp": {"~=1.8.0, <1.8.14"},
         "aiobotocore": {">=2.4.2,<2.6"},
-        "storey": {"~=1.6.2"},
+        "storey": {"~=1.6.3"},
         "nuclio-sdk": {">=0.3.0"},
         "bokeh": {"~=2.4, >=2.4.2"},
         # protobuf is limited just for docs
@@ -127,7 +127,7 @@ def test_requirement_specifiers_convention():
         "numpy": {">=1.16.5, <1.23.0"},
         "boto3": {">=1.24.59,<1.27"},
         "dask-ml": {"~=1.4,<1.9.0"},
-        "pyarrow": {">=10.0, <12"},
+        "pyarrow": {">=10.0, <13"},
         "nbclassic": {">=0.2.8"},
         "pandas": {">=1.2, <3"},
         "gitpython": {"~=3.1, >= 3.1.30"},


### PR DESCRIPTION
[ML-4853](https://jira.iguazeng.com/browse/ML-4853)

By raising pyarrow upper bound and replacing `is_numeric` with `is_numeric_dtype`.