### PR TITLE
[LogCollector] Fix get_log size calculation

### DIFF
--- a/server/api/utils/clients/log_collector.py
+++ b/server/api/utils/clients/log_collector.py
@@ -206,6 +206,8 @@ class LogCollectorClient(
                         http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
                         mlrun.errors.err_to_str(exc),
                     )
+
+                # breath
                 await asyncio.sleep(3)
 
     async def has_logs(

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -341,6 +341,84 @@ func (suite *LogCollectorTestSuite) TestStartLogOnPodStates() {
 	}
 }
 
+func (suite *LogCollectorTestSuite) TestGetLogsWithSize() {
+	runUID := uuid.New().String()
+
+	// creat log file for runUID and pod
+	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
+
+	// write log file
+	// write 1k log lines
+	for i := 0; i < 1000; i++ {
+		logText := fmt.Sprintf("Some fake pod logs %d\n", i)
+		err := common.WriteToFile(logFilePath, []byte(logText), true)
+		suite.Require().NoError(err, "Failed to write to file")
+	}
+	fileContents, err := os.ReadFile(logFilePath)
+	suite.Require().NoError(err)
+
+	fileContentsLength := len(fileContents)
+
+	for _, testCase := range []struct {
+		name             string
+		offset           int
+		readSize         int
+		expectedReadSize int
+	}{
+		{
+			name:             "Read it all",
+			offset:           0,
+			readSize:         -1,
+			expectedReadSize: fileContentsLength,
+		},
+		{
+			name:             "Read nothing",
+			offset:           0,
+			readSize:         0,
+			expectedReadSize: 0,
+		},
+		{
+			name:             "Read 100 bytes",
+			offset:           0,
+			readSize:         100,
+			expectedReadSize: 100,
+		},
+		{
+			name:             "Read 100 bytes with offset",
+			offset:           10,
+			readSize:         100,
+			expectedReadSize: 100,
+		},
+		{
+			name:             "Overflowing read size return what is left",
+			offset:           fileContentsLength - 1,
+			readSize:         100,
+			expectedReadSize: 1,
+		},
+		{
+			name:             "Overflowing offset",
+			offset:           fileContentsLength,
+			readSize:         -1,
+			expectedReadSize: 0,
+		},
+	} {
+		suite.Run(testCase.name, func() {
+			nopStream := &nop.GetLogsResponseStreamNop{}
+			err := suite.logCollectorServer.GetLogs(&log_collector.GetLogsRequest{
+				RunUID:      runUID,
+				Offset:      int64(testCase.offset),
+				Size:        int64(testCase.readSize),
+				ProjectName: suite.projectName,
+			}, nopStream)
+			suite.Require().NoError(err, "Failed to get logs")
+
+			// verify logs
+			suite.Require().Equal(testCase.expectedReadSize, int(len(nopStream.Logs)))
+		})
+	}
+
+}
+
 func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 
 	runUID := uuid.New().String()

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -390,6 +390,15 @@ func (suite *LogCollectorTestSuite) TestGetLogsWithSize() {
 			expectedReadSize: 100,
 		},
 		{
+
+			// further explanation - This edge case is when the offset + readSize + buffer size is larger than the file size
+			// so we must reduce the buffer size to fit the needed size
+			name:             "Overflowing read size + bufferSize",
+			offset:           fileContentsLength - int(1.5*float64(suite.logCollectorServer.getLogsBufferSizeBytes)),
+			readSize:         int(1.3 * float64(suite.logCollectorServer.getLogsBufferSizeBytes)),
+			expectedReadSize: int(1.3 * float64(suite.logCollectorServer.getLogsBufferSizeBytes)),
+		},
+		{
 			name:             "Overflowing read size return what is left",
 			offset:           fileContentsLength - 1,
 			readSize:         100,

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -344,7 +344,7 @@ func (suite *LogCollectorTestSuite) TestStartLogOnPodStates() {
 func (suite *LogCollectorTestSuite) TestGetLogsWithSize() {
 	runUID := uuid.New().String()
 
-	// creat log file for runUID and pod
+	// create log file for runUID and pod
 	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
 
 	// write log file
@@ -423,7 +423,7 @@ func (suite *LogCollectorTestSuite) TestGetLogsSuccessful() {
 
 	runUID := uuid.New().String()
 
-	// creat log file for runUID and pod
+	// create log file for runUID and pod
 	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
 
 	// write log file

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -413,7 +413,7 @@ func (suite *LogCollectorTestSuite) TestGetLogsWithSize() {
 			suite.Require().NoError(err, "Failed to get logs")
 
 			// verify logs
-			suite.Require().Equal(testCase.expectedReadSize, int(len(nopStream.Logs)))
+			suite.Require().Equal(testCase.expectedReadSize, len(nopStream.Logs))
 		})
 	}
 

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -1083,7 +1083,7 @@ func (s *Server) getChunkSize(
 	}
 
 	// if the size we need to read is bigger than the buffer, use the buffer size
-	leftToRead := endIndex - totalLogsSize
+	leftToRead := endIndex - totalLogsSize - initialOffset
 
 	if leftToRead >= int64(s.getLogsBufferSizeBytes) {
 		return int64(s.getLogsBufferSizeBytes)

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -747,7 +747,7 @@ func (s *Server) startLogStreaming(ctx context.Context,
 			return
 		}
 
-		// breath
+		// breathe
 		// stream pod logs might return fast when there is nothing to read and no error occurred
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -1082,7 +1082,7 @@ func (s *Server) getChunkSize(
 		totalLogsSize += initialOffset
 	}
 
-	// if the size we need to read is bigger that buffer, use the buffer size
+	// if the size we need to read is bigger than the buffer, use the buffer size
 	leftToRead := endSize - totalLogsSize
 
 	if leftToRead >= int64(s.getLogsBufferSizeBytes) {


### PR DESCRIPTION
seems like the size and offset calculation were a bit off wrt calculating the chunk size to read
add some UT to cover its usages

https://jira.iguazeng.com/browse/ML-4747