### PR TITLE
[Requirements] Change numpy version for tensorflow 2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ kfp~=1.8
 nest-asyncio~=1.0
 ipython~=8.10
 nuclio-jupyter~=0.9.14
-# >=1.16.5 from pandas 1.2.1 and <1.27.0 from storey
 numpy>=1.16.5, <1.27.0
 pandas>=1.2, <3
 # used as a the engine for parquet files by pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ kfp~=1.8
 nest-asyncio~=1.0
 ipython~=8.10
 nuclio-jupyter~=0.9.14
-# >=1.16.5 from pandas 1.2.1 and <1.23.0 from storey
-numpy>=1.16.5, <1.23.0
+# >=1.16.5 from pandas 1.2.1 and <1.27.0 from storey
+numpy>=1.16.5, <1.27.0
 pandas>=1.2, <3
 # used as a the engine for parquet files by pandas
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)

--- a/tests/test_log_serialization.py
+++ b/tests/test_log_serialization.py
@@ -26,7 +26,6 @@ def my_func(context):
     print(f"Run: {context.name} (uid={context.uid})")
 
     context.log_result("float", 1.5)
-    context.log_result("np-float", np.float(1.5))
     context.log_result("np-float32", np.float32(1.5))
     context.log_result("date", datetime.datetime(2018, 1, 1))
     context.log_result("np-date", np.datetime64("2018-01-01"))

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -123,7 +123,7 @@ def test_requirement_specifiers_convention():
         # All of these are actually valid, they just don't use ~= so the test doesn't "understand" that
         # TODO: make test smart enough to understand that
         "urllib3": {">=1.26.9, <1.27"},
-        "numpy": {">=1.16.5, <1.23.0"},
+        "numpy": {">=1.16.5, <1.27.0"},
         "boto3": {">=1.28.0,<1.29.0"},
         "dask-ml": {"~=1.4,<1.9.0"},
         "pyarrow": {">=10.0, <15"},


### PR DESCRIPTION
[ML-4855](https://jira.iguazeng.com/browse/ML-4855)
Also clean test that use numpy.float (deprecated in newer versions of numpy).



Datastore system tests pass (s3, azure, google and dbfs)
