### PR TITLE
[Feature store] Fix timestamp conversion in merger

### DIFF
--- a/mlrun/feature_store/retrieval/base.py
+++ b/mlrun/feature_store/retrieval/base.py
@@ -385,19 +385,24 @@ class BaseMerger(abc.ABC):
         pass
 
     def _normalize_timestamp_column(
-        self, entity_timestamp_column, reference_df, featureset_df, featureset_name
+        self,
+        entity_timestamp_column,
+        reference_df,
+        featureset_timestamp,
+        featureset_df,
+        featureset_name,
     ):
         reference_df_timestamp_type = reference_df[entity_timestamp_column].dtype.name
-        featureset_df_timestamp_type = featureset_df[entity_timestamp_column].dtype.name
+        featureset_df_timestamp_type = featureset_df[featureset_timestamp].dtype.name
 
         if reference_df_timestamp_type != featureset_df_timestamp_type:
             logger.info(
                 f"Merger detected timestamp resolution incompatibility between feature set {featureset_name} and "
                 f"others: {reference_df_timestamp_type} and {featureset_df_timestamp_type}. Converting feature set "
-                f"timestamp column '{entity_timestamp_column}' to type {reference_df_timestamp_type}."
+                f"timestamp column '{featureset_timestamp}' to type {reference_df_timestamp_type}."
             )
-            featureset_df[entity_timestamp_column] = featureset_df[
-                entity_timestamp_column
+            featureset_df[featureset_timestamp] = featureset_df[
+                featureset_timestamp
             ].astype(reference_df_timestamp_type)
 
         return featureset_df

--- a/mlrun/feature_store/retrieval/dask_merger.py
+++ b/mlrun/feature_store/retrieval/dask_merger.py
@@ -53,7 +53,11 @@ class DaskFeatureMerger(BaseMerger):
         from dask.dataframe.multi import merge_asof
 
         featureset_df = self._normalize_timestamp_column(
-            entity_timestamp_column, entity_df, featureset_df, featureset_name
+            entity_timestamp_column,
+            entity_df,
+            featureset_timestamp,
+            featureset_df,
+            featureset_name,
         )
 
         def sort_partition(partition, timestamp):

--- a/mlrun/feature_store/retrieval/local_merger.py
+++ b/mlrun/feature_store/retrieval/local_merger.py
@@ -48,7 +48,11 @@ class LocalFeatureMerger(BaseMerger):
         featureset_df.sort_values(by=featureset_timstamp, inplace=True)
 
         featureset_df = self._normalize_timestamp_column(
-            entity_timestamp_column, entity_df, featureset_df, featureset_name
+            entity_timestamp_column,
+            entity_df,
+            featureset_timstamp,
+            featureset_df,
+            featureset_name,
         )
 
         merged_df = pd.merge_asof(

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -223,6 +223,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             read_back_df_storey,
             check_categorical=False,
             check_like=True,
+            check_dtype=False,
         )
 
     @classmethod


### PR DESCRIPTION
Fixes `TestFeatureStore::test_as_of_join_different_ts`.

Also fix `TestFeatureStoreSparkEngine::test_ingest_with_steps_extractor` (unrelated failure).