### PR TITLE
[Datastore] Remove run ID from stream and Kafka target status

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1428,9 +1428,6 @@ class StreamTarget(BaseStoreTarget):
     def as_df(self, columns=None, df_module=None, **kwargs):
         raise NotImplementedError()
 
-    def get_path(self):
-        return TargetPathObject(self.path or "")
-
 
 class KafkaTarget(BaseStoreTarget):
     kind = TargetTypes.kafka
@@ -1501,9 +1498,6 @@ class KafkaTarget(BaseStoreTarget):
 
     def purge(self):
         pass
-
-    def get_path(self):
-        return TargetPathObject(self.path or "")
 
 
 class TSDBTarget(BaseStoreTarget):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1726,6 +1726,10 @@ class DataTargetBase(ModelObj):
         return super().from_dict(struct, fields=fields)
 
     def get_path(self):
+        # polymorphism won't work here, because from_dict always returns an instance of the base type (DataTargetBase)
+        if self.kind in ["stream", "kafka"]:
+            return TargetPathObject(self.path or "")
+
         if self.path:
             is_single_file = hasattr(self, "is_single_file") and self.is_single_file()
             return TargetPathObject(self.path, self.run_id, is_single_file)

--- a/tests/datastore/test_targets.py
+++ b/tests/datastore/test_targets.py
@@ -17,7 +17,7 @@ import pytest
 
 import mlrun.errors
 from mlrun.datastore import StreamTarget
-from mlrun.datastore.targets import KafkaTarget
+from mlrun.datastore.targets import BaseStoreTarget, KafkaTarget
 from mlrun.feature_store import FeatureSet
 
 
@@ -47,6 +47,10 @@ def test_stream_target_path_is_without_run_id():
     # make sure that run ID wasn't added to the path
     assert mock_graph.kwargs.get("stream_path") == path
 
+    # make sure the path is still right after deserialization (which loses the specific type)
+    stream_target = BaseStoreTarget.from_dict(stream_target.to_dict())
+    assert stream_target.get_target_path() == url
+
 
 # ML-5484, ML-5559
 def test_kafka_target_path_is_without_run_id():
@@ -61,6 +65,10 @@ def test_kafka_target_path_is_without_run_id():
     kafka_target.add_writer_step(mock_graph, None, None, key_columns={})
     # make sure that run ID wasn't added to the topic
     assert mock_graph.kwargs.get("topic") == topic
+
+    # make sure the path is still right after deserialization (which loses the specific type)
+    kafka_target = BaseStoreTarget.from_dict(kafka_target.to_dict())
+    assert kafka_target.get_target_path() == url
 
 
 # ML-5560


### PR DESCRIPTION
[ML-5559](https://jira.iguazeng.com/browse/ML-5559)

Follow up fix for #4967.