### PR TITLE
[Artifacts] Datasets should only allow an existing column to be used as label

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -177,6 +177,10 @@ class DatasetArtifact(Artifact):
         self.spec.label_column = label_column
 
         if df is not None:
+            if label_column not in df.columns:
+                raise mlrun.errors.MLRunValueError(
+                    f"Provided dataframe doesn't include a column \"{label_column}\", so it can't be used as label"
+                )
             if hasattr(df, "dask"):
                 # If df is a Dask DataFrame, and it's small in-memory, convert to Pandas
                 if (df.memory_usage(deep=True).sum().compute() / 1e9) < max_ddf_size:

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -177,7 +177,7 @@ class DatasetArtifact(Artifact):
         self.spec.label_column = label_column
 
         if df is not None:
-            if label_column not in df.columns:
+            if label_column and label_column not in df.columns:
                 raise mlrun.errors.MLRunValueError(
                     f"Provided dataframe doesn't include a column \"{label_column}\", so it can't be used as label"
                 )

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -235,6 +235,19 @@ def test_log_dataset_with_column_overflow(monkeypatch):
     assert artifact.status.header_original_length == 6
 
 
+def test_create_dataset_non_existing_label():
+    project = mlrun.new_project("artifact-experiment", save=False)
+    df = pandas.DataFrame(
+        {
+            "column_1": [0, 1, 2, 3, 4],
+            "column_2": [5, 6, 7, 8, 9],
+        }
+    )
+
+    with pytest.raises(mlrun.errors.MLRunValueError):
+        project.log_dataset("my_dataset", df=df, label_column="column_3")
+
+
 def test_dataset_preview_size_limit_from_large_dask_dataframe(monkeypatch):
     """
     To simplify testing the behavior of a large Dask DataFrame as a mlrun


### PR DESCRIPTION
[ML-5533](https://jira.iguazeng.com/browse/ML-5533)

This PR adds validation logic to the Dataset initializer method so that only an existing column of a dataframe can be used as a data label.

Such change is beneficial when logging datasets through the SDK.