### PR TITLE
[Model Monitoring] Update the "last_request" field for each request

### DIFF
--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -16,7 +16,7 @@ import math
 import re
 import uuid
 from collections import OrderedDict
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -633,11 +633,11 @@ class SetEventMetadata(MapClass):
 
     def __init__(
         self,
-        id_path: str = None,
-        key_path: str = None,
-        random_id: bool = None,
+        id_path: Optional[str] = None,
+        key_path: Optional[str] = None,
+        random_id: Optional[bool] = None,
         **kwargs,
-    ):
+    ) -> None:
         """Set the event metadata (id, key) from the event body
 
         set the event metadata fields (id and key) from the event body data structure

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import collections
 import datetime
 import json

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -278,7 +278,7 @@ class EventStreamProcessor:
             graph.add_step(
                 "ProcessBeforeEndpointUpdate",
                 name="ProcessBeforeEndpointUpdate",
-                after="sample",
+                after="Rename",
             )
 
         apply_process_before_endpoint_update()

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import pathlib
 import typing
 

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -417,12 +417,16 @@ class MonitoringDeployment:
         )
 
         # Create a new serving function for the streaming process
-        function = mlrun.code_to_function(
-            name="model-monitoring-stream",
-            project=project,
-            filename=str(_STREAM_PROCESSING_FUNCTION_PATH),
-            kind="serving",
-            image=tracking_policy.stream_image,
+        function = typing.cast(
+            mlrun.runtimes.ServingRuntime,
+            mlrun.code_to_function(
+                name="model-monitoring-stream",
+                project=project,
+                filename=str(_STREAM_PROCESSING_FUNCTION_PATH),
+                kind=mlrun.run.RuntimeKinds.serving,
+                image=tracking_policy.stream_image,
+                handler="handler",
+            ),
         )
 
         # Create monitoring serving graph

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -425,7 +425,6 @@ class MonitoringDeployment:
                 filename=str(_STREAM_PROCESSING_FUNCTION_PATH),
                 kind=mlrun.run.RuntimeKinds.serving,
                 image=tracking_policy.stream_image,
-                handler="handler",
             ),
         )
 

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -18,7 +18,6 @@ import typing
 import sqlalchemy.orm
 from fastapi import Depends
 
-import mlrun.common.schemas.model_monitoring
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.model_monitoring.stream_processing
 import mlrun.model_monitoring.tracking_policy
@@ -543,7 +542,7 @@ class MonitoringDeployment:
         )
 
         task.spec.parameters[
-            mlrun.common.schemas.model_monitoring.EventFieldType.BATCH_INTERVALS_DICT
+            mm_constants.EventFieldType.BATCH_INTERVALS_DICT
         ] = batch_dict
 
         data = {
@@ -700,13 +699,13 @@ class MonitoringDeployment:
         if function_name in mm_constants.MonitoringFunctionNames.all():
             # Set model monitoring access key for managing permissions
             function.set_env_from_secret(
-                mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+                mm_constants.ProjectSecretKeys.ACCESS_KEY,
                 server.api.utils.singletons.k8s.get_k8s_helper().get_project_secret_name(
                     project
                 ),
                 server.api.crud.secrets.Secrets().generate_client_project_secret_key(
                     server.api.crud.secrets.SecretsClientType.model_monitoring,
-                    mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+                    mm_constants.ProjectSecretKeys.ACCESS_KEY,
                 ),
             )
 


### PR DESCRIPTION
Fixes [ML-5335](https://jira.iguazeng.com/browse/ML-5335) and [ML-5347](https://jira.iguazeng.com/browse/ML-5347).
The source of these issues is that the "last_request" field of the model endpoint is not updated for every request. This behavior stems from the sample step in the monitoring stream graph.
The solution introduced in this PR is to move the "update endpoint" branch after the "rename" step.
It guarantees a reliable "last_request" field, independent of the cadence of events.

The main change is 319f759, the other commits are mostly style and typing.

The graph before the change:
![ml-5335-before](https://github.com/mlrun/mlrun/assets/36337649/04c0131f-bfa8-43c6-8dc2-5b9a27853dd8)

After:
![ml-5335-after](https://github.com/mlrun/mlrun/assets/36337649/8368cd36-d7cc-4363-a9f7-5a6911aab4c7)