### PR TITLE
[Builder] Mount AWS credentials to /tmp/aws

### DIFF
--- a/server/api/utils/builder.py
+++ b/server/api/utils/builder.py
@@ -347,7 +347,7 @@ def configure_kaniko_ecr_init_container(
 
     else:
         aws_credentials_file_env_key = "AWS_SHARED_CREDENTIALS_FILE"
-        aws_credentials_file_env_value = "/tmp/credentials"
+        aws_credentials_file_env_value = "/tmp/aws/credentials"
 
         # set the credentials file location in the init container
         init_container_env[
@@ -363,7 +363,7 @@ def configure_kaniko_ecr_init_container(
         # mount the AWS credentials secret
         kpod.mount_secret(
             config.httpdb.builder.docker_registry_secret,
-            path="/tmp",
+            path="/tmp/aws",
         )
 
     kpod.append_init_container(

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -585,7 +585,7 @@ def test_build_runtime_ecr_with_aws_secret(monkeypatch):
         if volume.secret
     ]
     aws_mount = {
-        "mount_path": "/tmp",
+        "mount_path": "/tmp/aws",
         "mount_propagation": None,
         "name": "aws-secret",
         "read_only": None,
@@ -598,7 +598,7 @@ def test_build_runtime_ecr_with_aws_secret(monkeypatch):
 
     aws_creds_location_env = {
         "name": "AWS_SHARED_CREDENTIALS_FILE",
-        "value": "/tmp/credentials",
+        "value": "/tmp/aws/credentials",
         "value_from": None,
     }
     assert aws_creds_location_env in [


### PR DESCRIPTION
The mount sets the permissions for the directory to read only. Setting it to tmp, blocks writing anything to it. Block /tmp/aws instead.
https://jira.iguazeng.com/browse/ML-4937