### PR TITLE
[Tests] Improve the model monitoring framework system test

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -183,7 +183,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
 
         time.sleep(5)
         self.serving_fn.invoke(self.infer_path, self.infer_input)
-        time.sleep(1.2 * timedelta(minutes=self.app_interval).total_seconds())
+        time.sleep(1.8 * timedelta(minutes=self.app_interval).total_seconds())
 
         ep_id = self._get_model_enpoint_id()
         self._test_v3io_records(ep_id)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -189,7 +189,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
 
         time.sleep(5)
         self.serving_fn.invoke(self.infer_path, self.infer_input)
-        time.sleep(1.8 * timedelta(minutes=self.app_interval).total_seconds())
+        time.sleep(2 * timedelta(minutes=self.app_interval).total_seconds())
 
         ep_id = self._get_model_enpoint_id()
         self._test_v3io_records(ep_id)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -26,7 +26,6 @@ import pytest
 from sklearn.datasets import load_iris
 
 import mlrun
-from mlrun.common.schemas.function import FunctionState
 from mlrun.model_monitoring import TrackingPolicy
 from mlrun.model_monitoring.application import ModelMonitoringApplication
 from mlrun.model_monitoring.writer import _TSDB_BE, _TSDB_TABLE, ModelMonitoringWriter
@@ -178,12 +177,6 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         cls._test_kv_record(ep_id)
         cls._test_tsdb_record(ep_id)
 
-    def _test_monitoring_stream_is_ready(self) -> None:
-        fn = self.project.get_function("model-monitoring-stream")
-        assert (
-            fn.status.state == FunctionState.ready
-        ), "The monitoring stream is not up. Please check the deployment."
-
     def test_app_flow(self) -> None:
         self.project = typing.cast(mlrun.projects.MlrunProject, self.project)
         self._log_model()
@@ -198,5 +191,4 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         self.serving_fn.invoke(self.infer_path, self.infer_input)
         time.sleep(2 * timedelta(minutes=self.app_interval).total_seconds())
 
-        self._test_monitoring_stream_is_ready()
         self._test_v3io_records(ep_id=self._get_model_enpoint_id())

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -191,5 +191,4 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         self.serving_fn.invoke(self.infer_path, self.infer_input)
         time.sleep(2 * timedelta(minutes=self.app_interval).total_seconds())
 
-        ep_id = self._get_model_enpoint_id()
-        self._test_v3io_records(ep_id)
+        self._test_v3io_records(ep_id=self._get_model_enpoint_id())


### PR DESCRIPTION
* Increase the wait time to avoid checking the data before the apps run.
* Build and deploy the two apps and model serving concurrently (with thread pools).
* ~~Test the monitoring stream pod. In about half of the cases, its deployment fails. We should still look into this issue.~~
  Unfortunately, I didn't find a reliable way to test the stream pod status.

Thanks to the concurrency improvement, the test time is reduced to about 6 minutes, although the sleep time is increased by one minute.