### PR TITLE
[Logger] Use orjson to dump log lines

### DIFF
--- a/mlrun/datastore/filestore.py
+++ b/mlrun/datastore/filestore.py
@@ -105,4 +105,3 @@ class FileStore(DataStore):
                 return
             except FileExistsError:
                 time.sleep(0.1)
-                pass

--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -12,22 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 from enum import Enum
 from sys import stdout
 from traceback import format_exception
 from typing import IO, Optional, Union
 
+import orjson
+import pydantic
+
 from mlrun.config import config
 
 
-class JSONFormatter(logging.Formatter):
-    def __init__(self):
-        super(JSONFormatter, self).__init__()
-        self._json_encoder = json.JSONEncoder()
+class _BaseFormatter(logging.Formatter):
+    def _json_dump(self, json_object):
+        def default(obj):
+            if isinstance(obj, pydantic.BaseModel):
+                return obj.dict()
+            raise TypeError
 
-    def format(self, record):
+        return orjson.dumps(
+            json_object,
+            option=orjson.OPT_NAIVE_UTC
+            | orjson.OPT_SERIALIZE_NUMPY
+            | orjson.OPT_SORT_KEYS,
+            default=default,
+        ).decode()
+
+
+class JSONFormatter(_BaseFormatter):
+    def format(self, record) -> str:
         record_with = getattr(record, "with", {})
         if record.exc_info:
             record_with.update(exc_info=format_exception(*record.exc_info))
@@ -38,14 +52,22 @@ class JSONFormatter(logging.Formatter):
             "with": record_with,
         }
 
-        return self._json_encoder.encode(record_fields)
+        return self._json_dump(record_fields)
 
 
-class HumanReadableFormatter(logging.Formatter):
+class HumanReadableFormatter(_BaseFormatter):
     def format(self, record) -> str:
+        more = self._resolve_more(record)
+        return (
+            f"> {self.formatTime(record, self.datefmt)} [{record.levelname.lower()}] "
+            f"{record.getMessage().rstrip()}{more}"
+        )
+
+    def _resolve_more(self, record):
         record_with = self._record_with(record)
-        more = f": {record_with}" if record_with else ""
-        return f"> {self.formatTime(record, self.datefmt)} [{record.levelname.lower()}] {record.getMessage()}{more}"
+        record_with_encoded = self._json_dump(record_with) if record_with else ""
+        more = f": {record_with_encoded}" if record_with_encoded else ""
+        return more
 
     def _record_with(self, record):
         record_with = getattr(record, "with", {})
@@ -56,8 +78,7 @@ class HumanReadableFormatter(logging.Formatter):
 
 class HumanReadableExtendedFormatter(HumanReadableFormatter):
     def format(self, record) -> str:
-        record_with = self._record_with(record)
-        more = f": {record_with}" if record_with else ""
+        more = self._resolve_more(record)
         return (
             "> "
             f"{self.formatTime(record, self.datefmt)} "

--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -29,7 +29,19 @@ class _BaseFormatter(logging.Formatter):
         def default(obj):
             if isinstance(obj, pydantic.BaseModel):
                 return obj.dict()
-            raise TypeError
+
+            # EAFP all the way.
+            # Leave the unused "exc" in for debugging ease
+            try:
+                return obj.__log__()
+            except Exception as exc:  # noqa
+                try:
+                    return obj.__repr__()
+                except Exception as exc:  # noqa
+                    try:
+                        return str(obj)
+                    except Exception as exc:
+                        raise TypeError from exc
 
         return orjson.dumps(
             json_object,

--- a/tests/integration/sdk_api/run/test_main.py
+++ b/tests/integration/sdk_api/run/test_main.py
@@ -15,6 +15,7 @@ import datetime
 import os
 import pathlib
 import sys
+import tempfile
 import traceback
 from base64 import b64encode
 from subprocess import PIPE, run
@@ -254,20 +255,25 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
                     "--some-arg",
                 ],
                 True,
-                "'status':'completed'",
+                '"status":"completed"',
             ],
         ],
     )
     def test_main_run_args_validation(self, op, args, raise_on_error, expected_output):
-        out = self._exec_main(
-            op,
-            args,
-            raise_on_error=raise_on_error,
-        )
-        if not raise_on_error:
-            out = out.stderr.decode("utf-8")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = [
+                "--out-path",
+                tmpdir,
+            ] + args
+            out = self._exec_main(
+                op,
+                args,
+                raise_on_error=raise_on_error,
+            )
+            if not raise_on_error:
+                out = out.stderr.decode("utf-8")
 
-        assert out.find(expected_output) != -1, out
+            assert out.find(expected_output) != -1, out
 
     def test_main_run_args_from_env(self):
         os.environ["MLRUN_EXEC_CODE"] = b64encode(code.encode("utf-8")).decode("utf-8")

--- a/tests/integration/sdk_api/run/test_main.py
+++ b/tests/integration/sdk_api/run/test_main.py
@@ -216,7 +216,7 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
                 [
                     "--bad-flag",
                     "--name",
-                    "test_main_run_basic",
+                    "test-main-run-basic",
                     "--dump",
                     f"{examples_path}/training.py",
                 ],
@@ -228,7 +228,7 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
             # bad flag with no command
             [
                 "run",
-                ["--name", "test_main_run_basic", "--bad-flag"],
+                ["--name", "test-main-run-basic", "--bad-flag"],
                 False,
                 "Error: Invalid value for '[URL]': URL (--bad-flag) cannot start with '-', "
                 "ensure the command options are typed correctly. Preferably use '--' to separate options and "
@@ -237,7 +237,7 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
             # bad flag after -- separator
             [
                 "run",
-                ["--name", "test_main_run_basic", "--", "-notaflag"],
+                ["--name", "test-main-run-basic", "--", "-notaflag"],
                 False,
                 "Error: Invalid value for '[URL]': URL (-notaflag) cannot start with '-', "
                 "ensure the command options are typed correctly. Preferably use '--' to separate options and "
@@ -248,7 +248,7 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
                 "run",
                 [
                     "--name",
-                    "test_main_run_basic",
+                    "test-main-run-basic",
                     "--",
                     f"{examples_path}/training.py",
                     "--some-arg",

--- a/tests/integration/sdk_api/run/test_main.py
+++ b/tests/integration/sdk_api/run/test_main.py
@@ -254,7 +254,7 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
                     "--some-arg",
                 ],
                 True,
-                "'status': 'completed'",
+                "'status':'completed'",
             ],
         ],
     )

--- a/tests/utils/logger/test_logger.py
+++ b/tests/utils/logger/test_logger.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import dataclasses
 import datetime
 from io import StringIO
 from typing import Generator
@@ -23,9 +24,12 @@ from mlrun.utils.helpers import now_date
 from mlrun.utils.logger import FormatterKinds, Logger, create_logger
 
 
-class SomeObject(pydantic.BaseModel):
-    name: str
-    date: datetime.datetime
+class ArbitraryClassForLogging:
+    def __init__(self, name):
+        self.name = name
+
+    def __log__(self):
+        return {"name": self.name}
 
 
 @pytest.fixture(params=[formatter_kind.name for formatter_kind in list(FormatterKinds)])
@@ -46,16 +50,45 @@ def test_regular(make_stream_logger):
     assert "SomeText" in stream.getvalue()
 
 
-def test_log_pydantic(make_stream_logger):
+def test_log_arbitrary_structures(make_stream_logger):
+    @dataclasses.dataclass
+    class DataclassObj:
+        name: str
+        date: datetime.datetime
+
+    class UnboundClass:
+        pass
+
+    class SomePydanticObject(pydantic.BaseModel):
+        name: str
+        date: datetime.datetime
+
     stream, test_logger = make_stream_logger
     now_date_instance = now_date()
+    another_now_date_instance = now_date(tz=datetime.timezone.min)
     test_logger.debug(
-        "object-in-more", so=SomeObject(name="some-name", date=now_date_instance)
+        "object-in-more",
+        so=SomePydanticObject(name="some-name", date=now_date_instance),
+        dc=DataclassObj(name="another-name", date=another_now_date_instance),
+        uc=UnboundClass(),
+        ac=ArbitraryClassForLogging(name="ArbitraryClassForLogging"),
     )
     log_line = stream.getvalue().strip()
     assert "object-in-more" in log_line
+
+    # pydantic
     assert now_date_instance.isoformat() in log_line
     assert '"name":"some-name"' in log_line
+
+    # dataclass
+    assert another_now_date_instance.isoformat() in log_line
+    assert '"name":"another-name"' in log_line
+
+    # unbound class
+    assert "UnboundClass" in log_line
+
+    # arbitrary class
+    assert "ArbitraryClassForLogging" in log_line
 
 
 def test_log_level(make_stream_logger):


### PR DESCRIPTION
Making it a bit faster but the main reason for this change is to enable logging of pydantic structure / arbitrary datetime objects when being logged