### PR TITLE
[Builder] Add mlrun requirement when installing PyPs on mlrun base image

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1242,7 +1242,7 @@ class MlrunProject(ModelObj):
             raise ValueError("'schedule' argument is not supported for 'local' engine.")
 
         # engine could be "remote" or "remote:local"
-        if image and ((engine and "remote" in engine) or schedule):
+        if image and ((engine and "remote" not in engine) and not schedule):
             logger.warning("Image is only relevant for 'remote' engine, ignoring it")
 
         if embed:

--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -47,7 +47,6 @@ def make_dockerfile(
     builder_env: typing.List[client.V1EnvVar] = None,
     extra_args: str = "",
     project_secrets: typing.List[client.V1EnvVar] = None,
-    constraints_path: str = None,
 ):
     """
     Generates the content of a Dockerfile for building a container image.
@@ -69,8 +68,6 @@ def make_dockerfile(
             e.g. extra_args="--skip-tls-verify --build-arg A=val"
     :param project_secrets: A list of Kubernetes V1EnvVar objects representing the project secrets,
             which will be used as build-time arguments in the Dockerfile.
-    :param constraints_path: The path to the constraints file (e.g., constraints.txt) containing
-            the Python dependencies constraints.
     :return: The content of the Dockerfile as a string.
     """
     dock = f"FROM {base_image}\n"
@@ -135,10 +132,7 @@ def make_dockerfile(
         dock += (
             f"RUN echo 'Installing {requirements_path}...'; cat {requirements_path}\n"
         )
-        constraints_flag = ""
-        if constraints_path:
-            constraints_flag = f" -c {constraints_path}"
-        dock += f"RUN python -m pip install -r {requirements_path}{constraints_flag}\n"
+        dock += f"RUN python -m pip install -r {requirements_path}\n"
     if extra:
         dock += extra
     mlrun.utils.logger.debug("Resolved dockerfile", dockfile_contents=dock)

--- a/server/api/utils/helpers.py
+++ b/server/api/utils/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import asyncio
+import re
 from typing import Optional
 
 from timelength import TimeLength
@@ -89,3 +90,14 @@ def time_string_to_seconds(time_str: str, min_seconds: int = 60) -> Optional[int
         raise ValueError(f"Invalid time string {time_str}, must be at least 1 minute")
 
     return total_seconds
+
+
+def extract_image_tag(image_reference):
+    # Define a regular expression pattern for extracting the image tag
+    pattern = r"(?<=:)[\w.-]+"  # This matches any word character,dots,hyphens after a colon (:)
+
+    # Use re.search to find the first match in the string
+    match = re.search(pattern, image_reference)
+
+    # Check if a match is found and return the result
+    return match.group() if match else None


### PR DESCRIPTION
Add mlrun to the requirements even though it is already installed because we want pip to include mlrun constraints when installing other packages.
A few rules to note:
1. mlrun version specifier overrides everything
2. Take mlrun version from enriched base image tag if possible