### PR TITLE
[Logs] Add get log size endpoint and sdk method

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -520,6 +520,19 @@ class HTTPRunDB(RunDBInterface):
 
         return "unknown", resp.content
 
+    def get_log_size(self, uid, project=""):
+        """Retrieve log size in bytes.
+
+        :param uid: Run UID
+        :param project: Project name for which the log belongs
+        :returns: The log file size in bytes for the given run UID.
+        """
+        path = self._path_of("logs", project, uid)
+        path += "/size"
+        error = f"get log size {project}/{uid}"
+        resp = self.api_call("GET", path, error)
+        return resp.json()["size"]
+
     def watch_log(self, uid, project="", watch=True, offset=0):
         """Retrieve logs of a running process by chunks of 1MB, and watch the progress of the execution until it
         completes. This method will print out the logs and continue to periodically poll for, and print,

--- a/server/api/api/endpoints/logs.py
+++ b/server/api/api/endpoints/logs.py
@@ -114,9 +114,7 @@ async def get_log_size(
         mlrun.common.schemas.AuthorizationAction.read,
         auth_info,
     )
-    log_file_size = await server.api.crud.Logs().get_log_size(
-        project, uid
-    )
+    log_file_size = await server.api.crud.Logs().get_log_size(project, uid)
     return {
         "size": log_file_size,
     }

--- a/server/api/api/endpoints/logs.py
+++ b/server/api/api/endpoints/logs.py
@@ -97,3 +97,26 @@ async def get_log(
         media_type="text/plain",
         headers=headers,
     )
+
+
+@router.get("/projects/{project}/logs/{uid}/size")
+async def get_log_size(
+    project: str,
+    uid: str,
+    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
+        server.api.api.deps.authenticate_request
+    ),
+):
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.log,
+        project,
+        uid,
+        mlrun.common.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+    log_file_size = await server.api.crud.Logs().get_log_size(
+        project, uid
+    )
+    return {
+        "size": log_file_size,
+    }

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -95,7 +95,7 @@ class Logs(
         self,
         project: str,
         run_uid: str,
-     ):
+    ):
         logger.debug("Getting log size for run", project=project, run_uid=run_uid)
         log_collector_client = (
             server.api.utils.clients.log_collector.LogCollectorClient()

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -100,10 +100,16 @@ class Logs(
         log_collector_client = (
             server.api.utils.clients.log_collector.LogCollectorClient()
         )
-        return await log_collector_client.get_log_size(
+        log_file_size = await log_collector_client.get_log_size(
             project=project,
             run_uid=run_uid,
         )
+        if log_file_size < 0:
+            # If the log file size is negative, it means the log file doesn't exist
+            raise mlrun.errors.MLRunNotFoundError(
+                f"Log file for {project}/{run_uid} not found",
+            )
+        return log_file_size
 
     async def get_logs(
         self,

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -68,9 +68,9 @@ class Logs(
         logger.debug("Deleting logs for project", project=project)
         await self._delete_logs(project)
 
-    async def delete_run_logs(self, project: str, uid: str):
-        logger.debug("Deleting logs for run", project=project, run_uid=uid)
-        await self._delete_logs(project, [uid])
+    async def delete_run_logs(self, project: str, run_uid: str):
+        logger.debug("Deleting logs for run", project=project, run_uid=run_uid)
+        await self._delete_logs(project, [run_uid])
 
     @staticmethod
     def delete_project_logs_legacy(
@@ -90,6 +90,20 @@ class Logs(
         logs_path = server.api.api.utils.log_path(project, run_uid)
         if logs_path.exists():
             shutil.rmtree(str(logs_path))
+
+    async def get_log_size(
+        self,
+        project: str,
+        run_uid: str,
+     ):
+        logger.debug("Getting log size for run", project=project, run_uid=run_uid)
+        log_collector_client = (
+            server.api.utils.clients.log_collector.LogCollectorClient()
+        )
+        return await log_collector_client.get_log_size(
+            project=project,
+            run_uid=run_uid,
+        )
 
     async def get_logs(
         self,

--- a/server/api/utils/clients/log_collector.py
+++ b/server/api/utils/clients/log_collector.py
@@ -150,7 +150,9 @@ class LogCollectorClient(
 
         # check if this run has logs to collect
         try:
-            log_size = await self.get_log_size(run_uid, project, verbose, raise_on_error)
+            log_size = await self.get_log_size(
+                run_uid, project, verbose, raise_on_error
+            )
             if not log_size:
                 logger.debug(
                     "Run has no logs to collect",
@@ -233,7 +235,7 @@ class LogCollectorClient(
         if not response.success:
             if self._retryable_error(
                 response.errorMessage,
-                    LogCollectorErrorRegex.get_log_size_retryable_errors(),
+                LogCollectorErrorRegex.get_log_size_retryable_errors(),
             ):
                 if verbose:
                     logger.warning(

--- a/server/api/utils/clients/log_collector.py
+++ b/server/api/utils/clients/log_collector.py
@@ -153,7 +153,7 @@ class LogCollectorClient(
             log_size = await self.get_log_size(
                 run_uid, project, verbose, raise_on_error
             )
-            if not log_size:
+            if log_size <= 0:
                 logger.debug(
                     "Run has no logs to collect",
                     run_uid=run_uid,

--- a/server/api/utils/clients/log_collector.py
+++ b/server/api/utils/clients/log_collector.py
@@ -61,7 +61,7 @@ class LogCollectorErrorRegex:
     )
 
     @classmethod
-    def has_logs_retryable_errors(cls):
+    def get_log_size_retryable_errors(cls):
         return [
             cls.readdirent_resource_temporarily_unavailable,
         ]
@@ -150,8 +150,8 @@ class LogCollectorClient(
 
         # check if this run has logs to collect
         try:
-            has_logs = await self.has_logs(run_uid, project, verbose, raise_on_error)
-            if not has_logs:
+            log_size = await self.get_log_size(run_uid, project, verbose, raise_on_error)
+            if not log_size:
                 logger.debug(
                     "Run has no logs to collect",
                     run_uid=run_uid,
@@ -210,47 +210,47 @@ class LogCollectorClient(
                 # breath
                 await asyncio.sleep(3)
 
-    async def has_logs(
+    async def get_log_size(
         self,
         run_uid: str,
         project: str,
         verbose: bool = True,
         raise_on_error: bool = True,
-    ) -> bool:
+    ) -> int:
         """
-        Check if the log collector service has logs for the given run
+        Returns the log file size for the given run
         :param run_uid: The run uid
         :param project: The project name
         :param verbose: Whether to log errors
         :param raise_on_error: Whether to raise an exception on error
-        :return: Whether the log collector service has logs for the given run
+        :return: The log file size of the run, if it exists
         """
-        request = self._log_collector_pb2.HasLogsRequest(
+        request = self._log_collector_pb2.GetLogSizeRequest(
             runUID=run_uid, projectName=project
         )
 
-        response = await self._call("HasLogs", request)
+        response = await self._call("GetLogSize", request)
         if not response.success:
             if self._retryable_error(
                 response.errorMessage,
-                LogCollectorErrorRegex.has_logs_retryable_errors(),
+                    LogCollectorErrorRegex.get_log_size_retryable_errors(),
             ):
                 if verbose:
                     logger.warning(
-                        "Failed to check if run has logs to collect, retrying",
+                        "Failed to get log file size, retrying",
                         run_uid=run_uid,
                         error=response.errorMessage,
                     )
-                return False
+                return 0
 
-            msg = f"Failed to check if run has logs to collect for {run_uid}"
+            msg = f"Failed to log file size for {run_uid}"
             if verbose:
                 logger.warning(msg, error=response.errorMessage)
             if raise_on_error:
                 raise LogCollectorErrorCode.map_error_code_to_mlrun_error(
                     response.errorCode, response.errorMessage, msg
                 )
-        return response.hasLogs
+        return response.logSize
 
     async def stop_logs(
         self,

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -604,7 +604,7 @@ func (suite *LogCollectorTestSuite) TestGetLogSize() {
 	getLogSizeResponse, err := suite.logCollectorServer.GetLogSize(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to get log size")
 	suite.Require().True(getLogSizeResponse.Success, "Expected get log size request to succeed")
-	suite.Require().Zero(getLogSizeResponse.LogSize, "Expected size to be zero")
+	suite.Require().Equal(int64(-1), getLogSizeResponse.LogSize, "Expected size to be negative")
 
 	// create log file for runUID and pod
 	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
@@ -614,7 +614,7 @@ func (suite *LogCollectorTestSuite) TestGetLogSize() {
 	err = common.WriteToFile(logFilePath, []byte(logText), false)
 	suite.Require().NoError(err, "Failed to write to file")
 
-	// check if run has logs
+	// get the log size
 	getLogSizeResponse, err = suite.logCollectorServer.GetLogSize(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to get log size")
 	suite.Require().True(getLogSizeResponse.Success, "Expected get log size request to succeed")

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -593,18 +593,18 @@ func (suite *LogCollectorTestSuite) TestReadLogsFromFileWhileWriting() {
 	suite.Require().Equal(totalWritten, totalRead, "Expected total written to be equal to total read")
 }
 
-func (suite *LogCollectorTestSuite) TestHasLogs() {
+func (suite *LogCollectorTestSuite) TestGetLogSize() {
 	runUID := uuid.New().String()
-	request := &log_collector.HasLogsRequest{
+	request := &log_collector.GetLogSizeRequest{
 		RunUID:      runUID,
 		ProjectName: suite.projectName,
 	}
 
-	// call has logs with no logs
-	hasLogsResponse, err := suite.logCollectorServer.HasLogs(suite.ctx, request)
-	suite.Require().NoError(err, "Failed to check if has logs")
-	suite.Require().True(hasLogsResponse.Success, "Expected has logs request to succeed")
-	suite.Require().False(hasLogsResponse.HasLogs, "Expected run to not have logs")
+	// call get log size with no logs
+	getLogSizeResponse, err := suite.logCollectorServer.GetLogSize(suite.ctx, request)
+	suite.Require().NoError(err, "Failed to get log size")
+	suite.Require().True(getLogSizeResponse.Success, "Expected get log size request to succeed")
+	suite.Require().Zero(getLogSizeResponse.LogSize, "Expected size to be zero")
 
 	// create log file for runUID and pod
 	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(suite.projectName, runUID)
@@ -615,10 +615,10 @@ func (suite *LogCollectorTestSuite) TestHasLogs() {
 	suite.Require().NoError(err, "Failed to write to file")
 
 	// check if run has logs
-	hasLogsResponse, err = suite.logCollectorServer.HasLogs(suite.ctx, request)
-	suite.Require().NoError(err, "Failed to check if has logs")
-	suite.Require().True(hasLogsResponse.Success, "Expected has logs request to succeed")
-	suite.Require().True(hasLogsResponse.HasLogs, "Expected run to have logs")
+	getLogSizeResponse, err = suite.logCollectorServer.GetLogSize(suite.ctx, request)
+	suite.Require().NoError(err, "Failed to get log size")
+	suite.Require().True(getLogSizeResponse.Success, "Expected get log size request to succeed")
+	suite.Require().Equal(int64(len(logText)), getLogSizeResponse.LogSize, "Expected size to be equal to log size")
 }
 
 func (suite *LogCollectorTestSuite) TestStopLog() {

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -449,7 +449,7 @@ func (s *Server) GetLogSize(ctx context.Context, request *protologcollector.GetL
 				"projectName", request.ProjectName)
 			return &protologcollector.GetLogSizeResponse{
 				Success: true,
-				LogSize: 0,
+				LogSize: -1,
 			}, nil
 		}
 

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -426,15 +426,16 @@ func (s *Server) GetLogs(request *protologcollector.GetLogsRequest, responseStre
 	return nil
 }
 
-// HasLogs returns true if the log file exists for a given run id
-func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogsRequest) (*protologcollector.HasLogsResponse, error) {
+// GetLogSize returns the size of the log file for a given run id
+func (s *Server) GetLogSize(ctx context.Context, request *protologcollector.GetLogSizeRequest) (*protologcollector.GetLogSizeResponse, error) {
 	s.Logger.DebugWithCtx(ctx,
-		"Received has log request",
+		"Received get log size request",
 		"runUID", request.RunUID,
 		"project", request.ProjectName)
 
 	// get log file path
-	if _, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName); err != nil {
+	filePath, err := s.getLogFilePath(ctx, request.RunUID, request.ProjectName)
+	if err != nil {
 		if strings.Contains(errors.RootCause(err).Error(), "not found") {
 
 			// if the log file is not found, return false but no error
@@ -442,30 +443,47 @@ func (s *Server) HasLogs(ctx context.Context, request *protologcollector.HasLogs
 				"Log file not found",
 				"runUID", request.RunUID,
 				"projectName", request.ProjectName)
-			return &protologcollector.HasLogsResponse{
+			return &protologcollector.GetLogSizeResponse{
 				Success: true,
-				HasLogs: false,
+				LogSize: 0,
 			}, nil
 		}
 
 		// if there was an error, return it
 		s.Logger.ErrorWithCtx(ctx,
-			"Failed to check if has log file",
+			"Failed to check if log file exists",
 			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
 			"runUID", request.RunUID,
 			"projectName", request.ProjectName)
 
 		// do not return the 'err' itself, so that mlrun api would catch the response
 		// and will resolve the response on its own.
-		return &protologcollector.HasLogsResponse{
+		return &protologcollector.GetLogSizeResponse{
 			Success:      false,
 			ErrorCode:    common.ErrCodeInternal,
 			ErrorMessage: common.GetErrorStack(err, common.DefaultErrorStackDepth),
 		}, nil
 	}
-	return &protologcollector.HasLogsResponse{
+
+	// open log file and calc its size
+	currentLogFileSize, err := common.GetFileSize(filePath)
+	if err != nil {
+		s.Logger.ErrorWithCtx(ctx,
+			"Failed to get log file size",
+			"err", common.GetErrorStack(err, common.DefaultErrorStackDepth),
+			"runUID", request.RunUID,
+			"projectName", request.ProjectName)
+		err = errors.Wrapf(err, "Failed to get log file size for run id %s", request.RunUID)
+		return &protologcollector.GetLogSizeResponse{
+			Success:      false,
+			ErrorCode:    common.ErrCodeInternal,
+			ErrorMessage: common.GetErrorStack(err, common.DefaultErrorStackDepth),
+		}, nil
+	}
+
+	return &protologcollector.GetLogSizeResponse{
 		Success: true,
-		HasLogs: true,
+		LogSize: currentLogFileSize,
 	}, nil
 }
 

--- a/server/log-collector/proto/log_collector.proto
+++ b/server/log-collector/proto/log_collector.proto
@@ -21,7 +21,7 @@ option go_package = "proto/build/log_collector";
 service LogCollector {
   rpc StartLog(StartLogRequest) returns (BaseResponse) {}
   rpc GetLogs(GetLogsRequest) returns (stream GetLogsResponse) {}
-  rpc HasLogs(HasLogsRequest) returns (HasLogsResponse) {}
+  rpc GetLogSize(GetLogSizeRequest) returns (GetLogSizeResponse) {}
   rpc StopLogs(StopLogsRequest) returns (BaseResponse) {}
   rpc DeleteLogs(StopLogsRequest) returns (BaseResponse) {}
 }
@@ -54,14 +54,14 @@ message GetLogsResponse {
   string errorMessage = 4;
 }
 
-message HasLogsRequest {
+message GetLogSizeRequest {
   string runUID = 1;
   string projectName = 2;
 }
 
-message HasLogsResponse {
+message GetLogSizeResponse {
   bool success = 1;
-  bool hasLogs = 2;
+  int64 logSize = 2;
   int32 errorCode = 3;
   string errorMessage = 4;
 }

--- a/tests/api/crud/test_logs.py
+++ b/tests/api/crud/test_logs.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import unittest.mock
+
 import fastapi.testclient
+import pytest
 import sqlalchemy.orm
 
+import mlrun.errors
 import server.api.crud
+import server.api.utils.clients.log_collector
+from tests.api.utils.clients.test_log_collector import GetLogSizeResponse
 
 
 class TestLogs:
@@ -43,3 +49,29 @@ class TestLogs:
         server.api.crud.Logs().store_log(data1, project, uid, append=False)
         log = server.api.crud.Logs()._get_logs_legacy_method(db, project, uid)
         assert data1 == log, "get log append=False"
+
+    @pytest.mark.parametrize(
+        "return_value, expected_error",
+        [
+            (5, False),
+            (0, False),
+            (-1, True),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_get_log_size(
+        self, db: sqlalchemy.orm.Session, return_value, expected_error
+    ):
+        log_collector = server.api.utils.clients.log_collector.LogCollectorClient()
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=GetLogSizeResponse(True, None, return_value)
+        )
+
+        project = "project-name"
+        uid = "m33"
+        if expected_error:
+            with pytest.raises(mlrun.errors.MLRunNotFoundError):
+                await server.api.crud.Logs().get_log_size(project, uid)
+        else:
+            log_size = await server.api.crud.Logs().get_log_size(project, uid)
+            assert return_value == log_size

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -197,6 +197,9 @@ def test_log(create_server):
     db.store_run({"metadata": {"name": "run-name"}, "asd": "asd"}, uid, prj)
     db.store_log(uid, prj, body)
 
+    log_size = db.get_log_size(uid, prj)
+    assert log_size == len(body), "bad log size"
+
     state, data = db.get_log(uid, prj)
     assert data == body, "bad log data"
 

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -197,9 +197,6 @@ def test_log(create_server):
     db.store_run({"metadata": {"name": "run-name"}, "asd": "asd"}, uid, prj)
     db.store_log(uid, prj, body)
 
-    log_size = db.get_log_size(uid, prj)
-    assert log_size == len(body), "bad log size"
-
     state, data = db.get_log(uid, prj)
     assert data == body, "bad log data"
 

--- a/tests/system/logs/test_logs.py
+++ b/tests/system/logs/test_logs.py
@@ -64,4 +64,11 @@ class TestLogCollector(tests.system.base.TestMLRunSystem):
         # verify the logs are not empty
         assert logs, "Expected logs to be not empty"
 
+        # test log size
+        log_size = mlrun.get_run_db().get_log_size(
+            uid=run.metadata.uid,
+            project=proj.name,
+        )
+        assert log_size, "Expected log size to be not zero"
+
         self._logger.debug("Finished log collector test")


### PR DESCRIPTION
Add an option to get a log file size for a specific run, without getting the actual logs.
Supported both as an endpoint in the SDK.

This was implemented by replacing the log collector's `HasLogs` function with `GetLogSize`.
`get_logs` will use `GetLogSize` to verify there are actually logs to get, instead of `HasLogs`.

Resolves https://jira.iguazeng.com/browse/ML-5411 