### PR TITLE
[Data types] Avoid using deprecated data type

### DIFF
--- a/mlrun/data_types/to_pandas.py
+++ b/mlrun/data_types/to_pandas.py
@@ -234,7 +234,7 @@ def _to_corrected_pandas_type(dt):
     elif type(dt) == DoubleType:
         return np.float64
     elif type(dt) == BooleanType:
-        return np.bool  # type: ignore[attr-defined]
+        return bool
     elif type(dt) == TimestampType:
         return "datetime64[ns]"
     else:


### PR DESCRIPTION
Fixes error when using newer versions of numpy:
```
E           AttributeError: module 'numpy' has no attribute 'bool'.
E           `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
```