### PR TITLE
[Model Monitoring] Saving feature_stats as empty dict and not as null in the model_endpoint [1.6.x]

### DIFF
--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -89,7 +89,7 @@ class ModelEndpoints:
                             model_obj.spec.feature_stats
                         )
                     )
-                model_endpoint.status.feature_stats = model_obj.spec.feature_stats
+                    model_endpoint.status.feature_stats = model_obj.spec.feature_stats
             # Get labels from model object if not found in model endpoint object
             if not model_endpoint.spec.label_names and model_obj.spec.outputs:
                 model_label_names = [


### PR DESCRIPTION
port from #5068

(cherry picked from commit ea5d6ad31f2d50997cf859c129d6e346cb725042)