### PR TITLE
[Artifacts] Overwrite `spec.db_key` when importing artifact with `new_key` arg

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1672,6 +1672,10 @@ class MlrunProject(ModelObj):
             artifact.metadata.updated = None
             artifact.metadata.tag = tag or artifact.metadata.tag
             if new_key:
+                if artifact.spec.db_key:
+                    logger.warning(
+                        f"Overwriting artifact old db_key '{artifact.spec.db_key}' with new key '{new_key}'"
+                    )
                 artifact.spec.db_key = new_key
             return artifact
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1671,6 +1671,8 @@ class MlrunProject(ModelObj):
             artifact.metadata.project = self.metadata.name
             artifact.metadata.updated = None
             artifact.metadata.tag = tag or artifact.metadata.tag
+            if new_key:
+                artifact.spec.db_key = new_key
             return artifact
 
         # Obtaining the item's absolute path from the project context, in case the user provided a relative path

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1674,7 +1674,8 @@ class MlrunProject(ModelObj):
             if new_key:
                 if artifact.spec.db_key:
                     logger.warning(
-                        f"Overwriting artifact old db_key '{artifact.spec.db_key}' with new key '{new_key}'"
+                        f"Overwriting artifact old db_key '{artifact.spec.db_key}' with new key '{new_key}' - "
+                        f"artifact can be fetched using the new key only"
                     )
                 artifact.spec.db_key = new_key
             return artifact

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -106,14 +106,17 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
                 # export the artifact to a file
                 model.export(f"{results_dir}/a.{suffix}")
 
+                new_key = f"mod-{suffix}"
+
                 # import and log the artifact to the new project
                 artifact = target_project.import_artifact(
                     f"{results_dir}/a.{suffix}",
-                    f"mod-{suffix}",
+                    new_key=new_key,
                     artifact_path=results_dir,
                 )
                 assert artifact.kind == "model"
-                assert artifact.metadata.key == f"mod-{suffix}"
+                assert artifact.metadata.key == new_key
+                assert artifact.spec.db_key == new_key
                 assert artifact.metadata.project == "log-mod2"
                 temp_path, model_spec, extra_dataitems = mlrun.artifacts.get_model(
                     artifact.uri

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -875,6 +875,7 @@ def test_import_artifact_using_relative_path():
     artifact = project.import_artifact("artifact.yaml", "y")
     assert artifact.spec.get_body() == "123"
     assert artifact.metadata.key == "y"
+    assert artifact.spec.db_key == "y"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/4917, we retain existing `spec.db_key` when logging artifacts.

When importing artifacts using `project.import_artifact`, we can set an explicit `new_key`. This `new_key` was set in the artifact's metadata, but not in the spec db_key property, causing artifacts with an existing `db_key` to be saved in the db with it instead of the new key.

In this PR - if `new_key` is given it will overwrite both `metadata.key` and `spec.db_key`.

Fixes https://jira.iguazeng.com/browse/ML-5544