### PR TITLE
[Model Monitoring] Create TSDB schema for batch infer

### DIFF
--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -601,7 +601,9 @@ class BatchProcessor:
             container=self.tsdb_container,
             token=self.v3io_access_key,
         )
-        logger.info("Creating table in TSDB", table=self.tsdb_path)
+        logger.info(
+            "Creating table in TSDB if it does not already exist", table=self.tsdb_path
+        )
         self.frames.create(
             backend="tsdb",
             table=self.tsdb_path,

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -27,6 +27,7 @@ import requests
 import v3io
 import v3io.dataplane
 import v3io_frames
+from v3io_frames.frames_pb2 import IGNORE
 
 import mlrun.common.helpers
 import mlrun.common.model_monitoring.helpers
@@ -599,6 +600,13 @@ class BatchProcessor:
             address=mlrun.mlconf.v3io_framesd,
             container=self.tsdb_container,
             token=self.v3io_access_key,
+        )
+        logger.info("Creating table in TSDB", table=self.tsdb_path)
+        self.frames.create(
+            backend="tsdb",
+            table=self.tsdb_path,
+            if_exists=IGNORE,
+            rate="1/s",
         )
 
     def post_init(self):

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1057,8 +1057,8 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
 @pytest.mark.enterprise
 class TestModelInferenceTSDBRecord(TestMLRunSystem):
     """
-    Test that batch inference without a model endpoint (serving) records the
-    results in V3IO TSDB.
+    Test that batch inference records results to V3IO TSDB when tracking is
+    enabled and the selected model does not have a serving endpoint.
     """
 
     project_name = "infer-model-tsdb"

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1116,6 +1116,5 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
             context=mlrun.get_or_create_ctx(
                 name=f"{self.name_prefix}-context"
             ),  # pyright: ignore[reportGeneralTypeIssues]
-            default_batch_image="mlrun/mlrun:1.6.0-rc4",
         )
         self._test_v3io_tsdb_record()

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -37,6 +37,7 @@ import mlrun.model_monitoring.api
 import mlrun.serving.routers
 from mlrun.errors import MLRunNotFoundError
 from mlrun.model import BaseMetadata
+from mlrun.model_monitoring.writer import _TSDB_BE, ModelMonitoringWriter
 from mlrun.runtimes import BaseRuntime
 from mlrun.utils.v3io_clients import get_frames_client
 from tests.system.base import TestMLRunSystem
@@ -1025,7 +1026,7 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
         ]
 
     def test_inference_feature_set(self) -> None:
-        self.project.log_model(
+        self.project.log_model(  # pyright: ignore[reportOptionalMemberAccess]
             self.model_name,
             body=pickle.dumps(self.classif),
             model_file="classif.pkl",
@@ -1042,9 +1043,79 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
             model_endpoint_name=f"{self.name_prefix}-test",
             function_name=self.function_name,
             endpoint_id=self.endpoint_id,
-            context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),
+            context=mlrun.get_or_create_ctx(
+                name=f"{self.name_prefix}-context"
+            ),  # pyright: ignore[reportGeneralTypeIssues]
             infer_results_df=self.infer_results_df,
             trigger_monitoring_job=True,
         )
 
         self._test_feature_names()
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestModelInferenceTSDBRecord(TestMLRunSystem):
+    """
+    Test that batch inference without a model endpoint (serving) records the
+    results in V3IO TSDB.
+    """
+
+    project_name = "infer-model-tsdb"
+    name_prefix = "infer-model-only"
+
+    @classmethod
+    def custom_setup_class(cls) -> None:
+        dataset = load_iris()
+        cls.train_set = pd.DataFrame(
+            dataset.data,  # pyright: ignore[reportGeneralTypeIssues]
+            columns=[
+                "sepal_length_cm",
+                "sepal_width_cm",
+                "petal_length_cm",
+                "petal_width_cm",
+            ],
+        )
+        cls.model_name = "clf_model"
+
+        cls.infer_results_df = cls.train_set.copy()
+        cls.infer_results_df[
+            mlrun.common.schemas.EventFieldType.TIMESTAMP
+        ] = datetime.utcnow()
+
+    def _log_model(self) -> str:
+        model = self.project.log_model(  # pyright: ignore[reportOptionalMemberAccess]
+            self.model_name,
+            model_dir=os.path.relpath(self.assets_path),
+            model_file="model.pkl",
+            training_set=self.train_set,
+            artifact_path=f"v3io:///projects/{self.project_name}",
+        )
+        return model.uri
+
+    @classmethod
+    def _test_v3io_tsdb_record(cls) -> None:
+        frames = ModelMonitoringWriter._get_v3io_frames_client(
+            v3io_container="users",
+        )
+        df: pd.DataFrame = frames.read(
+            backend=_TSDB_BE,
+            table=f"pipelines/{cls.project_name}/model-endpoints/events",
+            start="now-5m",
+        )
+        assert not df.empty
+
+    def test_record(self) -> None:
+        model_uri = self._log_model()
+        mlrun.model_monitoring.api.record_results(
+            project=self.project_name,
+            infer_results_df=self.infer_results_df,
+            model_path=model_uri,
+            trigger_monitoring_job=True,
+            model_endpoint_name=f"{self.name_prefix}-test",
+            context=mlrun.get_or_create_ctx(
+                name=f"{self.name_prefix}-context"
+            ),  # pyright: ignore[reportGeneralTypeIssues]
+            default_batch_image="mlrun/mlrun:1.6.0-rc4",
+        )
+        self._test_v3io_tsdb_record()

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1103,7 +1103,14 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
             table=f"pipelines/{cls.project_name}/model-endpoints/events",
             start="now-5m",
         )
-        assert not df.empty
+        assert len(df) == 1, "Expected a single record in the TSDB"
+        assert {
+            "endpoint_id",
+            "record_type",
+            "hellinger_mean",
+            "kld_mean",
+            "tvd_mean",
+        } == set(df.columns), "Unexpected columns in the TSDB record"
 
     def test_record(self) -> None:
         model_uri = self._log_model()


### PR DESCRIPTION
Fixes [ML-4696](https://jira.iguazeng.com/browse/ML-4696) and covers the case with a system test.

In the case of inference without a deployed model endpoint (serving), the TSDB schema was not created.
Therefore, writing to it failed silently:
https://github.com/mlrun/mlrun/blob/ca5fe2031f522e961d0a737ce305a643e686b3f5/mlrun/model_monitoring/batch.py#L947-L960

I have also verified that the test fails on 1.6.0-rc4:
```
> 2023-11-08 16:37:43,262 [warning] Could not write drift measures to TSDB: {'err': Error("cannot call API - write error: backend Write failed: failed to create adapter: No TSDB schema file found at 'v3io-webapi:8081/users/pipelines/infer-model-tsdb/model-endpoints/events/'."), 'tsdb_path': 'pipelines/infer-model-tsdb/model-endpoints/events/', 'endpoint': '0fafe04448e086149232e8fd53a53c2554b8ce57'}
```

```
================================================= short test summary info =================================================
FAILED tests/system/model_monitoring/test_model_monitoring.py::TestModelInferenceTSDBRecord::test_record - v3io_frames.errors.ReadError: can't query: Failed on TSDB Select: Failed to read/update the TSDB schema.: Failed to read schema at path 'pipelines/infer-model-tsdb/model-endpoints/events/.schema'.: Expected a 2xx response status code: HTTP/1.1 404 Not Found
============================================= 1 failed, 53 warnings in 59.38s =============================================
```