### PR TITLE
[Workflows] Disregard project name on named runs while filtering

### DIFF
--- a/server/api/api/endpoints/pipelines.py
+++ b/server/api/api/endpoints/pipelines.py
@@ -42,6 +42,7 @@ async def list_pipelines(
     sort_by: str = "",
     page_token: str = "",
     filter_: str = Query("", alias="filter"),
+    name__contains: str = Query("", alias="name--contains"),
     format_: mlrun.common.schemas.PipelinesFormat = Query(
         mlrun.common.schemas.PipelinesFormat.metadata_only, alias="format"
     ),
@@ -76,6 +77,7 @@ async def list_pipelines(
             sort_by,
             page_token,
             filter_,
+            name__contains,
             computed_format,
             page_size,
         )

--- a/server/api/api/endpoints/pipelines.py
+++ b/server/api/api/endpoints/pipelines.py
@@ -42,7 +42,7 @@ async def list_pipelines(
     sort_by: str = "",
     page_token: str = "",
     filter_: str = Query("", alias="filter"),
-    name__contains: str = Query("", alias="name--contains"),
+    name_contains: str = Query("", alias="name-contains"),
     format_: mlrun.common.schemas.PipelinesFormat = Query(
         mlrun.common.schemas.PipelinesFormat.metadata_only, alias="format"
     ),
@@ -77,7 +77,7 @@ async def list_pipelines(
             sort_by,
             page_token,
             filter_,
-            name__contains,
+            name_contains,
             computed_format,
             page_size,
         )

--- a/server/api/crud/pipelines.py
+++ b/server/api/crud/pipelines.py
@@ -452,11 +452,9 @@ class Pipelines(
             return runs
 
         def filter_by(run):
-            run_name = run.get("name", "")
-            if self.resolve_project_from_pipeline(run) != "*":
-                run_name = run_name.replace(
-                    self.resolve_project_from_pipeline(run) + "-", ""
-                )
+            run_name = run.get("name", "").replace(
+                self.resolve_project_from_pipeline(run) + "-", ""
+            )
             if target_name in run_name:
                 return True
             return False

--- a/server/api/crud/pipelines.py
+++ b/server/api/crud/pipelines.py
@@ -452,8 +452,8 @@ class Pipelines(
             return runs
 
         def filter_by(run):
-            run_name = run.get("name", "").replace(
-                self.resolve_project_from_pipeline(run) + "-", ""
+            run_name = run.get("name", "").removeprefix(
+                self.resolve_project_from_pipeline(run) + "-"
             )
             if target_name in run_name:
                 return True

--- a/server/api/crud/pipelines.py
+++ b/server/api/crud/pipelines.py
@@ -454,7 +454,9 @@ class Pipelines(
         def filter_by(run):
             run_name = run.get("name", "")
             if self.resolve_project_from_pipeline(run) != "*":
-                run_name = run_name.replace(self.resolve_project_from_pipeline(run) + "-", "")
+                run_name = run_name.replace(
+                    self.resolve_project_from_pipeline(run) + "-", ""
+                )
             if target_name in run_name:
                 return True
             return False

--- a/server/api/crud/pipelines.py
+++ b/server/api/crud/pipelines.py
@@ -46,6 +46,7 @@ class Pipelines(
         sort_by: str = "",
         page_token: str = "",
         filter_: str = "",
+        name__contains: str = "",
         format_: mlrun.common.schemas.PipelinesFormat = mlrun.common.schemas.PipelinesFormat.metadata_only,
         page_size: typing.Optional[int] = None,
     ) -> typing.Tuple[int, typing.Optional[int], typing.List[dict]]:
@@ -81,8 +82,8 @@ class Pipelines(
                 run_project = self.resolve_project_from_pipeline(run_dict)
                 if run_project == project:
                     project_runs.append(run_dict)
-            runs = project_runs
-            total_size = len(project_runs)
+            runs = self._filter_runs_by_name(project_runs, project, name__contains)
+            total_size = len(runs)
             next_page_token = None
         else:
             response = kfp_client._run_api.list_runs(
@@ -93,8 +94,14 @@ class Pipelines(
                 filter=filter_,
             )
             runs = [run.to_dict() for run in response.runs or []]
-            total_size = response.total_size
+            runs = self._filter_runs_by_name(runs, project, name__contains)
             next_page_token = response.next_page_token
+            # In-memory filtering turns Kubeflow's counting inaccurate if there are multiple pages of data
+            # so don't pass it to the client in such case
+            if next_page_token:
+                total_size = -1
+            else:
+                total_size = len(runs)
         runs = self._format_runs(db_session, runs, format_)
 
         return total_size, next_page_token, runs
@@ -433,3 +440,25 @@ class Pipelines(
             ):
                 return data.get("id", "")
         return ""
+
+    @staticmethod
+    def _filter_runs_by_name(runs: list, project_name: str, target_name: str) -> list:
+        """Filter runs by their name while ignoring the project string on them
+
+        :param runs: list of runs to be filtered
+        :param project_name: string to be disregarded while filtering
+        :param name: string that should be part of a valid run name
+        :return: filtered list of runs
+        """
+        if not target_name:
+            return runs
+
+        def filter_by(run):
+            run_name = run.get("name", "")
+            if project_name != "*":
+                run_name = run_name.replace(project_name + "-", "")
+            if target_name in run_name:
+                return True
+            return False
+
+        return list(filter(filter_by, runs))

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -239,7 +239,7 @@ def test_list_pipelines_name_contains(
     response = client.get(
         f"projects/{project_name}/pipelines",
         params={
-            "name--contains": run_name_filter,
+            "name-contains": run_name_filter,
         },
     )
 

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -210,7 +210,7 @@ def test_list_pipelines_time_fields_default(
         ("test-project", "test", ["id1", "id2", "id3", "id4"]),
         ("test-project", "another", ["id4"]),
         ("test-project", "test-project-", []),
-        ("*", "project", ["id1", "id2", "id3", "id4"]),
+        ("*", "project", ["id1", "id2"]),
         ("*", "workflow", ["id3", "id4"]),
     ],
 )
@@ -223,7 +223,7 @@ def test_list_pipelines_name_contains(
     expected_runs_ids: list,
 ) -> None:
     server.api.crud.Pipelines().resolve_project_from_pipeline = unittest.mock.Mock(
-        return_value=project_name
+        return_value="test-project"
     )
     runs = _generate_list_runs_project_name_mocks()
     expected_page_size = (

--- a/tests/api/api/test_pipelines.py
+++ b/tests/api/api/test_pipelines.py
@@ -22,6 +22,7 @@ import deepdiff
 import fastapi.testclient
 import kfp
 import kfp_server_api.models
+import pytest
 import sqlalchemy.orm
 
 import mlrun.common.schemas
@@ -201,6 +202,56 @@ def test_list_pipelines_time_fields_default(
     )
 
 
+@pytest.mark.parametrize(
+    "project_name, run_name_filter, expected_runs_ids",
+    [
+        ("test-project", "workflow", ["id3", "id4"]),
+        ("test-project", "project", ["id1", "id2"]),
+        ("test-project", "test", ["id1", "id2", "id3", "id4"]),
+        ("test-project", "another", ["id4"]),
+        ("test-project", "test-project-", []),
+        ("*", "project", ["id1", "id2", "id3", "id4"]),
+        ("*", "workflow", ["id3", "id4"]),
+    ],
+)
+def test_list_pipelines_name_contains(
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    kfp_client_mock: kfp.Client,
+    project_name: str,
+    run_name_filter: str,
+    expected_runs_ids: list,
+) -> None:
+    server.api.crud.Pipelines().resolve_project_from_pipeline = unittest.mock.Mock(
+        return_value=project_name
+    )
+    runs = _generate_list_runs_project_name_mocks()
+    expected_page_size = (
+        mlrun.common.schemas.PipelinesPagination.default_page_size
+        if project_name == "*"
+        else mlrun.common.schemas.PipelinesPagination.max_page_size
+    )
+    _mock_list_runs(
+        kfp_client_mock,
+        runs,
+        expected_page_size=expected_page_size,
+    )
+    response = client.get(
+        f"projects/{project_name}/pipelines",
+        params={
+            "name--contains": run_name_filter,
+        },
+    )
+
+    expected_runs = server.api.crud.Pipelines()._format_runs(
+        db, [run.to_dict() for run in runs if run.id in expected_runs_ids]
+    )
+    expected_response = mlrun.common.schemas.PipelinesOutput(
+        runs=expected_runs, total_size=len(expected_runs), next_page_token=None
+    )
+    _assert_list_pipelines_response(expected_response, response)
+
+
 def test_list_pipelines_specific_project(
     db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,
@@ -319,6 +370,51 @@ def _generate_list_runs_mocks():
         kfp_server_api.models.api_run.ApiRun(
             id="id4",
             name="run4",
+            description="desc4",
+            pipeline_spec=kfp_server_api.models.api_pipeline_spec.ApiPipelineSpec(
+                pipeline_id="pipe_id4",
+                workflow_manifest=workflow_manifest,
+            ),
+        ),
+    ]
+
+
+def _generate_list_runs_project_name_mocks():
+    """
+    Generate mock runs for KFP taking into account the naming patterns used by MLRun in a real world scenario
+    """
+    workflow_manifest = _generate_workflow_manifest()
+    return [
+        kfp_server_api.models.api_run.ApiRun(
+            id="id1",
+            name="test-project 0000-00-00 00-00-01",
+            description="desc1",
+            pipeline_spec=kfp_server_api.models.api_pipeline_spec.ApiPipelineSpec(
+                pipeline_id="pipe_id1",
+                workflow_manifest=workflow_manifest,
+            ),
+        ),
+        kfp_server_api.models.api_run.ApiRun(
+            id="id2",
+            name="test-project 0000-00-00 00-00-02",
+            description="desc2",
+            pipeline_spec=kfp_server_api.models.api_pipeline_spec.ApiPipelineSpec(
+                pipeline_id="pipe_id2",
+                workflow_manifest=workflow_manifest,
+            ),
+        ),
+        kfp_server_api.models.api_run.ApiRun(
+            id="id3",
+            name="test-project-test-workflow 0000-00-00 00-00-03",
+            description="desc3",
+            pipeline_spec=kfp_server_api.models.api_pipeline_spec.ApiPipelineSpec(
+                pipeline_id="pipe_id3",
+                workflow_manifest=workflow_manifest,
+            ),
+        ),
+        kfp_server_api.models.api_run.ApiRun(
+            id="id4",
+            name="test-project-test-another-workflow 0000-00-00 00-00-04",
             description="desc4",
             pipeline_spec=kfp_server_api.models.api_pipeline_spec.ApiPipelineSpec(
                 pipeline_id="pipe_id4",


### PR DESCRIPTION
[ML-5540](https://jira.iguazeng.com/browse/ML-5540)

When listing runs, MLRun's UI removes the project string from their names to avoid visual repetition and allow for a cleaner list for the end user since the project's name prefixes every run in a project. However, this change is only done to runs explicitly named by the user when triggered. The ones that weren't named keep the project's name on the UI listing.

Despite being reasonable, this frontend-only change creates an unexpected behavior when a user searches for runs using the project name as the query. In such case, all existing project runs will be listed despite, apparently, only the non-named runs having the `project_name` string on their name. In other words, the named runs shouldn't appear since they don't show the project name at all to the user.

To address the inconsistency, this PR adds a new parameter to the `/projects/<project_name>/pipelines` API route: `name--contains`. When used, the MLRun API will employ its contents on an in-memory filter for all runs returned by Kubeflow. This new filter will evaluate named runs without considering the project's name and allow non-named runs to be filtered with the project's name. This change should make the filtering process work as expected from the perspective of a UI user.

# An important caveat
The new filtering will present a problem when the user requests a list of runs for all projects simultaneously, in other words, when `/projects/*/pipelines` is called.

In this case, MLRun makes a paginated request to Kubeflow but delegates to the client the responsibility of making further calls for each page. When this happens, MLRun cannot guess the total number of records that match the filter. The number informed by the Kubeflow API might not be valid since it doesn't consider the in-memory filtering that MLRun will do on each page. In this case, I suggest we return `-1` on the `total_size` field to indicate to a client that the total number of records is unknown.

