### PR TITLE
[Config] Remove an unused legacy `setup.cfg` file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test = pytest


### PR DESCRIPTION
This file is not used anymore, including the test alias.