### PR TITLE
[Nuclio] Revert duplicate enrichment on build

### DIFF
--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -718,11 +718,7 @@ def _build_function(
         launcher.enrich_runtime(runtime=fn, full=is_nuclio_runtime)
 
         fn.save(versioned=False)
-        if fn.kind in RuntimeKinds.nuclio_runtimes():
-            server.api.api.utils.apply_enrichment_and_validation_on_function(
-                fn,
-                auth_info,
-            )
+        if is_nuclio_runtime:
             monitoring_application = (
                 fn.metadata.labels.get(mm_constants.ModelMonitoringAppLabel.KEY)
                 == mm_constants.ModelMonitoringAppLabel.VAL

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -719,98 +719,13 @@ def _build_function(
 
         fn.save(versioned=False)
         if is_nuclio_runtime:
-            monitoring_application = (
-                fn.metadata.labels.get(mm_constants.ModelMonitoringAppLabel.KEY)
-                == mm_constants.ModelMonitoringAppLabel.VAL
-            )
-            serving_to_monitor = (
-                fn.kind == RuntimeKinds.serving and fn.spec.track_models
-            )
-
-            if serving_to_monitor or monitoring_application:
-                if not mlrun.mlconf.is_ce_mode():
-                    model_monitoring_access_key = process_model_monitoring_secret(
-                        db_session,
-                        fn.metadata.project,
-                        mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
-                    )
-                else:
-                    model_monitoring_access_key = None
-                if serving_to_monitor:
-                    try:
-                        if serving_to_monitor:
-                            # Handle model monitoring
-                            logger.info(
-                                "Tracking enabled, initializing model monitoring"
-                            )
-
-                            if fn.spec.tracking_policy:
-                                # Convert to `TrackingPolicy` object as `fn.spec.tracking_policy` is provided as a dict
-                                fn.spec.tracking_policy = TrackingPolicy.from_dict(
-                                    fn.spec.tracking_policy
-                                )
-                            else:
-                                # Initialize tracking policy with default values
-                                fn.spec.tracking_policy = TrackingPolicy()
-
-                            if not mlrun.mlconf.is_ce_mode():
-                                # create v3io stream for model_monitoring_stream
-                                create_model_monitoring_stream(
-                                    project=fn.metadata.project,
-                                    function=fn,
-                                    monitoring_application=monitoring_application,
-                                    stream_path=server.api.crud.model_monitoring.get_stream_path(
-                                        project=fn.metadata.project,
-                                        application_name=mm_constants.MonitoringFunctionNames.STREAM,
-                                    ),
-                                )
-
-                            # deploy model monitoring stream, model monitoring batch job,
-                            monitoring_deploy = server.api.crud.model_monitoring.deployment.MonitoringDeployment()
-                            monitoring_deploy.deploy_monitoring_functions(
-                                project=fn.metadata.project,
-                                db_session=db_session,
-                                auth_info=auth_info,
-                                tracking_policy=fn.spec.tracking_policy,
-                                model_monitoring_access_key=model_monitoring_access_key,
-                            )
-
-                    except Exception as exc:
-                        logger.warning(
-                            f"Failed deploying model monitoring infrastructure for the "
-                            f"{'project' if serving_to_monitor else f'{fn.metadata.name} application'}",
-                            project=fn.metadata.project,
-                            exc=exc,
-                            traceback=traceback.format_exc(),
-                        )
-                if monitoring_application:
-                    if not mlrun.mlconf.is_ce_mode():
-                        # create v3io stream for model monitoring application
-                        create_model_monitoring_stream(
-                            project=fn.metadata.project,
-                            function=fn,
-                            monitoring_application=monitoring_application,
-                            stream_path=server.api.crud.model_monitoring.get_stream_path(
-                                project=fn.metadata.project,
-                                application_name=fn.metadata.name,
-                            ),
-                            access_key=model_monitoring_access_key,
-                        )
-                    # apply stream trigger to monitoring application
-                    monitoring_deploy = server.api.crud.model_monitoring.deployment.MonitoringDeployment()
-                    fn = monitoring_deploy._apply_stream_trigger(
-                        project=fn.metadata.project,
-                        function=fn,
-                        model_monitoring_access_key=model_monitoring_access_key,
-                        function_name=fn.metadata.name,
-                        auth_info=auth_info,
-                    )
-            server.api.crud.runtimes.nuclio.function.deploy_nuclio_function(
+            fn = _deploy_nuclio_runtime(
+                auth_info,
+                builder_env,
+                client_python_version,
+                client_version,
+                db_session,
                 fn,
-                auth_info=auth_info,
-                client_version=client_version,
-                client_python_version=client_python_version,
-                builder_env=builder_env,
             )
             # deploy only start the process, the get status API is used to check readiness
             ready = False
@@ -843,6 +758,128 @@ def _build_function(
             reason=f"Runtime error: {err_to_str(err)}",
         )
     return fn, ready
+
+
+def _deploy_nuclio_runtime(
+    auth_info, builder_env, client_python_version, client_version, db_session, fn
+):
+    monitoring_application = (
+        fn.metadata.labels.get(mm_constants.ModelMonitoringAppLabel.KEY)
+        == mm_constants.ModelMonitoringAppLabel.VAL
+    )
+    serving_to_monitor = fn.kind == RuntimeKinds.serving and fn.spec.track_models
+    if serving_to_monitor or monitoring_application:
+        if not mlrun.mlconf.is_ce_mode():
+            model_monitoring_access_key = process_model_monitoring_secret(
+                db_session,
+                fn.metadata.project,
+                mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+            )
+        else:
+            model_monitoring_access_key = None
+        if serving_to_monitor:
+            _deploy_serving_monitoring(
+                auth_info,
+                db_session,
+                fn,
+                model_monitoring_access_key,
+                monitoring_application,
+                serving_to_monitor,
+            )
+        if monitoring_application:
+            fn = _deploy_monitoring_application(
+                auth_info, fn, model_monitoring_access_key, monitoring_application
+            )
+    server.api.crud.runtimes.nuclio.function.deploy_nuclio_function(
+        fn,
+        auth_info=auth_info,
+        client_version=client_version,
+        client_python_version=client_python_version,
+        builder_env=builder_env,
+    )
+    return fn
+
+
+def _deploy_serving_monitoring(
+    auth_info,
+    db_session,
+    fn,
+    model_monitoring_access_key,
+    monitoring_application,
+    serving_to_monitor,
+):
+    try:
+        # Handle model monitoring
+        logger.info("Tracking enabled, initializing model monitoring")
+
+        if fn.spec.tracking_policy:
+            # Convert to `TrackingPolicy` object as `fn.spec.tracking_policy` is provided as a dict
+            fn.spec.tracking_policy = TrackingPolicy.from_dict(fn.spec.tracking_policy)
+        else:
+            # Initialize tracking policy with default values
+            fn.spec.tracking_policy = TrackingPolicy()
+
+        if not mlrun.mlconf.is_ce_mode():
+            # create v3io stream for model_monitoring_stream
+            create_model_monitoring_stream(
+                project=fn.metadata.project,
+                function=fn,
+                monitoring_application=monitoring_application,
+                stream_path=server.api.crud.model_monitoring.get_stream_path(
+                    project=fn.metadata.project,
+                    application_name=mm_constants.MonitoringFunctionNames.STREAM,
+                ),
+            )
+
+        # deploy model monitoring stream, model monitoring batch job,
+        monitoring_deploy = (
+            server.api.crud.model_monitoring.deployment.MonitoringDeployment()
+        )
+        monitoring_deploy.deploy_monitoring_functions(
+            project=fn.metadata.project,
+            db_session=db_session,
+            auth_info=auth_info,
+            tracking_policy=fn.spec.tracking_policy,
+            model_monitoring_access_key=model_monitoring_access_key,
+        )
+
+    except Exception as exc:
+        logger.warning(
+            f"Failed deploying model monitoring infrastructure for the "
+            f"{'project' if serving_to_monitor else f'{fn.metadata.name} application'}",
+            project=fn.metadata.project,
+            exc=exc,
+            traceback=traceback.format_exc(),
+        )
+
+
+def _deploy_monitoring_application(
+    auth_info, fn, model_monitoring_access_key, monitoring_application
+):
+    if not mlrun.mlconf.is_ce_mode():
+        # create v3io stream for model monitoring application
+        create_model_monitoring_stream(
+            project=fn.metadata.project,
+            function=fn,
+            monitoring_application=monitoring_application,
+            stream_path=server.api.crud.model_monitoring.get_stream_path(
+                project=fn.metadata.project,
+                application_name=fn.metadata.name,
+            ),
+            access_key=model_monitoring_access_key,
+        )
+    # apply stream trigger to monitoring application
+    monitoring_deploy = (
+        server.api.crud.model_monitoring.deployment.MonitoringDeployment()
+    )
+    fn = monitoring_deploy._apply_stream_trigger(
+        project=fn.metadata.project,
+        function=fn,
+        model_monitoring_access_key=model_monitoring_access_key,
+        function_name=fn.metadata.name,
+        auth_info=auth_info,
+    )
+    return fn
 
 
 def _parse_start_function_body(db_session, data):

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -784,7 +784,6 @@ def _deploy_nuclio_runtime(
                 fn,
                 model_monitoring_access_key,
                 monitoring_application,
-                serving_to_monitor,
             )
         if monitoring_application:
             fn = _deploy_monitoring_application(
@@ -806,7 +805,6 @@ def _deploy_serving_monitoring(
     fn,
     model_monitoring_access_key,
     monitoring_application,
-    serving_to_monitor,
 ):
     try:
         # Handle model monitoring
@@ -845,8 +843,7 @@ def _deploy_serving_monitoring(
 
     except Exception as exc:
         logger.warning(
-            f"Failed deploying model monitoring infrastructure for the "
-            f"{'project' if serving_to_monitor else f'{fn.metadata.name} application'}",
+            "Failed deploying model monitoring infrastructure for the project application",
             project=fn.metadata.project,
             exc=exc,
             traceback=traceback.format_exc(),


### PR DESCRIPTION
The enrichment is already done in
```
launcher.enrich_runtime(runtime=fn, full=is_nuclio_runtime)
```
For some reason some side feature branch reverted the removal of the enrichment.
Also refactored by method extraction because `_build_function` was over 200 lines...