### PR TITLE
[Pipelines] Ignore get run status for remote:local

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -45,11 +45,11 @@ def get_workflow_engine(engine_kind, local=False):
     if pipeline_context.is_run_local(local):
         if engine_kind == "kfp":
             logger.warning(
-                "running kubeflow pipeline locally, note some ops may not run locally!"
+                "Running kubeflow pipeline locally, note some ops may not run locally!"
             )
         elif engine_kind == "remote":
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "cannot run a remote pipeline locally using `kind='remote'` and `local=True`. "
+                "Cannot run a remote pipeline locally using `kind='remote'` and `local=True`. "
                 "in order to run a local pipeline remotely, please use `engine='remote:local'` instead"
             )
         return _LocalRunner
@@ -481,7 +481,7 @@ class _PipelineRunner(abc.ABC):
     @abc.abstractmethod
     def save(cls, project, workflow_spec: WorkflowSpec, target, artifact_path=None):
         raise NotImplementedError(
-            f"save operation not supported in {cls.engine} pipeline engine"
+            f"Save operation not supported in {cls.engine} pipeline engine"
         )
 
     @classmethod
@@ -747,7 +747,7 @@ class _LocalRunner(_PipelineRunner):
             state = mlrun.run.RunStatuses.succeeded
         except Exception as exc:
             err = exc
-            logger.exception("workflow run failed")
+            logger.exception("Workflow run failed")
             project.notifiers.push(
                 f":x: Workflow {workflow_id} run failed!, error: {err_to_str(exc)}",
                 mlrun.common.schemas.NotificationSeverity.ERROR,
@@ -879,7 +879,7 @@ class _RemoteRunner(_PipelineRunner):
 
         except Exception as exc:
             err = exc
-            logger.exception("workflow run failed")
+            logger.exception("Workflow run failed")
             project.notifiers.push(
                 f":x: Workflow {workflow_name} run failed!, error: {err_to_str(exc)}",
                 mlrun.common.schemas.NotificationSeverity.ERROR,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2648,12 +2648,12 @@ class MlrunProject(ModelObj):
             )
         workflow_spec.clear_tmp()
         if (timeout or watch) and not workflow_spec.schedule:
+            status_engine = run._engine
             # run's engine gets replaced with inner engine if engine is remote,
             # so in that case we need to get the status from the remote engine manually
-            if engine == "remote":
+            # TODO: support watch for remote:local
+            if engine == "remote" and status_engine.engine != "local":
                 status_engine = _RemoteRunner
-            else:
-                status_engine = run._engine
 
             status_engine.get_run_status(project=self, run=run, timeout=timeout)
         return run

--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -262,7 +262,7 @@ class WorkflowRunners(
                 workflow_id = ""
             else:
                 raise mlrun.errors.MLRunNotFoundError(
-                    f"workflow id of run {project}:{uid} not found"
+                    f"Workflow id of run {project}:{uid} not found"
                 )
 
         return mlrun.common.schemas.GetWorkflowResponse(workflow_id=workflow_id)


### PR DESCRIPTION
This is not yet supported.
What needs to be done is to watch the run of the remote engine because it starts a kubejob and runs the functions locally on that pod but it requires some design.
The KFP runner also lists the runs with a label of the workflow id - need to make sure this label is added to the local runs as well to get the results.
This will fix system test `test_remote_pipeline_with_local_engine_from_github` which is not really testing anything because it doesn't wait for the pipeline to complete.