### PR TITLE
[Dataset] Document overwriting behavior of `log_dataset`

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -664,6 +664,8 @@ class MLClientCtx(object):
     ):
         """Log a dataset artifact and optionally upload it to datastore
 
+        if the dataset exists with the same key and tag, it will be overwritten.
+
         Example::
 
             raw_data = {

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -664,7 +664,7 @@ class MLClientCtx(object):
     ):
         """Log a dataset artifact and optionally upload it to datastore
 
-        if the dataset exists with the same key and tag, it will be overwritten.
+        If the dataset exists with the same key and tag, it will be overwritten.
 
         Example::
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1499,9 +1499,9 @@ class MlrunProject(ModelObj):
         **kwargs,
     ) -> DatasetArtifact:
         """
-        log a dataset artifact and optionally upload it to datastore.
+        Log a dataset artifact and optionally upload it to datastore.
 
-        if the dataset already exists with the same key and tag, it will be overwritten.
+        If the dataset already exists with the same key and tag, it will be overwritten.
 
         example::
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1497,7 +1497,9 @@ class MlrunProject(ModelObj):
         **kwargs,
     ) -> DatasetArtifact:
         """
-        log a dataset artifact and optionally upload it to datastore
+        log a dataset artifact and optionally upload it to datastore.
+
+        if the dataset exists with the same key and tag, it will be overwritten.
 
         example::
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1426,6 +1426,8 @@ class MlrunProject(ModelObj):
     ):
         """log an output artifact and optionally upload it to datastore
 
+        if the artifact already exists with the same key and tag, it will be overwritten.
+
         example::
 
             project.log_artifact(
@@ -1499,7 +1501,7 @@ class MlrunProject(ModelObj):
         """
         log a dataset artifact and optionally upload it to datastore.
 
-        if the dataset exists with the same key and tag, it will be overwritten.
+        if the dataset already exists with the same key and tag, it will be overwritten.
 
         example::
 
@@ -1578,6 +1580,8 @@ class MlrunProject(ModelObj):
         **kwargs,
     ):
         """log a model artifact and optionally upload it to datastore
+
+        if the model already exists with the same key and tag, it will be overwritten.
 
         example::
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1424,9 +1424,9 @@ class MlrunProject(ModelObj):
         target_path=None,
         **kwargs,
     ):
-        """log an output artifact and optionally upload it to datastore
+        """Log an output artifact and optionally upload it to datastore
 
-        if the artifact already exists with the same key and tag, it will be overwritten.
+        If the artifact already exists with the same key and tag, it will be overwritten.
 
         example::
 
@@ -1579,9 +1579,9 @@ class MlrunProject(ModelObj):
         extra_data=None,
         **kwargs,
     ):
-        """log a model artifact and optionally upload it to datastore
+        """Log a model artifact and optionally upload it to datastore
 
-        if the model already exists with the same key and tag, it will be overwritten.
+        If the model already exists with the same key and tag, it will be overwritten.
 
         example::
 


### PR DESCRIPTION
If you try to register an artifact from the UI with the same key and tag as an existing artifact it fails uniqueness validation.
However, in the SDK it is possible to log a artifact with key/tag of an existing artifact, and the data itself is overridden

This behavior is OK, but since it is different in the SDK and the UI, this PR adds information on it in the sdk functions' dosctring (for logging artifact / dataset / model).

Resolves https://jira.iguazeng.com/browse/ML-5523