### PR TITLE
[Tests] Avoid running helper methods as tests

### DIFF
--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -258,7 +258,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         return result
 
     @staticmethod
-    def test_name():
+    def get_test_name():
         return (
             os.environ.get("PYTEST_CURRENT_TEST")
             .split(":")[-1]
@@ -267,11 +267,11 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             .replace("]", "")
         )
 
-    def test_output_subdir_path(self, url=True):
-        return f"{self.output_dir(url=url)}/{self.test_name()}"
+    def get_test_output_subdir_path(self, url=True):
+        return f"{self.output_dir(url=url)}/{self.get_test_name()}"
 
     def set_targets(self, feature_set, also_in_remote=False):
-        dir_name = self.test_name()
+        dir_name = self.get_test_name()
         if self.run_local or also_in_remote:
             target_path = f"{self.output_dir(url=False)}/{dir_name}"
             feature_set.set_targets(
@@ -367,7 +367,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
     def test_ingest_to_csv(self):
         key = "patient_id"
-        base_path = self.test_output_subdir_path()
+        base_path = self.get_test_output_subdir_path()
         csv_path_spark = f"{base_path}_spark"
         csv_path_storey = f"{base_path}_storey.csv"
 
@@ -1166,7 +1166,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
         target = ParquetTarget(
             name="pq",
-            path=f"{self.output_dir()}/{self.test_name()}/",
+            path=f"{self.output_dir()}/{self.get_test_name()}/",
             partitioned=False,
         )
 
@@ -1219,7 +1219,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
         target = ParquetTarget(
             name="pq",
-            path=f"{self.output_dir()}/{self.test_name()}/",
+            path=f"{self.output_dir()}/{self.get_test_name()}/",
             partitioned=False,
         )
 
@@ -1493,7 +1493,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
     def test_ingest_with_steps_drop_features(self):
         key = "patient_id"
-        base_path = self.test_output_subdir_path()
+        base_path = self.get_test_output_subdir_path()
         csv_path_spark = f"{base_path}_spark"
         csv_path_storey = f"{base_path}_storey.csv"
 
@@ -1553,7 +1553,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
     def test_ingest_with_steps_onehot(self):
         key = "patient_id"
-        base_path = self.test_output_subdir_path()
+        base_path = self.get_test_output_subdir_path()
         csv_path_spark = f"{base_path}_spark"
         csv_path_storey = f"{base_path}_storey.csv"
 
@@ -1594,7 +1594,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
     @pytest.mark.parametrize("with_original_features", [True, False])
     def test_ingest_with_steps_mapvalues(self, with_original_features):
         key = "patient_id"
-        base_path = self.test_output_subdir_path()
+        base_path = self.get_test_output_subdir_path()
         csv_path_spark = f"{base_path}_spark"
         csv_path_storey = f"{base_path}_storey.csv"
 
@@ -1651,7 +1651,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
     def test_mapvalues_with_partial_mapping(self):
         # checks partial mapping -> only part of the values in field are replaced.
         key = "patient_id"
-        csv_path_spark = self.test_output_subdir_path()
+        csv_path_spark = self.get_test_output_subdir_path()
         original_df = pd.read_parquet(self.get_pq_source_path())
         measurements = fstore.FeatureSet(
             "measurements_spark",
@@ -1689,7 +1689,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
 
     def test_mapvalues_with_mixed_types(self):
         key = "patient_id"
-        csv_path_spark = self.test_output_subdir_path()
+        csv_path_spark = self.get_test_output_subdir_path()
         measurements = fstore.FeatureSet(
             "measurements_spark",
             entities=[fstore.Entity(key)],
@@ -1727,7 +1727,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
     @pytest.mark.parametrize("timestamp_col", [None, "timestamp"])
     def test_ingest_with_steps_extractor(self, timestamp_col):
         key = "patient_id"
-        base_path = self.test_output_subdir_path()
+        base_path = self.get_test_output_subdir_path()
         out_path_spark = f"{base_path}_spark"
         out_path_storey = f"{base_path}_storey"
 
@@ -2232,7 +2232,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
                 "f2": ["newest", "only-value"],
             }
         )
-        base_path = self.test_output_subdir_path(url=False)
+        base_path = self.get_test_output_subdir_path(url=False)
         left_path = f"{base_path}/df_left.parquet"
         right_path = f"{base_path}/df_right.parquet"
 
@@ -2248,7 +2248,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         fset2 = fstore.FeatureSet("fs2-as-of", entities=["ent"], timestamp_key=ts_r)
         self.set_targets(fset2, also_in_remote=True)
 
-        base_url = self.test_output_subdir_path()
+        base_url = self.get_test_output_subdir_path()
         left_url = f"{base_url}/df_left.parquet"
         right_url = f"{base_url}/df_right.parquet"
 
@@ -2302,7 +2302,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             }
         )
 
-        base_path = self.test_output_subdir_path(url=False)
+        base_path = self.get_test_output_subdir_path(url=False)
         path = f"{base_path}/df_for_filter.parquet"
 
         fsys = fsspec.filesystem(


### PR DESCRIPTION
Methods that start with `test_` are picked up by pytest and run as tests.