### PR TITLE
[Artifacts] Fix iteration in uid calculation during migration

### DIFF
--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -590,7 +590,7 @@ def _migrate_artifacts_batch(
 
         # uid - calculate as the hash of the artifact object
         uid = fill_artifact_object_hash(
-            artifact_dict, iteration, new_artifact.producer_id
+            artifact_dict, new_artifact.iteration, new_artifact.producer_id
         )
         new_artifact.uid = uid
 


### PR DESCRIPTION
Take the resolved iteration, in case the `iter` value wasn't present in the artifacts metadata and was set to `None`.