### PR TITLE
[Workflow] Ensure "owner" label exists on runner

### DIFF
--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import getpass
 import json
 import os
 import os.path
@@ -381,8 +380,7 @@ def mlrun_op(
 
     if "V3IO_USERNAME" in os.environ and "v3io_user" not in labels:
         labels["v3io_user"] = os.environ.get("V3IO_USERNAME")
-    if "owner" not in labels:
-        labels["owner"] = os.environ.get("V3IO_USERNAME") or getpass.getuser()
+    mlrun.utils.enrich_owner_label(labels)
 
     if name:
         cmd += ["--name", name]

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-import getpass
-import os
 from typing import Optional
 
 import IPython
@@ -73,9 +71,7 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
     ):
         run.metadata.labels["kind"] = runtime.kind
         if "owner" not in run.metadata.labels:
-            run.metadata.labels["owner"] = (
-                os.environ.get("V3IO_USERNAME") or getpass.getuser()
-            )
+            mlrun.utils.enrich_owner_label(run.metadata.labels)
         if run.spec.output_path:
             run.spec.output_path = run.spec.output_path.replace(
                 "{{run.user}}", run.metadata.labels["owner"]

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import enum
-import getpass
 import http
 import re
 import typing
@@ -441,8 +440,7 @@ class BaseRuntime(ModelObj):
 
     def _store_function(self, runspec, meta, db):
         meta.labels["kind"] = self.kind
-        if "owner" not in meta.labels:
-            meta.labels["owner"] = environ.get("V3IO_USERNAME") or getpass.getuser()
+        mlrun.utils.enrich_owner_label(meta.labels)
         if runspec.spec.output_path:
             runspec.spec.output_path = runspec.spec.output_path.replace(
                 "{{run.user}}", meta.labels["owner"]

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -14,6 +14,7 @@
 
 import enum
 import functools
+import getpass
 import hashlib
 import inspect
 import itertools
@@ -534,6 +535,11 @@ def match_labels(labels, conditions):
         else:
             match = match and (condition.strip() in labels)
     return match
+
+
+def enrich_owner_label(labels: dict, owner: str = None):
+    if "owner" not in labels:
+        labels["owner"] = owner or os.environ.get("V3IO_USERNAME") or getpass.getuser()
 
 
 def match_times(time_from, time_to, obj, key):

--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -205,6 +205,7 @@ class WorkflowRunners(
         else:
             labels["job-type"] = "workflow-runner"
             labels["workflow"] = runner.metadata.name
+        mlrun.utils.enrich_owner_label(labels)
 
         run_spec = self._prepare_run_object_for_single_run(
             project=project,


### PR DESCRIPTION
Ensure "owner" label exists on the workflow runner.
Owner is taken from the `V3IO_USERNAME` env var or the logged-in username.

Also, moved the owner label enrichment to a common helper function so it can be reused across the codebase.

Resolves https://jira.iguazeng.com/browse/ML-5412