### PR TITLE
[Images] Add build-essential to mlrun/mlrun

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -30,6 +30,7 @@ RUN python -m pip  list --disable-pip-version-check --format freeze \
 ENV PIP_NO_CACHE_DIR=1
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+  build-essential \
   cmake \
   gcc \
   wget \


### PR DESCRIPTION
As https://github.com/mlrun/mlrun/pull/5042 this is also needed for horovod.
build-essential package include development tools for creating DEB packages from the source code of an application - https://itsfoss.com/build-essential-ubuntu/

Fixes this error:
```
 CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
      CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
      -- Configuring incomplete, errors occurred!
```