### PR TITLE
[Datastore] bugfix Azure delete

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -39,7 +39,6 @@ def extra_requirements() -> typing.Dict[str, typing.List[str]]:
         "azure-blob-storage": [
             "msrest~=0.6.21",
             "azure-core~=1.24",
-            "azure-storage-blob>=12.13, !=12.18.0",
             "adlfs==2023.9.0",
             "pyopenssl>=23",
         ],

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -14,8 +14,6 @@ s3fs==2023.9.0
 # https://github.com/Azure/azure-sdk-for-python/issues/24765#issuecomment-1150310498
 msrest~=0.6.21
 azure-core~=1.24
-# Excluding 12.18.0 due to https://github.com/Azure/azure-sdk-for-python/issues/32056
-azure-storage-blob>=12.13, !=12.18.0
 # This version is required in order to support the self._strip_protocol
 # function in Azure Blob File System functions (such as _ls and more).
 adlfs==2023.9.0

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -15,7 +15,6 @@
 import time
 from pathlib import Path
 
-from azure.storage.blob import BlobServiceClient
 from fsspec.registry import get_filesystem_class
 
 import mlrun.errors
@@ -32,13 +31,7 @@ class AzureBlobStore(DataStore):
 
     def __init__(self, parent, schema, name, endpoint="", secrets: dict = None):
         super().__init__(parent, name, schema, endpoint, secrets=secrets)
-        self.bsc = None
-
-        con_string = self._get_secret_or_env("AZURE_STORAGE_CONNECTION_STRING")
-        if con_string:
-            self.bsc = BlobServiceClient.from_connection_string(con_string)
-        else:
-            self.get_filesystem()
+        self.get_filesystem()
 
     def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
@@ -86,89 +79,54 @@ class AzureBlobStore(DataStore):
         return path
 
     def upload(self, key, src_path):
-        if self.bsc:
-            # Need to strip leading / from key
-            with self.bsc.get_blob_client(
-                container=self.endpoint, blob=key[1:]
-            ) as blob_client:
-                with open(src_path, "rb") as data:
-                    blob_client.upload_blob(data, overwrite=True)
-        else:
-            remote_path = self._convert_key_to_remote_path(key)
-            self._filesystem.put_file(src_path, remote_path, overwrite=True)
+        remote_path = self._convert_key_to_remote_path(key)
+        self._filesystem.put_file(src_path, remote_path, overwrite=True)
 
     def get(self, key, size=None, offset=0):
-        if self.bsc:
-            with self.bsc.get_blob_client(
-                container=self.endpoint, blob=key[1:]
-            ) as blob_client:
-                size = size if size else None
-                blob = blob_client.download_blob(offset, size).readall()
-                return blob
-        else:
-            remote_path = self._convert_key_to_remote_path(key)
-            end = offset + size if size else None
-            blob = self._filesystem.cat_file(remote_path, start=offset, end=end)
-            return blob
+        remote_path = self._convert_key_to_remote_path(key)
+        end = offset + size if size else None
+        blob = self._filesystem.cat_file(remote_path, start=offset, end=end)
+        return blob
 
     def put(self, key, data, append=False):
         if append:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Append mode not supported for Azure blob datastore"
             )
-        if self.bsc:
-            with self.bsc.get_blob_client(
-                container=self.endpoint, blob=key[1:]
-            ) as blob_client:
-                # Note that append=True is not supported. If the blob already exists, this call will fail
-                blob_client.upload_blob(data, overwrite=True)
+        remote_path = self._convert_key_to_remote_path(key)
+        if isinstance(data, bytes):
+            mode = "wb"
+        elif isinstance(data, str):
+            mode = "w"
         else:
-            remote_path = self._convert_key_to_remote_path(key)
-            if isinstance(data, bytes):
-                mode = "wb"
-            elif isinstance(data, str):
-                mode = "w"
-            else:
-                raise TypeError("Data type unknown.  Unable to put in Azure!")
-            with self._filesystem.open(remote_path, mode) as f:
-                f.write(data)
+            raise TypeError("Data type unknown.  Unable to put in Azure!")
+        with self._filesystem.open(remote_path, mode) as f:
+            f.write(data)
 
     def stat(self, key):
-        if self.bsc:
-            with self.bsc.get_blob_client(
-                container=self.endpoint, blob=key[1:]
-            ) as blob_client:
-                props = blob_client.get_blob_properties()
-            size = props.size
-            modified = props.last_modified
+        remote_path = self._convert_key_to_remote_path(key)
+        files = self._filesystem.ls(remote_path, detail=True)
+        if len(files) == 1 and files[0]["type"] == "file":
+            size = files[0]["size"]
+            modified = files[0]["last_modified"]
+        elif len(files) == 1 and files[0]["type"] == "directory":
+            raise FileNotFoundError("Operation expects a file not a directory!")
         else:
-            remote_path = self._convert_key_to_remote_path(key)
-            files = self._filesystem.ls(remote_path, detail=True)
-            if len(files) == 1 and files[0]["type"] == "file":
-                size = files[0]["size"]
-                modified = files[0]["last_modified"]
-            elif len(files) == 1 and files[0]["type"] == "directory":
-                raise FileNotFoundError("Operation expects a file not a directory!")
-            else:
-                raise ValueError("Operation expects to receive a single file!")
+            raise ValueError("Operation expects to receive a single file!")
         return FileStats(size, time.mktime(modified.timetuple()))
 
     def listdir(self, key):
-        if self.bsc:
-            if key and not key.endswith("/"):
-                key = key[1:] + "/"
-            key_length = len(key)
-            with self.bsc.get_container_client(self.endpoint) as container_client:
-                blob_list = container_client.list_blobs(name_starts_with=key)
-            return [blob.name[key_length:] for blob in blob_list]
-        else:
-            remote_path = self._convert_key_to_remote_path(key)
-            if self._filesystem.isfile(remote_path):
-                return key
-            remote_path = f"{remote_path}/**"
-            files = self._filesystem.glob(remote_path)
-            key_length = len(key)
-            files = [
-                f.split("/", 1)[1][key_length:] for f in files if len(f.split("/")) > 1
-            ]
-            return files
+        remote_path = self._convert_key_to_remote_path(key)
+        if self._filesystem.isfile(remote_path):
+            return key
+        remote_path = f"{remote_path}/**"
+        files = self._filesystem.glob(remote_path)
+        key_length = len(key)
+        files = [
+            f.split("/", 1)[1][key_length:] for f in files if len(f.split("/")) > 1
+        ]
+        return files
+
+    def rm(self, path, recursive=False, maxdepth=None):
+        path = self._convert_key_to_remote_path(key=path)
+        super().rm(path=path, recursive=recursive, maxdepth=maxdepth)

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -344,6 +344,7 @@ class DatastoreProfile2Json(pydantic.BaseModel):
             "kafka_source": DatastoreProfileKafkaSource,
             "dbfs": DatastoreProfileDBFS,
             "gcs": DatastoreProfileGCS,
+            "az": DatastoreProfileAzureBlob,
         }
         if datastore_type in ds_profile_factory:
             return ds_profile_factory[datastore_type].parse_obj(decoded_dict)

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -144,7 +144,6 @@ def test_requirement_specifiers_convention():
         "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
         "pyyaml": {">=5.4.1, <6"},
         # other requirements
-        "azure-storage-blob": {">=12.13, !=12.18.0"},
         "aiohttp": {"~=3.8, <3.8.4"},
     }
 


### PR DESCRIPTION
We have removed the usage of the BlobServiceClient in the Azure Datastore.
From now on, we will rely solely on the azure fsspec class (AzureBlobFileSystem for the 'az' protocol) in the Datastore.

1) Fixed delete (rm in azure datastore) function.
2) Added tests for delete and download items.


[ML-5303](https://jira.iguazeng.com/browse/ML-5303)