### PR TITLE
[ModelObj] Do not remove empty lists from dict presentation

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -174,8 +174,7 @@ class ModelObj:
         #     return True
 
         return field_value is not None and not (
-            (isinstance(field_value, dict) or isinstance(field_value, list))
-            and not field_value
+            isinstance(field_value, dict) and not field_value
         )
 
     def _resolve_field_value_by_method(


### PR DESCRIPTION
This seems to be doing more harm than good. Sometimes an empty list is treated differently than `None` value