### PR TITLE
[Feature Store] Fix constructor following refactor of `to_dict()`

### DIFF
--- a/mlrun/feature_store/feature_vector.py
+++ b/mlrun/feature_store/feature_vector.py
@@ -384,7 +384,8 @@ class _JoinStep(ModelObj):
         self.right_step_name = right_step_name
         self.left_feature_set_names = (
             left_feature_set_names
-            if isinstance(left_feature_set_names, list)
+            if left_feature_set_names is None
+            or isinstance(left_feature_set_names, list)
             else [left_feature_set_names]
         )
         self.right_feature_set_name = right_feature_set_name


### PR DESCRIPTION
#4702 changed the handling of empty list parameters, and they are now removed on serialization, resulting in the default parameter replacing them.