### PR TITLE
[Datastore] Log databricks metadata run as an artifact

### DIFF
--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -97,7 +97,7 @@ def save_credentials(
 
 
 def run_mlrun_databricks_job(
-    context,
+    context: mlrun.MLClientCtx,
     task_parameters: dict,
     **kwargs,
 ):
@@ -209,4 +209,8 @@ def run_mlrun_databricks_job(
     logger.info(f"logs:\n{run_output.logs}")
     run_output_dict = run_output.as_dict()
     run_output_dict.pop("logs", None)
-    logger.info(f"Run output and metadata:\n{run_output_dict}\n")
+    context.log_artifact(
+        f"databricks_run_metadata_{context.uid}",
+        body=json.dumps(run_output_dict),
+        format="json",
+    )

--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -210,7 +210,7 @@ def run_mlrun_databricks_job(
     run_output_dict = run_output.as_dict()
     run_output_dict.pop("logs", None)
     context.log_artifact(
-        f"databricks_run_metadata_{context.uid}",
+        f"databricks_run_metadata",
         body=json.dumps(run_output_dict),
         format="json",
     )

--- a/mlrun/runtimes/databricks_job/databricks_wrapper.py
+++ b/mlrun/runtimes/databricks_job/databricks_wrapper.py
@@ -210,7 +210,7 @@ def run_mlrun_databricks_job(
     run_output_dict = run_output.as_dict()
     run_output_dict.pop("logs", None)
     context.log_artifact(
-        f"databricks_run_metadata",
+        "databricks_run_metadata",
         body=json.dumps(run_output_dict),
         format="json",
     )

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -137,8 +137,8 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
         artifacts = self.project.list_artifacts().to_objects()
 
         assert len(artifacts) == 1
-        key = f"{print_kwargs_run.metadata.name}_databricks_run_metadata_{print_kwargs_run.uid()}"
-        artifact = self.project.get_artifact(key=key)
+        key = f"{print_kwargs_run.metadata.name}_databricks_run_metadata"
+        artifact = self.project.get_artifact(key=key, tree=print_kwargs_run.uid())
         databricks_metadata = json.loads(artifact.to_dataitem().get()).get(
             "metadata", {}
         )

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -118,12 +118,6 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
 
             pd.testing.assert_frame_equal(expected_df, artifact_df)
 
-    def setup_method(self, method):
-        super().setup_method(method)
-        time.sleep(2)  # For project handling...
-        self._run_db.del_artifacts(project=self.project_name)
-        time.sleep(2)  # For deleting artifacts...
-
     def setup_class(self):
         super().setup_class()
         self.test_folder_name = "/databricks_system_test"
@@ -286,7 +280,6 @@ def import_mlrun():
         )
         self.assert_print_kwargs(print_kwargs_run=run)
         self._run_db.del_artifacts(project=self.project_name)
-        time.sleep(2)
         assert len(self.project.list_artifacts()) == 0
         second_run = function.run(runspec=run, project=self.project_name)
         self.assert_print_kwargs(print_kwargs_run=second_run)
@@ -316,8 +309,6 @@ def import_mlrun():
 
     def test_abort_task(self):
         #  clean up any active runs
-        if self.project.list_runs(state="running"):
-            self.project = mlrun.projects.new_project(self.project_name, overwrite=True)
         sleep_code = """
 
 import time
@@ -410,13 +401,10 @@ def main():
             handler="main",
             project=self.project_name,
         )
-        time.sleep(2)
         self._check_artifacts(paths_dict=paths_dict)
         self._run_db.del_artifacts(project=self.project_name)
-        time.sleep(2)
         assert (
             len(self.project.list_artifacts()) == 0
         )  # Make sure all artifacts have been deleted.
         function.run(runspec=run, project=self.project_name)  # test rerun.
-        time.sleep(4)
         self._check_artifacts(paths_dict=paths_dict)

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -122,6 +122,7 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
         super().setup_method(method)
         time.sleep(2)  # For project handling...
         self._run_db.del_artifacts(project=self.project_name)
+        time.sleep(2)  # For deleting artifacts...
 
     def setup_class(self):
         super().setup_class()

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -99,7 +99,8 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
 
     def _check_artifacts(self, paths_dict):
         artifacts = self.project.list_artifacts().to_objects()
-        assert len(artifacts) == len(paths_dict) + 1  #  +1 becuase metadata artifact.
+        #  +1 because of metadata artifact
+        assert len(artifacts) == len(paths_dict) + 1
         for expected_name, expected_dbfs_path in paths_dict.items():
             db_key = f"databricks-test-main_{expected_name}"
             artifact = self.project.get_artifact(key=db_key)
@@ -133,7 +134,6 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
         assert print_kwargs_run.status.state == "completed"
         logs = self._run_db.get_log(uid=print_kwargs_run.uid())[1].decode()
         assert "{'param1': 'value1', 'param2': 'value2'}\n" in logs
-        #  Should be inside the metadata:
         artifacts = self.project.list_artifacts().to_objects()
 
         assert len(artifacts) == 1
@@ -244,7 +244,7 @@ def import_mlrun():
         )
 
         self._add_databricks_env(function=function)
-        test_params = default_test_params
+        test_params = copy.deepcopy(default_test_params)
         run_name = f"mlrun_task_{uuid.uuid4()}"
         test_params["task_parameters"]["databricks_run_name"] = run_name
         run = function.run(
@@ -279,7 +279,7 @@ def import_mlrun():
         function = function_ref.to_function()
 
         self._add_databricks_env(function=function)
-        test_params = default_test_params
+        test_params = copy.deepcopy(default_test_params)
         run_name = f"mlrun_task_{uuid.uuid4()}"
         test_params["task_parameters"]["databricks_run_name"] = run_name
         run = function.run(
@@ -317,7 +317,6 @@ def import_mlrun():
             )
 
     def test_abort_task(self):
-        #  clean up any active runs
         sleep_code = """
 
 import time

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -99,7 +99,7 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
 
     def _check_artifacts(self, paths_dict):
         artifacts = self.project.list_artifacts().to_objects()
-        #  +1 because of metadata artifact
+        # +1 because of metadata artifact
         assert len(artifacts) == len(paths_dict) + 1
         for expected_name, expected_dbfs_path in paths_dict.items():
             db_key = f"databricks-test-main_{expected_name}"

--- a/tests/system/runtimes/test_databricks.py
+++ b/tests/system/runtimes/test_databricks.py
@@ -119,8 +119,9 @@ class TestDatabricksRuntime(tests.system.base.TestMLRunSystem):
             pd.testing.assert_frame_equal(expected_df, artifact_df)
 
     def setup_method(self, method):
-        time.sleep(2)  # For project handling...
         super().setup_method(method)
+        time.sleep(2)  # For project handling...
+        self._run_db.del_artifacts(project=self.project_name)
 
     def setup_class(self):
         super().setup_class()
@@ -283,6 +284,9 @@ def import_mlrun():
             project=self.project_name, params=default_test_params, **function_kwargs
         )
         self.assert_print_kwargs(print_kwargs_run=run)
+        self._run_db.del_artifacts(project=self.project_name)
+        time.sleep(2)
+        assert len(self.project.list_artifacts()) == 0
         second_run = function.run(runspec=run, project=self.project_name)
         self.assert_print_kwargs(print_kwargs_run=second_run)
 
@@ -365,7 +369,6 @@ def handler(**kwargs):
         return dbfs_path
 
     def test_log_artifact(self):
-        self._run_db.del_artifacts(project=self.project_name)
         test_name = inspect.currentframe().f_code.co_name
         parquet_artifact_dbfs_path = self._upload_df(
             filename_extension="parquet", test_name=test_name


### PR DESCRIPTION
Including relevant information such as run_id, job_id run_name and more...

1) Update the wrapper to log the metadata as an artifact.
2) Add tests that check the artifact.

[ML-5310](https://jira.iguazeng.com/browse/ML-5310)
