### PR TITLE
[Model Monitoring] Use timezone aware timestamps and objects

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -51,7 +51,6 @@ class EventFieldType:
     LAST_REQUEST = "last_request"
     METRIC = "metric"
     METRICS = "metrics"
-    TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
     BATCH_INTERVALS_DICT = "batch_intervals_dict"
     DEFAULT_BATCH_INTERVALS = "default_batch_intervals"
     MINUTES = "minutes"

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -460,8 +460,9 @@ def _generate_model_endpoint(
         ] = possible_drift_threshold
 
     model_endpoint.spec.monitoring_mode = monitoring_mode
-    model_endpoint.status.first_request = datetime.datetime.now()
-    model_endpoint.status.last_request = datetime.datetime.now()
+    model_endpoint.status.first_request = (
+        model_endpoint.status.last_request
+    ) = datetime.datetime.now()
     if sample_set_statistics:
         model_endpoint.status.feature_stats = sample_set_statistics
 

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -462,7 +462,7 @@ def _generate_model_endpoint(
     model_endpoint.spec.monitoring_mode = monitoring_mode
     model_endpoint.status.first_request = (
         model_endpoint.status.last_request
-    ) = datetime.datetime.now()
+    ) = datetime.datetime.now().strftime(EventFieldType.TIME_FORMAT)
     if sample_set_statistics:
         model_endpoint.status.feature_stats = sample_set_statistics
 

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -387,7 +387,9 @@ def write_monitoring_df(
     # Modify the DataFrame to the required structure that will be used later by the monitoring batch job
     if EventFieldType.TIMESTAMP not in infer_results_df.columns:
         # Initialize timestamp column with the current time
-        infer_results_df[EventFieldType.TIMESTAMP] = datetime.datetime.now()
+        infer_results_df[EventFieldType.TIMESTAMP] = datetime.datetime.now(
+            tz=datetime.timezone.utc
+        )
 
     # `endpoint_id` is the monitoring feature set entity and therefore it should be defined as the df index before
     # the ingest process
@@ -462,7 +464,7 @@ def _generate_model_endpoint(
     model_endpoint.spec.monitoring_mode = monitoring_mode
     model_endpoint.status.first_request = (
         model_endpoint.status.last_request
-    ) = datetime.datetime.now().isoformat()
+    ) = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     if sample_set_statistics:
         model_endpoint.status.feature_stats = sample_set_statistics
 

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -462,7 +462,7 @@ def _generate_model_endpoint(
     model_endpoint.spec.monitoring_mode = monitoring_mode
     model_endpoint.status.first_request = (
         model_endpoint.status.last_request
-    ) = datetime.datetime.now().strftime(EventFieldType.TIME_FORMAT)
+    ) = datetime.datetime.now().isoformat()
     if sample_set_statistics:
         model_endpoint.status.feature_stats = sample_set_statistics
 

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -912,7 +912,7 @@ class BatchProcessor:
         drift_status: mlrun.common.schemas.model_monitoring.DriftStatus,
         drift_measure: float,
         drift_result: Dict[str, Dict[str, Any]],
-        timestamp: pd._libs.tslibs.timestamps.Timestamp,
+        timestamp: pd.Timestamp,
     ):
         """Update drift results in input stream.
 
@@ -951,10 +951,7 @@ class BatchProcessor:
         # Update the results in tsdb:
         tsdb_drift_measures = {
             "endpoint_id": endpoint_id,
-            "timestamp": pd.to_datetime(
-                timestamp,
-                format=mlrun.common.schemas.model_monitoring.EventFieldType.TIME_FORMAT,
-            ),
+            "timestamp": timestamp,
             "record_type": "drift_measures",
             "tvd_mean": drift_result["tvd_mean"],
             "kld_mean": drift_result["kld_mean"],
@@ -965,7 +962,7 @@ class BatchProcessor:
             self.frames.write(
                 backend="tsdb",
                 table=self.tsdb_path,
-                dfs=pd.DataFrame.from_dict([tsdb_drift_measures]),
+                dfs=pd.DataFrame.from_records([tsdb_drift_measures]),
                 index_cols=["timestamp", "endpoint_id", "record_type"],
             )
         except v3io_frames.errors.Error as err:

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -202,12 +202,10 @@ class _BatchWindowGenerator:
                 first_request=first_request,
             )
             return None
-        # See mm_constants.EventFieldType.TIME_FORMAT
         return cls._date_string2timestamp(first_request)
 
     @staticmethod
     def _date_string2timestamp(date_string: str) -> int:
-        # See mm_constants.EventFieldType.TIME_FORMAT
         return int(datetime.datetime.fromisoformat(date_string).timestamp())
 
     def get_batch_window(

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -134,7 +134,7 @@ def bump_model_endpoint_last_request(
         + datetime.timedelta(
             seconds=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
         )
-    ).strftime(EventFieldType.TIME_FORMAT)
+    ).isoformat()
     logger.info(
         "Bumping model endpoint last request time",
         project=project,

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -741,8 +741,8 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
         ):
             return None
 
-        # Adjust timestamp format
-        timestamp = datetime.datetime.strptime(timestamp[:-6], "%Y-%m-%d %H:%M:%S.%f")
+        # Convert timestamp to a datetime object
+        timestamp = datetime.datetime.fromisoformat(timestamp)
 
         # Separate each model invocation into sub events that will be stored as dictionary
         # in list of events. This list will be used as the body for the storey event.

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -529,9 +529,8 @@ class ProcessBeforeTSDB(mlrun.feature_store.steps.MapClass):
 
         # Getting event timestamp and endpoint_id
         base_event = {k: event[k] for k in base_fields}
-        base_event[EventFieldType.TIMESTAMP] = pd.to_datetime(
-            base_event[EventFieldType.TIMESTAMP],
-            format=EventFieldType.TIME_FORMAT,
+        base_event[EventFieldType.TIMESTAMP] = datetime.datetime.fromisoformat(
+            base_event[EventFieldType.TIMESTAMP]
         )
 
         # base_metrics includes the stats about the average latency and the amount of predictions over time

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -18,7 +18,6 @@ import json
 import os
 import typing
 
-import pandas as pd
 import storey
 
 import mlrun

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import json
 from http import HTTPStatus
 from typing import Any, NewType
@@ -25,7 +26,6 @@ from v3io_frames.frames_pb2 import IGNORE
 import mlrun.common.model_monitoring
 import mlrun.model_monitoring
 import mlrun.utils.v3io_clients
-from mlrun.common.schemas.model_monitoring import EventFieldType
 from mlrun.common.schemas.model_monitoring.constants import ResultStatusApp, WriterEvent
 from mlrun.common.schemas.notification import NotificationKind, NotificationSeverity
 from mlrun.serving.utils import StepToDict
@@ -178,9 +178,8 @@ class ModelMonitoringWriter(StepToDict):
 
     def _update_tsdb(self, event: _AppResultEvent) -> None:
         event = _AppResultEvent(event.copy())
-        event[WriterEvent.END_INFER_TIME] = pd.to_datetime(
-            event[WriterEvent.END_INFER_TIME],
-            format=EventFieldType.TIME_FORMAT,
+        event[WriterEvent.END_INFER_TIME] = datetime.datetime.fromisoformat(
+            event[WriterEvent.END_INFER_TIME]
         )
         del event[WriterEvent.RESULT_EXTRA_DATA]
         try:

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -164,7 +164,7 @@ class TestBatchWindowGenerator:
     def test_last_updated_is_in_the_past() -> None:
         last_request = datetime.datetime(2023, 11, 16, 12, 0, 0)
         last_updated = _BatchWindowGenerator._get_last_updated_time(
-            last_request=last_request.strftime(EventFieldType.TIME_FORMAT),
+            last_request=last_request.isoformat(),
         )
         assert last_updated
         assert (

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -267,15 +267,15 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-record-results"
+    project_name = "test-monitoring-record-results-2"
     name_prefix = "infer-monitoring"
 
     # TODO - remove this when TSDB future time issue is resolved
     # https://jira.iguazeng.com/browse/ML-5407
-    tsdb_query_end = "now+3h"
+    tsdb_query_end = "now"
 
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = None
+    image: typing.Optional[str] = "jonathandaniel503/mlrun:ml-5407"
 
     @classmethod
     def custom_setup_class(cls) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -274,6 +274,9 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
     # https://jira.iguazeng.com/browse/ML-5407
     tsdb_query_end = "now+3h"
 
+    # Set image to "<repo>/mlrun:<tag>" for local testing
+    image: typing.Optional[str] = None
+
     @classmethod
     def custom_setup_class(cls) -> None:
         # model
@@ -336,6 +339,7 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
             application_class=self.app_data.class_.__name__,
             name=self.app_data.class_.name,
             requirements=self.app_data.requirements,
+            image="mlrun/mlrun" if self.image is None else self.image,
             **self.app_data.kwargs,
         )
         self.project.deploy_function(fn)
@@ -356,6 +360,7 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
     def _deploy_monitoring_infra(self) -> None:
         self.project.enable_model_monitoring(  # pyright: ignore[reportOptionalMemberAccess]
             base_period=self.app_interval,
+            **({} if self.image is None else {"default_controller_image": self.image}),
         )
 
     def test_inference_feature_set(self) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -271,6 +271,7 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
     name_prefix = "infer-monitoring"
 
     # TODO - remove this when TSDB future time issue is resolved
+    # https://jira.iguazeng.com/browse/ML-5407
     tsdb_query_end = "now+3h"
 
     @classmethod

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -66,7 +66,6 @@ class _V3IORecordsChecker:
     _logger: Logger
     apps_data: list[_AppData]
     app_interval: int
-    tsdb_query_end: str = "now"
 
     @classmethod
     def custom_setup_class(cls, project_name: str) -> None:
@@ -98,7 +97,7 @@ class _V3IORecordsChecker:
             backend=_TSDB_BE,
             table=_TSDB_TABLE,
             start=f"now-{5 * cls.app_interval}m",
-            end=cls.tsdb_query_end,
+            end="now",
         )
         assert not df.empty, "No TSDB data"
         assert (

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -126,9 +126,9 @@ class _V3IORecordsChecker:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-5407-1"
+    project_name = "test-monitoring-app-flow"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "jonathandaniel503/mlrun:ml-5407-1"
+    image: typing.Optional[str] = None
 
     @classmethod
     def custom_setup_class(cls) -> None:
@@ -266,10 +266,10 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-rec-5407-1"
+    project_name = "test-monitoring-record-results"
     name_prefix = "infer-monitoring"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "jonathandaniel503/mlrun:ml-5407-1"
+    image: typing.Optional[str] = None
 
     @classmethod
     def custom_setup_class(cls) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -126,9 +126,9 @@ class _V3IORecordsChecker:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-app-flow"
+    project_name = "test-monitoring-5407-1"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = None
+    image: typing.Optional[str] = "jonathandaniel503/mlrun:ml-5407-1"
 
     @classmethod
     def custom_setup_class(cls) -> None:
@@ -266,10 +266,10 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-record-results"
+    project_name = "test-monitoring-rec-5407-1"
     name_prefix = "infer-monitoring"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = None
+    image: typing.Optional[str] = "jonathandaniel503/mlrun:ml-5407-1"
 
     @classmethod
     def custom_setup_class(cls) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -351,8 +351,6 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
             endpoint_id=self.endpoint_id,
             context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),  # pyright: ignore[reportGeneralTypeIssues]
             infer_results_df=self.infer_results_df,
-            trigger_monitoring_job=True,
-            last_in_batch_set=True,
         )
 
     def _deploy_monitoring_infra(self) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -267,15 +267,10 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-record-results-2"
+    project_name = "test-monitoring-record-results"
     name_prefix = "infer-monitoring"
-
-    # TODO - remove this when TSDB future time issue is resolved
-    # https://jira.iguazeng.com/browse/ML-5407
-    tsdb_query_end = "now"
-
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "jonathandaniel503/mlrun:ml-5407"
+    image: typing.Optional[str] = None
 
     @classmethod
     def custom_setup_class(cls) -> None:


### PR DESCRIPTION
Fixes [ML-5407](https://jira.iguazeng.com/browse/ML-5407) - remove +3h TSDB end time.

This change is generally backward compatible. We previously TZ oblivious timestamps in model monitoring, and these can be parsed by the [`datetime.datetime.fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) function, resulting in an object without a TZ.
