### PR TITLE
[API] Skip monitoring when CRD state is not populated

### DIFF
--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1007,12 +1007,7 @@ class BaseRuntimeHandler(ABC):
                         desired_run_state,
                     ) = self._resolve_crd_object_status_info(crd_object)
 
-                    if not desired_run_state:
-                        if force:
-                            raise mlrun.errors.MLRunPreconditionFailedError(
-                                "Could not resolve run state from CRD object"
-                            )
-
+                    if not desired_run_state and not force:
                         logger.warning(
                             "Could not resolve run state from CRD object. Skipping deletion",
                             crd_object_name=crd_object["metadata"]["name"],
@@ -1543,8 +1538,8 @@ class BaseRuntimeHandler(ABC):
         )
         db_run_state = run.get("status", {}).get("state")
         if db_run_state:
-            if db_run_state == run_state:
-                return False, run_state, run
+            if not run_state or db_run_state == run_state:
+                return False, db_run_state, run
 
             if db_run_state == RunStates.aborting:
                 logger.debug(

--- a/server/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/api/runtime_handlers/sparkjob/spark3job.py
@@ -434,6 +434,8 @@ with ctx:
         self, crd_object: dict
     ) -> Tuple[bool, Optional[datetime], Optional[str]]:
         state = crd_object.get("status", {}).get("applicationState", {}).get("state")
+        if not state:
+            return False, None, None
         in_terminal_state = state in SparkApplicationStates.terminal_states()
         desired_run_state = SparkApplicationStates.spark_application_state_to_run_state(
             state

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import copy
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -483,6 +484,60 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         assert stale_runs[0]["run_updates"] == {
             "status.error": f"Run aborted due to exceeded state threshold: {threshold_state}",
         }
+
+    @pytest.mark.parametrize(
+        "force",
+        (
+            True,
+            False,
+        ),
+    )
+    def test_delete_resources_stateless_crd(
+        self, db: Session, client: TestClient, force
+    ):
+        stateless_crd = copy.deepcopy(self.completed_crd_dict)
+        stateless_crd["status"]["applicationState"]["state"] = None
+        list_namespaced_crds_calls = [
+            [stateless_crd],
+        ]
+
+        list_namespaced_pods_calls = []
+        if force:
+            # additional time for wait for pods deletion
+            list_namespaced_crds_calls.append([self.completed_crd_dict])
+            list_namespaced_pods_calls = [
+                # for the get_logger_pods with proper selector
+                [self.driver_pod],
+                # additional time for wait for pods deletion - simulate pods gone
+                [],
+            ]
+            self._mock_list_namespaced_pods(list_namespaced_pods_calls)
+
+        self._mock_list_namespaced_crds(list_namespaced_crds_calls)
+        self._mock_list_namespaced_config_map([self.config_map])
+        self._mock_delete_namespaced_custom_objects()
+        self.runtime_handler.delete_resources(get_db(), db, force=force)
+
+        # deletion was skipped
+        self._assert_delete_namespaced_custom_objects(
+            self.runtime_handler,
+            [] if not force else [stateless_crd["metadata"]["name"]],
+            [] if not force else stateless_crd["metadata"]["namespace"],
+        )
+        self._assert_list_namespaced_crds_calls(
+            self.runtime_handler,
+            len(list_namespaced_crds_calls),
+        )
+
+        if force:
+            self._assert_list_namespaced_pods_calls(
+                self.runtime_handler,
+                len(list_namespaced_pods_calls),
+                self.pod_label_selector,
+            )
+        self._assert_run_reached_state(
+            db, self.project, self.run_uid, RunStates.created
+        )
 
     def _generate_get_logger_pods_label_selector(self, runtime_handler):
         logger_pods_label_selector = super()._generate_get_logger_pods_label_selector(


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-5014
Notes on the solution:

- If the crd has no state and we are in monitoring we skip the specific run.
- if the crd has no state and we are in delete resource flow we force deletion but don't update the run state.