### PR TITLE
[Runtimes] Databricks output as logs

### DIFF
--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -208,4 +208,4 @@ def run_mlrun_databricks_job(
     logger.info(f"logs:\n{run_output.logs}")
     run_output_dict = run_output.as_dict()
     run_output_dict.pop('logs', None)
-    logger.info(f"Run output and metadata:\n{run_output_dict}")
+    logger.info(f"Run output and metadata:\n{run_output_dict}\n")

--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -207,5 +207,5 @@ def run_mlrun_databricks_job(
     logger.info(f"job finished: {run.run_page_url}")
     logger.info(f"logs:\n{run_output.logs}")
     run_output_dict = run_output.as_dict()
-    run_output_dict.pop('logs', None)
+    run_output_dict.pop("logs", None)
     logger.info(f"Run output and metadata:\n{run_output_dict}\n")

--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -206,3 +206,6 @@ def run_mlrun_databricks_job(
 
     logger.info(f"job finished: {run.run_page_url}")
     logger.info(f"logs:\n{run_output.logs}")
+    run_output_dict = run_output.as_dict()
+    run_output_dict.pop('logs', None)
+    logger.info(f"Run output and metadata:\n{run_output_dict}")

--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -204,6 +204,7 @@ def run_mlrun_databricks_job(
         workspace.dbfs.delete(script_path_on_dbfs)
         workspace.dbfs.delete(artifact_json_path)
 
+    #  This code will not run in the case of an exception, within the outer try-finally block:
     logger.info(f"job finished: {run.run_page_url}")
     logger.info(f"logs:\n{run_output.logs}")
     run_output_dict = run_output.as_dict()

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -140,7 +140,6 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
         #  Should be inside the metadata:
         assert "run_id" in logs
 
-
     def _add_databricks_env(self, function, is_cluster_id_required=True):
         cluster_id = os.environ.get("DATABRICKS_CLUSTER_ID", None)
         if not cluster_id and is_cluster_id_required:

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -137,6 +137,9 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
         assert print_kwargs_run.status.state == "completed"
         logs = cls._run_db.get_log(uid=print_kwargs_run.uid())[1].decode()
         assert "{'param1': 'value1', 'param2': 'value2'}\n" in logs
+        #  Should be inside the metadata:
+        assert "run_id" in logs
+
 
     def _add_databricks_env(self, function, is_cluster_id_required=True):
         cluster_id = os.environ.get("DATABRICKS_CLUSTER_ID", None)


### PR DESCRIPTION
Add databricks output to logs....
Including non-logs info - such as metadata.

[ML-5310](https://jira.iguazeng.com/browse/ML-5310)