### PR TITLE
[Artifacts] Fix argument name in create_artifact

### DIFF
--- a/server/api/api/endpoints/artifacts_v2.py
+++ b/server/api/api/endpoints/artifacts_v2.py
@@ -31,7 +31,7 @@ from server.api.api.utils import artifact_project_and_resource_name_extractor
 router = APIRouter()
 
 
-@router.post("/projects/{project}/artifacts")
+@router.post("/projects/{project}/artifacts", status_code=HTTPStatus.CREATED.value)
 async def create_artifact(
     project: str,
     artifact: mlrun.common.schemas.Artifact,

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -89,7 +89,7 @@ class Artifacts(
             key,
             tag,
             iteration=iter,
-            tree=producer_id,
+            producer_id=producer_id,
             best_iteration=best_iteration,
         )
 

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -171,7 +171,7 @@ class DBInterface(ABC):
         tag="",
         uid=None,
         iteration=None,
-        tree="",
+        producer_id="",
         best_iteration=False,
     ):
         pass

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -44,7 +44,7 @@ from mlrun.config import config
 from mlrun.secrets import SecretsStore
 from mlrun.utils import logger
 from server.api.initial_data import init_data
-from server.api.main import BASE_VERSIONED_API_PREFIX, app
+from server.api.main import API_PREFIX, BASE_VERSIONED_API_PREFIX, app
 
 
 @pytest.fixture(autouse=True)
@@ -128,6 +128,24 @@ def client(db) -> Generator:
         with TestClient(app) as test_client:
             set_base_url_for_test_client(test_client)
             yield test_client
+
+
+@pytest.fixture()
+def client_v2(db) -> Generator:
+    """
+    client_v2 is a test client that doesn't have the version prefix in the url.
+    When using this client, the version prefix must be added to the url manually.
+    This is useful when tests use several endpoints that are not under the same version prefix.
+    """
+    with TemporaryDirectory(suffix="mlrun-logs") as log_dir:
+        mlconf.httpdb.logs_path = log_dir
+        mlconf.monitoring.runs.interval = 0
+        mlconf.runtimes_cleanup_interval = 0
+        mlconf.httpdb.projects.periodic_sync_interval = "0 seconds"
+
+        with TestClient(app) as test_client_v2:
+            set_base_url_for_test_client(test_client_v2, API_PREFIX)
+            yield test_client_v2
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fixing a typo where `tree` and `producer_id` were not used correctly in `create_artifact`.
Also - set the `create_artifact` response status code to 201 (created).

In this PR I also added the `client_v2` fixture, that is not attaching the version prefix to the api endpoints.
This is useful when tests use several endpoints that are not under the same version prefix (e.g. create project with `v1`, then create artifact with `v2`).