### PR TITLE
[Docs] Ignore colab tutorial in search

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -35,4 +35,5 @@ python:
 
 search:
   ignore:
+    # https://github.com/readthedocs/readthedocs.org/issues/10911
     - docs/tutorials/colab/01-mlrun-basics-colab.ipynb

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -36,4 +36,4 @@ python:
 search:
   ignore:
     # https://github.com/readthedocs/readthedocs.org/issues/10911
-    - 01-mlrun-basics-colab.html
+    - '*/01-mlrun-basics-colab.html'

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -37,3 +37,9 @@ search:
   ignore:
     # https://github.com/readthedocs/readthedocs.org/issues/10911
     - '*/01-mlrun-basics-colab.html'
+
+    # Defaults
+    - search.html
+    - search/index.html
+    - 404.html
+    - 404/index.html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,3 +32,7 @@ python:
     - requirements: dev-requirements.txt
     - requirements: dockerfiles/mlrun-api/requirements.txt
     - requirements: docs/requirements.txt
+
+search:
+  ignore:
+    - docs/tutorials/colab/01-mlrun-basics-colab.ipynb

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -36,4 +36,4 @@ python:
 search:
   ignore:
     # https://github.com/readthedocs/readthedocs.org/issues/10911
-    - docs/tutorials/colab/01-mlrun-basics-colab.ipynb
+    - 01-mlrun-basics-colab.html


### PR DESCRIPTION
This file has a few problems:
1. It's html tags aren't balanced causing a malfunctioning search index - https://github.com/readthedocs/readthedocs.org/issues/10911
2. It uses `mlrun db` which is deprecated since client/server separation.
3. It's not part of the toctree in the docs.