### PR TITLE
[RunDB] Add get_log_size to rundb interface

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -631,6 +631,9 @@ class RunDBInterface(ABC):
     ):
         pass
 
+    def get_log_size(self, uid, project=""):
+        pass
+
     def watch_log(self, uid, project="", watch=True, offset=0):
         pass
 

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -898,6 +898,9 @@ class SQLRunDB(RunDBInterface):
         # done from ingest()
         pass
 
+    def get_log_size(self, uid, project=""):
+        raise NotImplementedError("Getting log size is not supported on the server")
+
     def watch_log(self, uid, project="", watch=True, offset=0):
         raise NotImplementedError("Watching logs is not supported on the server")
 


### PR DESCRIPTION
Followup to #4836, so the method will be easily accessible.