### PR TITLE
[API] Cascade and batch multiple runs deletion

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -107,6 +107,7 @@ default_config = {
     },
     "crud": {
         "runs": {
+            # deleting runs is a heavy operation that includes deleting runtime resources, therefore we do it in chunks
             "batch_delete_runs_chunk_size": 10,
         }
     },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -105,6 +105,11 @@ default_config = {
             "list_runs_time_period_in_days": 7,  # days
         }
     },
+    "crud": {
+        "runs": {
+            "batch_delete_runs_chunk_size": 10,
+        }
+    },
     # the grace period (in seconds) that will be given to runtime resources (after they're in terminal state)
     # before deleting them (4 hours)
     "runtime_resources_deletion_grace_period": "14400",

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -160,13 +160,10 @@ class RunStates(object):
         return list(set(RunStates.all()) - set(RunStates.terminal_states()))
 
     @staticmethod
-    def allowed_for_deletion_states():
+    def not_allowed_for_deletion_states():
         return [
-            RunStates.completed,
-            RunStates.error,
-            RunStates.aborted,
-            RunStates.unknown,
-            RunStates.created,
+            RunStates.running,
+            RunStates.pending,
         ]
 
 

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -164,6 +164,7 @@ class RunStates(object):
         return [
             RunStates.running,
             RunStates.pending,
+            # TODO: add aborting state once we have it
         ]
 
 

--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -159,6 +159,16 @@ class RunStates(object):
     def non_terminal_states():
         return list(set(RunStates.all()) - set(RunStates.terminal_states()))
 
+    @staticmethod
+    def allowed_for_deletion_states():
+        return [
+            RunStates.completed,
+            RunStates.error,
+            RunStates.aborted,
+            RunStates.unknown,
+            RunStates.created,
+        ]
+
 
 class SparkApplicationStates:
     """

--- a/server/api/api/endpoints/runs.py
+++ b/server/api/api/endpoints/runs.py
@@ -338,6 +338,7 @@ async def delete_runs(
                 auth_info,
             )
 
+    # TODO: make a background task?
     await run_in_threadpool(
         server.api.crud.Runs().delete_runs,
         db_session,

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -228,7 +228,7 @@ class Runs(
             and state
             in mlrun.runtimes.constants.RunStates.not_allowed_for_deletion_states()
         ):
-            raise mlrun.errors.MLRunBadRequestError(
+            raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Can not delete runs in {state} state"
             )
 
@@ -265,12 +265,16 @@ class Runs(
                     )
                 )
             results = await asyncio.gather(*tasks, return_exceptions=True)
-            for result in results:
+            for i, result in enumerate(results):
                 if isinstance(result, Exception):
                     failed_deletions += 1
                     last_exception = result
+                    run = runs_list[i]
                     logger.warning(
                         "Failed to delete run",
+                        run_uid=run.uid,
+                        run_name=run.name,
+                        project=run.project,
                         error=mlrun.errors.err_to_str(result),
                     )
 

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -229,7 +229,7 @@ class Runs(
             in mlrun.runtimes.constants.RunStates.not_allowed_for_deletion_states()
         ):
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Can not delete runs in {state} state"
+                f"Can not delete runs in {state} state, consider aborting the run first."
             )
 
         if not runs_list:

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
+import datetime
 import typing
 
 import sqlalchemy.orm
@@ -135,7 +137,7 @@ class Runs(
         requested_logs: bool = None,
         return_as_run_structs: bool = True,
         with_notifications: bool = False,
-    ):
+    ) -> mlrun.lists.RunList:
         project = project or mlrun.mlconf.default_project
         return server.api.utils.singletons.db.get_db().list_runs(
             session=db_session,
@@ -161,7 +163,7 @@ class Runs(
             with_notifications=with_notifications,
         )
 
-    def delete_run(
+    async def delete_run(
         self,
         db_session: sqlalchemy.orm.Session,
         uid: str,
@@ -205,7 +207,7 @@ class Runs(
         )
         server.api.utils.singletons.db.get_db().del_run(db_session, uid, project, iter)
 
-    def delete_runs(
+    async def delete_runs(
         self,
         db_session: sqlalchemy.orm.Session,
         name=None,
@@ -213,11 +215,60 @@ class Runs(
         labels=None,
         state=None,
         days_ago: int = 0,
+        runs_list: mlrun.lists.RunList = None,
     ):
         project = project or mlrun.mlconf.default_project
-        server.api.utils.singletons.db.get_db().del_runs(
-            db_session, name, project, labels, state, days_ago
-        )
+        # TODO: validate state
+        # states = [state] or [valid states for deletion]
+        if not runs_list:
+            start_time_from = None
+            if days_ago:
+                start_time_from = datetime.datetime.now(
+                    datetime.timezone.utc
+                ) - datetime.timedelta(days=days_ago)
+
+            runs_list = self.list_runs(
+                db_session,
+                name,
+                project=project,
+                labels=labels,
+                states=[state] if state is not None else None,
+                start_time_from=start_time_from,
+            )
+
+        failed_deletions = 0
+        last_exception = None
+        while runs_list:
+            tasks = []
+            for run in runs_list[
+                : mlrun.config.config.crud.runs.batch_delete_runs_chunk_size
+            ]:
+                tasks.append(
+                    self.delete_run(
+                        db_session,  # TODO: create a new session for each
+                        run["metadata"]["uid"],
+                        run["metadata"]["iteration"],
+                        project,
+                    )
+                )
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    failed_deletions += 1
+                    last_exception = result
+                    logger.warning(
+                        "Failed to delete run",
+                        error=mlrun.errors.err_to_str(result),
+                    )
+
+            runs_list = runs_list[
+                : mlrun.config.config.crud.runs.batch_delete_runs_chunk_size
+            ]
+
+        if failed_deletions:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"Failed to delete {failed_deletions} runs"
+            ) from last_exception
 
     def abort_run(
         self,

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -283,7 +283,7 @@ class Runs(
 
         if failed_deletions:
             raise mlrun.errors.MLRunRuntimeError(
-                f"Failed to delete {failed_deletions} runs"
+                f"Failed to delete {failed_deletions} run(s). Error: {mlrun.errors.err_to_str(last_exception)}"
             ) from last_exception
 
     def abort_run(

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlrun.common.schemas
+import mlrun.lists
 import mlrun.model
 
 
@@ -105,7 +106,7 @@ class DBInterface(ABC):
         requested_logs: bool = None,
         return_as_run_structs: bool = True,
         with_notifications: bool = False,
-    ):
+    ) -> mlrun.lists.RunList:
         pass
 
     @abstractmethod

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -328,7 +328,7 @@ class SQLDB(DBInterface):
         requested_logs: bool = None,
         return_as_run_structs: bool = True,
         with_notifications: bool = False,
-    ):
+    ) -> RunList:
         project = project or config.default_project
         query = self._find_runs(session, uid, project, labels)
         if name is not None:

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -160,8 +160,10 @@ class SQLRunDB(RunDBInterface):
             project,
         )
 
-    def del_runs(self, name=None, project=None, labels=None, state=None, days_ago=0):
-        return self._transform_db_error(
+    async def del_runs(
+        self, name=None, project=None, labels=None, state=None, days_ago=0
+    ):
+        return await self._transform_db_error(
             server.api.crud.Runs().delete_runs,
             self.session,
             name,

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -88,3 +88,50 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
 
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
             server.api.crud.Runs().get_run(db, "uid", 0, project)
+
+    @pytest.mark.asyncio
+    async def test_delete_runs(self, db: sqlalchemy.orm.Session):
+        mlrun.mlconf.log_collector.mode = mlrun.common.schemas.LogsCollectorMode.sidecar
+
+        project = "project-name"
+        run_name = "run-name"
+        for uid in range(20):
+            server.api.crud.Runs().store_run(
+                db,
+                {
+                    "metadata": {
+                        "name": run_name,
+                        "labels": {
+                            "kind": "job",
+                        },
+                        "uid": str(uid),
+                        "iteration": 0,
+                    },
+                },
+                str(uid),
+                project=project,
+            )
+
+        runs = server.api.crud.Runs().list_runs(db, run_name, project=project)
+        assert len(runs) == 20
+
+        k8s_helper = server.api.utils.singletons.k8s.get_k8s_helper()
+        with unittest.mock.patch.object(
+            k8s_helper.v1api, "delete_namespaced_pod"
+        ) as delete_namespaced_pod_mock, unittest.mock.patch.object(
+            k8s_helper.v1api,
+            "list_namespaced_pod",
+            return_value=k8s_client.V1PodList(items=[]),
+        ), unittest.mock.patch.object(
+            server.api.runtime_handlers.BaseRuntimeHandler, "_ensure_run_logs_collected"
+        ), unittest.mock.patch.object(
+            server.api.utils.clients.log_collector.LogCollectorClient, "stop_logs"
+        ) as stop_logs_mock, unittest.mock.patch.object(
+            server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
+        ) as delete_logs_mock:
+            await server.api.crud.Runs().delete_runs(db, name=run_name, project=project)
+            runs = server.api.crud.Runs().list_runs(db, run_name, project=project)
+            assert len(runs) == 0
+            delete_namespaced_pod_mock.assert_not_called()
+            assert stop_logs_mock.call_count == 20
+            assert delete_logs_mock.call_count == 20

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -135,3 +135,54 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
             delete_namespaced_pod_mock.assert_not_called()
             assert stop_logs_mock.call_count == 20
             assert delete_logs_mock.call_count == 20
+
+    @pytest.mark.asyncio
+    async def test_delete_runs_failure(self, db: sqlalchemy.orm.Session):
+        """
+        This test creates 3 runs, and then tries to delete them.
+        The first run is deleted successfully, the second one fails with an exception, and the third one is deleted
+        """
+        project = "project-name"
+        run_name = "run-name"
+        for uid in range(3):
+            server.api.crud.Runs().store_run(
+                db,
+                {
+                    "metadata": {
+                        "name": run_name,
+                        "labels": {
+                            "kind": "job",
+                        },
+                        "uid": str(uid),
+                        "iteration": 0,
+                    },
+                },
+                str(uid),
+                project=project,
+            )
+
+        runs = server.api.crud.Runs().list_runs(db, run_name, project=project)
+        assert len(runs) == 3
+
+        k8s_helper = server.api.utils.singletons.k8s.get_k8s_helper()
+        with unittest.mock.patch.object(
+            k8s_helper.v1api, "delete_namespaced_pod"
+        ), unittest.mock.patch.object(
+            k8s_helper.v1api,
+            "list_namespaced_pod",
+            side_effect=[
+                k8s_client.V1PodList(items=[]),
+                Exception("Boom!"),
+                k8s_client.V1PodList(items=[]),
+            ],
+        ), unittest.mock.patch.object(
+            server.api.runtime_handlers.BaseRuntimeHandler, "_ensure_run_logs_collected"
+        ):
+            with pytest.raises(mlrun.errors.MLRunRuntimeError) as exc:
+                await server.api.crud.Runs().delete_runs(
+                    db, name=run_name, project=project
+                )
+            assert "Failed to delete 1 run(s). Error: Boom!" in str(exc.value)
+
+            runs = server.api.crud.Runs().list_runs(db, run_name, project=project)
+            assert len(runs) == 1

--- a/tests/api/test_rundb.py
+++ b/tests/api/test_rundb.py
@@ -103,7 +103,9 @@ async def test_runs(db: RunDBInterface):
         db.read_run(uid3)
 
     label = "l1"
-    db.del_runs(labels=[label])
+    runs = db.list_runs(labels=[label])
+    assert 1 == len(runs), "labels length"
+    await db.del_runs(labels=[label])
     for run in db.list_runs():
         assert label not in run["metadata"]["labels"], "del_runs"
 


### PR DESCRIPTION
Delete run now deletes all of the runtime resources (pods, crds, logs...)
That means that deleting multiple runs should take deletion of the resources into consideration which makes it a heavy operation.
This PR adds async batch runs deletion.

https://jira.iguazeng.com/browse/ML-5307