### PR TITLE
[Project] Add `tree` argument to `get_artifact`

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3148,7 +3148,7 @@ class MlrunProject(ModelObj):
             mock=mock,
         )
 
-    def get_artifact(self, key, tag=None, iter=None):
+    def get_artifact(self, key, tag=None, iter=None, tree=None):
         """Return an artifact object
 
         :param key: artifact key
@@ -3157,7 +3157,9 @@ class MlrunProject(ModelObj):
         :return: Artifact object
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        artifact = db.read_artifact(key, tag, iter=iter, project=self.metadata.name)
+        artifact = db.read_artifact(
+            key, tag, iter=iter, project=self.metadata.name, tree=tree
+        )
         return dict_to_artifact(artifact)
 
     def list_artifacts(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3154,6 +3154,7 @@ class MlrunProject(ModelObj):
         :param key: artifact key
         :param tag: version tag
         :param iter: iteration number (for hyper-param tasks)
+        :param tree: the producer id (tree)
         :return: Artifact object
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -660,12 +660,18 @@ def dict_to_json(struct):
 
 
 def parse_artifact_uri(uri, default_project=""):
-    """parse artifact uri into project, key, tag, iter, tree
-    uri format: [<project>/]<key>[#<iter>][:<tag>][@<tree>]
+    """
+    Parse artifact URI into project, key, tag, iter, tree
+    URI format: [<project>/]<key>[#<iter>][:<tag>][@<tree>]
 
     :param uri:            uri to parse
-    :param default_project: default project name if not in uri
-    :returns: project, key, iter, tag, tree
+    :param default_project: default project name if not in URI
+    :returns: a tuple of:
+        [0] = project name
+        [1] = key
+        [2] = iteration
+        [3] = tag
+        [4] = tree
     """
     uri_pattern = r"^((?P<project>.*)/)?(?P<key>.*?)(\#(?P<iteration>.*?))?(:(?P<tag>.*?))?(@(?P<tree>.*))?$"
     match = re.match(uri_pattern, uri)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -660,11 +660,18 @@ def dict_to_json(struct):
 
 
 def parse_artifact_uri(uri, default_project=""):
-    uri_pattern = r"^((?P<project>.*)/)?(?P<key>.*?)(\#(?P<iteration>.*?))?(:(?P<tag>.*?))?(@(?P<uid>.*))?$"
+    """parse artifact uri into project, key, tag, iter, tree
+    uri format: [<project>/]<key>[#<iter>][:<tag>][@<tree>]
+
+    :param uri:            uri to parse
+    :param default_project: default project name if not in uri
+    :returns: project, key, iter, tag, tree
+    """
+    uri_pattern = r"^((?P<project>.*)/)?(?P<key>.*?)(\#(?P<iteration>.*?))?(:(?P<tag>.*?))?(@(?P<tree>.*))?$"
     match = re.match(uri_pattern, uri)
     if not match:
         raise ValueError(
-            "Uri not in supported format [<project>/]<key>[#<iteration>][:<tag>][@<uid>]"
+            "Uri not in supported format [<project>/]<key>[#<iteration>][:<tag>][@<tree>]"
         )
     group_dict = match.groupdict()
     iteration = group_dict["iteration"]
@@ -680,7 +687,7 @@ def parse_artifact_uri(uri, default_project=""):
         group_dict["key"],
         iteration,
         group_dict["tag"],
-        group_dict["uid"],
+        group_dict["tree"],
     )
 
 

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -463,7 +463,7 @@ def _migrate_artifacts_table_v2(
     ).count()
 
     if total_artifacts_count == 0:
-        # no artifacts to migrate
+        logger.info("No v1 artifacts in the system, skipping migration")
         return
 
     logger.info(


### PR DESCRIPTION
Add an optional argument to get an artifact with a specific `tree` (`producer_id`).

Additionally, improve the naming and docstring of `mlrun.utils.parse_artifact_uri` for better usability.

Related to https://jira.iguazeng.com/browse/ML-4974