### PR TITLE
[API] Mark background task as failed when abort run fails

### DIFF
--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -384,6 +384,10 @@ class Runs(
                 "status.state": mlrun.runtimes.constants.RunStates.error,
                 "status.error": f"Failed to abort run, error: {err}",
             }
+            server.api.utils.singletons.db.get_db().update_run(
+                db_session, run_updates, uid, project, iter
+            )
+            raise exc
 
         server.api.utils.singletons.db.get_db().update_run(
             db_session, run_updates, uid, project, iter

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -234,8 +234,9 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
             server.api.crud.RuntimeResources(),
             "delete_runtime_resources",
             side_effect=mlrun.errors.MLRunInternalServerError("BOOM"),
-        ):
+        ), pytest.raises(mlrun.errors.MLRunInternalServerError) as exc:
             server.api.crud.Runs().abort_run(db, project, run_uid, 0)
+        assert "BOOM" == str(exc.value)
 
         run = server.api.crud.Runs().get_run(db, run_uid, 0, project)
         assert run["status"]["state"] == mlrun.runtimes.constants.RunStates.error


### PR DESCRIPTION
Raising an exception so that the background task will know it failed.
https://jira.iguazeng.com/browse/ML-5403