### PR TITLE
[Datastore] Avoid setting number of replicas in `KafkaSource`

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -963,11 +963,8 @@ class KafkaSource(OnlineSource):
             explicit_ack_mode=explicit_ack_mode,
             extra_attributes=extra_attributes,
         )
-        func = function.add_trigger("kafka", trigger)
-        replicas = 1 if not partitions else len(partitions)
-        func.spec.min_replicas = replicas
-        func.spec.max_replicas = replicas
-        return func
+        function = function.add_trigger("kafka", trigger)
+        return function
 
 
 class SQLSource(BaseSourceDriver):

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -378,6 +378,9 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
             filename=str(self.assets_path / "map_avro.py"),
         )
 
+        func.spec.min_replicas = 1
+        func.spec.max_replicas = 1
+
         run_config = fstore.RunConfig(local=False, function=func).apply(
             mlrun.auto_mount()
         )


### PR DESCRIPTION
Instead, let the function spec decide this as is normally the case.

[ML-5109](https://jira.iguazeng.com/browse/ML-5109)