### PR TITLE
[Project] Return clear error messages when set_source triggers unresolvable function dependencies

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1109,8 +1109,14 @@ class MlrunProject(ModelObj):
                 )
 
         self.spec.workdir = workdir or self.spec.workdir
-        # reset function objects (to recalculate build attributes)
-        self.sync_functions()
+        try:
+            # reset function objects (to recalculate build attributes)
+            self.sync_functions()
+        except mlrun.errors.MLRunMissingDependencyError as exc:
+            logger.error(
+                "Failed to resolve all dependencies specified by the new project source. Aborting"
+            )
+            raise exc
 
     def get_artifact_uri(
         self, key: str, category: str = "artifact", tag: str = None, iter: int = None
@@ -2386,7 +2392,12 @@ class MlrunProject(ModelObj):
             else:
                 if not isinstance(f, dict):
                     raise ValueError("function must be an object or dict")
-                name, func = _init_function_from_dict(f, self, name)
+                try:
+                    name, func = _init_function_from_dict(f, self, name)
+                except FileNotFoundError as exc:
+                    raise mlrun.errors.MLRunMissingDependencyError(
+                        f"File {exc.filename} not found while syncing project functions"
+                    ) from exc
             func.spec.build.code_origin = origin
             funcs[name] = func
             if save:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1114,7 +1114,8 @@ class MlrunProject(ModelObj):
             self.sync_functions()
         except mlrun.errors.MLRunMissingDependencyError as exc:
             logger.error(
-                "Failed to resolve all dependencies specified by the new project source. Aborting"
+                "Failed to resolve all function related dependencies "
+                "while working with the new project source. Aborting"
             )
             raise exc
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -86,6 +86,20 @@ def test_sync_functions_with_names_different_than_default(rundb_mock):
     assert project.spec._function_definitions == project_function_definition
 
 
+def test_sync_functions_unavailable_file():
+    project_name = "project-name"
+    project = mlrun.new_project(project_name, save=False)
+    project.spec._function_definitions["non-existing-function"] = {
+        "handler": "func",
+        "image": "mlrun/mlrun",
+        "kind": "job",
+        "name": "func",
+        "url": "func.py",
+    }
+    with pytest.raises(mlrun.errors.MLRunMissingDependencyError):
+        project.sync_functions()
+
+
 def test_export_project_dir_doesnt_exist():
     project_name = "project-name"
     project_file_path = (


### PR DESCRIPTION
[ML-5047](https://jira.iguazeng.com/browse/ML-5047)

Both sync_functions and set_source must return more explicit error messages to help the user debug synchronization issues.

Here's an example of what the output can look like:
```
[error] Failed to resolve all function related dependencies while working with the new project source. Aborting
Traceback (most recent call last):
  File "/Users/laury/dev/iguazio/misc_workspace/mlrun/mlrun/projects/project.py", line 2397, in sync_functions
    name, func = _init_function_from_dict(f, self, name)
  File "/Users/laury/dev/iguazio/misc_workspace/mlrun/mlrun/projects/project.py", line 3570, in _init_function_from_dict
    func = code_to_function(
  File "/Users/laury/dev/iguazio/misc_workspace/mlrun/mlrun/run.py", line 745, in code_to_function
    name, spec, code = nuclio.build_file(
  File "/Users/laury/anaconda3/envs/mlrun/lib/python3.9/site-packages/nuclio/build.py", line 68, in build_file
    code = url2repo(filename).get()
  File "/Users/laury/anaconda3/envs/mlrun/lib/python3.9/site-packages/nuclio/archive.py", line 165, in get
    with open(self.path, 'r') as fp:
FileNotFoundError: [Errno 2] No such file or directory: 'data-prep.py'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/laury/dev/iguazio/misc_workspace/mlrun/mlrun/projects/project.py", line 1120, in set_source
    raise exc
  File "/Users/laury/dev/iguazio/misc_workspace/mlrun/mlrun/projects/project.py", line 1114, in set_source
    self.sync_functions()
  File "/Users/laury/dev/iguazio/misc_workspace/mlrun/mlrun/projects/project.py", line 2399, in sync_functions
    raise mlrun.errors.MLRunMissingDependencyError(
mlrun.errors.MLRunMissingDependencyError: File data-prep.py not found while syncing project functions
```