### PR TITLE
[Runtimes] Fixed missing `force_build` in `deploy()` for spark and serving runtimes

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3008,7 +3008,7 @@ class MlrunProject(ModelObj):
             * True: The existing params are replaced by the new ones
         :param extra_args:  A string containing additional builder arguments in the format of command-line options,
             e.g. extra_args="--skip-tls-verify --build-arg A=val"r
-        :param force_build:
+        :param force_build: set True for force building the image
         """
 
         if skip_deployed:

--- a/mlrun/runtimes/kubejob.py
+++ b/mlrun/runtimes/kubejob.py
@@ -175,7 +175,7 @@ class KubejobRuntime(KubeResource):
         :param show_on_failure:         show logs only in case of build failure
         :param force_build:             set True for force building the image, even when no changes were made
 
-        :return True if the function is ready (deployed)
+        :return: True if the function is ready (deployed)
         """
 
         build = self.spec.build

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -586,6 +586,7 @@ class ServingRuntime(RemoteRuntime):
         verbose=False,
         auth_info: mlrun.common.schemas.AuthInfo = None,
         builder_env: dict = None,
+        force_build: bool = False,
     ):
         """deploy model serving function to a local/remote cluster
 
@@ -596,6 +597,7 @@ class ServingRuntime(RemoteRuntime):
         :param auth_info: The auth info to use to communicate with the Nuclio dashboard, required only when providing
                           dashboard
         :param builder_env: env vars dict for source archive config/credentials e.g. builder_env={"GIT_TOKEN": token}
+        :param force_build: set True for force building the image
         """
         load_mode = self.spec.load_mode
         if load_mode and load_mode not in ["sync", "async"]:
@@ -635,7 +637,13 @@ class ServingRuntime(RemoteRuntime):
             logger.info(f"deploy root function {self.metadata.name} ...")
 
         return super().deploy(
-            dashboard, project, tag, verbose, auth_info, builder_env=builder_env
+            dashboard,
+            project,
+            tag,
+            verbose,
+            auth_info,
+            builder_env=builder_env,
+            force_build=force_build,
         )
 
     def _get_runtime_env(self):

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -856,6 +856,7 @@ class Spark3Runtime(KubejobRuntime):
         mlrun_version_specifier=None,
         builder_env: dict = None,
         show_on_failure: bool = False,
+        force_build: bool = False,
     ):
         """deploy function, build container with dependencies
 
@@ -867,8 +868,9 @@ class Spark3Runtime(KubejobRuntime):
         :param builder_env:             Kaniko builder pod env vars dict (for config/credentials)
                                         e.g. builder_env={"GIT_TOKEN": token}
         :param show_on_failure:         show logs only in case of build failure
+        :param force_build:             set True for force building the image, even when no changes were made
 
-        :return True if the function is ready (deployed)
+        :return: True if the function is ready (deployed)
         """
         # connect will populate the config from the server config
         mlrun.db.get_run_db()
@@ -882,6 +884,7 @@ class Spark3Runtime(KubejobRuntime):
             mlrun_version_specifier=mlrun_version_specifier,
             builder_env=builder_env,
             show_on_failure=show_on_failure,
+            force_build=force_build,
         )
 
     @staticmethod


### PR DESCRIPTION
Calling `project.build_function()` on a Spark runtime would explode with:
```
TypeError: deploy() got an unexpected keyword argument 'force_build'
```
Reason is that the `force_build` param was missing in the `Spark3Runtime.deploy()` method - it was overlooked when this functionality was implemented.
Same is done for `ServingRuntime` (though it's usually not directly invoked through project functions).
Added the missing parameter.


