### PR TITLE
[Model Monitoring] Start from the last analyzed time in the controller

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-import enum
+
 import hashlib
 from dataclasses import dataclass
+from enum import Enum, IntEnum
 from typing import Optional
 
 import mlrun.common.helpers
-import mlrun.common.types
+from mlrun.common.types import StrEnum
 
 
 class EventFieldType:
@@ -90,7 +90,7 @@ class ApplicationEvent:
     OUTPUT_STREAM_URI = "output_stream_uri"
 
 
-class WriterEvent(mlrun.common.types.StrEnum):
+class WriterEvent(StrEnum):
     APPLICATION_NAME = "application_name"
     ENDPOINT_ID = "endpoint_id"
     START_INFER_TIME = "start_infer_time"
@@ -154,12 +154,12 @@ class FileTargetKind:
     LOG_STREAM = "log_stream"
 
 
-class ModelMonitoringMode(str, enum.Enum):
+class ModelMonitoringMode(str, Enum):
     enabled = "enabled"
     disabled = "disabled"
 
 
-class EndpointType(enum.IntEnum):
+class EndpointType(IntEnum):
     NODE_EP = 1  # end point that is not a child of a router
     ROUTER = 2  # endpoint that is router
     LEAF_EP = 3  # end point that is a child of a router
@@ -257,7 +257,7 @@ class DriftStatus(enum.Enum):
     POSSIBLE_DRIFT = "POSSIBLE_DRIFT"
 
 
-class ResultKindApp(enum.Enum):
+class ResultKindApp(Enum):
     """
     Enum for the result kind values
     """
@@ -268,7 +268,7 @@ class ResultKindApp(enum.Enum):
     system_performance = 3
 
 
-class ResultStatusApp(enum.IntEnum):
+class ResultStatusApp(IntEnum):
     """
     Enum for the result status values, detected means that the app detected some problem.
     """

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -145,6 +145,10 @@ class ModelMonitoringStoreKinds:
     EVENTS = "events"
 
 
+class SchedulingKeys:
+    LAST_ANALYZED = "last_analyzed"
+
+
 class FileTargetKind:
     ENDPOINTS = "endpoints"
     EVENTS = "events"

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -251,7 +251,7 @@ class EndpointUID:
         return self.uid
 
 
-class DriftStatus(enum.Enum):
+class DriftStatus(Enum):
     """
     Enum for the drift status values.
     """

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -108,11 +108,23 @@ class _BatchWindow:
     ) -> Iterator[Tuple[datetime.datetime, datetime.datetime]]:
         """Generate the batch interval time ranges."""
         if self._start is not None:
+            entered = False
             for timestamp in range(self._start, self._stop, self._step):
+                entered = True
                 start_time = datetime.datetime.utcfromtimestamp(timestamp)
                 end_time = datetime.datetime.utcfromtimestamp(timestamp + self._step)
                 yield start_time, end_time
                 self._update_last_analyzed(timestamp + self._step)
+            if not entered:
+                logger.info(
+                    "All the data is set, but no complete intervals were found. "
+                    "Wait for last_updated to be updated.",
+                    endpoint=self._endpoint,
+                    application=self._application,
+                    start=self._start,
+                    stop=self._stop,
+                    step=self._step,
+                )
         else:
             logger.warn(
                 "The first request time is not not found for this endpoint. "

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -452,7 +452,6 @@ class MonitoringApplicationController:
                         inputs=df,
                     )
 
-                    # create and push data to all applications
                     cls._push_to_applications(
                         current_stats=current_stats,
                         feature_stats=feature_stats,
@@ -461,7 +460,7 @@ class MonitoringApplicationController:
                         endpoint_id=endpoint_id,
                         latest_request=latest_request,
                         project=project,
-                        applications_names=applications_names,
+                        applications_names=[application],
                         model_monitoring_access_key=model_monitoring_access_key,
                         parquet_target_path=parquet_target_path,
                     )

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -26,12 +26,12 @@ import mlrun
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.data_types.infer
 import mlrun.feature_store as fstore
-import mlrun.utils.v3io_clients
 from mlrun.datastore import get_stream_pusher
 from mlrun.datastore.targets import ParquetTarget
 from mlrun.model_monitoring.batch import calculate_inputs_statistics
 from mlrun.model_monitoring.helpers import get_monitoring_parquet_path, get_stream_path
 from mlrun.utils import logger
+from mlrun.utils.v3io_clients import get_v3io_client
 
 
 class _BatchWindow:
@@ -55,13 +55,11 @@ class _BatchWindow:
         self._endpoint = endpoint
         self._application = application
         self._first_request = first_request
+        self._kv_storage = get_v3io_client(endpoint=mlrun.mlconf.v3io_api).kv
+        self._v3io_container = self.V3IO_CONTAINER_FORMAT.format(project=project)
         self._start = self._get_last_analyzed()
         self._stop = last_updated
         self._step = timedelta_seconds
-        self._kv_storage = mlrun.utils.v3io_clients.get_v3io_client(
-            endpoint=mlrun.mlconf.v3io_api
-        ).kv
-        self._v3io_container = self.V3IO_CONTAINER_FORMAT.format(project=project)
 
     def _get_last_analyzed(self) -> Optional[int]:
         try:

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -411,7 +411,7 @@ class MonitoringApplicationController:
                                 "Not enough model events since the beginning of the batch interval",
                                 featureset_name=m_fs.metadata.name,
                                 endpoint=endpoint[mm_constants.EventFieldType.UID],
-                                min_rqeuired_events=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events,
+                                min_required_events=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events,
                                 start_time=start_infer_time,
                                 end_time=end_infer_time,
                             )
@@ -422,7 +422,7 @@ class MonitoringApplicationController:
                         logger.warn(
                             "Parquet not found, probably due to not enough model events",
                             endpoint=endpoint[mm_constants.EventFieldType.UID],
-                            min_rqeuired_events=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events,
+                            min_required_events=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events,
                         )
                         return
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -91,7 +91,7 @@ class _BatchWindow:
         )
         return last_analyzed
 
-    def get_interval_range(
+    def get_intervals(
         self,
     ) -> Iterator[Tuple[datetime.datetime, datetime.datetime]]:
         """
@@ -362,7 +362,7 @@ class MonitoringApplicationController:
             )
 
             # TODO: run on all intervals
-            intervals = list(batch_window.get_interval_range())
+            intervals = list(batch_window.get_intervals())
             if not intervals:
                 logger.warn(
                     "No intervals were found for this endpoint",

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -34,6 +34,7 @@ from mlrun.utils import logger
 class _BatchWindow:
     def __init__(
         self,
+        project: str,
         endpoint: str,
         application: str,
         timedelta_seconds: int,
@@ -135,11 +136,19 @@ class _BatchWindowGenerator:
         return int(datetime.datetime.fromisoformat(first_request).timestamp())
 
     def get_batch_window(
-        self, endpoint: str, application: str, first_request: Optional[str]
+        self,
+        project: str,
+        endpoint: str,
+        application: str,
+        first_request: Optional[str],
     ) -> _BatchWindow:
-        """Get the batch window for a specific endpoint and application"""
+        """
+        Get the batch window for a specific endpoint and application.
+        first_request is the first request time to the endpoint.
+        """
 
         return _BatchWindow(
+            project=project,
             endpoint=endpoint,
             application=application,
             timedelta_seconds=self._timedelta,
@@ -307,6 +316,7 @@ class MonitoringApplicationController:
             # Getting batch interval start time and end time
             application_name = applications_names[0]
             batch_window = batch_window_generator.get_batch_window(
+                project=project,
                 endpoint=endpoint_id,
                 application=application_name,
                 first_request=endpoint[mm_constants.EventFieldType.FIRST_REQUEST],

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -68,14 +68,22 @@ class _BatchWindow:
         )
         return datetime.timedelta(minutes=minutes, hours=hours, days=days)
 
-    def get_interval_range(
-        self,
-        now_func: Callable[[], datetime.datetime] = datetime.datetime.now,
-    ) -> Tuple[datetime.datetime, datetime.datetime]:
-        """Getting batch interval time range"""
-        end_time = now_func() - datetime.timedelta(
+    @staticmethod
+    def _get_last_updated_time(
+        now_func: Callable[[], datetime.datetime] = datetime.datetime.now
+    ) -> datetime.datetime:
+        """
+        Get the last updated time of a model endpoint.
+        Note: this is an approximation of this time. Once we save it in the DB,
+        we will have the exact time and won't use now_func.
+        """
+        return now_func() - datetime.timedelta(
             seconds=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
         )
+
+    def get_interval_range(self) -> Tuple[datetime.datetime, datetime.datetime]:
+        """Getting batch interval time range"""
+        end_time = self._get_last_updated_time()
         start_time = end_time - self._timedelta
         return start_time, end_time
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -471,19 +471,13 @@ class MonitoringApplicationController:
             )
             return endpoint_id, e
 
-    def _delete_old_parquet(self, endpoints: List[Dict[str, Any]], days: int = 1):
-        """Delete application parquets that are older than 24 hours.
-        now_func: Callable[[], datetime.datetime] = datetime.datetime.now,
-        batch_dict: dict[str, int],
-        # Initialize the dictionary of batch interval ranges
-        pattern = "[" + characters_to_remove + "]"
-        self.batch_dict = {}
+    def _delete_old_parquet(self, endpoints: list[dict[str, Any]], days: int = 1):
+        """
+        Delete application parquets older than the argument days.
 
-
-        :param endpoints: List of dictionaries of model endpoints records.
+        :param endpoints: A list of dictionaries of model endpoints records.
         """
         if self.parquet_directory.startswith("v3io:///"):
-
             target = mlrun.datastore.targets.BaseStoreTarget(
                 path=self.parquet_directory
             )

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -18,7 +18,7 @@ import json
 import os
 import re
 import time
-from typing import Any, Iterator, Optional, Tuple, Union, cast
+from typing import Any, Callable, Iterator, Optional, Tuple, Union, cast
 
 from v3io.dataplane.response import HttpResponseError
 
@@ -167,14 +167,14 @@ class _BatchWindowGenerator:
         )
 
     @staticmethod
-    def _get_last_updated_time() -> int:
+    def _get_last_updated_time(now_func: Callable[[], float] = time.time) -> int:
         """
         Get the last updated time of a model endpoint.
         Note: this is an approximation of this time. Once we save it in the DB,
         we will have the exact time and won't use now_func.
         """
         return int(
-            time.time()
+            now_func()
             - cast(
                 float,
                 mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs,

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -88,7 +88,7 @@ class TestBatchInterval:
         mock = Mock(spec=["kv"])
         mock.kv.get = Mock(side_effect=HttpResponseError)
         with patch(
-            "mlrun.model_monitoring.batch_application.get_v3io_client",
+            "mlrun.model_monitoring.controller.get_v3io_client",
             return_value=mock,
         ):
             return list(

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -14,9 +14,11 @@
 
 import datetime
 import typing
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
+from unittest.mock import Mock, patch
 
 import pytest
+from v3io.dataplane.response import HttpResponseError
 
 from mlrun.common.model_monitoring.helpers import (
     _MAX_FLOAT,
@@ -24,11 +26,7 @@ from mlrun.common.model_monitoring.helpers import (
     Histogram,
     pad_features_hist,
 )
-from mlrun.common.schemas.model_monitoring import EventFieldType
-from mlrun.model_monitoring.controller import (
-    MonitoringApplicationController,
-    _BatchWindowGenerator,
-)
+from mlrun.model_monitoring.controller import _BatchWindow, _BatchWindowGenerator
 
 
 class _HistLen(typing.NamedTuple):
@@ -80,45 +78,35 @@ def test_pad_features_hist(
 
 
 class TestBatchInterval:
-    interval_range = MonitoringApplicationController._get_interval_range
-
     @staticmethod
-    def _fake_now_func_factory(
-        delta: datetime.timedelta,
-        base_time: datetime.datetime = datetime.datetime(2021, 1, 1, 12, 0, 0),
-    ) -> Callable[[], datetime.datetime]:
-        def fake_now_func() -> datetime.datetime:
-            nonlocal base_time
-            current_time = base_time
-            base_time += delta
-            return current_time
-
-        return fake_now_func
-
-    @classmethod
     @pytest.fixture
     def intervals(
-        cls, minutes_delta: int = 6
+        timedelta_seconds: int = int(datetime.timedelta(minutes=6).total_seconds()),
+        first_request: int = int(datetime.datetime(2021, 1, 1, 12, 0, 0).timestamp()),
+        last_updated: int = int(datetime.datetime(2021, 1, 1, 13, 1, 0).timestamp()),
     ) -> list[Tuple[datetime.datetime, datetime.datetime]]:
-        now_func = cls._fake_now_func_factory(
-            delta=datetime.timedelta(minutes=minutes_delta)
-        )
-        return [
-            MonitoringApplicationController._get_interval_range(
-                batch_dict={
-                    EventFieldType.MINUTES: minutes_delta,
-                    EventFieldType.HOURS: 0,
-                    EventFieldType.DAYS: 0,
-                },
-                now_func=now_func,
+        mock = Mock(spec=["kv"])
+        mock.kv.get = Mock(side_effect=HttpResponseError)
+        with patch(
+            "mlrun.model_monitoring.batch_application.get_v3io_client",
+            return_value=mock,
+        ):
+            return list(
+                _BatchWindow(
+                    project="project",
+                    endpoint="ep",
+                    application="app",
+                    timedelta_seconds=timedelta_seconds,
+                    first_request=first_request,
+                    last_updated=last_updated,
+                ).get_intervals()
             )
-            for _ in range(5)
-        ]
 
     @staticmethod
-    def test_touching_interval(
+    def test_touching_intervals(
         intervals: list[Tuple[datetime.datetime, datetime.datetime]]
     ) -> None:
+        assert len(intervals) > 1, "There should be more than one interval"
         for prev, curr in zip(intervals[:-1], intervals[1:]):
             assert prev[1] == curr[0], "The intervals should be touching"
 


### PR DESCRIPTION
A part of [ML-5036](https://jira.iguazeng.com/browse/ML-5036) - the controller side.

Store the "last_analyzed" data per endpoint & application and start from it to avoid skipping over data.

And --- a comeback of #4016 🎉 