### PR TITLE
[Pipelines] Upgrade KFP SDK to the latest patch release available under 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@ aiohttp-retry~=2.8
 click~=8.1
 # 3.0/3.2 iguazio system uses 1.0.1, but we needed >=1.6.0 to be compatible with k8s>=12.0 to fix scurity issue
 # since the sdk is still mark as beta (and not stable) I'm limiting to only patch changes
-# 1.8.14 introduced new features related to ParallelFor, while our actual kfp server is 1.8.1, which isn't compatible
-# with the new features, therefore limiting to 1.8.13
-kfp~=1.8.0, <1.8.14
+kfp~=1.8
 nest-asyncio~=1.0
 ipython~=8.10
 nuclio-jupyter~=0.9.13


### PR DESCRIPTION
[ML-4028](https://jira.iguazeng.com/browse/ML-4028)

In order to allow for a more flexible Kubernetes package version resolution on our SDK, we must first do a full patch upgrade on Kubeflow SDK package. The current PR takes care of this.