### PR TITLE
[Builder] Fix resolving secret name for using mlrun default registry

### DIFF
--- a/mlrun/api/utils/builder.py
+++ b/mlrun/api/utils/builder.py
@@ -28,6 +28,7 @@ import mlrun.api.utils.singletons.k8s
 import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.errors
+import mlrun.model
 import mlrun.runtimes.utils
 import mlrun.utils
 from mlrun.config import config
@@ -619,7 +620,7 @@ def build_runtime(
     client_version=None,
     client_python_version=None,
 ):
-    build = runtime.spec.build
+    build: mlrun.model.ImageBuilder = runtime.spec.build
     namespace = runtime.metadata.namespace
     project = runtime.metadata.project
     if skip_deployed and runtime.is_deployed():
@@ -659,6 +660,9 @@ def build_runtime(
         return True
 
     build.image = mlrun.runtimes.utils.resolve_function_image_name(runtime, build.image)
+    build.secret = mlrun.runtimes.utils.resolve_function_image_secret(
+        build.image, build.secret
+    )
     runtime.status.state = ""
 
     inline = None  # noqa: F841

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -272,6 +272,18 @@ def resolve_function_image_name(function, image: typing.Optional[str] = None) ->
     return generate_function_image_name(project, name, tag)
 
 
+def resolve_function_image_secret(
+    resolved_target_image: str, secret: typing.Optional[str] = None
+) -> str:
+
+    # secret is not give, take from config if target image prefix equals to the default one
+    if not secret:
+        parsed_registry, parsed_repository = helpers.get_parsed_docker_registry()
+        if resolved_target_image.startswith(parsed_registry):
+            secret = config.httpdb.builder.docker_registry_secret
+    return secret
+
+
 def generate_function_image_name(project: str, name: str, tag: str) -> str:
     _, repository = helpers.get_parsed_docker_registry()
     repository = helpers.get_docker_repository_or_default(repository)


### PR DESCRIPTION
When using the default registry explicitly, the secret name is not automatically populated as opposed to how it works when using "." as image prefix (which turns "." -> "default registry")

This PR simply checks whether the target image uses mlrun default registry and if no secret name is provided (as an override) it simply populates the secret name from mlrun default configuration

https://jira.iguazeng.com/browse/ML-4953