### PR TITLE
[API] Handle recurrent abort runs

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -189,6 +189,7 @@ default_config = {
                 "migrations": "3600",
                 "load_project": "60",
                 "run_abortion": "600",
+                "abort_grace_period": "10",
             },
             "runtimes": {"dask": "600"},
         },

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -375,6 +375,7 @@ async def start_function(
         background_tasks,
         _start_function,
         background_timeout,
+        None,
         # args for _start_function
         function,
         auth_info,

--- a/server/api/api/endpoints/runs.py
+++ b/server/api/api/endpoints/runs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import datetime
+import uuid
 from http import HTTPStatus
 from typing import List
 
@@ -25,6 +26,7 @@ import server.api.crud
 import server.api.utils.auth.verifier
 import server.api.utils.background_tasks
 import server.api.utils.singletons.project_member
+from mlrun.utils import logger
 from mlrun.utils.helpers import datetime_from_iso
 from server.api.api import deps
 from server.api.api.utils import log_and_raise
@@ -417,6 +419,76 @@ async def abort_run(
     except ValueError:
         log_and_raise(HTTPStatus.BAD_REQUEST.value, reason="bad JSON body")
 
+    run = await run_in_threadpool(
+        server.api.crud.Runs().get_run, db_session, uid, iter, project
+    )
+
+    current_run_state = run.get("status", {}).get("state")
+    if current_run_state in [
+        mlrun.runtimes.constants.RunStates.aborting,
+        mlrun.runtimes.constants.RunStates.aborted,
+    ]:
+        background_task_id = run.get("status", {}).get("abort_task_id")
+        if background_task_id:
+            # get the background task and check if it's still running
+            try:
+                background_task = await run_in_threadpool(
+                    server.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task,
+                    db_session,
+                    background_task_id,
+                    project,
+                )
+
+                if (
+                    background_task.status.state
+                    in mlrun.common.schemas.BackgroundTaskState.running
+                ):
+                    logger.debug(
+                        "Abort background task is still running, returning it",
+                        background_task_id=background_task_id,
+                        project=project,
+                        uid=uid,
+                    )
+                    return background_task
+
+                # if the background task completed, give some grace time before triggering another one
+                elif (
+                    background_task.status.state
+                    == mlrun.common.schemas.BackgroundTaskState.succeeded
+                ):
+                    grace_timedelta = datetime.timedelta(
+                        seconds=int(
+                            mlrun.mlconf.background_tasks.default_timeouts.operations.abort_grace_period
+                        )
+                    )
+                    if (
+                        datetime.datetime.utcnow() - background_task.metadata.updated
+                        < grace_timedelta
+                    ):
+                        logger.debug(
+                            "Abort background task completed, but grace time didn't pass yet, returning it",
+                            background_task_id=background_task_id,
+                            project=project,
+                            uid=uid,
+                        )
+                        return background_task
+                    else:
+                        logger.debug(
+                            "Abort background task completed, but grace time passed, creating a new one",
+                            background_task_id=background_task_id,
+                            project=project,
+                            uid=uid,
+                        )
+
+            except mlrun.errors.MLRunNotFoundError:
+                logger.warning(
+                    "Abort background task not found, creating a new one",
+                    background_task_id=background_task_id,
+                    project=project,
+                    uid=uid,
+                )
+
+    new_background_task_id = str(uuid.uuid4())
     background_task = await run_in_threadpool(
         server.api.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task,
         db_session,
@@ -424,12 +496,15 @@ async def abort_run(
         background_tasks,
         server.api.crud.Runs().abort_run,
         mlrun.mlconf.background_tasks.default_timeouts.operations.run_abortion,
+        new_background_task_id,
         # args for abort_run
         db_session,
         project,
         uid,
         iter,
         run_updates=data,
+        run=run,
+        new_background_task_id=new_background_task_id,
     )
 
     return background_task

--- a/server/api/constants.py
+++ b/server/api/constants.py
@@ -16,6 +16,8 @@ from enum import Enum
 
 from mlrun.common.types import StrEnum
 
+internal_abort_task_id = "internal-abort"
+
 
 class LogSources(Enum):
     AUTO = "auto"

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -324,7 +324,14 @@ class Runs(
             )
 
         abort_task_id = run.get("status", {}).get("abort_task_id")
-        if abort_task_id == server.api.constants.internal_abort_task_id:
+        if (
+            abort_task_id == server.api.constants.internal_abort_task_id
+            and current_run_state
+            in [
+                mlrun.runtimes.constants.RunStates.aborting,
+                mlrun.runtimes.constants.RunStates.aborted,
+            ]
+        ):
             logger.warning(
                 "Run was aborted by monitoring, skipping abort",
             )

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -323,12 +323,9 @@ class Runs(
                 "Run is already in terminal state, can not be aborted"
             )
 
-        # ensure we are not triggering multiple internal aborts
-        abort_task_id = run.get("status", {}).get("abort_task_id")
+        # ensure we are not triggering multiple internal aborts / internal abort on top of user abort
         if (
-            new_background_task_id
-            == abort_task_id
-            == server.api.constants.internal_abort_task_id
+            new_background_task_id == server.api.constants.internal_abort_task_id
             and current_run_state
             in [
                 mlrun.runtimes.constants.RunStates.aborting,
@@ -336,7 +333,9 @@ class Runs(
             ]
         ):
             logger.warning(
-                "Run was aborted by monitoring, skipping abort",
+                "Run is aborting/aborted, skipping internal abort",
+                new_background_task_id=new_background_task_id,
+                current_run_state=current_run_state,
             )
             return
 

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -323,9 +323,12 @@ class Runs(
                 "Run is already in terminal state, can not be aborted"
             )
 
+        # ensure we are not triggering multiple internal aborts
         abort_task_id = run.get("status", {}).get("abort_task_id")
         if (
-            abort_task_id == server.api.constants.internal_abort_task_id
+            new_background_task_id
+            == abort_task_id
+            == server.api.constants.internal_abort_task_id
             and current_run_state
             in [
                 mlrun.runtimes.constants.RunStates.aborting,

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -33,6 +33,7 @@ import mlrun.utils.notifications
 import mlrun.utils.version
 import server.api.api.utils
 import server.api.apiuvicorn as uvicorn
+import server.api.constants
 import server.api.crud
 import server.api.db.base
 import server.api.initial_data
@@ -702,6 +703,10 @@ async def _abort_stale_runs(stale_runs: typing.List[dict]):
     async def abort_run(stale_run):
         # Using semaphore to limit the chunk we get from the thread pool for run aborting
         async with semaphore:
+            # mark abort as internal, it doesn't have a background task
+            stale_run[
+                "new_background_task_id"
+            ] = server.api.constants.internal_abort_task_id
             await fastapi.concurrency.run_in_threadpool(
                 server.api.db.session.run_function_with_new_db_session,
                 server.api.crud.Runs().abort_run,

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1540,6 +1540,16 @@ class BaseRuntimeHandler(ABC):
             if db_run_state == run_state:
                 return False, run_state, run
 
+            if db_run_state == RunStates.aborting:
+                logger.debug(
+                    "Run is in aborting state. Not changing state",
+                    project=project,
+                    uid=uid,
+                    db_run_state=db_run_state,
+                    run_state=run_state,
+                )
+                return False, run_state, run
+
             # if the current run state is terminal and different from the desired - log
             if db_run_state in RunStates.terminal_states():
 

--- a/server/api/utils/background_tasks.py
+++ b/server/api/utils/background_tasks.py
@@ -39,10 +39,11 @@ class ProjectBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         background_tasks: fastapi.BackgroundTasks,
         function,
         timeout: int = None,  # in seconds
+        name: str = None,
         *args,
         **kwargs,
     ) -> mlrun.common.schemas.BackgroundTask:
-        name = str(uuid.uuid4())
+        name = name or str(uuid.uuid4())
         logger.debug(
             "Creating background task",
             name=name,

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -21,7 +21,6 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
 import fastapi
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -640,8 +639,7 @@ def test_store_run_masking(db: Session, client: TestClient, k8s_secrets_mock):
         assert value == expected_value
 
 
-@pytest.mark.asyncio
-async def test_abort_run_already_in_progress(db: Session, client: TestClient) -> None:
+def test_abort_run_already_in_progress(db: Session, client: TestClient) -> None:
     project = "some-project"
     background_task_name = "background-task-name"
     run_in_progress = {

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import copy
 import time
 import unittest.mock
@@ -19,6 +20,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
+import fastapi
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -635,6 +638,192 @@ def test_store_run_masking(db: Session, client: TestClient, k8s_secrets_mock):
     for param, expected_value in expected_response_params.items():
         value = mlrun.utils.get_in(response_body, param)
         assert value == expected_value
+
+
+@pytest.mark.asyncio
+async def test_abort_run_already_in_progress(db: Session, client: TestClient) -> None:
+    project = "some-project"
+    background_task_name = "background-task-name"
+    run_in_progress = {
+        "metadata": {
+            "name": "run-name-1",
+            "labels": {"kind": mlrun.runtimes.RuntimeKinds.job},
+        },
+        "status": {
+            "state": mlrun.runtimes.constants.RunStates.aborting,
+            "abort_task_id": background_task_name,
+        },
+    }
+    run_in_progress_uid = "in-progress-uid"
+    server.api.crud.Runs().store_run(
+        db, run_in_progress, run_in_progress_uid, project=project
+    )
+
+    # mock abortion already in progress
+    server.api.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task(
+        db,
+        project,
+        fastapi.BackgroundTasks(),
+        asyncio.sleep,
+        timeout=100,
+        name=background_task_name,
+        delay=5,
+    )
+
+    # abort again should return the same background task
+    response = client.post(
+        f"projects/{project}/runs/{run_in_progress_uid}/abort", json={}
+    )
+    assert response.status_code == HTTPStatus.ACCEPTED.value
+    background_task = mlrun.common.schemas.BackgroundTask(**response.json())
+    assert (
+        background_task.status.state == mlrun.common.schemas.BackgroundTaskState.running
+    )
+    assert background_task.metadata.name == background_task_name
+
+
+def test_abort_aborted_run_with_background_task(
+    db: Session, client: TestClient
+) -> None:
+    project = "some-project"
+    run_in_progress = {
+        "metadata": {
+            "name": "run-name-1",
+            "labels": {"kind": mlrun.runtimes.RuntimeKinds.job},
+        },
+        "status": {"state": mlrun.runtimes.constants.RunStates.running},
+    }
+    run_in_progress_uid = "in-progress-uid"
+    server.api.crud.Runs().store_run(
+        db, run_in_progress, run_in_progress_uid, project=project
+    )
+
+    with unittest.mock.patch.object(
+        server.api.crud.RuntimeResources, "delete_runtime_resources"
+    ):
+        response = client.post(
+            f"projects/{project}/runs/{run_in_progress_uid}/abort", json={}
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED.value
+        background_task_1 = mlrun.common.schemas.BackgroundTask(**response.json())
+        background_task_1 = server.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task(
+            db, background_task_1.metadata.name, project
+        )
+        assert (
+            background_task_1.status.state
+            == mlrun.common.schemas.BackgroundTaskState.succeeded
+        )
+        run = server.api.crud.Runs().get_run(db, run_in_progress_uid, 0, project)
+        assert run["status"]["state"] == mlrun.runtimes.constants.RunStates.aborted
+        assert run["status"]["abort_task_id"] == background_task_1.metadata.name
+
+        # abort again should return the same background task
+        response = client.post(
+            f"projects/{project}/runs/{run_in_progress_uid}/abort", json={}
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED.value
+        background_task_2 = mlrun.common.schemas.BackgroundTask(**response.json())
+        background_task_2 = server.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task(
+            db, background_task_2.metadata.name, project
+        )
+        assert (
+            background_task_2.status.state
+            == mlrun.common.schemas.BackgroundTaskState.succeeded
+        )
+        assert background_task_2.metadata.name == background_task_1.metadata.name
+
+
+def test_abort_aborted_run_passed_grace_period(db: Session, client: TestClient) -> None:
+    mlrun.mlconf.background_tasks.default_timeouts.operations.abort_grace_period = 0
+    project = "some-project"
+    run_in_progress = {
+        "metadata": {
+            "name": "run-name-1",
+            "labels": {"kind": mlrun.runtimes.RuntimeKinds.job},
+        },
+        "status": {"state": mlrun.runtimes.constants.RunStates.running},
+    }
+    run_in_progress_uid = "in-progress-uid"
+    server.api.crud.Runs().store_run(
+        db, run_in_progress, run_in_progress_uid, project=project
+    )
+
+    with unittest.mock.patch.object(
+        server.api.crud.RuntimeResources, "delete_runtime_resources"
+    ):
+        # abort once
+        response = client.post(
+            f"projects/{project}/runs/{run_in_progress_uid}/abort", json={}
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED.value
+        background_task_1 = mlrun.common.schemas.BackgroundTask(**response.json())
+        background_task_1 = server.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task(
+            db, background_task_1.metadata.name, project
+        )
+        assert (
+            background_task_1.status.state
+            == mlrun.common.schemas.BackgroundTaskState.succeeded
+        )
+        run = server.api.crud.Runs().get_run(db, run_in_progress_uid, 0, project)
+        assert run["status"]["state"] == mlrun.runtimes.constants.RunStates.aborted
+        assert run["status"]["abort_task_id"] == background_task_1.metadata.name
+
+        # abort again should create a new failed background task
+        response = client.post(
+            f"projects/{project}/runs/{run_in_progress_uid}/abort", json={}
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED.value
+        background_task_2 = mlrun.common.schemas.BackgroundTask(**response.json())
+        background_task_2 = server.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task(
+            db, background_task_2.metadata.name, project
+        )
+        assert (
+            background_task_2.status.state
+            == mlrun.common.schemas.BackgroundTaskState.failed
+        )
+        assert background_task_2.metadata.name != background_task_1.metadata.name
+        assert (
+            background_task_2.status.error
+            == "Run is already in terminal state, can not be aborted"
+        )
+
+
+def test_abort_run_background_task_not_found(db: Session, client: TestClient) -> None:
+    project = "some-project"
+    run_in_progress = {
+        "metadata": {
+            "name": "run-name-1",
+            "labels": {"kind": mlrun.runtimes.RuntimeKinds.job},
+        },
+        "status": {
+            "state": mlrun.runtimes.constants.RunStates.aborting,
+            # add a background task id that doesn't exist
+            "abort_task_id": "background-task-name",
+        },
+    }
+    run_in_progress_uid = "in-progress-uid"
+    server.api.crud.Runs().store_run(
+        db, run_in_progress, run_in_progress_uid, project=project
+    )
+
+    with unittest.mock.patch.object(
+        server.api.crud.RuntimeResources, "delete_runtime_resources"
+    ):
+        response = client.post(
+            f"projects/{project}/runs/{run_in_progress_uid}/abort", json={}
+        )
+        assert response.status_code == HTTPStatus.ACCEPTED.value
+        background_task_1 = mlrun.common.schemas.BackgroundTask(**response.json())
+        background_task_1 = server.api.utils.background_tasks.ProjectBackgroundTasksHandler().get_background_task(
+            db, background_task_1.metadata.name, project
+        )
+        assert (
+            background_task_1.status.state
+            == mlrun.common.schemas.BackgroundTaskState.succeeded
+        )
+        run = server.api.crud.Runs().get_run(db, run_in_progress_uid, 0, project)
+        assert run["status"]["state"] == mlrun.runtimes.constants.RunStates.aborted
+        assert run["status"]["abort_task_id"] == background_task_1.metadata.name
 
 
 def _store_run(db, uid, project="some-project"):


### PR DESCRIPTION
Add the background task id of the abortion to the run status.
When aborting again, check with the ID if there is a task already running.
Do a best effort to determine if it is running or just finished, return it.
Otherwise, create. new task.
https://jira.iguazeng.com/browse/ML-5279