### PR TITLE
[Model Monitoring] Update the number of application stream shards to 1

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -457,7 +457,7 @@ default_config = {
     },
     "model_endpoint_monitoring": {
         "serving_stream_args": {"shard_count": 1, "retention_period_hours": 24},
-        "application_stream_args": {"shard_count": 3, "retention_period_hours": 24},
+        "application_stream_args": {"shard_count": 1, "retention_period_hours": 24},
         "drift_thresholds": {"default": {"possible_drift": 0.5, "drift_detected": 0.7}},
         # Store prefixes are used to handle model monitoring storing policies based on project and kind, such as events,
         # stream, and endpoints.


### PR DESCRIPTION
Avoid flooding the logs with uninformative "shard not found" debug messages.
Fixes the MLRun part of [ML-5325](https://jira.iguazeng.com/browse/ML-5325).

There are still "garbage" logs before the first record to the stream, which should be treated in Nuclio ([NUC-113](https://jira.iguazeng.com/browse/NUC-113)).