### PR TITLE
[Model Monitoring] Fix `remove_model_monitoring_function` to remove function from db

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2177,6 +2177,7 @@ class MlrunProject(ModelObj):
             == mm_constants.ModelMonitoringAppLabel.VAL
         ):
             self.remove_function(name=name)
+            mlrun.db.get_run_db().delete_function(name=name.lower())
             logger.info(f"{name} function has been removed from {self.name} project")
         else:
             raise logger.error(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2167,7 +2167,7 @@ class MlrunProject(ModelObj):
         self.spec.remove_function(name)
 
     def remove_model_monitoring_function(self, name):
-        """remove the specified model-monitoring-app function from the project
+        """remove the specified model-monitoring-app function from the project and from the db
 
         :param name: name of the model-monitoring-app function (under the project)
         """


### PR DESCRIPTION
first introduce #4550
[ML-5547](https://jira.iguazeng.com/browse/ML-5547) 