### PR TITLE
[CI] Enforce mlrun now on test scheduler

### DIFF
--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -21,7 +21,6 @@ import unittest.mock
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from dateutil.tz import tzlocal
 from deepdiff import DeepDiff
 from sqlalchemy.orm import Session
 
@@ -171,7 +170,7 @@ async def test_create_schedule(db: Session, scheduler: Scheduler, store: bool):
     # but executing the actual functional code - bumping the counter - happens a few microseconds afterwards.
     # To avoid transient errors on slow systems, we add extra margin.
     time_to_sleep = (
-        end_date - datetime.now()
+        end_date - mlrun.utils.now_date()
     ).total_seconds() + schedule_end_time_margin
 
     await asyncio.sleep(time_to_sleep)
@@ -319,7 +318,7 @@ async def test_create_schedule_mlrun_function(
         cron_trigger,
     )
     time_to_sleep = (
-        end_date - datetime.now()
+        end_date - mlrun.utils.now_date()
     ).total_seconds() + schedule_end_time_margin
 
     await asyncio.sleep(time_to_sleep)
@@ -411,7 +410,7 @@ async def test_schedule_upgrade_from_scheduler_without_credentials_store(
         )
     )
     time_to_sleep = (
-        end_date - datetime.now()
+        end_date - mlrun.utils.now_date()
     ).total_seconds() + schedule_end_time_margin
 
     await asyncio.sleep(time_to_sleep)
@@ -818,7 +817,7 @@ async def test_rescheduling(db: Session, scheduler: Scheduler):
     )
 
     # wait so one run will complete
-    time_to_sleep = (start_date - datetime.now()).total_seconds() + 1
+    time_to_sleep = (start_date - mlrun.utils.now_date()).total_seconds() + 1
     await asyncio.sleep(time_to_sleep)
 
     # stop the scheduler and assert indeed only one call happened
@@ -953,8 +952,9 @@ async def test_schedule_access_key_generation(
     scheduled_object = _create_mlrun_function_and_matching_scheduled_object(db, project)
     cron_trigger = mlrun.common.schemas.ScheduleCronTrigger(year="1999")
     access_key = "generated-access-key"
+    get_or_create_access_key_mock = unittest.mock.Mock(return_value=access_key)
     server.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key = (
-        unittest.mock.Mock(return_value=access_key)
+        get_or_create_access_key_mock
     )
     scheduler.create_schedule(
         db,
@@ -965,14 +965,15 @@ async def test_schedule_access_key_generation(
         scheduled_object,
         cron_trigger,
     )
-    server.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key.assert_called_once()
+    get_or_create_access_key_mock.assert_called_once()
     _assert_schedule_auth_secrets(
         k8s_secrets_mock.resolve_auth_secret_name("", access_key), "", access_key
     )
 
     access_key = "generated-access-key-2"
+    get_or_create_access_key_mock = unittest.mock.Mock(return_value=access_key)
     server.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key = (
-        unittest.mock.Mock(return_value=access_key)
+        get_or_create_access_key_mock
     )
     scheduler.update_schedule(
         db,
@@ -983,7 +984,7 @@ async def test_schedule_access_key_generation(
         schedule_name,
         labels={"label-key": "label-value"},
     )
-    server.api.utils.auth.verifier.AuthVerifier().get_or_create_access_key.assert_called_once()
+    get_or_create_access_key_mock.assert_called_once()
     _assert_schedule_auth_secrets(
         k8s_secrets_mock.resolve_auth_secret_name("", access_key), "", access_key
     )
@@ -1221,7 +1222,7 @@ async def test_update_schedule(
         hour=end_date.hour,
         minute=end_date.minute,
         second=end_date.second,
-        tzinfo=tzlocal(),
+        tzinfo=timezone.utc,
     )
 
     _assert_schedule(
@@ -1235,7 +1236,7 @@ async def test_update_schedule(
         config.httpdb.scheduling.default_concurrency_limit,
     )
     time_to_sleep = (
-        end_date - datetime.now()
+        end_date - mlrun.utils.now_date()
     ).total_seconds() + schedule_end_time_margin
 
     await asyncio.sleep(time_to_sleep)
@@ -1336,7 +1337,7 @@ async def test_schedule_job_concurrency_limit(
     runs = get_db().list_runs(db, project=project_name)
     assert len(runs) == 0
 
-    now = datetime.now(timezone.utc)
+    now = mlrun.utils.now_date()
     now_plus_1_seconds = now + timedelta(seconds=1)
     now_plus_5_seconds = now + timedelta(seconds=5)
     cron_trigger = mlrun.common.schemas.ScheduleCronTrigger(
@@ -1357,7 +1358,7 @@ async def test_schedule_job_concurrency_limit(
 
     random_sleep_time = random.randint(1, 5)
     await asyncio.sleep(random_sleep_time)
-    after_sleep_timestamp = datetime.now(timezone.utc)
+    after_sleep_timestamp = mlrun.utils.now_date()
 
     schedule = scheduler.get_schedule(
         db,
@@ -1395,7 +1396,7 @@ async def test_schedule_job_next_run_time(
     While the 1st run is still running, manually invoke the schedule (should fail due to concurrency limit)
     and check that the next run time is updated.
     """
-    now = datetime.now(timezone.utc)
+    now = mlrun.utils.now_date()
     now_plus_1_seconds = now + timedelta(seconds=1)
     now_plus_5_seconds = now + timedelta(seconds=5)
     cron_trigger = mlrun.common.schemas.ScheduleCronTrigger(
@@ -1423,7 +1424,7 @@ async def test_schedule_job_next_run_time(
         concurrency_limit=1,
     )
 
-    while datetime.now(timezone.utc) < now_plus_5_seconds:
+    while mlrun.utils.now_date() < now_plus_5_seconds:
         runs = get_db().list_runs(db, project=project_name)
         if len(runs) == 1:
             break
@@ -1434,7 +1435,7 @@ async def test_schedule_job_next_run_time(
 
     # invoke schedule should fail due to concurrency limit
     # the next run time should be updated to the next second after the invocation failure
-    schedule_invocation_timestamp = datetime.now(timezone.utc)
+    schedule_invocation_timestamp = mlrun.utils.now_date()
     await scheduler.invoke_schedule(
         db, mlrun.common.schemas.AuthInfo(), project_name, schedule_name
     )
@@ -1676,13 +1677,13 @@ def _get_start_and_end_time_for_scheduled_trigger(
     The scheduler executes the job on round seconds (when microsecond == 0)
     Therefore if the start time will be a round second - let's say 12:08:06.000000 and the end time 12:08:07.000000
     it means two executions will happen - at 06 and 07 second.
-    This is obviously very rare (since the times are based on datetime.now()) - usually the start time
+    This is obviously very rare (since the times are based on mlrun.utils.now_date()) - usually the start time
     will be something like 12:08:06.100000 then the end time will be 12:08:07.10000 - meaning there will be only
      one execution on the 07 second.
     So instead of conditioning every assertion we're doing on whether the start time was a round second,
      we simply make sure it's not a round second.
     """
-    now = datetime.now()
+    now = mlrun.utils.now_date()
     if now.microsecond == 0:
         now = now + timedelta(seconds=1, milliseconds=1)
     start_date = now + timedelta(seconds=1)


### PR DESCRIPTION
observed some transient errors on this suite, decided to do some unification with time stamps and usage of datetime now. might not resolve the transient error, but test dates would be accurate wrt timezone