### PR TITLE
[Model Monitoring] Fix path filtering according to nuclio changes

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -180,7 +180,7 @@ class EventStreamProcessor:
 
         apply_event_routing()
 
-        # Step 2 - Filter out events with '-' in path which indicates that the event is supposed to be processed
+        # Step 2 - Filter out events with '-' in the path basename from going forward
         # through the next steps of the stream graph
         def apply_storey_filter_stream_events():
             # Remove none values from each event

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -180,14 +180,14 @@ class EventStreamProcessor:
 
         apply_event_routing()
 
-        # Step 2 - Filter out events with no '-' in path which indicates that the event is supposed to be processed
+        # Step 2 - Filter out events with '-' in path which indicates that the event is supposed to be processed
         # through the next steps of the stream graph
         def apply_storey_filter_stream_events():
             # Remove none values from each event
             graph.add_step(
                 "storey.Filter",
                 "filter_stream_event",
-                _fn="('-' not in event.path)",
+                _fn="('-' not in event.path.split('/')[-1])",
                 full_event=True,
             )
 


### PR DESCRIPTION
Works also on previous nuclio versions.
According to @TomerShor the changes are only when using `V3ioStream`.
[ML-5659](https://jira.iguazeng.com/browse/ML-5659)