### PR TITLE
[CI] Fix some tests

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -422,6 +422,19 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
+    def get_pipeline(
+        self,
+        run_id: str,
+        namespace: str = None,
+        timeout: int = 30,
+        format_: Union[
+            str, mlrun.common.schemas.PipelinesFormat
+        ] = mlrun.common.schemas.PipelinesFormat.summary,
+        project: str = None,
+    ):
+        pass
+
+    @abstractmethod
     def list_pipelines(
         self,
         project: str,

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -345,6 +345,18 @@ class NopDB(RunDBInterface):
     def delete_feature_vector(self, name, project="", tag=None, uid=None):
         pass
 
+    def get_pipeline(
+        self,
+        run_id: str,
+        namespace: str = None,
+        timeout: int = 30,
+        format_: Union[
+            str, mlrun.common.schemas.PipelinesFormat
+        ] = mlrun.common.schemas.PipelinesFormat.summary,
+        project: str = None,
+    ):
+        pass
+
     def list_pipelines(
         self,
         project: str,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -611,7 +611,7 @@ def code_to_function(
     Instantiated runtimes are considered 'functions' in mlrun, but they are
     anything from nuclio functions to generic kubernetes pods to spark jobs.
     Functions are meant to be focused, and as such limited in scope and size.
-    Typically a function can be expressed in a single python module with
+    Typically, a function can be expressed in a single python module with
     added support from custom docker images and commands for the environment.
     The returned runtime object can be further configured if more
     customization is required.

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -740,6 +740,18 @@ class SQLRunDB(RunDBInterface):
             version,
         )
 
+    def get_pipeline(
+        self,
+        run_id: str,
+        namespace: str = None,
+        timeout: int = 30,
+        format_: Union[
+            str, mlrun.common.schemas.PipelinesFormat
+        ] = mlrun.common.schemas.PipelinesFormat.summary,
+        project: str = None,
+    ):
+        raise NotImplementedError()
+
     def list_pipelines(
         self,
         project: str,

--- a/tests/system/datastore/test_v3io.py
+++ b/tests/system/datastore/test_v3io.py
@@ -69,6 +69,8 @@ class TestV3ioDataStore(TestMLRunSystem):
             data_item.store._upload(
                 object_path, tempfile_1_path, max_chunk_size=100 * 1024
             )
+
+            self._logger.debug("Downloading the object")
             data_item.download(tempfile_2_path)
 
             cmp_process = subprocess.Popen(cmp_command, stdout=subprocess.PIPE)

--- a/tests/system/logs/test_logs.py
+++ b/tests/system/logs/test_logs.py
@@ -19,9 +19,13 @@ import tests.system.base
 
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestLogCollector(tests.system.base.TestMLRunSystem):
-    custom_project_names_to_delete = []
+
+    def custom_setup(self):
+        super().custom_setup()
+        self.custom_project_names_to_delete = []
 
     def custom_teardown(self):
+        super().custom_teardown()
         for name in self.custom_project_names_to_delete:
             self._delete_test_project(name)
 

--- a/tests/system/logs/test_logs.py
+++ b/tests/system/logs/test_logs.py
@@ -19,7 +19,6 @@ import tests.system.base
 
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestLogCollector(tests.system.base.TestMLRunSystem):
-
     def custom_setup(self):
         super().custom_setup()
         self.custom_project_names_to_delete = []

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -60,13 +60,14 @@ def pipe_test():
 @pytest.mark.enterprise
 class TestProject(TestMLRunSystem):
     project_name = "project-system-test-project"
-    custom_project_names_to_delete = []
     _logger_redirected = False
 
     def custom_setup(self):
-        pass
+        super().custom_setup()
+        self.custom_project_names_to_delete = []
 
     def custom_teardown(self):
+        super().custom_teardown()
         if self._logger_redirected:
             mlrun.utils.logger.replace_handler_stream("default", sys.stdout)
             self._logger_redirected = False
@@ -78,8 +79,6 @@ class TestProject(TestMLRunSystem):
         for name in self.custom_project_names_to_delete:
             self._delete_test_project(name)
 
-        self.custom_project_names_to_delete = []
-
     @property
     def assets_path(self):
         return (
@@ -89,6 +88,12 @@ class TestProject(TestMLRunSystem):
 
     def _create_project(self, project_name, with_repo=False, overwrite=False):
         self.custom_project_names_to_delete.append(project_name)
+        self._logger.debug(
+            "Creating new project",
+            project_name=project_name,
+            with_repo=False,
+            overwrite=overwrite,
+        )
         proj = mlrun.new_project(
             project_name, str(self.assets_path), overwrite=overwrite
         )
@@ -113,6 +118,11 @@ class TestProject(TestMLRunSystem):
         proj.set_workflow("main", "./kflow.py", args_schema=[arg])
         proj.set_workflow("newflow", "./newflow.py", handler="newpipe")
         proj.spec.artifact_path = "v3io:///projects/{{run.project}}"
+        self._logger.debug(
+            "Saving project",
+            project_name=project_name,
+            project=proj.to_yaml(),
+        )
         proj.save()
         return proj
 
@@ -467,7 +477,7 @@ class TestProject(TestMLRunSystem):
             handler="iris_generator",
             requirements=["requests"],
         )
-        self._logger.debug("set project function", project=project.to_yaml())
+        self._logger.debug("Set project function", project=project.to_yaml())
         run = project.run(
             "newflow",
             engine=engine,
@@ -487,28 +497,35 @@ class TestProject(TestMLRunSystem):
 
     def test_kfp_runs_getting_deleted_on_project_deletion(self):
         project_name = "kfppipedelete"
-        self.custom_project_names_to_delete.append(project_name)
-
         project = self._create_project(project_name)
         self._initialize_sleep_workflow(project)
         project.run("main", engine="kfp")
 
         db = mlrun.get_run_db()
         project_pipeline_runs = db.list_pipelines(project=project_name)
+        self._logger.debug(
+            "Got project pipeline runs", runs_length=len(project_pipeline_runs.runs)
+        )
         # expecting to have pipeline run
         assert (
             project_pipeline_runs.runs
         ), "no pipeline runs found for project, expected to have pipeline run"
         # deleting project with deletion strategy cascade so it will delete any related resources ( pipelines as well )
+
+        self._logger.debug("Deleting project", project_name=project_name)
         db.delete_project(
             name=project_name,
             deletion_strategy=mlrun.common.schemas.DeletionStrategy.cascade,
         )
         # create the project again ( using new_project, instead of get_or_create_project so it won't create project
         # from project.yaml in the context that might contain project.yaml
+        self._logger.debug("Recreating project", project_name=project_name)
         mlrun.new_project(project_name)
 
         project_pipeline_runs = db.list_pipelines(project=project_name)
+        self._logger.debug(
+            "Got project pipeline runs", runs_length=len(project_pipeline_runs.runs)
+        )
         assert (
             not project_pipeline_runs.runs
         ), "pipeline runs found for project after deletion, expected to be empty"
@@ -1000,7 +1017,7 @@ class TestProject(TestMLRunSystem):
         project.save()
         project.run("main", arguments={"x": 1}, engine="remote:kfp", watch=True)
 
-    @pytest.mark.parametrize("pull_state_mode", ["disabled", "enabled"])
+    @pytest.mark.parametrize("pull_state_mode", ["disabled"])
     def test_abort_step_in_workflow(self, pull_state_mode):
         project_name = "test-abort-step"
         self.custom_project_names_to_delete.append(project_name)
@@ -1197,6 +1214,7 @@ class TestProject(TestMLRunSystem):
             image="mlrun/mlrun",
             handler="handler",
         )
+        self._logger.debug("Set project workflow", project=project.name)
         project.set_workflow("main", workflow_path)
 
     @pytest.mark.parametrize(

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1017,7 +1017,7 @@ class TestProject(TestMLRunSystem):
         project.save()
         project.run("main", arguments={"x": 1}, engine="remote:kfp", watch=True)
 
-    @pytest.mark.parametrize("pull_state_mode", ["disabled"])
+    @pytest.mark.parametrize("pull_state_mode", ["disabled", "enabled"])
     def test_abort_step_in_workflow(self, pull_state_mode):
         project_name = "test-abort-step"
         self.custom_project_names_to_delete.append(project_name)

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -50,9 +50,9 @@ need_private_git = pytest.mark.skipif(
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestArchiveSources(tests.system.base.TestMLRunSystem):
     project_name = "git-tests"
-    custom_project_names_to_delete = []
 
     def custom_setup(self):
+        super().custom_setup()
         self.remote_code_dir = f"v3io:///projects/{self.project_name}/code/"
         self.uploaded_code = False
         # upload test files to cluster
@@ -62,8 +62,10 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
                     "GIT_TOKEN": os.environ["MLRUN_SYSTEM_TESTS_PRIVATE_GIT_TOKEN"],
                 }
             )
+        self.custom_project_names_to_delete = []
 
     def custom_teardown(self):
+        super().custom_teardown()
         for name in self.custom_project_names_to_delete:
             self._delete_test_project(name)
 

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -113,7 +113,8 @@ class TestNuclioRuntime(tests.system.base.TestMLRunSystem):
         assert resp.status_code == 200
 
         response = self._run_db.api_call(
-            "GET", "funcs", params={"project": self.project_name}
+            "GET",
+            f"projects/{self.project_name}/functions",
         )
 
         assert response.ok


### PR DESCRIPTION
putting a list as class attribute field means it is shared across class instances, this is a bug and should not happen
each test creates a class instance, which then means each test deletes all previous projects as well (though they are not found but that is something else).
added `get_pipeline` to base to allow abstraction propagate to autocompletion 
added some log lines for future test cycles
