### PR TITLE
[Feature Store] Replace calls to deprecated `deploy_ingestion_service_v2()`

### DIFF
--- a/docs/data-prep/ingest-data-fs.md
+++ b/docs/data-prep/ingest-data-fs.md
@@ -134,7 +134,7 @@ error stream. <br>
 source = HTTPSource()
 func = mlrun.code_to_function("ingest", kind="serving").apply(mount_v3io())
 config = RunConfig(function=func)
-fstore.deploy_ingestion_service_v2(my_set, source, run_config=config)
+my_set.deploy_ingestion_service(source, run_config=config)
 ```
 
 To learn more about `deploy_ingestion_service` go to {py:class}`~mlrun.feature_store.deploy_ingestion_service`.
@@ -220,7 +220,7 @@ kafka_source = KafkaSource(
         
 run_config = fstore.RunConfig(local=False).apply(mlrun.auto_mount())
 
-stocks_set_endpoint = fstore.deploy_ingestion_service(featureset=stocks_set, source=kafka_source,run_config=run_config)
+stocks_set_endpoint = stocks_set.deploy_ingestion_service(source=kafka_source,run_config=run_config)
 ```        
        
 
@@ -265,7 +265,7 @@ kafka_source = KafkaSource(
     
 run_config = fstore.RunConfig(local=False).apply(mlrun.auto_mount())
 
-stocks_set_endpoint = fstore.deploy_ingestion_service(featureset=stocks_set, source=kafka_source,run_config=run_config)
+stocks_set_endpoint = stocks_set.deploy_ingestion_service(source=kafka_source,run_config=run_config)
 ```
 
 

--- a/docs/feature-store/end-to-end-demo/01-ingest-datasources.ipynb
+++ b/docs/feature-store/end-to-end-demo/01-ingest-datasources.ipynb
@@ -1351,8 +1351,8 @@
     "\n",
     "# Deploy the transactions feature set's ingestion service over a real-time (Nuclio) serverless function\n",
     "# you can use the run_config parameter to pass function/service specific configuration\n",
-    "transaction_set_endpoint, function = fstore.deploy_ingestion_service_v2(\n",
-    "    featureset=transaction_set, source=source\n",
+    "transaction_set_endpoint, function = transaction_set.deploy_ingestion_service(\n",
+    "    source=source\n",
     ")"
    ]
   },
@@ -1485,9 +1485,7 @@
     "\n",
     "# Deploy the transactions feature set's ingestion service over a real-time (Nuclio) serverless function\n",
     "# you can use the run_config parameter to pass function/service specific configuration\n",
-    "events_set_endpoint, function = fstore.deploy_ingestion_service_v2(\n",
-    "    featureset=user_events_set, source=source\n",
-    ")"
+    "events_set_endpoint, function = user_events_set.deploy_ingestion_service(source=source)"
    ]
   },
   {

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -933,7 +933,7 @@ def _deploy_ingestion_service_v2(
         source = HTTPSource()
         func = mlrun.code_to_function("ingest", kind="serving").apply(mount_v3io())
         config = RunConfig(function=func)
-        fstore.deploy_ingestion_service(my_set, source, run_config=config)
+        my_set.deploy_ingestion_service(source, run_config=config)
 
     :param featureset:    feature set object or uri
     :param source:        data source object describing the online or offline source
@@ -1025,7 +1025,7 @@ def deploy_ingestion_service(
         source = HTTPSource()
         func = mlrun.code_to_function("ingest", kind="serving").apply(mount_v3io())
         config = RunConfig(function=func)
-        fstore.deploy_ingestion_service(my_set, source, run_config=config)
+        my_set.deploy_ingestion_service(source, run_config=config)
 
     :param featureset:    feature set object or uri
     :param source:        data source object describing the online or offline source
@@ -1036,8 +1036,7 @@ def deploy_ingestion_service(
 
     :return: URL to access the deployed ingestion service
     """
-    endpoint, _ = deploy_ingestion_service_v2(
-        featureset=featureset,
+    endpoint, _ = featureset.deploy_ingestion_service(
         source=source,
         targets=targets,
         name=name,

--- a/tests/feature-store/test_featureset.py
+++ b/tests/feature-store/test_featureset.py
@@ -25,7 +25,7 @@ from mlrun.model import DataSource, DataTargetBase
 @mock.patch("mlrun.feature_store.api._ingest")
 def test_ingest_method(mock_ingest):
     # Create an instance of FeatureSet
-    fs = FeatureSet()
+    fset = FeatureSet()
 
     # Define your test inputs
     test_source = "test_source"
@@ -39,7 +39,7 @@ def test_ingest_method(mock_ingest):
     test_overwrite = True
 
     # Call the ingest method
-    fs.ingest(
+    fset.ingest(
         source=test_source,
         targets=test_targets,
         namespace=test_namespace,
@@ -53,7 +53,7 @@ def test_ingest_method(mock_ingest):
 
     # Assert that mlrun.feature_store.api.ingest was called with the correct parameters
     mock_ingest.assert_called_once_with(
-        fs,
+        fset,
         test_source,
         test_targets,
         test_namespace,
@@ -69,7 +69,7 @@ def test_ingest_method(mock_ingest):
 @mock.patch("mlrun.feature_store.api._preview")
 def test_preview_method(mock_preview):
     # Create an instance of FeatureSet
-    fs = FeatureSet()
+    fset = FeatureSet()
 
     # Define your test inputs
     test_source = "test_source"
@@ -80,7 +80,7 @@ def test_preview_method(mock_preview):
     test_sample_size = 100
 
     # Call the preview method
-    fs.preview(
+    fset.preview(
         source=test_source,
         entity_columns=test_entity_columns,
         namespace=test_namespace,
@@ -91,7 +91,7 @@ def test_preview_method(mock_preview):
 
     # Assert that mlrun.feature_store.api.preview was called with the correct parameters
     mock_preview.assert_called_once_with(
-        fs,
+        fset,
         test_source,
         test_entity_columns,
         test_namespace,
@@ -104,7 +104,7 @@ def test_preview_method(mock_preview):
 @mock.patch("mlrun.feature_store.api._deploy_ingestion_service_v2")
 def test_deploy_ingestion_service(mock_deploy):
     # Create an instance of FeatureSet
-    fs = FeatureSet()
+    fset = FeatureSet()
 
     # Define your test inputs
     test_source = DataSource()  # Assuming DataSource is a valid class
@@ -117,7 +117,7 @@ def test_deploy_ingestion_service(mock_deploy):
     test_verbose = True
 
     # Call the deploy_ingestion_service method
-    fs.deploy_ingestion_service(
+    fset.deploy_ingestion_service(
         source=test_source,
         targets=test_targets,
         name=test_name,
@@ -125,7 +125,7 @@ def test_deploy_ingestion_service(mock_deploy):
         verbose=test_verbose,
     )
 
-    # Assert that mlrun.feature_store.api.deploy_ingestion_service_v2 was called with the correct parameters
+    # Assert that deploy_ingestion_service was called with the correct parameters
     mock_deploy.assert_called_once_with(
-        fs, test_source, test_targets, test_name, test_run_config, test_verbose
+        fset, test_source, test_targets, test_name, test_run_config, test_verbose
     )

--- a/tests/feature-store/test_infer.py
+++ b/tests/feature-store/test_infer.py
@@ -147,7 +147,7 @@ def test_check_permissions(rundb_mock, monkeypatch):
         fstore.get_online_feature_service(feature_vector)
 
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
-        fstore.deploy_ingestion_service_v2(featureset=data_set1)
+        data_set1.deploy_ingestion_service()
 
     with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
         data_set1.purge_targets()

--- a/tests/integration/sdk_api/feature_store/test_feature_store.py
+++ b/tests/integration/sdk_api/feature_store/test_feature_store.py
@@ -35,7 +35,6 @@ class TestFeatureStore(tests.integration.sdk_api.base.TestMLRunIntegration):
         )
 
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
-            fstore.deploy_ingestion_service_v2(
-                featureset=fset,
+            fset.deploy_ingestion_service(
                 source=v3io_source,
             )

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2759,8 +2759,7 @@ class TestFeatureStore(TestMLRunSystem):
         run_config = fstore.RunConfig(function=function, local=False).apply(
             mlrun.mount_v3io()
         )
-        fstore.deploy_ingestion_service_v2(
-            featureset=fset,
+        fset.deploy_ingestion_service(
             source=v3io_source,
             run_config=run_config,
             targets=[ParquetTarget(flush_after_seconds=1)],
@@ -2967,8 +2966,8 @@ class TestFeatureStore(TestMLRunSystem):
         run_config = fstore.RunConfig(function=function, local=False).apply(
             mlrun.mount_v3io()
         )
-        fstore.deploy_ingestion_service_v2(
-            featureset=fset, source=source, run_config=run_config, targets=targets
+        fset.deploy_ingestion_service(
+            source=source, run_config=run_config, targets=targets
         )
 
         fset.reload()  # refresh to ingestion service updates

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -383,8 +383,7 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
         run_config = fstore.RunConfig(local=False, function=func).apply(
             mlrun.auto_mount()
         )
-        stocks_set_endpoint, _ = fstore.deploy_ingestion_service_v2(
-            featureset=stocks_set,
+        stocks_set_endpoint, _ = stocks_set.deploy_ingestion_service(
             source=kafka_source,
             targets=[target],
             run_config=run_config,


### PR DESCRIPTION
And a few mentions of the older `mlrun.feature_store.api.deploy_ingestion_service()`.