### PR TITLE
[CI] Use Javascript regex conventions

### DIFF
--- a/.github/pr-title-validation-config.json
+++ b/.github/pr-title-validation-config.json
@@ -5,7 +5,7 @@
   },
   "CHECKS": {
     "regexp": "^((\\[\\p{Lu}[^\\]]+\\])+|Revert) .*$",
-    "regexpFlags": "",
+    "regexpFlags": "im",
     "ignoreLabels": []
   },
   "MESSAGES": {

--- a/.github/pr-title-validation-config.json
+++ b/.github/pr-title-validation-config.json
@@ -4,7 +4,7 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "regexp": "^((\\[\\p{Lu}[^\\]]+\\])+|Revert) .*$",
+    "regexp": "^((\\[[[A-Z][^\\]]+\\]+)|Revert) .*$",
     "regexpFlags": "im",
     "ignoreLabels": []
   },


### PR DESCRIPTION
Javascript is not familiar with  `\\p{Lu}` so falling back to A-Z which means every pr title must start with a capital letter