### PR TITLE
[Artifacts] Fix migrating artifacts without iteration

### DIFF
--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -577,14 +577,13 @@ def _migrate_artifacts_batch(
 
         # iteration - the artifact's iteration
         iteration = artifact_metadata.get("iter", None)
-        if iteration is not None:
-            new_artifact.iteration = int(iteration)
+        new_artifact.iteration = int(iteration) if iteration else 0
 
         # best iteration
         # if iteration == 0 it means it is from a single run since link artifacts were already
         # handled above - so we can set is as best iteration.
         # otherwise set to false, the best iteration artifact will be updated later
-        if iteration is not None and iteration == 0:
+        if new_artifact.iteration == 0:
             new_artifact.best_iteration = True
         else:
             new_artifact.best_iteration = False


### PR DESCRIPTION
Before the refactor, artifacts that weren't created as part of a hyper param run did not have an `iter` field.
When we migrate the artifacts to the new V2 table, we set the `iteration` and `best_iteration` fields on the record itself.

Previously we ignored these fields if the artifact didn't have an `iter` field in its metadata, but then these artifacts weren't returned when listing artifacts with `best_iteration=True` (which is the default UI behavior).

Now, if artifacts do not have an `iter` field, we set `iteration = 0` and `best_iteration = True`, so they are returned properly as before.

Resolves https://jira.iguazeng.com/browse/ML-5337