### PR TITLE
[DB] Update labels for existing features if needed

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2936,9 +2936,10 @@ class SQLDB(DBInterface):
                     ),
                     None,
                 )
-                # update it with the new labels in case they were changed
-                labels = feature_dict.get("labels") or {}
-                update_labels(feature, labels)
+                if feature:
+                    # update it with the new labels in case they were changed
+                    labels = feature_dict.get("labels") or {}
+                    update_labels(feature, labels)
 
     @staticmethod
     def _update_feature_set_entities(feature_set: FeatureSet, entity_dicts: List[dict]):

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2927,7 +2927,7 @@ class SQLDB(DBInterface):
                 update_labels(feature, labels)
                 feature_set.features.append(feature)
             elif feature_name not in features_to_remove:
-                # check if the existing feature's labels were changed, and update them if needed
+                # get the existing feature from the feature set
                 feature = next(
                     (
                         feature
@@ -2936,11 +2936,9 @@ class SQLDB(DBInterface):
                     ),
                     None,
                 )
+                # update it with the new labels in case they were changed
                 labels = feature_dict.get("labels") or {}
-                if not server.api.utils.helpers.are_object_labels_equal_to_labels_dict(
-                    feature.labels, labels
-                ):
-                    update_labels(feature, labels)
+                update_labels(feature, labels)
 
     @staticmethod
     def _update_feature_set_entities(feature_set: FeatureSet, entity_dicts: List[dict]):

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2916,7 +2916,8 @@ class SQLDB(DBInterface):
         ]
 
         for feature_dict in feature_dicts:
-            if feature_dict["name"] in features_to_add:
+            feature_name = feature_dict["name"]
+            if feature_name in features_to_add:
                 labels = feature_dict.get("labels") or {}
                 feature = Feature(
                     name=feature_dict["name"],
@@ -2925,6 +2926,21 @@ class SQLDB(DBInterface):
                 )
                 update_labels(feature, labels)
                 feature_set.features.append(feature)
+            elif feature_name not in features_to_remove:
+                # check if the existing feature's labels were changed, and update them if needed
+                feature = next(
+                    (
+                        feature
+                        for feature in feature_set.features
+                        if feature.name == feature_name
+                    ),
+                    None,
+                )
+                labels = feature_dict.get("labels") or {}
+                if not server.api.utils.helpers.are_object_labels_equal_to_labels_dict(
+                    feature.labels, labels
+                ):
+                    update_labels(feature, labels)
 
     @staticmethod
     def _update_feature_set_entities(feature_set: FeatureSet, entity_dicts: List[dict]):

--- a/server/api/utils/helpers.py
+++ b/server/api/utils/helpers.py
@@ -122,22 +122,3 @@ def is_request_from_leader(
     if projects_role and projects_role.value == leader_name:
         return True
     return False
-
-
-def are_object_labels_equal_to_labels_dict(
-    object_labels_list: list, labels_dict: dict
-) -> bool:
-    """
-    Compare object labels list to labels dict
-    :param object_labels_list: a sqlalchemy InstrumentedList, which is a list of Label objects
-                               with name and value fields
-    :param labels_dict: a dict of labels
-    :return: True if the labels are equal in both, False otherwise
-    """
-    if len(object_labels_list) != len(labels_dict):
-        return False
-
-    for label in object_labels_list:
-        if label.name not in labels_dict or labels_dict[label.name] != label.value:
-            return False
-    return True

--- a/server/api/utils/helpers.py
+++ b/server/api/utils/helpers.py
@@ -122,3 +122,22 @@ def is_request_from_leader(
     if projects_role and projects_role.value == leader_name:
         return True
     return False
+
+
+def are_object_labels_equal_to_labels_dict(
+    object_labels_list: list, labels_dict: dict
+) -> bool:
+    """
+    Compare object labels list to labels dict
+    :param object_labels_list: a sqlalchemy InstrumentedList, which is a list of Label objects
+                               with name and value fields
+    :param labels_dict: a dict of labels
+    :return: True if the labels are equal in both, False otherwise
+    """
+    if len(object_labels_list) != len(labels_dict):
+        return False
+
+    for label in object_labels_list:
+        if label.name not in labels_dict or labels_dict[label.name] != label.value:
+            return False
+    return True


### PR DESCRIPTION
**Bug:**
A feature set has features without any labels.
When adding a feature with the same name and  new labels, the labels are not saved in the database.

**RCA:**
In the DB layer, when we update the feature (in `_update_feature_set_features`) we only look at the `features_to_add`, according to their name.
Since the features already exist on the feature set, we ignore them and don't update their labels.

**Fix:**
Check the existing features labels compared to the "new" feature labels, and update them if needed.

Resolves https://jira.iguazeng.com/browse/ML-5574