### PR TITLE
[Model Monitoring] Improve the model monitoring application Python API

### DIFF
--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -148,8 +148,9 @@ class ModelMonitoringApplication(StepToDict, ABC):
         """
         raise NotImplementedError
 
-    @staticmethod
+    @classmethod
     def _resolve_event(
+        cls,
         event: dict[str, Any],
     ) -> Tuple[
         str,
@@ -183,10 +184,10 @@ class ModelMonitoringApplication(StepToDict, ABC):
         end_time = pd.Timestamp(event[mm_constant.ApplicationEvent.END_INFER_TIME])
         return (
             event[mm_constant.ApplicationEvent.APPLICATION_NAME],
-            ModelMonitoringApplication._dict_to_histogram(
+            cls._dict_to_histogram(
                 json.loads(event[mm_constant.ApplicationEvent.CURRENT_STATS])
             ),
-            ModelMonitoringApplication._dict_to_histogram(
+            cls._dict_to_histogram(
                 json.loads(event[mm_constant.ApplicationEvent.FEATURE_STATS])
             ),
             ParquetTarget(

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -73,7 +73,7 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
     example for very simple custom application::
         # mlrun: start-code
         class MyApp(ApplicationBase):
-            def run_application(
+            def do_tracking(
                 self,
                 sample_df_stats: pd.DataFrame,
                 feature_stats: pd.DataFrame,
@@ -110,7 +110,7 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
             hasattr(self, "context") and isinstance(self.context, mlrun.MLClientCtx)
         ):
             self._lazy_init(app_name=resolved_event[0])
-        results = self.run_application(*resolved_event)
+        results = self.do_tracking(*resolved_event)
         results = results if isinstance(results, list) else [results]
         return results, event
 
@@ -118,7 +118,7 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
         self.context = self._create_context_for_logging(app_name=app_name)
 
     @abstractmethod
-    def run_application(
+    def do_tracking(
         self,
         application_name: str,
         sample_df_stats: pd.DataFrame,

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -67,9 +67,9 @@ class ApplicationResult:
 
 class ModelMonitoringApplication(StepToDict, ABC):
     """
-    Class representing a model monitoring application. Subclass this to create custom monitoring logic.
+    A base class for a model monitoring application. Inherit from this to create custom monitoring logic.
 
-    example for very simple costume application::
+    example for very simple custom application::
         # mlrun: start-code
         class MyApp(ModelMonitoringApplication):
 

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -65,14 +65,13 @@ class ApplicationResult:
         }
 
 
-class ModelMonitoringApplication(StepToDict, ABC):
+class ModelMonitoringApplicationBase(StepToDict, ABC):
     """
     A base class for a model monitoring application. Inherit from this to create custom monitoring logic.
 
     example for very simple custom application::
         # mlrun: start-code
-        class MyApp(ModelMonitoringApplication):
-
+        class MyApp(ApplicationBase):
             def run_application(
                 self,
                 sample_df_stats: pd.DataFrame,
@@ -83,15 +82,14 @@ class ModelMonitoringApplication(StepToDict, ABC):
                 latest_request: pd.Timestamp,
                 endpoint_id: str,
                 output_stream_uri: str,
-            ) -> Union[ModelMonitoringApplicationResult, list[ModelMonitoringApplicationResult]
-            ]:
+            ) -> ApplicationResult:
                 self.context.log_artifact(TableArtifact("sample_df_stats", df=sample_df_stats))
-                return ModelMonitoringApplicationResult(
+                return Result(
                     name="data_drift_test",
                     value=0.5,
                     kind=mm_constant.ResultKindApp.data_drift,
-                    status = mm_constant.ResultStatusApp.detected,
-                    extra_data={})
+                    status=mm_constant.ResultStatusApp.detected,
+                )
 
         # mlrun: end-code
     """

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -14,6 +14,7 @@
 
 import dataclasses
 import json
+from abc import ABC, abstractmethod
 from typing import Any, Optional, Tuple, Union
 
 import numpy as np
@@ -64,7 +65,7 @@ class ApplicationResult:
         }
 
 
-class ModelMonitoringApplication(StepToDict):
+class ModelMonitoringApplication(StepToDict, ABC):
     """
     Class representing a model monitoring application. Subclass this to create custom monitoring logic.
 
@@ -116,6 +117,7 @@ class ModelMonitoringApplication(StepToDict):
     def _lazy_init(self, app_name: str):
         self.context = self._create_context_for_logging(app_name=app_name)
 
+    @abstractmethod
     def run_application(
         self,
         application_name: str,

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -67,7 +67,8 @@ class ApplicationResult:
 
 class ModelMonitoringApplicationBase(StepToDict, ABC):
     """
-    A base class for a model monitoring application. Inherit from this to create custom monitoring logic.
+    A base class for a model monitoring application.
+    Inherit from this class to create a custom model monitoring application.
 
     example for very simple custom application::
         # mlrun: start-code
@@ -84,7 +85,7 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
                 output_stream_uri: str,
             ) -> ApplicationResult:
                 self.context.log_artifact(TableArtifact("sample_df_stats", df=sample_df_stats))
-                return Result(
+                return ApplicationResult(
                     name="data_drift_test",
                     value=0.5,
                     kind=mm_constant.ResultKindApp.data_drift,
@@ -101,7 +102,8 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
         Process the monitoring event and return application results.
 
         :param event:   (dict) The monitoring event to process.
-        :returns:       (list[ApplicationResult]) The application results.
+        :returns:       (list[ApplicationResult], dict) The application results
+                        and the original event for the application.
         """
         resolved_event = self._resolve_event(event)
         if not (

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -31,7 +31,7 @@ from mlrun.utils import logger
 
 
 @dataclasses.dataclass
-class ModelMonitoringApplicationResult:
+class ApplicationResult:
     """
     Class representing the result of a custom model monitoring application.
 
@@ -97,14 +97,12 @@ class ModelMonitoringApplication(StepToDict):
 
     kind = "monitoring_application"
 
-    def do(
-        self, event: dict[str, Any]
-    ) -> Tuple[list[ModelMonitoringApplicationResult], dict]:
+    def do(self, event: dict[str, Any]) -> Tuple[list[ApplicationResult], dict]:
         """
         Process the monitoring event and return application results.
 
         :param event:   (dict) The monitoring event to process.
-        :returns:       (list[ModelMonitoringApplicationResult]) The application results.
+        :returns:       (list[ApplicationResult]) The application results.
         """
         resolved_event = self._resolve_event(event)
         if not (
@@ -129,9 +127,7 @@ class ModelMonitoringApplication(StepToDict):
         latest_request: pd.Timestamp,
         endpoint_id: str,
         output_stream_uri: str,
-    ) -> Union[
-        ModelMonitoringApplicationResult, list[ModelMonitoringApplicationResult]
-    ]:
+    ) -> Union[ApplicationResult, list[ApplicationResult]]:
         """
         Implement this method with your custom monitoring logic.
 
@@ -145,8 +141,8 @@ class ModelMonitoringApplication(StepToDict):
         :param endpoint_id:             (str) ID of the monitored model endpoint
         :param output_stream_uri:       (str) URI of the output stream for results
 
-        :returns:                       (ModelMonitoringApplicationResult) or
-                                        (list[ModelMonitoringApplicationResult]) of the application results.
+        :returns:                       (ApplicationResult) or
+                                        (list[ApplicationResult]) of the application results.
         """
         raise NotImplementedError
 
@@ -260,7 +256,7 @@ class PushToMonitoringWriter(StepToDict):
         self.output_stream = None
         self.name = name or "PushToMonitoringWriter"
 
-    def do(self, event: Tuple[list[ModelMonitoringApplicationResult], dict]) -> None:
+    def do(self, event: Tuple[list[ApplicationResult], dict]) -> None:
         """
         Push application results to the monitoring writer stream.
 

--- a/mlrun/model_monitoring/application.py
+++ b/mlrun/model_monitoring/application.py
@@ -32,7 +32,7 @@ from mlrun.utils import logger
 
 
 @dataclasses.dataclass
-class ApplicationResult:
+class ModelMonitoringApplicationResult:
     """
     Class representing the result of a custom model monitoring application.
 
@@ -83,9 +83,9 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
                 latest_request: pd.Timestamp,
                 endpoint_id: str,
                 output_stream_uri: str,
-            ) -> ApplicationResult:
+            ) -> ModelMonitoringApplicationResult:
                 self.context.log_artifact(TableArtifact("sample_df_stats", df=sample_df_stats))
-                return ApplicationResult(
+                return ModelMonitoringApplicationResult(
                     name="data_drift_test",
                     value=0.5,
                     kind=mm_constant.ResultKindApp.data_drift,
@@ -97,12 +97,14 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
 
     kind = "monitoring_application"
 
-    def do(self, event: dict[str, Any]) -> Tuple[list[ApplicationResult], dict]:
+    def do(
+        self, event: dict[str, Any]
+    ) -> Tuple[list[ModelMonitoringApplicationResult], dict]:
         """
         Process the monitoring event and return application results.
 
         :param event:   (dict) The monitoring event to process.
-        :returns:       (list[ApplicationResult], dict) The application results
+        :returns:       (list[ModelMonitoringApplicationResult], dict) The application results
                         and the original event for the application.
         """
         resolved_event = self._resolve_event(event)
@@ -129,7 +131,9 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
         latest_request: pd.Timestamp,
         endpoint_id: str,
         output_stream_uri: str,
-    ) -> Union[ApplicationResult, list[ApplicationResult]]:
+    ) -> Union[
+        ModelMonitoringApplicationResult, list[ModelMonitoringApplicationResult]
+    ]:
         """
         Implement this method with your custom monitoring logic.
 
@@ -143,8 +147,8 @@ class ModelMonitoringApplicationBase(StepToDict, ABC):
         :param endpoint_id:             (str) ID of the monitored model endpoint
         :param output_stream_uri:       (str) URI of the output stream for results
 
-        :returns:                       (ApplicationResult) or
-                                        (list[ApplicationResult]) of the application results.
+        :returns:                       (ModelMonitoringApplicationResult) or
+                                        (list[ModelMonitoringApplicationResult]) of the application results.
         """
         raise NotImplementedError
 
@@ -259,7 +263,7 @@ class PushToMonitoringWriter(StepToDict):
         self.output_stream = None
         self.name = name or "PushToMonitoringWriter"
 
-    def do(self, event: Tuple[list[ApplicationResult], dict]) -> None:
+    def do(self, event: Tuple[list[ModelMonitoringApplicationResult], dict]) -> None:
         """
         Push application results to the monitoring writer stream.
 

--- a/mlrun/model_monitoring/evidently_application.py
+++ b/mlrun/model_monitoring/evidently_application.py
@@ -64,7 +64,7 @@ if _HAS_EVIDENTLY:
     from evidently.utils.dashboard import TemplateParams
 
 
-class EvidentlyModelMonitoringApplication(ModelMonitoringApplicationBase):
+class EvidentlyModelMonitoringApplicationBase(ModelMonitoringApplicationBase):
     def __init__(
         self, evidently_workspace_path: str, evidently_project_id: "STR_UUID"
     ) -> None:

--- a/mlrun/model_monitoring/evidently_application.py
+++ b/mlrun/model_monitoring/evidently_application.py
@@ -20,7 +20,7 @@ import pandas as pd
 import semver
 
 from mlrun.errors import MLRunIncompatibleVersionError
-from mlrun.model_monitoring.application import ModelMonitoringApplication
+from mlrun.model_monitoring.application import ModelMonitoringApplicationBase
 
 SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.11")
 
@@ -64,7 +64,7 @@ if _HAS_EVIDENTLY:
     from evidently.utils.dashboard import TemplateParams
 
 
-class EvidentlyModelMonitoringApplication(ModelMonitoringApplication):
+class EvidentlyModelMonitoringApplication(ModelMonitoringApplicationBase):
     def __init__(
         self, evidently_workspace_path: str, evidently_project_id: "STR_UUID"
     ) -> None:

--- a/mlrun/model_monitoring/evidently_application.py
+++ b/mlrun/model_monitoring/evidently_application.py
@@ -70,7 +70,8 @@ class EvidentlyModelMonitoringApplicationBase(ModelMonitoringApplicationBase):
     ) -> None:
         """
         A class for integrating Evidently for mlrun model monitoring within a monitoring application.
-        Note: evidently is not installed by default and must be installed separately.
+        Note: evidently is not installed by default in the mlrun/mlrun image.
+        It must be installed separately to use this class.
 
         :param evidently_workspace_path:    (str) The path to the Evidently workspace.
         :param evidently_project_id:        (str) The ID of the Evidently project.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -53,7 +53,7 @@ from ..datastore import store_manager
 from ..features import Feature
 from ..model import EntrypointParam, ImageBuilder, ModelObj
 from ..model_monitoring.application import (
-    ModelMonitoringApplication,
+    ModelMonitoringApplicationBase,
     PushToMonitoringWriter,
 )
 from ..run import code_to_function, get_object, import_function, new_function
@@ -1745,7 +1745,7 @@ class MlrunProject(ModelObj):
     def set_model_monitoring_function(
         self,
         func: typing.Union[str, mlrun.runtimes.BaseRuntime, None] = None,
-        application_class: typing.Union[str, ModelMonitoringApplication] = None,
+        application_class: typing.Union[str, ModelMonitoringApplicationBase] = None,
         name: str = None,
         image: str = None,
         handler=None,
@@ -1815,7 +1815,7 @@ class MlrunProject(ModelObj):
     def create_model_monitoring_function(
         self,
         func: str = None,
-        application_class: typing.Union[str, ModelMonitoringApplication] = None,
+        application_class: typing.Union[str, ModelMonitoringApplicationBase] = None,
         name: str = None,
         image: str = None,
         handler: str = None,
@@ -1866,7 +1866,7 @@ class MlrunProject(ModelObj):
     def _instantiate_model_monitoring_function(
         self,
         func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,
-        application_class: typing.Union[str, ModelMonitoringApplication] = None,
+        application_class: typing.Union[str, ModelMonitoringApplicationBase] = None,
         name: str = None,
         image: str = None,
         handler: str = None,

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -38,7 +38,7 @@ class DemoMonitoringApp(ModelMonitoringApplicationBase):
         super().__init_subclass__()
         cls.check_num_events = check_num_events
 
-    def run_application(
+    def do_tracking(
         self,
         application_name: str,
         sample_df_stats: pd.DataFrame,

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -21,7 +21,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
 )
 from mlrun.model_monitoring.application import (
     ModelMonitoringApplication,
-    ModelMonitoringApplicationResult,
+    ApplicationResult,
 )
 
 EXPECTED_EVENTS_COUNT = (
@@ -49,13 +49,13 @@ class DemoMonitoringApp(ModelMonitoringApplication):
         latest_request: pd.Timestamp,
         endpoint_id: str,
         output_stream_uri: str,
-    ) -> list[ModelMonitoringApplicationResult]:
+    ) -> list[ApplicationResult]:
         self.context.logger.info("Running demo app")
         if self.check_num_events:
             assert len(sample_df) == EXPECTED_EVENTS_COUNT
         self.context.logger.info("Asserted sample_df length")
         return [
-            ModelMonitoringApplicationResult(
+            ApplicationResult(
                 name="data_drift_test",
                 value=2.15,
                 kind=ResultKindApp.data_drift,

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -20,7 +20,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
     ResultStatusApp,
 )
 from mlrun.model_monitoring.application import (
-    ModelMonitoringApplication,
+    ModelMonitoringApplicationBase,
     ApplicationResult,
 )
 
@@ -29,7 +29,7 @@ EXPECTED_EVENTS_COUNT = (
 )
 
 
-class DemoMonitoringApp(ModelMonitoringApplication):
+class DemoMonitoringApp(ModelMonitoringApplicationBase):
     name = "monitoring-test"
     check_num_events = True
 

--- a/tests/system/model_monitoring/assets/application.py
+++ b/tests/system/model_monitoring/assets/application.py
@@ -21,7 +21,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
 )
 from mlrun.model_monitoring.application import (
     ModelMonitoringApplicationBase,
-    ApplicationResult,
+    ModelMonitoringApplicationResult,
 )
 
 EXPECTED_EVENTS_COUNT = (
@@ -49,13 +49,13 @@ class DemoMonitoringApp(ModelMonitoringApplicationBase):
         latest_request: pd.Timestamp,
         endpoint_id: str,
         output_stream_uri: str,
-    ) -> list[ApplicationResult]:
+    ) -> list[ModelMonitoringApplicationResult]:
         self.context.logger.info("Running demo app")
         if self.check_num_events:
             assert len(sample_df) == EXPECTED_EVENTS_COUNT
         self.context.logger.info("Asserted sample_df length")
         return [
-            ApplicationResult(
+            ModelMonitoringApplicationResult(
                 name="data_drift_test",
                 value=2.15,
                 kind=ResultKindApp.data_drift,

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -160,7 +160,7 @@ class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
                 self.evidently_workspace, self.evidently_project_id
             )
 
-    def run_application(
+    def do_tracking(
         self,
         application_name: str,
         sample_df_stats: pd.DataFrame,

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -26,7 +26,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
 from mlrun.model_monitoring.application import ApplicationResult
 from mlrun.model_monitoring.evidently_application import (
     _HAS_EVIDENTLY,
-    EvidentlyModelMonitoringApplication,
+    EvidentlyModelMonitoringApplicationBase,
 )
 
 if _HAS_EVIDENTLY:
@@ -131,7 +131,7 @@ if _HAS_EVIDENTLY:
         return workspace, project
 
 
-class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplication):
+class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
     name = "evidently-app-test"
 
     def _lazy_init(self, *args, **kwargs) -> None:

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -23,7 +23,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
     ResultKindApp,
     ResultStatusApp,
 )
-from mlrun.model_monitoring.application import ApplicationResult
+from mlrun.model_monitoring.application import ModelMonitoringApplicationResult
 from mlrun.model_monitoring.evidently_application import (
     _HAS_EVIDENTLY,
     EvidentlyModelMonitoringApplicationBase,
@@ -171,7 +171,7 @@ class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
         latest_request: pd.Timestamp,
         endpoint_id: str,
         output_stream_uri: str,
-    ) -> ApplicationResult:
+    ) -> ModelMonitoringApplicationResult:
         self.context.logger.info("Running evidently app")
 
         sample_df = sample_df[self.columns]
@@ -190,7 +190,7 @@ class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
         self.log_project_dashboard(None, end_infer_time + datetime.timedelta(minutes=1))
 
         self.context.logger.info("Logged evidently objects")
-        return ApplicationResult(
+        return ModelMonitoringApplicationResult(
             name="data_drift_test",
             value=0.5,
             kind=ResultKindApp.data_drift,

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -23,7 +23,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
     ResultKindApp,
     ResultStatusApp,
 )
-from mlrun.model_monitoring.application import ModelMonitoringApplicationResult
+from mlrun.model_monitoring.application import ApplicationResult
 from mlrun.model_monitoring.evidently_application import (
     _HAS_EVIDENTLY,
     EvidentlyModelMonitoringApplication,
@@ -171,7 +171,7 @@ class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplication):
         latest_request: pd.Timestamp,
         endpoint_id: str,
         output_stream_uri: str,
-    ) -> ModelMonitoringApplicationResult:
+    ) -> ApplicationResult:
         self.context.logger.info("Running evidently app")
 
         sample_df = sample_df[self.columns]
@@ -190,7 +190,7 @@ class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplication):
         self.log_project_dashboard(None, end_infer_time + datetime.timedelta(minutes=1))
 
         self.context.logger.info("Logged evidently objects")
-        return ModelMonitoringApplicationResult(
+        return ApplicationResult(
             name="data_drift_test",
             value=0.5,
             kind=ResultKindApp.data_drift,

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -33,7 +33,7 @@ import mlrun
 import mlrun.feature_store
 import mlrun.model_monitoring.api
 from mlrun.model_monitoring import TrackingPolicy
-from mlrun.model_monitoring.application import ModelMonitoringApplication
+from mlrun.model_monitoring.application import ModelMonitoringApplicationBase
 from mlrun.model_monitoring.evidently_application import SUPPORTED_EVIDENTLY_VERSION
 from mlrun.model_monitoring.writer import _TSDB_BE, _TSDB_TABLE, ModelMonitoringWriter
 from mlrun.utils.logger import Logger
@@ -49,7 +49,7 @@ from .assets.custom_evidently_app import CustomEvidentlyMonitoringApp
 
 @dataclass
 class _AppData:
-    class_: typing.Type[ModelMonitoringApplication]
+    class_: typing.Type[ModelMonitoringApplicationBase]
     rel_path: str
     requirements: list[str] = field(default_factory=list)
     kwargs: dict[str, typing.Any] = field(default_factory=dict)


### PR DESCRIPTION
Resolves [ML-5456](https://jira.iguazeng.com/browse/ML-5456).

* Rename the "Application" base classes to "ApplicationBase"
* Inherit from `ABC`, mark the run method as an `abstractmethod` to block direct instantiation by mistake
* Rename the `run_application` method of the `ApplicationBase` class to `do_tracking`
* Fix some docstrings + a typo