### PR TITLE
[Model Monitoring] Fix the controller windows loop - continue, don't return

### DIFF
--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -371,7 +371,7 @@ class MonitoringApplicationController:
         parquet_directory: str,
         storage_options: dict,
         model_monitoring_access_key: str,
-    ):
+    ) -> Optional[Tuple[str, Exception]]:
         """
         Process a model endpoint and trigger the monitoring applications. This function running on different process
         for each endpoint. In addition, this function will generate a parquet file that includes the relevant data
@@ -470,9 +470,10 @@ class MonitoringApplicationController:
                         model_monitoring_access_key=model_monitoring_access_key,
                         parquet_target_path=parquet_target_path,
                     )
-        except FileNotFoundError as e:
+        except Exception as e:
             logger.error(
-                f"Exception for endpoint {endpoint[mm_constants.EventFieldType.UID]}"
+                "Encountered an exception",
+                endpoint_id=endpoint[mm_constants.EventFieldType.UID],
             )
             return endpoint_id, e
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -433,7 +433,7 @@ class MonitoringApplicationController:
                                 start_time=start_infer_time,
                                 end_time=end_infer_time,
                             )
-                            return
+                            continue
 
                     # Continue if not enough events provided since the deployment of the model endpoint
                     except FileNotFoundError:
@@ -442,7 +442,7 @@ class MonitoringApplicationController:
                             endpoint=endpoint[mm_constants.EventFieldType.UID],
                             min_required_events=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_max_events,
                         )
-                        return
+                        continue
 
                     # Get the timestamp of the latest request:
                     latest_request = df[mm_constants.EventFieldType.TIMESTAMP].iloc[-1]

--- a/mlrun/model_monitoring/controller_handler.py
+++ b/mlrun/model_monitoring/controller_handler.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import mlrun
 from mlrun.model_monitoring.controller import MonitoringApplicationController
@@ -29,4 +28,4 @@ def handler(context: mlrun.run.MLClientCtx):
     )
     monitor_app_controller.run()
     if monitor_app_controller.endpoints_exceptions:
-        print(monitor_app_controller.endpoints_exceptions)
+        context.logger.error(monitor_app_controller.endpoints_exceptions)


### PR DESCRIPTION
While iterating over time windows, we should not return or raise exceptions.
The loop is expected to continue for the sake of marking the current time window as completed by updating the last analyzed time.

I expect this to fix [ML-5181](https://jira.iguazeng.com/browse/ML-5181).