### PR TITLE
[Model Monitoring] Fix labels when calling `list_model_monitoring_functions`

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3241,13 +3241,16 @@ class MlrunProject(ModelObj):
         :param labels: Return functions that have specific labels assigned to them.
         :returns: List of function objects.
         """
-        labels = labels or []
+
+        model_monitoring_labels_list = [
+            f"{mm_constants.ModelMonitoringAppLabel.KEY}={mm_constants.ModelMonitoringAppLabel.VAL}"
+        ]
+        if labels:
+            model_monitoring_labels_list += labels
         return self.list_functions(
             name=name,
             tag=tag,
-            labels=[
-                f"{mm_constants.ModelMonitoringAppLabel.KEY}={mm_constants.ModelMonitoringAppLabel.VAL}"
-            ].extend(labels),
+            labels=model_monitoring_labels_list,
         )
 
     def list_runs(


### PR DESCRIPTION
When calling `list_model_monitoring_functions`, the expected value is a list of registered model monitoring functions with optional additional labels (along with the default label of `mlrun__type=mlrun__model-monitoring-application`). However, at the moment, if no additional label has been provided, this function returns all registered functions, including non-monitoring functions. 

In this PR, we fix that bug and make sure that only model monitoring functions are retrieved, even if no additional labels are provided.  

   