### PR TITLE
[Config] Migrate `pytest.ini` config to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ python_files = [
     "tests/*/test_*.py",
     "tests/test_*.py",
 ]
+timeout = 1800  # 30 minutes per test
+log_cli = true
+log_level = "DEBUG"
 
 [tool.importlinter]
 root_packages = [

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-# 30 minutes per test
-timeout = 1800
-log_cli = true
-log_level = DEBUG


### PR DESCRIPTION
Following
- https://github.com/mlrun/mlrun/pull/4479
- https://github.com/mlrun/mlrun/pull/4931

Move all Pytest's related configurations to `pyproject.toml`.

Resolves [ML-5578](https://jira.iguazeng.com/browse/ML-5578).