### PR TITLE
[Artifacts] Remove `legacy` format

### DIFF
--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -59,8 +59,8 @@ class ArtifactIdentifier(pydantic.BaseModel):
 
 
 class ArtifactsFormat(mlrun.common.types.StrEnum):
+    # TODO: add a format that returns a minimal response
     full = "full"
-    legacy = "legacy"
 
 
 class ArtifactMetadata(pydantic.BaseModel):

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -114,8 +114,6 @@ class Artifacts(
             producer_id,
             object_uid,
         )
-        if format_ == mlrun.common.schemas.artifact.ArtifactsFormat.legacy:
-            return _transform_artifact_struct_to_legacy_format(artifact)
         return artifact
 
     def list_artifacts(
@@ -151,12 +149,7 @@ class Artifacts(
             best_iteration,
             producer_id=producer_id,
         )
-        if format_ != mlrun.common.schemas.artifact.ArtifactsFormat.legacy:
-            return artifacts
-        return [
-            _transform_artifact_struct_to_legacy_format(artifact)
-            for artifact in artifacts
-        ]
+        return artifacts
 
     def list_artifact_tags(
         self,
@@ -197,16 +190,3 @@ class Artifacts(
         server.api.utils.singletons.db.get_db().del_artifacts(
             db_session, name, project, tag, labels, producer_id=producer_id
         )
-
-
-def _transform_artifact_struct_to_legacy_format(artifact):
-    # Check if this is already in legacy format
-    if "metadata" not in artifact:
-        return artifact
-
-    # Simply flatten the dictionary
-    legacy_artifact = {"kind": artifact["kind"]}
-    for section in ["metadata", "spec", "status"]:
-        for key, value in artifact[section].items():
-            legacy_artifact[key] = value
-    return legacy_artifact

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -312,24 +312,13 @@ def test_list_artifacts_with_format_query(db: Session, client: TestClient) -> No
         )
         assert not is_legacy_artifact(artifacts[0])
 
-    # request legacy format
+    # request legacy format - expect failure (legacy format is not supported anymore)
     for artifact_path in [
         f"{LEGACY_API_ARTIFACTS_PATH}?project={PROJECT}&format=legacy",
         f"{API_ARTIFACTS_PATH.format(project=PROJECT)}?format=legacy",
     ]:
         resp = client.get(artifact_path)
-        assert resp.status_code == HTTPStatus.OK.value
-
-        artifacts = resp.json()["artifacts"]
-        assert (
-            deepdiff.DeepDiff(
-                [artifact["tag"] for artifact in resp.json()["artifacts"]],
-                ["latest", TAG],
-                ignore_order=True,
-            )
-            == {}
-        )
-        assert is_legacy_artifact(artifacts[0])
+        assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY.value
 
     # explicitly request full format
     for artifact_path in [
@@ -372,16 +361,13 @@ def test_get_artifact_with_format_query(db: Session, client: TestClient) -> None
         artifact = resp.json()
         assert not is_legacy_artifact(artifact["data"])
 
-    # request legacy format
+    # request legacy format - expect failure (legacy format is not supported anymore)
     for artifact_path in [
         f"{LEGACY_API_GET_ARTIFACT_PATH.format(project=PROJECT, key=KEY, tag=TAG)}&format=legacy",
         f"{GET_API_ARTIFACT_PATH.format(project=PROJECT, key=KEY, tag=TAG)}&format=legacy",
     ]:
         resp = client.get(artifact_path)
-        assert resp.status_code == HTTPStatus.OK.value
-
-        artifact = resp.json()
-        assert is_legacy_artifact(artifact["data"])
+        assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY.value
 
     # explicitly request full format
     for artifact_path in [


### PR DESCRIPTION
In the artifact refactor we removed all legacy artifacts, so we do not support this artifact format anymore.
If a request is made with a `format=legacy` query, it will get a 422 (Unprocessable Entity) response from FastAPI.