### PR TITLE
[Model Monitoring] Sync the controller range with the stream pod flush interval

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -462,7 +462,7 @@ default_config = {
         "default_http_sink_app": "http://nuclio-{project}-{application_name}.mlrun.svc.cluster.local:8080",
         "batch_processing_function_branch": "master",
         "parquet_batching_max_events": 10_000,
-        "parquet_batching_timeout_secs": timedelta(minutes=30).total_seconds(),
+        "parquet_batching_timeout_secs": timedelta(minutes=1).total_seconds(),
         # See mlrun.model_monitoring.stores.ModelEndpointStoreType for available options
         "store_type": "v3io-nosql",
         "endpoint_store_connection": "",

--- a/mlrun/model_monitoring/batch_application.py
+++ b/mlrun/model_monitoring/batch_application.py
@@ -17,7 +17,7 @@ import datetime
 import json
 import os
 import re
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -187,7 +187,7 @@ class BatchApplicationProcessor:
     @staticmethod
     def model_endpoint_process(
         endpoint: dict,
-        applications_names: List[str],
+        applications_names: list[str],
         bath_dict: dict,
         project: str,
         parquet_directory: str,

--- a/mlrun/model_monitoring/batch_application.py
+++ b/mlrun/model_monitoring/batch_application.py
@@ -17,7 +17,7 @@ import datetime
 import json
 import os
 import re
-from typing import Tuple
+from typing import Callable, Tuple
 
 import numpy as np
 import pandas as pd
@@ -249,10 +249,8 @@ class BatchApplicationProcessor:
                             mlrun.common.schemas.model_monitoring.EventFieldType.UID
                         ],
                         min_rqeuired_events=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events,
-                        start_time=str(
-                            datetime.datetime.now() - datetime.timedelta(hours=1)
-                        ),
-                        end_time=str(datetime.datetime.now()),
+                        start_time=start_time,
+                        end_time=end_time,
                     )
                     return
 
@@ -319,17 +317,22 @@ class BatchApplicationProcessor:
             return endpoint_id, e
 
     @staticmethod
-    def _get_interval_range(batch_dict) -> Tuple[datetime.datetime, datetime.datetime]:
+    def _get_interval_range(
+        batch_dict: dict[str, int],
+        now_func: Callable[[], datetime.datetime] = datetime.datetime.now,
+    ) -> Tuple[datetime.datetime, datetime.datetime]:
         """Getting batch interval time range"""
         minutes, hours, days = (
             batch_dict[mlrun.common.schemas.model_monitoring.EventFieldType.MINUTES],
             batch_dict[mlrun.common.schemas.model_monitoring.EventFieldType.HOURS],
             batch_dict[mlrun.common.schemas.model_monitoring.EventFieldType.DAYS],
         )
-        start_time = datetime.datetime.now() - datetime.timedelta(
+        end_time = now_func() - datetime.timedelta(
+            seconds=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
+        )
+        start_time = end_time - datetime.timedelta(
             minutes=minutes, hours=hours, days=days
         )
-        end_time = datetime.datetime.now()
         return start_time, end_time
 
     def _parse_batch_dict_str(self):


### PR DESCRIPTION
The first effort for [ML-5036](https://jira.iguazeng.com/browse/ML-5036).

* Shorten the max stream pod flush rate from 30 min -> 1 min
* Update the controller ("batch application") interval range getter logic from:
   [now- delta, now]
   to:
   [(now - 1 min) - delta, (now - 1 min)]

The above points reduce the risk of event loss during the monitoring function processing.

Add unit tests to cover some behavior.
