### PR TITLE
[Datastore] Fix `ParquetTarget.write_dataframe()` and improve error

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -456,7 +456,7 @@ class BaseStoreTarget(DataTargetBase):
             self.get_target_path(),
             credentials_prefix_secrets,
         )
-        if self.get_target_path().startswith("ds://"):
+        if self.get_target_path() and self.get_target_path().startswith("ds://"):
             return store, store.url + resolved_store_path
         else:
             return store, self.get_target_path()
@@ -1984,6 +1984,8 @@ def _get_target_path(driver, resource, run_id_mode=False):
 
 
 def generate_path_with_chunk(target, chunk_id, path):
+    if path is None:
+        return ""
     prefix, suffix = os.path.splitext(path)
     if chunk_id and not target.partitioned and not target.time_partitioning_granularity:
         return f"{prefix}/{chunk_id:0>4}{suffix}"


### PR DESCRIPTION
Improves error when attempting to write too many partitions.

[ML-5622](https://jira.iguazeng.com/browse/ML-5622)
[ML-5677](https://jira.iguazeng.com/browse/ML-5677)