### PR TITLE
[Doc] Add `KubeResource` to docs and fix some malformed doctrings

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -499,6 +499,7 @@ class HTTPRunDB(RunDBInterface):
             - state - The state of the runtime object which generates this log, if it exists. In case no known state
               exists, this will be ``unknown``.
             - content - The actual log content.
+
             * in case size = -1, return the state and the final offset
         """
         if size is None:
@@ -2995,14 +2996,15 @@ class HTTPRunDB(RunDBInterface):
         While the main goal of the controller job is to handle the monitoring processing and triggering applications,
         the goal of the model monitoring writer function is to write all the monitoring application results to the
         databases. Note that the default scheduling policy of the controller job is to run every 10 min.
+
         :param project:                  Project name.
         :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
                                          function, which is a real time nuclio functino, will be deployed with the same
                                          image. By default, the image is mlrun/mlrun.
         :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
                                          is running. By default, the base period is 5 minutes.
-        :return: model monitoring controller job as a dictionary. You can easily convert the resulted function into a
-                 runtime object by calling ~mlrun.new_function.
+        :returns: model monitoring controller job as a dictionary. You can easily convert the resulted function into a
+                  runtime object by calling ~mlrun.new_function.
         """
 
         params = {

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2972,7 +2972,7 @@ class HTTPRunDB(RunDBInterface):
         :param with_schedule:       If true, submit the model monitoring scheduled job as well.
 
 
-        :return: model monitoring batch job as a dictionary. You can easily convert the resulted function into a
+        :returns: model monitoring batch job as a dictionary. You can easily convert the returned function into a
                  runtime object by calling ~mlrun.new_function.
         """
 
@@ -3003,7 +3003,7 @@ class HTTPRunDB(RunDBInterface):
                                          image. By default, the image is mlrun/mlrun.
         :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
                                          is running. By default, the base period is 5 minutes.
-        :returns: model monitoring controller job as a dictionary. You can easily convert the resulted function into a
+        :returns: model monitoring controller job as a dictionary. You can easily convert the returned function into a
                   runtime object by calling ~mlrun.new_function.
         """
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -1037,9 +1037,10 @@ class FeatureSet(ModelObj):
     ) -> list[str]:
         """
         Checks whether a feature set can be merged to the right of this feature set.
+
         :param other_feature_set:   The feature set to be merged to the right of this feature set.
         :param relations:           The relations that were defined on this feature set.
-        :return:                    If the two feature sets can be merged, a list of the left join keys is returned.
+        :returns:                   If the two feature sets can be merged, a list of the left join keys is returned.
                                     Otherwise, an empty list is returned.
                                     (The right join keys are always the entities of the other feature set)
         """

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1947,13 +1947,14 @@ class MlrunProject(ModelObj):
         While the main goal of the controller job is to handle the monitoring processing and triggering applications,
         the goal of the model monitoring writer function is to write all the monitoring application results to the
         databases. Note that the default scheduling policy of the controller job is to run every 10 min.
+
         :param default_controller_image: The default image of the model monitoring controller job. Note that the writer
                                          function, which is a real time nuclio functino, will be deployed with the same
                                          image. By default, the image is mlrun/mlrun.
         :param base_period:              The time period in minutes in which the model monitoring controller job
                                          runs. By default, the base period is 10 minutes. The schedule for the job
-                                         will be the following cron expression: "*/{base_period} * * * *".
-        :return: model monitoring controller job as a dictionary.
+                                         will be the following cron expression: "\*/{base_period} \* \* \* \*".
+        :returns: model monitoring controller job as a dictionary.
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
         return db.create_model_monitoring_controller(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1942,7 +1942,7 @@ class MlrunProject(ModelObj):
         default_controller_image: str = "mlrun/mlrun",
         base_period: int = 10,
     ) -> dict:
-        """
+        r"""
         Submit model monitoring application controller job along with deploying the model monitoring writer function.
         While the main goal of the controller job is to handle the monitoring processing and triggering applications,
         the goal of the model monitoring writer function is to write all the monitoring application results to the

--- a/mlrun/runtimes/__init__.py
+++ b/mlrun/runtimes/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "RemoteSparkRuntime",
     "Spark3Runtime",
     "DatabricksRuntime",
+    "KubeResource",
 ]
 
 from mlrun.runtimes.utils import resolve_spark_operator_version
@@ -34,7 +35,7 @@ from .constants import MPIJobCRDVersions
 from .daskjob import DaskCluster  # noqa
 from .databricks_job.databricks_runtime import DatabricksRuntime
 from .function import RemoteRuntime
-from .kubejob import KubejobRuntime  # noqa
+from .kubejob import KubejobRuntime, KubeResource  # noqa
 from .local import HandlerRuntime, LocalRuntime  # noqa
 from .mpijob import MpiRuntimeContainer, MpiRuntimeV1, MpiRuntimeV1Alpha1  # noqa
 from .nuclio import nuclio_init_hook

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -902,7 +902,7 @@ class AutoMountType(str, Enum):
 
 class KubeResource(BaseRuntime):
     """
-    A parent class for runtimes which generate k8s resources when executing.
+    A parent class for runtimes that generate k8s resources when executing.
     """
 
     kind = "job"

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -901,6 +901,9 @@ class AutoMountType(str, Enum):
 
 
 class KubeResource(BaseRuntime):
+    """
+    A parent class for runtimes which generate k8s resources when executing.
+    """
     kind = "job"
     _is_nested = True
 
@@ -1186,7 +1189,7 @@ class KubeResource(BaseRuntime):
         For Iguazio we handle security context internally -
         see mlrun.common.schemas.function.SecurityContextEnrichmentModes
 
-        Example:
+        Example::
 
             from kubernetes import client as k8s_client
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -904,6 +904,7 @@ class KubeResource(BaseRuntime):
     """
     A parent class for runtimes which generate k8s resources when executing.
     """
+
     kind = "job"
     _is_nested = True
 


### PR DESCRIPTION
The `KubeResource` class has documentation for several functions which are not documented elsewhere (for example `with_security_context`). Added this class to the documentation so that it's visible.
Also fixed some small docstring issues (mostly fixing `:return:` to `:returns:`).