### PR TITLE
[Artifacts] Fix tag migrations

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -3415,7 +3415,9 @@ class SQLDB(DBInterface):
             )
 
         for tag in query:
-            uids.append(self._query(session, cls).get(tag.obj_id).uid)
+            obj = self._query(session, cls).get(tag.obj_id)
+            if obj:
+                uids.append(obj.uid)
         return uids
 
     def _query(self, session, cls, **kw):

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -3415,6 +3415,7 @@ class SQLDB(DBInterface):
             )
 
         for tag in query:
+            # TODO: query db in a single call
             obj = self._query(session, cls).get(tag.obj_id)
             if obj:
                 uids.append(obj.uid)

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -648,7 +648,7 @@ def _migrate_artifacts_batch(
     # add the new artifacts to the db session
     db_session.add_all(new_artifacts)
 
-    # commit the new artifacts first, so they will get an id
+    # commit the new artifacts first, so they will get an id that can be used when creating tags and labels
     db._commit(db_session, new_artifacts)
 
     # migrate artifact labels to the new table ("artifact_v2_labels")

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -663,7 +663,12 @@ def _migrate_artifacts_batch(
     return last_migrated_artifact_id, link_artifact_ids
 
 
-def _get_tag_names(db, db_session, artifact, artifact_metadata):
+def _get_tag_names(
+    db: server.api.db.sqldb.db.SQLDB,
+    db_session: sqlalchemy.orm.Session,
+    artifact: server.api.db.sqldb.models.Artifact,
+    artifact_metadata: dict,
+):
     # the tag might not be set in the artifact metadata, so we need to get it from the db
     query = db._query(
         db_session,

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -170,8 +170,8 @@ def test_store_artifact_with_empty_dict(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.OK.value
 
 
-def test_create_artifact(db: Session, client_v2: TestClient):
-    _create_project(client_v2, prefix="v1")
+def test_create_artifact(db: Session, unprefixed_client: TestClient):
+    _create_project(unprefixed_client, prefix="v1")
     data = {
         "kind": "artifact",
         "metadata": {
@@ -189,7 +189,7 @@ def test_create_artifact(db: Session, client_v2: TestClient):
         "status": {},
     }
     url = "v2/projects/{project}/artifacts".format(project=PROJECT)
-    resp = client_v2.post(
+    resp = unprefixed_client.post(
         url,
         json=data,
     )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -131,9 +131,9 @@ def client(db) -> Generator:
 
 
 @pytest.fixture()
-def client_v2(db) -> Generator:
+def unprefixed_client(db) -> Generator:
     """
-    client_v2 is a test client that doesn't have the version prefix in the url.
+    unprefixed_client is a test client that doesn't have the version prefix in the url.
     When using this client, the version prefix must be added to the url manually.
     This is useful when tests use several endpoints that are not under the same version prefix.
     """

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -956,13 +956,12 @@ def test_migrate_artifact_v2_tag(db: DBInterface, db_session: Session):
         db_session,
         server.api.db.sqldb.models.ArtifactV2,
     )
-    new_artifacts = query_all.all()
-    assert len(new_artifacts) == 1
+    new_artifact = query_all.one()
 
     # validate there are 2 tags in total - the specific tag and the latest
     query_all_tags = db._query(
         db_session,
-        new_artifacts[0].Tag,
+        new_artifact.Tag,
     )
     new_artifact_tags = query_all_tags.all()
     assert len(new_artifact_tags) == 2


### PR DESCRIPTION
2 fixes regarding for creating tags when migrating artifacts to the new v2 table:
1. Commit the artifacts first, before the tags and labels, so the artifact object will get a db `id` which will be set in the tags and labels.
2. Search for existing multiple tags in the DB that are attached to the artifact, instead of taking the tag name from the artifact metadata.

Fixes https://jira.iguazeng.com/browse/ML-5220