### PR TITLE
[Schedules] Fix `get_schedule` when the last-run was deleted

### DIFF
--- a/server/api/utils/scheduler.py
+++ b/server/api/utils/scheduler.py
@@ -898,29 +898,32 @@ class Scheduler:
 
         return schedule
 
-    @staticmethod
     def _enrich_schedule_with_last_run(
-        db_session: Session, schedule_output: mlrun.common.schemas.ScheduleOutput
+        self, db_session: Session, schedule_output: mlrun.common.schemas.ScheduleOutput
     ):
         if schedule_output.last_run_uri:
-            run_project, run_uid, iteration, _ = RunObject.parse_uri(
-                schedule_output.last_run_uri
-            )
-            try:
-                run_data = get_db().read_run(
-                    db_session, run_uid, run_project, iteration
-                )
+            run_data = self._get_last_run(db_session, schedule_output.last_run_uri)
+            if run_data:
                 schedule_output.last_run = run_data
-            except mlrun.errors.MLRunNotFoundError:
+            else:
                 # Possibly the last-run was already deleted (ML-4902). Continue, and clear the last_run_uri in
                 # the response.
-                logger.debug(
-                    "Failed to find the last run for schedule. Continuing",
-                    project=schedule_output.project,
-                    schedule_name=schedule_output.name,
-                    run_uid=run_uid,
-                )
                 schedule_output.last_run_uri = None
+
+    @staticmethod
+    def _get_last_run(db_session, last_run_uri):
+        run_project, run_uid, iteration, _ = RunObject.parse_uri(last_run_uri)
+        try:
+            run_data = get_db().read_run(db_session, run_uid, run_project, iteration)
+            return run_data
+        except mlrun.errors.MLRunNotFoundError:
+            logger.debug(
+                "Failed to find the last run for schedule. Continuing",
+                project=run_project,
+                run_uid=run_uid,
+                iteration=iteration,
+            )
+            return None
 
     def _enrich_schedule_with_credentials(
         self, schedule_output: mlrun.common.schemas.ScheduleOutput


### PR DESCRIPTION
When listing schedules, the UI asks for `/projects/<project>/schedules?include_last_run=yes` which tries to enrich the schedule record with the details of the last run executed. 
If deleting the last-run of a given schedule, the last-run uid is still stored in the schedule itself, and it doesn't get removed when the job is deleted from the DB. Therefore, when `_enrich_schedule_with_last_run` tries to retrieve the details of that run (based on its uid) from the DB, the call fails and this fails the `list-schedules` REST call with 404. This situation persists until another run is triggered by the schedule, and the last_run field is updated to point at the new run executed.

The fix is to gracefully handle the situation where the last run is not found in the DB, and also clear the `last_run_uri` from the returned schedule.

Fixes [ML-4902](https://jira.iguazeng.com/browse/ML-4902)