### PR TITLE
[Requirements] Limit pandas to <2.2 because it requires sqlalchemy 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ nest-asyncio~=1.0
 ipython~=8.10
 nuclio-jupyter~=0.9.14
 numpy>=1.16.5, <1.27.0
-pandas>=1.2, <3
+# pandas 2.2 requires sqlalchemy 2
+pandas>=1.2, <2.2
 # used as a the engine for parquet files by pandas
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)
 # <15 to prevent bugs due to major upgrading

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,7 +128,7 @@ def test_requirement_specifiers_convention():
         "dask-ml": {"~=1.4,<1.9.0"},
         "pyarrow": {">=10.0, <15"},
         "nbclassic": {">=0.2.8"},
-        "pandas": {">=1.2, <3"},
+        "pandas": {">=1.2, <2.2"},
         "gitpython": {"~=3.1, >= 3.1.30"},
         "pydantic": {"~=1.10, >=1.10.8"},
         "pyopenssl": {">=23"},


### PR DESCRIPTION
Fixes this error
```
>       cur = self.con.cursor()
E       AttributeError: 'Connection' object has no attribute 'cursor'
```
which is caused by pandas refusing to import sqlalchemy because it's below 2.0.0.

https://github.com/pandas-dev/pandas/commit/b57080bf216582454e379a4e702fd7246dfbb8c4#diff-ccd2950d6f16d881f395b22ef38c981ed269b2b1609dd26a9d6e9daf0f78e104R55