### PR TITLE
[Model Monitoring] Fix bumping the last request for batch inference 

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -207,6 +207,10 @@ class MLRunTaskCancelledError(Exception):
     pass
 
 
+class MLRunValueError(ValueError):
+    pass
+
+
 class MLRunFatalFailureError(Exception):
     """
     Internal exception meant to be used inside mlrun.utils.helpers.retry_until_successful to signal the loop not to

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -29,7 +29,12 @@ from mlrun.common.model_monitoring.helpers import FeatureStats, pad_features_his
 from mlrun.datastore import get_stream_pusher
 from mlrun.datastore.targets import ParquetTarget
 from mlrun.model_monitoring.batch import calculate_inputs_statistics
-from mlrun.model_monitoring.helpers import get_monitoring_parquet_path, get_stream_path
+from mlrun.model_monitoring.helpers import (
+    _BatchDict,
+    batch_dict2timedelta,
+    get_monitoring_parquet_path,
+    get_stream_path,
+)
 from mlrun.utils import logger
 from mlrun.utils.v3io_clients import get_v3io_client
 
@@ -165,15 +170,9 @@ class _BatchWindowGenerator:
             self._batch_dict[pair_list[0]] = float(pair_list[1])
 
     def _get_timedelta(self) -> int:
-        """Get the timedelta from a batch dictionary"""
-        self._batch_dict = cast(dict[str, int], self._batch_dict)
-        minutes, hours, days = (
-            self._batch_dict[mm_constants.EventFieldType.MINUTES],
-            self._batch_dict[mm_constants.EventFieldType.HOURS],
-            self._batch_dict[mm_constants.EventFieldType.DAYS],
-        )
+        """Get the timedelta in seconds from the batch dictionary"""
         return int(
-            datetime.timedelta(minutes=minutes, hours=hours, days=days).total_seconds()
+            batch_dict2timedelta(cast(_BatchDict, self._batch_dict)).total_seconds()
         )
 
     @classmethod

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -21,11 +21,18 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
 from mlrun.common.schemas.model_monitoring import EventFieldType
 from mlrun.errors import MLRunInvalidArgumentError
+from mlrun.errors import MLRunValueError
 from mlrun.model_monitoring.model_endpoint import ModelEndpoint
 from mlrun.utils import logger
 
 if typing.TYPE_CHECKING:
     from mlrun.db.base import RunDBInterface
+
+
+class _BatchDict(typing.TypedDict):
+    minutes: int
+    hours: int
+    days: int
 
 
 def get_stream_path(project: str = None, application_name: str = None):
@@ -96,6 +103,21 @@ def get_connection_string(secret_provider: typing.Callable = None) -> str:
             secret_provider=secret_provider,
         )
         or mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection
+    )
+
+
+def batch_dict2timedelta(batch_dict: _BatchDict) -> datetime.timedelta:
+    """
+    Convert a batch dictionary to timedelta.
+
+    :param batch_dict:  Batch dict.
+
+    :return:            Timedelta.
+    """
+    return datetime.timedelta(
+        days=batch_dict[EventFieldType.DAYS],
+        hours=batch_dict[EventFieldType.HOURS],
+        minutes=batch_dict[EventFieldType.MINUTES],
     )
 
 

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import datetime
 import typing
 
 import mlrun
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
-from mlrun.common.schemas.model_monitoring import EventFieldType
-from mlrun.errors import MLRunInvalidArgumentError
+from mlrun.common.schemas.model_monitoring import (
+    EventFieldType,
+    MonitoringFunctionNames,
+)
 from mlrun.errors import MLRunValueError
 from mlrun.model_monitoring.model_endpoint import ModelEndpoint
 from mlrun.utils import logger
@@ -121,12 +122,35 @@ def batch_dict2timedelta(batch_dict: _BatchDict) -> datetime.timedelta:
     )
 
 
+def _get_monitoring_time_window_from_controller_run(
+    project: str, db: "RunDBInterface"
+) -> datetime.timedelta:
+    """
+    Get timedelta for the controller to run.
+
+    :param project: Project name.
+    :param db:      DB interface.
+
+    :return:    Timedelta for the controller to run.
+    """
+    run_name = MonitoringFunctionNames.APPLICATION_CONTROLLER
+    runs = db.list_runs(project=project, name=run_name, sort=True)
+    if not runs:
+        raise MLRunValueError(f"No {run_name} runs were found")
+    last_run = runs[0]
+    try:
+        batch_dict = last_run["spec"]["parameters"]["batch_intervals_dict"]
+    except KeyError:
+        raise MLRunValueError(
+            f"Could not find `batch_intervals_dict` in {run_name} run"
+        )
+    return batch_dict2timedelta(batch_dict)
+
+
 def bump_model_endpoint_last_request(
     project: str,
     model_endpoint: ModelEndpoint,
     db: "RunDBInterface",
-    minutes_delta: int = 10,  # TODO: move to config - should be the same as `batch_interval`
-    seconds_delta: int = 1,
 ) -> None:
     """
     Update the last request field of the model endpoint to be after the current last request time.
@@ -134,10 +158,6 @@ def bump_model_endpoint_last_request(
     :param project:         Project name.
     :param model_endpoint:  Model endpoint object.
     :param db:              DB interface.
-    :param minutes_delta:   Minutes delta to add to the last request time.
-    :param seconds_delta:   Seconds delta to add to the last request time. This is mainly to ensure that the last
-                            request time is strongly greater than the previous one (with respect to the window time)
-                            after adding the minutes delta.
     """
     if not model_endpoint.status.last_request:
         logger.error(
@@ -145,14 +165,10 @@ def bump_model_endpoint_last_request(
             project=project,
             endpoint_id=model_endpoint.metadata.uid,
         )
-        raise MLRunInvalidArgumentError("Model endpoint last request time is empty")
-
+        raise MLRunValueError("Model endpoint last request time is empty")
     bumped_last_request = (
         datetime.datetime.fromisoformat(model_endpoint.status.last_request)
-        + datetime.timedelta(
-            minutes=minutes_delta,
-            seconds=seconds_delta,
-        )
+        + _get_monitoring_time_window_from_controller_run(project, db)
         + datetime.timedelta(
             seconds=mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
         )

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -115,11 +115,7 @@ def batch_dict2timedelta(batch_dict: _BatchDict) -> datetime.timedelta:
 
     :return:            Timedelta.
     """
-    return datetime.timedelta(
-        days=batch_dict[EventFieldType.DAYS],
-        hours=batch_dict[EventFieldType.HOURS],
-        minutes=batch_dict[EventFieldType.MINUTES],
-    )
+    return datetime.timedelta(**batch_dict)
 
 
 def _get_monitoring_time_window_from_controller_run(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -276,6 +276,7 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
         # model
         cls.classif = SVC()
         cls.model_name = "svc"
+        # data
         cls.columns = ["a1", "a2", "b"]
         cls.y_name = "t"
         cls.num_rows = 15
@@ -285,9 +286,10 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
         cls.training_set = cls.x_train.join(cls.y_train)
         cls.test_set = cls.x_test.join(cls.y_test)
         cls.infer_results_df = cls.test_set
-        # cls.infer_results_df[EventFieldType.TIMESTAMP] = datetime.utcnow()  # TODO - add timestamp
+        # endpoint
         cls.endpoint_id = "58d42fdd76ad999c377fad1adcafd2790b5a89b9"
         cls.function_name = f"{cls.name_prefix}-function"
+        # training
         cls._train()
 
         # model monitoring app
@@ -363,7 +365,8 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
         with ThreadPoolExecutor() as executor:
             executor.submit(self._deploy_monitoring_app)
             executor.submit(self._deploy_monitoring_infra)
-            executor.submit(self._record_results)
+            future = executor.submit(self._record_results)
+            future.result()
 
         time.sleep(1.4 * self.app_interval_seconds)
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -365,8 +365,8 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
         with ThreadPoolExecutor() as executor:
             executor.submit(self._deploy_monitoring_app)
             executor.submit(self._deploy_monitoring_infra)
-            future = executor.submit(self._record_results)
-            future.result()
+
+        self._record_results()
 
         time.sleep(1.4 * self.app_interval_seconds)
 


### PR DESCRIPTION
Resolves [ML-5495](https://jira.iguazeng.com/browse/ML-5495).

Take the actual monitoring time window from the last run of the controller's job.