### PR TITLE
[Datastore] Support Dbfs datastore profiles

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -194,19 +194,20 @@ class StoreManager:
 
         if schema == "ds":
             profile_name = endpoint
-            datastore = TemporaryClientDatastoreProfiles().get(profile_name)
-            if not datastore:
+            datastore_profile = TemporaryClientDatastoreProfiles().get(profile_name)
+            if not datastore_profile:
                 project_name = urlparse(url).username or mlrun.mlconf.default_project
-                datastore = mlrun.db.get_run_db(
+                datastore_profile = mlrun.db.get_run_db(
                     secrets=self._secrets
                 ).get_datastore_profile(profile_name, project_name)
 
-            if secrets and datastore.secrets():
-                secrets = merge(secrets, datastore.secrets())
+            if secrets and datastore_profile.secrets():
+                secrets = merge(secrets, datastore_profile.secrets())
             else:
-                secrets = secrets or datastore.secrets()
-            url = datastore.url(subpath)
-            schema, endpoint, parsed_url = parse_url(url)
+                secrets = secrets or datastore_profile.secrets()
+            url = datastore_profile.url(subpath)
+            #  schema, endpoint, parsed_url = parse_url(url)  # TODO test if buggy if we use 2 different instances.
+            schema, _, parsed_url = parse_url(url)  # TODO test if buggy if we use 2 different instances.
             subpath = parsed_url.path
 
         if schema == "memory":
@@ -233,3 +234,6 @@ class StoreManager:
             self._stores[store_key] = store
         # in file stores in windows path like c:\a\b the drive letter is dropped from the path, so we return the url
         return store, url if store.kind == "file" else subpath
+
+    def reset_secrets(self):
+        self._secrets = {}

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -206,8 +206,7 @@ class StoreManager:
             else:
                 secrets = secrets or datastore_profile.secrets()
             url = datastore_profile.url(subpath)
-            #  schema, endpoint, parsed_url = parse_url(url)  # TODO test if buggy if we use 2 different instances.
-            schema, _, parsed_url = parse_url(url)  # TODO test if buggy if we use 2 different instances.
+            schema, endpoint, parsed_url = parse_url(url)
             subpath = parsed_url.path
 
         if schema == "memory":

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -40,11 +40,11 @@ class DatastoreProfile(pydantic.BaseModel):
     def generate_secret_key(profile_name: str, project: str):
         secret_name_separator = "."
         full_key = (
-            "datastore-profiles"
-            + secret_name_separator
-            + project
-            + secret_name_separator
-            + profile_name
+                "datastore-profiles"
+                + secret_name_separator
+                + project
+                + secret_name_separator
+                + profile_name
         )
         return full_key
 
@@ -182,6 +182,13 @@ class DatastoreProfileRedis(DatastoreProfile):
         return self.endpoint_url + subpath
 
 
+class DatastoreProfileDBFS(DatastoreProfile):
+    type: str = pydantic.Field("dbfs")
+    _private_attributes = ("token",)
+    endpoint_url: typing.Optional[str] = None  # host
+    token: typing.Optional[str] = None
+
+
 class DatastoreProfile2Json(pydantic.BaseModel):
     @staticmethod
     def _to_json(attributes):
@@ -238,6 +245,7 @@ class DatastoreProfile2Json(pydantic.BaseModel):
             "basic": DatastoreProfileBasic,
             "kafka_target": DatastoreProfileKafkaTarget,
             "kafka_source": DatastoreProfileKafkaSource,
+            "dbfs": DatastoreProfileDBFS,
         }
         if datastore_type in ds_profile_factory:
             return ds_profile_factory[datastore_type].parse_obj(decoded_dict)

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -40,21 +40,21 @@ class DatastoreProfile(pydantic.BaseModel):
     def generate_secret_key(profile_name: str, project: str):
         secret_name_separator = "."
         full_key = (
-                "datastore-profiles"
-                + secret_name_separator
-                + project
-                + secret_name_separator
-                + profile_name
+            "datastore-profiles"
+            + secret_name_separator
+            + project
+            + secret_name_separator
+            + profile_name
         )
         return full_key
 
     @classmethod
-    def secrets(self) -> dict:
+    def secrets(cls) -> dict:
         return None
 
     @classmethod
-    def url(self, subpath) -> str:
-        return None
+    def url(cls, subpath) -> str:
+        return subpath
 
 
 class TemporaryClientDatastoreProfiles(metaclass=mlrun.utils.singleton.Singleton):
@@ -187,6 +187,10 @@ class DatastoreProfileDBFS(DatastoreProfile):
     _private_attributes = ("token",)
     endpoint_url: typing.Optional[str] = None  # host
     token: typing.Optional[str] = None
+
+    @classmethod
+    def url(cls, subpath) -> str:
+        return f"dbfs://{subpath}"
 
 
 class DatastoreProfile2Json(pydantic.BaseModel):

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -48,13 +48,11 @@ class DatastoreProfile(pydantic.BaseModel):
         )
         return full_key
 
-    @classmethod
-    def secrets(cls) -> dict:
+    def secrets(self) -> dict:
         return None
 
-    @classmethod
-    def url(cls, subpath) -> str:
-        return subpath
+    def url(self, subpath) -> str:
+        return None
 
 
 class TemporaryClientDatastoreProfiles(metaclass=mlrun.utils.singleton.Singleton):
@@ -188,9 +186,16 @@ class DatastoreProfileDBFS(DatastoreProfile):
     endpoint_url: typing.Optional[str] = None  # host
     token: typing.Optional[str] = None
 
-    @classmethod
-    def url(cls, subpath) -> str:
+    def url(self, subpath) -> str:
         return f"dbfs://{subpath}"
+
+    def secrets(self) -> dict:
+        res = {}
+        if self.token:
+            res["DATABRICKS_TOKEN"] = self.token
+        if self.endpoint_url:
+            res["DATABRICKS_HOST"] = self.endpoint_url
+        return res if res else None
 
 
 class DatastoreProfile2Json(pydantic.BaseModel):

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -14,12 +14,11 @@
 
 import pathlib
 
-import fsspec
 from fsspec.implementations.dbfs import DatabricksFile, DatabricksFileSystem
 
 import mlrun.errors
 
-from .base import DataStore, FileStats
+from .base import DataStore, FileStats, makeDatastoreSchemaSanitizer
 
 
 class DatabricksFileBugFixed(DatabricksFile):
@@ -91,7 +90,11 @@ class DBFSStore(DataStore):
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
         if not self._filesystem:
-            self._filesystem = fsspec.filesystem("dbfs", **self.get_storage_options())
+            self._filesystem = makeDatastoreSchemaSanitizer(
+                cls=DatabricksFileSystemDisableCache,
+                using_bucket=False,
+                **self.get_storage_options(),
+            )
         return self._filesystem
 
     def get_storage_options(self):

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -22,6 +22,8 @@ from .base import DataStore, FileStats, get_range, makeDatastoreSchemaSanitizer
 
 
 class S3Store(DataStore):
+    using_bucket = True
+
     def __init__(self, parent, schema, name, endpoint="", secrets: dict = None):
         super().__init__(parent, name, schema, endpoint, secrets)
         # will be used in case user asks to assume a role and work through fsspec
@@ -108,7 +110,9 @@ class S3Store(DataStore):
             return None
 
         self._filesystem = makeDatastoreSchemaSanitizer(
-            s3fs.S3FileSystem, **self.get_storage_options()
+            s3fs.S3FileSystem,
+            using_bucket=self.using_bucket,
+            **self.get_storage_options(),
         )
         return self._filesystem
 
@@ -173,7 +177,7 @@ class S3Store(DataStore):
         if not key.endswith("/"):
             key += "/"
         # Object names is S3 are not fully following filesystem semantics - they do not start with /, even for
-        # "absolute paths". Therefore, we are are removing leading / from path filter.
+        # "absolute paths". Therefore, we are removing leading / from path filter.
         if key.startswith("/"):
             key = key[1:]
         key_length = len(key)

--- a/tests/integration/test_dbfs_store/test_dbfs_store.py
+++ b/tests/integration/test_dbfs_store/test_dbfs_store.py
@@ -377,3 +377,18 @@ class TestDBFSStore:
             .reset_index(drop=True)
         )
         assert dd.assert_eq(appended_df, response_df)
+
+    def test_multiple_dataitems(self, use_datastore_profile):
+        if not use_datastore_profile:
+            pytest.skip("test_multiple_dataitems relevant for profiles only.")
+        data_item, _ = self._get_data_item(use_profile=use_datastore_profile)
+        test_profile = DatastoreProfileDBFS(
+            name="test_profile",
+            endpoint_url="test_host",
+            token="test_token",
+        )
+        register_temporary_client_datastore_profile(test_profile)
+        test_data_item = mlrun.run.get_dataitem(
+            "ds://test_profile/test_directory/test_file.txt", secrets={}
+        )
+        assert data_item.store.to_dict() != test_data_item.store.to_dict()


### PR DESCRIPTION
1) Add support for datastore Profiles.
2) Add tests.

Pay attention!
Support for datastore profiles and dask dataframe (dd) will be added in a future PR.


[ML-4828](https://jira.iguazeng.com/browse/ML-4828)