### PR TITLE
[FeatureStore] Change APIs to be FeatureSet/FeatureVector class methods

### DIFF
--- a/tests/feature-store/test_featureset.py
+++ b/tests/feature-store/test_featureset.py
@@ -1,0 +1,130 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from unittest import mock
+
+from mlrun.data_types import InferOptions
+from mlrun.feature_store.common import RunConfig
+from mlrun.feature_store.feature_set import FeatureSet
+from mlrun.model import DataSource, DataTargetBase
+
+
+@mock.patch("mlrun.feature_store.api.ingest")
+def test_ingest_method(mock_ingest):
+    # Create an instance of FeatureSet
+    fs = FeatureSet()
+
+    # Define your test inputs
+    test_source = "test_source"
+    test_targets = ["target1", "target2"]
+    test_namespace = "test_namespace"
+    test_return_df = True
+    test_infer_options = InferOptions.default()
+    test_run_config = RunConfig()
+    test_mlrun_context = "test_mlrun_context"
+    test_spark_context = "test_spark_context"
+    test_overwrite = True
+
+    # Call the ingest method
+    fs.ingest(
+        source=test_source,
+        targets=test_targets,
+        namespace=test_namespace,
+        return_df=test_return_df,
+        infer_options=test_infer_options,
+        run_config=test_run_config,
+        mlrun_context=test_mlrun_context,
+        spark_context=test_spark_context,
+        overwrite=test_overwrite,
+    )
+
+    # Assert that mlrun.feature_store.api.ingest was called with the correct parameters
+    mock_ingest.assert_called_once_with(
+        fs,
+        test_source,
+        test_targets,
+        test_namespace,
+        test_return_df,
+        test_infer_options,
+        test_run_config,
+        test_mlrun_context,
+        test_spark_context,
+        test_overwrite,
+    )
+
+
+@mock.patch("mlrun.feature_store.api.preview")
+def test_preview_method(mock_preview):
+    # Create an instance of FeatureSet
+    fs = FeatureSet()
+
+    # Define your test inputs
+    test_source = "test_source"
+    test_entity_columns = ["col1", "col2"]
+    test_namespace = "test_namespace"
+    test_options = InferOptions.default()  # Assuming InferOptions is available
+    test_verbose = True
+    test_sample_size = 100
+
+    # Call the preview method
+    fs.preview(
+        source=test_source,
+        entity_columns=test_entity_columns,
+        namespace=test_namespace,
+        options=test_options,
+        verbose=test_verbose,
+        sample_size=test_sample_size,
+    )
+
+    # Assert that mlrun.feature_store.api.preview was called with the correct parameters
+    mock_preview.assert_called_once_with(
+        test_source,
+        test_entity_columns,
+        test_namespace,
+        test_options,
+        test_verbose,
+        test_sample_size,
+    )
+
+
+@mock.patch("mlrun.feature_store.api.deploy_ingestion_service_v2")
+def test_deploy_ingestion_service(mock_deploy):
+    # Create an instance of FeatureSet
+    fs = FeatureSet()
+
+    # Define your test inputs
+    test_source = DataSource()  # Assuming DataSource is a valid class
+    test_targets = [
+        DataTargetBase(),
+        DataTargetBase(),
+    ]  # Replace with valid DataTargetBase instances
+    test_name = "test_service"
+    test_run_config = RunConfig()  # Assuming RunConfig is a valid class
+    test_verbose = True
+
+    # Call the deploy_ingestion_service method
+    fs.deploy_ingestion_service(
+        source=test_source,
+        targets=test_targets,
+        name=test_name,
+        run_config=test_run_config,
+        verbose=test_verbose,
+    )
+
+    # Assert that mlrun.feature_store.api.deploy_ingestion_service_v2 was called with the correct parameters
+    mock_deploy.assert_called_once_with(
+        fs, test_source, test_targets, test_name, test_run_config, test_verbose
+    )

--- a/tests/feature-store/test_featurevec.py
+++ b/tests/feature-store/test_featurevec.py
@@ -1,0 +1,108 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from datetime import datetime
+from unittest import mock
+
+from mlrun.feature_store.common import RunConfig
+from mlrun.feature_store.feature_vector import FeatureVector, FixedWindowType
+from mlrun.model import DataTargetBase
+
+
+@mock.patch("mlrun.feature_store.api.get_online_feature_service")
+def test_get_online_feature_service(mock_get_online_service):
+    fv = FeatureVector()
+
+    test_run_config = RunConfig()
+    test_fixed_window_type = FixedWindowType.LastClosedWindow
+    test_impute_policy = {"policy": "mean"}
+    test_update_stats = True
+    test_entity_keys = ["key1", "key2"]
+
+    fv.get_online_feature_service(
+        run_config=test_run_config,
+        fixed_window_type=test_fixed_window_type,
+        impute_policy=test_impute_policy,
+        update_stats=test_update_stats,
+        entity_keys=test_entity_keys,
+    )
+
+    mock_get_online_service.assert_called_once_with(
+        fv,
+        test_run_config,
+        test_fixed_window_type,
+        test_impute_policy,
+        test_update_stats,
+        test_entity_keys,
+    )
+
+
+@mock.patch("mlrun.feature_store.api.get_offline_features")
+def test_get_offline_features(mock_get_offline_features):
+    fv = FeatureVector()
+
+    # Define your test inputs
+    test_entity_rows = None
+    test_entity_timestamp_column = "timestamp"
+    test_target = DataTargetBase()  # Assuming DataTargetBase is a valid class
+    test_run_config = RunConfig()  # Assuming RunConfig is a valid class
+    test_drop_columns = ["col1", "col2"]
+    test_start_time = "2021-01-01"
+    test_end_time = datetime.now()
+    test_with_indexes = True
+    test_update_stats = False
+    test_engine = "test_engine"
+    test_engine_args = {"arg1": "value1"}
+    test_query = "SELECT * FROM table"
+    test_order_by = "col1"
+    test_spark_service = "test_spark_service"
+    test_timestamp_for_filtering = {"col1": "2021-01-01"}
+
+    fv.get_offline_features(
+        entity_rows=test_entity_rows,
+        entity_timestamp_column=test_entity_timestamp_column,
+        target=test_target,
+        run_config=test_run_config,
+        drop_columns=test_drop_columns,
+        start_time=test_start_time,
+        end_time=test_end_time,
+        with_indexes=test_with_indexes,
+        update_stats=test_update_stats,
+        engine=test_engine,
+        engine_args=test_engine_args,
+        query=test_query,
+        order_by=test_order_by,
+        spark_service=test_spark_service,
+        timestamp_for_filtering=test_timestamp_for_filtering,
+    )
+    mock_get_offline_features.assert_called_once_with(
+        fv,
+        test_entity_rows,
+        test_entity_timestamp_column,
+        test_target,
+        test_run_config,
+        test_drop_columns,
+        test_start_time,
+        test_end_time,
+        test_with_indexes,
+        test_update_stats,
+        test_engine,
+        test_engine_args,
+        test_query,
+        test_order_by,
+        test_spark_service,
+        test_timestamp_for_filtering,
+    )


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4622
Add APIs to FeatureSet and FeatureVector

class FeatureSet:
  ingest() // new method - shadows mlrun.feature_store.api.ingest 
  preview() // new method - shadows mlrun.feature_store.api.preview
  deploy_ingestion_service() - shadows mlrun.feature_store.api.deploy_ingestion_service_v2

class FeatureVector:
  get_offline_features() // new method - shadows mlrun.feature_store.api.get_offline_features 
  get_online_feature_service() new method - shadowsmlrun.feature_store.api.get_online_feature_service
