### PR TITLE
[Artifacts] Header length information for datasets must be stored as a status property

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -153,12 +153,13 @@ class ArtifactSpec(ModelObj):
 
 
 class ArtifactStatus(ModelObj):
-    _dict_fields = ["state", "stats", "preview"]
+    _dict_fields = ["state", "stats", "preview", "header_original_length"]
 
     def __init__(self):
         self.state = "created"
         self.stats = None
         self.preview = None
+        self.header_original_length = None
 
     def base_dict(self):
         return super().to_dict()

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -106,7 +106,6 @@ class DatasetArtifactSpec(ArtifactSpec):
     _dict_fields = ArtifactSpec._dict_fields + [
         "schema",
         "header",
-        "header_original_length",
         "length",
         "column_metadata",
         "features",
@@ -119,7 +118,6 @@ class DatasetArtifactSpec(ArtifactSpec):
         super().__init__()
         self.schema = None
         self.header = None
-        self.header_original_length = None
         self.length = None
         self.column_metadata = None
         self.features = None
@@ -273,7 +271,7 @@ class DatasetArtifact(Artifact):
         # reset index while dropping existing index
         # that way it wont create another index if one already there
         preview_df = preview_df.reset_index(drop=True)
-        artifact.spec.header_original_length = len(preview_df.columns)
+        artifact.status.header_original_length = len(preview_df.columns)
         if len(preview_df.columns) > max_preview_columns and not ignore_preview_limits:
             preview_df = preview_df.iloc[:, :max_preview_columns]
         artifact.spec.header = preview_df.columns.values.tolist()

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -219,6 +219,22 @@ def test_get_log_dataset_dont_duplicate_index_column():
     assert index_counter == 1
 
 
+def test_log_dataset_with_column_overflow(monkeypatch):
+    context = mlrun.get_or_create_ctx("test")
+    source_url = mlrun.get_sample_path("data/iris/iris.data.raw.csv")
+    df = mlrun.get_dataitem(source_url).as_df()
+
+    monkeypatch.setattr(mlrun.artifacts.dataset, "max_preview_columns", 10)
+    artifact = context.log_dataset("iris", df=df, upload=False)
+    assert len(artifact.spec.header) == 5
+    assert artifact.status.header_original_length == 5
+
+    monkeypatch.setattr(mlrun.artifacts.dataset, "max_preview_columns", 2)
+    artifact = context.log_dataset("iris", df=df, upload=False)
+    assert len(artifact.spec.header) == 2
+    assert artifact.status.header_original_length == 5
+
+
 def test_dataset_preview_size_limit_from_large_dask_dataframe(monkeypatch):
     """
     To simplify testing the behavior of a large Dask DataFrame as a mlrun


### PR DESCRIPTION
[ML-4922](https://jira.iguazeng.com/browse/ML-4922)

This PR is a follow-up to https://github.com/mlrun/mlrun/pull/4779, and it changes the `header_original_length` field to be part of `ArtifactStatus` instead of `DatasetArtifactSpec`.