### PR TITLE
[Spark] Remove logging of spark options

### DIFF
--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -1112,9 +1112,6 @@ def _ingest_with_spark(
             spark_options = target.get_spark_options(
                 key_columns, timestamp_key, overwrite
             )
-            logger.info(
-                f"writing to target {target.name}, spark options {spark_options}"
-            )
 
             df_to_write = df
             df_to_write = target.prepare_spark_df(


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-5409
To enable Spark's access to storage, it's necessary to provide Spark with the appropriate credentials. This Pull Request eliminates the logging of this confidential information.