### PR TITLE
[Dataset] Don't fail uploading dataset if `df` or `body` are empty

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -246,9 +246,8 @@ class DatasetArtifact(Artifact):
                     body=body, target=self.target_path, artifact_path=artifact_path
                 )
             else:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Unable to upload dataset, dataframe is not defined"
-                )
+                # don't fail if no df or body
+                self.spec.size, self.metadata.hash = None, None
 
     def resolve_dataframe_target_hash_path(self, dataframe, artifact_path: str):
         if not artifact_path:


### PR DESCRIPTION
An exception was mistakenly added in https://github.com/mlrun/mlrun/pull/5027 when there is no dataframe or body to the upload in a dataset artifact.
In this PR we maintain the previous behavior of simply setting the artifact's size and hash to `None` if there is no df to upload.

Resolves https://jira.iguazeng.com/browse/ML-5645 