### PR TITLE
[Logs] Validate positive offset when getting logs

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -492,7 +492,7 @@ class HTTPRunDB(RunDBInterface):
         :param uid: Log unique ID
         :param project: Project name for which the log belongs
         :param offset: Retrieve partial log, get up to ``size`` bytes starting at offset ``offset``
-            from beginning of log
+            from beginning of log (must be >= 0)
         :param size: If set to ``-1`` will retrieve and print all data to end of the log by chunks of 1MB each.
         :returns: The following objects:
 
@@ -501,6 +501,8 @@ class HTTPRunDB(RunDBInterface):
             - content - The actual log content.
             * in case size = -1, return the state and the final offset
         """
+        if offset < 0:
+            raise MLRunInvalidArgumentError("Offset must be >= 0")
         if size is None:
             size = int(mlrun.mlconf.httpdb.logs.pull_logs_default_size_limit)
         elif size == -1:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -502,7 +502,7 @@ class HTTPRunDB(RunDBInterface):
             * in case size = -1, return the state and the final offset
         """
         if offset < 0:
-            raise MLRunInvalidArgumentError("Offset must be >= 0")
+            raise MLRunInvalidArgumentError("Offset cannot be negative")
         if size is None:
             size = int(mlrun.mlconf.httpdb.logs.pull_logs_default_size_limit)
         elif size == -1:

--- a/server/api/api/endpoints/logs.py
+++ b/server/api/api/endpoints/logs.py
@@ -79,6 +79,10 @@ async def get_log(
         server.api.api.deps.get_db_session
     ),
 ):
+    if offset < 0:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Offset cannot be negative",
+        )
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.log,
         project,

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -342,6 +342,10 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 		return nil
 	}
 
+	if request.Offset < 0 {
+		return errors.New("Offset cannot be negative")
+	}
+
 	// get log file path
 	filePath, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName)
 	if err != nil {


### PR DESCRIPTION
When getting logs, the offset is an offset inside the log file.
Passing a negative offset can cause several issues when calculating the chunk sizes and result with large logs returning in the responses, and errors such as:
```
MLRunRuntimeError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))
```

Resolves https://jira.iguazeng.com/browse/ML-5391