### PR TITLE
[API] Change Swagger URL to unversioned API

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -97,9 +97,9 @@ app = fastapi.FastAPI(
     version=config.version,
     debug=config.httpdb.debug,
     # adding /api prefix
-    openapi_url=f"{BASE_VERSIONED_API_PREFIX}/openapi.json",
-    docs_url=f"{BASE_VERSIONED_API_PREFIX}/docs",
-    redoc_url=f"{BASE_VERSIONED_API_PREFIX}/redoc",
+    openapi_url=f"{API_PREFIX}/openapi.json",
+    docs_url=f"{API_PREFIX}/docs",
+    redoc_url=f"{API_PREFIX}/redoc",
     default_response_class=fastapi.responses.ORJSONResponse,
     lifespan=lifespan,
 )

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -169,8 +169,8 @@ def test_store_artifact_with_empty_dict(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.OK.value
 
 
-def test_create_artifact(db: Session, unprefixed_client: TestClient):
-    _create_project(unprefixed_client, prefix="v1")
+def test_create_artifact(db: Session, unversioned_client: TestClient):
+    _create_project(unversioned_client, prefix="v1")
     data = {
         "kind": "artifact",
         "metadata": {
@@ -188,7 +188,7 @@ def test_create_artifact(db: Session, unprefixed_client: TestClient):
         "status": {},
     }
     url = "v2/projects/{project}/artifacts".format(project=PROJECT)
-    resp = unprefixed_client.post(
+    resp = unversioned_client.post(
         url,
         json=data,
     )

--- a/tests/api/api/test_docs.py
+++ b/tests/api/api/test_docs.py
@@ -23,9 +23,9 @@ from mlrun.utils import logger
 
 
 def test_docs(
-    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    db: sqlalchemy.orm.Session, unversioned_client: fastapi.testclient.TestClient
 ) -> None:
-    response = client.get("openapi.json")
+    response = unversioned_client.get("openapi.json")
     assert response.status_code == http.HTTPStatus.OK.value
 
 
@@ -34,10 +34,10 @@ def test_docs(
     reason="Supposed to run only for CI backward compatibility tests",
 )
 def test_save_openapi_json(
-    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+    db: sqlalchemy.orm.Session, unversioned_client: fastapi.testclient.TestClient
 ) -> None:
     """The purpose of the test is to create an openapi.json file that is used to run backward compatibility tests"""
-    response = client.get("openapi.json")
+    response = unversioned_client.get("openapi.json")
     path = os.path.abspath(os.getcwd())
     if os.getenv("MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH"):
         path = os.getenv("MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH")

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -954,7 +954,7 @@ def test_project_with_parameters(
     ],
 )
 def test_delete_project_not_found_in_leader(
-    unprefixed_client: TestClient,
+    unversioned_client: TestClient,
     mock_project_leader_iguazio_client,
     delete_api_version: str,
 ) -> None:
@@ -963,16 +963,16 @@ def test_delete_project_not_found_in_leader(
         spec=mlrun.common.schemas.ProjectSpec(),
     )
 
-    response = unprefixed_client.post("v1/projects", json=project.dict())
+    response = unversioned_client.post("v1/projects", json=project.dict())
     assert response.status_code == HTTPStatus.CREATED.value
     _assert_project_response(project, response)
 
-    response = unprefixed_client.delete(
+    response = unversioned_client.delete(
         f"{delete_api_version}/projects/{project.metadata.name}",
     )
     assert response.status_code == HTTPStatus.ACCEPTED.value
 
-    response = unprefixed_client.get(
+    response = unversioned_client.get(
         f"v1/projects/{project.metadata.name}",
     )
     assert response.status_code == HTTPStatus.NOT_FOUND.value

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -135,9 +135,9 @@ def client(db) -> Generator:
 
 
 @pytest.fixture()
-def unprefixed_client(db) -> Generator:
+def unversioned_client(db) -> Generator:
     """
-    unprefixed_client is a test client that doesn't have the version prefix in the url.
+    unversioned_client is a test client that doesn't have the version prefix in the url.
     When using this client, the version prefix must be added to the url manually.
     This is useful when tests use several endpoints that are not under the same version prefix.
     """
@@ -147,9 +147,9 @@ def unprefixed_client(db) -> Generator:
         mlconf.runtimes_cleanup_interval = 0
         mlconf.httpdb.projects.periodic_sync_interval = "0 seconds"
 
-        with TestClient(app) as test_client_v2:
-            set_base_url_for_test_client(test_client_v2, API_PREFIX)
-            yield test_client_v2
+        with TestClient(app) as unversioned_test_client:
+            set_base_url_for_test_client(unversioned_test_client, API_PREFIX)
+            yield unversioned_test_client
 
 
 @pytest.fixture()


### PR DESCRIPTION
Swagger URL shouldn't be versioned since it docs all versions.