### PR TITLE
[Packager] Add timestamp to archive directory path for uniqueness

### DIFF
--- a/mlrun/package/utils/_archiver.py
+++ b/mlrun/package/utils/_archiver.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import datetime
 import os
 import tarfile
 import zipfile
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+import mlrun.utils
 
 from ._supported_format import SupportedFormat
 
@@ -104,7 +105,7 @@ class _ZipArchiver(_Archiver):
         # Create the directory path, add timestamp to avoid collisions:
         directory_path = output_path / archive_path.stem
         directory_path = directory_path.with_name(
-            f"{directory_path.name}-{datetime.datetime.now()}"
+            f"{directory_path.name}-{mlrun.utils.now_date().isoformat()}"
         )
         os.makedirs(directory_path)
 

--- a/mlrun/package/utils/_archiver.py
+++ b/mlrun/package/utils/_archiver.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
 import os
 import tarfile
 import zipfile
@@ -100,8 +101,11 @@ class _ZipArchiver(_Archiver):
         archive_path = Path(archive_path)
         output_path = Path(output_path)
 
-        # Create the directory path:
+        # Create the directory path, add timestamp to avoid collisions:
         directory_path = output_path / archive_path.stem
+        directory_path = directory_path.with_name(
+            f"{directory_path.name}-{datetime.datetime.now()}"
+        )
         os.makedirs(directory_path)
 
         # Extract:

--- a/tests/package/utils/test_archiver.py
+++ b/tests/package/utils/test_archiver.py
@@ -94,7 +94,7 @@ def test_archiver(archive_format: str, directory_layout: List[str]):
         )
     )
     assert extracted_dir_path.exists()
-    assert extracted_dir_path == output_path / directory_name
+    assert extracted_dir_path.name.startswith((output_path / directory_name).name)
 
     # Validate all files were extracted as they originally were:
     for path in directory_layout:

--- a/tests/system/projects/assets/create_file_artifact.py
+++ b/tests/system/projects/assets/create_file_artifact.py
@@ -1,0 +1,37 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import tempfile
+
+
+def create_file_artifact() -> str:
+    # Create a temporary directory
+    temp_dir = tempfile.mkdtemp()
+
+    file_content = b"This is the content of the file."
+    file_name = "example.txt"
+
+    # Create the full path to the file within the temporary directory
+    file_path = os.path.join(temp_dir, file_name)
+
+    # Write the content to the file
+    with open(file_path, "wb") as file:
+        file.write(file_content)
+
+    print(
+        f"Temporary directory '{temp_dir}' created successfully with file '{file_name}'."
+    )
+    return str(temp_dir)

--- a/tests/system/projects/assets/use_artifact.py
+++ b/tests/system/projects/assets/use_artifact.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+from typing import List, Union
+
+
+def use_artifact(artifact: Union[str, Path, List[Union[str, Path]]]):
+    print(artifact)


### PR DESCRIPTION
The packager saves file artifacts as zip archives.
When zip artifacts are exported and the imported, the files lose their `.zip` suffix, but still remain extractable zip files.

When the packager then tries to unpack these archives, it assumes the files has a `.zip` suffix, and tries to extract them to a directory of the same name (e.g. extract `my-artifact.zip` to `my-artifact` dir). 
The directory creation fails in case the suffix is missing, because a file of the same name already exists.

The simple solution is to just add a random suffix (`datetime.now()`) to the directory name, as it is just a temporary directory. The directory can then be created and the artifacts are usable in the run.

Fixes https://jira.iguazeng.com/browse/ML-5614 