### PR TITLE
[DB] Lock db rows when tagging artifacts

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -902,8 +902,8 @@ class SQLDB(DBInterface):
             session,
             ArtifactV2,
             project=project,
-        ).filter(
-            ArtifactV2.key.in_([artifact.key for artifact in artifacts])
+        ).filter(ArtifactV2.key.in_([artifact.key for artifact in artifacts])).order_by(
+            ArtifactV2.key.asc()
         ).populate_existing().with_for_update().all()
 
         objects = []

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -903,7 +903,7 @@ class SQLDB(DBInterface):
             ArtifactV2,
             project=project,
         ).filter(ArtifactV2.key.in_([artifact.key for artifact in artifacts])).order_by(
-            ArtifactV2.key.asc()
+            ArtifactV2.id.asc()
         ).populate_existing().with_for_update().all()
 
         objects = []

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -914,6 +914,7 @@ class SQLDB(DBInterface):
                 .filter(
                     ArtifactV2.producer_id != artifact.producer_id,
                 )
+                .with_for_update()
             )
 
             # delete the tags
@@ -937,6 +938,7 @@ class SQLDB(DBInterface):
                     ArtifactV2.producer_id == artifact.producer_id,
                     ArtifactV2.iteration == artifact.iteration,
                 )
+                .with_for_update()
             )
 
             tag = query.one_or_none()


### PR DESCRIPTION
We have seen cases where parallel runs with the same "producer_id" are all trying to log artifacts with the same tag simultaneously.
This sometimes caused multiple "latest" tags pointing to artifacts with the same key, iteration and producer id, due to the tagging race conditions.

To avoid that, we want to lock the row of the specific artifacts that are being tagged.
This is done using SQL's "FOR UPDATE" (see [this](https://www.cockroachlabs.com/blog/select-for-update/) for more info).
The artifacts will be locked for the entire transaction, until the session is committed.

Resolves https://jira.iguazeng.com/browse/ML-5596