### PR TITLE
[Nuclio] Allow not creating an http trigger for Nuclio functions by default

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -310,6 +310,17 @@ fn.with_node_selection(node_selector={"app.iguazio.com/lifecycle" : "non-preempt
 ### Serving/Nuclio triggers
 
 Docs: [Nuclio Triggers](https://github.com/nuclio/nuclio-jupyter/blob/development/nuclio/triggers.py)
+
+By default, Nuclio deploys a default HTTP trigger if the function doesn't have one. This is because users typically want to invoke functions through HTTP. 
+However, we provide a way to disable the default HTTP trigger using:
+`function.disable_default_http_trigger()`
+
+Also, you can explicitly enable the default HTTP trigger creation with:
+`function.enable_default_http_trigger()`
+
+If you didn't set this parameter explicitly, the value is taken from [Nuclio platform configuration](https://github.com/nuclio/nuclio/blob/development/docs/tasks/configuring-a-platform.md). 
+ Therefore, if you haven't disabled the default HTTP trigger, don't have a custom one, and are unable to invoke the function, we recommend checking the Nuclio platform configuration.
+
 ```python
 import nuclio
 serve = mlrun.import_function('hub://v2_model_server')

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -163,6 +163,7 @@ class NuclioSpec(KubeResourceSpec):
         add_templated_ingress_host_mode=None,
         clone_target_dir=None,
         state_thresholds=None,
+        disable_default_http_trigger=None,
     ):
 
         super().__init__(
@@ -209,6 +210,8 @@ class NuclioSpec(KubeResourceSpec):
 
         self.min_replicas = min_replicas or 1
         self.max_replicas = max_replicas or 4
+
+        self.disable_default_http_trigger = disable_default_http_trigger
 
         # When True it will set Nuclio spec.noBaseImagesPull to False (negative logic)
         # indicate that the base image should be pulled from the container registry (not cached)
@@ -682,6 +685,22 @@ class RemoteRuntime(KubeResource):
         raise NotImplementedError(
             "State thresholds do not apply for nuclio as it has its own function pods healthiness monitoring"
         )
+
+    def disable_default_http_trigger(
+        self,
+    ):
+        """
+        Disables nuclio's default http trigger creation
+        """
+        self.spec.disable_default_http_trigger = True
+
+    def enable_default_http_trigger(
+        self,
+    ):
+        """
+        Enables nuclio's default http trigger creation
+        """
+        self.spec.disable_default_http_trigger = False
 
     def _get_state(
         self,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -120,6 +120,7 @@ class NuclioSpec(KubeResourceSpec):
         "base_image_pull",
         "service_type",
         "add_templated_ingress_host_mode",
+        "disable_default_http_trigger",
     ]
 
     def __init__(

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -692,6 +692,7 @@ class RemoteRuntime(KubeResource):
             "State thresholds do not apply for nuclio as it has its own function pods healthiness monitoring"
         )
 
+    @min_nuclio_versions("1.12.8")
     def disable_default_http_trigger(
         self,
     ):

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -883,11 +883,15 @@ class RemoteRuntime(KubeResource):
 
         # here we check that if default http trigger is disabled, function contains a custom http trigger
         # Otherwise, the function is not invokable, so we raise an error
-        if "spec.triggers.http" not in self.spec.config and self.spec.disable_default_http_trigger:
+        if (
+            "spec.triggers.http" not in self.spec.config
+            and self.spec.disable_default_http_trigger
+        ):
             raise mlrun.errors.MLRunPreconditionFailedError(
                 "Default http trigger creation is disabled and there is no any other custom http trigger, "
                 "so function can not be invoked via http. Either enable default http trigger creation or create"
-                "custom http trigger")
+                "custom http trigger"
+            )
 
         if not method:
             method = "POST" if body else "GET"

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -906,8 +906,8 @@ class RemoteRuntime(KubeResource):
                 # here we check that if default http trigger is disabled, function contains a custom http trigger
                 # Otherwise, the function is not invokable, so we raise an error
                 if (
-                        "spec.triggers.http" not in self.spec.config
-                        and self.spec.disable_default_http_trigger
+                    "spec.triggers.http" not in self.spec.config
+                    and self.spec.disable_default_http_trigger
                 ):
                     raise mlrun.errors.MLRunPreconditionFailedError(
                         "Default http trigger creation is disabled and there is no any other custom http trigger, "

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -918,9 +918,7 @@ class RemoteRuntime(KubeResource):
                 if state not in ["ready", "scaledToZero"]:
                     logger.warning(f"Function is in the {state} state")
                 if not self.status.address:
-                    raise ValueError(
-                        "no function address first run .deploy()"
-                    )
+                    raise ValueError("no function address first run .deploy()")
 
             path = self._resolve_invocation_url(path, force_external_address)
 

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -417,6 +417,11 @@ class RemoteRuntime(KubeResource):
         :param extra_attributes: key/value dict of extra nuclio trigger attributes
         :return: function object (self)
         """
+        if self.disable_default_http_trigger:
+            logger.warning(
+                "Adding HTTP trigger despite the default HTTP trigger creation being disabled"
+            )
+
         annotations = annotations or {}
         if worker_timeout:
             gateway_timeout = gateway_timeout or (worker_timeout + 60)

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -915,9 +915,11 @@ class RemoteRuntime(KubeResource):
                         "custom http trigger"
                     )
                 state, _, _ = self._get_state(dashboard, auth_info=auth_info)
-                if state != "ready" or not self.status.address:
+                if state not in ["ready", "scaledToZero"]:
+                    logger.warning(f"Function is in the {state} state")
+                if not self.status.address:
                     raise ValueError(
-                        "no function address or not ready, first run .deploy()"
+                        "no function address first run .deploy()"
                     )
 
             path = self._resolve_invocation_url(path, force_external_address)

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -188,7 +188,7 @@ class ServingSpec(NuclioSpec):
             service_type=service_type,
             add_templated_ingress_host_mode=add_templated_ingress_host_mode,
             clone_target_dir=clone_target_dir,
-            disable_default_http_trigger=disable_default_http_trigger
+            disable_default_http_trigger=disable_default_http_trigger,
         )
 
         self.models = models or {}

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -147,6 +147,7 @@ class ServingSpec(NuclioSpec):
         add_templated_ingress_host_mode=None,
         clone_target_dir=None,
         state_thresholds=None,
+        disable_default_http_trigger=None,
     ):
         super().__init__(
             command=command,
@@ -187,6 +188,7 @@ class ServingSpec(NuclioSpec):
             service_type=service_type,
             add_templated_ingress_host_mode=add_templated_ingress_host_mode,
             clone_target_dir=clone_target_dir,
+            disable_default_http_trigger=disable_default_http_trigger
         )
 
         self.models = models or {}

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -640,7 +640,7 @@ def _handle_nuclio_deploy_status(
         verbose=verbose,
         auth_info=auth_info,
     )
-    if state == "ready":
+    if state in ["ready", "scaledToZero"]:
         logger.info("Nuclio function deployed successfully", name=name)
     if state in ["error", "unhealthy"]:
         logger.error(f"Nuclio deploy error, {text}", name=name)

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -485,8 +485,8 @@ def _set_source_code_and_handler(function, config):
 def _set_disable_http_trigger_creation(function, nuclio_spec):
     if function.spec.disable_default_http_trigger is not None:
         nuclio_spec.set_config(
-            "spec.disableDefaultHTTPTrigger",
-            function.spec.disable_default_http_trigger)
+            "spec.disableDefaultHTTPTrigger", function.spec.disable_default_http_trigger
+        )
 
 
 def _resolve_and_set_base_image(

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -204,7 +204,6 @@ def _compile_function_config(
     _set_function_scheduling_params(function, nuclio_spec)
     _set_function_replicas(function, nuclio_spec)
     _set_misc_specs(function, nuclio_spec)
-    _set_disable_http_trigger_creation(function, nuclio_spec)
 
     # if the user code is given explicitly or from a source, we need to set the handler and relevant attributes
     if (
@@ -462,6 +461,10 @@ def _set_misc_specs(function, nuclio_spec):
                 function.spec, "security_context"
             ),
         )
+    if function.spec.disable_default_http_trigger is not None:
+        nuclio_spec.set_config(
+            "spec.disableDefaultHTTPTrigger", function.spec.disable_default_http_trigger
+        )
 
 
 def _set_source_code_and_handler(function, config):
@@ -479,13 +482,6 @@ def _set_source_code_and_handler(function, config):
             config,
             "spec.handler",
             "mlrun.serving.serving_wrapper:handler",
-        )
-
-
-def _set_disable_http_trigger_creation(function, nuclio_spec):
-    if function.spec.disable_default_http_trigger is not None:
-        nuclio_spec.set_config(
-            "spec.disableDefaultHTTPTrigger", function.spec.disable_default_http_trigger
         )
 
 

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -204,6 +204,7 @@ def _compile_function_config(
     _set_function_scheduling_params(function, nuclio_spec)
     _set_function_replicas(function, nuclio_spec)
     _set_misc_specs(function, nuclio_spec)
+    _set_disable_http_trigger_creation(function, nuclio_spec)
 
     # if the user code is given explicitly or from a source, we need to set the handler and relevant attributes
     if (
@@ -479,6 +480,13 @@ def _set_source_code_and_handler(function, config):
             "spec.handler",
             "mlrun.serving.serving_wrapper:handler",
         )
+
+
+def _set_disable_http_trigger_creation(function, nuclio_spec):
+    if function.spec.disable_default_http_trigger is not None:
+        nuclio_spec.set_config(
+            "spec.disableDefaultHTTPTrigger",
+            function.spec.disable_default_http_trigger)
 
 
 def _resolve_and_set_base_image(

--- a/server/api/crud/runtimes/nuclio/helpers.py
+++ b/server/api/crud/runtimes/nuclio/helpers.py
@@ -95,7 +95,7 @@ def enrich_function_with_ingress(config, mode, service_type):
 
         # if there are no http triggers and default http trigger creation disabled,
         # function is not invokable
-        if config["spec"].get("disableDefaultHTTPTrigger"):
+        if config["spec"].get("disableDefaultHTTPTrigger", False):
             return
         # function has an HTTP trigger without an ingress
         # TODO: read from nuclio-api frontend-spec

--- a/server/api/crud/runtimes/nuclio/helpers.py
+++ b/server/api/crud/runtimes/nuclio/helpers.py
@@ -92,6 +92,11 @@ def enrich_function_with_ingress(config, mode, service_type):
     # we would enrich it with an ingress
     http_trigger = resolve_function_http_trigger(config["spec"])
     if not http_trigger:
+
+        # if there are no http triggers and default http trigger creation disabled,
+        # function is not invokable
+        if config["spec"].get("disableDefaultHTTPTrigger"):
+            return
         # function has an HTTP trigger without an ingress
         # TODO: read from nuclio-api frontend-spec
         http_trigger = {

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1629,6 +1629,8 @@ class TestNuclioRuntime(TestRuntimeBase):
     def test_deploy_with_disabled_http_trigger_creation(
         self, db: Session, client: TestClient
     ):
+        # TODO: delete version mocking as soon as we release it in nuclio
+        mlconf.nuclio_version = "1.12.8"
         function = self._generate_runtime(self.runtime_kind)
         function.disable_default_http_trigger()
 
@@ -1641,6 +1643,8 @@ class TestNuclioRuntime(TestRuntimeBase):
     def test_deploy_with_enabled_http_trigger_creation(
         self, db: Session, client: TestClient
     ):
+        # TODO: delete version mocking as soon as we release it in nuclio
+        mlconf.nuclio_version = "1.12.8"
         function = self._generate_runtime(self.runtime_kind)
         function.enable_default_http_trigger()
 
@@ -1653,6 +1657,8 @@ class TestNuclioRuntime(TestRuntimeBase):
     def test_invoke_with_disabled_http_trigger_creation(
         self, db: Session, client: TestClient
     ):
+        # TODO: delete version mocking as soon as we release it in nuclio
+        mlconf.nuclio_version = "1.12.8"
         function = self._generate_runtime(self.runtime_kind)
         function.disable_default_http_trigger()
 

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1636,7 +1636,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         args, _ = nuclio.deploy.deploy_config.call_args
         deploy_spec = args[0]["spec"]
 
-        assert not deploy_spec["disableDefaultHTTPTrigger"]
+        assert deploy_spec["disableDefaultHTTPTrigger"]
 
     def test_deploy_with_enabled_http_trigger_creation(
         self, db: Session, client: TestClient
@@ -1648,7 +1648,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         args, _ = nuclio.deploy.deploy_config.call_args
         deploy_spec = args[0]["spec"]
 
-        assert deploy_spec["disableDefaultHTTPTrigger"]
+        assert not deploy_spec["disableDefaultHTTPTrigger"]
 
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1650,6 +1650,17 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         assert not deploy_spec["disableDefaultHTTPTrigger"]
 
+    def test_invoke_with_disabled_http_trigger_creation(
+        self, db: Session, client: TestClient
+    ):
+        function = self._generate_runtime(self.runtime_kind)
+        function.disable_default_http_trigger()
+
+        self.execute_function(function)
+        args, _ = nuclio.deploy.deploy_config.call_args
+        with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+            function.invoke("/")
+
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well
 class TestNuclioMLRunRuntime(TestNuclioRuntime):

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1658,6 +1658,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         self.execute_function(function)
         args, _ = nuclio.deploy.deploy_config.call_args
+
         with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
             function.invoke("/")
 

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1626,6 +1626,30 @@ class TestNuclioRuntime(TestRuntimeBase):
         assert deploy_spec["readinessTimeoutSeconds"] == 501
         assert deploy_spec["waitReadinessTimeoutBeforeFailure"]
 
+    def test_deploy_with_disabled_http_trigger_creation(
+        self, db: Session, client: TestClient
+    ):
+        function = self._generate_runtime(self.runtime_kind)
+        function.disable_default_http_trigger()
+
+        self.execute_function(function)
+        args, _ = nuclio.deploy.deploy_config.call_args
+        deploy_spec = args[0]["spec"]
+
+        assert not deploy_spec["disableDefaultHTTPTrigger"]
+
+    def test_deploy_with_enabled_http_trigger_creation(
+        self, db: Session, client: TestClient
+    ):
+        function = self._generate_runtime(self.runtime_kind)
+        function.enable_default_http_trigger()
+
+        self.execute_function(function)
+        args, _ = nuclio.deploy.deploy_config.call_args
+        deploy_spec = args[0]["spec"]
+
+        assert deploy_spec["disableDefaultHTTPTrigger"]
+
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well
 class TestNuclioMLRunRuntime(TestNuclioRuntime):


### PR DESCRIPTION
Jira - https://jira.iguazeng.com/browse/NUC-58 , https://jira.iguazeng.com/browse/ML-4032

Recently, we implemented a new functionality in Nuclio that allows deploying functions without a default HTTP trigger. This pull request expands this capability in MLRun, enabling users to disable or enable the default HTTP trigger through MLRun.