### PR TITLE
[Execution] Fix non logging worker lables

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -977,7 +977,7 @@ class MLClientCtx(object):
         """
         # If it's a OpenMPI job, get the global rank and compare to the logging rank (worker) set in MLRun's
         # configuration:
-        if self._labels.get("kind", "job") == "mpijob":
+        if self._labels.get("kind", "job") == "mpijob" and self._labels.get("host"):
             # The host (pod name) of each worker is created by k8s, and by default it uses the rank number as the id in
             # the following template: ...-worker-<rank>
             rank = int(self._labels["host"].rsplit("-", 1)[1])

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -411,7 +411,7 @@ class MLClientCtx(object):
                 self._artifacts_manager.artifacts[key] = artifact_obj
             self._state = status.get("state", self._state)
 
-        # Do not store run if not logging worker to avoid conflicts like host label
+        # No need to store the run for every worker
         if store_run and self.is_logging_worker():
             self.store_run()
         return self
@@ -974,10 +974,11 @@ class MLClientCtx(object):
         """
         # If it's a OpenMPI job, get the global rank and compare to the logging rank (worker) set in MLRun's
         # configuration:
-        if self._labels.get("kind", "job") == "mpijob" and self._labels.get("host"):
+        labels = self.labels
+        if "host" in labels and labels.get("kind", "job") == "mpijob":
             # The host (pod name) of each worker is created by k8s, and by default it uses the rank number as the id in
             # the following template: ...-worker-<rank>
-            rank = int(self._labels["host"].rsplit("-", 1)[1])
+            rank = int(labels["host"].rsplit("-", 1)[1])
             return rank == mlrun.mlconf.packagers.logging_worker
 
         # Single worker is always the logging worker:

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -1095,7 +1095,7 @@ class MLClientCtx(object):
         """Remove labels that should not be stored to the corresponding run"""
         labels = deepcopy(self._labels)
         # Remove host (pod name) label if it's not a logging worker:
-        if labels.get("host") and not self.is_logging_worker():
+        if "host" in labels and not self.is_logging_worker():
             del labels["host"]
 
         return labels

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -1095,8 +1095,8 @@ class MLClientCtx(object):
         """Remove labels that should not be stored to the corresponding run"""
         labels = deepcopy(self._labels)
         # Remove host (pod name) label if it's not a logging worker:
-        if "host" in labels and not self.is_logging_worker():
-            del labels["host"]
+        if not self.is_logging_worker():
+            labels.pop("host", None)
 
         return labels
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -1025,7 +1025,6 @@ class MLClientCtx(object):
         if self._state != "completed":
             struct["status.state"] = self._state
 
-        # TODO: test that non logging workers do not override the labels
         if self.is_logging_worker():
             struct["metadata.labels"] = self._labels
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -977,10 +977,10 @@ class MLClientCtx(object):
         """
         # If it's a OpenMPI job, get the global rank and compare to the logging rank (worker) set in MLRun's
         # configuration:
-        if self.labels.get("kind", "job") == "mpijob":
+        if self._labels.get("kind", "job") == "mpijob":
             # The host (pod name) of each worker is created by k8s, and by default it uses the rank number as the id in
             # the following template: ...-worker-<rank>
-            rank = int(self.labels["host"].rsplit("-", 1)[1])
+            rank = int(self._labels["host"].rsplit("-", 1)[1])
             return rank == mlrun.mlconf.packagers.logging_worker
 
         # Single worker is always the logging worker:

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -201,7 +201,10 @@ class MLClientCtx(object):
     @property
     def labels(self):
         """Dictionary with labels (read-only)"""
-        return deepcopy(self._labels)
+        labels = deepcopy(self._labels)
+        if not self.is_logging_worker():
+            labels.pop("host", None)
+        return labels
 
     @property
     def annotations(self):
@@ -393,7 +396,7 @@ class MLClientCtx(object):
                     if v:
                         self._set_input(k, v)
 
-        if host and not is_api and self.is_logging_worker():
+        if host and not is_api:
             self.set_label("host", host)
 
         start = get_in(attrs, "status.start_time")
@@ -908,7 +911,7 @@ class MLClientCtx(object):
                 "uid": self._uid,
                 "iteration": self._iteration,
                 "project": self._project,
-                "labels": self._labels,
+                "labels": self.labels,
                 "annotations": self._annotations,
             },
             "spec": {
@@ -1004,7 +1007,7 @@ class MLClientCtx(object):
                 _struct[key] = val
 
         struct = {
-            "metadata.labels": self._labels,
+            "metadata.labels": self.labels,
             "metadata.annotations": self._annotations,
             "spec.parameters": self._parameters,
             "spec.outputs": self._outputs,


### PR DESCRIPTION
The host label is needed to resolve if the worker is the logging worker or not.
Do not set labels from non logging workers
https://jira.iguazeng.com/browse/ML-5536