### PR TITLE
Revert "[Feature Store] Use timestamp key to get online features"

### DIFF
--- a/mlrun/feature_store/retrieval/storey_merger.py
+++ b/mlrun/feature_store/retrieval/storey_merger.py
@@ -91,7 +91,6 @@ class StoreyFeatureMerger(BaseMerger):
                 "storey.QueryByKey",
                 f"query-{name}",
                 features=column_names,
-                time_field=feature_set.spec.timestamp_key,
                 table=feature_set.uri,
                 key_field=entity_list,
                 aliases=aliases,

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -1423,9 +1423,7 @@ class TestFeatureStore(TestMLRunSystem):
         name = f"measurements_{uuid.uuid4()}"
 
         # write to kv
-        data_set = fstore.FeatureSet(
-            name, entities=[Entity("first_name")], timestamp_key="time"
-        )
+        data_set = fstore.FeatureSet(name, entities=[Entity("first_name")])
 
         data_set.add_aggregation(
             name="bids",
@@ -1441,14 +1439,8 @@ class TestFeatureStore(TestMLRunSystem):
 
         vector = fstore.FeatureVector("my-vec", features)
         with fstore.get_online_feature_service(vector) as svc:
-            resp = svc.get(
-                [{"first_name": "moshe", "time": test_base_time.isoformat()}]
-            )
-            expected = {
-                "bids_sum_1h": 2000.0,
-                "last_name": "cohen",
-                "time": "2020-12-01T17:33:15",
-            }
+            resp = svc.get([{"first_name": "moshe"}])
+            expected = {"bids_sum_1h": 2000.0, "last_name": "cohen"}
             assert resp[0] == expected
 
     _split_graph_expected_default = pd.DataFrame(


### PR DESCRIPTION
Reverts mlrun/mlrun#4989

Fixes `TestFeatureStore::test_ingest_and_query`.