### PR TITLE
[SDK] Remove nuclio `dashboard` param

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -748,7 +748,6 @@ class DataFrameSource:
     Reads data frame as input source for a flow.
 
     :parameter key_field: the column to be used as the key for events. Can be a list of keys. Defaults to None
-    :parameter time_field: DEPRECATED.
     :parameter context: MLRun context. Defaults to None
     """
 

--- a/mlrun/kfpops.py
+++ b/mlrun/kfpops.py
@@ -480,7 +480,6 @@ def deploy_op(
     function,
     func_url=None,
     source="",
-    dashboard="",
     project="",
     models: list = None,
     env: dict = None,
@@ -490,8 +489,6 @@ def deploy_op(
     cmd = ["python", "-m", "mlrun", "deploy"]
     if source:
         cmd += ["-s", source]
-    if dashboard:
-        cmd += ["-d", dashboard]
     if tag:
         cmd += ["--tag", tag]
     if verbose:

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -344,7 +344,6 @@ class DeployStatus:
 
 def deploy_function(
     function: Union[str, mlrun.runtimes.BaseRuntime],
-    dashboard: str = "",
     models: list = None,
     env: dict = None,
     tag: str = None,
@@ -356,7 +355,6 @@ def deploy_function(
     """deploy real-time (nuclio based) functions
 
     :param function:   name of the function (in the project) or function object
-    :param dashboard:  DEPRECATED. Keep empty to allow auto-detection by MLRun API.
     :param models:     list of model items
     :param env:        dict of extra environment variables
     :param tag:        extra version tag
@@ -371,9 +369,7 @@ def deploy_function(
             "deploy is used with real-time functions, for other kinds use build_function()"
         )
     if engine == "kfp":
-        return function.deploy_step(
-            dashboard=dashboard, models=models, env=env, tag=tag, verbose=verbose
-        )
+        return function.deploy_step(models=models, env=env, tag=tag, verbose=verbose)
     else:
         if env:
             function.set_envs(env)
@@ -392,9 +388,7 @@ def deploy_function(
                 function=function,
             )
 
-        address = function.deploy(
-            dashboard=dashboard, tag=tag, verbose=verbose, builder_env=builder_env
-        )
+        address = function.deploy(tag=tag, verbose=verbose, builder_env=builder_env)
         # return object with the same outputs as the KFP op (allow using the same pipeline)
         return DeployStatus(
             state=function.status.state,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3175,7 +3175,6 @@ class MlrunProject(ModelObj):
     def deploy_function(
         self,
         function: typing.Union[str, mlrun.runtimes.BaseRuntime],
-        dashboard: str = "",
         models: list = None,
         env: dict = None,
         tag: str = None,
@@ -3186,7 +3185,6 @@ class MlrunProject(ModelObj):
         """deploy real-time (nuclio based) functions
 
         :param function:    name of the function (in the project) or function object
-        :param dashboard:   DEPRECATED. Keep empty to allow auto-detection by MLRun API.
         :param models:      list of model items
         :param env:         dict of extra environment variables
         :param tag:         extra version tag
@@ -3196,7 +3194,6 @@ class MlrunProject(ModelObj):
         """
         return deploy_function(
             function,
-            dashboard=dashboard,
             models=models,
             env=env,
             tag=tag,

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -564,9 +564,11 @@ class RemoteRuntime(KubeResource):
             self.metadata.tag = tag
 
         if dashboard:
+            # TODO: remove in 1.8.0
             warnings.warn(
                 "'dashboard' parameter is no longer supported on client side, "
-                "it is being configured through the MLRun API.",
+                "it is being configured through the MLRun API. It will be removed in 1.8.0.",
+                FutureWarning,
             )
 
         save_record = False

--- a/mlrun/runtimes/function.py
+++ b/mlrun/runtimes/function.py
@@ -528,7 +528,6 @@ class RemoteRuntime(KubeResource):
 
     def deploy(
         self,
-        dashboard="",
         project="",
         tag="",
         verbose=False,
@@ -538,7 +537,6 @@ class RemoteRuntime(KubeResource):
     ):
         """Deploy the nuclio function to the cluster
 
-        :param dashboard:  DEPRECATED. Keep empty to allow auto-detection by MLRun API
         :param project:    project name
         :param tag:        function tag
         :param verbose:    set True for verbose logging
@@ -562,14 +560,6 @@ class RemoteRuntime(KubeResource):
             self.metadata.project = project
         if tag:
             self.metadata.tag = tag
-
-        if dashboard:
-            # TODO: remove in 1.8.0
-            warnings.warn(
-                "'dashboard' parameter is no longer supported on client side, "
-                "it is being configured through the MLRun API. It will be removed in 1.8.0.",
-                FutureWarning,
-            )
 
         save_record = False
         # Attempt auto-mounting, before sending to remote build
@@ -811,7 +801,6 @@ class RemoteRuntime(KubeResource):
 
     def deploy_step(
         self,
-        dashboard="",
         project="",
         models=None,
         env=None,
@@ -821,7 +810,6 @@ class RemoteRuntime(KubeResource):
     ):
         """return as a Kubeflow pipeline step (ContainerOp), recommended to use mlrun.deploy_function() instead
 
-        :param dashboard:      DEPRECATED. Keep empty to allow auto-detection by MLRun API.
         :param project:        project name, defaults to function project
         :param models:         model name and paths
         :param env:            dict of environment variables
@@ -854,7 +842,6 @@ class RemoteRuntime(KubeResource):
             name,
             self,
             func_url=url,
-            dashboard=dashboard,
             project=project,
             models=models,
             env=env,
@@ -884,7 +871,7 @@ class RemoteRuntime(KubeResource):
         :param body:     request body (str, bytes or a dict for json requests)
         :param method:   HTTP method (GET, PUT, ..)
         :param headers:  key/value dict with http headers
-        :param dashboard: nuclio dashboard address
+        :param dashboard: nuclio dashboard address (deprecated)
         :param force_external_address:   use the external ingress URL
         :param auth_info: service AuthInfo
         :param mock:     use mock server vs a real Nuclio function (for local simulations)
@@ -892,6 +879,14 @@ class RemoteRuntime(KubeResource):
                                      see this link for more information:
                                      https://requests.readthedocs.io/en/latest/api/#requests.request
         """
+        if dashboard:
+            # TODO: remove in 1.8.0
+            warnings.warn(
+                "'dashboard' parameter is no longer supported on client side, "
+                "it is being configured through the MLRun API. It will be removed in 1.8.0.",
+                FutureWarning,
+            )
+
         if not method:
             method = "POST" if body else "GET"
 
@@ -1231,7 +1226,6 @@ def get_nuclio_deploy_status(
     name,
     project,
     tag,
-    dashboard="",
     last_log_timestamp=0,
     verbose=False,
     resolve_address=True,
@@ -1243,13 +1237,12 @@ def get_nuclio_deploy_status(
     :param name:                function name
     :param project:             project name
     :param tag:                 function tag
-    :param dashboard:           DEPRECATED. Keep empty to allow auto-detection by MLRun API.
     :param last_log_timestamp:  last log timestamp
     :param verbose:             print logs
     :param resolve_address:     whether to resolve function address
     :param auth_info:           authentication information
     """
-    api_address = find_dashboard_url(dashboard or mlconf.nuclio_dashboard_url)
+    api_address = find_dashboard_url(mlconf.nuclio_dashboard_url)
     name = get_fullname(name, project, tag)
     get_err_message = f"Failed to get function {name} deploy status"
 

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -643,7 +643,6 @@ class ServingRuntime(RemoteRuntime):
             logger.info(f"deploy root function {self.metadata.name} ...")
 
         return super().deploy(
-            dashboard,
             project,
             tag,
             verbose,

--- a/mlrun/runtimes/serving.py
+++ b/mlrun/runtimes/serving.py
@@ -588,7 +588,6 @@ class ServingRuntime(RemoteRuntime):
 
     def deploy(
         self,
-        dashboard="",
         project="",
         tag="",
         verbose=False,
@@ -598,7 +597,6 @@ class ServingRuntime(RemoteRuntime):
     ):
         """deploy model serving function to a local/remote cluster
 
-        :param dashboard: DEPRECATED. Keep empty to allow auto-detection by MLRun API
         :param project:   optional, override function specified project name
         :param tag:       specify unique function tag (a different function service is created for every tag)
         :param verbose:   verbose logging

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -269,7 +269,7 @@ def test_ensemble_get_metadata_of_models():
     expected = {"name": "VotingEnsemble", "version": "v1", "inputs": [], "outputs": []}
     assert resp == expected, f"wrong get models response {resp}"
 
-    mlrun.deploy_function(fn, dashboard="bad-address", mock=True)
+    mlrun.deploy_function(fn, mock=True)
     resp = fn.invoke("/v2/models/m1")
     expected = {"name": "m1", "version": "", "inputs": [], "outputs": []}
     assert resp == expected, f"wrong get models response {resp}"
@@ -653,18 +653,18 @@ def test_mock_deploy():
     mlrun.mlconf.mock_nuclio_deployment = ""
 
     # test mock deployment is working
-    mlrun.deploy_function(fn, dashboard="bad-address", mock=True)
+    mlrun.deploy_function(fn, mock=True)
     resp = fn.invoke("/v2/models/my/infer", testdata)
     assert resp["outputs"] == 5 * 100, f"wrong data response {resp}"
 
     # test mock deployment is working via project object
-    project.deploy_function(fn, dashboard="bad-address", mock=True)
+    project.deploy_function(fn, mock=True)
     resp = fn.invoke("/v2/models/my/infer", testdata)
     assert resp["outputs"] == 5 * 100, f"wrong data response {resp}"
 
     # test that it tries real deployment when turned off
     with pytest.raises(Exception):
-        mlrun.deploy_function(fn, dashboard="bad-address")
+        mlrun.deploy_function(fn)
         fn.invoke("/v2/models/my/infer", testdata)
 
     # set the mock through the config
@@ -737,7 +737,7 @@ def test_deploy_with_dashboard_argument():
         return_value=(None, None),
     )
 
-    mlrun.deploy_function(fn, dashboard="bad-address")
+    mlrun.deploy_function(fn)
 
     # test that the remote builder was called even with dashboard argument
     assert db_instance.remote_builder.call_count == 1


### PR DESCRIPTION
Remove unused dashboard param.
Deprecate it only in `invoke` because it wasn't deprecated there.
https://jira.iguazeng.com/browse/ML-4899
