### PR TITLE
[Model Monitoring] Fix "divide by zero" warning in KL divergence metric

### DIFF
--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -143,8 +143,8 @@ class KullbackLeiblerDivergence(HistogramDistanceMetric, metric_name="kld"):
         t_u = self._calc_kl_div(self.distrib_t, self.distrib_u, kld_scaling)
         u_t = self._calc_kl_div(self.distrib_u, self.distrib_t, kld_scaling)
         result = t_u + u_t
-        if capping:
-            return capping if result == float("inf") else result
+        if capping and result == float("inf"):
+            return capping
         return result
 
 

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -130,7 +130,9 @@ class KullbackLeiblerDivergence(HistogramDistanceMetric, metric_name="kld"):
             )
         )
 
-    def compute(self, capping: float = None, kld_scaling: float = 1e-4) -> float:
+    def compute(
+        self, capping: Optional[float] = None, kld_scaling: float = 1e-4
+    ) -> float:
         """
         :param capping:      A bounded value for the KL Divergence. For infinite distance, the result is replaced with
                              the capping value which indicates a huge differences between the distributions.

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -117,7 +117,7 @@ class KullbackLeiblerDivergence(HistogramDistanceMetric, metric_name="kld"):
     def _calc_kl_div(
         actual_dist: np.array, expected_dist: np.array, kld_scaling: float
     ) -> float:
-        """Return the assymetric KL divergence"""
+        """Return the asymmetric KL divergence"""
         return np.sum(
             np.where(
                 actual_dist != 0,

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -118,16 +118,15 @@ class KullbackLeiblerDivergence(HistogramDistanceMetric, metric_name="kld"):
         actual_dist: np.array, expected_dist: np.array, kld_scaling: float
     ) -> float:
         """Return the asymmetric KL divergence"""
+        # We take 0*log(0) == 0 for this calculation
+        mask = actual_dist != 0
+        actual_dist = actual_dist[mask]
+        expected_dist = expected_dist[mask]
         return np.sum(
-            np.where(
-                actual_dist != 0,
-                (actual_dist)
-                * np.log(
-                    actual_dist
-                    / np.where(expected_dist != 0, expected_dist, kld_scaling)
-                ),
-                0,
-            )
+            actual_dist
+            * np.log(
+                actual_dist / np.where(expected_dist != 0, expected_dist, kld_scaling)
+            ),
         )
 
     def compute(

--- a/tests/model_monitoring/test_metrics.py
+++ b/tests/model_monitoring/test_metrics.py
@@ -109,27 +109,21 @@ def _norm_arr(arr: np.ndarray) -> np.ndarray:
 
 @pytest.mark.parametrize(
     "metric_class",
-    # HistogramDistanceMetric.__subclasses__(),
-    [
-        KullbackLeiblerDivergence,
-        # TotalVarianceDistance,
-        # HellingerDistance,
-    ],
+    HistogramDistanceMetric.__subclasses__(),
 )
-# @given(
-#     distrib=st.builds(
-#         _norm_arr,
-#         arrays(
-#             dtype=np.float64,
-#             elements=st.floats(min_value=0, max_value=1),
-#             shape=st.integers(min_value=1, max_value=500),
-#         ),
-#     )
-# )
+@given(
+    distrib=st.builds(
+        _norm_arr,
+        arrays(
+            dtype=np.float64,
+            elements=st.floats(min_value=0, max_value=1),
+            shape=st.integers(min_value=1, max_value=500),
+        ),
+    )
+)
 @pytest.mark.filterwarnings("error")
 def test_same_distrib_gives_zero_distance(
-    metric_class: Type[HistogramDistanceMetric],
-    distrib: np.ndarray = np.array([0.0, 1.0]),
+    metric_class: Type[HistogramDistanceMetric], distrib: np.ndarray
 ) -> None:
     return test_histogram_metric_calculation(
         metric_class=metric_class,

--- a/tests/model_monitoring/test_metrics.py
+++ b/tests/model_monitoring/test_metrics.py
@@ -109,20 +109,27 @@ def _norm_arr(arr: np.ndarray) -> np.ndarray:
 
 @pytest.mark.parametrize(
     "metric_class",
-    HistogramDistanceMetric.__subclasses__(),
+    # HistogramDistanceMetric.__subclasses__(),
+    [
+        KullbackLeiblerDivergence,
+        # TotalVarianceDistance,
+        # HellingerDistance,
+    ],
 )
-@given(
-    distrib=st.builds(
-        _norm_arr,
-        arrays(
-            dtype=np.float64,
-            elements=st.floats(min_value=0, max_value=1),
-            shape=st.integers(min_value=1, max_value=500),
-        ),
-    )
-)
+# @given(
+#     distrib=st.builds(
+#         _norm_arr,
+#         arrays(
+#             dtype=np.float64,
+#             elements=st.floats(min_value=0, max_value=1),
+#             shape=st.integers(min_value=1, max_value=500),
+#         ),
+#     )
+# )
+@pytest.mark.filterwarnings("error")
 def test_same_distrib_gives_zero_distance(
-    distrib: np.ndarray, metric_class: Type[HistogramDistanceMetric]
+    metric_class: Type[HistogramDistanceMetric],
+    distrib: np.ndarray = np.array([0.0, 1.0]),
 ) -> None:
     return test_histogram_metric_calculation(
         metric_class=metric_class,


### PR DESCRIPTION
Fixes [ML-5054](https://jira.iguazeng.com/browse/ML-5054).

We divided by zero and multiplied by inf before selecting the elements with `np.where`.
This change masks the arrays first to avoid these unnecessary and warning-producing calculations.

BTW, scipy has a nice utility function `xlogy` that calculates the log and tolerates zeros: [`scipy.special.xlogy`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.xlogy.html#scipy.special.xlogy).
I didn't use it, as this code is in the SDK, and it doesn't list scipy in its requirements.