### PR TITLE
[Requirements] Fix Apple silicon conda dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ cd mlrun
 
 Create a conda environment and activate it
 ```shell script
-conda create -n mlrun python=3.9
+conda create -n mlrun python=3.9 protobuf
 conda activate mlrun
 ``` 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ cd mlrun
 
 Create a conda environment and activate it
 ```shell script
-conda create -n mlrun python=3.9 protobuf
+conda create -n mlrun python=3.9
 conda activate mlrun
 ``` 
 

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,9 @@ install-requirements: ## Install all requirements needed for development
 		-r docs/requirements.txt
 
 .PHONY: install-conda-requirements
-install-conda-requirements: install-requirements ## Install all requirements needed for development with specific conda packages for arm64
+install-conda-requirements: ## Install all requirements needed for development with specific conda packages for arm64
 	conda install --yes --file conda-arm64-requirements.txt
+	make install-requirements
 
 .PHONY: install-complete-requirements
 install-complete-requirements: ## Install all requirements needed for development and testing

--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -1,5 +1,5 @@
 # with moving to arm64 for the new M1/M2 macs some packages are not yet compatible via pip and require
 # conda which supports different architecture environments on the same machine
 lightgbm>=3.0
-protobuf>=3.20.3, <4
-pyyaml>=5.4.1, <6
+protobuf>=3.20.3, <4  # required for v3io client, see docs/requirments.txt for the contraint
+pyyaml>=5.4.1, <6     # see requirements.txt for the contraint

--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -1,3 +1,5 @@
 # with moving to arm64 for the new M1/M2 macs some packages are not yet compatible via pip and require
 # conda which supports different architecture environments on the same machine
 lightgbm>=3.0
+protobuf>=3.20.3, <4
+pyyaml>=5.4.1, <6

--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -1,5 +1,9 @@
 # with moving to arm64 for the new M1/M2 macs some packages are not yet compatible via pip and require
 # conda which supports different architecture environments on the same machine
 lightgbm>=3.0
-protobuf>=3.20.3, <4  # required for v3io client, see docs/requirments.txt for the contraint
-pyyaml>=5.4.1, <6     # see requirements.txt for the contraint
+
+# required for v3io client, see docs/requirments.txt for the contraint
+protobuf>=3.20.3, <4
+
+# see requirements.txt for the contraint
+pyyaml>=5.4.1, <6

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -102,7 +102,6 @@ def test_requirement_specifiers_convention():
         "nuclio-sdk": {">=0.3.0"},
         "bokeh": {"~=2.4, >=2.4.2"},
         # protobuf is limited just for docs
-        "protobuf": {"~=3.20.3"},
         "sphinx-book-theme": {"~=1.0.1"},
         "setuptools": {"~=65.5"},
         "transformers": {"~=4.11.3"},
@@ -143,6 +142,9 @@ def test_requirement_specifiers_convention():
         "aioresponses": {"~=0.7"},
         # conda requirements since conda does not support ~= operator
         "lightgbm": {">=3.0"},
+        "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
+        "pyyaml": {">=5.4.1, <6"},
+        # other requirements
         "azure-storage-blob": {">=12.13, !=12.18.0"},
     }
 
@@ -177,6 +179,8 @@ def test_requirement_specifiers_inconsistencies():
         # conda requirements since conda does not support ~= operator and
         # since platform condition is not required for docker
         "lightgbm": {"~=3.0", "~=3.0; platform_machine != 'arm64'", ">=3.0"},
+        "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
+        "pyyaml": {"~=5.1", ">=5.4.1, <6"},
     }
 
     for (


### PR DESCRIPTION
Without `protobuf` - a simple
```py
import mlrun
```
fails.

`protobuf` can probably be installed also via [brew](https://formulae.brew.sh/formula/protobuf), but conda is also fine.

The error from a vanilla installation before this change:
```sh
python -c "import mlrun"
```
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/Jonathan_Daniel/projects/mlrun/mlrun/__init__.py", line 32, in <module>
    from .datastore import DataItem, store_manager
  File "/Users/Jonathan_Daniel/projects/mlrun/mlrun/datastore/__init__.py", line 48, in <module>
    from .base import DataItem
  File "/Users/Jonathan_Daniel/projects/mlrun/mlrun/datastore/base.py", line 33, in <module>
    from .store_resources import is_store_uri, parse_store_uri
  File "/Users/Jonathan_Daniel/projects/mlrun/mlrun/datastore/store_resources.py", line 24, in <module>
    from .targets import get_online_target
  File "/Users/Jonathan_Daniel/projects/mlrun/mlrun/datastore/targets.py", line 33, in <module>
    from mlrun.utils.v3io_clients import get_frames_client
  File "/Users/Jonathan_Daniel/projects/mlrun/mlrun/utils/v3io_clients.py", line 18, in <module>
    from v3io_frames import Client as get_client
  File "/Users/Jonathan_Daniel/anaconda3/envs/mlrun/lib/python3.9/site-packages/v3io_frames/__init__.py", line 26, in <module>
    from .grpc import Client as gRPCClient  # noqa
  File "/Users/Jonathan_Daniel/anaconda3/envs/mlrun/lib/python3.9/site-packages/v3io_frames/grpc.py", line 31, in <module>
    from .http import format_go_time
  File "/Users/Jonathan_Daniel/anaconda3/envs/mlrun/lib/python3.9/site-packages/v3io_frames/http.py", line 32, in <module>
    from .pbutils import df2msg, msg2df, pb2py
  File "/Users/Jonathan_Daniel/anaconda3/envs/mlrun/lib/python3.9/site-packages/v3io_frames/pbutils.py", line 18, in <module>
    import google.protobuf.pyext._message as message
ModuleNotFoundError: No module named 'google.protobuf.pyext._message'
```

To verify the current way works:
```sh
conda deactivate && \
conda env remove -n mlrun && \
conda clean --all -y && \
pip cache purge && \
conda create -n mlrun -y python=3.9 && \
conda activate mlrun && \
make install-conda-requirements && \
python -c "import mlrun"
```

Note:
* I had to add also PyYAML - as its build fails when there's no cache (<6).
* I swapped the command order in the make rule - conda deps must be installed first.