### PR TITLE
[Runtimes] Modify logger level when handler is not provided

### DIFF
--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -360,7 +360,7 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
                 if resp:
                     run_obj_dict = json.loads(resp)
                 else:
-                    logger.error("empty context tmp file")
+                    logger.debug("empty context tmp file")
             else:
                 logger.info("no context file found")
 


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-5026

not a bug, the log level should be changed ( from error to debug ) in the case a handler was not provided when running a function.