### PR TITLE
[Model Monitoring] Don't delay the controller's schedule

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1944,8 +1944,9 @@ class MlrunProject(ModelObj):
         :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
                                          function, which is a real time nuclio functino, will be deployed with the same
                                          image. By default, the image is mlrun/mlrun.
-        :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
-                                         is running. By default, the base period is 5 minutes.
+        :param base_period:              The frequency in minutes in which the model monitoring controller job
+                                         runs. By default, the base period is 10 minutes. The schedule for the job
+                                         will be the following cron expression: "*/{base_period} * * * *".
         :return: model monitoring controller job as a dictionary.
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1944,7 +1944,7 @@ class MlrunProject(ModelObj):
         :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
                                          function, which is a real time nuclio functino, will be deployed with the same
                                          image. By default, the image is mlrun/mlrun.
-        :param base_period:              The frequency in minutes in which the model monitoring controller job
+        :param base_period:              The time period in minutes in which the model monitoring controller job
                                          runs. By default, the base period is 10 minutes. The schedule for the job
                                          will be the following cron expression: "*/{base_period} * * * *".
         :return: model monitoring controller job as a dictionary.

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -213,6 +213,6 @@ class TestMonitoringAppFlow(TestMLRunSystem):
         time.sleep(self.app_interval_seconds + 2)
         self.serving_fn.invoke(self.infer_path, self.next_window_input)
         # wait for the completed window to be processed
-        time.sleep(2.2 * self.app_interval_seconds)
+        time.sleep(1.2 * self.app_interval_seconds)
 
         self._test_v3io_records(ep_id=self._get_model_enpoint_id())


### PR DESCRIPTION
Fixes [ML-5223](https://jira.iguazeng.com/browse/ML-5223).
The "delay" mechanism in the schedule was designed for the legacy batch job.
It isn't relevant for the model monitoring applications framework, where we address the intricate scheduling details in the controller.

I ran the e2e system test locally.