### PR TITLE
[API] Fix run logs not deleted in worker

### DIFF
--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -344,7 +344,6 @@ class Runs(
             mlrun.mlconf.log_collector.mode
             != mlrun.common.schemas.LogsCollectorMode.legacy
         ):
-            await server.api.crud.Logs().stop_logs_for_run(project, uid)
             await server.api.crud.Logs().delete_run_logs(project, uid)
         else:
             await run_in_threadpool(

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -551,13 +551,6 @@ func (s *Server) StopLogs(ctx context.Context, request *protologcollector.StopLo
 
 // DeleteLogs deletes the log file for a given run id or project
 func (s *Server) DeleteLogs(ctx context.Context, request *protologcollector.StopLogsRequest) (*protologcollector.BaseResponse, error) {
-	if !s.isChief {
-		s.Logger.DebugWithCtx(ctx,
-			"Server is not the chief, ignoring delete logs request",
-			"project", request.Project,
-			"numRunIDs", len(request.RunUIDs))
-		return s.successfulBaseResponse(), nil
-	}
 
 	// validate project name
 	if request.Project == "" {

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -77,13 +77,10 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
         ), unittest.mock.patch.object(
             server.api.runtime_handlers.BaseRuntimeHandler, "_ensure_run_logs_collected"
         ), unittest.mock.patch.object(
-            server.api.utils.clients.log_collector.LogCollectorClient, "stop_logs"
-        ) as stop_logs_mock, unittest.mock.patch.object(
             server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
         ) as delete_logs_mock:
             await server.api.crud.Runs().delete_run(db, "uid", 0, project)
             delete_namespaced_pod_mock.assert_called_once()
-            stop_logs_mock.assert_called_once()
             delete_logs_mock.assert_called_once()
 
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
@@ -125,15 +122,12 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
         ), unittest.mock.patch.object(
             server.api.runtime_handlers.BaseRuntimeHandler, "_ensure_run_logs_collected"
         ), unittest.mock.patch.object(
-            server.api.utils.clients.log_collector.LogCollectorClient, "stop_logs"
-        ) as stop_logs_mock, unittest.mock.patch.object(
             server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
         ) as delete_logs_mock:
             await server.api.crud.Runs().delete_runs(db, name=run_name, project=project)
             runs = server.api.crud.Runs().list_runs(db, run_name, project=project)
             assert len(runs) == 0
             delete_namespaced_pod_mock.assert_not_called()
-            assert stop_logs_mock.call_count == 20
             assert delete_logs_mock.call_count == 20
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Requests to the log collector for stopping and deleting logs were ignored if they didn't come from the Chief. 
This caused requests to delete runs to not delete logs, if the workers handled them.

Stopping logs can only happen in the Chief because it keeps an in-memory state of which runs are currently collected for logs.
Stop logs is called for terminated runs, and since we can delete runs that are terminated or creating (ie . meaning we do not have logs for them yet) we can skip stopping logs before deleting run logs.

As for deletion - the Chief-only limitation was instilled due to the chief being the sole deleter of projects, however there is no actual limitation in the log collector for the worker to delete the logs.

So to allow workers to delete runs:
- Don't stop logs explicitly before deleting run.
- Allow workers in the log collector to delete logs.

Fixes https://jira.iguazeng.com/browse/ML-4883