### PR TITLE
[DB] Support case-insensitive label queries

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -3705,14 +3705,17 @@ class SQLDB(DBInterface):
         for lbl in labels:
             if "=" in lbl:
                 name, value = [v.strip() for v in lbl.split("=", 1)]
-                cond = and_(cls.Label.name == name, cls.Label.value == value)
+                cond = and_(
+                    generate_query_predicate_for_name(cls.Label.name, name),
+                    generate_query_predicate_for_name(cls.Label.value, value),
+                )
                 preds.append(cond)
                 label_names_with_values.add(name)
             else:
                 label_names_no_values.add(lbl.strip())
 
         for name in label_names_no_values.difference(label_names_with_values):
-            preds.append(cls.Label.name == name)
+            preds.append(generate_query_predicate_for_name(cls.Label.name, name))
 
         if len(preds) == 1:
             # A single label predicate is a common case, and there's no need to burden the DB with


### PR DESCRIPTION
Add the option to use tilde `~` as a prefix to enable case-insensitive label queries. This works the same as it does for names, meaning it's not just case-insensitive, but also searches for substring. For example, looking for `~IKA` will match `pikachu`.
The same works for label name and value, so if an artifact has a label `Key : Value`, looking for `Key=~V` will do an exact match on the key but insensitive match on the value, looking for `~K=~V` will do insensitive match on both.

This change works on every label query that uses the `_add_labels_filter` method, so it works for artifacts, functions, runs, fsets, fvecs, projects and schedules. 

Fixes [ML-5480](https://jira.iguazeng.com/browse/ML-5480)