### PR TITLE
[API] Delete run logs when deleting run

### DIFF
--- a/server/api/api/endpoints/runs.py
+++ b/server/api/api/endpoints/runs.py
@@ -170,8 +170,7 @@ async def delete_run(
         mlrun.common.schemas.AuthorizationAction.delete,
         auth_info,
     )
-    await run_in_threadpool(
-        server.api.crud.Runs().delete_run,
+    await server.api.crud.Runs().delete_run(
         db_session,
         uid,
         iter,

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -355,9 +355,16 @@ class Logs(
             # fallback to deleting logs explicitly if the log collector failed
             if run_uids:
                 for run_uid in run_uids:
-                    self.delete_run_logs_legacy(project, run_uid)
+                    await run_in_threadpool(
+                        self.delete_run_logs_legacy,
+                        project,
+                        run_uid,
+                    )
             else:
-                self.delete_project_logs_legacy(project)
+                await run_in_threadpool(
+                    self.delete_project_logs_legacy,
+                    project,
+                )
 
         logger.debug(
             f"Successfully deleted {resource} logs", project=project, runs=run_uids

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -49,12 +49,45 @@ class Logs(
         with log_file.open(mode) as fp:
             fp.write(body)
 
-    def delete_logs(
+    async def stop_logs_for_project(
         self,
+        project_name: str,
+    ) -> None:
+        logger.debug("Stopping logs for project", project=project_name)
+        await self._stop_logs(project_name)
+
+    async def stop_logs_for_run(
+        self,
+        project_name: str,
+        run_uid: str,
+    ) -> None:
+        logger.debug("Stopping logs for run", project=project_name, run_uid=run_uid)
+        await self._stop_logs(project_name, [run_uid])
+
+    async def delete_project_logs(self, project: str):
+        logger.debug("Deleting logs for project", project=project)
+        await self._delete_logs(project)
+
+    async def delete_run_logs(self, project: str, uid: str):
+        logger.debug("Deleting logs for run", project=project, run_uid=uid)
+        await self._delete_logs(project, [uid])
+
+    @staticmethod
+    def delete_project_logs_legacy(
         project: str,
     ):
         project = project or mlrun.mlconf.default_project
         logs_path = server.api.api.utils.project_logs_path(project)
+        if logs_path.exists():
+            shutil.rmtree(str(logs_path))
+
+    @staticmethod
+    def delete_run_logs_legacy(
+        project: str,
+        run_uid: str,
+    ):
+        project = project or mlrun.mlconf.default_project
+        logs_path = server.api.api.utils.log_path(project, run_uid)
         if logs_path.exists():
             shutil.rmtree(str(logs_path))
 
@@ -272,3 +305,60 @@ class Logs(
             for file in os.listdir(str(logs_path))
             if os.path.isfile(os.path.join(str(logs_path), file))
         ]
+
+    @staticmethod
+    async def _stop_logs(
+        project_name: str,
+        run_uids: typing.List[str] = None,
+    ) -> None:
+        resource = "project" if not run_uids else "run"
+        try:
+            log_collector_client = (
+                server.api.utils.clients.log_collector.LogCollectorClient()
+            )
+            await log_collector_client.stop_logs(
+                project=project_name,
+                run_uids=run_uids,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed stopping logs for {resource}, Ignoring",
+                exc=mlrun.errors.err_to_str(exc),
+                project=project_name,
+                run_uids=run_uids,
+            )
+        else:
+            logger.debug(
+                f"Successfully stopped logs for {resource}",
+                project=project_name,
+                run_uids=run_uids,
+            )
+
+    async def _delete_logs(self, project: str, run_uids: typing.List[str] = None):
+        resource = "project" if not run_uids else "run"
+        try:
+            log_collector_client = (
+                server.api.utils.clients.log_collector.LogCollectorClient()
+            )
+            await log_collector_client.delete_logs(
+                project=project,
+                run_uids=run_uids,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed deleting {resource} logs via the log collector. Falling back to deleting logs explicitly",
+                exc=mlrun.errors.err_to_str(exc),
+                project=project,
+                runs=run_uids,
+            )
+
+            # fallback to deleting logs explicitly if the log collector failed
+            if run_uids:
+                for run_uid in run_uids:
+                    self.delete_run_logs_legacy(project, run_uid)
+            else:
+                self.delete_project_logs_legacy(project)
+
+        logger.debug(
+            f"Successfully deleted {resource} logs", project=project, runs=run_uids
+        )

--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -168,7 +168,7 @@ class Projects(
             mlrun.mlconf.log_collector.mode
             == mlrun.common.schemas.LogsCollectorMode.legacy
         ):
-            server.api.crud.Logs().delete_logs(name)
+            server.api.crud.Logs().delete_project_logs_legacy(name)
 
         # delete db resources
         server.api.utils.singletons.db.get_db().delete_project_related_resources(

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -15,6 +15,7 @@
 import typing
 
 import sqlalchemy.orm
+from fastapi.concurrency import run_in_threadpool
 
 import mlrun.common.schemas
 import mlrun.config
@@ -273,4 +274,8 @@ class Runs(
             await server.api.crud.Logs().stop_logs_for_run(project, uid)
             await server.api.crud.Logs().delete_run_logs(project, uid)
         else:
-            server.api.crud.Logs().delete_run_logs_legacy(project, uid)
+            await run_in_threadpool(
+                server.api.crud.Logs().delete_run_logs_legacy,
+                project,
+                uid,
+            )

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -26,6 +26,7 @@ import mlrun.utils.singleton
 import server.api.api.utils
 import server.api.constants
 import server.api.runtime_handlers
+import server.api.utils.clients.log_collector
 import server.api.utils.singletons.db
 from mlrun.utils import logger
 
@@ -161,7 +162,7 @@ class Runs(
             with_notifications=with_notifications,
         )
 
-    def delete_run(
+    async def delete_run(
         self,
         db_session: sqlalchemy.orm.Session,
         uid: str,
@@ -204,6 +205,8 @@ class Runs(
             runtime_kind=runtime_kind,
         )
         server.api.utils.singletons.db.get_db().del_run(db_session, uid, project, iter)
+
+        await self._post_delete_run(project, uid)
 
     def delete_runs(
         self,
@@ -260,3 +263,14 @@ class Runs(
         server.api.utils.singletons.db.get_db().update_run(
             db_session, run_updates, uid, project, iter
         )
+
+    @staticmethod
+    async def _post_delete_run(project, uid):
+        if (
+            mlrun.mlconf.log_collector.mode
+            != mlrun.common.schemas.LogsCollectorMode.legacy
+        ):
+            await server.api.crud.Logs().stop_logs_for_run(project, uid)
+            await server.api.crud.Logs().delete_run_logs(project, uid)
+        else:
+            server.api.crud.Logs().delete_run_logs_legacy(project, uid)

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -151,8 +151,8 @@ class SQLRunDB(RunDBInterface):
             with_notifications=with_notifications,
         )
 
-    def del_run(self, uid, project=None, iter=None):
-        return self._transform_db_error(
+    async def del_run(self, uid, project=None, iter=None):
+        return await self._transform_db_error(
             server.api.crud.Runs().delete_run,
             self.session,
             uid,

--- a/server/api/utils/projects/member.py
+++ b/server/api/utils/projects/member.py
@@ -21,7 +21,6 @@ import mlrun.common.schemas
 import mlrun.utils.singleton
 import server.api.crud
 import server.api.utils.clients.log_collector
-from mlrun.utils import logger
 
 
 class Member(abc.ABC):
@@ -158,56 +157,5 @@ class Member(abc.ABC):
             mlrun.mlconf.log_collector.mode
             != mlrun.common.schemas.LogsCollectorMode.legacy
         ):
-            await self._stop_logs_for_project(project_name)
-            await self._delete_project_logs(project_name)
-
-    @staticmethod
-    async def _stop_logs_for_project(
-        project_name: str,
-    ) -> None:
-
-        logger.debug("Stopping logs for project", project=project_name)
-
-        try:
-            log_collector_client = (
-                server.api.utils.clients.log_collector.LogCollectorClient()
-            )
-            await log_collector_client.stop_logs(
-                project=project_name,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed stopping logs for project's runs. Ignoring",
-                exc=mlrun.errors.err_to_str(exc),
-                project=project_name,
-            )
-
-        logger.debug(
-            "Successfully stopped logs for project's runs", project=project_name
-        )
-
-    @staticmethod
-    async def _delete_project_logs(
-        project_name: str,
-    ) -> None:
-
-        logger.debug("Deleting logs for project", project=project_name)
-
-        try:
-            log_collector_client = (
-                server.api.utils.clients.log_collector.LogCollectorClient()
-            )
-            await log_collector_client.delete_logs(
-                project=project_name,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed deleting project logs via the log collector. Falling back to deleting logs explicitly",
-                exc=mlrun.errors.err_to_str(exc),
-                project=project_name,
-            )
-
-            # fallback to deleting logs explicitly if the project logs deletion failed
-            server.api.crud.Logs().delete_logs(project_name)
-
-        logger.debug("Successfully deleted project logs", project=project_name)
+            await server.api.crud.Logs().stop_logs_for_project(project_name)
+            await server.api.crud.Logs().delete_project_logs(project_name)

--- a/tests/api/test_rundb.py
+++ b/tests/api/test_rundb.py
@@ -28,6 +28,7 @@ from mlrun.db.base import RunDBInterface
 from server.api.initial_data import init_data
 from server.api.rundb import sqldb
 from server.api.utils.singletons.db import initialize_db
+from server.api.utils.singletons.logs_dir import initialize_logs_dir
 from tests.conftest import new_run, run_now
 
 dbs = [
@@ -67,7 +68,10 @@ def new_func(labels, **kw):
     return obj
 
 
-def test_runs(db: RunDBInterface):
+@pytest.mark.asyncio
+async def test_runs(db: RunDBInterface):
+    initialize_logs_dir()
+
     run1 = new_run("s1", {"l1": "v1", "l2": "v2"}, x=1)
     db.store_run(run1, "uid1")
     run2 = new_run("s1", {"l2": "v2", "l3": "v3"}, x=2)
@@ -94,7 +98,7 @@ def test_runs(db: RunDBInterface):
     run3["status"] = updates["status"]
     assert run3 == runs[0], "state run"
 
-    db.del_run(uid3)
+    await db.del_run(uid3)
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
         db.read_run(uid3)
 


### PR DESCRIPTION
When deleting a run, delete its logs using the log collector first, and if it fails call the legacy deletion in which the api deletes the files by itself.

Also - refactored a bit of the code so deleting logs will be in the `Logs` crud, and so we can share code between runs an projects.

Resolves [ML-4883](https://jira.iguazeng.com/browse/ML-4883)