### PR TITLE
[Project] Enable adding git to a project after project creation

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -17,6 +17,7 @@ import glob
 import http
 import importlib.util as imputil
 import json
+import os
 import pathlib
 import shutil
 import tempfile
@@ -2291,8 +2292,8 @@ class MlrunProject(ModelObj):
         :param name:   name for the remote (default is 'origin')
         :param branch: Git branch to use as source
         """
-        if not self.spec.repo:
-            raise ValueError("git repo is not set/defined")
+        if not self.spec.repo and not self.is_git_initialized():
+            raise ValueError("git repo is not valid/initialized")
         self.spec.repo.create_remote(name, url=url)
         url = url.replace("https://", "git://")
         if not branch:
@@ -2304,6 +2305,20 @@ class MlrunProject(ModelObj):
             url = f"{url}#{branch}"
         self.spec._source = self.spec.source or url
         self.spec.origin_url = self.spec.origin_url or url
+
+    def is_git_initialized(self):
+        context = self.context
+        git_dir_path = os.path.join(context, ".git")
+
+        if os.path.exists(git_dir_path) and os.path.isdir(git_dir_path):
+            try:
+                self.spec.repo = git.Repo(context)
+                return True
+            except git.InvalidGitRepositoryError:
+                logger.warning("Invalid Git repository")
+            except Exception as e:
+                logger.error(f"Error initializing Git repository: {e}")
+        return False
 
     def push(
         self,

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -17,6 +17,7 @@ import os.path
 import pathlib
 import re
 import shutil
+import subprocess
 import tempfile
 import unittest.mock
 import zipfile
@@ -1477,3 +1478,33 @@ def test_load_project_from_yaml_with_function(context):
             )
             == {}
         )
+
+
+def test_project_create_remote():
+    # test calling create_remote without git_init=True on project creation
+
+    # Set the current working directory to a temporary directory
+    temp_dir = tempfile.mkdtemp()
+    os.chdir(temp_dir)
+
+    # create a project
+    project_name = "project-name"
+    project = mlrun.get_or_create_project(project_name, context=temp_dir)
+
+    try:
+        # initialize git repo
+        subprocess.run(["git", "init"])
+
+        project.create_remote(
+            url="https://github.com/mlrun/some-git-repo.git",
+            name="mlrun-remote",
+            branch="master",
+        )
+
+        assert project.spec.repo is not None
+        assert project.spec.repo.active_branch.name == "master"
+        assert "mlrun-remote" in [remote.name for remote in project.spec.repo.remotes]
+
+    finally:
+        # cleanup
+        shutil.rmtree(temp_dir)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1484,6 +1484,7 @@ def test_project_create_remote():
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Set the current working directory to a temporary directory
+        original_working_dir = os.getcwd()
         os.chdir(tmp_dir)
 
         # create a project
@@ -1499,3 +1500,4 @@ def test_project_create_remote():
         assert project.spec.repo is not None
         assert project.spec.repo.active_branch.name == "master"
         assert "mlrun-remote" in [remote.name for remote in project.spec.repo.remotes]
+        os.chdir(original_working_dir)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -17,7 +17,6 @@ import os.path
 import pathlib
 import re
 import shutil
-import subprocess
 import tempfile
 import unittest.mock
 import zipfile
@@ -1483,17 +1482,13 @@ def test_load_project_from_yaml_with_function(context):
 def test_project_create_remote():
     # test calling create_remote without git_init=True on project creation
 
-    # Set the current working directory to a temporary directory
-    temp_dir = tempfile.mkdtemp()
-    os.chdir(temp_dir)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Set the current working directory to a temporary directory
+        os.chdir(tmp_dir)
 
-    # create a project
-    project_name = "project-name"
-    project = mlrun.get_or_create_project(project_name, context=temp_dir)
-
-    try:
-        # initialize git repo
-        subprocess.run(["git", "init"])
+        # create a project
+        project_name = "project-name"
+        project = mlrun.get_or_create_project(project_name, context=tmp_dir)
 
         project.create_remote(
             url="https://github.com/mlrun/some-git-repo.git",
@@ -1504,7 +1499,3 @@ def test_project_create_remote():
         assert project.spec.repo is not None
         assert project.spec.repo.active_branch.name == "master"
         assert "mlrun-remote" in [remote.name for remote in project.spec.repo.remotes]
-
-    finally:
-        # cleanup
-        shutil.rmtree(temp_dir)


### PR DESCRIPTION
Creating a project using mlrun.get_or_create_project() without specifying init_git=True and then using create_remote() was causing an error even if git is already initialized in the current context.

resolves :
https://jira.iguazeng.com/browse/ML-5078