### PR TITLE
[Project] Wait for project to be deleted in Nuclio when deleting project

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -408,6 +408,8 @@ default_config = {
             "iguazio_access_key": "",
             "iguazio_list_projects_default_page_size": 200,
             "iguazio_client_job_cache_ttl": "20 minutes",
+            "nuclio_project_deletion_verification_timeout": "60 seconds",
+            "nuclio_project_deletion_verification_interval": "5 seconds",
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",


### PR DESCRIPTION
When deleting a project, deleting model endpoint resources deletes a directory that contains files that can be used by Nuclio functions - specifically function with V3IO Stream trigger.
The client that consumes from the V3IO stream, uses a state file to store information about the stream consumption. This state file is stored in the directory mentioned above.

There are cases where MLRrun deletes the directory before the Nuclio function is deleted. When the stream client sees that its state file doesn't exist - it creates it again, essentially recreates the previously deleted directory.
When the function is eventually deleted, it does not delete this state file or its parent directories (by design).

This can cause conflicts later when mlrun tries to create this directory for a **new project of the same name**, but there is already an existing directory with files.

To overcome this, when we delete a project - before deleting model endpoint resources, wait for the project (including its functions) is deleted in Nuclio.

**Note:** Although an async nuclio client already exists, I decided to extend the sync nuclio client `get_project` functionality to minimize the code changes using the async client will require (risky this late in the 1.6.x game).

Resolves https://jira.iguazeng.com/browse/ML-5588