### PR TITLE
[API] Force delete pods after grace period passed

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -194,6 +194,10 @@ class MLRunTimeoutError(MLRunHTTPStatusError, TimeoutError):
     error_status_code = HTTPStatus.GATEWAY_TIMEOUT.value
 
 
+class MLRunRetryExhaustedError(Exception):
+    pass
+
+
 class MLRunFatalFailureError(Exception):
     """
     Internal exception meant to be used inside mlrun.utils.helpers.retry_until_successful to signal the loop not to

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -186,6 +186,9 @@ class KubeResourceSpec(FunctionSpec):
             state_thresholds
             or mlrun.mlconf.function.spec.state_thresholds.default.to_dict()
         )
+        # Termination grace period is internal for runtimes that have a pod termination hook hence it is not in the
+        # _dict_fields and doesn't have a setter.
+        self._termination_grace_period_seconds = None
         self.__fields_pending_discard = {}
 
     @property
@@ -256,6 +259,10 @@ class KubeResourceSpec(FunctionSpec):
         self._security_context = transform_attribute_to_k8s_class_instance(
             "security_context", security_context
         )
+
+    @property
+    def termination_grace_period_seconds(self) -> typing.Optional[int]:
+        return self._termination_grace_period_seconds
 
     def to_dict(self, fields=None, exclude=None):
         exclude = exclude or []

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1117,7 +1117,7 @@ def retry_until_successful(
             f"Operation did not complete on time. last exception: {last_exception}"
         )
 
-    raise Exception(
+    raise mlrun.errors.MLRunRetryExhaustedError(
         f"Failed to execute command by the given deadline."
         f" last_exception: {last_exception},"
         f" function_name: {_function.__name__},"

--- a/server/api/runtime_handlers/kubejob.py
+++ b/server/api/runtime_handlers/kubejob.py
@@ -194,7 +194,6 @@ class KubeRuntimeHandler(BaseRuntimeHandler):
 class DatabricksRuntimeHandler(KubeRuntimeHandler):
     kind = "databricks"
     class_modes = {RuntimeClassMode.run: "databricks"}
-    pod_grace_period_seconds = 60
 
     @staticmethod
     def _get_lifecycle():

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -145,7 +145,7 @@ class K8sHelper(mlrun.common.secrets.SecretProviderInterface):
                 logger.info(f"Pod {resp.metadata.name} created")
                 return resp.metadata.name, resp.metadata.namespace
 
-    def delete_pod(self, name, namespace=None, grace_period_seconds=0):
+    def delete_pod(self, name, namespace=None, grace_period_seconds=None):
         try:
             api_response = self.v1api.delete_namespaced_pod(
                 name,
@@ -705,4 +705,5 @@ def kube_resource_spec_to_pod_spec(
         else None,
         tolerations=kube_resource_spec.tolerations,
         security_context=kube_resource_spec.security_context,
+        termination_grace_period_seconds=kube_resource_spec.termination_grace_period_seconds,
     )

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -399,7 +399,7 @@ class TestRuntimeHandlerBase:
             unittest.mock.call(
                 expected_pod_name,
                 expected_pod_namespace,
-                grace_period_seconds=0,
+                grace_period_seconds=None,
                 propagation_policy="Background",
             )
             for expected_pod_name in expected_pod_names


### PR DESCRIPTION
This was raised by databricks runtime as it uses a grace period of 60 seconds to lay off some time for the cancel task execution.
When testing state thresholds it was apparent that for states like pending scheduled and image pull backoff, the pod would hang on terminating forever, for these states, the cancel task is not needed therefore we can force deletion.

https://jira.iguazeng.com/browse/ML-5271