### PR TITLE
[Datastore] Add validation for empty URL

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -80,10 +80,6 @@ class DataStore:
         if not url:
             raise mlrun.errors.MLRunInvalidArgumentError("Cannot parse an empty URL")
         parsed_url = urllib.parse.urlparse(url)
-        if not parsed_url.scheme:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Failed to parse '{url}' as it is not a valid URL"
-            )
         netloc = f"//{parsed_url.netloc}" if parsed_url.netloc else "//"
         return f"{parsed_url.scheme}:{netloc}{parsed_url.path}"
 

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -77,10 +77,15 @@ class DataStore:
         Extract only the schema, netloc, and path from an input URL if they exist,
         excluding parameters, query, or fragments.
         """
+        if not url:
+            raise mlrun.errors.MLRunInvalidArgumentError("Cannot parse an empty URL")
         parsed_url = urllib.parse.urlparse(url)
-        scheme = f"{parsed_url.scheme}:" if parsed_url.scheme else ""
+        if not parsed_url.scheme:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Failed to parse '{url}' as it is not a valid URL"
+            )
         netloc = f"//{parsed_url.netloc}" if parsed_url.netloc else "//"
-        return f"{scheme}{netloc}{parsed_url.path}"
+        return f"{parsed_url.scheme}:{netloc}{parsed_url.path}"
 
     @staticmethod
     def uri_to_kfp(endpoint, subpath):

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -343,19 +343,6 @@ def test_object_from_empty_url():
         data_item.as_df()
 
 
-def test_object_from_invalid_url():
-    user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
-    store = mlrun.datastore.datastore.StoreManager(
-        secrets={"V3IO_ACCESS_KEY": "api-access-key"}
-    )
-    data_item = store.object(url="abc", secrets=user1_secrets)
-    with pytest.raises(
-        mlrun.errors.MLRunInvalidArgumentError,
-        match="Failed to parse 'abc' as it is not a valid URL",
-    ):
-        data_item.as_df()
-
-
 def test_fsspec():
     with TemporaryDirectory() as tmpdir:
         print(tmpdir)

--- a/tests/test_datastores.py
+++ b/tests/test_datastores.py
@@ -331,6 +331,31 @@ def test_verify_data_stores_are_cached_when_not_api():
     assert store._stores["v3io://some-system"]._secrets == {}
 
 
+def test_object_from_empty_url():
+    user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
+    store = mlrun.datastore.datastore.StoreManager(
+        secrets={"V3IO_ACCESS_KEY": "api-access-key"}
+    )
+    data_item = store.object(url="", secrets=user1_secrets)
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="Cannot parse an empty URL"
+    ):
+        data_item.as_df()
+
+
+def test_object_from_invalid_url():
+    user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
+    store = mlrun.datastore.datastore.StoreManager(
+        secrets={"V3IO_ACCESS_KEY": "api-access-key"}
+    )
+    data_item = store.object(url="abc", secrets=user1_secrets)
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="Failed to parse 'abc' as it is not a valid URL",
+    ):
+        data_item.as_df()
+
+
 def test_fsspec():
     with TemporaryDirectory() as tmpdir:
         print(tmpdir)


### PR DESCRIPTION
Require that it be nonempty and to have a scheme.

[ML-4617](https://jira.iguazeng.com/browse/ML-4617)