### PR TITLE
[Pipelines] Patch unsupported features during user workflow parsing

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -46,6 +46,7 @@ from ..utils import (
     logger,
     new_pipe_metadata,
     normalize_name,
+    unsupported,
     version,
 )
 from .base import RunDBError, RunDBInterface
@@ -1461,9 +1462,10 @@ class HTTPRunDB(RunDBInterface):
                 cleanup_ttl=cleanup_ttl,
                 op_transformers=ops,
             )
-            kfp.compiler.Compiler().compile(
-                pipeline, pipe_file, type_check=False, pipeline_conf=conf
-            )
+            with unsupported.disable_unsupported_external_features():
+                kfp.compiler.Compiler().compile(
+                    pipeline, pipe_file, type_check=False, pipeline_conf=conf
+                )
 
         if pipe_file.endswith(".yaml"):
             headers = {"content-type": "application/yaml"}

--- a/mlrun/utils/unsupported.py
+++ b/mlrun/utils/unsupported.py
@@ -34,14 +34,14 @@ def disable_unsupported_external_features():
     """
     try:
         originals = []
-        for d in dependencies:
-            module_name, _, callable_name = d.rpartition(".")
+        for dependency in dependencies:
+            module_name, _, callable_name = dependency.rpartition(".")
             try:
                 curr = getattr(import_module(module_name), callable_name)
             except (ImportError, KeyError) as exc:
                 logger.debug(
                     "Module import for dependency patching failed",
-                    dependency=d,
+                    dependency=dependency,
                     exc_info=err_to_str(exc),
                 )
                 continue
@@ -49,7 +49,7 @@ def disable_unsupported_external_features():
             if not isclass(curr):
                 logger.debug(
                     "MLRun only supports patching of features based on classes",
-                    dependency=d,
+                    dependency=dependency,
                 )
                 continue
 
@@ -60,7 +60,7 @@ def disable_unsupported_external_features():
                 }
             )
             curr.__init__ = mock.MagicMock(
-                side_effect=NotImplementedError(f"MLRun does not support {d}")
+                side_effect=NotImplementedError(f"MLRun does not support {dependency}")
             )
         # Signal the caller that the context is ready
         yield
@@ -73,9 +73,9 @@ def disable_unsupported_external_features():
         yield
     finally:
         # When caller signals for the closure of the context, we revert all patches
-        for o in originals:
+        for original in originals:
             try:
-                o["class"].__init__ = o["original_method"]
+                original["class"].__init__ = original["original_method"]
             except Exception as exc:
                 logger.warning(
                     "Error while trying to re-enable an external feature not supported by MLRun",

--- a/mlrun/utils/unsupported.py
+++ b/mlrun/utils/unsupported.py
@@ -50,7 +50,6 @@ def disable_unsupported_external_features():
                 logger.debug(
                     "MLRun only supports patching of features based on classes",
                     dependency=d,
-                    exc_info=err_to_str(exc),
                 )
                 continue
 

--- a/mlrun/utils/unsupported.py
+++ b/mlrun/utils/unsupported.py
@@ -30,7 +30,7 @@ def disable_unsupported_external_features():
     """
     Disables functionality external to MLRun that is known to cause problems during workflow parsing
     This function operates on a best-effort basis and lets errors pass mostly silently
-    Only features based on classes are supported, since this patches their __init__
+    Only features based on classes are supported since this patches their __init__
     """
     try:
         originals = []

--- a/mlrun/utils/unsupported.py
+++ b/mlrun/utils/unsupported.py
@@ -1,0 +1,86 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from importlib import import_module
+from inspect import isclass
+from unittest import mock
+
+from mlrun.errors import err_to_str
+from mlrun.utils import logger
+
+dependencies = [
+    "kfp.dsl.ParallelFor",
+]
+
+
+@contextmanager
+def disable_unsupported_external_features():
+    """
+    Disables functionality external to MLRun that is known to cause problems during workflow parsing
+    This function operates on a best-effort basis and lets errors pass mostly silently
+    Only features based on classes are supported, since this patches their __init__
+    """
+    try:
+        originals = []
+        for d in dependencies:
+            module_name, _, callable_name = d.rpartition(".")
+            try:
+                curr = getattr(import_module(module_name), callable_name)
+            except (ImportError, KeyError) as exc:
+                logger.debug(
+                    "Module import for dependency patching failed",
+                    dependency=d,
+                    exc_info=err_to_str(exc),
+                )
+                continue
+
+            if not isclass(curr):
+                logger.debug(
+                    "MLRun only supports patching of features based on classes",
+                    dependency=d,
+                    exc_info=err_to_str(exc),
+                )
+                continue
+
+            originals.append(
+                {
+                    "original_method": curr.__init__,
+                    "class": curr,
+                }
+            )
+            curr.__init__ = mock.MagicMock(
+                side_effect=NotImplementedError(f"MLRun does not support {d}")
+            )
+        # Signal the caller that the context is ready
+        yield
+    except Exception as exc:
+        logger.warning(
+            "Error while trying to disable external features not supported by MLRun; unexpected behaviour may occur",
+            exc_info=err_to_str(exc),
+        )
+        # Tentatively, allow user to proceed
+        yield
+    finally:
+        # When caller signals for the closure of the context, we revert all patches
+        for o in originals:
+            try:
+                o["class"].__init__ = o["original_method"]
+            except Exception as exc:
+                logger.warning(
+                    "Error while trying to re-enable an external feature not supported by MLRun",
+                    exc_info=err_to_str(exc),
+                )
+                # Continue trying to re-enable other external features
+                continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@ aiohttp-retry~=2.8
 click~=8.1
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
-# 1.8.14 introduced new features related to ParallelFor, while our actual kfp server is 1.8.1, which isn't compatible
-# with the new features, therefore limiting to 1.8.13
-kfp~=1.8.0, <1.8.14
+kfp~=1.8
 nest-asyncio~=1.0
 ipython~=8.10
 nuclio-jupyter~=0.9.13

--- a/tests/utils/test_unsupported.py
+++ b/tests/utils/test_unsupported.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp.dsl import ParallelFor
+from pytest import raises
+
+from mlrun.utils import unsupported
+
+
+def test_unsupported_parallelfor():
+    # Create an object with an invalid parameter to trigger the expected Kubeflow behaviour
+    with raises(ValueError):
+        ParallelFor(loop_args=[1], parallelism=-1)
+
+    with unsupported.disable_unsupported_external_features():
+        # Creation of an unsupported class must raise a NotImplementedError when done in context
+        with raises(NotImplementedError):
+            ParallelFor(loop_args=[1], parallelism=-1)
+
+    # Interact with the native Kubeflow class again to confirm that the context has been cleaned up
+    with raises(ValueError):
+        ParallelFor(loop_args=[1], parallelism=-1)


### PR DESCRIPTION
[ML-4028](https://jira.iguazeng.com/browse/ML-4028)

To add flexibility to our Kubeflow SDK version requirement, we need a system to inform users when they try to use an unsupported feature available on newer versions. This PR introduces such a system.

It's important to note that our goal here is to be user-friendly rather than intrusive. This is why, if the patching of an unsupported feature fails, this system prioritizes giving back control to the user and allowing them to proceed.

Because of where the context manager introduced on this PR has to be used, it has a **lot of disruptive potential to regular user interactions when creating workflows, so an extensive review is recommended** for this PR. 

# Caveats and alternatives
Patching external functionality is hardly ever pretty work, but this PR doesn't employ the best strategy to avoid overengineering a situational feature.

If we ever consider expanding our unsupported features list, we might want to consider more solid approaches, such as:

## Import hooks
Traditionally, this would be the preferred method to solve our current problem. However, it's unlikely to work consistently since the user might import `kfp` before MLRun's execution starts.

That being said, if we would like to research this path further, this snippet would be a sound starting point:
```python
from importlib.abc import PathEntryFinder
import sys

class UnsupportedDependencies(PathEntryFinder):
    __dependencies = {
        "kfp.dsl.ParallelFor": "ParallelFor is not currently supported by MLRun",
    }

    def find_spec(self, fullname, path, target=None):
        if fullname in self.__dependencies.keys():
            raise NotImplementedError(
                self.__dependencies.get(
                    fullname, "This feature is not currently supported by MLRun"
                )
            )
        return None

sys.meta_path.insert(0, UnsupportedDependencies())
```

## Audithooks
Python's Audit Hooks can also be a solid alternative here since they work independently from when an import has taken place. We might need to use memory addresses or object IDs to test if an unsupported Class of function is being invoked. 

A good starting point could be something like this:
```python
from sys import addaudithook

dependencies = ["ParallelFor"]

def unsupported_dependencies(event, arg):
    if event == "object.__getattr__" and any([d in arg[0] for d in dependencies]):
        raise NotImplementedError(f"{arg[0]} is not currently supported by MLRun")

addaudithook(unsupported_dependencies)
```

## Unittest patches
Patching functionality is second nature to `unittest,` so it'd make sense to try and use it here. And since it's part of the standard Python distribution, it's likely to be available on all environments in which we run MLRun.

However, it has its caveats. For one, it only patches references (and not the actual objects), so late imports can override it. Beyond that, `unittest` needs to consider how the user makes the actual import in their file. E.g.: `from kfp.dsl import ParallelFor` requires a different treatment to `from kfp import dsl; dsl.ParallelFor`. The first calls for `mock.patch("<user_file_name>.ParallelFor", ...)` while the second requires `mock.patch("kfp.dsl.ParallelFor", ...)`


