### PR TITLE
[Tests] Use a unique name for the monitoring app sys test

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -127,7 +127,9 @@ class _V3IORecordsChecker:
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
     project_name = "test-app-flow"
-    project_name += datetime.now().strftime("%y%m%d%H%M")  # a workaround for ML-5588
+    project_name += datetime.now().strftime(  # remove when ML-5588 is fixed
+        "%y%m%d%H%M"
+    )
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -19,7 +19,7 @@ import typing
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -126,7 +126,8 @@ class _V3IORecordsChecker:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-app-flow"
+    project_name = "test-app-flow"
+    project_name += datetime.now().strftime("%y%m%d%H%M")  # a workaround for ML-5588
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
 


### PR DESCRIPTION
A workaround for [ML-5588](https://jira.iguazeng.com/browse/ML-5588). Add a datetime-based suffix to the project name for uniqueness.

I checked it locally twice and it passed.