### PR TITLE
[Project] Fix load project with artifacts test

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1176,7 +1176,8 @@ class TestProject(TestMLRunSystem):
 
         # create a new project from the same spec, and validate the artifact was loaded properly
         project3 = mlrun.load_project(context=context, name=project_3_name)
-        artifacts = project3.list_artifacts(name=artifact_db_key_2)
+        # since it is imported from yaml, the artifact is saved with the set key
+        artifacts = project3.list_artifacts(name=another_artifact_key)
         assert len(artifacts) == 1
         assert artifacts[0]["metadata"]["key"] == another_artifact_key
 


### PR DESCRIPTION
When registering artifacts during project loading, if the artifact was exported, it will be imported using `import_artifact`.
Following #4970, `import_artifact` overwrites the db_key to the given new key.

This PR aligns `test_load_project_with_artifact_db_key` to the new change.