### PR TITLE
[Datasets] Support uploading dataset body when it is not a dataframe

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -231,7 +231,7 @@ class DatasetArtifact(Artifact):
         if not suffix and not self.spec.target_path.startswith("memory://"):
             self.spec.target_path = self.spec.target_path + "." + format
 
-        if self._df:
+        if self._df is not None:
             self.spec.size, self.metadata.hash = upload_dataframe(
                 self._df,
                 self.spec.target_path,

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -231,13 +231,24 @@ class DatasetArtifact(Artifact):
         if not suffix and not self.spec.target_path.startswith("memory://"):
             self.spec.target_path = self.spec.target_path + "." + format
 
-        self.spec.size, self.metadata.hash = upload_dataframe(
-            self._df,
-            self.spec.target_path,
-            format=format,
-            src_path=self.spec.src_path,
-            **self._kw,
-        )
+        if self._df:
+            self.spec.size, self.metadata.hash = upload_dataframe(
+                self._df,
+                self.spec.target_path,
+                format=format,
+                src_path=self.spec.src_path,
+                **self._kw,
+            )
+        else:
+            body = self.get_body()
+            if body:
+                self._upload_body(
+                    body=body, target=self.target_path, artifact_path=artifact_path
+                )
+            else:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "Unable to upload dataset, dataframe is not defined"
+                )
 
     def resolve_dataframe_target_hash_path(self, dataframe, artifact_path: str):
         if not artifact_path:


### PR DESCRIPTION
When logging a dataset artifact and uploading to the target path, it was only uploaded if it contained a dataframe.
For other cases, such as where the dataset was an imported parquet file, it was just ignored and wasn't actually uploaded to the data store, causing it to be basically useless.

In this PR, when uploading a dataset we check if the dataframe is set, and if not we try to upload the dataset's body.

Resolves https://jira.iguazeng.com/browse/ML-5613