### PR TITLE
[Automation] Support patch with data node registry

### DIFF
--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -26,7 +26,12 @@ SSH_USER:
 SSH_PASSWORD:
 
 # Docker registry you can push to. Make sure you are logged into it before running the script
+# For iguazio datanode registry use <data-node-ip>:8009/mlrun
 DOCKER_REGISTRY:
+
+# Use when your registry is connected to a DNS which is accessible from the cluster
+# For iguazio datanode registry use: datanode-registry.iguazio-platform.app.<system-name>.<lab.iguazeng/cloud-cd>.com:80/mlrun
+OVERWRITE_IMAGE_REGISTRY:
 
 # Optional - will attempt docker login if defined, need to login manually otherwise
 REGISTRY_USERNAME:

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -213,6 +213,11 @@ class MLRunPatcher(object):
 
     def _replace_deployment_images(self, container, built_image):
         logger.info("Replace mlrun-api-chief")
+        if self._config.get("OVERWRITE_IMAGE_REGISTRY"):
+            built_image = built_image.replace(
+                self._config["DOCKER_REGISTRY"], self._config["OVERWRITE_IMAGE_REGISTRY"]
+            )
+
         self._exec_remote(
             [
                 "kubectl",

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -215,7 +215,8 @@ class MLRunPatcher(object):
         logger.info("Replace mlrun-api-chief")
         if self._config.get("OVERWRITE_IMAGE_REGISTRY"):
             built_image = built_image.replace(
-                self._config["DOCKER_REGISTRY"], self._config["OVERWRITE_IMAGE_REGISTRY"]
+                self._config["DOCKER_REGISTRY"],
+                self._config["OVERWRITE_IMAGE_REGISTRY"],
             )
 
         self._exec_remote(


### PR DESCRIPTION
Add support to push the built images to the iguazio data node registry.
This requires using the data node IP from the local host and to overwrite the IP with the domain named registry from the app cluster.