### PR TITLE
[Model Monitoring] Fix the e2e sys test wait time

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -345,6 +345,6 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
             executor.submit(self._deploy_monitoring_infra)
             executor.submit(self._record_results)
 
-        time.sleep(1.2 * self.app_interval_seconds)
+        time.sleep(1.4 * self.app_interval_seconds)
 
         self._test_v3io_records(self.endpoint_id)


### PR DESCRIPTION
In some edge cases, it might take longer for the controller -> app -> writer to complete.