### PR TITLE
[Tests] Use a unique name for the monitoring app sys test [1.6.x]

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -19,7 +19,7 @@ import typing
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -126,7 +126,10 @@ class _V3IORecordsChecker:
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-monitoring-app-flow"
+    project_name = "test-app-flow"
+    project_name += datetime.now().strftime(  # remove when ML-5588 is fixed
+        "%y%m%d%H%M"
+    )
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
 


### PR DESCRIPTION
Backport #5067 to 1.6.x.

This should fix the `tests/system/model_monitoring/test_app.py::TestMonitoringAppFlow::test_app_flow` system test failures also on the 1.6.x branch.
https://github.com/mlrun/mlrun/actions/runs/7781461481/job/21228976349#step:9:1362