### PR TITLE
[Model Monitoring] Save all the metrics of an application in KV storage

### DIFF
--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -39,7 +39,8 @@ class ModelMonitoringApplicationResult:
     :param endpoint_id:           (str) ID of the monitored model endpoint.
     :param start_infer_time:      (pd.Timestamp) Start time of the monitoring schedule.
     :param end_infer_time:        (pd.Timestamp) End time of the monitoring schedule.
-    :param result_name:           (str) Name of the application result.
+    :param result_name:           (str) Name of the application result. This name must be
+                                        unique for each metric in a single application.
     :param result_value:          (float) Value of the application result.
     :param result_kind:           (ResultKindApp) Kind of application result.
     :param result_status:         (ResultStatusApp) Status of the application result.

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -143,11 +143,13 @@ class ModelMonitoringWriter(StepToDict):
         event = _AppResultEvent(event.copy())
         endpoint_id = event.pop(WriterEvent.ENDPOINT_ID)
         app_name = event.pop(WriterEvent.APPLICATION_NAME)
+        metric_name = event.pop(WriterEvent.RESULT_NAME)
+        attributes = {metric_name: json.dumps(event)}
         self._kv_client.update(
             container=self._v3io_container,
             table_path=endpoint_id,
             key=app_name,
-            attributes=event,
+            attributes=attributes,
         )
         if endpoint_id not in self._kv_schemas:
             self._generate_kv_schema(endpoint_id)

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -143,7 +143,7 @@ class ModelMonitoringWriter(StepToDict):
         event = _AppResultEvent(event.copy())
         endpoint_id = event.pop(WriterEvent.ENDPOINT_ID)
         app_name = event.pop(WriterEvent.APPLICATION_NAME)
-        self._kv_client.put(
+        self._kv_client.update(
             container=self._v3io_container,
             table_path=endpoint_id,
             key=app_name,

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -157,11 +157,6 @@ class ModelMonitoringWriter(StepToDict):
         """Generate V3IO KV schema file which will be used by the model monitoring applications dashboard in Grafana."""
         fields = [
             {
-                "name": WriterEvent.APPLICATION_NAME,
-                "type": "string",
-                "nullable": False,
-            },
-            {
                 "name": WriterEvent.START_INFER_TIME,
                 "type": "string",
                 "nullable": False,

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -158,41 +158,7 @@ class ModelMonitoringWriter(StepToDict):
     def _generate_kv_schema(self, endpoint_id: str):
         """Generate V3IO KV schema file which will be used by the model monitoring applications dashboard in Grafana."""
         fields = [
-            {
-                "name": WriterEvent.START_INFER_TIME,
-                "type": "string",
-                "nullable": False,
-            },
-            {
-                "name": WriterEvent.END_INFER_TIME,
-                "type": "string",
-                "nullable": False,
-            },
-            {
-                "name": WriterEvent.RESULT_NAME,
-                "type": "string",
-                "nullable": False,
-            },
-            {
-                "name": WriterEvent.RESULT_KIND,
-                "type": "int",
-                "nullable": False,
-            },
-            {
-                "name": WriterEvent.RESULT_VALUE,
-                "type": "double",
-                "nullable": False,
-            },
-            {
-                "name": WriterEvent.RESULT_STATUS,
-                "type": "int",
-                "nullable": False,
-            },
-            {
-                "name": WriterEvent.RESULT_EXTRA_DATA,
-                "type": "string",
-                "nullable": False,
-            },
+            {"name": WriterEvent.RESULT_NAME, "type": "string", "nullable": False}
         ]
         res = self._kv_client.create_schema(
             container=self._v3io_container,


### PR DESCRIPTION
Resolves [ML-5400](https://jira.iguazeng.com/browse/ML-5400).
Save in the following file:
```
/users/pipelines/{project_name}/monitoring-apps/{model_endpoint_id}
```
The key is the application name, and the value is a dictionary with metric names as the keys:
```
app1:
  {
     m1: "...",
     m2: "...",
  }