### PR TITLE
[Artifacts] Remove updatable fields from UID calc

### DIFF
--- a/.run/Patch remote.run.xml
+++ b/.run/Patch remote.run.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Patch remote" type="PythonConfigurationType" factoryName="Python">
     <module name="mlrun" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
@@ -23,7 +24,7 @@
       </ENTRIES>
     </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/automation/patch_igz/patch_remote.py" />
-    <option name="PARAMETERS" value="-lc -v" />
+    <option name="PARAMETERS" value="-v" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -88,6 +88,12 @@ class ArtifactSpec(ModelObj):
     ]
 
     _extra_fields = ["annotations", "producer", "sources", "license", "encoding"]
+    _exclude_fields_from_uid_hash = [
+        # if the artifact is first created, it will not have a db_key,
+        # exclude it so further updates of the artifacts will have the same hash
+        "db_key",
+        "extra_data",
+    ]
 
     def __init__(
         self,
@@ -1066,3 +1072,39 @@ def convert_legacy_artifact_to_new_format(
     artifact.status = artifact.status.from_dict(legacy_artifact_dict)
 
     return artifact
+
+
+def fill_artifact_object_hash(object_dict, iteration=None, producer_id=None):
+    # remove artifact related fields before calculating hash
+    object_dict.setdefault("metadata", {})
+    labels = object_dict["metadata"].pop("labels", None)
+    object_updated_timestamp = object_dict["metadata"].pop("updated", None)
+
+    artifact_cls = mlrun.artifacts.artifact_types.get(
+        object_dict.get("kind", "artifact"), Artifact
+    )()
+    spec_fields_to_exclude = artifact_cls.spec._exclude_fields_from_uid_hash
+    spec_fields_to_exclude_values = []
+    object_dict.setdefault("spec", {})
+    for field in spec_fields_to_exclude:
+        spec_fields_to_exclude_values.append(object_dict["spec"].pop(field, None))
+
+    # make sure we have a key, producer_id and iteration, as they determine the artifact uniqueness
+    if not object_dict["metadata"].get("key"):
+        raise ValueError("Artifact key is not set")
+    object_dict["metadata"]["iter"] = iteration or object_dict["metadata"].get("iter")
+    object_dict["metadata"]["tree"] = object_dict["metadata"].get("tree") or producer_id
+
+    # calc hash and fill
+    uid = mlrun.utils.helpers.fill_object_hash(object_dict, "uid")
+
+    # restore original values
+    if labels:
+        object_dict["metadata"]["labels"] = labels
+    if object_updated_timestamp:
+        object_dict["metadata"]["updated"] = object_updated_timestamp
+    for key, value in zip(spec_fields_to_exclude, spec_fields_to_exclude_values):
+        if value:
+            object_dict["spec"][key] = value
+
+    return uid

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -44,6 +44,12 @@ class ModelArtifactSpec(ArtifactSpec):
         "feature_stats",
         "model_target_file",
     ]
+    _exclude_fields_from_uid_hash = ArtifactSpec._exclude_fields_from_uid_hash + [
+        "metrics",
+        "feature_vector",
+        "feature_weights",
+        "feature_stats",
+    ]
 
     def __init__(
         self,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -965,35 +965,6 @@ def fill_object_hash(object_dict, uid_property_name, tag=""):
     return uid
 
 
-def fill_artifact_object_hash(object_dict, iteration=None, producer_id=None):
-    # remove artifact related fields before calculating hash
-    object_dict.setdefault("metadata", {})
-    labels = object_dict["metadata"].pop("labels", None)
-    object_updated_timestamp = object_dict["metadata"].pop("updated", None)
-
-    # if the artifact is first created, it will not have a db_key, so we need to pop it from the spec
-    # so further updates of the artifacts will have the same hash
-    db_key = object_dict.get("spec", {}).pop("db_key", None)
-
-    # make sure we have a key, producer_id and iteration, as they determine the artifact uniqueness
-    if not object_dict["metadata"].get("key"):
-        raise ValueError("artifact key is not set")
-    object_dict["metadata"]["iter"] = iteration or object_dict["metadata"].get("iter")
-    object_dict["metadata"]["tree"] = object_dict["metadata"].get("tree") or producer_id
-
-    # calc hash and fill
-    uid = fill_object_hash(object_dict, "uid")
-
-    # restore original values
-    if labels:
-        object_dict["metadata"]["labels"] = labels
-    if object_updated_timestamp:
-        object_dict["metadata"]["updated"] = object_updated_timestamp
-    if db_key:
-        object_dict.setdefault("spec", {})["db_key"] = db_key
-    return uid
-
-
 def fill_function_hash(function_dict, tag=""):
     return fill_object_hash(function_dict, "hash", tag)
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -34,12 +34,12 @@ import mlrun.errors
 import mlrun.model
 import server.api.db.session
 import server.api.utils.helpers
+from mlrun.artifacts.base import fill_artifact_object_hash
 from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.lists import ArtifactList, FunctionList, RunList
 from mlrun.model import RunObject
 from mlrun.utils import (
-    fill_artifact_object_hash,
     fill_function_hash,
     fill_object_hash,
     generate_artifact_uri,
@@ -525,6 +525,12 @@ class SQLDB(DBInterface):
                 self._should_update_artifact(existing_artifact, uid, iter)
                 or always_overwrite
             ):
+                logger.debug(
+                    "Updating an existing artifact",
+                    project=project,
+                    key=key,
+                    iteration=iter,
+                )
                 db_artifact = existing_artifact
                 self._update_artifact_record_from_dict(
                     db_artifact,

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -32,10 +32,10 @@ import server.api.db.sqldb.models
 import server.api.utils.db.alembic
 import server.api.utils.db.backup
 import server.api.utils.db.mysql
+from mlrun.artifacts.base import fill_artifact_object_hash
 from mlrun.config import config
 from mlrun.errors import MLRunPreconditionFailedError, err_to_str
 from mlrun.utils import (
-    fill_artifact_object_hash,
     is_legacy_artifact,
     is_link_artifact,
     logger,

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -307,7 +307,7 @@ class TestArtifacts:
 
         # ids are auto generated using this util function
         expected_uids = [
-            mlrun.utils.fill_artifact_object_hash(artifact_body)
+            mlrun.artifacts.base.fill_artifact_object_hash(artifact_body)
             for artifact_body in [artifact_1_body, artifact_2_body]
         ]
         uids = [artifact["metadata"]["uid"] for artifact in artifacts]


### PR DESCRIPTION
### Bug
Creating a model artifact, adding evaluation values to the model, storing the artifact again expecting it to update to logged one but instead it creates a new model artifact.

### Fix
Remove updatable spec fields from the UID hash calculation. It is expected that if the model metrics / content was changed but the file path is the same, the artifact will be updated instead of creating a new artifact.