### PR TITLE
[Requirements] Fix databricks requirements

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -70,7 +70,7 @@ def extra_requirements() -> typing.Dict[str, typing.List[str]]:
         ],
         "redis": ["redis~=4.3"],
         "mlflow": ["mlflow~=2.8"],
-        "databricks-sdk": ["databricks-sdk~=0.15.0"],
+        "databricks-sdk": ["databricks-sdk~=0.13.0"],
         "sqlalchemy": ["sqlalchemy~=1.4"],
         "dask": [
             "dask~=2023.9.0",

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -37,6 +37,8 @@ avro~=1.11
 redis~=4.3
 graphviz~=0.20.0
 mlflow~=2.8
+# any newer version then 0.13 should be tested with adlfs,gcsfs and s3fs installation.
+# we experience a different in google-auth package in databricks-sdk>0.13
 databricks-sdk~=0.13.0
 # sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
 sqlalchemy~=1.4

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -37,7 +37,7 @@ avro~=1.11
 redis~=4.3
 graphviz~=0.20.0
 mlflow~=2.8
-databricks-sdk~=0.15.0
+databricks-sdk~=0.13.0
 # sqlalchemy version should be aligned with mlrun-api due to common use with the model monitoring database
 sqlalchemy~=1.4
 dask~=2023.9.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -117,6 +117,7 @@ def test_requirement_specifiers_convention():
         "adlfs": {"==2023.9.0"},
         "s3fs": {"==2023.9.2"},
         "gcsfs": {"==2023.9.2"},
+        "databricks-sdk": {"~=0.13.0"},
         "distributed": {"~=2023.9.0"},
         "dask": {"~=2023.9.0"},
         # All of these are actually valid, they just don't use ~= so the test doesn't "understand" that


### PR DESCRIPTION
Databricks version 0.15.0 can cause conflicts with gcs.
The required version is 0.13.0.

[ML-5441](https://jira.iguazeng.com/browse/ML-5441)