### PR TITLE
[Model Monitoring] Always add ±inf bins to histograms

### DIFF
--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import sys
 import typing
@@ -106,9 +105,20 @@ def _get_edges(hist: Histogram) -> BinEdges:
 
 
 def pad_hist(hist: Histogram) -> None:
-    """Add [-inf, x_0] and [x_n, inf] bins to the histogram inplace"""
+    """
+    Add [-inf, x_0] and [x_n, inf] bins to the histogram inplace unless present
+    """
     counts = _get_counts(hist)
     edges = _get_edges(hist)
+
+    def is_padded() -> bool:
+        factor = 1000
+        minus_inf = -_MAX_FLOAT / factor
+        plus_inf = _MAX_FLOAT / factor
+        return edges[0] <= minus_inf and edges[-1] >= plus_inf
+
+    if is_padded():
+        return
 
     counts.insert(0, 0)
     edges.insert(0, -_MAX_FLOAT)

--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -122,5 +122,7 @@ def pad_features_hist(feature_stats: FeatureStats) -> None:
     Given a feature statistics dictionary, pad the histograms with edges bins
     inplace to cover input statistics from -inf to inf.
     """
+    hist_key = "hist"
     for feature in feature_stats.values():
-        pad_hist(Histogram(feature["hist"]))
+        if hist_key in feature:
+            pad_hist(Histogram(feature[hist_key]))

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -765,6 +765,11 @@ class BatchProcessor:
                     mlrun.common.schemas.model_monitoring.EventFieldType.FEATURE_STATS
                 ]
             )
+            # Pad the original feature stats to accommodate current data out
+            # of the original range (unless already padded)
+            mlrun.common.model_monitoring.helpers.pad_features_hist(
+                mlrun.common.model_monitoring.helpers.FeatureStats(feature_stats)
+            )
 
             # Get the current stats:
             current_stats = calculate_inputs_statistics(

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -25,6 +25,7 @@ import mlrun
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.data_types.infer
 import mlrun.feature_store as fstore
+from mlrun.common.model_monitoring.helpers import FeatureStats, pad_features_hist
 from mlrun.datastore import get_stream_pusher
 from mlrun.datastore.targets import ParquetTarget
 from mlrun.model_monitoring.batch import calculate_inputs_statistics
@@ -451,6 +452,10 @@ class MonitoringApplicationController:
                     feature_stats = json.loads(
                         endpoint[mm_constants.EventFieldType.FEATURE_STATS]
                     )
+
+                    # Pad the original feature stats to accommodate current
+                    # data out of the original range (unless already padded)
+                    pad_features_hist(FeatureStats(feature_stats))
 
                     # Get the current stats:
                     current_stats = calculate_inputs_statistics(

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -26,6 +26,7 @@ from mlrun.common.model_monitoring.helpers import (
     FeatureStats,
     Histogram,
     pad_features_hist,
+    pad_hist,
 )
 from mlrun.common.schemas.model_monitoring.constants import EventFieldType
 from mlrun.db.nopdb import NopDB
@@ -54,6 +55,17 @@ def feature_stats() -> FeatureStats:
 
 
 @pytest.fixture
+def histogram() -> Histogram:
+    return Histogram([[0, 1], [1.1, 2.2, 3.3]])
+
+
+@pytest.fixture
+def padded_histogram(histogram: Histogram) -> Histogram:
+    pad_hist(histogram)
+    return histogram
+
+
+@pytest.fixture
 def orig_feature_stats_hist_data(feature_stats: FeatureStats) -> dict[str, _HistLen]:
     data: dict[str, _HistLen] = {}
     for feat_name, feat in feature_stats.items():
@@ -72,6 +84,21 @@ def _check_padded_hist_spec(hist: Histogram, orig_data: _HistLen) -> None:
     assert edges_len == orig_data.edges_len + 2
     assert counts[0] == counts[-1] == 0
     assert (-edges[0]) == edges[-1] == _MAX_FLOAT
+
+
+def test_pad_hist(histogram: Histogram) -> None:
+    orig_data = _HistLen(
+        counts_len=len(histogram[0]),
+        edges_len=len(histogram[1]),
+    )
+    pad_hist(histogram)
+    _check_padded_hist_spec(histogram, orig_data)
+
+
+def test_padded_hist_unchanged(padded_histogram: Histogram) -> None:
+    orig_hist = padded_histogram.copy()
+    pad_hist(padded_histogram)
+    assert padded_histogram == orig_hist, "A padded histogram should not be changed"
 
 
 def test_pad_features_hist(


### PR DESCRIPTION
Fixes [ML-5387](https://jira.iguazeng.com/browse/ML-5387).

In "batch infer" model endpoints, these bins might not be present, resulting in an inconsistent behavior between shared and unshared features (e.g., "target").
It is beneficial and required to add these bins, as some "live" data may fall under them.