### PR TITLE
[Auth] Add missing permission check when scheduling workflows

### DIFF
--- a/server/api/api/endpoints/workflows.py
+++ b/server/api/api/endpoints/workflows.py
@@ -137,6 +137,16 @@ async def submit_workflow(
         spec=workflow_request.spec,
         arguments=workflow_request.arguments,
     )
+
+    if workflow_spec.schedule:
+        await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+            resource_type=mlrun.common.schemas.AuthorizationResourceTypes.schedule,
+            project_name=project.metadata.name,
+            resource_name=workflow_spec.name,
+            action=mlrun.common.schemas.AuthorizationAction.create,
+            auth_info=auth_info,
+        )
+
     updated_request = workflow_request.copy()
     updated_request.spec = workflow_spec
 

--- a/server/api/api/endpoints/workflows.py
+++ b/server/api/api/endpoints/workflows.py
@@ -108,28 +108,40 @@ async def submit_workflow(
         action=mlrun.common.schemas.AuthorizationAction.read,
         auth_info=auth_info,
     )
+
+    # If workflow spec has not passed need to create on same name:
+    requested_workflow_name = getattr(workflow_request.spec, "name", name)
+
     # Check permission CREATE workflow on new workflow's name
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         resource_type=mlrun.common.schemas.AuthorizationResourceTypes.workflow,
         project_name=project.metadata.name,
-        # If workflow spec has not passed need to create on same name:
-        resource_name=getattr(workflow_request.spec, "name", name),
+        resource_name=requested_workflow_name,
         action=mlrun.common.schemas.AuthorizationAction.create,
         auth_info=auth_info,
     )
-    # Re-route to chief in case of schedule
-    if (
-        _is_requested_schedule(name, workflow_request.spec, project)
-        and mlrun.mlconf.httpdb.clusterization.role
-        != mlrun.common.schemas.ClusterizationRole.chief
-    ):
-        chief_client = server.api.utils.clients.chief.Client()
-        return await chief_client.submit_workflow(
-            project=project.metadata.name,
-            name=name,
-            request=request,
-            json=workflow_request.dict(),
+
+    # Validate permissions and re-route to chief if needed in case of schedule
+    if _is_requested_schedule(name, workflow_request.spec, project):
+        await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+            resource_type=mlrun.common.schemas.AuthorizationResourceTypes.schedule,
+            project_name=project.metadata.name,
+            resource_name=requested_workflow_name,
+            action=mlrun.common.schemas.AuthorizationAction.create,
+            auth_info=auth_info,
         )
+
+        if (
+            mlrun.mlconf.httpdb.clusterization.role
+            != mlrun.common.schemas.ClusterizationRole.chief
+        ):
+            chief_client = server.api.utils.clients.chief.Client()
+            return await chief_client.submit_workflow(
+                project=project.metadata.name,
+                name=name,
+                request=request,
+                json=workflow_request.dict(),
+            )
 
     workflow_spec = _fill_workflow_missing_fields_from_project(
         project=project,
@@ -137,15 +149,6 @@ async def submit_workflow(
         spec=workflow_request.spec,
         arguments=workflow_request.arguments,
     )
-
-    if workflow_spec.schedule:
-        await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-            resource_type=mlrun.common.schemas.AuthorizationResourceTypes.schedule,
-            project_name=project.metadata.name,
-            resource_name=workflow_spec.name,
-            action=mlrun.common.schemas.AuthorizationAction.create,
-            auth_info=auth_info,
-        )
 
     updated_request = workflow_request.copy()
     updated_request.spec = workflow_spec


### PR DESCRIPTION
The new `submit_workflow` endpoint allows scheduling workflows, but doesn't check for `create` permissions on the `schedule` resource. Add this check if a schedule was provided, like we do in `submit_job`.