### PR TITLE
[Feature Store] Set unit and timezone of default start and end times

### DIFF
--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
+import pytz
 from storey import EmitEveryEvent, EmitPolicy
 
 import mlrun
@@ -929,9 +930,11 @@ class FeatureSet(ModelObj):
                 )
             df = self.spec.source.to_dataframe(
                 columns=columns,
+                # overwrite `source.start_time` when the source is schedule.
                 start_time=start_time
-                or pd.Timestamp.min,  # overwrite `source.start_time` when the source is schedule.
-                end_time=end_time or pd.Timestamp.max,
+                or pd.to_datetime(pd.Timestamp.min, unit="ns").replace(tzinfo=pytz.UTC),
+                end_time=end_time
+                or pd.to_datetime(pd.Timestamp.max, unit="ns").replace(tzinfo=pytz.UTC),
                 time_field=time_column,
                 **kwargs,
             )


### PR DESCRIPTION
For compatibility with pandas 2. It also fixes a warning about this deprecation in pandas 1.

[ML-5023](https://jira.iguazeng.com/browse/ML-5023)