### PR TITLE
[Model Monitoring] Fix update\bumping endpoint last_request timestamp when using batch infer

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -29,7 +29,7 @@ from mlrun.utils import datetime_now, logger
 
 from .batch import VirtualDrift
 from .features_drift_table import FeaturesDriftTablePlot
-from .helpers import bump_model_endpoint_last_request
+from .helpers import update_model_endpoint_last_request
 from .model_endpoint import ModelEndpoint
 
 # A union of all supported dataset types:
@@ -199,21 +199,12 @@ def record_results(
         )
 
     # Update the last request time
-    db.patch_model_endpoint(
+    update_model_endpoint_last_request(
         project=project,
-        endpoint_id=model_endpoint.metadata.uid,
-        attributes={EventFieldType.LAST_REQUEST: timestamp},
+        model_endpoint=model_endpoint,
+        current_request=timestamp,
+        db=db,
     )
-
-    if model_endpoint.spec.stream_path == "":
-        logger.info(
-            "Updating the last request time to mark the current monitoring window as completed",
-            project=project,
-            endpoint_id=model_endpoint.metadata.uid,
-        )
-        bump_model_endpoint_last_request(
-            project=project, model_endpoint=model_endpoint, db=db
-        )
 
     if trigger_monitoring_job:
         # Run the monitoring batch drift job

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -161,6 +161,7 @@ def update_model_endpoint_last_request(
     :param db:              DB interface.
     """
     if model_endpoint.spec.stream_path != "":
+        current_request = current_request.isoformat()
         logger.info(
             "Update model endpoint last request time (EP with serving)",
             project=project,
@@ -171,7 +172,7 @@ def update_model_endpoint_last_request(
         db.patch_model_endpoint(
             project=project,
             endpoint_id=model_endpoint.metadata.uid,
-            attributes={EventFieldType.LAST_REQUEST: current_request.isoformat()},
+            attributes={EventFieldType.LAST_REQUEST: current_request},
         )
     else:
         try:
@@ -194,7 +195,7 @@ def update_model_endpoint_last_request(
             project=project,
             endpoint_id=model_endpoint.metadata.uid,
             last_request=model_endpoint.status.last_request,
-            current_request=current_request,
+            current_request=current_request.isoformat(),
             bumped_last_request=bumped_last_request,
         )
         db.patch_model_endpoint(

--- a/tests/model_monitoring/test_monitoring_api.py
+++ b/tests/model_monitoring/test_monitoring_api.py
@@ -63,5 +63,5 @@ def test_record_result_updates_last_request() -> None:
     db_mock.patch_model_endpoint.assert_called_once()
     assert (
         db_mock.patch_model_endpoint.call_args.kwargs["attributes"]["last_request"]
-        == datetime_mock
+        == datetime_mock.isoformat()
     ), "last_request attribute of the model endpoint was not updated as expected"


### PR DESCRIPTION
First introduce #4709.
[ML-5607](https://jira.iguazeng.com/browse/ML-5607)

Now we are updating last request only once in record_result run.