### PR TITLE
[Artifacts] Improve object hash calculation

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -506,7 +506,7 @@ class SQLDB(DBInterface):
             artifact_dict.setdefault("metadata", {})["project"] = project
 
         # calculate uid
-        uid = fill_artifact_object_hash(artifact_dict, "uid", iter, producer_id)
+        uid = fill_artifact_object_hash(artifact_dict, iter, producer_id)
 
         # If object was referenced by UID, the request cannot modify it
         if original_uid and uid != original_uid:
@@ -536,7 +536,6 @@ class SQLDB(DBInterface):
                 uid,
                 iter,
                 best_iteration,
-                tag,
                 producer_id,
             )
             self._upsert(session, [db_artifact])
@@ -895,7 +894,6 @@ class SQLDB(DBInterface):
         uid: str,
         iter: int = None,
         best_iteration: bool = False,
-        tag: str = None,
         producer_id: str = None,
     ):
         artifact_record.project = project
@@ -948,7 +946,7 @@ class SQLDB(DBInterface):
         best_iteration=False,
     ):
         if not uid:
-            uid = fill_artifact_object_hash(artifact, "uid", iteration, producer_id)
+            uid = fill_artifact_object_hash(artifact, iteration, producer_id)
 
         # check if the object already exists
         query = self._query(session, ArtifactV2, key=key, project=project, uid=uid)
@@ -970,7 +968,6 @@ class SQLDB(DBInterface):
             uid,
             iteration,
             best_iteration,
-            tag,
             producer_id,
         )
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -758,13 +758,14 @@ class SQLDB(DBInterface):
         artifacts = self.list_artifacts(session, project=project, category=category)
         results = []
         for artifact in artifacts:
-            results.append(
-                (
-                    project,
-                    artifact["spec"].get("db_key"),
-                    artifact["metadata"].get("tag"),
+            if artifact["metadata"].get("tag") is not None:
+                results.append(
+                    (
+                        project,
+                        artifact["spec"].get("db_key"),
+                        artifact["metadata"].get("tag"),
+                    )
                 )
-            )
 
         return results
 
@@ -923,8 +924,6 @@ class SQLDB(DBInterface):
         artifact_dict["metadata"]["updated"] = str(updated_datetime)
         artifact_dict["metadata"]["created"] = str(artifact_record.created)
         artifact_dict["kind"] = kind
-        if tag:
-            artifact_dict["metadata"]["tag"] = tag
 
         db_key = artifact_dict.get("spec", {}).get("db_key")
         if not db_key:

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -614,7 +614,7 @@ def _migrate_artifacts_batch(
 
         # uid - calculate as the hash of the artifact object
         uid = fill_artifact_object_hash(
-            artifact_dict, "uid", iteration, new_artifact.producer_id
+            artifact_dict, iteration, new_artifact.producer_id
         )
         new_artifact.uid = uid
 


### PR DESCRIPTION
In this PR:
- Remove `labels` and `db_key` from the artifact dict when calculating object hash - When updating an artifact, we need the object hash to be the same as the existing artifact's hash. Including both in the calculation might case a duplicate record to be created instead of updating.
- Don't add `tag` to the artifact dict when creating a new artifact - This solves an issue when the `latest` tag remained in the `metadata` of every newly created artifact, even if the tag itself pointed to a different artifact.
When getting artifacts, the tag is added on runtime from the actual tag in the DB.

Resolves https://jira.iguazeng.com/browse/ML-5153 