### PR TITLE
[Utils] Skip 'derecated' when looking for caller function's namespace

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1177,7 +1177,9 @@ def get_caller_globals():
         # Otherwise, we keep going up the stack until we find it.
         for level in range(2, len(stack)):
             namespace = stack[level][0].f_globals
-            if not namespace["__name__"].startswith("mlrun."):
+            if (not namespace["__name__"].startswith("mlrun.")) and (
+                not namespace["__name__"].startswith("deprecated.")
+            ):
                 return namespace
     except Exception:
         return None


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-5343
In specific situations, such as when invoking the `init_featureset_graph()` function, we must determine the namespace from which the call originates in order to generate user-introduced objects within that namespace. Presently, we search for the first namespace that is not prefixed with 'mlrun.*'. However, in cases where a 'deprecated' decorator is used, an additional namespace appears before the primary one, labeled as 'deprecated.*'. We should also disregard this additional namespace.