### PR TITLE
[Requirements] Temporarily blacklist aiohttp 3.8.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all:
 .PHONY: install-requirements
 install-requirements: ## Install all requirements needed for development
 	python -m pip install --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
-	python -m pip install \
+	python -m pip install --upgrade \
 		$(MLRUN_PIP_NO_CACHE_FLAG) \
 		-r requirements.txt \
 		-r extras-requirements.txt \

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all:
 .PHONY: install-requirements
 install-requirements: ## Install all requirements needed for development
 	python -m pip install --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
-	python -m pip install --upgrade \
+	python -m pip install \
 		$(MLRUN_PIP_NO_CACHE_FLAG) \
 		-r requirements.txt \
 		-r extras-requirements.txt \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # >=1.26.9, <1.27 from botocore 1.19.28 inside boto3 1.16.28 inside nuclio-jupyter 0.8.8
 urllib3>=1.26.9, <1.27
 GitPython~=3.1, >= 3.1.30
-# 3.8.4 breaks our unit tests. blacklist for now until we fix it
-aiohttp~=3.8, !=3.8.4
+# 3.8.4 and 3.9 breaks our unit tests. blacklist for now until we fix it
+aiohttp~=3.8, <=3.8.4
 aiohttp-retry~=2.8
 click~=8.1
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # >=1.26.9, <1.27 from botocore 1.19.28 inside boto3 1.16.28 inside nuclio-jupyter 0.8.8
 urllib3>=1.26.9, <1.27
 GitPython~=3.1, >= 3.1.30
-aiohttp~=3.8
+# 3.8.4 breaks our unit tests. blacklist for now until we fix it
+aiohttp~=3.8, !=3.8.4
 aiohttp-retry~=2.8
 click~=8.1
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 urllib3>=1.26.9, <1.27
 GitPython~=3.1, >= 3.1.30
 # 3.8.4 and 3.9 breaks our unit tests. blacklist for now until we fix it
-aiohttp~=3.8, <=3.8.4
+aiohttp~=3.8, <3.8.4
 aiohttp-retry~=2.8
 click~=8.1
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -146,7 +146,7 @@ def test_requirement_specifiers_convention():
         "pyyaml": {">=5.4.1, <6"},
         # other requirements
         "azure-storage-blob": {">=12.13, !=12.18.0"},
-        "aiohttp": {"~=3.8, <=3.8.4"},
+        "aiohttp": {"~=3.8, <3.8.4"},
     }
 
     for (

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -146,7 +146,7 @@ def test_requirement_specifiers_convention():
         "pyyaml": {">=5.4.1, <6"},
         # other requirements
         "azure-storage-blob": {">=12.13, !=12.18.0"},
-        'aiohttp': {'~=3.8, !=3.8.4'}
+        "aiohttp": {"~=3.8, !=3.8.4"},
     }
 
     for (

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -146,7 +146,7 @@ def test_requirement_specifiers_convention():
         "pyyaml": {">=5.4.1, <6"},
         # other requirements
         "azure-storage-blob": {">=12.13, !=12.18.0"},
-        "aiohttp": {"~=3.8, !=3.8.4"},
+        "aiohttp": {"~=3.8, <=3.8.4"},
     }
 
     for (

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -146,6 +146,7 @@ def test_requirement_specifiers_convention():
         "pyyaml": {">=5.4.1, <6"},
         # other requirements
         "azure-storage-blob": {">=12.13, !=12.18.0"},
+        'aiohttp': {'~=3.8, !=3.8.4'}
     }
 
     for (


### PR DESCRIPTION
aiohttp 3.8.4 breaks our unit tests. blacklist for now until we fix it to unblock other PRs.
