### PR TITLE
[LogCollector] Fix big stop logs

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -16,6 +16,7 @@ import enum
 import functools
 import hashlib
 import inspect
+import itertools
 import json
 import os
 import pathlib
@@ -1520,3 +1521,18 @@ def time_string_to_seconds(time_str: str) -> Optional[int]:
         raise ValueError(f"Invalid time string {time_str}, must be at least 1 second")
 
     return total_seconds
+
+
+def iterate_list_by_chunks(
+    iterable_list: typing.Iterable, chunk_size: int
+) -> typing.Iterable:
+    """
+    Iterate over a list and yield chunks of the list in the given chunk size
+    e.g.: for list of [a,b,c,d,e,f] and chunk_size of 2, will yield [a,b], [c,d], [e,f]
+    """
+    if chunk_size <= 0 or not iterable_list:
+        yield iterable_list
+        return
+    iterator = iter(iterable_list)
+    while chunk := list(itertools.islice(iterator, chunk_size)):
+        yield chunk

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -747,25 +747,34 @@ async def _stop_logs():
         await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
 
-async def _stop_logs_for_runs(runs: list):
-    project_to_run_uids = {}
+async def _stop_logs_for_runs(runs: list, chunk_size: int = 10):
+    project_to_run_uids = collections.defaultdict(list)
     for run in runs:
         project_name = run.get("metadata", {}).get("project", None)
         run_uid = run.get("metadata", {}).get("uid", None)
-        project_to_run_uids.setdefault(project_name, []).append(run_uid)
+        project_to_run_uids[project_name].append(run_uid)
 
     for project_name, run_uids in project_to_run_uids.items():
-        try:
-            await server.api.utils.clients.log_collector.LogCollectorClient().stop_logs(
-                project_name, run_uids
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed stopping logs for runs. Ignoring",
-                exc=err_to_str(exc),
-                project=project_name,
-                run_uids=run_uids,
-            )
+        if not run_uids:
+            logger.debug("No runs to stop logs for", project=project_name)
+            continue
+
+        # if we wont chunk the run uids, the grpc message might include many uids which will overflow the max message
+        # size.
+        for chunked_run_uids in mlrun.utils.helpers.iterate_list_by_chunks(
+            run_uids, chunk_size
+        ):
+            try:
+                await server.api.utils.clients.log_collector.LogCollectorClient().stop_logs(
+                    project_name, chunked_run_uids
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed stopping logs for runs. Ignoring",
+                    exc=err_to_str(exc),
+                    project=project_name,
+                    run_uids=run_uids,
+                )
 
 
 def main():

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -773,7 +773,7 @@ async def _stop_logs_for_runs(runs: list, chunk_size: int = 10):
                     "Failed stopping logs for runs. Ignoring",
                     exc=err_to_str(exc),
                     project=project_name,
-                    run_uids=run_uids,
+                    chunked_run_uids=chunked_run_uids,
                 )
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -913,3 +913,18 @@ def test_retry_until_successful():
     test_run(0.02)
 
     test_run(mlrun.utils.create_linear_backoff(0.02, 0.02))
+
+
+@pytest.mark.parametrize(
+    "iterable_list, chunk_size, expected_chunked_list",
+    [
+        (["a", "b", "c"], 1, [["a"], ["b"], ["c"]]),
+        (["a", "b", "c"], 2, [["a", "b"], ["c"]]),
+        (["a", "b", "c"], 3, [["a", "b", "c"]]),
+        (["a", "b", "c"], 4, [["a", "b", "c"]]),
+        (["a", "b", "c"], 0, [["a", "b", "c"]]),
+    ],
+)
+def test_iterate_list_by_chunks(iterable_list, chunk_size, expected_chunked_list):
+    chunked_list = mlrun.utils.iterate_list_by_chunks(iterable_list, chunk_size)
+    assert list(chunked_list) == expected_chunked_list


### PR DESCRIPTION
When list of run uids is too big, it exceeds grpc message size and fails with

```
> 2023-11-09 18:35:56,028 [warning] Failed stopping logs for runs. Ignoring: {'exc': '<AioRpcError of RPC that terminated with:\n\tstatus = StatusCode.RESOURCE_EXHAUSTED\n\tdetails = "grpc: received message larger than max (12470570 vs. 4194304)"\n\tdebug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:8282 {created_time:"2023-11-09T18:35:56.025126602+00:00", grpc_status:8, grpc_message:"grpc: received message larger than max (12470570 vs. 4194304)"}"\n>', 'project': 'load-project-0', 'run_uids':  .....
```

This PR chunk the list of run uids into a smaller portion ensuring the message size is relatively small

https://jira.iguazeng.com/browse/ML-4989