### PR TITLE
[HTTPDB] Keep watching on created and aborting states

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -574,7 +574,12 @@ class HTTPRunDB(RunDBInterface):
             else:
                 nil_resp += 1
 
-            if watch and state in ["pending", "running"]:
+            if watch and state in [
+                mlrun.runtimes.constants.RunStates.pending,
+                mlrun.runtimes.constants.RunStates.running,
+                mlrun.runtimes.constants.RunStates.created,
+                mlrun.runtimes.constants.RunStates.aborting,
+            ]:
                 continue
             else:
                 # the whole log was retrieved


### PR DESCRIPTION
When "watching" a run, keep watching if the run is in transitional states, which include:
- `pending`
- `running`
- `created`
- `aborting`

Also, use constants instead of raw strings.

Resolves https://jira.iguazeng.com/browse/ML-5430