### PR TITLE
[Automation] Extend MLRun CE deploy script to allow for a forceful Kubeflow Pipelines installation

### DIFF
--- a/automation/deployment/README.md
+++ b/automation/deployment/README.md
@@ -34,6 +34,8 @@ To disable the components that are installed by default, you can use the followi
 - `--disable-prometheus-stack`: Disable the installation of the Prometheus stack.
 - `--disable-spark-operator`: Disable the installation of the Spark operator.
 
+This CLI tool automatically detects if the current CPU architecture supports Kubeflow Pipelines and disables its installation if not. Use `--force-enable-pipelines` if you'd like to bypass this behavior and install it regardless.
+
 To override the images used by the CE, you can use the following flags:
 - `--override-jupyter-image`: Override the jupyter image. Format: `<repo>:<tag>`
 - `--override-mlrun-api-image`: Override the mlrun-api image. Format: `<repo>:<tag>`

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -131,6 +131,11 @@ def cli():
     help="Disable the installation of Kubeflow Pipelines",
 )
 @click.option(
+    "--force-enable-pipelines",
+    is_flag=True,
+    help="Install Kubeflow Pipelines even when the available CPU architecture doesn't support it",
+)
+@click.option(
     "--disable-prometheus-stack",
     is_flag=True,
     help="Disable the installation of the Prometheus stack",
@@ -192,6 +197,7 @@ def deploy(
     override_mlrun_ui_image: str = None,
     override_jupyter_image: str = None,
     disable_pipelines: bool = False,
+    force_enable_pipelines: bool = False,
     disable_prometheus_stack: bool = False,
     disable_spark_operator: bool = False,
     disable_log_collector: bool = False,
@@ -222,6 +228,7 @@ def deploy(
         override_mlrun_ui_image=override_mlrun_ui_image,
         override_jupyter_image=override_jupyter_image,
         disable_pipelines=disable_pipelines,
+        force_enable_pipelines=force_enable_pipelines,
         disable_prometheus_stack=disable_prometheus_stack,
         disable_spark_operator=disable_spark_operator,
         disable_log_collector=disable_log_collector,


### PR DESCRIPTION
Currently, the MLRun CE deploy script reads the local CPU architecture to infer whether Helm can install Kubeflow Pipelines. This check doesn't consider that the target cluster of the procedure may be running in a separate environment with a different CPU, like a Virtual Machine.

This PR adds the flag `--force-enable-pipelines` to bypass this behavior if the user chooses to.