### PR TITLE
[Execution] Don't add host label to non logging workers

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -393,7 +393,7 @@ class MLClientCtx(object):
                     if v:
                         self._set_input(k, v)
 
-        if host and not is_api:
+        if host and not is_api and self.is_logging_worker():
             self.set_label("host", host)
 
         start = get_in(attrs, "status.start_time")


### PR DESCRIPTION
Host label describes the running pod. When running with multiple workers, it will result with conflicting values and as consequence, storing the run will fail.
https://jira.iguazeng.com/browse/ML-5512