### PR TITLE
[API] Verify project deletion with new db session

### DIFF
--- a/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
+++ b/mlrun/model_monitoring/stores/kv_model_endpoint_store.py
@@ -295,7 +295,7 @@ class KVModelEndpointStore(ModelEndpointStore):
             )
         except (v3io_frames.errors.DeleteError, v3io_frames.errors.CreateError) as e:
             # Frames might raise an exception if schema file does not exist.
-            logger.warning("Failed to delete TSDB schema file:", err=e)
+            logger.warning("Failed to delete TSDB schema file", err=e)
             pass
 
         # Final cleanup of tsdb path

--- a/server/api/api/endpoints/operations.py
+++ b/server/api/api/endpoints/operations.py
@@ -55,17 +55,20 @@ async def trigger_migrations(
     # note in api.py we do declare to use the authenticate_request dependency - meaning we do have authentication
     global current_migration_background_task_name
 
-    task, task_name = await run_in_threadpool(
+    task_callback, background_task, task_name = await run_in_threadpool(
         _get_or_create_migration_background_task,
         current_migration_background_task_name,
     )
-    if not task:
+    if not task_callback and not background_task:
+        # Not waiting for migrations, returning OK
         return fastapi.Response(status_code=http.HTTPStatus.OK.value)
 
-    background_tasks.add_task(task)
-    background_task = server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
-        task_name
-    )
+    if not background_task:
+        # No task in progress, creating a new one
+        background_tasks.add_task(task_callback)
+        background_task = server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+            task_name
+        )
 
     response.status_code = http.HTTPStatus.ACCEPTED.value
     current_migration_background_task_name = background_task.metadata.name
@@ -74,7 +77,11 @@ async def trigger_migrations(
 
 def _get_or_create_migration_background_task(
     task_name: str,
-) -> typing.Tuple[typing.Optional[typing.Callable], str]:
+) -> typing.Tuple[
+    typing.Optional[typing.Callable],
+    typing.Optional[mlrun.common.schemas.BackgroundTask],
+    str,
+]:
     if (
         mlrun.mlconf.httpdb.state
         == mlrun.common.schemas.APIStates.migrations_in_progress
@@ -82,7 +89,7 @@ def _get_or_create_migration_background_task(
         background_task = server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
             task_name
         )
-        return background_task
+        return None, background_task, task_name
     elif mlrun.mlconf.httpdb.state == mlrun.common.schemas.APIStates.migrations_failed:
         raise mlrun.errors.MLRunPreconditionFailedError(
             "Migrations were already triggered and failed. Restart the API to retry"
@@ -91,14 +98,18 @@ def _get_or_create_migration_background_task(
         mlrun.mlconf.httpdb.state
         != mlrun.common.schemas.APIStates.waiting_for_migrations
     ):
-        return None, ""
+        return None, None, ""
 
     logger.info("Starting the migration process")
-    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
+    (
+        task,
+        task_name,
+    ) = server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
         server.api.utils.background_tasks.BackgroundTaskKinds.db_migrations,
         None,
         _perform_migration,
     )
+    return task, None, task_name
 
 
 async def _perform_migration():

--- a/server/api/api/endpoints/operations.py
+++ b/server/api/api/endpoints/operations.py
@@ -90,11 +90,17 @@ def _get_or_create_migration_background_task(
         return None
 
     logger.info("Starting the migration process")
-    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
-        background_tasks,
+    (
+        task,
+        _task_name,
+    ) = server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
         server.api.utils.background_tasks.BackgroundTaskKinds.db_migrations,
         None,
         _perform_migration,
+    )
+    background_tasks.add_task(task)
+    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+        _task_name
     )
 
 

--- a/server/api/api/endpoints/projects.py
+++ b/server/api/api/endpoints/projects.py
@@ -209,14 +209,14 @@ async def delete_project(
         # task from v2 to complete. In order for this request not to time out, we want to start the background task
         # for deleting the project and return 202 to the leader. Later, in the project deletion wrapper task, we will
         # wait for this background task to complete before marking the task as done.
-        await run_in_threadpool(
+        task, _ = await run_in_threadpool(
             server.api.api.utils.get_or_create_project_deletion_background_task,
             name,
             deletion_strategy,
-            background_tasks,
             db_session,
             auth_info,
         )
+        background_tasks.add_task(task)
         return fastapi.Response(status_code=http.HTTPStatus.ACCEPTED.value)
 
     is_running_in_background = await run_in_threadpool(

--- a/server/api/api/endpoints/projects_v2.py
+++ b/server/api/api/endpoints/projects_v2.py
@@ -99,13 +99,16 @@ async def delete_project(
         response.status_code = http.HTTPStatus.NO_CONTENT.value
         return server.api.crud.Projects().verify_project_is_empty(db_session, name)
 
-    background_task = await run_in_threadpool(
+    task, task_name = await run_in_threadpool(
         server.api.api.utils.get_or_create_project_deletion_background_task,
         name,
         deletion_strategy,
-        background_tasks,
         db_session,
         auth_info,
     )
+    background_tasks.add_task(task)
+
     response.status_code = http.HTTPStatus.ACCEPTED.value
-    return background_task
+    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+        task_name
+    )

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -38,6 +38,7 @@ import mlrun.utils.notifications.notification_pusher
 import server.api.constants
 import server.api.crud
 import server.api.db.base
+import server.api.db.session
 import server.api.utils.auth.verifier
 import server.api.utils.background_tasks
 import server.api.utils.clients.iguazio
@@ -1066,8 +1067,8 @@ def artifact_project_and_resource_name_extractor(artifact):
 
 
 def get_or_create_project_deletion_background_task(
-    project_name: str, deletion_strategy: str, background_tasks, db_session, auth_info
-) -> typing.Optional[mlrun.common.schemas.BackgroundTask]:
+    project_name: str, deletion_strategy: str, db_session, auth_info
+) -> typing.Tuple[typing.Callable, str]:
     """
     This method is responsible for creating a background task for deleting a project.
     The project deletion flow is as follows:
@@ -1125,7 +1126,6 @@ def get_or_create_project_deletion_background_task(
         )
 
     return server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
-        background_tasks,
         background_task_kind,
         mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
         _delete_project,
@@ -1146,8 +1146,8 @@ async def _delete_project(
 ):
     def _verify_project_is_deleted():
         try:
-            get_project_member().get_project(
-                db_session, project_name, auth_info.session
+            server.api.db.session.run_function_with_new_db_session(
+                get_project_member().get_project, project_name, auth_info.session
             )
         except mlrun.errors.MLRunNotFoundError:
             return
@@ -1171,7 +1171,7 @@ async def _delete_project(
             5,
             120,
             logger,
-            False,
+            True,
             _verify_project_is_deleted,
         )
 

--- a/server/api/utils/background_tasks/internal.py
+++ b/server/api/utils/background_tasks/internal.py
@@ -14,6 +14,7 @@
 #
 import asyncio
 import datetime
+import functools
 import traceback
 import typing
 import uuid
@@ -44,13 +45,12 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
     @server.api.utils.helpers.ensure_running_on_chief
     def create_background_task(
         self,
-        background_tasks: fastapi.BackgroundTasks,
         kind: str,
         timeout: typing.Optional[int],  # in seconds
         function,
         *args,
         **kwargs,
-    ) -> mlrun.common.schemas.BackgroundTask:
+    ) -> typing.Tuple[typing.Callable, str]:
         name = str(uuid.uuid4())
         # sanity
         if name in self._internal_background_tasks:
@@ -64,15 +64,10 @@ class InternalBackgroundTasksHandler(metaclass=mlrun.utils.singleton.Singleton):
         background_task = self._generate_background_task(name, kind, timeout)
         self._internal_background_tasks[name] = background_task
         self._set_active_task_name_by_kind(kind, name)
-        background_tasks.add_task(
-            self.background_task_wrapper,
-            name=name,
-            function=function,
-            *args,
-            **kwargs,
+        task = functools.partial(
+            self.background_task_wrapper, name, function, *args, **kwargs
         )
-
-        return self.get_background_task(name)
+        return task, name
 
     @server.api.utils.helpers.ensure_running_on_chief
     def list_background_tasks(

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -504,7 +504,7 @@ class K8sHelper(mlrun.common.secrets.SecretProviderInterface):
         except ApiException as exc:
             if exc.status == 404:
                 logger.info(
-                    "Project secret does not exist, nothing to delete.",
+                    "Project secret does not exist, nothing to delete",
                     secret_name=secret_name,
                 )
                 return None

--- a/tests/api/api/test_background_tasks.py
+++ b/tests/api/api/test_background_tasks.py
@@ -85,11 +85,17 @@ def create_internal_background_task(
     function = bump_counter
     if failed_task:
         function = failing_function
-    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
-        background_tasks,
+    (
+        task,
+        task_name,
+    ) = server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
         "bump_counter",
         None,
         function,
+    )
+    background_tasks.add_task(task)
+    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+        task_name
     )
 
 
@@ -101,8 +107,15 @@ def create_long_internal_background_task(
     background_tasks: fastapi.BackgroundTasks,
     timeout: int = 5,
 ):
-    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
-        background_tasks, "long_bump_counter", None, long_function, sleep_time=timeout
+    (
+        task,
+        task_name,
+    ) = server.api.utils.background_tasks.InternalBackgroundTasksHandler().create_background_task(
+        "long_bump_counter", None, long_function, sleep_time=timeout
+    )
+    background_tasks.add_task(task)
+    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+        task_name
     )
 
 


### PR DESCRIPTION
Due to session isolation levels, keeping the same db session results in the verification always failing as it does not know that the project was deleted by a different session. For some reason, this caused mlrun-api-chief container to restart each time a project was deleted.
Along side this fix I also moved the background task addition to the endpoint functions instead of sharing the background tasks object between threads for better thread safety.