### PR TITLE
[Project] Improve workflow path validation

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -113,7 +113,7 @@ class WorkflowSpec(mlrun.model.ModelObj):
                 # we need to make sure we don't add it twice
                 and not workflow_path.startswith(context)
             ):
-                workflow_path = os.path.join(context, workflow_path)
+                workflow_path = os.path.join(context, workflow_path.lstrip("./"))
         return workflow_path
 
     def merge_args(self, extra_args):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1224,18 +1224,18 @@ class MlrunProject(ModelObj):
         :param name:          Name of the workflow
         :param workflow_path: URL (remote) / Path (absolute or relative to the project code path i.e.
                 <project.spec.get_code_path()>/<workflow_path>) for the workflow file.
-        :param embed:         add the workflow code into the project.yaml
-        :param engine:        workflow processing engine ("kfp", "local", "remote" or "remote:local")
-        :param args_schema:   list of arg schema definitions (:py:class`~mlrun.model.EntrypointParam`)
-        :param handler:       workflow function handler
+        :param embed:         Add the workflow code into the project.yaml
+        :param engine:        Workflow processing engine ("kfp", "local", "remote" or "remote:local")
+        :param args_schema:   List of arg schema definitions (:py:class`~mlrun.model.EntrypointParam`)
+        :param handler:       Workflow function handler
         :param schedule:      ScheduleCronTrigger class instance or a standard crontab expression string
                               (which will be converted to the class using its `from_crontab` constructor),
                               see this link for help:
                               https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html#module-apscheduler.triggers.cron
                               Note that "local" engine does not support this argument
-        :param ttl:           pipeline ttl in secs (after that the pods will be removed)
-        :param image:         image for workflow runner job, only for scheduled and remote workflows
-        :param args:          argument values (key=value, ..)
+        :param ttl:           Pipeline ttl in secs (after that the pods will be removed)
+        :param image:         Image for workflow runner job, only for scheduled and remote workflows
+        :param args:          Argument values (key=value, ..)
         """
 
         # validate the provided workflow_path

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3555,13 +3555,13 @@ class MlrunProject(ModelObj):
                 return
 
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Invalid '{param_name}': '{file_path}'.  Got a remote URL without a file suffix."
+                f"Invalid '{param_name}': '{file_path}'. Got a remote URL without a file suffix."
             )
 
         code_path = self.spec.get_code_path()
 
         # If the file path is a relative path, it is completed by joining it with the code_path.
-        code_path_relative = not path.isabs(code_path) and not file_path.startswith(
+        code_path_relative = not path.isabs(file_path) and not file_path.startswith(
             code_path
         )
         if code_path_relative:
@@ -3571,9 +3571,9 @@ class MlrunProject(ModelObj):
 
         if not path.isfile(abs_path):
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Invalid '{param_name}': '{file_path}'.  Got a path to a non-existing file."
+                f"Invalid '{param_name}': '{file_path}'. Got a path to a non-existing file."
                 f"Path must be absolute or relative to the project code path i.e. "
-                f"<project.spec.get_code_path()>/<{param_name}>)"
+                f"<project.spec.get_code_path()>/<{param_name}>)."
             )
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -19,7 +19,6 @@ import inspect
 import itertools
 import json
 import os
-import pathlib
 import re
 import sys
 import time
@@ -279,34 +278,6 @@ def get_regex_list_as_string(regex_list: List) -> str:
     with and condition between them.
     """
     return "".join(["(?={regex})".format(regex=regex) for regex in regex_list]) + ".*$"
-
-
-def is_file_path_invalid(code_path: str, file_path: str) -> bool:
-    """
-    The function checks if the given file_path is a valid path.
-    If the file_path is a relative path, it is completed by joining it with the code_path.
-    Otherwise, the file_path is used as is.
-    Additionally, it checks if the resulting path exists as a file, unless the file_path is a remote URL.
-    If the file_path has no suffix, it is considered invalid.
-
-    :param code_path: The base directory or code path to search for the file in case of relative file_path
-    :param file_path: The file path to be validated
-    :return: True if the file path is invalid, False otherwise
-    """
-    if not file_path:
-        return True
-
-    if file_path.startswith("./") or (
-        "://" not in file_path and os.path.basename(file_path) == file_path
-    ):
-        abs_path = os.path.join(code_path, file_path.lstrip("./"))
-    else:
-        abs_path = file_path
-
-    return (
-        not (os.path.isfile(abs_path) or "://" in file_path)
-        or not pathlib.Path(file_path).suffix
-    )
 
 
 def tag_name_regex_as_string() -> str:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1108,10 +1108,11 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
         (
             "./",
             pytest.raises(
-                ValueError,
+                mlrun.errors.MLRunInvalidArgumentError,
                 match=str(
                     re.escape(
-                        "Invalid 'workflow_path': './'. Please provide a valid URL/path to a file."
+                        "Invalid 'workflow_path': './'. Got a path to a non-existing file.Path must be absolute or "
+                        "relative to the project code path i.e. <project.spec.get_code_path()>/<workflow_path>)."
                     )
                 ),
             ),
@@ -1119,10 +1120,10 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
         (
             "https://test",
             pytest.raises(
-                ValueError,
+                mlrun.errors.MLRunInvalidArgumentError,
                 match=str(
                     re.escape(
-                        "Invalid 'workflow_path': 'https://test'. Please provide a valid URL/path to a file."
+                        "Invalid 'workflow_path': 'https://test'. Got a remote URL without a file suffix."
                     )
                 ),
             ),
@@ -1130,19 +1131,17 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
         (
             "",
             pytest.raises(
-                ValueError,
-                match=str(
-                    re.escape(
-                        "Invalid 'workflow_path': ''. Please provide a valid URL/path to a file."
-                    )
-                ),
+                mlrun.errors.MLRunInvalidArgumentError,
+                match=str(re.escape("workflow_path must be provided.")),
             ),
         ),
         ("https://test.py", does_not_raise()),
         # relative path
         ("./workflow.py", does_not_raise()),
+        ("./assets/handler.py", does_not_raise()),
         # only file name
         ("workflow.py", does_not_raise()),
+        ("assets/handler.py", does_not_raise()),
         # absolute path
         (
             str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
@@ -1150,9 +1149,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
         ),
     ],
 )
-def test_set_workflow_with_invalid_path(
-    chdir_to_test_location, workflow_path, exception
-):
+def test_set_workflow_path_validation(chdir_to_test_location, workflow_path, exception):
     proj = mlrun.new_project("proj", save=False)
     with exception:
         proj.set_workflow("main", workflow_path)


### PR DESCRIPTION
Fixes nested paths inside project code path e.g.
```
code_path = ./
workflow_path = src/workflow.py or ./src/workflow.py
```

https://jira.iguazeng.com/browse/ML-5568