### PR TITLE
[Run] Save enriched function to db when submitting job schedule with custom spec

### DIFF
--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -964,14 +964,14 @@ def submit_run_sync(
                 cron_trigger = mlrun.common.schemas.ScheduleCronTrigger(**cron_trigger)
             schedule_labels = task["metadata"].get("labels")
 
-            # if the task is pointing to a remote function (hub://), we need to save it to the db
+            # save the generated function enriched with the specific configuration to the db
             # and update the task to point to the saved function, so that the scheduler will be able to
-            # access the db version of the function, and not the remote one (which can be changed between runs)
-            if "://" in task["spec"]["function"]:
-                function_uri = fn.save(versioned=True)
-                data.pop("function", None)
-                data.pop("function_url", None)
-                task["spec"]["function"] = function_uri.replace("db://", "")
+            # access the db version of the function, and not the original function with the default spec
+            # (which can be changed between runs)
+            function_uri = fn.save(versioned=True)
+            data.pop("function", None)
+            data.pop("function_url", None)
+            task["spec"]["function"] = function_uri.replace("db://", "")
 
             is_update = get_scheduler().store_schedule(
                 db_session,

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -87,6 +87,48 @@ def test_submit_run_sync(db: Session, client: TestClient):
     ), "schedule was not updated"
 
 
+def test_submit_run_sync_schedule_with_function_overrides(
+    db: Session, client: TestClient
+):
+    auth_info = mlrun.common.schemas.AuthInfo()
+    tests.api.api.utils.create_project(client, PROJECT)
+    project, function_name, function_tag, original_function = _mock_original_function(
+        client
+    )
+    original_function_uri = f"{project}/{function_name}:{function_tag}"
+    resources = {
+        "limits": {
+            "cpu": "3m",
+            "memory": "3Mi",
+            "nvidia.com/gpu": "3",
+        },
+        "requests": {"cpu": "3", "memory": "3Mi"},
+    }
+    submit_job_body = {
+        "schedule": "0 * * * *",
+        "task": {
+            "spec": {
+                "function": f"{project}/{function_name}:{function_tag}",
+            },
+            "metadata": {"name": "sometask", "project": project},
+        },
+        "function": {
+            "metadata": {"credentials": {"access_key": "some-access-key-override"}},
+            "spec": {
+                "resources": resources,
+            },
+        },
+    }
+    _, _, _, response_data = server.api.api.utils.submit_run_sync(
+        db, auth_info, submit_job_body
+    )
+    assert response_data["data"]["action"] == "created"
+
+    # validate the function uri was changed in the task configuration, meaning a new function was created
+    # and set as the task's function
+    assert submit_job_body["task"]["spec"]["function"] != original_function_uri
+
+
 def test_generate_function_and_task_from_submit_run_body_body_override_values(
     db: Session, client: TestClient
 ):
@@ -1371,7 +1413,7 @@ def _mock_original_function(
         original_function,
     ) = _generate_original_function(access_key=access_key, kind=kind)
     resp = client.post(
-        f"func/{project}/{function_name}",
+        f"projects/{project}/functions/{function_name}",
         json=original_function,
         params={"tag": function_tag},
     )


### PR DESCRIPTION
When submitting a scheduled batch run and overriding the function's configuration, the task still keeps a reference for the original function URI, with the default values.
So although the actual run includes the custom spec, this affects editing a schedule (in the UI) by not populating the config fields with the correct custom values.

To overcome this, we create a new versioned function in the DB with the enriched configuration, and set its URI on the scheduled task, same as we do with hub functions.
Now, the task will reference the enriched function instead of the original one.

Fixes https://jira.iguazeng.com/browse/ML-5111