### PR TITLE
[API] Add resource search before failing run in monitoring

### DIFF
--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -184,13 +184,9 @@ class BaseRuntimeHandler(ABC):
     def monitor_runs(self, db: DBInterface, db_session: Session) -> List[dict]:
         namespace = server.api.utils.singletons.k8s.get_k8s_helper().resolve_namespace()
         label_selector = self._get_default_label_selector()
-        crd_group, crd_version, crd_plural = self._get_crd_info()
-        runtime_resource_is_crd = False
-        if crd_group and crd_version and crd_plural:
-            runtime_resource_is_crd = True
-            runtime_resources = self._list_crd_objects(namespace, label_selector)
-        else:
-            runtime_resources = self._list_pods(namespace, label_selector)
+        runtime_resources, runtime_resource_is_crd = self._get_runtime_resources(
+            label_selector, namespace
+        )
         project_run_uid_map = self._list_runs_for_monitoring(db, db_session)
         # project -> uid -> {"name": <runtime-resource-name>}
         run_runtime_resources_map = {}
@@ -587,13 +583,9 @@ class BaseRuntimeHandler(ABC):
                 namespace = (
                     server.api.utils.singletons.k8s.get_k8s_helper().resolve_namespace()
                 )
-                crd_group, crd_version, crd_plural = self._get_crd_info()
-                if crd_group and crd_version and crd_plural:
-                    runtime_resources = self._list_crd_objects(
-                        namespace, label_selector
-                    )
-                else:
-                    runtime_resources = self._list_pods(namespace, label_selector)
+                runtime_resources, _ = self._get_runtime_resources(
+                    label_selector, namespace
+                )
                 if runtime_resources:
                     logger.debug(
                         "Monitoring did not discover a runtime resource that corresponded to a run in a "
@@ -613,6 +605,16 @@ class BaseRuntimeHandler(ABC):
                 ] = "A runtime resource related to this run could not be found"
                 run.setdefault("status", {})["last_update"] = now.isoformat()
                 db.store_run(db_session, run, run_uid, project)
+
+    def _get_runtime_resources(self, label_selector, namespace):
+        crd_group, crd_version, crd_plural = self._get_crd_info()
+        if crd_group and crd_version and crd_plural:
+            runtime_resource_is_crd = True
+            runtime_resources = self._list_crd_objects(namespace, label_selector)
+        else:
+            runtime_resource_is_crd = False
+            runtime_resources = self._list_pods(namespace, label_selector)
+        return runtime_resources, runtime_resource_is_crd
 
     def _add_object_label_selector_if_needed(
         self,

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -505,7 +505,10 @@ class TestRuntimeHandlerBase:
         assert (
             get_k8s_helper().v1api.list_namespaced_pod.call_count
             == expected_number_of_calls
-        ), f"Unexpected number of calls to list_namespaced_pod {get_k8s_helper().v1api.list_namespaced_pod.call_count}, expected {expected_number_of_calls}"
+        ), (
+            f"Unexpected number of calls to list_namespaced_pod "
+            f"{get_k8s_helper().v1api.list_namespaced_pod.call_count}, expected {expected_number_of_calls}"
+        )
         expected_label_selector = (
             expected_label_selector or runtime_handler._get_default_label_selector()
         )

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -505,7 +505,7 @@ class TestRuntimeHandlerBase:
         assert (
             get_k8s_helper().v1api.list_namespaced_pod.call_count
             == expected_number_of_calls
-        )
+        ), f"Unexpected number of calls to list_namespaced_pod {get_k8s_helper().v1api.list_namespaced_pod.call_count}, expected {expected_number_of_calls}"
         expected_label_selector = (
             expected_label_selector or runtime_handler._get_default_label_selector()
         )

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -207,10 +207,11 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             {
                 "runs_monitoring_interval": 0,
                 "debouncing_interval": None,
-                "list_namespaced_pods_calls": [[]],
+                "list_namespaced_pods_calls": [[], []],
                 "interval_time_to_add_to_run_update_time": 0,
                 "start_run_states": RunStates.non_terminal_states(),
                 "expected_reached_state": RunStates.error,
+                "monitor_cycles": 1,
             },
             # monitoring interval and debouncing interval are configured which means debouncing interval will
             # be the debounce period, run is still in the debounce period that's why expecting not to override state
@@ -229,10 +230,11 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             {
                 "runs_monitoring_interval": 30,
                 "debouncing_interval": 100,
-                "list_namespaced_pods_calls": [[], [], []],
+                "list_namespaced_pods_calls": [[], [], [], []],
                 "interval_time_to_add_to_run_update_time": -200,
                 "start_run_states": RunStates.non_terminal_states(),
                 "expected_reached_state": RunStates.error,
+                "monitor_cycles": 3,
             },
             # monitoring interval configured and debouncing interval isn't configured which means
             # monitoring interval * 2 will be the debounce period.
@@ -240,10 +242,11 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             {
                 "runs_monitoring_interval": 30,
                 "debouncing_interval": None,
-                "list_namespaced_pods_calls": [[], [], []],
+                "list_namespaced_pods_calls": [[], [], [], []],
                 "interval_time_to_add_to_run_update_time": -65,
                 "start_run_states": RunStates.non_terminal_states(),
                 "expected_reached_state": RunStates.error,
+                "monitor_cycles": 3,
             },
             # monitoring interval configured and debouncing interval isn't configured which means
             # monitoring interval * 2 will be the debounce period.
@@ -276,6 +279,9 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "expected_reached_state", RunStates.running
             )
             start_run_states = test_case.get("start_run_states", [RunStates.running])
+            monitor_cycles = test_case.get(
+                "monitor_cycles", len(list_namespaced_pods_calls)
+            )
             for idx in range(len(start_run_states)):
                 self.run["status"]["state"] = start_run_states[idx]
 
@@ -303,11 +309,10 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 self._mock_list_namespaced_pods(list_namespaced_pods_calls)
 
                 # Triggering monitor cycle
-                expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-                self._mock_list_namespaced_pods(list_namespaced_pods_calls)
-                for i in range(expected_number_of_list_pods_calls):
+                for i in range(monitor_cycles):
                     self.runtime_handler.monitor_runs(get_db(), db)
 
+                expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
                 self._assert_list_namespaced_pods_calls(
                     self.runtime_handler, expected_number_of_list_pods_calls
                 )

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -408,6 +408,13 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         3. job in running state that should not be aborted
         4. job in succeeded state that should not be aborted
         """
+        # set big debouncing interval to avoid having to mock resources for all the runs on every monitor cycle
+        mlrun.mlconf.monitoring.runs.missing_runtime_resources_debouncing_interval = (
+            server.api.utils.helpers.time_string_to_seconds(
+                mlrun.mlconf.function.spec.state_thresholds.default.running
+            )
+            * 2
+        )
         image_pull_backoff_job_uid = str(uuid.uuid4())
         running_long_uid = str(uuid.uuid4())
         running_short_uid = str(uuid.uuid4())
@@ -575,6 +582,13 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         assert stale_run_updates == expected_run_updates
 
     def test_state_thresholds_pending_states(self, db: Session, client: TestClient):
+        # set big debouncing interval to avoid having to mock resources for all the runs on every monitor cycle
+        mlrun.mlconf.monitoring.runs.missing_runtime_resources_debouncing_interval = (
+            server.api.utils.helpers.time_string_to_seconds(
+                mlrun.mlconf.function.spec.state_thresholds.default.pending_scheduled
+            )
+            * 2
+        )
         pending_uid = str(uuid.uuid4())
         pending_scheduled_stale_uid = str(uuid.uuid4())
         pending_scheduled_uid = str(uuid.uuid4())

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -383,20 +383,23 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         stale_run_name = "my-spark-stale"
         new_run_name = "my-spark-new"
 
+        threshold_in_seconds = server.api.utils.helpers.time_string_to_seconds(
+            getattr(
+                mlrun.mlconf.function.spec.state_thresholds.default,
+                threshold_state,
+            )
+        )
+        # set big debouncing interval to avoid having to mock resources for all the runs on every monitor cycle
+        mlrun.mlconf.monitoring.runs.missing_runtime_resources_debouncing_interval = (
+            threshold_in_seconds * 2
+        )
+
         # create the runs
         for uid, name, start_time in [
             (
                 stale_job_uid,
                 stale_run_name,
-                datetime.now(timezone.utc)
-                - timedelta(
-                    seconds=server.api.utils.helpers.time_string_to_seconds(
-                        getattr(
-                            mlrun.mlconf.function.spec.state_thresholds.default,
-                            threshold_state,
-                        )
-                    )
-                ),
+                datetime.now(timezone.utc) - timedelta(seconds=threshold_in_seconds),
             ),
             (new_job_uid, new_run_name, datetime.now(timezone.utc)),
         ]:


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-4975

In case the resource was not listed for some reason when listing resources to monitor, search for the resource one more time before declaring the run has failed.