### PR TITLE
[Package] Corrections and Bug Fixes

### DIFF
--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -24,7 +24,7 @@ from .utils import TypeHintUtils
 
 class Packager(ABC):
     """
-    The abstract base class for a packager. A packager is a static class that has two main duties:
+    The abstract base class for a packager. Packager has two main duties:
 
     1. **Packing** - get an object that was returned from a function and log it to MLRun. The user can specify packing
        configurations to the packager using log hints. The packed object can be an artifact or a result.

--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pathlib
-import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, List, Tuple, Type, Union
@@ -316,7 +314,9 @@ class Packager(ABC):
             f"priority={self.priority})"
         )
 
-    def get_data_item_local_path(self, data_item: DataItem, add_to_future_clearing_path: bool = None) -> str:
+    def get_data_item_local_path(
+        self, data_item: DataItem, add_to_future_clearing_path: bool = None
+    ) -> str:
         """
         Get the local path to the item handled by the data item provided. The local path can be the same as the data
         item in case the data item points to a local path, or will be downloaded to a temporary directory and return
@@ -336,9 +336,8 @@ class Packager(ABC):
         local_path = data_item.local()
 
         # Check if needed to add to the future clear list:
-        if (
-            add_to_future_clearing_path or
-            (add_to_future_clearing_path is None and data_item.kind != "file")
+        if add_to_future_clearing_path or (
+            add_to_future_clearing_path is None and data_item.kind != "file"
         ):
             self.add_future_clearing_path(path=local_path)
 

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -558,13 +558,13 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         if missing_arguments:
             if is_packing:
                 raise MLRunPackagePackingError(
-                    f"The packager '{self.__name__}' could not pack the package due to missing configurations: "
-                    f"{', '.join(missing_arguments)}. Add the missing arguments to the log hint of this object in "
-                    f"order to pack it. Make sure you pass a dictionary log hint and not a string in order to pass "
-                    f"configurations in the log hint."
+                    f"The packager '{self.__class__.__name__}' could not pack the package due to missing "
+                    f"configurations: {', '.join(missing_arguments)}. Add the missing arguments to the log hint of this "
+                    f"object in order to pack it. Make sure you pass a dictionary log hint and not a string in order to "
+                    f"pass configurations in the log hint."
                 )
             raise MLRunPackageUnpackingError(
-                f"The packager '{self.__name__}' could not unpack the package due to missing instructions: "
+                f"The packager '{self.__class__.__name__}' could not unpack the package due to missing instructions: "
                 f"{', '.join(missing_arguments)}. Missing instructions are likely due to an update in the packager's "
                 f"code that not support the old implementation. This backward compatibility should not occur. To "
                 f"overcome it, try to edit the instructions in the artifact's spec to enable unpacking it again."
@@ -577,7 +577,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         if incorrect_arguments:
             arguments_type = "configurations" if is_packing else "instructions"
             logger.warn(
-                f"Unexpected {arguments_type} given for {self.__name__}: {', '.join(incorrect_arguments)}. "
+                f"Unexpected {arguments_type} given for {self.__class__.__name__}: {', '.join(incorrect_arguments)}. "
                 f"Possible {arguments_type} are: {', '.join(possible_arguments.keys())}. The packager tries to "
                 f"continue by ignoring the incorrect arguments."
             )

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -501,10 +501,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         :return: The un-pickled python object.
         """
         # Get the pkl file to local directory:
-        pickle_path = data_item.local()
-
-        # Add the pickle path to the clearing list:
-        self.add_future_clearing_path(path=pickle_path)
+        pickle_path = self.get_data_item_local_path(data_item=data_item)
 
         # Unpickle and return:
         return Pickler.unpickle(

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -559,9 +559,9 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
             if is_packing:
                 raise MLRunPackagePackingError(
                     f"The packager '{self.__class__.__name__}' could not pack the package due to missing "
-                    f"configurations: {', '.join(missing_arguments)}. Add the missing arguments to the log hint of this "
-                    f"object in order to pack it. Make sure you pass a dictionary log hint and not a string in order to "
-                    f"pass configurations in the log hint."
+                    f"configurations: {', '.join(missing_arguments)}. Add the missing arguments to the log hint of "
+                    f"this object in order to pack it. Make sure you pass a dictionary log hint and not a string in "
+                    f"order to pass configurations in the log hint."
                 )
             raise MLRunPackageUnpackingError(
                 f"The packager '{self.__class__.__name__}' could not unpack the package due to missing instructions: "

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -90,6 +90,10 @@ class _DefaultPackagerMeta(ABCMeta):
         # Create a packager instance:
         packager = cls()
 
+        # Get the packager's name and module:
+        packager_name = packager.__class__.__name__
+        packager_module = packager.__module__
+
         # Get the original packager class doc string:
         packager_doc_string = cls._packager_doc.split("\n")
         packager_doc_string = "\n".join(line[4:] for line in packager_doc_string)
@@ -124,11 +128,11 @@ class _DefaultPackagerMeta(ABCMeta):
             argument_name = pack_or_unpack.upper()
             return (
                 getattr(packager, argument_name)
-                if packager.__name__ == "DefaultPackager"
-                or method_name not in packager.__dict__
+                if packager_name == "DefaultPackager"
+                or method_name not in packager.__class__.__dict__
                 else (
                     f"Refer to the packager's "
-                    f":py:meth:`~{packager.__module__}.{packager.__name__}.{method_name}` method."
+                    f":py:meth:`~{packager_module}.{packager_name}.{method_name}` method."
                 )
             )
 
@@ -150,7 +154,7 @@ class _DefaultPackagerMeta(ABCMeta):
                 "\n", ""
             )
             artifact_types += (
-                f"\n\n* :py:meth:`{artifact_type}<{packager.__module__}.{packager.__name__}.pack_{artifact_type}>` - "
+                f"\n\n* :py:meth:`{artifact_type}<{packager_module}.{packager_name}.pack_{artifact_type}>` - "
                 + artifact_type_doc
             )
             # Add the artifact type configurations (ignoring the `obj` and `key` parameters):

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import inspect
+from abc import ABCMeta
 from types import MethodType
 from typing import Any, List, Tuple, Type, Union
 
@@ -23,11 +24,11 @@ from mlrun.datastore import DataItem
 from mlrun.utils import logger
 
 from ..errors import MLRunPackagePackingError, MLRunPackageUnpackingError
-from ..packager import Packager, _PackagerMeta
+from ..packager import Packager
 from ..utils import DEFAULT_PICKLE_MODULE, ArtifactType, Pickler, TypeHintUtils
 
 
-class _DefaultPackagerMeta(_PackagerMeta):
+class _DefaultPackagerMeta(ABCMeta):
     """
     Metaclass for `DefaultPackager` to override `__doc__` attribute into a class property. This way sphinx will get a
     dynamically generated docstring that will include a summary of the packager.
@@ -50,7 +51,7 @@ class _DefaultPackagerMeta(_PackagerMeta):
         return super().__new__(mcls, name, bases, namespace, **kwargs)
 
     @property
-    def __doc__(cls) -> str:
+    def __doc__(cls: Type["DefaultPackager"]) -> str:
         """
         Override the `__doc__` attribute of a `DefaultPackager` to be a property in order to auto-summarize the
         packager's class docstring. The summary is concatenated after the original class doc string.
@@ -86,6 +87,9 @@ class _DefaultPackagerMeta(_PackagerMeta):
 
         :returns: The original docstring with the generated packager summary.
         """
+        # Create a packager instance:
+        packager = cls()
+
         # Get the original packager class doc string:
         packager_doc_string = cls._packager_doc.split("\n")
         packager_doc_string = "\n".join(line[4:] for line in packager_doc_string)
@@ -93,21 +97,23 @@ class _DefaultPackagerMeta(_PackagerMeta):
         # Parse the packable type section:
         type_name = (
             "Any type"
-            if cls.PACKABLE_OBJECT_TYPE is ...
+            if packager.PACKABLE_OBJECT_TYPE is ...
             else (
-                f"``{str(cls.PACKABLE_OBJECT_TYPE)}``"
-                if TypeHintUtils.is_typing_type(type_hint=cls.PACKABLE_OBJECT_TYPE)
-                else f"``{cls.PACKABLE_OBJECT_TYPE.__module__}.{cls.PACKABLE_OBJECT_TYPE.__name__}``"
+                f"``{str(packager.PACKABLE_OBJECT_TYPE)}``"
+                if TypeHintUtils.is_typing_type(type_hint=packager.PACKABLE_OBJECT_TYPE)
+                else f"``{packager.PACKABLE_OBJECT_TYPE.__module__}.{packager.PACKABLE_OBJECT_TYPE.__name__}``"
             )
         )
         packing_type = f"**Packing Type**: {type_name}"
 
         # Subclasses support section:
-        packing_sub_classes = f"**Packing Sub-Classes**: {cls.PACK_SUBCLASSES}"
+        packing_sub_classes = f"**Packing Sub-Classes**: {packager.PACK_SUBCLASSES}"
 
         # Priority section:
         priority_value = (
-            cls.PRIORITY if cls.PRIORITY is not ... else "Default priority (5)"
+            packager.priority
+            if packager.priority is not ...
+            else "Default priority (5)"
         )
         priority = f"**Priority**: {priority_value}"
 
@@ -117,9 +123,13 @@ class _DefaultPackagerMeta(_PackagerMeta):
             method_name = f"get_{pack_or_unpack}"
             argument_name = pack_or_unpack.upper()
             return (
-                getattr(cls, argument_name)
-                if cls.__name__ == "DefaultPackager" or method_name not in cls.__dict__
-                else f"Refer to the packager's :py:meth:`~{cls.__module__}.{cls.__name__}.{method_name}` method."
+                getattr(packager, argument_name)
+                if packager.__name__ == "DefaultPackager"
+                or method_name not in packager.__dict__
+                else (
+                    f"Refer to the packager's "
+                    f":py:meth:`~{packager.__module__}.{packager.__name__}.{method_name}` method."
+                )
             )
 
         default_artifact_types = (
@@ -130,17 +140,17 @@ class _DefaultPackagerMeta(_PackagerMeta):
 
         # Artifact types section:
         artifact_types = "**Artifact Types**:"
-        for artifact_type in cls.get_supported_artifact_types():
+        for artifact_type in packager.get_supported_artifact_types():
             # Get the packing method docstring:
             method_doc = docstring_parser.parse(
-                getattr(cls, f"pack_{artifact_type}").__doc__
+                getattr(packager, f"pack_{artifact_type}").__doc__
             )
             # Add the artifact type bullet:
             artifact_type_doc = f"{method_doc.short_description or ''}{method_doc.long_description or ''}".replace(
                 "\n", ""
             )
             artifact_types += (
-                f"\n\n* :py:meth:`{artifact_type}<{cls.__module__}.{cls.__name__}.pack_{artifact_type}>` - "
+                f"\n\n* :py:meth:`{artifact_type}<{packager.__module__}.{packager.__name__}.pack_{artifact_type}>` - "
                 + artifact_type_doc
             )
             # Add the artifact type configurations (ignoring the `obj` and `key` parameters):
@@ -189,8 +199,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
       the artifact type was not provided, it uses the default). For example: if the artifact type is `x` then
       the class method ``pack_x`` must be implemented. The signature of each pack class method must be::
 
-          @classmethod
-          def pack_x(cls, obj: Any, key: str, ...) -> Union[Tuple[Artifact, dict], dict]:
+          def pack_x(self, obj: Any, key: str, ...) -> Union[Tuple[Artifact, dict], dict]:
               pass
 
       Where 'x' is the artifact type, 'obj' is the object to pack, `key` is the key to name the artifact and `...` are
@@ -205,8 +214,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
       For example: if the artifact type stored within the ``DataItem`` is `x` then the class method
       ``unpack_x`` must be implemented. The signature of each unpack class method must be::
 
-          @classmethod
-          def unpack_x(cls, data_item: mlrun.DataItem, ...) -> Any:
+          def unpack_x(self, data_item: mlrun.DataItem, ...) -> Any:
               pass
 
       Where 'x' is the artifact type, 'data_item' is the artifact's data item to unpack, `...` are the instructions that
@@ -255,7 +263,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
           with open("./some_file.txt", "w") as file:
               file.write("Pack me")
           artifact = Artifact(key="my_artifact")
-          cls.future_clear(path="./some_file.txt")
+          self.add_future_clearing_path(path="./some_file.txt")
           return artifact, None
 
     """
@@ -272,8 +280,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     #: The default artifact type to unpack from.
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.OBJECT
 
-    @classmethod
-    def get_default_packing_artifact_type(cls, obj: Any) -> str:
+    def get_default_packing_artifact_type(self, obj: Any) -> str:
         """
         Get the default artifact type for packing an object of this packager.
 
@@ -281,10 +288,9 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
 
         :return: The default artifact type.
         """
-        return cls.DEFAULT_PACKING_ARTIFACT_TYPE
+        return self.DEFAULT_PACKING_ARTIFACT_TYPE
 
-    @classmethod
-    def get_default_unpacking_artifact_type(cls, data_item: DataItem) -> str:
+    def get_default_unpacking_artifact_type(self, data_item: DataItem) -> str:
         """
         Get the default artifact type used for unpacking a data item holding an object of this packager. The method
         is used when a data item is sent for unpacking without it being a package, but is a simple url or an old /
@@ -294,10 +300,9 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
 
         :return: The default artifact type.
         """
-        return cls.DEFAULT_UNPACKING_ARTIFACT_TYPE
+        return self.DEFAULT_UNPACKING_ARTIFACT_TYPE
 
-    @classmethod
-    def get_supported_artifact_types(cls) -> List[str]:
+    def get_supported_artifact_types(self) -> List[str]:
         """
         Get all the supported artifact types on this packager.
 
@@ -307,13 +312,12 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         # unpacked. Result has no unpacking so we add it separately.
         return [
             key[len("pack_") :]
-            for key in dir(cls)
-            if key.startswith("pack_") and f"unpack_{key[len('pack_'):]}" in dir(cls)
+            for key in dir(self)
+            if key.startswith("pack_") and f"unpack_{key[len('pack_'):]}" in dir(self)
         ] + ["result"]
 
-    @classmethod
     def pack(
-        cls,
+        self,
         obj: Any,
         key: str = None,
         artifact_type: str = None,
@@ -332,16 +336,16 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         """
         # Get default artifact type in case it was not provided:
         if artifact_type is None:
-            artifact_type = cls.get_default_packing_artifact_type(obj=obj)
+            artifact_type = self.get_default_packing_artifact_type(obj=obj)
 
         # Set empty dictionary in case no configurations were given:
         configurations = configurations or {}
 
         # Get the packing method according to the artifact type:
-        pack_method = getattr(cls, f"pack_{artifact_type}")
+        pack_method = getattr(self, f"pack_{artifact_type}")
 
         # Validate correct configurations were passed:
-        cls._validate_method_arguments(
+        self._validate_method_arguments(
             method=pack_method,
             arguments=configurations,
             is_packing=True,
@@ -350,9 +354,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         # Call the packing method and return the package:
         return pack_method(obj=obj, key=key, **configurations)
 
-    @classmethod
     def unpack(
-        cls,
+        self,
         data_item: DataItem,
         artifact_type: str = None,
         instructions: dict = None,
@@ -371,16 +374,18 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         """
         # Get default artifact type in case it was not provided:
         if artifact_type is None:
-            artifact_type = cls.get_default_unpacking_artifact_type(data_item=data_item)
+            artifact_type = self.get_default_unpacking_artifact_type(
+                data_item=data_item
+            )
 
         # Set empty dictionary in case no instructions were given:
         instructions = instructions or {}
 
         # Get the unpacking method according to the artifact type:
-        unpack_method = getattr(cls, f"unpack_{artifact_type}")
+        unpack_method = getattr(self, f"unpack_{artifact_type}")
 
         # Validate correct instructions were passed:
-        cls._validate_method_arguments(
+        self._validate_method_arguments(
             method=unpack_method,
             arguments=instructions,
             is_packing=False,
@@ -389,9 +394,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         # Call the unpacking method and return the object:
         return unpack_method(data_item, **instructions)
 
-    @classmethod
     def is_packable(
-        cls, obj: Any, artifact_type: str = None, configurations: dict = None
+        self, obj: Any, artifact_type: str = None, configurations: dict = None
     ) -> bool:
         """
         Check if this packager can pack an object of the provided type as the provided artifact type.
@@ -410,11 +414,11 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         object_type = type(obj)
 
         # Check type (ellipses means any type):
-        if cls.PACKABLE_OBJECT_TYPE is not ...:
+        if self.PACKABLE_OBJECT_TYPE is not ...:
             if not TypeHintUtils.is_matching(
                 object_type=object_type,
-                type_hint=cls.PACKABLE_OBJECT_TYPE,
-                include_subclasses=cls.PACK_SUBCLASSES,
+                type_hint=self.PACKABLE_OBJECT_TYPE,
+                include_subclasses=self.PACK_SUBCLASSES,
                 reduce_type_hint=False,
             ):
                 return False
@@ -422,16 +426,15 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         # Check the artifact type:
         if (
             artifact_type is not None
-            and artifact_type not in cls.get_supported_artifact_types()
+            and artifact_type not in self.get_supported_artifact_types()
         ):
             return False
 
         # Packable:
         return True
 
-    @classmethod
     def pack_object(
-        cls,
+        self,
         obj: Any,
         key: str,
         pickle_module_name: str = DEFAULT_PICKLE_MODULE,
@@ -454,12 +457,11 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         artifact = Artifact(key=key, src_path=pickle_path)
 
         # Add the pickle path to the clearing list:
-        cls.add_future_clearing_path(path=pickle_path)
+        self.add_future_clearing_path(path=pickle_path)
 
         return artifact, instructions
 
-    @classmethod
-    def pack_result(cls, obj: Any, key: str) -> dict:
+    def pack_result(self, obj: Any, key: str) -> dict:
         """
         Pack an object as a result.
 
@@ -470,9 +472,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         """
         return {key: obj}
 
-    @classmethod
     def unpack_object(
-        cls,
+        self,
         data_item: DataItem,
         pickle_module_name: str = DEFAULT_PICKLE_MODULE,
         object_module_name: str = None,
@@ -503,7 +504,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         pickle_path = data_item.local()
 
         # Add the pickle path to the clearing list:
-        cls.add_future_clearing_path(path=pickle_path)
+        self.add_future_clearing_path(path=pickle_path)
 
         # Unpickle and return:
         return Pickler.unpickle(
@@ -515,9 +516,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
             object_module_version=object_module_version,
         )
 
-    @classmethod
     def _validate_method_arguments(
-        cls, method: MethodType, arguments: dict, is_packing: bool
+        self, method: MethodType, arguments: dict, is_packing: bool
     ):
         """
         Validate keyword arguments to pass to a method. Used for validating log hint configurations for packing methods
@@ -561,13 +561,13 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         if missing_arguments:
             if is_packing:
                 raise MLRunPackagePackingError(
-                    f"The packager '{cls.__name__}' could not pack the package due to missing configurations: "
+                    f"The packager '{self.__name__}' could not pack the package due to missing configurations: "
                     f"{', '.join(missing_arguments)}. Add the missing arguments to the log hint of this object in "
                     f"order to pack it. Make sure you pass a dictionary log hint and not a string in order to pass "
                     f"configurations in the log hint."
                 )
             raise MLRunPackageUnpackingError(
-                f"The packager '{cls.__name__}' could not unpack the package due to missing instructions: "
+                f"The packager '{self.__name__}' could not unpack the package due to missing instructions: "
                 f"{', '.join(missing_arguments)}. Missing instructions are likely due to an update in the packager's "
                 f"code that not support the old implementation. This backward compatibility should not occur. To "
                 f"overcome it, try to edit the instructions in the artifact's spec to enable unpacking it again."
@@ -580,7 +580,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         if incorrect_arguments:
             arguments_type = "configurations" if is_packing else "instructions"
             logger.warn(
-                f"Unexpected {arguments_type} given for {cls.__name__}: {', '.join(incorrect_arguments)}. "
+                f"Unexpected {arguments_type} given for {self.__name__}: {', '.join(incorrect_arguments)}. "
                 f"Possible {arguments_type} are: {', '.join(possible_arguments.keys())}. The packager tries to "
                 f"continue by ignoring the incorrect arguments."
             )

--- a/mlrun/package/packagers/numpy_packagers.py
+++ b/mlrun/package/packagers/numpy_packagers.py
@@ -261,8 +261,7 @@ class NumPyNDArrayPackager(DefaultPackager):
     # method:
     _ARRAY_SIZE_AS_RESULT = 10
 
-    @classmethod
-    def get_default_packing_artifact_type(cls, obj: np.ndarray) -> str:
+    def get_default_packing_artifact_type(self, obj: np.ndarray) -> str:
         """
         Get the default artifact type. Will be a result if the array size is less than 10, otherwise file.
 
@@ -270,12 +269,11 @@ class NumPyNDArrayPackager(DefaultPackager):
 
         :return: The default artifact type.
         """
-        if obj.size < cls._ARRAY_SIZE_AS_RESULT:
+        if obj.size < self._ARRAY_SIZE_AS_RESULT:
             return ArtifactType.RESULT
         return ArtifactType.FILE
 
-    @classmethod
-    def get_default_unpacking_artifact_type(cls, data_item: DataItem) -> str:
+    def get_default_unpacking_artifact_type(self, data_item: DataItem) -> str:
         """
         Get the default artifact type used for unpacking. Returns dataset if the data item represents a
         `DatasetArtifact` and otherwise, file.
@@ -289,8 +287,7 @@ class NumPyNDArrayPackager(DefaultPackager):
             return ArtifactType.DATASET
         return ArtifactType.FILE
 
-    @classmethod
-    def pack_result(cls, obj: np.ndarray, key: str) -> dict:
+    def pack_result(self, obj: np.ndarray, key: str) -> dict:
         """
         Pack an array as a result.
 
@@ -307,9 +304,8 @@ class NumPyNDArrayPackager(DefaultPackager):
 
         return super().pack_result(obj=obj, key=key)
 
-    @classmethod
     def pack_file(
-        cls,
+        self,
         obj: np.ndarray,
         key: str,
         file_format: str = DEFAULT_NUMPY_ARRAY_FORMAT,
@@ -328,7 +324,7 @@ class NumPyNDArrayPackager(DefaultPackager):
         # Save to file:
         formatter = NumPySupportedFormat.get_format_handler(fmt=file_format)
         temp_directory = pathlib.Path(tempfile.mkdtemp())
-        cls.add_future_clearing_path(path=temp_directory)
+        self.add_future_clearing_path(path=temp_directory)
         file_path = temp_directory / f"{key}.{file_format}"
         formatter.save(obj=obj, file_path=str(file_path), **save_kwargs)
 
@@ -338,9 +334,8 @@ class NumPyNDArrayPackager(DefaultPackager):
 
         return artifact, instructions
 
-    @classmethod
     def pack_dataset(
-        cls,
+        self,
         obj: np.ndarray,
         key: str,
         file_format: str = "",
@@ -372,8 +367,7 @@ class NumPyNDArrayPackager(DefaultPackager):
 
         return artifact, {}
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> np.ndarray:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> np.ndarray:
         """
         Unpack a numppy array from file.
 
@@ -385,7 +379,7 @@ class NumPyNDArrayPackager(DefaultPackager):
         """
         # Get the file:
         file_path = data_item.local()
-        cls.add_future_clearing_path(path=file_path)
+        self.add_future_clearing_path(path=file_path)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:
@@ -405,8 +399,7 @@ class NumPyNDArrayPackager(DefaultPackager):
 
         return obj
 
-    @classmethod
-    def unpack_dataset(cls, data_item: DataItem) -> np.ndarray:
+    def unpack_dataset(self, data_item: DataItem) -> np.ndarray:
         """
         Unpack a numppy array from a dataset artifact.
 
@@ -434,9 +427,8 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.FILE
     PRIORITY = 4
 
-    @classmethod
     def pack_file(
-        cls,
+        self,
         obj: NumPyArrayCollectionType,
         key: str,
         file_format: str = DEFAULT_NUMPPY_ARRAY_COLLECTION_FORMAT,
@@ -455,7 +447,7 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
         # Save to file:
         formatter = NumPySupportedFormat.get_format_handler(fmt=file_format)
         temp_directory = pathlib.Path(tempfile.mkdtemp())
-        cls.add_future_clearing_path(path=temp_directory)
+        self.add_future_clearing_path(path=temp_directory)
         file_path = temp_directory / f"{key}.{file_format}"
         formatter.save(obj=obj, file_path=str(file_path), **save_kwargs)
 
@@ -464,9 +456,8 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
 
         return artifact, {"file_format": file_format}
 
-    @classmethod
     def unpack_file(
-        cls, data_item: DataItem, file_format: str = None
+        self, data_item: DataItem, file_format: str = None
     ) -> Dict[str, np.ndarray]:
         """
         Unpack a numppy array collection from file.
@@ -479,7 +470,7 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
         """
         # Get the file:
         file_path = data_item.local()
-        cls.add_future_clearing_path(path=file_path)
+        self.add_future_clearing_path(path=file_path)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:
@@ -507,9 +498,8 @@ class NumPyNDArrayDictPackager(_NumPyNDArrayCollectionPackager):
 
     PACKABLE_OBJECT_TYPE = Dict[str, np.ndarray]
 
-    @classmethod
     def is_packable(
-        cls, obj: Any, artifact_type: str = None, configurations: dict = None
+        self, obj: Any, artifact_type: str = None, configurations: dict = None
     ) -> bool:
         """
         Check if the object provided is a dictionary of numpy arrays.
@@ -531,7 +521,7 @@ class NumPyNDArrayDictPackager(_NumPyNDArrayCollectionPackager):
             return False
 
         # Check the artifact type is supported:
-        if artifact_type and artifact_type not in cls.get_supported_artifact_types():
+        if artifact_type and artifact_type not in self.get_supported_artifact_types():
             return False
 
         # Check an edge case where the dictionary is empty (this packager will pack empty dictionaries only if given
@@ -539,13 +529,12 @@ class NumPyNDArrayDictPackager(_NumPyNDArrayCollectionPackager):
         if not obj:
             return (
                 configurations.get("file_format", None)
-                in NumPySupportedFormat.get_multi_array_formats()
+                in NumPySupportedFormat().get_multi_array_formats()
             )
 
         return True
 
-    @classmethod
-    def pack_result(cls, obj: Dict[str, np.ndarray], key: str) -> dict:
+    def pack_result(self, obj: Dict[str, np.ndarray], key: str) -> dict:
         """
         Pack a dictionary of numpy arrays as a result.
 
@@ -561,9 +550,8 @@ class NumPyNDArrayDictPackager(_NumPyNDArrayCollectionPackager):
             }
         }
 
-    @classmethod
     def unpack_file(
-        cls, data_item: DataItem, file_format: str = None
+        self, data_item: DataItem, file_format: str = None
     ) -> Dict[str, np.ndarray]:
         """
         Unpack a numppy array dictionary from file.
@@ -588,9 +576,8 @@ class NumPyNDArrayListPackager(_NumPyNDArrayCollectionPackager):
 
     PACKABLE_OBJECT_TYPE = List[np.ndarray]
 
-    @classmethod
     def is_packable(
-        cls, obj: Any, artifact_type: str = None, configurations: dict = None
+        self, obj: Any, artifact_type: str = None, configurations: dict = None
     ) -> bool:
         """
         Check if the object provided is a list of numpy arrays.
@@ -609,7 +596,7 @@ class NumPyNDArrayListPackager(_NumPyNDArrayCollectionPackager):
             return False
 
         # Check the artifact type is supported:
-        if artifact_type and artifact_type not in cls.get_supported_artifact_types():
+        if artifact_type and artifact_type not in self.get_supported_artifact_types():
             return False
 
         # Check an edge case where the list is empty (this packager will pack empty lists only if given specific file
@@ -617,13 +604,12 @@ class NumPyNDArrayListPackager(_NumPyNDArrayCollectionPackager):
         if not obj:
             return (
                 configurations.get("file_format", None)
-                in NumPySupportedFormat.get_multi_array_formats()
+                in NumPySupportedFormat().get_multi_array_formats()
             )
 
         return True
 
-    @classmethod
-    def pack_result(cls, obj: List[np.ndarray], key: str) -> dict:
+    def pack_result(self, obj: List[np.ndarray], key: str) -> dict:
         """
         Pack a list of numpy arrays as a result.
 
@@ -634,9 +620,8 @@ class NumPyNDArrayListPackager(_NumPyNDArrayCollectionPackager):
         """
         return {key: [array.tolist() for array in obj]}
 
-    @classmethod
     def unpack_file(
-        cls, data_item: DataItem, file_format: str = None
+        self, data_item: DataItem, file_format: str = None
     ) -> List[np.ndarray]:
         """
         Unpack a numppy array list from file.
@@ -663,8 +648,7 @@ class NumPyNumberPackager(DefaultPackager):
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.RESULT
     PACK_SUBCLASSES = True  # To include all dtypes ('float32', 'uint8', ...)
 
-    @classmethod
-    def pack_result(cls, obj: np.number, key: str) -> dict:
+    def pack_result(self, obj: np.number, key: str) -> dict:
         """
         Pack a numpy number as a result.
 

--- a/mlrun/package/packagers/numpy_packagers.py
+++ b/mlrun/package/packagers/numpy_packagers.py
@@ -378,8 +378,7 @@ class NumPyNDArrayPackager(DefaultPackager):
         :return: The unpacked array.
         """
         # Get the file:
-        file_path = data_item.local()
-        self.add_future_clearing_path(path=file_path)
+        file_path = self.get_data_item_local_path(data_item=data_item)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:
@@ -469,8 +468,7 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
         :return: The unpacked array collection.
         """
         # Get the file:
-        file_path = data_item.local()
-        self.add_future_clearing_path(path=file_path)
+        file_path = self.get_data_item_local_path(data_item=data_item)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:

--- a/mlrun/package/packagers/pandas_packagers.py
+++ b/mlrun/package/packagers/pandas_packagers.py
@@ -682,8 +682,7 @@ class PandasDataFramePackager(DefaultPackager):
     PACKABLE_OBJECT_TYPE = pd.DataFrame
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.DATASET
 
-    @classmethod
-    def get_default_unpacking_artifact_type(cls, data_item: DataItem) -> str:
+    def get_default_unpacking_artifact_type(self, data_item: DataItem) -> str:
         """
         Get the default artifact type used for unpacking. Returns dataset if the data item represents a
         `DatasetArtifact` and otherwise, file.
@@ -697,8 +696,7 @@ class PandasDataFramePackager(DefaultPackager):
             return ArtifactType.DATASET
         return ArtifactType.FILE
 
-    @classmethod
-    def pack_result(cls, obj: pd.DataFrame, key: str) -> dict:
+    def pack_result(self, obj: pd.DataFrame, key: str) -> dict:
         """
         Pack a dataframe as a result.
 
@@ -728,9 +726,8 @@ class PandasDataFramePackager(DefaultPackager):
 
         return super().pack_result(obj=dataframe_dictionary, key=key)
 
-    @classmethod
     def pack_file(
-        cls,
+        self,
         obj: pd.DataFrame,
         key: str,
         file_format: str = None,
@@ -762,7 +759,7 @@ class PandasDataFramePackager(DefaultPackager):
         # Save to file:
         formatter = PandasSupportedFormat.get_format_handler(fmt=file_format)
         temp_directory = pathlib.Path(tempfile.mkdtemp())
-        cls.add_future_clearing_path(path=temp_directory)
+        self.add_future_clearing_path(path=temp_directory)
         file_path = temp_directory / f"{key}.{file_format}"
         read_kwargs = formatter.to(
             obj=obj, file_path=str(file_path), flatten=flatten, **to_kwargs
@@ -773,8 +770,7 @@ class PandasDataFramePackager(DefaultPackager):
 
         return artifact, {"file_format": file_format, "read_kwargs": read_kwargs}
 
-    @classmethod
-    def pack_dataset(cls, obj: pd.DataFrame, key: str, file_format: str = "parquet"):
+    def pack_dataset(self, obj: pd.DataFrame, key: str, file_format: str = "parquet"):
         """
         Pack a pandas dataframe as a dataset.
 
@@ -786,9 +782,8 @@ class PandasDataFramePackager(DefaultPackager):
         """
         return DatasetArtifact(key=key, df=obj, format=file_format), {}
 
-    @classmethod
     def unpack_file(
-        cls,
+        self,
         data_item: DataItem,
         file_format: str = None,
         read_kwargs: dict = None,
@@ -805,7 +800,7 @@ class PandasDataFramePackager(DefaultPackager):
         """
         # Get the file:
         file_path = data_item.local()
-        cls.add_future_clearing_path(path=file_path)
+        self.add_future_clearing_path(path=file_path)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:
@@ -822,8 +817,7 @@ class PandasDataFramePackager(DefaultPackager):
             read_kwargs = {}
         return formatter.read(file_path=file_path, **read_kwargs)
 
-    @classmethod
-    def unpack_dataset(cls, data_item: DataItem):
+    def unpack_dataset(self, data_item: DataItem):
         """
         Unpack a padnas dataframe from a dataset artifact.
 
@@ -864,8 +858,7 @@ class PandasSeriesPackager(PandasDataFramePackager):
     PACKABLE_OBJECT_TYPE = pd.Series
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.FILE
 
-    @classmethod
-    def get_supported_artifact_types(cls) -> List[str]:
+    def get_supported_artifact_types(self) -> List[str]:
         """
         Get all the supported artifact types on this packager. It will be the same as `PandasDataFramePackager` but
         without the 'dataset' artifact type support.
@@ -876,8 +869,7 @@ class PandasSeriesPackager(PandasDataFramePackager):
         supported_artifacts.remove("dataset")
         return supported_artifacts
 
-    @classmethod
-    def pack_result(cls, obj: pd.Series, key: str) -> dict:
+    def pack_result(self, obj: pd.Series, key: str) -> dict:
         """
         Pack a series as a result.
 
@@ -888,9 +880,8 @@ class PandasSeriesPackager(PandasDataFramePackager):
         """
         return super().pack_result(obj=pd.DataFrame(obj), key=key)
 
-    @classmethod
     def pack_file(
-        cls,
+        self,
         obj: pd.Series,
         key: str,
         file_format: str = None,
@@ -926,9 +917,8 @@ class PandasSeriesPackager(PandasDataFramePackager):
         # Return the artifact with the updated instructions:
         return artifact, {**instructions, "column_name": column_name}
 
-    @classmethod
     def unpack_file(
-        cls,
+        self,
         data_item: DataItem,
         file_format: str = None,
         read_kwargs: dict = None,

--- a/mlrun/package/packagers/pandas_packagers.py
+++ b/mlrun/package/packagers/pandas_packagers.py
@@ -799,8 +799,7 @@ class PandasDataFramePackager(DefaultPackager):
         :return: The unpacked series.
         """
         # Get the file:
-        file_path = data_item.local()
-        self.add_future_clearing_path(path=file_path)
+        file_path = self.get_data_item_local_path(data_item=data_item)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -155,11 +155,8 @@ class StrPackager(DefaultPackager):
 
         :return: The unpacked string.
         """
-        # Get the file to a local temporary directory:
-        path = data_item.local()
-
-        # Mark the downloaded file for future clear:
-        self.add_future_clearing_path(path=path)
+        # Get the file:
+        path = self.get_data_item_local_path(data_item=data_item)
 
         # If it's not a directory, return the file path. Otherwise, it should be extracted according to the archive
         # format:
@@ -237,8 +234,7 @@ class _BuiltinCollectionPackager(DefaultPackager):
         :return: The unpacked builtin collection.
         """
         # Get the file:
-        file_path = data_item.local()
-        self.add_future_clearing_path(path=file_path)
+        file_path = self.get_data_item_local_path(data_item=data_item)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -45,8 +45,7 @@ class NonePackager(DefaultPackager):
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.RESULT
 
     # TODO: `None` as pickle will be available from Python 3.10, so this method can be removed once we move to 3.10.
-    @classmethod
-    def get_supported_artifact_types(cls) -> List[str]:
+    def get_supported_artifact_types(self) -> List[str]:
         """
         Get all the supported artifact types on this packager. It will be the same as `DefaultPackager` but without the
         'object' artifact type support (None cannot be pickled, only from Python 3.10, and it should not be pickled
@@ -95,9 +94,8 @@ class StrPackager(DefaultPackager):
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.RESULT
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.PATH
 
-    @classmethod
     def pack_path(
-        cls, obj: str, key: str, archive_format: str = DEFAULT_ARCHIVE_FORMAT
+        self, obj: str, key: str, archive_format: str = DEFAULT_ARCHIVE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a path string value content (pack the file or directory in that path).
@@ -138,9 +136,11 @@ class StrPackager(DefaultPackager):
 
         return artifact, instructions
 
-    @classmethod
     def unpack_path(
-        cls, data_item: DataItem, is_directory: bool = False, archive_format: str = None
+        self,
+        data_item: DataItem,
+        is_directory: bool = False,
+        archive_format: str = None,
     ) -> str:
         """
         Unpack a data item representing a path string. If the path is of a file, the file is downloaded to a local
@@ -159,7 +159,7 @@ class StrPackager(DefaultPackager):
         path = data_item.local()
 
         # Mark the downloaded file for future clear:
-        cls.add_future_clearing_path(path=path)
+        self.add_future_clearing_path(path=path)
 
         # If it's not a directory, return the file path. Otherwise, it should be extracted according to the archive
         # format:
@@ -182,7 +182,7 @@ class StrPackager(DefaultPackager):
         )
 
         # Mark the extracted content for future clear:
-        cls.add_future_clearing_path(path=directory_path)
+        self.add_future_clearing_path(path=directory_path)
 
         # Return the extracted directory path:
         return directory_path
@@ -196,9 +196,8 @@ class _BuiltinCollectionPackager(DefaultPackager):
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.RESULT
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.FILE
 
-    @classmethod
     def pack_file(
-        cls,
+        self,
         obj: Union[dict, list],
         key: str,
         file_format: str = DEFAULT_STRUCT_FILE_FORMAT,
@@ -215,7 +214,7 @@ class _BuiltinCollectionPackager(DefaultPackager):
         # Write to file:
         formatter = StructFileSupportedFormat.get_format_handler(fmt=file_format)
         temp_directory = pathlib.Path(tempfile.mkdtemp())
-        cls.add_future_clearing_path(path=temp_directory)
+        self.add_future_clearing_path(path=temp_directory)
         file_path = temp_directory / f"{key}.{file_format}"
         formatter.write(obj=obj, file_path=str(file_path))
 
@@ -225,9 +224,8 @@ class _BuiltinCollectionPackager(DefaultPackager):
 
         return artifact, instructions
 
-    @classmethod
     def unpack_file(
-        cls, data_item: DataItem, file_format: str = None
+        self, data_item: DataItem, file_format: str = None
     ) -> Union[dict, list]:
         """
         Unpack a builtin collection from file.
@@ -240,7 +238,7 @@ class _BuiltinCollectionPackager(DefaultPackager):
         """
         # Get the file:
         file_path = data_item.local()
-        cls.add_future_clearing_path(path=file_path)
+        self.add_future_clearing_path(path=file_path)
 
         # Get the archive format by the file extension if needed:
         if file_format is None:
@@ -265,8 +263,7 @@ class DictPackager(_BuiltinCollectionPackager):
 
     PACKABLE_OBJECT_TYPE = dict
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> dict:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> dict:
         """
         Unpack a dictionary from file.
 
@@ -292,8 +289,7 @@ class ListPackager(_BuiltinCollectionPackager):
 
     PACKABLE_OBJECT_TYPE = list
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> list:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> list:
         """
         Unpack a list from file.
 
@@ -338,8 +334,7 @@ class TuplePackager(ListPackager):
 
     PACKABLE_OBJECT_TYPE = tuple
 
-    @classmethod
-    def pack_result(cls, obj: tuple, key: str) -> dict:
+    def pack_result(self, obj: tuple, key: str) -> dict:
         """
         Pack a tuple as a result.
 
@@ -350,9 +345,8 @@ class TuplePackager(ListPackager):
         """
         return super().pack_result(obj=list(obj), key=key)
 
-    @classmethod
     def pack_file(
-        cls, obj: tuple, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
+        self, obj: tuple, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a tuple as a file by the given format.
@@ -365,8 +359,7 @@ class TuplePackager(ListPackager):
         """
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> tuple:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> tuple:
         """
         Unpack a tuple from file.
 
@@ -386,8 +379,7 @@ class SetPackager(ListPackager):
 
     PACKABLE_OBJECT_TYPE = set
 
-    @classmethod
-    def pack_result(cls, obj: set, key: str) -> dict:
+    def pack_result(self, obj: set, key: str) -> dict:
         """
         Pack a set as a result.
 
@@ -398,9 +390,8 @@ class SetPackager(ListPackager):
         """
         return super().pack_result(obj=list(obj), key=key)
 
-    @classmethod
     def pack_file(
-        cls, obj: set, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
+        self, obj: set, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a set as a file by the given format.
@@ -413,8 +404,7 @@ class SetPackager(ListPackager):
         """
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> set:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> set:
         """
         Unpack a set from file.
 
@@ -434,9 +424,8 @@ class FrozensetPackager(SetPackager):
 
     PACKABLE_OBJECT_TYPE = frozenset
 
-    @classmethod
     def pack_file(
-        cls, obj: frozenset, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
+        self, obj: frozenset, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a frozenset as a file by the given format.
@@ -449,8 +438,7 @@ class FrozensetPackager(SetPackager):
         """
         return super().pack_file(obj=set(obj), key=key, file_format=file_format)
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> frozenset:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> frozenset:
         """
         Unpack a frozenset from file.
 
@@ -472,8 +460,7 @@ class BytesPackager(ListPackager):
 
     PACKABLE_OBJECT_TYPE = bytes
 
-    @classmethod
-    def pack_result(cls, obj: bytes, key: str) -> dict:
+    def pack_result(self, obj: bytes, key: str) -> dict:
         """
         Pack bytes as a result.
 
@@ -484,9 +471,8 @@ class BytesPackager(ListPackager):
         """
         return {key: obj}
 
-    @classmethod
     def pack_file(
-        cls, obj: bytes, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
+        self, obj: bytes, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a bytes as a file by the given format.
@@ -499,8 +485,7 @@ class BytesPackager(ListPackager):
         """
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> bytes:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> bytes:
         """
         Unpack a bytes from file.
 
@@ -520,8 +505,7 @@ class BytearrayPackager(BytesPackager):
 
     PACKABLE_OBJECT_TYPE = bytearray
 
-    @classmethod
-    def pack_result(cls, obj: bytearray, key: str) -> dict:
+    def pack_result(self, obj: bytearray, key: str) -> dict:
         """
         Pack a bytearray as a result.
 
@@ -532,9 +516,8 @@ class BytearrayPackager(BytesPackager):
         """
         return {key: bytes(obj)}
 
-    @classmethod
     def pack_file(
-        cls, obj: bytearray, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
+        self, obj: bytearray, key: str, file_format: str = DEFAULT_STRUCT_FILE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a bytearray as a file by the given format.
@@ -547,8 +530,7 @@ class BytearrayPackager(BytesPackager):
         """
         return super().pack_file(obj=bytes(obj), key=key, file_format=file_format)
 
-    @classmethod
-    def unpack_file(cls, data_item: DataItem, file_format: str = None) -> bytearray:
+    def unpack_file(self, data_item: DataItem, file_format: str = None) -> bytearray:
         """
         Unpack a bytearray from file.
 
@@ -578,8 +560,7 @@ class PathPackager(StrPackager):
     PACK_SUBCLASSES = True
     DEFAULT_PACKING_ARTIFACT_TYPE = "path"
 
-    @classmethod
-    def pack_result(cls, obj: pathlib.Path, key: str) -> dict:
+    def pack_result(self, obj: pathlib.Path, key: str) -> dict:
         """
         Pack the `Path` as a string result.
 
@@ -590,9 +571,8 @@ class PathPackager(StrPackager):
         """
         return super().pack_result(obj=str(obj), key=key)
 
-    @classmethod
     def pack_path(
-        cls, obj: pathlib.Path, key: str, archive_format: str = DEFAULT_ARCHIVE_FORMAT
+        self, obj: pathlib.Path, key: str, archive_format: str = DEFAULT_ARCHIVE_FORMAT
     ) -> Tuple[Artifact, dict]:
         """
         Pack a `Path` value (pack the file or directory in that path).
@@ -605,9 +585,11 @@ class PathPackager(StrPackager):
         """
         return super().pack_path(obj=str(obj), key=key, archive_format=archive_format)
 
-    @classmethod
     def unpack_path(
-        cls, data_item: DataItem, is_directory: bool = False, archive_format: str = None
+        self,
+        data_item: DataItem,
+        is_directory: bool = False,
+        archive_format: str = None,
     ) -> pathlib.Path:
         """
         Unpack a data item representing a `Path`. If the path is of a file, the file is downloaded to a local

--- a/mlrun/package/utils/_pickler.py
+++ b/mlrun/package/utils/_pickler.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import importlib
+import importlib.metadata as importlib_metadata
 import os
 import sys
 import tempfile
@@ -188,26 +189,15 @@ class Pickler:
         """
         # First we'll try to get the module version from `importlib`:
         try:
-            # Since Python 3.8, `version` is part of `importlib.metadata`. Before 3.8, we'll use the module
-            # `importlib_metadata` to get `version`.
-            if (
-                sys.version_info[1] > 7
-            ):  # TODO: Remove once Python 3.7 is not supported.
-                from importlib.metadata import version
-            else:
-                from importlib_metadata import version
-
-            return version(module_name)
-        except (ModuleNotFoundError, importlib.metadata.PackageNotFoundError):
-            # User won't necessarily have the `importlib_metadata` module, so we will ignore it by catching
-            # `ModuleNotFoundError`. `PackageNotFoundError` is ignored as well as this is raised when `version` could
-            # not find the package related to the module.
+            return importlib_metadata.version(module_name)
+        except importlib.metadata.PackageNotFoundError:
+            # `PackageNotFoundError` is ignored this is raised when `version` could not find the package related to the
+            # module.
             pass
 
-        # Secondly, if importlib could not get the version (most likely 'importlib_metadata' is not installed), we'll
-        # try to use `pkg_resources` to get the version (the version will be found only if the package name is equal to
-        # the module name. For example, if the module name is 'x' then the way we installed the package must be
-        # 'pip install x'):
+        # Secondly, if importlib could not get the version, we'll try to use `pkg_resources` to get the version (the
+        # version will be found only if the package name is equal to the module name. For example, if the module name is
+        # 'x' then the way we installed the package must be 'pip install x'):
         import pkg_resources
 
         with warnings.catch_warnings():

--- a/mlrun/package/utils/_supported_format.py
+++ b/mlrun/package/utils/_supported_format.py
@@ -24,7 +24,7 @@ class SupportedFormat(ABC, Generic[FileHandlerType]):
     Library of supported formats by some builtin MLRun packagers.
     """
 
-    # Add here the all the supported formats in ALL CAPS and their value as a string:
+    # Add here all the supported formats in ALL CAPS and their value as a string:
     ...
 
     # The map to use in the method `get_format_handler`. A dictionary of string key to a class type to handle that

--- a/tests/package/packagers_testers/default_packager_tester.py
+++ b/tests/package/packagers_testers/default_packager_tester.py
@@ -57,7 +57,7 @@ class DefaultPackagerTester(PackagerTester):
     A tester for the `DefaultPackager`.
     """
 
-    PACKAGER_IN_TEST = DefaultPackager
+    PACKAGER_IN_TEST = DefaultPackager()
 
     TESTS = [
         PackTest(

--- a/tests/package/packagers_testers/numpy_packagers_testers.py
+++ b/tests/package/packagers_testers/numpy_packagers_testers.py
@@ -15,6 +15,7 @@
 import os
 import tempfile
 from typing import Dict, List, Tuple
+import itertools
 
 import numpy as np
 
@@ -41,27 +42,30 @@ _COMMON_OBJECT_INSTRUCTIONS = {
 }
 
 
-_ARRAY_SAMPLE = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+_ARRAY_SAMPLES = [
+    np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    np.array([{"A": 1}, {"B": 2}, {"C": 3}]),
+]
 
 
-def pack_array() -> np.ndarray:
-    return _ARRAY_SAMPLE
+def pack_array(i: int) -> np.ndarray:
+    return _ARRAY_SAMPLES[i]
 
 
-def validate_array(result: List[List[int]]) -> bool:
-    return (np.array(result) == _ARRAY_SAMPLE).all()
+def validate_array(result: list, i: int) -> bool:
+    return (np.array(result) == _ARRAY_SAMPLES[i]).all()
 
 
-def unpack_array(obj: np.ndarray):
+def unpack_array(obj: np.ndarray, i: int):
     assert isinstance(obj, np.ndarray)
-    assert (obj == _ARRAY_SAMPLE).all()
+    assert (obj == _ARRAY_SAMPLES[i]).all()
 
 
-def prepare_array_file(file_format: str) -> Tuple[str, str]:
+def prepare_array_file(file_format: str, i: int) -> Tuple[str, str]:
     temp_directory = tempfile.mkdtemp()
     file_path = os.path.join(temp_directory, f"my_array.{file_format}")
     formatter = NumPySupportedFormat.get_format_handler(fmt=file_format)
-    formatter.save(obj=_ARRAY_SAMPLE, file_path=file_path)
+    formatter.save(obj=_ARRAY_SAMPLES[i], file_path=file_path)
     return file_path, temp_directory
 
 
@@ -73,35 +77,48 @@ class NumPyNDArrayPackagerTester(PackagerTester):
     PACKAGER_IN_TEST = NumPyNDArrayPackager()
 
     TESTS = [
-        PackTest(
-            pack_handler="pack_array",
-            log_hint="my_result",
-            validation_function=validate_array,
-            pack_parameters={},
-            default_artifact_type_object=np.ones(1),
-        ),
+        *[
+            PackTest(
+                pack_handler="pack_array",
+                log_hint="my_result",
+                validation_function=validate_array,
+                pack_parameters={"i": i},
+                validation_parameters={"i": i},
+                default_artifact_type_object=np.ones(1),
+            ) for i in range(len(_ARRAY_SAMPLES))
+        ],
         *[
             UnpackTest(
                 prepare_input_function=prepare_array_file,
                 unpack_handler="unpack_array",
-                prepare_parameters={"file_format": file_format},
+                prepare_parameters={"file_format": file_format, "i": 0},
+                unpack_parameters={"i": 0},
             )
             for file_format in NumPySupportedFormat.get_single_array_formats()
         ],
-        PackToUnpackTest(
-            pack_handler="pack_array",
-            log_hint="my_result: result",
-        ),
-        PackToUnpackTest(
-            pack_handler="pack_array",
-            log_hint="my_result: object",
-            expected_instructions=_COMMON_OBJECT_INSTRUCTIONS,
-            unpack_handler="unpack_array",
-        ),
+        *[
+            PackToUnpackTest(
+                pack_handler="pack_array",
+                log_hint="my_result: result",
+                pack_parameters={"i": i},
+            ) for i in range(len(_ARRAY_SAMPLES))
+        ],
+        *[
+            PackToUnpackTest(
+                pack_handler="pack_array",
+                log_hint="my_result: object",
+                expected_instructions=_COMMON_OBJECT_INSTRUCTIONS,
+                unpack_handler="unpack_array",
+                pack_parameters={"i": i},
+                unpack_parameters={"i": i},
+            ) for i in range(len(_ARRAY_SAMPLES))
+        ],
         PackToUnpackTest(
             pack_handler="pack_array",
             log_hint="my_result: dataset",
             unpack_handler="unpack_array",
+            pack_parameters={"i": 0},
+            unpack_parameters={"i": 0},
         ),
         *[
             PackToUnpackTest(
@@ -113,9 +130,23 @@ class NumPyNDArrayPackagerTester(PackagerTester):
                 },
                 expected_instructions={"file_format": file_format},
                 unpack_handler="unpack_array",
+                pack_parameters={"i": 0},
+                unpack_parameters={"i": 0},
             )
             for file_format in NumPySupportedFormat.get_single_array_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_array",
+            log_hint={
+                "key": "my_array",
+                "artifact_type": "file",
+                "file_format": NumPySupportedFormat.NPY,
+            },
+            expected_instructions={"file_format": NumPySupportedFormat.NPY, "allow_pickle": True},
+            unpack_handler="unpack_array",
+            pack_parameters={"i": 1},
+            unpack_parameters={"i": 1},
+        )
     ]
 
 
@@ -161,37 +192,40 @@ class NumPyNumberPackagerTester(PackagerTester):
     ]
 
 
-_ARRAY_DICT_SAMPLE = {f"my_array_{i}": _ARRAY_SAMPLE * i for i in range(1, 5)}
+_ARRAY_DICT_SAMPLES = [
+    {f"my_array_{i}": _ARRAY_SAMPLES[0] * i for i in range(1, 5)},
+    {f"my_object_array_{i}": _ARRAY_SAMPLES[1] for i in range(1, 5)},
+]
 
 
-def pack_array_dict() -> Dict[str, np.ndarray]:
-    return _ARRAY_DICT_SAMPLE
+def pack_array_dict(i: int) -> Dict[str, np.ndarray]:
+    return _ARRAY_DICT_SAMPLES[i]
 
 
-def unpack_array_dict(obj: Dict[str, np.ndarray]):
+def unpack_array_dict(obj: Dict[str, np.ndarray], i: int):
     assert isinstance(obj, dict) and all(
         isinstance(key, str) and isinstance(value, np.ndarray)
         for key, value in obj.items()
     )
-    assert obj.keys() == _ARRAY_DICT_SAMPLE.keys()
-    for obj_array, sample_array in zip(obj.values(), _ARRAY_DICT_SAMPLE.values()):
+    assert obj.keys() == _ARRAY_DICT_SAMPLES[i].keys()
+    for obj_array, sample_array in zip(obj.values(), _ARRAY_DICT_SAMPLES[i].values()):
         assert (obj_array == sample_array).all()
 
 
-def validate_array_dict(result: Dict[str, list]) -> bool:
+def validate_array_dict(result: Dict[str, list], i: int) -> bool:
     # Numppy arrays are serialized as lists:
-    for key in _ARRAY_DICT_SAMPLE:
+    for key in _ARRAY_DICT_SAMPLES[i]:
         array = result.pop(key)
-        if not (np.array(array) == _ARRAY_DICT_SAMPLE[key]).all():
+        if not (np.array(array) == _ARRAY_DICT_SAMPLES[i][key]).all():
             return False
     return len(result) == 0
 
 
-def prepare_array_dict_file(file_format: str, **save_kwargs) -> Tuple[str, str]:
+def prepare_array_dict_file(file_format: str, i: int, **save_kwargs) -> Tuple[str, str]:
     temp_directory = tempfile.mkdtemp()
     file_path = os.path.join(temp_directory, f"my_file.{file_format}")
     formatter = NumPySupportedFormat.get_format_handler(fmt=file_format)
-    formatter.save(obj=_ARRAY_DICT_SAMPLE, file_path=file_path, **save_kwargs)
+    formatter.save(obj=_ARRAY_DICT_SAMPLES[i], file_path=file_path, **save_kwargs)
     return file_path, temp_directory
 
 
@@ -203,32 +237,44 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
     PACKAGER_IN_TEST = NumPyNDArrayDictPackager()
 
     TESTS = [
-        PackTest(
-            pack_handler="pack_array_dict",
-            log_hint="my_result: result",
-            validation_function=validate_array_dict,
-        ),
+        [
+            PackTest(
+                pack_handler="pack_array_dict",
+                log_hint="my_result: result",
+                validation_function=validate_array_dict,
+                pack_parameters={"i": i},
+                validation_parameters={"i": i},
+            ) for i in range(len(_ARRAY_DICT_SAMPLES))
+        ],
         *[
             UnpackTest(
                 prepare_input_function=prepare_array_dict_file,
                 unpack_handler="unpack_array_dict",
-                prepare_parameters={"file_format": file_format},
+                prepare_parameters={"file_format": file_format, "i": 0},
+                unpack_parameters={"i": 0},
             )
             for file_format in NumPySupportedFormat.get_multi_array_formats()
         ],
-        PackToUnpackTest(
-            pack_handler="pack_array_dict",
-            log_hint="my_array: result",
-        ),
-        PackToUnpackTest(
-            pack_handler="pack_array_dict",
-            log_hint="my_array: object",
-            expected_instructions={
-                **COMMON_OBJECT_INSTRUCTIONS,
-                "object_module_name": dict.__module__,
-            },
-            unpack_handler="unpack_array_dict",
-        ),
+        *[
+            PackToUnpackTest(
+                pack_handler="pack_array_dict",
+                log_hint="my_array: result",
+                pack_parameters={"i": i},
+            ) for i in range(len(_ARRAY_DICT_SAMPLES))
+        ],
+        *[
+            PackToUnpackTest(
+                pack_handler="pack_array_dict",
+                log_hint="my_array: object",
+                expected_instructions={
+                    **COMMON_OBJECT_INSTRUCTIONS,
+                    "object_module_name": dict.__module__,
+                },
+                unpack_handler="unpack_array_dict",
+                pack_parameters={"i": i},
+                unpack_parameters={"i": i},
+            ) for i in range(len(_ARRAY_DICT_SAMPLES))
+        ],
         *[
             PackToUnpackTest(
                 pack_handler="pack_array_dict",
@@ -240,38 +286,56 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
                     "file_format": file_format,
                 },
                 unpack_handler="unpack_array_dict",
+                pack_parameters={"i": 0},
+                unpack_parameters={"i": 0},
             )
             for file_format in NumPySupportedFormat.get_multi_array_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_array_dict",
+            log_hint={
+                "key": "my_array",
+                "file_format": NumPySupportedFormat.NPZ,
+            },
+            expected_instructions={
+                "file_format": NumPySupportedFormat.NPZ,
+                "allow_pickle": True,
+            },
+            unpack_handler="unpack_array_dict",
+            pack_parameters={"i": 1},
+            unpack_parameters={"i": 1},
+        )
     ]
 
 
-_ARRAY_LIST_SAMPLE = list(_ARRAY_DICT_SAMPLE.values())
+_ARRAY_LIST_SAMPLES = [
+    list(array_dict.values()) for array_dict in _ARRAY_DICT_SAMPLES
+]
 
 
-def pack_array_list() -> List[np.ndarray]:
-    return _ARRAY_LIST_SAMPLE
+def pack_array_list(i: int) -> List[np.ndarray]:
+    return _ARRAY_LIST_SAMPLES[i]
 
 
-def unpack_array_list(obj: List[np.ndarray]):
+def unpack_array_list(obj: List[np.ndarray], i: int):
     assert isinstance(obj, list) and all(isinstance(value, np.ndarray) for value in obj)
-    for obj_array, sample_array in zip(obj, _ARRAY_LIST_SAMPLE):
+    for obj_array, sample_array in zip(obj, _ARRAY_LIST_SAMPLES[i]):
         assert (obj_array == sample_array).all()
 
 
-def validate_array_list(result: List[list]) -> bool:
+def validate_array_list(result: List[list], i: int) -> bool:
     # Numppy arrays are serialized as lists:
-    for result_array, sample_array in zip(result, _ARRAY_LIST_SAMPLE):
+    for result_array, sample_array in zip(result, _ARRAY_LIST_SAMPLES[i]):
         if not (np.array(result_array) == sample_array).all():
             return False
     return True
 
 
-def prepare_array_list_file(file_format: str, **save_kwargs) -> Tuple[str, str]:
+def prepare_array_list_file(file_format: str, i: int, **save_kwargs) -> Tuple[str, str]:
     temp_directory = tempfile.mkdtemp()
     file_path = os.path.join(temp_directory, f"my_file.{file_format}")
     formatter = NumPySupportedFormat.get_format_handler(fmt=file_format)
-    formatter.save(obj=_ARRAY_LIST_SAMPLE, file_path=file_path, **save_kwargs)
+    formatter.save(obj=_ARRAY_LIST_SAMPLES[i], file_path=file_path, **save_kwargs)
     return file_path, temp_directory
 
 
@@ -283,32 +347,44 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
     PACKAGER_IN_TEST = NumPyNDArrayListPackager()
 
     TESTS = [
-        PackTest(
-            pack_handler="pack_array_list",
-            log_hint="my_result: result",
-            validation_function=validate_array_list,
-        ),
+        *[
+            PackTest(
+                pack_handler="pack_array_list",
+                log_hint="my_result: result",
+                validation_function=validate_array_list,
+                pack_parameters={"i": i},
+                validation_parameters={"i": i},
+            ) for i in range(len(_ARRAY_LIST_SAMPLES))
+        ],
         *[
             UnpackTest(
                 prepare_input_function=prepare_array_list_file,
                 unpack_handler="unpack_array_list",
-                prepare_parameters={"file_format": file_format},
+                prepare_parameters={"file_format": file_format, "i": 0},
+                unpack_parameters={"i": 0},
             )
             for file_format in NumPySupportedFormat.get_multi_array_formats()
         ],
-        PackToUnpackTest(
-            pack_handler="pack_array_list",
-            log_hint="my_array: result",
-        ),
-        PackToUnpackTest(
-            pack_handler="pack_array_list",
-            log_hint="my_array: object",
-            expected_instructions={
-                **COMMON_OBJECT_INSTRUCTIONS,
-                "object_module_name": dict.__module__,
-            },
-            unpack_handler="unpack_array_list",
-        ),
+        *[
+            PackToUnpackTest(
+                pack_handler="pack_array_list",
+                log_hint="my_array: result",
+                pack_parameters={"i": i},
+            ) for i in range(len(_ARRAY_LIST_SAMPLES))
+        ],
+        *[
+            PackToUnpackTest(
+                pack_handler="pack_array_list",
+                log_hint="my_array: object",
+                expected_instructions={
+                    **COMMON_OBJECT_INSTRUCTIONS,
+                    "object_module_name": list.__module__,
+                },
+                unpack_handler="unpack_array_list",
+                pack_parameters={"i": i},
+                unpack_parameters={"i": i},
+            ) for i in range(len(_ARRAY_LIST_SAMPLES))
+        ],
         *[
             PackToUnpackTest(
                 pack_handler="pack_array_list",
@@ -320,7 +396,23 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
                     "file_format": file_format,
                 },
                 unpack_handler="unpack_array_list",
+                pack_parameters={"i": 0},
+                unpack_parameters={"i": 0},
             )
             for file_format in NumPySupportedFormat.get_multi_array_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_array_list",
+            log_hint={
+                "key": "my_array",
+                "file_format": NumPySupportedFormat.NPZ,
+            },
+            expected_instructions={
+                "file_format": NumPySupportedFormat.NPZ,
+                "allow_pickle": True,
+            },
+            unpack_handler="unpack_array_list",
+            pack_parameters={"i": 1},
+            unpack_parameters={"i": 1},
+        )
     ]

--- a/tests/package/packagers_testers/numpy_packagers_testers.py
+++ b/tests/package/packagers_testers/numpy_packagers_testers.py
@@ -15,7 +15,6 @@
 import os
 import tempfile
 from typing import Dict, List, Tuple
-import itertools
 
 import numpy as np
 

--- a/tests/package/packagers_testers/numpy_packagers_testers.py
+++ b/tests/package/packagers_testers/numpy_packagers_testers.py
@@ -70,7 +70,7 @@ class NumPyNDArrayPackagerTester(PackagerTester):
     A tester for the `NumPyNDArrayPackager`.
     """
 
-    PACKAGER_IN_TEST = NumPyNDArrayPackager
+    PACKAGER_IN_TEST = NumPyNDArrayPackager()
 
     TESTS = [
         PackTest(
@@ -140,7 +140,7 @@ class NumPyNumberPackagerTester(PackagerTester):
     A tester for the `NumPyNumberPackager`.
     """
 
-    PACKAGER_IN_TEST = NumPyNumberPackager
+    PACKAGER_IN_TEST = NumPyNumberPackager()
 
     TESTS = [
         PackTest(
@@ -200,7 +200,7 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
     A tester for the `NumPyNDArrayDictPackager`.
     """
 
-    PACKAGER_IN_TEST = NumPyNDArrayDictPackager
+    PACKAGER_IN_TEST = NumPyNDArrayDictPackager()
 
     TESTS = [
         PackTest(
@@ -280,7 +280,7 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
     A tester for the `NumPyNDArrayListPackager`.
     """
 
-    PACKAGER_IN_TEST = NumPyNDArrayListPackager
+    PACKAGER_IN_TEST = NumPyNDArrayListPackager()
 
     TESTS = [
         PackTest(

--- a/tests/package/packagers_testers/numpy_packagers_testers.py
+++ b/tests/package/packagers_testers/numpy_packagers_testers.py
@@ -84,7 +84,8 @@ class NumPyNDArrayPackagerTester(PackagerTester):
                 pack_parameters={"i": i},
                 validation_parameters={"i": i},
                 default_artifact_type_object=np.ones(1),
-            ) for i in range(len(_ARRAY_SAMPLES))
+            )
+            for i in range(len(_ARRAY_SAMPLES))
         ],
         *[
             UnpackTest(
@@ -100,7 +101,8 @@ class NumPyNDArrayPackagerTester(PackagerTester):
                 pack_handler="pack_array",
                 log_hint="my_result: result",
                 pack_parameters={"i": i},
-            ) for i in range(len(_ARRAY_SAMPLES))
+            )
+            for i in range(len(_ARRAY_SAMPLES))
         ],
         *[
             PackToUnpackTest(
@@ -110,7 +112,8 @@ class NumPyNDArrayPackagerTester(PackagerTester):
                 unpack_handler="unpack_array",
                 pack_parameters={"i": i},
                 unpack_parameters={"i": i},
-            ) for i in range(len(_ARRAY_SAMPLES))
+            )
+            for i in range(len(_ARRAY_SAMPLES))
         ],
         PackToUnpackTest(
             pack_handler="pack_array",
@@ -141,11 +144,14 @@ class NumPyNDArrayPackagerTester(PackagerTester):
                 "artifact_type": "file",
                 "file_format": NumPySupportedFormat.NPY,
             },
-            expected_instructions={"file_format": NumPySupportedFormat.NPY, "allow_pickle": True},
+            expected_instructions={
+                "file_format": NumPySupportedFormat.NPY,
+                "allow_pickle": True,
+            },
             unpack_handler="unpack_array",
             pack_parameters={"i": 1},
             unpack_parameters={"i": 1},
-        )
+        ),
     ]
 
 
@@ -243,7 +249,8 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
                 validation_function=validate_array_dict,
                 pack_parameters={"i": i},
                 validation_parameters={"i": i},
-            ) for i in range(len(_ARRAY_DICT_SAMPLES))
+            )
+            for i in range(len(_ARRAY_DICT_SAMPLES))
         ],
         *[
             UnpackTest(
@@ -259,7 +266,8 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
                 pack_handler="pack_array_dict",
                 log_hint="my_array: result",
                 pack_parameters={"i": i},
-            ) for i in range(len(_ARRAY_DICT_SAMPLES))
+            )
+            for i in range(len(_ARRAY_DICT_SAMPLES))
         ],
         *[
             PackToUnpackTest(
@@ -272,7 +280,8 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
                 unpack_handler="unpack_array_dict",
                 pack_parameters={"i": i},
                 unpack_parameters={"i": i},
-            ) for i in range(len(_ARRAY_DICT_SAMPLES))
+            )
+            for i in range(len(_ARRAY_DICT_SAMPLES))
         ],
         *[
             PackToUnpackTest(
@@ -303,13 +312,11 @@ class NumPyNDArrayDictPackagerTester(PackagerTester):
             unpack_handler="unpack_array_dict",
             pack_parameters={"i": 1},
             unpack_parameters={"i": 1},
-        )
+        ),
     ]
 
 
-_ARRAY_LIST_SAMPLES = [
-    list(array_dict.values()) for array_dict in _ARRAY_DICT_SAMPLES
-]
+_ARRAY_LIST_SAMPLES = [list(array_dict.values()) for array_dict in _ARRAY_DICT_SAMPLES]
 
 
 def pack_array_list(i: int) -> List[np.ndarray]:
@@ -353,7 +360,8 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
                 validation_function=validate_array_list,
                 pack_parameters={"i": i},
                 validation_parameters={"i": i},
-            ) for i in range(len(_ARRAY_LIST_SAMPLES))
+            )
+            for i in range(len(_ARRAY_LIST_SAMPLES))
         ],
         *[
             UnpackTest(
@@ -369,7 +377,8 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
                 pack_handler="pack_array_list",
                 log_hint="my_array: result",
                 pack_parameters={"i": i},
-            ) for i in range(len(_ARRAY_LIST_SAMPLES))
+            )
+            for i in range(len(_ARRAY_LIST_SAMPLES))
         ],
         *[
             PackToUnpackTest(
@@ -382,7 +391,8 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
                 unpack_handler="unpack_array_list",
                 pack_parameters={"i": i},
                 unpack_parameters={"i": i},
-            ) for i in range(len(_ARRAY_LIST_SAMPLES))
+            )
+            for i in range(len(_ARRAY_LIST_SAMPLES))
         ],
         *[
             PackToUnpackTest(
@@ -413,5 +423,5 @@ class NumPyNDArrayListPackagerTester(PackagerTester):
             unpack_handler="unpack_array_list",
             pack_parameters={"i": 1},
             unpack_parameters={"i": 1},
-        )
+        ),
     ]

--- a/tests/package/packagers_testers/pandas_packagers_testers.py
+++ b/tests/package/packagers_testers/pandas_packagers_testers.py
@@ -103,7 +103,7 @@ class PandasDataFramePackagerTester(PackagerTester):
     A tester for the `PandasDataFramePackager`.
     """
 
-    PACKAGER_IN_TEST = PandasDataFramePackager
+    PACKAGER_IN_TEST = PandasDataFramePackager()
 
     TESTS = list(
         itertools.chain.from_iterable(
@@ -231,7 +231,7 @@ class PandasSeriesPackagerTester(PackagerTester):
     A tester for the `PandasSeriesPackager`.
     """
 
-    PACKAGER_IN_TEST = PandasSeriesPackager
+    PACKAGER_IN_TEST = PandasSeriesPackager()
 
     TESTS = list(
         itertools.chain.from_iterable(

--- a/tests/package/packagers_testers/python_standard_library_packagers_testers.py
+++ b/tests/package/packagers_testers/python_standard_library_packagers_testers.py
@@ -66,7 +66,7 @@ class NonePackagerTester(PackagerTester):
     A tester for the `NonePackager`.
     """
 
-    PACKAGER_IN_TEST = NonePackager
+    PACKAGER_IN_TEST = NonePackager()
 
     TESTS = [
         PackTest(
@@ -102,7 +102,7 @@ class IntPackagerTester(PackagerTester):
     A tester for the `IntPackager`.
     """
 
-    PACKAGER_IN_TEST = IntPackager
+    PACKAGER_IN_TEST = IntPackager()
 
     TESTS = [
         PackTest(
@@ -147,7 +147,7 @@ class FloatPackagerTester(PackagerTester):
     A tester for the `FloatPackager`.
     """
 
-    PACKAGER_IN_TEST = FloatPackager
+    PACKAGER_IN_TEST = FloatPackager()
 
     TESTS = [
         PackTest(
@@ -192,7 +192,7 @@ class BoolPackagerTester(PackagerTester):
     A tester for the `BoolPackager`.
     """
 
-    PACKAGER_IN_TEST = BoolPackager
+    PACKAGER_IN_TEST = BoolPackager()
 
     TESTS = [
         PackTest(
@@ -278,7 +278,7 @@ class StrPackagerTester(PackagerTester):
     A tester for the `StrPackager`.
     """
 
-    PACKAGER_IN_TEST = StrPackager
+    PACKAGER_IN_TEST = StrPackager()
 
     TESTS = [
         PackTest(
@@ -358,7 +358,7 @@ class DictPackagerTester(PackagerTester):
     A tester for the `DictPackager`.
     """
 
-    PACKAGER_IN_TEST = DictPackager
+    PACKAGER_IN_TEST = DictPackager()
 
     TESTS = [
         PackTest(
@@ -434,7 +434,7 @@ class ListPackagerTester(PackagerTester):
     A tester for the `ListPackager`.
     """
 
-    PACKAGER_IN_TEST = ListPackager
+    PACKAGER_IN_TEST = ListPackager()
 
     TESTS = [
         PackTest(
@@ -511,7 +511,7 @@ class TuplePackagerTester(PackagerTester):
     A tester for the `TuplePackager`.
     """
 
-    PACKAGER_IN_TEST = TuplePackager
+    PACKAGER_IN_TEST = TuplePackager()
 
     TESTS = [
         PackTest(
@@ -588,7 +588,7 @@ class SetPackagerTester(PackagerTester):
     A tester for the `SetPackager`.
     """
 
-    PACKAGER_IN_TEST = SetPackager
+    PACKAGER_IN_TEST = SetPackager()
 
     TESTS = [
         PackTest(
@@ -665,7 +665,7 @@ class FrozensetPackagerTester(PackagerTester):
     A tester for the `FrozensetPackager`.
     """
 
-    PACKAGER_IN_TEST = FrozensetPackager
+    PACKAGER_IN_TEST = FrozensetPackager()
 
     TESTS = [
         PackTest(
@@ -742,7 +742,7 @@ class BytearrayPackagerTester(PackagerTester):
     A tester for the `BytearrayPackager`.
     """
 
-    PACKAGER_IN_TEST = BytearrayPackager
+    PACKAGER_IN_TEST = BytearrayPackager()
 
     TESTS = [
         PackTest(
@@ -819,7 +819,7 @@ class BytesPackagerTester(PackagerTester):
     A tester for the `BytesPackager`.
     """
 
-    PACKAGER_IN_TEST = BytesPackager
+    PACKAGER_IN_TEST = BytesPackager()
 
     TESTS = [
         PackTest(
@@ -923,7 +923,7 @@ class PathPackagerTester(PackagerTester):
     A tester for the `PathPackager`.
     """
 
-    PACKAGER_IN_TEST = PathPackager
+    PACKAGER_IN_TEST = PathPackager()
 
     TESTS = [
         PackTest(

--- a/tests/package/test_packagers.py
+++ b/tests/package/test_packagers.py
@@ -271,7 +271,7 @@ def test_packager_pack_to_unpack(
         ]
         assert (
             unpackaging_instructions["packager_name"]
-            == tester.PACKAGER_IN_TEST.__name__
+            == tester.PACKAGER_IN_TEST.__class__.__name__
         )
         if tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE is not ...:
             # Check the object name noted match the packager handled type (at least subclass of it):

--- a/tests/package/test_usage.py
+++ b/tests/package/test_usage.py
@@ -273,9 +273,8 @@ class BaseClassPackager(DefaultPackager):
     PACKABLE_OBJECT_TYPE = BaseClass
     PACK_SUBCLASSES = True
 
-    @classmethod
     def unpack_object(
-        cls,
+        self,
         data_item: DataItem,
         pickle_module_name: str = "cloudpickle",
         object_module_name: str = None,


### PR DESCRIPTION
Some corrections and bug fixes for `mlrun.package`:
- [x] Remove python 3.7 support.
- [x] Change packager classes to stateful (used to be static class methods).
- [x] Fix deleting local files when loading.
- [x] Numpy pickling arrays enablement.

