### PR TITLE
[Model Monitoring] Fix the labels aggregation in `list_model_monitoring_functions`

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3228,13 +3228,13 @@ class MlrunProject(ModelObj):
         :param labels: Return functions that have specific labels assigned to them.
         :returns: List of function objects.
         """
+        labels = labels or []
         return self.list_functions(
             name=name,
             tag=tag,
             labels=[
                 f"{mm_constants.ModelMonitoringAppLabel.KEY}={mm_constants.ModelMonitoringAppLabel.VAL}"
-            ]
-            + labels,
+            ].extend(labels),
         )
 
     def list_runs(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3213,7 +3213,12 @@ class MlrunProject(ModelObj):
             # convert dict to function objects
             return [mlrun.new_function(runtime=func) for func in functions]
 
-    def list_model_monitoring_functions(self, name=None, tag=None, labels=None):
+    def list_model_monitoring_functions(
+        self,
+        name: Optional[str] = None,
+        tag: Optional[str] = None,
+        labels: Optional[list[str]] = None,
+    ) -> Optional[list]:
         """Retrieve a list of all the model monitoring functions.
         example::
             functions = project.list_model_monitoring_functions()


### PR DESCRIPTION
The following error occurs when calling the mentioned method without arguments:
```
TypeError: can only concatenate list (not "NoneType") to list
```

Following #4550.

This fix solves the following issue:
```
> 2023-11-13 12:19:03,511 [info] There are no monitoring application found in this project
```
![image](https://github.com/mlrun/mlrun/assets/36337649/b5db59e0-1055-490a-960e-ce8247caf168)

Similarly to #4565, this error could be caught by a type checker.