### PR TITLE
[CI] Extend PR title checker for side branches

### DIFF
--- a/.github/pr-title-validation-config-side-branch.json
+++ b/.github/pr-title-validation-config-side-branch.json
@@ -4,13 +4,13 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "regexp": "^((\\[[[A-Z][^\\]]+\\])|Revert) .*$",
+    "regexp": "^((\\[[[A-Z][^\\]]+\\])|Revert) .* \\[.+\\]$",
     "regexpFlags": "im",
     "ignoreLabels": []
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "PR title should be in the following format: '[Component] Brief summary'",
+    "failure": "PR title should be in the following format: '[Component] Brief summary [Branch name]'",
     "notice": ""
   }
 }

--- a/.github/workflows/pr-title-validation.yaml
+++ b/.github/workflows/pr-title-validation.yaml
@@ -27,8 +27,17 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/development'
     steps:
       - uses: thehanimo/pr-title-checker@v1.4.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           configuration_path: .github/pr-title-validation-config.json
+  check-side-branch:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/development'
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.4.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          configuration_path: .github/pr-title-validation-config-side-branch.json


### PR DESCRIPTION
If the PR is not for development, ensure that the title ends with  `[<branch-name>]`