### PR TITLE
[CI] Enable log collector in deployer and OS system tests

### DIFF
--- a/.run/Deploy CE.run.xml
+++ b/.run/Deploy CE.run.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Deploy CE" type="PythonConfigurationType" factoryName="Python">
     <module name="mlrun" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
@@ -23,7 +24,7 @@
       </ENTRIES>
     </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/automation/deployment/ce.py" />
-    <option name="PARAMETERS" value="deploy --verbose --minikube --registry-secret-name=&quot;&quot; --override-mlrun-api-image=&quot;mlrun/mlrun-api:FILL ME&quot; --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER=&quot;mlrun[complete] @ git+https://github.com/mlrun/mlrun@FILL ME&quot;' --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__SCHEDULING__MIN_ALLOWED_INTERVAL=&quot;0 seconds&quot;' --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS=&quot;100&quot;" />
+    <option name="PARAMETERS" value="deploy --verbose --minikube --registry-secret-name=&quot;&quot; --mlrun-version=&quot;FILL ME&quot; --override-mlrun-api-image=&quot;mlrun/mlrun-api:FILL ME&quot; --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER=&quot;mlrun[complete] @ git+https://github.com/mlrun/mlrun@FILL ME&quot;' --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__SCHEDULING__MIN_ALLOWED_INTERVAL=&quot;0 seconds&quot;' --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS=&quot;100&quot;" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -114,6 +114,10 @@ def cli():
     help="Override the mlrun-api image. Format: <repo>:<tag>",
 )
 @click.option(
+    "--override-mlrun-log-collector-image",
+    help="Override the mlrun-log-collector image. Format: <repo>:<tag>",
+)
+@click.option(
     "--override-mlrun-ui-image",
     help="Override the mlrun-ui image. Format: <repo>:<tag>",
 )
@@ -135,6 +139,11 @@ def cli():
     "--disable-spark-operator",
     is_flag=True,
     help="Disable the installation of the Spark operator",
+)
+@click.option(
+    "--disable-log-collector",
+    is_flag=True,
+    help="Disable the mlrun API log collector sidecar and use legacy mode instead",
 )
 @click.option(
     "--devel",
@@ -179,11 +188,13 @@ def deploy(
     registry_username: str = None,
     registry_password: str = None,
     override_mlrun_api_image: str = None,
+    override_mlrun_log_collector_image: str = None,
     override_mlrun_ui_image: str = None,
     override_jupyter_image: str = None,
     disable_pipelines: bool = False,
     disable_prometheus_stack: bool = False,
     disable_spark_operator: bool = False,
+    disable_log_collector: bool = False,
     skip_registry_validation: bool = False,
     sqlite: str = None,
     devel: bool = False,
@@ -207,11 +218,13 @@ def deploy(
         mlrun_version=mlrun_version,
         chart_version=chart_version,
         override_mlrun_api_image=override_mlrun_api_image,
+        override_mlrun_log_collector_image=override_mlrun_log_collector_image,
         override_mlrun_ui_image=override_mlrun_ui_image,
         override_jupyter_image=override_jupyter_image,
         disable_pipelines=disable_pipelines,
         disable_prometheus_stack=disable_prometheus_stack,
         disable_spark_operator=disable_spark_operator,
+        disable_log_collector=disable_log_collector,
         skip_registry_validation=skip_registry_validation,
         devel=devel,
         minikube=minikube,

--- a/automation/deployment/deployer.py
+++ b/automation/deployment/deployer.py
@@ -28,8 +28,18 @@ class Constants:
     helm_chart_name = f"{helm_repo_name}/{helm_release_name}"
     helm_repo_url = "https://mlrun.github.io/ce"
     default_registry_secret_name = "registry-credentials"
-    mlrun_image_values = ["mlrun.api", "mlrun.ui", "jupyterNotebook"]
-    disableable_deployments = ["pipelines", "kube-prometheus-stack", "spark-operator"]
+    mlrun_image_values = [
+        "mlrun.api",
+        "mlrun.ui",
+        "jupyterNotebook",
+        "mlrun.api.sidecars.logCollector",
+    ]
+    disableable_components = [
+        "pipelines",
+        "kube-prometheus-stack",
+        "spark-operator",
+        "mlrun.api.sidecars.logCollector",
+    ]
     minikube_registry_port = 5000
     log_format = "> %(asctime)s [%(levelname)s] %(message)s"
 
@@ -93,11 +103,13 @@ class CommunityEditionDeployer:
         chart_version: str = None,
         mlrun_version: str = None,
         override_mlrun_api_image: str = None,
+        override_mlrun_log_collector_image: str = None,
         override_mlrun_ui_image: str = None,
         override_jupyter_image: str = None,
         disable_pipelines: bool = False,
         disable_prometheus_stack: bool = False,
         disable_spark_operator: bool = False,
+        disable_log_collector: bool = False,
         skip_registry_validation: bool = False,
         devel: bool = False,
         minikube: bool = False,
@@ -114,11 +126,13 @@ class CommunityEditionDeployer:
         :param chart_version: Version of the helm chart to deploy (defaults to the latest stable version)
         :param mlrun_version: Version of MLRun to deploy (defaults to the latest stable version)
         :param override_mlrun_api_image: Override the default MLRun API image
+        :param override_mlrun_log_collector_image: Override the default MLRun Log Collector image
         :param override_mlrun_ui_image: Override the default MLRun UI image
         :param override_jupyter_image: Override the default Jupyter image
         :param disable_pipelines: Disable the deployment of the pipelines component
         :param disable_prometheus_stack: Disable the deployment of the Prometheus stack component
         :param disable_spark_operator: Disable the deployment of the Spark operator component
+        :param disable_log_collector: Disable the mlrun API log collector sidecar and use legacy mode instead
         :param skip_registry_validation: Skip the validation of the registry URL
         :param devel: Deploy the development version of the helm chart
         :param minikube: Deploy the helm chart with minikube configuration
@@ -140,11 +154,13 @@ class CommunityEditionDeployer:
             chart_version,
             mlrun_version,
             override_mlrun_api_image,
+            override_mlrun_log_collector_image,
             override_mlrun_ui_image,
             override_jupyter_image,
             disable_pipelines,
             disable_prometheus_stack,
             disable_spark_operator,
+            disable_log_collector,
             devel,
             minikube,
             sqlite,
@@ -329,11 +345,13 @@ class CommunityEditionDeployer:
         chart_version: str = None,
         mlrun_version: str = None,
         override_mlrun_api_image: str = None,
+        override_mlrun_log_collector_image: str = None,
         override_mlrun_ui_image: str = None,
         override_jupyter_image: str = None,
         disable_pipelines: bool = False,
         disable_prometheus_stack: bool = False,
         disable_spark_operator: bool = False,
+        disable_log_collector: bool = False,
         devel: bool = False,
         minikube: bool = False,
         sqlite: str = None,
@@ -347,11 +365,13 @@ class CommunityEditionDeployer:
         :param chart_version: Version of the chart to use
         :param mlrun_version: Version of MLRun to use
         :param override_mlrun_api_image: Override MLRun API image to use
+        :param override_mlrun_log_collector_image: Override MLRun Log Collector image to use
         :param override_mlrun_ui_image: Override MLRun UI image to use
         :param override_jupyter_image: Override Jupyter image to use
         :param disable_pipelines: Disable pipelines
         :param disable_prometheus_stack: Disable Prometheus stack
         :param disable_spark_operator: Disable Spark operator
+        :param disable_log_collector: Disable the mlrun API log collector sidecar and use legacy mode instead
         :param devel: Use development chart
         :param minikube: Use minikube
         :param sqlite: Path to sqlite file to use as the mlrun database. If not supplied, will use MySQL deployment
@@ -382,11 +402,13 @@ class CommunityEditionDeployer:
             registry_secret_name,
             mlrun_version,
             override_mlrun_api_image,
+            override_mlrun_log_collector_image,
             override_mlrun_ui_image,
             override_jupyter_image,
             disable_pipelines,
             disable_prometheus_stack,
             disable_spark_operator,
+            disable_log_collector,
             sqlite,
             minikube,
         ).items():
@@ -430,11 +452,13 @@ class CommunityEditionDeployer:
         registry_secret_name: str = None,
         mlrun_version: str = None,
         override_mlrun_api_image: str = None,
+        override_mlrun_log_collector_image: str = None,
         override_mlrun_ui_image: str = None,
         override_jupyter_image: str = None,
         disable_pipelines: bool = False,
         disable_prometheus_stack: bool = False,
         disable_spark_operator: bool = False,
+        disable_log_collector: bool = False,
         sqlite: str = None,
         minikube: bool = False,
     ) -> typing.Dict[str, str]:
@@ -444,11 +468,13 @@ class CommunityEditionDeployer:
         :param registry_secret_name: Name of the registry secret to use
         :param mlrun_version: Version of MLRun to use
         :param override_mlrun_api_image: Override MLRun API image to use
+        :param override_mlrun_log_collector_image: Override MLRun Log Collector image to use
         :param override_mlrun_ui_image: Override MLRun UI image to use
         :param override_jupyter_image: Override Jupyter image to use
         :param disable_pipelines: Disable pipelines
         :param disable_prometheus_stack: Disable Prometheus stack
         :param disable_spark_operator: Disable Spark operator
+        :param disable_log_collector: Disable the mlrun API log collector sidecar and use legacy mode instead
         :param sqlite: Path to sqlite file to use as the mlrun database. If not supplied, will use MySQL deployment
         :param minikube: Use minikube
         :return: Dictionary of helm values
@@ -475,21 +501,22 @@ class CommunityEditionDeployer:
                 override_mlrun_api_image,
                 override_mlrun_ui_image,
                 override_jupyter_image,
+                override_mlrun_log_collector_image,
             ],
         ):
             if overriden_image:
                 self._override_image_in_helm_values(helm_values, value, overriden_image)
 
         for deployment, disabled in zip(
-            Constants.disableable_deployments,
+            Constants.disableable_components,
             [
                 disable_pipelines,
                 disable_prometheus_stack,
                 disable_spark_operator,
+                disable_log_collector,
             ],
         ):
-            if disabled:
-                self._disable_deployment_in_helm_values(helm_values, deployment)
+            self._toggle_component_in_helm_values(helm_values, deployment, disabled)
 
         if sqlite:
             dir_path = os.path.dirname(sqlite)
@@ -508,7 +535,7 @@ class CommunityEditionDeployer:
                 "warning",
                 "Kubeflow Pipelines is not supported on ARM architecture. Disabling KFP installation.",
             )
-            self._disable_deployment_in_helm_values(helm_values, "pipelines")
+            self._toggle_component_in_helm_values(helm_values, "pipelines", True)
 
         self._log(
             "debug",
@@ -668,16 +695,20 @@ class CommunityEditionDeployer:
         helm_values[f"{image_helm_value}.image.repository"] = overriden_image_repo
         helm_values[f"{image_helm_value}.image.tag"] = overriden_image_tag
 
-    def _disable_deployment_in_helm_values(
-        self, helm_values: typing.Dict[str, str], deployment: str
+    def _toggle_component_in_helm_values(
+        self, helm_values: typing.Dict[str, str], deployment: str, disable: bool
     ) -> None:
         """
         Disable a deployment in the helm values.
         :param helm_values: Helm values to update
-        :param deployment: Deployment to disable
+        :param deployment: Deployment to toggle
+        :param disable: Whether to disable the deployment
         """
-        self._log("warning", "Disabling deployment", deployment=deployment)
-        helm_values[f"{deployment}.enabled"] = "false"
+        self._log(
+            "warning", "Toggling deployment", deployment=deployment, disable=disable
+        )
+        value = "false" if disable else "true"
+        helm_values[f"{deployment}.enabled"] = value
 
     def _run_command(
         self,

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -96,6 +96,7 @@ class Logs(
         project: str,
         run_uid: str,
     ):
+        logger.debug("Getting log size for run", project=project, run_uid=run_uid)
         if (
             mlrun.mlconf.log_collector.mode
             == mlrun.common.schemas.LogsCollectorMode.sidecar
@@ -126,7 +127,6 @@ class Logs(
             raise ValueError(
                 f"Invalid log collector mode {mlrun.mlconf.log_collector.mode}"
             )
-        logger.debug("Getting log size for run", project=project, run_uid=run_uid)
 
     async def get_logs(
         self,

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -96,8 +96,13 @@ class Logs(
         project: str,
         run_uid: str,
     ):
-        logger.debug("Getting log size for run", project=project, run_uid=run_uid)
         if (
+            mlrun.mlconf.log_collector.mode
+            == mlrun.common.schemas.LogsCollectorMode.sidecar
+        ):
+            return await self._get_log_size_from_log_collector(project, run_uid)
+
+        elif (
             mlrun.mlconf.log_collector.mode
             == mlrun.common.schemas.LogsCollectorMode.best_effort
         ):
@@ -117,16 +122,11 @@ class Logs(
         ):
             return self._get_log_size_legacy(project, run_uid)
 
-        elif (
-            mlrun.mlconf.log_collector.mode
-            == mlrun.common.schemas.LogsCollectorMode.sidecar
-        ):
-            return await self._get_log_size_from_log_collector(project, run_uid)
-
         else:
             raise ValueError(
                 f"Invalid log collector mode {mlrun.mlconf.log_collector.mode}"
             )
+        logger.debug("Getting log size for run", project=project, run_uid=run_uid)
 
     async def get_logs(
         self,

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -102,7 +102,7 @@ class Logs(
             == mlrun.common.schemas.LogsCollectorMode.legacy
         ):
             raise mlrun.errors.MLRunPreconditionFailedError(
-                "Cannot get log size in legacy mode",
+                "Cannot get log size in legacy log collector mode",
             )
 
         log_collector_client = (

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -97,6 +97,14 @@ class Logs(
         run_uid: str,
     ):
         logger.debug("Getting log size for run", project=project, run_uid=run_uid)
+        if (
+            mlrun.mlconf.log_collector.mode
+            == mlrun.common.schemas.LogsCollectorMode.legacy
+        ):
+            raise mlrun.errors.MLRunPreconditionFailedError(
+                "Cannot get log size in legacy mode",
+            )
+
         log_collector_client = (
             server.api.utils.clients.log_collector.LogCollectorClient()
         )

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -113,7 +113,7 @@ class Logs(
                 if mlrun.mlconf.log_collector.verbose:
                     logger.warning(
                         "Failed to get logs from logs collector, falling back to legacy method",
-                        exc=exc,
+                        exc=mlrun.errors.err_to_str(exc),
                     )
                 return self._get_log_size_legacy(project, run_uid)
 
@@ -169,7 +169,7 @@ class Logs(
                 if mlrun.mlconf.log_collector.verbose:
                     logger.warning(
                         "Failed to get logs from logs collector, falling back to legacy method",
-                        exc=exc,
+                        exc=mlrun.errors.err_to_str(exc),
                     )
                 log_stream = self._get_logs_legacy_method_generator_wrapper(
                     db_session,

--- a/server/api/crud/logs.py
+++ b/server/api/crud/logs.py
@@ -101,9 +101,7 @@ class Logs(
             mlrun.mlconf.log_collector.mode
             == mlrun.common.schemas.LogsCollectorMode.legacy
         ):
-            raise mlrun.errors.MLRunPreconditionFailedError(
-                "Cannot get log size in legacy log collector mode",
-            )
+            return self._get_log_size_legacy(project, run_uid)
 
         log_collector_client = (
             server.api.utils.clients.log_collector.LogCollectorClient()
@@ -300,11 +298,14 @@ class Logs(
             )
         return run
 
-    def get_log_mtime(self, project: str, uid: str) -> int:
+    @staticmethod
+    def _get_log_size_legacy(project: str, uid: str) -> int:
         log_file = server.api.api.utils.log_path(project, uid)
         if not log_file.exists():
-            raise FileNotFoundError(f"Log file does not exist: {log_file}")
-        return log_file.stat().st_mtime
+            raise mlrun.errors.MLRunNotFoundError(
+                f"Log file for {project}/{uid} not found",
+            )
+        return log_file.stat().st_size
 
     @staticmethod
     def log_file_exists_for_run_uid(project: str, uid: str) -> (bool, pathlib.Path):

--- a/tests/api/crud/test_logs.py
+++ b/tests/api/crud/test_logs.py
@@ -18,6 +18,7 @@ import fastapi.testclient
 import pytest
 import sqlalchemy.orm
 
+import mlrun.common.schemas
 import mlrun.errors
 import server.api.crud
 import server.api.utils.clients.log_collector
@@ -62,6 +63,7 @@ class TestLogs:
     async def test_get_log_size(
         self, db: sqlalchemy.orm.Session, return_value, expected_error
     ):
+        mlrun.mlconf.log_collector.mode = mlrun.common.schemas.LogsCollectorMode.sidecar
         log_collector = server.api.utils.clients.log_collector.LogCollectorClient()
         log_collector._call = unittest.mock.AsyncMock(
             return_value=GetLogSizeResponse(True, None, return_value)

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -30,9 +30,6 @@ V3IO_FRAMESD:
 # user used to add v3io mounts to pods - e.g. iguazio
 V3IO_USERNAME:
 
-# password used to generate control sessions (needed only in 2.8) - e.g. password
-V3IO_PASSWORD:
-
 # access key used to add v3io mounts to pods - e.g. 4c1c2011-618f-434a-abd6-d456770fd33c
 V3IO_ACCESS_KEY:
 
@@ -57,6 +54,7 @@ DATABRICKS_TOKEN:
 # - it is not for use)
 DATABRICKS_HOST:
 DATABRICKS_CLUSTER_ID:
+
 # AWS
 AWS_BUCKET_NAME:
 AWS_ACCESS_KEY_ID:


### PR DESCRIPTION
Add options in the deployer script to:
1. override the log collector image
2. disable log collector (was always disabled, now enabled by default)
3. disableable components will always be part of the helm command - if they were enabled, the script would not specify it and count on the default value. Now it will be explicit.

Add precondition check for get log size endpoint - supported only with log collector.

This will make the open source system tests run with log collector.