### PR TITLE
[Artifacts] Fix tag deletion to target only specified artifacts

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1140,14 +1140,10 @@ class SQLDB(DBInterface):
         tags: typing.List[str] = None,
         commit: bool = True,
     ):
-        artifacts_keys = [str(artifact.key) for artifact in artifacts]
-        query = (
-            session.query(ArtifactV2.Tag)
-            .join(ArtifactV2)
-            .filter(
-                ArtifactV2.project == project,
-                ArtifactV2.key.in_(artifacts_keys),
-            )
+        artifacts_ids = [artifact.id for artifact in artifacts]
+        query = session.query(ArtifactV2.Tag).filter(
+            ArtifactV2.Tag.project == project,
+            ArtifactV2.Tag.obj_id.in_(artifacts_ids),
         )
         if tags:
             query = query.filter(ArtifactV2.Tag.name.in_(tags))


### PR DESCRIPTION
The previous implementation of _delete_artifacts_tags gets a list of artifact objects, but then extract their key and deletes all the  tags that belong to artifact with those keys. 
The code should be much more precise and only the specific artifacts chosen should get their tags removed.

Resolves:
https://jira.iguazeng.com/browse/ML-4678