### PR TITLE
[Feature Store] Try to convert timestamp resolution before merge if necessary

### DIFF
--- a/mlrun/feature_store/retrieval/base.py
+++ b/mlrun/feature_store/retrieval/base.py
@@ -393,7 +393,8 @@ class BaseMerger(abc.ABC):
         if reference_df_timestamp_type != featureset_df_timestamp_type:
             logger.info(
                 f"Merger detected timestamp resolution incompatibility between feature set {featureset_name} and "
-                f"others: {reference_df_timestamp_type} and {featureset_df_timestamp_type}."
+                f"others: {reference_df_timestamp_type} and {featureset_df_timestamp_type}. Converting feature set "
+                f"timestamp column '{entity_timestamp_column}' to type {reference_df_timestamp_type}."
             )
             featureset_df[entity_timestamp_column] = featureset_df[
                 entity_timestamp_column

--- a/mlrun/feature_store/retrieval/base.py
+++ b/mlrun/feature_store/retrieval/base.py
@@ -310,6 +310,25 @@ class BaseMerger(abc.ABC):
                 "start_time and end_time can only be provided in conjunction with "
                 "a timestamp column, or when the at least one feature_set has a timestamp key"
             )
+
+        if entity_timestamp_column and entity_rows_keys and len(dfs) > 1:
+            entity_rows_timestamp_type = dfs[0][entity_timestamp_column].dtype.name
+            featureset_df_timestamp_type = dfs[1][entity_timestamp_column].dtype.name
+            if (
+                entity_rows_timestamp_type.startswith("datetime64[")
+                and featureset_df_timestamp_type.startswith("datetime64[")
+                and entity_rows_timestamp_type != featureset_df_timestamp_type
+            ):
+                logger.info(
+                    f"Merger detected timestamp resolution incompatibility between feature sets (type "
+                    f"{featureset_df_timestamp_type}) and entity rows (type {entity_rows_timestamp_type}). "
+                    f"Converting entity rows timestamp column '{entity_timestamp_column}' to type "
+                    f"{featureset_df_timestamp_type}."
+                )
+                dfs[0][entity_timestamp_column] = dfs[0][
+                    entity_timestamp_column
+                ].astype(featureset_df_timestamp_type)
+
         # join the feature data frames
         result_timestamp = self.merge(
             entity_timestamp_column=entity_timestamp_column,

--- a/mlrun/feature_store/retrieval/dask_merger.py
+++ b/mlrun/feature_store/retrieval/dask_merger.py
@@ -52,6 +52,10 @@ class DaskFeatureMerger(BaseMerger):
     ):
         from dask.dataframe.multi import merge_asof
 
+        featureset_df = self._normalize_timestamp_column(
+            entity_timestamp_column, entity_df, featureset_df, featureset_name
+        )
+
         def sort_partition(partition, timestamp):
             return partition.sort_values(timestamp)
 

--- a/mlrun/feature_store/retrieval/local_merger.py
+++ b/mlrun/feature_store/retrieval/local_merger.py
@@ -32,11 +32,10 @@ class LocalFeatureMerger(BaseMerger):
         entity_timestamp_column: str,
         featureset_name,
         featureset_timstamp,
-        featureset_df: list,
+        featureset_df,
         left_keys: list,
         right_keys: list,
     ):
-
         index_col_not_in_entity = "index" not in entity_df.columns
         index_col_not_in_featureset = "index" not in featureset_df.columns
         entity_df[entity_timestamp_column] = pd.to_datetime(
@@ -47,6 +46,10 @@ class LocalFeatureMerger(BaseMerger):
         )
         entity_df.sort_values(by=entity_timestamp_column, inplace=True)
         featureset_df.sort_values(by=featureset_timstamp, inplace=True)
+
+        featureset_df = self._normalize_timestamp_column(
+            entity_timestamp_column, entity_df, featureset_df, featureset_name
+        )
 
         merged_df = pd.merge_asof(
             entity_df,


### PR DESCRIPTION
Pandas 2 introduces timestamp resolutions, and does not allow `merge_asof` of dataframes with different timestamp resolutions. This PR introduces code that attempts to convert the timestamp resolution before merge, if necessary.

Fixes `TestFeatureStore::test_ingest_and_query` failure with
```
pandas.errors.MergeError: incompatible merge keys [1] dtype('<M8[ns]') and dtype('<M8[us]'), must be the same type
```