### PR TITLE
[Tests] Fix system tests failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ semver~=3.0
 dependency-injector~=4.41
 fsspec>=2023.1,<2023.7
 v3iofs~=0.1.17
-storey~=1.6.8
+storey~=1.6.9
 inflection~=0.5.0
 python-dotenv~=0.17.0
 # older version of setuptools contains vulnerabilities, see `GHSA-r9hx-vwmv-q579`, so we limit to 65.5 and above

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -419,11 +419,11 @@ class TestFeatureStore(TestMLRunSystem):
         pq_path = f"{tmpdir}/features.parquet"
         resp.to_parquet(pq_path)
         read_back_df = pd.read_parquet(pq_path)
-        assert read_back_df.equals(df_no_time)
+        pd.testing.assert_frame_equal(read_back_df, df_no_time, check_dtype=False)
         csv_path = f"{tmpdir}/features.csv"
         resp.to_csv(csv_path)
         read_back_df = pd.read_csv(csv_path, parse_dates=[2])
-        assert read_back_df.equals(df_no_time)
+        pd.testing.assert_frame_equal(read_back_df, df_no_time, check_dtype=False)
 
         assert isinstance(df_no_time.index, pd.core.indexes.range.RangeIndex)
         assert df_no_time.index.name is None
@@ -3350,10 +3350,10 @@ class TestFeatureStore(TestMLRunSystem):
             returned_df = fstore.ingest(prediction_set, df)
 
             read_back_df = pd.read_parquet(outdir)
-            assert read_back_df.equals(returned_df)
+            pd.testing.assert_frame_equal(read_back_df, returned_df, check_dtype=False)
 
             expected_df = pd.DataFrame({"number": [11, 22]}, index=["a", "b"])
-            assert read_back_df.equals(expected_df)
+            pd.testing.assert_frame_equal(read_back_df, expected_df, check_dtype=False)
 
     def test_pandas_write_partitioned_parquet(self):
         prediction_set = fstore.FeatureSet(
@@ -3383,7 +3383,7 @@ class TestFeatureStore(TestMLRunSystem):
                 f"{prediction_set.get_target_path()}year=2022/month=01/day=01/hour=01/"
             )
 
-            assert read_back_df.equals(returned_df)
+            pd.testing.assert_frame_equal(read_back_df, returned_df, check_dtype=False)
 
             expected_df = pd.DataFrame(
                 {
@@ -3395,7 +3395,8 @@ class TestFeatureStore(TestMLRunSystem):
                 },
                 index=["a", "b"],
             )
-            assert read_back_df.equals(expected_df)
+            expected_df.index.name = "id"
+            pd.testing.assert_frame_equal(read_back_df, expected_df, check_dtype=False)
 
     # regression test for #2557
     @pytest.mark.parametrize(

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -98,7 +98,7 @@ def test_requirement_specifiers_convention():
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "kfp": {"~=1.8.0, <1.8.14"},
         "aiobotocore": {">=2.4.2,<2.6"},
-        "storey": {"~=1.6.8"},
+        "storey": {"~=1.6.9"},
         "nuclio-sdk": {">=0.3.0"},
         "bokeh": {"~=2.4, >=2.4.2"},
         # protobuf is limited just for docs


### PR DESCRIPTION
Fixes the following tests:
```
FAILED tests/system/feature_store/test_feature_store.py::TestFeatureStore::test_get_offline_features_with_or_without_indexes - assert False
FAILED tests/system/feature_store/test_feature_store.py::TestFeatureStore::test_pandas_write_partitioned_parquet - assert False
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_relation_asof_join[False-False] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_relation_asof_join[False-True] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_relation_asof_join[True-False] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_relation_asof_join[True-True] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_as_of_join_result[ts] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_as_of_join_result[ts_r] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_time_filter[False-None] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_time_filter[False-other_ts] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
FAILED tests/system/feature_store/test_spark_engine.py::TestFeatureStoreSparkEngine::test_time_filter[False-timestamp_for_filtering3] - mlrun.runtimes.utils.RunError: An error occurred while calling o42.load.
```