### PR TITLE
[Docs] Fix `store_artifact` docstring in httpdb

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -795,7 +795,7 @@ class HTTPRunDB(RunDBInterface):
         """Store an artifact in the DB.
 
         :param key: Identifying key of the artifact.
-        :param artifact: The actual artifact to store.
+        :param artifact: The :py:class:`~mlrun.artifacts.Artifact` to store.
         :param uid: A unique ID for this specific version of the artifact
                     (deprecated, artifact uid is generated in the backend use `tree` instead)
         :param iter: The task iteration which generated this artifact. If ``iter`` is not ``None`` the iteration will


### PR DESCRIPTION
Be more explicit in the docstring as to what is the structure of the artifact to pass to `store_artifact`.

Resolves https://jira.iguazeng.com/browse/ML-5357 