### PR TITLE
[API] Reduce memory footprint of runs monitoring [1.3.x] 

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -93,6 +93,11 @@ default_config = {
     # runs monitoring debouncing interval in seconds for run with non-terminal state without corresponding k8s resource
     # by default the interval will be - (runs_monitoring_interval * 2 ), if set will override the default
     "runs_monitoring_missing_runtime_resources_debouncing_interval": None,
+    "monitoring": {
+        "runs": {
+            "list_runs_time_period_in_days": 7,  # days
+        }
+    },
     # the grace period (in seconds) that will be given to runtime resources (after they're in terminal state)
     # before deleting them (4 hours)
     "runtime_resources_deletion_grace_period": "14400",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -2320,7 +2320,21 @@ class BaseRuntimeHandler(ABC):
     def _list_runs_for_monitoring(
         self, db: DBInterface, db_session: Session, states: list = None
     ):
-        runs = db.list_runs(db_session, project="*", states=states)
+        last_update_time_from = None
+        if config.monitoring.runs.list_runs_time_period_in_days:
+            last_update_time_from = (
+                datetime.now()
+                - timedelta(
+                    days=int(config.monitoring.runs.list_runs_time_period_in_days)
+                )
+            ).isoformat()
+
+        runs = db.list_runs(
+            db_session,
+            project="*",
+            states=states,
+            last_update_time_from=last_update_time_from,
+        )
         project_run_uid_map = {}
         run_with_missing_data = []
         duplicated_runs = []


### PR DESCRIPTION
Back-porting 2 PRs to 1.3.x:
#4659 
#4662 

Back-porting had to be done manually due to the significant changes between 1.5.x and 1.3.x. As part of the difficulty to back-port, didn't include the unit test added in #4662.
