### PR TITLE
[Model Monitoring] Fix delete old parquet function

### DIFF
--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -86,7 +86,9 @@ class V3ioStore(DataStore):
                 ) from exc
             return None
         if v3io_access_key:
-            self._filesystem = fsspec.filesystem("v3io", v3io_access_key=v3io_access_key, v3io_api=mlrun.mlconf.v3io_api)
+            self._filesystem = fsspec.filesystem(
+                "v3io", v3io_access_key=v3io_access_key, v3io_api=mlrun.mlconf.v3io_api
+            )
         else:
             self._filesystem = fsspec.filesystem("v3io", **self.get_storage_options())
         return self._filesystem

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -73,7 +73,7 @@ class V3ioStore(DataStore):
         schema = "https" if self.secure else "http"
         return f"{schema}://{self.endpoint}"
 
-    def get_filesystem(self, silent=True, v3io_access_key=None):
+    def get_filesystem(self, silent=True):
         """return fsspec file system object, if supported"""
         if self._filesystem:
             return self._filesystem
@@ -85,12 +85,7 @@ class V3ioStore(DataStore):
                     "v3iofs or storey not installed, run pip install storey"
                 ) from exc
             return None
-        if v3io_access_key:
-            self._filesystem = fsspec.filesystem(
-                "v3io", v3io_access_key=v3io_access_key, v3io_api=mlrun.mlconf.v3io_api
-            )
-        else:
-            self._filesystem = fsspec.filesystem("v3io", **self.get_storage_options())
+        self._filesystem = fsspec.filesystem("v3io", **self.get_storage_options())
         return self._filesystem
 
     def get_storage_options(self):

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -73,7 +73,7 @@ class V3ioStore(DataStore):
         schema = "https" if self.secure else "http"
         return f"{schema}://{self.endpoint}"
 
-    def get_filesystem(self, silent=True):
+    def get_filesystem(self, silent=True, v3io_access_key=None):
         """return fsspec file system object, if supported"""
         if self._filesystem:
             return self._filesystem
@@ -85,7 +85,10 @@ class V3ioStore(DataStore):
                     "v3iofs or storey not installed, run pip install storey"
                 ) from exc
             return None
-        self._filesystem = fsspec.filesystem("v3io", **self.get_storage_options())
+        if v3io_access_key:
+            self._filesystem = fsspec.filesystem("v3io", v3io_access_key=v3io_access_key, v3io_api=mlrun.mlconf.v3io_api)
+        else:
+            self._filesystem = fsspec.filesystem("v3io", **self.get_storage_options())
         return self._filesystem
 
     def get_storage_options(self):

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -307,6 +307,7 @@ class MonitoringApplicationController:
         """
         Main method for run all the relevant monitoring application on each endpoint
         """
+        logger.info(f"[DAVID] start run")
         try:
             endpoints = self.db.list_model_endpoints(uids=self.model_endpoints)
             application = mlrun.get_or_create_project(
@@ -360,6 +361,7 @@ class MonitoringApplicationController:
                 if res:
                     self.endpoints_exceptions[res[0]] = res[1]
 
+            logger.info(f"[DAVID] before delete parquet")
             self._delete_old_parquet(endpoints=endpoints)
 
     @classmethod

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -498,13 +498,15 @@ class MonitoringApplicationController:
             # create fs with access to the user side (under projects)
             store, _ = mlrun.store_manager.get_or_create_store(
                 self.parquet_directory,
-                {"v3io_access_key": self.model_monitoring_access_key},
+                {"V3IO_ACCESS_KEY": self.model_monitoring_access_key},
             )
             fs = store.get_filesystem()
 
             # calculate time threshold (keep only files from the last 24 hours)
             time_to_keep = float(
-                (datetime.datetime.now() - datetime.timedelta(minutes=10)).strftime("%s")
+                (datetime.datetime.now() - datetime.timedelta(minutes=10)).strftime(
+                    "%s"
+                )
             )
             for endpoint in endpoints:
                 try:

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -489,12 +489,18 @@ class MonitoringApplicationController:
         :param endpoints: A list of dictionaries of model endpoints records.
         """
         if self.parquet_directory.startswith("v3io:///"):
-            target = mlrun.datastore.targets.BaseStoreTarget(
-                path=self.parquet_directory
-            )
-            store, _ = target._get_store_and_path()
+            # target = mlrun.datastore.targets.BaseStoreTarget(
+            #     path=self.parquet_directory
+            # )
+            # store, _ = target._get_store_and_path()
+            # fs = store.get_filesystem(v3io_access_key=self.model_monitoring_access_key)
+
             # create fs with access to the user side (under projects)
-            fs = store.get_filesystem(v3io_access_key=self.model_monitoring_access_key)
+            store, _ = mlrun.store_manager.get_or_create_store(
+                self.parquet_directory,
+                {"v3io_access_key": self.model_monitoring_access_key},
+            )
+            fs = store.get_filesystem()
 
             # calculate time threshold (keep only files from the last 24 hours)
             time_to_keep = float(

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -497,7 +497,7 @@ class MonitoringApplicationController:
                 path=self.parquet_directory
             )
             store, _ = target._get_store_and_path()
-            fs = store.get_filesystem()
+            fs = store.get_filesystem(v3io_access_key=self.model_monitoring_access_key)
 
             # calculate time threshold (keep only files from the last 24 hours)
             time_to_keep = float(

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -504,7 +504,7 @@ class MonitoringApplicationController:
 
             # calculate time threshold (keep only files from the last 24 hours)
             time_to_keep = float(
-                (datetime.datetime.now() - datetime.timedelta(days=days)).strftime("%s")
+                (datetime.datetime.now() - datetime.timedelta(minutes=10)).strftime("%s")
             )
             for endpoint in endpoints:
                 try:

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -489,12 +489,6 @@ class MonitoringApplicationController:
         :param endpoints: A list of dictionaries of model endpoints records.
         """
         if self.parquet_directory.startswith("v3io:///"):
-            # target = mlrun.datastore.targets.BaseStoreTarget(
-            #     path=self.parquet_directory
-            # )
-            # store, _ = target._get_store_and_path()
-            # fs = store.get_filesystem(v3io_access_key=self.model_monitoring_access_key)
-
             # create fs with access to the user side (under projects)
             store, _ = mlrun.store_manager.get_or_create_store(
                 self.parquet_directory,
@@ -629,9 +623,6 @@ class MonitoringApplicationController:
             target=ParquetTarget(
                 path=parquet_directory
                 + f"/key={endpoint_id}/{start_infer_time.strftime('%s')}/{application_name}.parquet",
-                partition_cols=[
-                    mm_constants.EventFieldType.ENDPOINT_ID,
-                ],
                 storage_options=storage_options,
             ),
         )

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -488,6 +488,8 @@ class MonitoringApplicationController:
 
         :param endpoints: A list of dictionaries of model endpoints records.
         """
+        logger.info("[DAVID] In _delete_old_parquet")
+
         if self.parquet_directory.startswith("v3io:///"):
             target = mlrun.datastore.targets.BaseStoreTarget(
                 path=self.parquet_directory
@@ -497,14 +499,17 @@ class MonitoringApplicationController:
 
             # calculate time threshold (keep only files from the last 24 hours)
             time_to_keep = float(
-                (datetime.datetime.now() - datetime.timedelta(days=days)).strftime("%s")
+                (datetime.datetime.now() - datetime.timedelta(minutes=10)).strftime("%s")
             )
+
+            logger.info(f"[DAVID] time_to_keep = {time_to_keep}")
             for endpoint in endpoints:
                 try:
                     apps_parquet_directories = fs.listdir(
                         path=f"{self.parquet_directory}"
                         f"/key={endpoint[mm_constants.EventFieldType.UID]}"
                     )
+                    logger.info(f"[DAVID] directories = {apps_parquet_directories}")
                     for directory in apps_parquet_directories:
                         if directory["mtime"] < time_to_keep:
                             # Delete files

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -514,8 +514,9 @@ class MonitoringApplicationController:
                     logger.info(f"[DAVID] directories = {apps_parquet_directories}")
                     for directory in apps_parquet_directories:
                         if directory["mtime"] < time_to_keep:
+                            logger.info(f"[DAVID] directory name = {directory['name']}")
                             # Delete files
-                            fs.rm(path=directory["name"], recursive=True)
+                            fs.rm(path=directory["name"])
                             # Delete directory
                             fs.rmdir(path=directory["name"])
                 except FileNotFoundError:

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -498,9 +498,7 @@ class MonitoringApplicationController:
 
             # calculate time threshold (keep only files from the last 24 hours)
             time_to_keep = float(
-                (datetime.datetime.now() - datetime.timedelta(minutes=10)).strftime(
-                    "%s"
-                )
+                (datetime.datetime.now() - datetime.timedelta(days=days)).strftime("%s")
             )
             for endpoint in endpoints:
                 try:


### PR DESCRIPTION
Parquet files are stored on the user side, while the controller operates on the server side. To delete these Parquet files through the controller, it's necessary to establish a file system with the appropriate v3io access key for the relevant permissions.

[ML-4982](https://jira.iguazeng.com/browse/ML-4982)