### PR TITLE
[Artifacts] Always add `latest` tag when creating an artifact

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -612,6 +612,7 @@ class SQLDB(DBInterface):
 
         self._upsert(session, [db_artifact])
         if tag:
+            validate_tag_name(tag, "artifact.metadata.tag")
             self.tag_objects_v2(
                 session, [db_artifact], project, tag, obj_name_attribute="key"
             )

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -616,11 +616,11 @@ class SQLDB(DBInterface):
                 session, [db_artifact], project, tag, obj_name_attribute="key"
             )
 
-            # we want to tag the artifact also as "latest" if it's the first time we store it
-            if tag != "latest":
-                self.tag_objects_v2(
-                    session, [db_artifact], project, "latest", obj_name_attribute="key"
-                )
+        # we want to tag the artifact also as "latest" if it's the first time we store it
+        if tag != "latest":
+            self.tag_objects_v2(
+                session, [db_artifact], project, "latest", obj_name_attribute="key"
+            )
 
         return uid
 


### PR DESCRIPTION
In the `create_artifact` flow we want to add the `latest` tag regardless of whether a tag was specified or not.