### PR TITLE
Add ds to allowed file paths

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -278,7 +278,7 @@ default_config = {
         "real_path": "",
         # comma delimited prefixes of paths allowed through the /files API (v3io & the real_path are always allowed).
         # These paths must be schemas (cannot be used for local files). For example "s3://mybucket,gcs://"
-        "allowed_file_paths": "s3://,gcs://,gs://,az://,dbfs://",
+        "allowed_file_paths": "s3://,gcs://,gs://,az://,dbfs://,ds://",
         "db_type": "sqldb",
         "max_workers": 64,
         # See mlrun.common.schemas.APIStates for options


### PR DESCRIPTION
Fix 'Unauthorized path' error when trying to preview/download artifact using datastore profile path.
https://jira.iguazeng.com/browse/ML-5464