### PR TITLE
[Nuclio] Introduce nuclio async client for mlrun api

### DIFF
--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -59,6 +59,7 @@ class AuthorizationResourceTypes(mlrun.common.types.StrEnum):
     hub_source = "hub-source"
     workflow = "workflow"
     datastore_profile = "datastore-profile"
+    api_gateways = "api-gateways"
 
     def to_resource_string(
         self,
@@ -94,6 +95,7 @@ class AuthorizationResourceTypes(mlrun.common.types.StrEnum):
             AuthorizationResourceTypes.hub_source: "/marketplace/sources",
             # workflow define how to run a pipeline and can be considered as the specification of a pipeline.
             AuthorizationResourceTypes.workflow: "/projects/{project_name}/workflows/{resource_name}",
+            AuthorizationResourceTypes.api_gateways: "/projects/{project_name}/api-gateways",
         }[self].format(project_name=project_name, resource_name=resource_name)
 
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -296,7 +296,7 @@ def add_target_steps(graph, resource, targets, to_df=False, final_step=None):
         driver.add_writer_step(
             graph,
             target.after_step or final_step,
-            features=features,
+            features=features if not target.after_step else None,
             key_columns=key_columns,
             timestamp_key=timestamp_key,
             featureset_status=resource.status,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3153,9 +3153,7 @@ class HTTPRunDB(RunDBInterface):
         """
         project = project or config.default_project
         error = "list api gateways"
-        resp = self.api_call(
-            "GET", f"projects/{project}/nuclio/api-gateways", error, params
-        )
+        resp = self.api_call("GET", f"projects/{project}/nuclio/api-gateways", error)
         return resp.json()
 
     def trigger_migrations(self) -> Optional[mlrun.common.schemas.BackgroundTask]:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3143,19 +3143,19 @@ class HTTPRunDB(RunDBInterface):
             body=dict_to_json(authorization_verification_input.dict()),
         )
 
-    def list_api_gateways(self, project_name=None):
+    def list_api_gateways(self, project=None):
         """
-        Returns the list of Nuclio api gateways
-        :param project_name: optional str parameter to filter by project, if not passed, default Nuclio's value is taken
+        Returns a list of Nuclio api gateways
+        :param project: optional str parameter to filter by project, if not passed, default Nuclio's value is taken
 
         :return: json with the list of Nuclio Api Gateways
-            (json example is here https://github.com/nuclio/nuclio/tree/development/cmd/dashboard#response-20)
+            (json example is here https://github.com/nuclio/nuclio/blob/development/docs/reference/api/README.md#listing-all-api-gateways)
         """
-        params = {}
-        if project_name:
-            params["project-name"] = project_name
+        project = project or config.default_project
         error = "list api gateways"
-        resp = self.api_call("GET", "api-gateways", error, params)
+        resp = self.api_call(
+            "GET", f"projects/{project}/nuclio/api-gateways", error, params
+        )
         return resp.json()
 
     def trigger_migrations(self) -> Optional[mlrun.common.schemas.BackgroundTask]:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3143,6 +3143,21 @@ class HTTPRunDB(RunDBInterface):
             body=dict_to_json(authorization_verification_input.dict()),
         )
 
+    def list_api_gateways(self, project_name=None):
+        """
+        Returns the list of Nuclio api gateways
+        :param project_name: optional str parameter to filter by project, if not passed, default Nuclio's value is taken
+
+        :return: json with the list of Nuclio Api Gateways
+            (json example is here https://github.com/nuclio/nuclio/tree/development/cmd/dashboard#response-20)
+        """
+        params = {}
+        if project_name:
+            params["project-name"] = project_name
+        error = "list api gateways"
+        resp = self.api_call("GET", "api-gateways", error, params)
+        return resp.json()
+
     def trigger_migrations(self) -> Optional[mlrun.common.schemas.BackgroundTask]:
         """Trigger migrations (will do nothing if no migrations are needed) and wait for them to finish if actually
         triggered

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3149,7 +3149,8 @@ class HTTPRunDB(RunDBInterface):
         :param project: optional str parameter to filter by project, if not passed, default Nuclio's value is taken
 
         :return: json with the list of Nuclio Api Gateways
-            (json example is here https://github.com/nuclio/nuclio/blob/development/docs/reference/api/README.md#listing-all-api-gateways)
+            (json example is here
+            https://github.com/nuclio/nuclio/blob/development/docs/reference/api/README.md#listing-all-api-gateways)
         """
         project = project or config.default_project
         error = "list api gateways"

--- a/server/api/api/api.py
+++ b/server/api/api/api.py
@@ -33,6 +33,7 @@ from server.api.api.endpoints import (
     jobs,
     logs,
     model_endpoints,
+    nuclio,
     operations,
     pipelines,
     projects,
@@ -158,5 +159,10 @@ api_router.include_router(
 api_router.include_router(
     datastore_profile.router,
     tags=["datastores"],
+    dependencies=[Depends(deps.authenticate_request)],
+)
+api_router.include_router(
+    nuclio.router,
+    tags=["nuclio"],
     dependencies=[Depends(deps.authenticate_request)],
 )

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from fastapi import APIRouter, Depends
+
+import mlrun.common.schemas
+import server.api.utils.clients.async_nuclio
+from server.api.api import deps
+
+router = APIRouter()
+
+
+@router.get("/projects/{project}/nuclio/api-gateways")
+async def list_api_gateways(
+    project: str,
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
+):
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+        project_name=project,
+        action=mlrun.common.schemas.AuthorizationAction.read,
+        auth_info=auth_info,
+    )
+
+    api_gateways = await server.api.utils.clients.async_nuclio.Client(
+        auth_info
+    ).list_api_gateways(project)
+
+    return await server.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.api_gateways,
+        list(api_gateways.values()) if api_gateways else [],
+        lambda _api_gateway: (
+            _api_gateway.get("metadata", {})
+            .get("labels", {})
+            .get("iguazio.com/username"),
+            _api_gateway.get("metadata", {}).get("name"),
+        ),
+        auth_info,
+    )

--- a/server/api/middlewares.py
+++ b/server/api/middlewares.py
@@ -64,6 +64,7 @@ async def log_request_response(request: fastapi.Request, call_next):
     try:
         response = await call_next(request)
     except Exception as exc:
+        exc = mlrun.errors.err_to_str(exc)
         logger.warning(
             "Request handling failed. Sending response",
             # User middleware (like this one) runs after the exception handling middleware, the only thing running after

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -74,17 +74,17 @@ class Client:
             except Exception:
                 response_body = {}
             self._handle_error_response(
-                method, path, response, response_body, error_message, kwargs
+                method, url, path, response, response_body, error_message, kwargs
             )
         else:
             return await response.json()
 
     def _handle_error_response(
-        self, method, path, response, response_body, error_message, kwargs
+        self, method, url, path, response, response_body, error_message, kwargs
     ):
         log_kwargs = copy.deepcopy(kwargs)
         log_kwargs.pop("json", None)
-        log_kwargs.update({"method": method, "path": path})
+        log_kwargs.update({"method": method, "url": url, "path": path})
 
         try:
             error = response_body.get("error", "")

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -1,0 +1,104 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import copy
+import urllib.parse
+
+import aiohttp
+
+import mlrun.common.schemas
+import mlrun.utils
+from mlrun.utils import logger
+
+NUCLIO_API_SESSIONS_ENDPOINT = "/api/sessions/"
+NUCLIO_API_GATEWAYS_ENDPOINT = "/api/api_gateways/"
+API_GATEWAY_NAMESPACE_HEADER = "X-Nuclio-Api-Gateway-Namespace"
+NUCLIO_PROJECT_NAME_HEADER = "X-Nuclio-Project-Name"
+
+
+class Client:
+    def __init__(self, auth_info: mlrun.common.schemas.AuthInfo):
+        self._session = None
+        self._auth = aiohttp.BasicAuth(auth_info.username, auth_info.session)
+        self._logger = logger.get_child("nuclio-client")
+        self._nuclio_dashboard_url = mlrun.mlconf.nuclio_dashboard_url
+
+    async def list_api_gateways(self, project_name=None):
+        headers = {}
+
+        if project_name:
+            headers[NUCLIO_PROJECT_NAME_HEADER] = project_name
+
+        return await self._send_request_to_api(
+            method="GET",
+            url=self._nuclio_dashboard_url,
+            path=NUCLIO_API_GATEWAYS_ENDPOINT,
+            headers=headers,
+        )
+
+    async def _ensure_async_session(self):
+        if not self._session:
+            self._session = mlrun.utils.AsyncClientWithRetry(
+                retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
+                == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
+                logger=logger,
+            )
+
+    async def _send_request_to_api(
+        self, method, url, path="/", error_message: str = "", **kwargs
+    ):
+        await self._ensure_async_session()
+        response = await self._session.request(
+            method=method,
+            url=urllib.parse.urljoin(url, path),
+            auth=self._auth,
+            verify_ssl=False,
+            **kwargs,
+        )
+        if not response:
+            return
+        if not response.ok:
+            try:
+                response_body = await response.json()
+            except Exception:
+                response_body = {}
+            self._handle_error_response(
+                method, path, response, response_body, error_message, kwargs
+            )
+        else:
+            return await response.json()
+
+    def _handle_error_response(
+        self, method, path, response, response_body, error_message, kwargs
+    ):
+        log_kwargs = copy.deepcopy(kwargs)
+        log_kwargs.pop("json", None)
+        log_kwargs.update({"method": method, "path": path})
+
+        try:
+            error = response_body.get("error", "")
+            error_stack_trace = response_body.get("errorStackTrace", "")
+        except Exception:
+            pass
+        else:
+            if error:
+                error_message = f"{error_message}: {str(error)}"
+            if error:
+                log_kwargs.update(
+                    {"error": error, "errorStackTrace": error_stack_trace}
+                )
+
+        self._logger.warning("Request to nuclio failed. Reason:", **log_kwargs)
+
+        mlrun.errors.raise_for_status(response, error_message)

--- a/tests/api/api/test_nuclio.py
+++ b/tests/api/api/test_nuclio.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import unittest
+from unittest.mock import patch
 
 import fastapi
 
@@ -23,7 +24,10 @@ import server.api.utils.clients.iguazio
 PROJECT = "project-name"
 
 
-def test_list_api_gateways(client: fastapi.testclient.TestClient):
+@patch.object(server.api.utils.clients.async_nuclio.Client, "list_api_gateways")
+def test_list_api_gateways(
+    list_api_gateway_mocked, client: fastapi.testclient.TestClient
+):
     mlrun.mlconf.httpdb.authentication.mode = "iguazio"
     server.api.utils.clients.iguazio.AsyncClient().verify_request_session = (
         unittest.mock.AsyncMock(
@@ -68,13 +72,9 @@ def test_list_api_gateways(client: fastapi.testclient.TestClient):
 
     expected_response_body = list(nuclio_api_response_body.values())
 
-    server.api.utils.clients.async_nuclio.Client.list_api_gateways = (
-        unittest.mock.AsyncMock()
-    )
-    server.api.utils.clients.async_nuclio.Client.list_api_gateways.return_value = (
-        nuclio_api_response_body
-    )
+    list_api_gateway_mocked.return_value = nuclio_api_response_body
     response = client.get(
         f"projects/{PROJECT}/nuclio/api-gateways",
     )
+
     assert response.json() == expected_response_body

--- a/tests/api/api/test_nuclio.py
+++ b/tests/api/api/test_nuclio.py
@@ -1,0 +1,80 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+import fastapi
+
+import mlrun
+import server.api.utils.clients.async_nuclio
+import server.api.utils.clients.iguazio
+
+PROJECT = "project-name"
+
+
+def test_list_api_gateways(client: fastapi.testclient.TestClient):
+    mlrun.mlconf.httpdb.authentication.mode = "iguazio"
+    server.api.utils.clients.iguazio.AsyncClient().verify_request_session = (
+        unittest.mock.AsyncMock(
+            return_value=(
+                mlrun.common.schemas.AuthInfo(
+                    username="admin",
+                    session="some-session",
+                    data_session="some-session",
+                    user_id=None,
+                    user_unix_id=0,
+                    user_group_ids=[],
+                )
+            )
+        )
+    )
+    nuclio_api_response_body = {
+        "test-basic": {
+            "metadata": {
+                "name": "test-basic",
+                "namespace": "default-tenant",
+                "labels": {
+                    "iguazio.com/username": "admin",
+                    "nuclio.io/project-name": "default",
+                },
+                "creationTimestamp": "2023-11-16T12:42:48Z",
+            },
+            "spec": {
+                "host": "test-basic-default.default-tenant.app.dev62.lab.iguazeng.com",
+                "name": "test-basic",
+                "path": "/",
+                "authenticationMode": "basicAuth",
+                "authentication": {
+                    "basicAuth": {"username": "test", "password": "test"}
+                },
+                "upstreams": [
+                    {"kind": "nucliofunction", "nucliofunction": {"name": "test"}}
+                ],
+            },
+            "status": {"name": "test-basic", "state": "ready"},
+        }
+    }
+
+    expected_response_body = list(nuclio_api_response_body.values())
+
+    server.api.utils.clients.async_nuclio.Client.list_api_gateways = (
+        unittest.mock.AsyncMock()
+    )
+    server.api.utils.clients.async_nuclio.Client.list_api_gateways.return_value = (
+        nuclio_api_response_body
+    )
+    response = client.get(
+        f"projects/{PROJECT}/nuclio/api-gateways",
+    )
+    assert response.json() == expected_response_body

--- a/tests/api/utils/clients/test_async_nuclio.py
+++ b/tests/api/utils/clients/test_async_nuclio.py
@@ -1,0 +1,93 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import http
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses as aioresponses_
+
+import mlrun.common.schemas
+import mlrun.config
+import mlrun.errors
+import server.api.utils.clients.async_nuclio
+
+
+@pytest.fixture()
+async def api_url() -> str:
+    return "http://nuclio-dashboard-url"
+
+
+@pytest.fixture()
+async def nuclio_client(
+    api_url,
+) -> server.api.utils.clients.async_nuclio.Client:
+    auth_info = mlrun.common.schemas.AuthInfo()
+    auth_info.username = "admin"
+    auth_info.session = "bed854c1-c57751553"
+    client = server.api.utils.clients.async_nuclio.Client(auth_info)
+    client._nuclio_dashboard_url = api_url
+    return client
+
+
+@pytest.fixture
+def mock_aioresponse():
+    with aioresponses_() as m:
+        yield m
+
+
+@pytest.mark.asyncio
+async def test_list_api_gateways(
+    api_url,
+    nuclio_client,
+    mock_aioresponse,
+):
+    response_body = {
+        "test-basic": {
+            "metadata": {
+                "name": "test-basic",
+                "namespace": "default-tenant",
+                "labels": {
+                    "iguazio.com/username": "admin",
+                    "nuclio.io/project-name": "default",
+                },
+                "creationTimestamp": "2023-11-16T12:42:48Z",
+            },
+            "spec": {
+                "host": "test-basic-default.default-tenant.app.dev62.lab.iguazeng.com",
+                "name": "test-basic",
+                "path": "/",
+                "authenticationMode": "basicAuth",
+                "authentication": {
+                    "basicAuth": {"username": "test", "password": "test"}
+                },
+                "upstreams": [
+                    {"kind": "nucliofunction", "nucliofunction": {"name": "test"}}
+                ],
+            },
+            "status": {"name": "test-basic", "state": "ready"},
+        }
+    }
+    request_url = f"{api_url}/api/api_gateways/"
+    mock_aioresponse.get(
+        request_url,
+        payload=response_body,
+        status=http.HTTPStatus.ACCEPTED,
+    )
+    r = await nuclio_client.list_api_gateways()
+    assert r == response_body
+
+    mock_aioresponse.get(request_url, status=http.HTTPStatus.UNAUTHORIZED)
+    with pytest.raises(aiohttp.client_exceptions.ClientResponseError):
+        await nuclio_client.list_api_gateways()

--- a/tests/api/utils/clients/test_async_nuclio.py
+++ b/tests/api/utils/clients/test_async_nuclio.py
@@ -48,7 +48,7 @@ def mock_aioresponse():
 
 
 @pytest.mark.asyncio
-async def test_list_api_gateways(
+async def test_nuclio_list_api_gateways(
     api_url,
     nuclio_client,
     mock_aioresponse,


### PR DESCRIPTION
We are introducing a new asynchronous client for the Nuclio API. Currently, only the method to retrieve API gateways has been implemented.
