### PR TITLE
[Model Monitoring] Update deprecated `get_offline_features` calls

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -612,7 +612,7 @@ def read_dataset_as_dataframe(
         if label_columns is None:
             label_columns = dataset.status.label_column
         # Get the features and parse to DataFrame:
-        dataset = mlrun.feature_store.get_offline_features(
+        dataset = dataset.get_offline_features(
             dataset.uri, drop_columns=drop_columns
         ).to_dataframe()
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -627,8 +627,7 @@ class MonitoringApplicationController:
 
         # get offline features based on application start and end time.
         # store the result parquet by partitioning by controller end processing time
-        offline_response = fstore.get_offline_features(
-            feature_vector=vector,
+        offline_response = vector.get_offline_features(
             start_time=start_infer_time,
             end_time=end_infer_time,
             timestamp_for_filtering=mm_constants.EventFieldType.TIMESTAMP,


### PR DESCRIPTION
Fixes [ML-5488](https://jira.iguazeng.com/browse/ML-5488).
Update only model monitoring usages to avoid noisy logs.