### PR TITLE
[Datastore] Filter out 'none' values when passing storage options for Azure

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -57,7 +57,7 @@ class AzureBlobStore(DataStore):
         return self._filesystem
 
     def get_storage_options(self):
-        return dict(
+        res = dict(
             account_name=self._get_secret_or_env("account_name")
             or self._get_secret_or_env("AZURE_STORAGE_ACCOUNT_NAME"),
             account_key=self._get_secret_or_env("account_key")
@@ -74,6 +74,9 @@ class AzureBlobStore(DataStore):
             or self._get_secret_or_env("AZURE_STORAGE_SAS_TOKEN"),
             credential=self._get_secret_or_env("credential"),
         )
+        # Filter out None values
+        res = {k: v for k, v in res.items() if v}
+        return res
 
     def _convert_key_to_remote_path(self, key):
         key = key.strip("/")
@@ -149,7 +152,7 @@ class AzureBlobStore(DataStore):
             for key in ["account_name", "account_key"]:
                 parsed_value = parsed_credential.get(key)
                 if parsed_value:
-                    if st[key] and st[key] != parsed_value:
+                    if key in st and st[key] != parsed_value:
                         if key == "account_name":
                             raise mlrun.errors.MLRunInvalidArgumentError(
                                 f"Storage option for '{key}' is '{st[key]}',\

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -74,9 +74,7 @@ class AzureBlobStore(DataStore):
             or self._get_secret_or_env("AZURE_STORAGE_SAS_TOKEN"),
             credential=self._get_secret_or_env("credential"),
         )
-        # Filter out None values
-        res = {k: v for k, v in res.items() if v}
-        return res
+        return self._sanitize_storage_options(res)
 
     def _convert_key_to_remote_path(self, key):
         key = key.strip("/")

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -72,6 +72,13 @@ class DataStore:
         return True
 
     @staticmethod
+    def _sanitize_storage_options(options):
+        if not options:
+            return {}
+        options = {k: v for k, v in options.items() if v is not None and v != ""}
+        return options
+
+    @staticmethod
     def _sanitize_url(url):
         """
         Extract only the schema, netloc, and path from an input URL if they exist,
@@ -107,7 +114,7 @@ class DataStore:
 
     def get_storage_options(self):
         """get fsspec storage options"""
-        return None
+        return self._sanitize_storage_options(None)
 
     def open(self, filepath, mode):
         file_system = self.get_filesystem(False)

--- a/mlrun/datastore/dbfs_store.py
+++ b/mlrun/datastore/dbfs_store.py
@@ -97,10 +97,11 @@ class DBFSStore(DataStore):
         return self._filesystem
 
     def get_storage_options(self):
-        return dict(
+        res = dict(
             token=self._get_secret_or_env("DATABRICKS_TOKEN"),
             instance=self._get_secret_or_env("DATABRICKS_HOST"),
         )
+        return self._sanitize_storage_options(res)
 
     def _verify_filesystem_and_key(self, key: str):
         if not self._filesystem:

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -59,12 +59,12 @@ class GoogleCloudStorageStore(DataStore):
             except json.JSONDecodeError:
                 # If it's not json, handle it as a filename
                 token = credentials
-            return dict(token=token)
+                return self._sanitize_storage_options(dict(token=token))
         else:
             logger.info(
                 "No GCS credentials available - auth will rely on auto-discovery of credentials"
             )
-            return None
+            return self._sanitize_storage_options(None)
 
     def _make_path(self, key):
         key = key.strip("/")

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -157,7 +157,7 @@ class S3Store(DataStore):
         if profile:
             storage_options["profile"] = profile
 
-        return storage_options
+        return self._sanitize_storage_options(storage_options)
 
     def get_bucket_and_key(self, key):
         path = self._join(key)[1:]

--- a/mlrun/datastore/v3io.py
+++ b/mlrun/datastore/v3io.py
@@ -89,10 +89,11 @@ class V3ioStore(DataStore):
         return self._filesystem
 
     def get_storage_options(self):
-        return dict(
+        res = dict(
             v3io_access_key=self._get_secret_or_env("V3IO_ACCESS_KEY"),
             v3io_api=mlrun.mlconf.v3io_api,
         )
+        return self._sanitize_storage_options(res)
 
     def _upload(self, key: str, src_path: str, max_chunk_size: int = ONE_GB):
         """helper function for upload method, allows for controlling max_chunk_size in testing"""


### PR DESCRIPTION
https://jira.iguazeng.com/browse/ML-5518
https://jira.iguazeng.com/browse/ML-5521

Hadoop configurations for Azure Spark were based on the presumption that underlying storage options are present only if they are non-empty. However, this assumption proved to be inaccurate. The proposed Pull Request (PR) addresses this issue by excluding empty storage options, thereby ensuring the proper functioning of Spark.
