### PR TITLE
[Model Monitoring] Update "last_updated" in `record_results`

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -198,6 +198,13 @@ def record_results(
             infer_results_df=infer_results_df,
         )
 
+    # Update the last request time
+    db.patch_model_endpoint(
+        project=project,
+        endpoint_id=model_endpoint.metadata.uid,
+        attributes={EventFieldType.LAST_REQUEST: timestamp},
+    )
+
     if model_endpoint.spec.stream_path == "":
         logger.info(
             "Updating the last request time to mark the current monitoring window as completed",

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -349,7 +349,7 @@ def get_drift_thresholds_if_not_none(
 def write_monitoring_df(
     endpoint_id: str,
     infer_results_df: pd.DataFrame,
-    infer_datetime: typing.Optional[datetime] = None,
+    infer_datetime: datetime,
     monitoring_feature_set: typing.Optional[mlrun.feature_store.FeatureSet] = None,
     feature_set_uri: str = "",
 ) -> None:
@@ -377,7 +377,7 @@ def write_monitoring_df(
     # Modify the DataFrame to the required structure that will be used later by the monitoring batch job
     if EventFieldType.TIMESTAMP not in infer_results_df.columns:
         # Initialize timestamp column with the current time
-        infer_results_df[EventFieldType.TIMESTAMP] = infer_datetime or datetime_now()
+        infer_results_df[EventFieldType.TIMESTAMP] = infer_datetime
 
     # `endpoint_id` is the monitoring feature set entity and therefore it should be defined as the df index before
     # the ingest process

--- a/tests/model_monitoring/test_monitoring_api.py
+++ b/tests/model_monitoring/test_monitoring_api.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+from unittest.mock import Mock, patch
+
 import mlrun.model_monitoring.api
+from mlrun.db import RunDBInterface
+from mlrun.model_monitoring import ModelEndpoint
 
 
 def test_read_dataset_as_dataframe():
@@ -36,3 +41,27 @@ def test_read_dataset_as_dataframe():
     )
     feature_columns.remove("feature_2")
     assert list(df.columns) == feature_columns
+
+
+def test_record_result_updates_last_request() -> None:
+    db_mock = Mock(spec=RunDBInterface)
+    datetime_mock = datetime.datetime(
+        2011, 11, 4, 0, 5, 23, 283000, tzinfo=datetime.timezone.utc
+    )
+    with patch("mlrun.model_monitoring.api.datetime_now", return_value=datetime_mock):
+        with patch("mlrun.model_monitoring.api.mlrun.get_run_db", return_value=db_mock):
+            with patch(
+                "mlrun.model_monitoring.api.get_or_create_model_endpoint",
+                spec=ModelEndpoint,
+            ):
+                mlrun.model_monitoring.api.record_results(
+                    project="some-project",
+                    model_path="path/to/model",
+                    model_endpoint_name="my-endpoint",
+                )
+
+    db_mock.patch_model_endpoint.assert_called_once()
+    assert (
+        db_mock.patch_model_endpoint.call_args.kwargs["attributes"]["last_request"]
+        == datetime_mock
+    ), "last_request attribute of the model endpoint was not updated as expected"


### PR DESCRIPTION
Fixes [ML-5566](https://jira.iguazeng.com/browse/ML-5566).

Inference with the `batch_inference` function did not update the "last_request" field of the model endpoint.
It caused issues in model monitoring, as we rely on this field in the windows logic.

The relevant system test passed (`tests/system/model_monitoring/test_app.py::TestRecordResults`).