### PR TITLE
[Model Monitoring] Upgrade evidently and specify the supported version

### DIFF
--- a/mlrun/model_monitoring/evidently_application.py
+++ b/mlrun/model_monitoring/evidently_application.py
@@ -21,7 +21,7 @@ import semver
 
 from mlrun.model_monitoring.application import ModelMonitoringApplication
 
-SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.7")
+SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.12")
 
 _HAS_EVIDENTLY = False
 try:
@@ -42,7 +42,8 @@ if _HAS_EVIDENTLY:
     from evidently.renderers.notebook_utils import determine_template
     from evidently.report.report import Report
     from evidently.suite.base_suite import Suite
-    from evidently.ui.workspace import STR_UUID, Workspace
+    from evidently.ui.type_aliases import STR_UUID
+    from evidently.ui.workspace import Workspace
     from evidently.utils.dashboard import TemplateParams
 
 

--- a/mlrun/model_monitoring/evidently_application.py
+++ b/mlrun/model_monitoring/evidently_application.py
@@ -13,16 +13,26 @@
 # limitations under the License.
 
 import uuid
+import warnings
 from typing import Union
 
 import pandas as pd
+import semver
 
 from mlrun.model_monitoring.application import ModelMonitoringApplication
+
+SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.7")
 
 _HAS_EVIDENTLY = False
 try:
     import evidently  # noqa: F401
 
+    if evidently.__version__ != SUPPORTED_EVIDENTLY_VERSION:
+        warnings.warn(
+            f"Evidently version {evidently.__version__} is not tested, use at "
+            "your own risk. The Supported evidently version is "
+            f"{SUPPORTED_EVIDENTLY_VERSION}."
+        )
     _HAS_EVIDENTLY = True
 except ModuleNotFoundError:
     pass

--- a/mlrun/model_monitoring/evidently_application.py
+++ b/mlrun/model_monitoring/evidently_application.py
@@ -21,7 +21,7 @@ import semver
 
 from mlrun.model_monitoring.application import ModelMonitoringApplication
 
-SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.12")
+SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.11")
 
 _HAS_EVIDENTLY = False
 try:

--- a/tests/model_monitoring/test_evidently_base.py
+++ b/tests/model_monitoring/test_evidently_base.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+import semver
+
+from mlrun.errors import MLRunIncompatibleVersionError
+from mlrun.model_monitoring.evidently_application import _check_evidently_version
+
+
+@pytest.mark.parametrize(
+    ("cur", "ref", "expectation"),
+    [
+        ("0.4.11", "0.4.11", does_not_raise()),
+        ("0.4.12", "0.4.11", does_not_raise()),
+        ("1.23.0", "1.1.32", does_not_raise()),
+        ("0.4.11", "0.4.12", pytest.raises(MLRunIncompatibleVersionError)),
+        ("0.4.11", "0.4.12", pytest.raises(MLRunIncompatibleVersionError)),
+        ("1.0.3", "0.9.9", pytest.raises(MLRunIncompatibleVersionError)),
+        ("0.6.0", "0.3.0", pytest.warns(UserWarning)),
+        pytest.param("0.6.0", "0.3.0", does_not_raise(), marks=pytest.mark.xfail),
+    ],
+)
+def test_version_check(
+    cur: str,
+    ref: str,
+    expectation: AbstractContextManager,
+) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with expectation:
+            _check_evidently_version(
+                cur=semver.Version.parse(cur), ref=semver.Version.parse(ref)
+            )

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -34,6 +34,7 @@ import mlrun.feature_store
 import mlrun.model_monitoring.api
 from mlrun.model_monitoring import TrackingPolicy
 from mlrun.model_monitoring.application import ModelMonitoringApplication
+from mlrun.model_monitoring.evidently_application import SUPPORTED_EVIDENTLY_VERSION
 from mlrun.model_monitoring.writer import _TSDB_BE, _TSDB_TABLE, ModelMonitoringWriter
 from mlrun.utils.logger import Logger
 from tests.system.base import TestMLRunSystem
@@ -136,7 +137,7 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
             _AppData(
                 class_=CustomEvidentlyMonitoringApp,
                 rel_path="assets/custom_evidently_app.py",
-                requirements=["evidently==0.4.7"],
+                requirements=[f"evidently=={SUPPORTED_EVIDENTLY_VERSION}"],
                 kwargs={
                     "evidently_workspace_path": cls.evidently_workspace_path,
                     "evidently_project_id": cls.evidently_project_id,


### PR DESCRIPTION
Resolves [ML-5374](https://jira.iguazeng.com/browse/ML-5374), [ML-5345](https://jira.iguazeng.com/browse/ML-5345).

- Since evidently broke the interface between patches, raise a warning when the current version is not "compatible".
- Upgrade to version [0.4.11](https://github.com/evidentlyai/evidently/releases/tag/v0.4.11).