### PR TITLE
[Datastore] Fix support for 'credential prefix'

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -96,10 +96,10 @@ class DataStore:
         """Whether the data store supports isdir"""
         return True
 
-    def _get_secret_or_env(self, key, default=None):
+    def _get_secret_or_env(self, key, default=None, prefix=None):
         # Project-secrets are mounted as env variables whose name can be retrieved from SecretsStore
         return mlrun.get_secret_or_env(
-            key, secret_provider=self._get_secret, default=default
+            key, secret_provider=self._get_secret, default=default, prefix=prefix
         )
 
     def get_storage_options(self):

--- a/mlrun/datastore/redis.py
+++ b/mlrun/datastore/redis.py
@@ -45,8 +45,9 @@ class RedisStore(DataStore):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Provide Redis username and password only via secrets"
             )
-        user = self._get_secret_or_env("REDIS_USER", "")
-        password = self._get_secret_or_env("REDIS_PASSWORD", "")
+        credentials_prefix = self._get_secret_or_env("CREDENTIALS_PREFIX")
+        user = self._get_secret_or_env("REDIS_USER", "", credentials_prefix)
+        password = self._get_secret_or_env("REDIS_PASSWORD", "", credentials_prefix)
         host = parsed_endpoint.hostname
         port = parsed_endpoint.port if parsed_endpoint.port else REDIS_DEFAULT_PORT
         schema = parsed_endpoint.scheme

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -436,8 +436,14 @@ class BaseStoreTarget(DataTargetBase):
         )
 
     def _get_store(self):
+        credentials_prefix_secrets = (
+            {"CREDENTIALS_PREFIX": self.credentials_prefix}
+            if self.credentials_prefix
+            else None
+        )
         store, _ = mlrun.store_manager.get_or_create_store(
-            self.get_target_path_with_credentials()
+            self.get_target_path(),
+            credentials_prefix_secrets,
         )
         return store
 
@@ -611,9 +617,6 @@ class BaseStoreTarget(DataTargetBase):
             if path_object
             else None
         )
-
-    def get_target_path_with_credentials(self):
-        return self.get_target_path()
 
     def get_target_templated_path(self):
         path_object = self._target_path_object
@@ -1281,10 +1284,6 @@ class RedisNoSqlTarget(NoSqlBaseTarget):
             "user": parsed_endpoint.username if parsed_endpoint.username else None,
             "auth": parsed_endpoint.password if parsed_endpoint.password else None,
         }
-
-    def get_target_path_with_credentials(self):
-        endpoint, uri = self._get_server_endpoint()
-        return endpoint
 
     def prepare_spark_df(self, df, key_columns, timestamp_key=None, spark_options=None):
         from pyspark.sql.functions import col


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4970
Resolve the issue with 'credentials prefix' for Redis when providing username and password through environment variables with prefixes