### PR TITLE
[Project] Log when project directory has existing git remote

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -103,7 +103,7 @@ def init_repo(context, url, init_git):
     repo = None
     context_path = pathlib.Path(context)
     if not context_path.exists():
-        context_path.mkdir(parents=True)
+        context_path.mkdir(parents=True, exist_ok=True)
     elif not context_path.is_dir():
         raise ValueError(f"Context {context} is not a dir path")
     try:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -109,7 +109,6 @@ def init_repo(context, url, init_git):
     try:
         repo = git.Repo(context)
         url = get_repo_url(repo)
-        logger.info("Identified git repo, using it", url=url)
     except Exception:
         if init_git:
             repo = git.Repo.init(context)
@@ -223,6 +222,7 @@ def new_project(
     if remote and url != remote:
         project.create_remote(remote)
     elif url:
+        logger.info("Identified pre-initialized git repo, using it", url=url)
         project.spec._source = url
         project.spec.origin_url = url
     if description:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -105,10 +105,11 @@ def init_repo(context, url, init_git):
     if not context_path.exists():
         context_path.mkdir(parents=True)
     elif not context_path.is_dir():
-        raise ValueError(f"context {context} is not a dir path")
+        raise ValueError(f"Context {context} is not a dir path")
     try:
         repo = git.Repo(context)
         url = get_repo_url(repo)
+        logger.info("Identified git repo, using it", url=url)
     except Exception:
         if init_git:
             repo = git.Repo.init(context)


### PR DESCRIPTION
When project context directory has pre-initialized git repo, it is added as source to project
This PR simply adds a log to inform the user that a git repo was found

https://jira.iguazeng.com/browse/ML-5040
https://jira.iguazeng.com/browse/ML-5042
