### PR TITLE
Revert "[Datastore] Fixing datastore profile target path resolution in CSV and Parquet targets (#4586)"

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -24,7 +24,6 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import pandas as pd
-from mergedeep import merge
 
 import mlrun
 import mlrun.utils.helpers
@@ -442,11 +441,11 @@ class BaseStoreTarget(DataTargetBase):
             if self.credentials_prefix
             else None
         )
-        store, resolved_store_path = mlrun.store_manager.get_or_create_store(
+        store, _ = mlrun.store_manager.get_or_create_store(
             self.get_target_path(),
             credentials_prefix_secrets,
         )
-        return store, store.url + resolved_store_path
+        return store
 
     def _get_column_list(self, features, timestamp_key, key_columns, with_type=False):
         result = []
@@ -495,18 +494,17 @@ class BaseStoreTarget(DataTargetBase):
             df.write.mode("overwrite").save(**options)
         elif hasattr(df, "dask"):
             dask_options = self.get_dask_options()
-            store, target_path = self._get_store()
-            storage_options = store.get_storage_options()
+            storage_options = self._get_store().get_storage_options()
             df = df.repartition(partition_size="100MB")
             try:
                 if dask_options["format"] == "parquet":
                     df.to_parquet(
-                        generate_path_with_chunk(self, chunk_id, target_path),
+                        generate_path_with_chunk(self, chunk_id),
                         storage_options=storage_options,
                     )
                 elif dask_options["format"] == "csv":
                     df.to_csv(
-                        generate_path_with_chunk(self, chunk_id, target_path),
+                        generate_path_with_chunk(self, chunk_id),
                         storage_options=storage_options,
                     )
                 else:
@@ -516,9 +514,8 @@ class BaseStoreTarget(DataTargetBase):
             except Exception as exc:
                 raise RuntimeError("Failed to write Dask Dataframe") from exc
         else:
-            store, target_path = self._get_store()
-            target_path = generate_path_with_chunk(self, chunk_id, target_path)
-            file_system = store.get_filesystem(False)
+            target_path = generate_path_with_chunk(self, chunk_id)
+            file_system = self._get_store().get_filesystem(False)
             if file_system.protocol == "file":
                 dir = os.path.dirname(target_path)
                 if dir:
@@ -554,16 +551,10 @@ class BaseStoreTarget(DataTargetBase):
                 # Partitioning will be performed on timestamp_key and then on self.partition_cols
                 # (We might want to give the user control on this order as additional functionality)
                 partition_cols += self.partition_cols or []
-
-            storage_options = store.get_storage_options()
-            if storage_options and self.storage_options:
-                storage_options = merge(storage_options, self.storage_options)
-            else:
-                storage_options = storage_options or self.storage_options
-
+            storage_options = self._get_store().get_storage_options()
             self._write_dataframe(
                 target_df,
-                storage_options,
+                self.storage_options or storage_options,
                 target_path,
                 partition_cols=partition_cols,
                 **kwargs,
@@ -682,8 +673,7 @@ class BaseStoreTarget(DataTargetBase):
         raise NotImplementedError()
 
     def purge(self):
-        store, target_path = self._get_store()
-        store.rm(target_path, recursive=True)
+        self._get_store().rm(self.get_target_path(), recursive=True)
 
     def as_df(
         self,
@@ -870,25 +860,18 @@ class ParquetTarget(BaseStoreTarget):
                 "update_last_written": featureset_status.update_last_written_for_target
             }
 
-        store, target_path = self._get_store()
-
-        storage_options = store.get_storage_options()
-        if storage_options and self.storage_options:
-            storage_options = merge(storage_options, self.storage_options)
-        else:
-            storage_options = storage_options or self.storage_options
-
         graph.add_step(
             name=self.name or "ParquetTarget",
             after=after,
             graph_shape="cylinder",
             class_name="storey.ParquetTarget",
-            path=target_path,
+            path=self.get_target_path(),
             columns=column_list,
             index_cols=tuple_key_columns,
             partition_cols=partition_cols,
             time_field=timestamp_key,
-            storage_options=storage_options,
+            storage_options=self.storage_options
+            or self._get_store().get_storage_options(),
             max_events=self.max_events,
             flush_after_seconds=self.flush_after_seconds,
             **self.attributes,
@@ -1026,17 +1009,17 @@ class CSVTarget(BaseStoreTarget):
         column_list = self._get_column_list(
             features=features, timestamp_key=timestamp_key, key_columns=key_columns
         )
-        store, target_path = self._get_store()
+
         graph.add_step(
             name=self.name or "CSVTarget",
             after=after,
             graph_shape="cylinder",
             class_name="storey.CSVTarget",
-            path=target_path,
+            path=self.get_target_path(),
             columns=column_list,
             header=True,
             index_cols=key_columns,
-            storage_options=store.get_storage_options(),
+            storage_options=self._get_store().get_storage_options(),
             **self.attributes,
         )
 
@@ -1940,8 +1923,8 @@ def _get_target_path(driver, resource, run_id_mode=False):
     return f"{data_prefix}/{kind_prefix}/{name}{suffix}"
 
 
-def generate_path_with_chunk(target, chunk_id, path):
-    prefix, suffix = os.path.splitext(path)
+def generate_path_with_chunk(target, chunk_id):
+    prefix, suffix = os.path.splitext(target.get_target_path())
     if chunk_id and not target.partitioned and not target.time_partitioning_granularity:
         return f"{prefix}/{chunk_id:0>4}{suffix}"
-    return path
+    return target.get_target_path()


### PR DESCRIPTION
This reverts commit 4546dc81bbf39e8d4800710ede6745a9706f1d69.
Wide failures in feature-store system tests (ex test_relation_join)