### PR TITLE
[Model Monitoring] Add model monitoring controller API 

### DIFF
--- a/mlrun/common/schemas/model_monitoring/__init__.py
+++ b/mlrun/common/schemas/model_monitoring/__init__.py
@@ -15,6 +15,7 @@
 # flake8: noqa  - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
 from .constants import (
+    ControllerPolicy,
     DriftStatus,
     EndpointType,
     EndpointUID,

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -286,3 +286,7 @@ class ResultStatusApp(IntEnum):
 class ModelMonitoringAppLabel:
     KEY = "mlrun__type"
     VAL = "mlrun__model-monitoring-application"
+
+
+class ControllerPolicy:
+    BASE_PERIOD = "base_period"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2934,11 +2934,6 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call(method="POST", path=path, params=params)
         return resp.json()["func"]
 
-    def delete_model_monitoring_controller(self, project: str):
-        '''Delete model monitoring controller scheduled job'''
-        path = f"projects/{project}/jobs/model-monitoring-controller"
-        self.api_call(method="DELETE", path=path)
-
     def create_hub_source(
         self, source: Union[dict, mlrun.common.schemas.IndexedHubSource]
     ):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2904,6 +2904,41 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call(method="POST", path=path, params=params)
         return resp.json()["func"]
 
+    def create_model_monitoring_controller(
+        self,
+        project: str = "",
+        default_controller_image: str = "mlrun/mlrun",
+        base_period: int = 5,
+    ):
+        """
+        Submit model monitoring application controller job along with deploying the model monitoring writer function.
+        While the main goal of the controller job is to handle the monitoring processing and triggering applications,
+        the goal of the model monitoring writer function is to write all the monitoring application results to the
+        databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+        :param project:                  Project name.
+        :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
+                                         function, which is a real time nuclio functino, will be deployed with the same
+                                         image. By default, the image is mlrun/mlrun.
+        :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
+                                         is running. By default, the base period is 5 minutes.
+        :return: model monitoring controller job as a dictionary. You can easily convert the resulted function into a
+                 runtime object by calling ~mlrun.new_function.
+        """
+
+        params = {
+            "default_controller_image": default_controller_image,
+            "base_period": base_period,
+        }
+        path = f"projects/{project}/jobs/model-monitoring-controller"
+
+        resp = self.api_call(method="POST", path=path, params=params)
+        return resp.json()["func"]
+
+    def delete_model_monitoring_controller(self, project: str):
+        '''Delete model monitoring controller scheduled job'''
+        path = f"projects/{project}/jobs/model-monitoring-controller"
+        self.api_call(method="DELETE", path=path)
+
     def create_hub_source(
         self, source: Union[dict, mlrun.common.schemas.IndexedHubSource]
     ):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2908,13 +2908,13 @@ class HTTPRunDB(RunDBInterface):
         self,
         project: str = "",
         default_controller_image: str = "mlrun/mlrun",
-        base_period: int = 5,
+        base_period: int = 10,
     ):
         """
         Submit model monitoring application controller job along with deploying the model monitoring writer function.
         While the main goal of the controller job is to handle the monitoring processing and triggering applications,
         the goal of the model monitoring writer function is to write all the monitoring application results to the
-        databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+        databases. Note that the default scheduling policy of the controller job is to run every 10 min.
         :param project:                  Project name.
         :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
                                          function, which is a real time nuclio functino, will be deployed with the same

--- a/mlrun/model_monitoring/tracking_policy.py
+++ b/mlrun/model_monitoring/tracking_policy.py
@@ -35,7 +35,8 @@ class TrackingPolicy(mlrun.model.ModelObj):
         ] = mlrun.common.schemas.schedule.ScheduleCronTrigger(minute="0", hour="*/1"),
         default_batch_image: str = "mlrun/mlrun",
         stream_image: str = "mlrun/mlrun",
-        application_batch: bool = True,
+        base_period: int = 5,
+        default_controller_image: str = "mlrun/mlrun",
     ):
         """
         Initialize TrackingPolicy object.
@@ -48,7 +49,11 @@ class TrackingPolicy(mlrun.model.ModelObj):
                                             is mlrun/mlrun.
         :param stream_image:                The image of the model monitoring stream real-time function. By default,
                                             the image is mlrun/mlrun.
-        :param application_batch
+        :param base_period:                 Minutes to determine the frequency in which the model monitoring controller
+                                            job is running. By default, the base period is 5 minutes.
+        :param default_controller_image:    The default image of the model monitoring controller job. Note that the
+                                            writer function, which is a real time nuclio functino, will be deployed
+                                            with the same image. By default, the image is mlrun/mlrun.
         """
         if isinstance(default_batch_intervals, str):
             default_batch_intervals = (
@@ -59,7 +64,8 @@ class TrackingPolicy(mlrun.model.ModelObj):
         self.default_batch_intervals = default_batch_intervals
         self.default_batch_image = default_batch_image
         self.stream_image = stream_image
-        self.application_batch = application_batch
+        self.base_period = base_period
+        self.default_controller_image = default_controller_image
 
     @classmethod
     def from_dict(cls, struct=None, fields=None, deprecated_fields: dict = None):

--- a/mlrun/model_monitoring/tracking_policy.py
+++ b/mlrun/model_monitoring/tracking_policy.py
@@ -35,7 +35,7 @@ class TrackingPolicy(mlrun.model.ModelObj):
         ] = mlrun.common.schemas.schedule.ScheduleCronTrigger(minute="0", hour="*/1"),
         default_batch_image: str = "mlrun/mlrun",
         stream_image: str = "mlrun/mlrun",
-        base_period: int = 5,
+        base_period: int = 10,
         default_controller_image: str = "mlrun/mlrun",
     ):
         """
@@ -50,7 +50,7 @@ class TrackingPolicy(mlrun.model.ModelObj):
         :param stream_image:                The image of the model monitoring stream real-time function. By default,
                                             the image is mlrun/mlrun.
         :param base_period:                 Minutes to determine the frequency in which the model monitoring controller
-                                            job is running. By default, the base period is 5 minutes.
+                                            job is running. By default, the base period is 10 minutes.
         :param default_controller_image:    The default image of the model monitoring controller job. Note that the
                                             writer function, which is a real time nuclio functino, will be deployed
                                             with the same image. By default, the image is mlrun/mlrun.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1934,13 +1934,13 @@ class MlrunProject(ModelObj):
     def enable_model_monitoring_controller(
         self,
         default_controller_image: str = "mlrun/mlrun",
-        base_period: int = 5,
+        base_period: int = 10,
     ) -> dict:
         """
         Submit model monitoring application controller job along with deploying the model monitoring writer function.
         While the main goal of the controller job is to handle the monitoring processing and triggering applications,
         the goal of the model monitoring writer function is to write all the monitoring application results to the
-        databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+        databases. Note that the default scheduling policy of the controller job is to run every 10 min.
         :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
                                          function, which is a real time nuclio functino, will be deployed with the same
                                          image. By default, the image is mlrun/mlrun.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1931,6 +1931,37 @@ class MlrunProject(ModelObj):
 
         return resolved_function_name, function_object, func
 
+    def enable_model_monitoring_controller(
+        self,
+        default_controller_image: str = "mlrun/mlrun",
+        base_period: int = 5,
+    ) -> dict:
+        """
+        Submit model monitoring application controller job along with deploying the model monitoring writer function.
+        While the main goal of the controller job is to handle the monitoring processing and triggering applications,
+        the goal of the model monitoring writer function is to write all the monitoring application results to the
+        databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+        :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
+                                         function, which is a real time nuclio functino, will be deployed with the same
+                                         image. By default, the image is mlrun/mlrun.
+        :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
+                                         is running. By default, the base period is 5 minutes.
+        :return: model monitoring controller job as a dictionary.
+        """
+        db = mlrun.db.get_run_db(secrets=self._secrets)
+        return db.create_model_monitoring_controller(
+            project=self.name,
+            default_controller_image=default_controller_image,
+            base_period=base_period,
+        )
+
+    def disable_model_monitoring_controller(self):
+        db = mlrun.db.get_run_db(secrets=self._secrets)
+        db.delete_function(
+            project=self.name,
+            name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
+        )
+
     def set_function(
         self,
         func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -37,6 +37,7 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import server.api.api.utils
+import server.api.crud.model_monitoring.deployment
 import server.api.crud.runtimes.nuclio.function
 import server.api.db.session
 import server.api.launcher
@@ -55,7 +56,6 @@ from mlrun.runtimes import RuntimeKinds, ServingRuntime
 from mlrun.runtimes.utils import get_item_name
 from mlrun.utils import get_in, logger, update_in
 from server.api.api import deps
-from server.api.crud.model_monitoring.deployment import MonitoringDeployment
 from server.api.crud.secrets import Secrets, SecretsClientType
 from server.api.utils.builder import build_runtime
 from server.api.utils.singletons.scheduler import get_scheduler
@@ -788,7 +788,10 @@ def _build_function(
                                 )
 
                             # deploy model monitoring stream, model monitoring batch job,
-                            MonitoringDeployment().deploy_monitoring_functions(
+                            monitoring_deploy = (
+                                server.api.crud.model_monitoring.deployment.MonitoringDeployment()
+                            )
+                            monitoring_deploy.deploy_monitoring_functions(
                                 project=fn.metadata.project,
                                 db_session=db_session,
                                 auth_info=auth_info,
@@ -818,7 +821,10 @@ def _build_function(
                             access_key=model_monitoring_access_key,
                         )
                     # apply stream trigger to monitoring application
-                    fn = MonitoringDeployment()._apply_stream_trigger(
+                    monitoring_deploy = (
+                        server.api.crud.model_monitoring.deployment.MonitoringDeployment()
+                    )
+                    fn = monitoring_deploy._apply_stream_trigger(
                         project=fn.metadata.project,
                         function=fn,
                         model_monitoring_access_key=model_monitoring_access_key,

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -19,8 +19,6 @@ from distutils.util import strtobool
 from http import HTTPStatus
 from typing import List, Optional
 
-import v3io
-import v3io.dataplane
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -39,7 +37,6 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import server.api.api.utils
-import server.api.crud.model_monitoring.deployment
 import server.api.crud.runtimes.nuclio.function
 import server.api.db.session
 import server.api.launcher
@@ -58,6 +55,7 @@ from mlrun.runtimes import RuntimeKinds, ServingRuntime
 from mlrun.runtimes.utils import get_item_name
 from mlrun.utils import get_in, logger, update_in
 from server.api.api import deps
+from server.api.crud.model_monitoring.deployment import MonitoringDeployment
 from server.api.crud.secrets import Secrets, SecretsClientType
 from server.api.utils.builder import build_runtime
 from server.api.utils.singletons.scheduler import get_scheduler
@@ -749,93 +747,84 @@ def _build_function(
             serving_to_monitor = (
                 fn.kind == RuntimeKinds.serving and fn.spec.track_models
             )
+            # if serving_to_monitor or monitoring_application:
             if serving_to_monitor or monitoring_application:
-                try:
-                    if not mlrun.mlconf.is_ce_mode():
-                        model_monitoring_access_key = process_model_monitoring_secret(
-                            db_session,
-                            fn.metadata.project,
-                            mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
-                        )
-                    else:
-                        model_monitoring_access_key = None
-                    if serving_to_monitor:
-                        # Handle model monitoring
-                        logger.info("Tracking enabled, initializing model monitoring")
+                if not mlrun.mlconf.is_ce_mode():
+                    model_monitoring_access_key = process_model_monitoring_secret(
+                        db_session,
+                        fn.metadata.project,
+                        mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+                    )
+                else:
+                    model_monitoring_access_key = None
+                if serving_to_monitor:
+                    try:
 
-                        if fn.spec.tracking_policy:
-                            # Convert to `TrackingPolicy` object as `fn.spec.tracking_policy` is provided as a dict
-                            fn.spec.tracking_policy = TrackingPolicy.from_dict(
-                                fn.spec.tracking_policy
+                        if serving_to_monitor:
+                            # Handle model monitoring
+                            logger.info(
+                                "Tracking enabled, initializing model monitoring"
                             )
-                        else:
-                            # Initialize tracking policy with default values
-                            fn.spec.tracking_policy = TrackingPolicy()
 
-                        if not mlrun.mlconf.is_ce_mode():
-                            # create v3io stream for model_monitoring_stream
-                            _create_model_monitoring_stream(
-                                project=fn.metadata.project,
-                                function=fn,
-                                monitoring_application=monitoring_application,
-                                stream_path=server.api.crud.model_monitoring.get_stream_path(
-                                    project=fn.metadata.project,
-                                    application_name=mm_constants.MonitoringFunctionNames.STREAM,
-                                ),
-                            )
-                            if fn.spec.tracking_policy.application_batch:
-                                # create v3io stream for  model_monitoring_writer | model monitoring application
-                                _create_model_monitoring_stream(
+                            if fn.spec.tracking_policy:
+                                # Convert to `TrackingPolicy` object as `fn.spec.tracking_policy` is provided as a dict
+                                fn.spec.tracking_policy = TrackingPolicy.from_dict(
+                                    fn.spec.tracking_policy
+                                )
+                            else:
+                                # Initialize tracking policy with default values
+                                fn.spec.tracking_policy = TrackingPolicy()
+
+                            if not mlrun.mlconf.is_ce_mode():
+                                # create v3io stream for model_monitoring_stream
+                                create_model_monitoring_stream(
                                     project=fn.metadata.project,
                                     function=fn,
                                     monitoring_application=monitoring_application,
                                     stream_path=server.api.crud.model_monitoring.get_stream_path(
                                         project=fn.metadata.project,
-                                        application_name=mm_constants.MonitoringFunctionNames.WRITER,
+                                        application_name=mm_constants.MonitoringFunctionNames.STREAM,
                                     ),
-                                    access_key=model_monitoring_access_key,
                                 )
 
-                        # deploy model monitoring stream, model monitoring batch job,
-                        # model monitoring batch application job and model monitoring writer
-                        server.api.crud.model_monitoring.deployment.MonitoringDeployment().deploy_monitoring_functions(
-                            project=fn.metadata.project,
-                            db_session=db_session,
-                            auth_info=auth_info,
-                            tracking_policy=fn.spec.tracking_policy,
-                            model_monitoring_access_key=model_monitoring_access_key,
-                        )
-
-                    if monitoring_application:
-                        if not mlrun.mlconf.is_ce_mode():
-                            # create v3io stream for model monitoring application
-                            _create_model_monitoring_stream(
+                            # deploy model monitoring stream, model monitoring batch job,
+                            MonitoringDeployment().deploy_monitoring_functions(
                                 project=fn.metadata.project,
-                                function=fn,
-                                monitoring_application=monitoring_application,
-                                stream_path=server.api.crud.model_monitoring.get_stream_path(
-                                    project=fn.metadata.project,
-                                    application_name=fn.metadata.name,
-                                ),
-                                access_key=model_monitoring_access_key,
+                                db_session=db_session,
+                                auth_info=auth_info,
+                                tracking_policy=fn.spec.tracking_policy,
+                                model_monitoring_access_key=model_monitoring_access_key,
                             )
-                        # apply stream trigger to monitoring application
-                        fn = server.api.crud.model_monitoring.deployment.MonitoringDeployment()._apply_stream_trigger(
+
+                    except Exception as exc:
+                        logger.warning(
+                            f"Failed deploying model monitoring infrastructure for the "
+                            f"{'project' if serving_to_monitor else f'{fn.metadata.name} application'}",
+                            project=fn.metadata.project,
+                            exc=exc,
+                            traceback=traceback.format_exc(),
+                        )
+                if monitoring_application:
+                    if not mlrun.mlconf.is_ce_mode():
+                        # create v3io stream for model monitoring application
+                        create_model_monitoring_stream(
                             project=fn.metadata.project,
                             function=fn,
-                            model_monitoring_access_key=model_monitoring_access_key,
-                            function_name=fn.metadata.name,
-                            auth_info=auth_info,
+                            monitoring_application=monitoring_application,
+                            stream_path=server.api.crud.model_monitoring.get_stream_path(
+                                project=fn.metadata.project,
+                                application_name=fn.metadata.name,
+                            ),
+                            access_key=model_monitoring_access_key,
                         )
-                except Exception as exc:
-                    logger.warning(
-                        f"Failed deploying model monitoring infrastructure for the "
-                        f"{'project' if serving_to_monitor else f'{fn.metadata.name} application'}",
+                    # apply stream trigger to monitoring application
+                    fn = MonitoringDeployment()._apply_stream_trigger(
                         project=fn.metadata.project,
-                        exc=exc,
-                        traceback=traceback.format_exc(),
+                        function=fn,
+                        model_monitoring_access_key=model_monitoring_access_key,
+                        function_name=fn.metadata.name,
+                        auth_info=auth_info,
                     )
-
             server.api.crud.runtimes.nuclio.function.deploy_nuclio_function(
                 fn,
                 auth_info=auth_info,
@@ -968,66 +957,6 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
         )
 
 
-def _create_model_monitoring_stream(
-    project: str,
-    function,
-    monitoring_application: bool,
-    stream_path: str,
-    access_key: str = None,
-):
-    if stream_path.startswith("v3io://"):
-        _init_serving_function_stream_args(fn=function)
-
-        _, container, stream_path = parse_model_endpoint_store_prefix(stream_path)
-
-        # TODO: How should we configure sharding here?
-        logger.info(
-            "Creating model endpoint stream for project",
-            project=project,
-            stream_path=stream_path,
-            container=container,
-            endpoint=config.v3io_api,
-        )
-
-        v3io_client = v3io.dataplane.Client(
-            endpoint=config.v3io_api, access_key=os.environ.get("V3IO_ACCESS_KEY")
-        )
-        stream_args = (
-            config.model_endpoint_monitoring.application_stream_args
-            if monitoring_application
-            else config.model_endpoint_monitoring.serving_stream_args
-        )
-        response = v3io_client.create_stream(
-            container=container,
-            path=stream_path,
-            shard_count=stream_args.shard_count,
-            retention_period_hours=stream_args.retention_period_hours,
-            raise_for_status=v3io.dataplane.RaiseForStatus.never,
-            access_key=access_key,
-        )
-
-        if not (response.status_code == 400 and "ResourceInUse" in str(response.body)):
-            response.raise_for_status([409, 204])
-
-
-def _init_serving_function_stream_args(fn: ServingRuntime):
-    logger.debug("Initializing serving function stream args")
-    if "stream_args" in fn.spec.parameters:
-        logger.debug("Adding access key to pipelines stream args")
-        if "access_key" not in fn.spec.parameters["stream_args"]:
-            logger.debug("pipelines access key added to stream args")
-            fn.spec.parameters["stream_args"]["access_key"] = os.environ.get(
-                "V3IO_ACCESS_KEY"
-            )
-    else:
-        logger.debug("pipelines access key added to stream args")
-        fn.spec.parameters["stream_args"] = {
-            "access_key": os.environ.get("V3IO_ACCESS_KEY")
-        }
-
-    fn.save(versioned=True)
-
-
 def _get_function_env_var(fn: ServingRuntime, var_name: str):
     for env_var in fn.spec.env:
         if get_item_name(env_var) == var_name:
@@ -1114,3 +1043,65 @@ def _is_nuclio_deploy_status_changed(
         or previous_status.get("address", "") != address
     )
     return has_changed
+
+
+def create_model_monitoring_stream(
+    project: str,
+    function,
+    stream_path: str,
+    monitoring_application: bool = None,
+    access_key: str = None,
+):
+    if stream_path.startswith("v3io://"):
+        import v3io.dataplane
+
+        _init_serving_function_stream_args(fn=function)
+
+        _, container, stream_path = parse_model_endpoint_store_prefix(stream_path)
+
+        # TODO: How should we configure sharding here?
+        logger.info(
+            "Creating model endpoint stream for project",
+            project=project,
+            stream_path=stream_path,
+            container=container,
+            endpoint=config.v3io_api,
+        )
+
+        v3io_client = v3io.dataplane.Client(
+            endpoint=config.v3io_api, access_key=os.environ.get("V3IO_ACCESS_KEY")
+        )
+        stream_args = (
+            config.model_endpoint_monitoring.application_stream_args
+            if monitoring_application
+            else config.model_endpoint_monitoring.serving_stream_args
+        )
+        response = v3io_client.create_stream(
+            container=container,
+            path=stream_path,
+            shard_count=stream_args.shard_count,
+            retention_period_hours=stream_args.retention_period_hours,
+            raise_for_status=v3io.dataplane.RaiseForStatus.never,
+            access_key=access_key,
+        )
+
+        if not (response.status_code == 400 and "ResourceInUse" in str(response.body)):
+            response.raise_for_status([409, 204])
+
+
+def _init_serving_function_stream_args(fn: ServingRuntime):
+    logger.debug("Initializing serving function stream args")
+    if "stream_args" in fn.spec.parameters:
+        logger.debug("Adding access key to pipelines stream args")
+        if "access_key" not in fn.spec.parameters["stream_args"]:
+            logger.debug("pipelines access key added to stream args")
+            fn.spec.parameters["stream_args"]["access_key"] = os.environ.get(
+                "V3IO_ACCESS_KEY"
+            )
+    else:
+        logger.debug("pipelines access key added to stream args")
+        fn.spec.parameters["stream_args"] = {
+            "access_key": os.environ.get("V3IO_ACCESS_KEY")
+        }
+
+    fn.save(versioned=True)

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -747,7 +747,7 @@ def _build_function(
             serving_to_monitor = (
                 fn.kind == RuntimeKinds.serving and fn.spec.track_models
             )
-            # if serving_to_monitor or monitoring_application:
+
             if serving_to_monitor or monitoring_application:
                 if not mlrun.mlconf.is_ce_mode():
                     model_monitoring_access_key = process_model_monitoring_secret(

--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -88,13 +88,13 @@ async def create_model_monitoring_controller(
     ),
     db_session: Session = fastapi.Depends(deps.get_db_session),
     default_controller_image: str = "mlrun/mlrun",
-    base_period: int = 5,
+    base_period: int = 10,
 ):
     """
     Submit model monitoring application controller job along with deploying the model monitoring writer function.
     While the main goal of the controller job is to handle the monitoring processing and triggering applications,
     the goal of the model monitoring writer function is to write all the monitoring application results to the
-    databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+    databases. Note that the default scheduling policy of the controller job is to run every 10 min.
 
     :param project:                  Project name.
     :param request:                  fastapi request for the HTTP connection.

--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -14,23 +14,27 @@
 #
 from typing import Any, Dict
 
-from fastapi import APIRouter, Depends
+import fastapi
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+import server.api.utils.clients.chief
 from mlrun.model_monitoring import TrackingPolicy
+from mlrun.utils import logger
 from server.api.api import deps
 from server.api.api.endpoints.functions import process_model_monitoring_secret
 from server.api.crud.model_monitoring.deployment import MonitoringDeployment
 
-router = APIRouter(prefix="/projects/{project}/jobs")
+router = fastapi.APIRouter(prefix="/projects/{project}/jobs")
 
 
 @router.post("/batch-monitoring")
 def deploy_monitoring_batch_job(
     project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
-    db_session: Session = Depends(deps.get_db_session),
+    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
+        deps.authenticate_request
+    ),
+    db_session: Session = fastapi.Depends(deps.get_db_session),
     default_batch_image: str = "mlrun/mlrun",
     with_schedule: bool = False,
 ) -> Dict[str, Any]:
@@ -73,3 +77,114 @@ def deploy_monitoring_batch_job(
     return {
         "func": batch_function,
     }
+
+
+@router.post("/model-monitoring-controller")
+async def create_model_monitoring_controller(
+    project: str,
+    request: fastapi.Request,
+    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
+        deps.authenticate_request
+    ),
+    db_session: Session = fastapi.Depends(deps.get_db_session),
+    default_controller_image: str = "mlrun/mlrun",
+    base_period: int = 5,
+):
+    """
+    Submit model monitoring application controller job along with deploying the model monitoring writer function.
+    While the main goal of the controller job is to handle the monitoring processing and triggering applications,
+    the goal of the model monitoring writer function is to write all the monitoring application results to the
+    databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+
+    :param project:                  Project name.
+    :param request:                  fastapi request for the HTTP connection.
+    :param auth_info:                The auth info of the request.
+    :param db_session:               A session that manages the current dialog with the database.
+    :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
+                                     function, which is a real time nuclio functino, will be deployed with the same
+                                     image. By default, the image is mlrun/mlrun.
+    :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
+                                     is running. By default, the base period is 5 minutes.
+    """
+
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.common.schemas.ClusterizationRole.chief
+    ):
+        logger.info(
+            "Requesting to deploy model monitoring controller, re-routing to chief",
+            function_name="model-monitoring-controller",
+            project=project,
+        )
+        chief_client = server.api.utils.clients.chief.Client()
+        params = {
+            "default_controller_image": default_controller_image,
+            "base_period": base_period,
+        }
+        return await chief_client.create_model_monitoring_controller(
+            project=project, request=request, json=params
+        )
+
+    model_monitoring_access_key = None
+    if not mlrun.mlconf.is_ce_mode():
+        # Generate V3IO Access Key
+        model_monitoring_access_key = process_model_monitoring_secret(
+            db_session,
+            project,
+            mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+        )
+
+    # Generate `TrackingPolicy` object with the relevant controller configurations
+    controller_policy = TrackingPolicy(
+        default_controller_image=default_controller_image, base_period=base_period
+    )
+    controller_function = MonitoringDeployment().deploy_model_monitoring_controller(
+        project=project,
+        model_monitoring_access_key=model_monitoring_access_key,
+        db_session=db_session,
+        auth_info=auth_info,
+        tracking_policy=controller_policy,
+    )
+
+    if isinstance(controller_function, mlrun.runtimes.kubejob.KubejobRuntime):
+        controller_function = controller_function.to_dict()
+
+    return {
+        "func": controller_function,
+    }
+
+
+@router.delete("/model-monitoring-controller")
+async def delete_model_monitoring_controller(
+    project: str,
+    request: fastapi.Request,
+    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
+        deps.authenticate_request
+    ),
+    db_session: Session = fastapi.Depends(deps.get_db_session),
+):
+    """
+    Submit model monitoring application controller job along with deploying the model monitoring writer function.
+    While the main goal of the controller job is to handle the monitoring processing and triggering applications,
+    the goal of the model monitoring writer function is to write all the monitoring application results to the
+    databases. Note that the default scheduling policy of the controller job is to run every 5 min.
+
+    :param project:                  Project name.
+    :param request:                  fastapi request for the HTTP connection.
+    :param auth_info:                The auth info of the request.
+    :param db_session:               A session that manages the current dialog with the database.
+    """
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.common.schemas.ClusterizationRole.chief
+    ):
+        logger.info(
+            "Requesting to deploy model monitoring controller, re-routing to chief",
+            function_name="model-monitoring-controller",
+            project=project,
+        )
+        chief_client = server.api.utils.clients.chief.Client()
+
+        return await chief_client.create_model_monitoring_controller(
+            project=project, request=request
+        )

--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -152,39 +152,3 @@ async def create_model_monitoring_controller(
     return {
         "func": controller_function,
     }
-
-
-@router.delete("/model-monitoring-controller")
-async def delete_model_monitoring_controller(
-    project: str,
-    request: fastapi.Request,
-    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
-        deps.authenticate_request
-    ),
-    db_session: Session = fastapi.Depends(deps.get_db_session),
-):
-    """
-    Submit model monitoring application controller job along with deploying the model monitoring writer function.
-    While the main goal of the controller job is to handle the monitoring processing and triggering applications,
-    the goal of the model monitoring writer function is to write all the monitoring application results to the
-    databases. Note that the default scheduling policy of the controller job is to run every 5 min.
-
-    :param project:                  Project name.
-    :param request:                  fastapi request for the HTTP connection.
-    :param auth_info:                The auth info of the request.
-    :param db_session:               A session that manages the current dialog with the database.
-    """
-    if (
-        mlrun.mlconf.httpdb.clusterization.role
-        != mlrun.common.schemas.ClusterizationRole.chief
-    ):
-        logger.info(
-            "Requesting to deploy model monitoring controller, re-routing to chief",
-            function_name="model-monitoring-controller",
-            project=project,
-        )
-        chief_client = server.api.utils.clients.chief.Client()
-
-        return await chief_client.create_model_monitoring_controller(
-            project=project, request=request
-        )

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -607,7 +607,7 @@ class MonitoringDeployment:
                 hours,
                 days,
             ) = (tracking_policy.base_period, 0, 0)
-            schedule = "*/{} * * * *".format(
+            schedule = "1/{} * * * *".format(
                 add_minutes_offset(
                     minute=tracking_policy.base_period,
                     offset=seconds2minutes(tracking_offset),

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -607,7 +607,7 @@ class MonitoringDeployment:
                 hours,
                 days,
             ) = (tracking_policy.base_period, 0, 0)
-            schedule = "{} * * * *".format(
+            schedule = "*/{} * * * *".format(
                 add_minutes_offset(
                     minute=tracking_policy.base_period,
                     offset=seconds2minutes(tracking_offset),

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -31,7 +31,6 @@ from mlrun import feature_store as fstore
 from mlrun.model_monitoring.writer import ModelMonitoringWriter
 from mlrun.utils import logger
 from server.api.api import deps
-from server.api.api.endpoints.functions import create_model_monitoring_stream
 from server.api.crud.model_monitoring.helpers import (
     Seconds,
     add_minutes_offset,
@@ -757,7 +756,7 @@ class MonitoringDeployment:
         function.metadata.project = project
 
         # create v3io stream for  model_monitoring_writer | model monitoring application
-        create_model_monitoring_stream(
+        server.api.api.endpoints.functions.create_model_monitoring_stream(
             project=project,
             function=function,
             monitoring_application=mm_constants.MonitoringFunctionNames.WRITER,

--- a/server/api/crud/model_monitoring/helpers.py
+++ b/server/api/crud/model_monitoring/helpers.py
@@ -58,7 +58,7 @@ def get_batching_interval_param(intervals_list: typing.List):
     )
 
 
-def _add_minutes_offset(
+def add_minutes_offset(
     minute: typing.Optional[typing.Union[int, str]],
     offset: Minutes,
 ) -> typing.Optional[typing.Union[int, str]]:
@@ -80,7 +80,7 @@ def convert_to_cron_string(
 ) -> str:
     """Convert the batch interval `ScheduleCronTrigger` into a cron trigger expression"""
     return "{} {} {} * *".format(
-        _add_minutes_offset(cron_trigger.minute, minute_delay),
+        add_minutes_offset(cron_trigger.minute, minute_delay),
         cron_trigger.hour,
         cron_trigger.day,
     ).replace("None", "*")

--- a/server/api/utils/clients/chief.py
+++ b/server/api/utils/clients/chief.py
@@ -202,6 +202,19 @@ class Client(
             json,
         )
 
+    async def create_model_monitoring_controller(
+        self, project: str, request: fastapi.Request, json: dict
+    ):
+        """
+        Model monitoring controller includes a scheduled job which is handled by the chief
+        """
+        return await self._proxy_request_to_chief(
+            "POST",
+            f"projects/{project}/jobs/model-monitoring-controller",
+            request,
+            json,
+        )
+
     async def _proxy_request_to_chief(
         self,
         method,

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -373,7 +373,7 @@ def test_tracking_on_serving(
         server.api.api.utils: ["apply_enrichment_and_validation_on_function"],
         server.api.api.endpoints.functions: [
             "process_model_monitoring_secret",
-            "_create_model_monitoring_stream",
+            "create_model_monitoring_stream",
         ],
         server.api.crud: ["ModelEndpoints"],
         nuclio.deploy: ["deploy_config"],

--- a/tests/api/crud/model_monitoring/test_helpers.py
+++ b/tests/api/crud/model_monitoring/test_helpers.py
@@ -19,7 +19,7 @@ import pytest
 from server.api.crud.model_monitoring.helpers import (
     Minutes,
     Seconds,
-    _add_minutes_offset,
+    add_minutes_offset,
     seconds2minutes,
 )
 
@@ -48,4 +48,4 @@ def test_add_minutes_offset(
     offset: Minutes,
     expected_result: typing.Optional[typing.Union[int, str]],
 ) -> None:
-    assert _add_minutes_offset(minute, offset) == expected_result
+    assert add_minutes_offset(minute, offset) == expected_result

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -92,6 +92,11 @@ class TestMonitoringAppFlow(TestMLRunSystem):
             cls._v3io_container
         )
 
+    def _submit_controller_and_deploy_writer(self) -> None:
+        self.project.enable_model_monitoring_controller(
+            base_period=1,
+        )
+
     def _set_and_deploy_monitoring_apps(self) -> None:
         with ThreadPoolExecutor() as executor:
             for app_data in self.apps_data:
@@ -130,7 +135,6 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         serving_fn.set_tracking(
             tracking_policy=TrackingPolicy(
                 default_batch_intervals=f"*/{cls.app_interval} * * * *",
-                application_batch=True,
             ),
         )
 
@@ -182,6 +186,7 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         self._log_model()
 
         with ThreadPoolExecutor() as executor:
+            executor.submit(self._submit_controller_and_deploy_writer)
             executor.submit(self._set_and_deploy_monitoring_apps)
             future = executor.submit(self._deploy_model_serving)
 


### PR DESCRIPTION
Expose an API for applying the new model monitoring applications flow without using `set_tracking`. In other words, the new API generates the controller application scheduler (with pre-defined base period) and deploys the nuclio writer pod along with the writer stream. 

The new API is available under the project:
`project.enable_model_monitoring_controller()`

To disable the controller, you can call the following API which is also available under the project: 
`project.disable_model_monitoring_controller()` 
However, while the schedule controller job will be deleted from the project, the writer nuclio function will still run (will be fixed in the future following https://jira.iguazeng.com/browse/ML-3432?jql=text%20~%20%22Delete%20Function%22). 


In addition, as part of enabling the new model monitoring features on Grafana without running the stream pod or the old batch application job, the model endpoint KV schema is now generated on model endpoint creation. 

Related JIRA - https://jira.iguazeng.com/browse/ML-4940