### PR TITLE
[Functions] Add more labels to the image builder pods to facilitate resource usage tracking

### DIFF
--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -533,7 +533,7 @@ def build_image(
             label_prefix + "name": name,
             label_prefix + "function": runtime.metadata.name,
             label_prefix + "tag": runtime.metadata.tag or "latest",
-        }
+        },
     )
 
     if to_mount:

--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -157,6 +157,7 @@ def make_kaniko_pod(
     runtime_spec=None,
     registry=None,
     extra_args="",
+    extra_labels={},
     project_secrets=None,
 ):
     extra_runtime_spec = {}
@@ -238,6 +239,7 @@ def make_kaniko_pod(
         project=project,
         default_pod_spec_attributes=extra_runtime_spec,
         resources=resources,
+        labels=extra_labels,
     )
     envs = (builder_env or []) + (project_secrets or [])
     kpod.env = envs or None
@@ -509,6 +511,7 @@ def build_image(
         extra_args=extra_args,
     )
 
+    label_prefix = mlrun.runtimes.utils.mlrun_key
     kpod = make_kaniko_pod(
         project,
         context,
@@ -526,6 +529,11 @@ def build_image(
         runtime_spec=runtime_spec,
         registry=registry,
         extra_args=extra_args,
+        extra_labels={
+            label_prefix + "name": name,
+            label_prefix + "function": runtime.metadata.name,
+            label_prefix + "tag": runtime.metadata.tag or "latest",
+        }
     )
 
     if to_mount:

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -591,7 +591,7 @@ class BasePod:
         project=None,
         default_pod_spec_attributes=None,
         resources=None,
-        labels={},
+        labels=None,
     ):
         self.namespace = namespace
         self.name = ""
@@ -608,7 +608,7 @@ class BasePod:
             "mlrun/task-name": task_name,
             "mlrun/class": kind,
             "mlrun/project": self.project,
-        } | labels
+        } | (labels or {})
         self._annotations = {}
         self._init_containers = []
         # will be applied on the pod spec only when calling .pod(), allows to override spec attributes

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -591,6 +591,7 @@ class BasePod:
         project=None,
         default_pod_spec_attributes=None,
         resources=None,
+        labels={},
     ):
         self.namespace = namespace
         self.name = ""
@@ -607,7 +608,7 @@ class BasePod:
             "mlrun/task-name": task_name,
             "mlrun/class": kind,
             "mlrun/project": self.project,
-        }
+        } | labels
         self._annotations = {}
         self._init_containers = []
         # will be applied on the pod spec only when calling .pod(), allows to override spec attributes


### PR DESCRIPTION
[ML-3728](https://jira.iguazeng.com/browse/ML-3728)

Add more MLRun-related labels to pods that build function and project images in order to facilitate monitoring.

The added labels are:
```
mlrun/name
mlrun/function
mlrun/tag
```  

It's worth noting that `mlrun/class` and `mlrun/project` are already present on builder pods.