### PR TITLE
[Model Monitoring] Fix monitoring jobs API query permissions 

### DIFF
--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -18,6 +18,7 @@ import fastapi
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+import server.api.utils.auth.verifier
 import server.api.utils.clients.chief
 from mlrun.model_monitoring import TrackingPolicy
 from mlrun.utils import logger
@@ -29,8 +30,9 @@ router = fastapi.APIRouter(prefix="/projects/{project}/jobs")
 
 
 @router.post("/batch-monitoring")
-def deploy_monitoring_batch_job(
+async def deploy_monitoring_batch_job(
     project: str,
+    request: fastapi.Request,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         deps.authenticate_request
     ),
@@ -43,6 +45,7 @@ def deploy_monitoring_batch_job(
     To submit a scheduled job as well, please set with_schedule = True.
 
     :param project:             Project name.
+    :param request:             fastapi request for the HTTP connection.
     :param auth_info:           The auth info of the request.
     :param db_session:          a session that manages the current dialog with the database.
     :param default_batch_image: The default image of the model monitoring batch job. By default, the image
@@ -51,6 +54,32 @@ def deploy_monitoring_batch_job(
 
     :return: model monitoring batch job as a dictionary.
     """
+
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
+        project_name=project,
+        resource_name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.BATCH,
+        action=mlrun.common.schemas.AuthorizationAction.store,
+        auth_info=auth_info,
+    )
+
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.common.schemas.ClusterizationRole.chief
+    ):
+        logger.info(
+            "Requesting to deploy model monitoring batch job, re-routing to chief",
+            function_name="model-monitoring-batch",
+            project=project,
+        )
+        chief_client = server.api.utils.clients.chief.Client()
+        params = {
+            "default_batch_image": default_batch_image,
+            "with_schedule": with_schedule,
+        }
+        return await chief_client.deploy_monitoring_batch_job(
+            project=project, request=request, json=params
+        )
 
     model_monitoring_access_key = None
     if not mlrun.mlconf.is_ce_mode():
@@ -106,6 +135,14 @@ async def create_model_monitoring_controller(
     :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
                                      is running. By default, the base period is 5 minutes.
     """
+
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
+        project_name=project,
+        resource_name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.APPLICATION_CONTROLLER,
+        action=mlrun.common.schemas.AuthorizationAction.store,
+        auth_info=auth_info,
+    )
 
     if (
         mlrun.mlconf.httpdb.clusterization.role

--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -63,7 +63,7 @@ async def deploy_monitoring_batch_job(
         auth_info=auth_info,
     )
 
-    if (
+    if with_schedule and (
         mlrun.mlconf.httpdb.clusterization.role
         != mlrun.common.schemas.ClusterizationRole.chief
     ):

--- a/server/api/utils/clients/chief.py
+++ b/server/api/utils/clients/chief.py
@@ -225,6 +225,19 @@ class Client(
             json,
         )
 
+    async def deploy_monitoring_batch_job(
+        self, project: str, request: fastapi.Request, json: dict
+    ):
+        """
+        Model monitoring batch includes a scheduled job which is handled by the chief
+        """
+        return await self._proxy_request_to_chief(
+            "POST",
+            f"projects/{project}/jobs/batch-monitoring",
+            request,
+            json,
+        )
+
     async def _proxy_request_to_chief(
         self,
         method,


### PR DESCRIPTION
Includes:
1. Validate authorization for both monitoring batch job and monitoring controller APIs.  
2. Add chief re-routing to monitoring batch job API (This API mainly used as part of the batch infer in cases the scheduled job hasn't been deployed through the monitoring basic flow). 

A fix for [ML-5676](https://jira.iguazeng.com/browse/ML-5676)