### PR TITLE
[Artifacts] Check existing artifact with uid when storing artifact

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -490,11 +490,6 @@ class SQLDB(DBInterface):
 
         original_uid = uid
 
-        # record with the given tag/uid
-        existing_artifact = self._get_existing_artifact(
-            session, project, key, uid, producer_id=producer_id, iteration=iter
-        )
-
         if isinstance(artifact, dict):
             artifact_dict = artifact
         else:
@@ -517,6 +512,11 @@ class SQLDB(DBInterface):
         # for easier querying, we mark artifacts without iteration as best iteration
         if not best_iteration and (iter is None or iter == 0):
             best_iteration = True
+
+        # try to get an existing artifact with the same calculated uid
+        existing_artifact = self._get_existing_artifact(
+            session, project, key, uid, producer_id=producer_id, iteration=iter
+        )
 
         # if the object is not new, we need to check if we need to update it or create a new one
         if existing_artifact:
@@ -950,6 +950,8 @@ class SQLDB(DBInterface):
             artifacts_to_commit.append(previous_best_iteration_artifacts)
 
         self._upsert(session, artifacts_to_commit)
+
+        return artifact_record.uid
 
     def _update_artifact_record_from_dict(
         self,

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -301,11 +301,11 @@ class TestMLRunSystem:
     ):
         self._logger.debug("Verifying run outputs", spec=run_outputs)
         assert run_outputs["plotly"].startswith(str(output_path))
-        assert run_outputs["mydf"] == f"store://artifacts/{project}/{name}_mydf:{uid}"
-        assert run_outputs["model"] == f"store://artifacts/{project}/{name}_model:{uid}"
+        assert run_outputs["mydf"] == f"store://artifacts/{project}/{name}_mydf@{uid}"
+        assert run_outputs["model"] == f"store://artifacts/{project}/{name}_model@{uid}"
         assert (
             run_outputs["html_result"]
-            == f"store://artifacts/{project}/{name}_html_result:{uid}"
+            == f"store://artifacts/{project}/{name}_html_result@{uid}"
         )
         if accuracy:
             assert run_outputs["accuracy"] == accuracy


### PR DESCRIPTION
When storing a new artifact, we first tried to get an existing artifact with the same project, key, producer_id, etc.

However, this was too broad. 
When we update artifact specs, we basically just create a new artifact with the same metadata but a different spec. 
When calculating the artifact's `uid`, we get a new `uid` - so it does become a new artifact, but when getting an existing artifact, we search for `one_or_none` - but get multiple artifacts.

In this PR I moved the check for an existing artifact to after the `uid` calculation, so the query for the existing artifact will include it and will be more specific.

In addition, I fixed the issue for marking best iteration artifacts so it will return the best iteration artifact's uid, just like `store_artifacts` returns the artifact's uid.

Finally, some minor fixes in the system tests to adjust to the new artifacts' URI.

Resolves https://jira.iguazeng.com/browse/ML-5336