### PR TITLE
[Artifacts] Fix timezone in created timestamp

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1306,12 +1306,12 @@ def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
     return time_obj.isoformat()
 
 
-def convert_to_datetime_with_timezone(value):
-    if not value or mlrun.utils.helpers.has_timezone(value):
-        return value
+def enrich_datetime_with_tz_info(timestamp_string):
+    if not timestamp_string or mlrun.utils.helpers.has_timezone(timestamp_string):
+        return timestamp_string
 
-    value += datetime.now(timezone.utc).astimezone().strftime("%z")
-    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f%z")
+    timestamp_string += datetime.now(timezone.utc).astimezone().strftime("%z")
+    return datetime.strptime(timestamp_string, "%Y-%m-%d %H:%M:%S.%f%z")
 
 
 def has_timezone(timestamp):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1306,6 +1306,24 @@ def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
     return time_obj.isoformat()
 
 
+def convert_to_datetime_with_timezone(value):
+    if not value or mlrun.utils.helpers.has_timezone(value):
+        return value
+
+    value += datetime.now(timezone.utc).astimezone().strftime("%z")
+    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f%z")
+
+
+def has_timezone(timestamp):
+    try:
+        dt = parser.parse(timestamp) if isinstance(timestamp, str) else timestamp
+
+        # Check if the parsed datetime object has timezone information
+        return dt.tzinfo is not None
+    except ValueError:
+        return False
+
+
 def as_list(element: Any) -> List[Any]:
     return element if isinstance(element, list) else [element]
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1307,10 +1307,12 @@ def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
 
 
 def enrich_datetime_with_tz_info(timestamp_string):
-    if not timestamp_string or mlrun.utils.helpers.has_timezone(timestamp_string):
+    if not timestamp_string:
         return timestamp_string
 
-    timestamp_string += datetime.now(timezone.utc).astimezone().strftime("%z")
+    if timestamp_string and not mlrun.utils.helpers.has_timezone(timestamp_string):
+        timestamp_string += datetime.now(timezone.utc).astimezone().strftime("%z")
+
     return datetime.strptime(timestamp_string, "%Y-%m-%d %H:%M:%S.%f%z")
 
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -972,13 +972,16 @@ class SQLDB(DBInterface):
         )
         updated_datetime = datetime.now(timezone.utc)
         artifact_record.updated = updated_datetime
-        if not artifact_record.created:
-            created = artifact_dict["metadata"].pop("created", None)
-            artifact_record.created = (
-                datetime.strptime(created, "%Y-%m-%d %H:%M:%S.%f%z")
-                if created
-                else datetime.now(timezone.utc)
-            )
+        created = (
+            str(artifact_record.created)
+            if artifact_record.created
+            else artifact_dict["metadata"].pop("created", None)
+        )
+        # make sure we have a datetime object with timezone both in the artifact record and in the artifact dict
+        created_datetime = mlrun.utils.convert_to_datetime_with_timezone(
+            created
+        ) or datetime.now(timezone.utc)
+        artifact_record.created = created_datetime
 
         # if iteration is not given, we assume it is a single iteration artifact, and thus we set the iteration to 0
         artifact_record.iteration = iter or 0
@@ -988,7 +991,7 @@ class SQLDB(DBInterface):
         artifact_record.uid = uid
 
         artifact_dict["metadata"]["updated"] = str(updated_datetime)
-        artifact_dict["metadata"]["created"] = str(artifact_record.created)
+        artifact_dict["metadata"]["created"] = str(created_datetime)
         artifact_dict["kind"] = kind
 
         db_key = artifact_dict.get("spec", {}).get("db_key")

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -978,7 +978,7 @@ class SQLDB(DBInterface):
             else artifact_dict["metadata"].pop("created", None)
         )
         # make sure we have a datetime object with timezone both in the artifact record and in the artifact dict
-        created_datetime = mlrun.utils.convert_to_datetime_with_timezone(
+        created_datetime = mlrun.utils.enrich_datetime_with_tz_info(
             created
         ) or datetime.now(timezone.utc)
         artifact_record.created = created_datetime


### PR DESCRIPTION
Artifacts created timestamps are saved in the DB as strings without timezone, and a milliseconds.
When first creating an artifact, the created timestamp includes timezone, but when updating it may not include it.
This can cause errors when updating artifacts and trying to force a format with timezone offset using `datetime.strptime`.

The fix is to always make sure the timestamp exists, whether creating a new artifact or updating it.

Fixes https://jira.iguazeng.com/browse/ML-5389  