### PR TITLE
[Feature Store] Fix timestamp precision in pyspark/pandas2 compatibilty workaround

### DIFF
--- a/mlrun/feature_store/retrieval/spark_merger.py
+++ b/mlrun/feature_store/retrieval/spark_merger.py
@@ -181,7 +181,7 @@ class SparkFeatureMerger(BaseMerger):
                                 field.name,
                                 pyspark_functions.date_format(
                                     pyspark_functions.to_timestamp(field.name),
-                                    "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                                    "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS",
                                 ),
                             )
                             type_conversion_dict[field.name] = "datetime64[ns]"


### PR DESCRIPTION
This issue affects `get_offline_features()` with `run_local=True`.

[ML-5202](https://jira.iguazeng.com/browse/ML-5202)