### PR TITLE
[Pipelines] Clean up Kubeflow specific data from Function definitions after workflow execution

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -597,7 +597,9 @@ class _KFPRunner(_PipelineRunner):
             try:
                 func.spec.rollback_fields()
             except AttributeError:
-                logger.debug(f"Function of type {type(func)} doesn't require a spec field rollback")
+                logger.debug(
+                    f"Function of type {type(func)} doesn't require a spec field rollback"
+                )
             except Exception as exc:
                 logger.warning(
                     f"Failed to rollback spec fields for function {func.metadata.name}",

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -595,15 +595,16 @@ class _KFPRunner(_PipelineRunner):
         # The user provided workflow code might have made changes to function specs that require cleanup
         for func in project.spec._function_objects.values():
             try:
-                func.spec.rollback_fields()
+                func.spec.discard_changes()
             except AttributeError:
                 logger.debug(
-                    f"Function of type {type(func)} doesn't require a spec field rollback"
+                    "Function does not require a field rollback", func_type=type(func)
                 )
             except Exception as exc:
                 logger.warning(
-                    f"Failed to rollback spec fields for function {func.metadata.name}",
+                    "Failed to rollback spec fields for function",
                     project=project,
+                    func_name=func.metadata.name,
                     exc_info=err_to_str(exc),
                 )
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -186,7 +186,7 @@ class KubeResourceSpec(FunctionSpec):
             state_thresholds
             or mlrun.mlconf.function.spec.state_thresholds.default.to_dict()
         )
-        self.__fields_pending_rollback = {}
+        self.__fields_pending_discard = {}
 
     @property
     def volumes(self) -> list:
@@ -333,9 +333,21 @@ class KubeResourceSpec(FunctionSpec):
                         resource_value,
                     )
 
-    def rollback_fields(self):
-        for k, v in self.__fields_pending_rollback.items():
+    def discard_changes(self):
+        """
+        Certain pipeline engines might make temporary changes to a function spec to ensure expected behavior.
+        Kubeflow, for instance, can use pipeline parameters to change resource requests/limits on a function.
+        Affected fields will be scheduled for cleanup automatically. Direct user intervention is not required.
+        """
+        for k, v in self.__fields_pending_discard.items():
             setattr(self, k, v)
+
+    def _add_field_to_pending_discard(self, field_name, field_value):
+        self.__fields_pending_discard.update(
+            {
+                field_name: copy.deepcopy(field_value),
+            }
+        )
 
     def _verify_and_set_requests(
         self,
@@ -347,12 +359,8 @@ class KubeResourceSpec(FunctionSpec):
         resources = verify_requests(resources_field_name, mem=mem, cpu=cpu)
         for pattern in mlrun.utils.regex.pipeline_param:
             if re.match(pattern, str(cpu)) or re.match(pattern, str(mem)):
-                self.__fields_pending_rollback.update(
-                    {
-                        resources_field_name: copy.deepcopy(
-                            getattr(self, resources_field_name)
-                        ),
-                    }
+                self._add_field_to_pending_discard(
+                    resources_field_name, getattr(self, resources_field_name)
                 )
         if not patch:
             update_in(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -347,9 +347,13 @@ class KubeResourceSpec(FunctionSpec):
         resources = verify_requests(resources_field_name, mem=mem, cpu=cpu)
         for pattern in mlrun.utils.regex.pipeline_param:
             if re.match(pattern, str(cpu)) or re.match(pattern, str(mem)):
-                self.__fields_pending_rollback.update({
-                    resources_field_name: copy.deepcopy(getattr(self, resources_field_name)),
-                })
+                self.__fields_pending_rollback.update(
+                    {
+                        resources_field_name: copy.deepcopy(
+                            getattr(self, resources_field_name)
+                        ),
+                    }
+                )
         if not patch:
             update_in(
                 getattr(self, resources_field_name),


### PR DESCRIPTION
[ML-4161](https://jira.iguazeng.com/browse/ML-4161)

When a Kubeflow workflow uses pipeline parameters to change resource requests/limits on a function, KFP-specific strings are left on the `_function_objects` dictionary. It's important to stress that this contamination only affects the client's local state and is not stored on the MLRun database since the API has safeguards in place against invalid strings. 

Example:
```
resources': {'requests': {'memory': '{{pipelineparam:op=;name=val}}'},
   'limits': {'memory': '{{pipelineparam:op=;name=val}}'}}
```

There are at least three reasonable strategies for dealing with this problem:
1. Add a filter to `mlrun.db.httpdb.HTTPRunDB.store_function` to avoid sending Kubeflow-specific values when saving the function after a workflow has been run. 
      a. Pros: the solution is straightforward
      b. Cons: if the `resources` field had any values before the workflow code was run, these would be overwritten on the API
2. Prepare a somewhat simple field rollback mechanism for function specs so that after a workflow is run, fields marked as pending rollback can be reverted
      a. Pros: guarantees that original values won't be lost; makes the fix self-contained to the workflow run process, so its consequences don't leak to other tasks on the client
      b. Cons: assumes that reverting field values might be something frequent enough to warrant a structure for it
3. Leverage a hook-style strategy so that `KubeResourceSpec` can proactively queue the field cleanup to be done at the end of a workflow run. In this scenario, `MlrunProject` would have a list of `Callable` to run right after a workflow, and `KubeResourceSpec` could send a function to it to perform the cleanup if appropriate
      a. Pros: ensures that `KubeResourceSpec` is the protagonist of its cleanup strategy
      b. Cons: the simplest way to implement this (that I could think of) would trigger a circular dependency by importing pipeline_context to `mlrun/runtimes/pod.py`. A more complex and scalable strategy might require a new dependency like [pluggy](https://github.com/pytest-dev/pluggy).

On this PR, I tentatively implemented the strategy 2. 
