### PR TITLE
[API] Do not enrich workflow schedule when given spec

### DIFF
--- a/server/api/api/endpoints/workflows.py
+++ b/server/api/api/endpoints/workflows.py
@@ -285,16 +285,19 @@ def _fill_workflow_missing_fields_from_project(
     Fill the workflow spec details from the project object, with favour to spec
 
     :param project:         MLRun project that contains the workflow.
-    :param workflow_name:   workflow name
-    :param spec:            workflow spec input
-    :param arguments:       arguments to workflow
+    :param workflow_name:   Workflow name
+    :param spec:            Workflow spec input
+    :param arguments:       Arguments to workflow
 
-    :return: completed workflow spec
+    :return: Completed workflow spec
     """
 
-    # while we expect workflow to be exists on project spec, we might get a case where the workflow is not exists.
-    # this is possible when workflow is not set prior to its execution.
+    # While we expect workflow to exist on project spec, we might get a case where the workflow does not exist.
+    # This is possible when workflow is not set prior to its execution.
     workflow = _get_workflow_by_name(project, workflow_name)
+    if spec and spec.schedule is None:
+        # Do not enrich with schedule from project's workflow when spec was provided
+        workflow.pop("schedule", None)
 
     if spec:
         # Merge between the workflow spec provided in the request with existing


### PR DESCRIPTION
When running a workflow, wether to schedule it or not is decided in the client. If a schedule was requested it will be in the workflow spec. This bug was caused by not requesting a schedule and then having the project enriching the workflow which not only adds a schedule the user didn't ask for, but it also fails when the request reaches the worker because the worker doesn't have a scheduler.

This also introduced another issue where a schedule (which is essentially a remote workflow) can start another remote workflow. There is no real reason to support this but the fix is a bit more complex and not worth the risk for 1.6. Will be done in another PR as this will be backported to 1.6.

https://jira.iguazeng.com/browse/ML-5652