### PR TITLE
[Model Monitoring] Fix monitoring functions SDK usage

### DIFF
--- a/mlrun/model_monitoring/batch_application.py
+++ b/mlrun/model_monitoring/batch_application.py
@@ -124,7 +124,7 @@ class BatchApplicationProcessor:
             endpoints = self.db.list_model_endpoints(uids=self.model_endpoints)
             application = mlrun.get_or_create_project(
                 self.project
-            ).list_model_monitoring_applications()
+            ).list_model_monitoring_functions()
             if application:
                 applications_names = np.unique(
                     [app.metadata.name for app in application]


### PR DESCRIPTION
Following #4550.

The "application batch" job couldn't run successfully before this change:
```
> 2023-11-12 14:08:07,789 [error] Failed to list endpoints: {'exc': AttributeError("'MlrunProject' object has no attribute 'list_model_monitoring_applications'")}
```
![image](https://github.com/mlrun/mlrun/assets/36337649/51f4a8ab-ab0d-44ba-9da0-f37001fb4f06)
