### PR TITLE
[Docs] Updates for FS/FV APIs are now FeatureSet / FeatureVector class methods

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -735,9 +735,7 @@ categorical_fset = fstore.FeatureSet(
     description="Categorical columns for heart disease dataset"
 )
 
-fstore.ingest(
-    featureset=categorical_fset,
-    source=ParquetSource(path="./data/heart_disease_categorical.parquet")
+categorical_fset.ingest(source=ParquetSource(path="./data/heart_disease_categorical.parquet")
 )
 ```
 
@@ -753,7 +751,7 @@ storey_set = fstore.FeatureSet(
     description="Heart disease data via storey engine",
     engine="storey"
 )
-fstore.ingest(featureset=storey_set, source=DataFrameSource(df=data))
+storey_set.ingest(source=DataFrameSource(df=data))
 
 # Pandas engine
 pandas_set = fstore.FeatureSet(
@@ -762,7 +760,7 @@ pandas_set = fstore.FeatureSet(
     description="Heart disease data via pandas engine",
     engine="pandas"
 )
-fstore.ingest(featureset=pandas_set, source=DataFrameSource(df=data))
+pandas_set.ingest(source=DataFrameSource(df=data))
 
 # Spark engine
 from pyspark.sql import SparkSession
@@ -774,7 +772,7 @@ spark_set = fstore.FeatureSet(
     description="Heart disease data via spark engine",
     engine="spark"
 )
-fstore.ingest(featureset=spark_set, source=CSVSource(path=v3io_data_path), spark_context=spark)
+spark_set.ingest(source=CSVSource(path=v3io_data_path), spark_context=spark)
 ```
 
 #### Ingestion methods
@@ -785,33 +783,33 @@ Docs: [Ingest data locally](./data-prep/ingest-data-fs.html#ingest-data-locally)
 # Local
 from mlrun.datastore.sources import CSVSource
 
-df = fstore.ingest(
-    featureset=fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")]),
+fs=fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
+df = fs.ingest(    
     source=CSVSource("mycsv", path="stocks.csv")
 )
 
 # Job
 from mlrun.datastore.sources import ParquetSource
 
-df = fstore.ingest(
-    featureset=fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")]),
-    source=ParquetSource("mypq", path="stocks.parquet"),
+fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
+df = fs.ingest(    
+    source=ParquetSource("mypq", path="stocks.parquet")
     run_config=fstore.RunConfig(image='mlrun/mlrun')
-)
+	)
 
 # Real-Time
 from mlrun.datastore.sources import HttpSource
 
-url, _ = fstore.deploy_ingestion_service_v2(
-    featureset=fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")]),
+fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
+url, _ = fs.deploy_ingestion_service(
     source=HttpSource(key_field="ticker"),
     run_config=fstore.RunConfig(image='mlrun/mlrun', kind="serving")
 )
 
 # Incremental
 cron_trigger = "* */1 * * *" # will run every hour
-fstore.ingest(
-    featureset=fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")]),
+fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
+fset.ingest(
     source=ParquetSource("mypq", path="stocks.parquet", time_field="time", schedule=cron_trigger),
     run_config=fstore.RunConfig(image='mlrun/mlrun')
 )

--- a/docs/data-prep/ingest-data-fs.md
+++ b/docs/data-prep/ingest-data-fs.md
@@ -90,6 +90,17 @@ source = CSVSource("mycsv", path="stocks.csv")
 targets = [CSVTarget("mycsv", path="./new_stocks.csv")]
 ingest(measurements, source, targets)
 ```
+You can **update a feature set** either by overwriting its data (`overwrite=true`), or by appending data (`overwrite=false`). 
+To append data you need to reuse the feature set that was used in previous ingestions 
+that was saved in the DB (and not create a new feature set on every ingest).<br>
+For example:
+```python
+    my_fset = fstore.get_feature_set("my_fset")
+except mlrun.errors.MLRunNotFoundError:
+    my_fset = FeatureSet("my_fset", entities=[Entity("key")])
+
+my_fset.ingest(overwrite=false)
+```
 
 To learn more about ingest, go to {py:class}`~mlrun.feature_store.ingest`.
 

--- a/docs/data-prep/ingest-data-fs.md
+++ b/docs/data-prep/ingest-data-fs.md
@@ -146,10 +146,12 @@ and the subsequent jobs ingest only the deltas since the previous run (from the 
 Example:
 
 ```
-cron_trigger = "* */1 * * *" #runs every hour
-source = ParquetSource("myparquet", path=path, schedule=cron_trigger)
-feature_set = fstore.FeatureSet(name=name, entities=[fstore.Entity("first_name")], timestamp_key="time",)
-fstore.ingest(feature_set, source, run_config=fstore.RunConfig())
+cron_trigger = "* */1 * * *" # will run every hour
+fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
+fs.ingest(
+    source=ParquetSource("mypq", path="stocks.parquet", time_field="time", schedule=cron_trigger),
+    run_config=fstore.RunConfig(image='mlrun/mlrun')
+)
 ```
 
 The default value for the `overwrite` parameter in the ingest function for scheduled ingest is `False`, meaning that the 

--- a/docs/feature-store/feature-sets.md
+++ b/docs/feature-store/feature-sets.md
@@ -73,10 +73,10 @@ Typical code, from defining the feature set through ingesting its data:
 my_fset = fstore.FeatureSet("my_fset", entities=[Entity("patient_id)], timestamp_key="timestamp", passthrough=True) 
 csv_source = CSVSource("my_csv", path="data.csv"), time_field="timestamp")
 # Ingest the source data, but only to online/nosql target
-fstore.ingest(my_fset, csv_source) 
+my_fset.ingest(csv_source) 
 vector = fstore.FeatureVector("myvector", features=[f"my_fset"])
 # Read the offline data directly from the csv source
-resp = fstore.get_offline_features(vector, entity_timestamp_column="timestamp", with_indexes=True) 
+resp = vector.get_offline_features(entity_timestamp_column="timestamp", with_indexes=True)  
 ```
 
 
@@ -108,7 +108,7 @@ feature_set.graph.to(DropColumns(drop_columns))\
                  .to(RenameColumns(mapping={'bad': 'bed'}))
 feature_set.add_aggregation('hr', ['avg'], ["1h"])
 feature_set.plot()
-fstore.ingest(feature_set, data_df)
+feature_set.ingest(data_df)
 ```
 
 Graph example (pandas engine):
@@ -119,7 +119,7 @@ def myfunc1(df, context=None):
 
 stocks_set = fstore.FeatureSet("stocks", entities=[Entity("ticker")], engine="pandas")
 stocks_set.graph.to(name="s1", handler="myfunc1")
-df = fstore.ingest(stocks_set, stocks_df)
+df = stocks_set.ingest(stocks_df)
 ```
 
 The graph steps can use built-in transformation classes, simple python classes, or function handlers. 

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -280,7 +280,7 @@ feature_set = fstore.FeatureSet("fs-new",
                                 )
 # Adding multiply step, with specific parameters
 feature_set.graph.to(MultiplyFeature(feature="number1", value=4))
-df_pandas = fstore.ingest(feature_set, data)
+df_pandas = feature_set.ingest(data)
 ```
 
 


### PR DESCRIPTION
[ML-4622](https://jira.iguazeng.com/browse/ML-4622)
[ML-3856](https://jira.iguazeng.com/browse/ML-3856): on sdk ingestion + recreation of the fset object, a new ingest with overwrite=false still creates a new run_id (ie behave like overwire=true)