### PR TITLE
[Project] Take project source into account when running `build_image`

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3048,9 +3048,12 @@ class MlrunProject(ModelObj):
         overwrite_build_params: bool = False,
         requirements_file: str = None,
         extra_args: str = None,
+        target_dir: str = None,
     ) -> typing.Union[BuildStatus, kfp.dsl.ContainerOp]:
         """Builder docker image for the project, based on the project's build config. Parameters allow to override
         the build config.
+        If the project has a source configured and pull_at_runtime is not configured, this source will be cloned to the
+        image built. The `target_dir` parameter allows specifying the target path where the code will be extracted.
 
         :param image: target image name/path. If not specified the project's existing `default_image` name will be
                         used. If not set, the `mlconf.default_project_image_name` value will be used
@@ -3072,6 +3075,7 @@ class MlrunProject(ModelObj):
             * True: The existing params are replaced by the new ones
         :param extra_args:  A string containing additional builder arguments in the format of command-line options,
             e.g. extra_args="--skip-tls-verify --build-arg A=val"r
+        :param target_dir: Path on the image where source code would be extracted (by default `/home/mlrun_code`)
         """
         if not base_image:
             base_image = mlrun.mlconf.default_base_image
@@ -3118,7 +3122,7 @@ class MlrunProject(ModelObj):
             if self.spec.source and not self.spec.load_source_on_run:
                 function.with_source_archive(
                     source=self.spec.source,
-                    workdir=self.spec.workdir,
+                    target_dir=target_dir,
                     pull_at_runtime=False,
                 )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3115,6 +3115,13 @@ class MlrunProject(ModelObj):
 
             function = mlrun.new_function("mlrun--project--image--builder", kind="job")
 
+            if self.spec.source and not self.spec.load_source_on_run:
+                function.with_source_archive(
+                    source=self.spec.source,
+                    workdir=self.spec.workdir,
+                    pull_at_runtime=False,
+                )
+
             build = self.spec.build
             result = self.build_function(
                 function=function,

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1547,8 +1547,8 @@ def test_project_create_remote():
 @pytest.mark.parametrize(
     "source_url, pull_at_runtime, base_image, image_name, target_dir",
     [
-        #        (None, None, "aaa/bbb", "ccc/ddd", None),
-        #        ("git://some/repo", False, None, ".some-image", None),
+        (None, None, "aaa/bbb", "ccc/ddd", ""),
+        ("git://some/repo", False, None, ".some-image", ""),
         (
             "git://some/other/repo",
             False,


### PR DESCRIPTION
The `project.build_image()` function did not take into account the project source. If the user is setting a source to the project (for example `git` source) and set `pull_at_runtime = False`, then it is expected that images used would contain the project source in them. This worked for specific functions when building them, but not in the project level.
The expectation is that running this code:
```
project = mlrun.get_or_create_project(
    name="project-name", context="./"
)

project.set_source(
    "git://some/repo",
    pull_at_runtime=False
)

project.build_image(image=".some-project-image")
```
Would build the `.some-project-image` image with the source in it, such that running a function will work without having to specify an image:
```
func = project.set_function(handler="package.function", name="func", kind="job")
func.save()
project.run_function("func", params={...})
```
This would work even without having the source code available on the dev site, and will not require pulling the code at execution time.

This fixes [ML-5481](https://jira.iguazeng.com/browse/ML-5481)