### PR TITLE
[Model Monitoring] Improve the error messages in drift table creation

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -706,7 +706,6 @@ def perform_drift_analysis(
 
     # Drift table plot
     html_plot = FeaturesDriftTablePlot().produce(
-        features=list(inputs_statistics.keys()),
         sample_set_statistics=sample_set_statistics,
         inputs_statistics=inputs_statistics,
         metrics=metrics,

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -668,7 +668,7 @@ def perform_drift_analysis(
     possible_drift_threshold: float,
     artifacts_tag: str = "",
     db_session=None,
-):
+) -> None:
     """
     Calculate drift per feature and produce the drift table artifact for logging post prediction. Note that most of
     the calculations were already made through the monitoring batch job.
@@ -694,7 +694,7 @@ def perform_drift_analysis(
     metrics = model_endpoint.status.drift_measures
     inputs_statistics = model_endpoint.status.current_stats
 
-    inputs_statistics.pop("timestamp", None)
+    inputs_statistics.pop(EventFieldType.TIMESTAMP, None)
 
     # Calculate drift for each feature
     virtual_drift = VirtualDrift()

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -93,7 +93,6 @@ class FeaturesDriftTablePlot:
 
     def produce(
         self,
-        features: list[str],
         sample_set_statistics: dict,
         inputs_statistics: dict,
         metrics: dict[str, Union[dict, float]],
@@ -113,7 +112,7 @@ class FeaturesDriftTablePlot:
         """
         # Plot the drift table:
         figure = self._plot(
-            features=features,
+            features=list(inputs_statistics.keys()),
             sample_set_statistics=sample_set_statistics,
             inputs_statistics=inputs_statistics,
             metrics=metrics,

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -276,7 +276,6 @@ class FeaturesDriftTablePlot:
         input_statistics: dict,
         metrics: dict,
         row_height: int,
-        feature: str,
     ) -> go.Table:
         """
         Plot the feature row to include in the table. The row will include only the columns of the statistics and
@@ -291,10 +290,10 @@ class FeaturesDriftTablePlot:
         :return: The feature row - `Table` trace.
         """
         # Add '\n' to the feature name in order to make it fit into its cell:
-        feature_name = "<br>".join(self._separate_feature_name(feature_name))
+        html_feature_name = "<br>".join(self._separate_feature_name(feature_name))
 
         # Initialize the cells values list with the bold feature name as the first value:
-        cells_values = [f"<b>{feature_name}</b>"]
+        cells_values = [f"<b>{html_feature_name}</b>"]
 
         # Add the statistics columns:
         for column in self._statistics_columns:
@@ -303,9 +302,9 @@ class FeaturesDriftTablePlot:
                 cells_values.append(input_statistics[column])
             except KeyError:
                 raise ValueError(
-                    f"The `input_statistics['{feature}']` dictionary does not "
-                    f"include the expected key '{column}'. Please check the "
-                    "current data."
+                    f"The `input_statistics['{feature_name}']` dictionary "
+                    f"does not include the expected key '{column}'. "
+                    "Please check the current data."
                 )
 
         # Add the metrics columns:
@@ -531,7 +530,6 @@ class FeaturesDriftTablePlot:
                         input_statistics=inputs_statistics[feature],
                         metrics=metrics[feature],
                         row_height=row_height,
-                        feature=feature,
                     ),
                     row=row,
                     col=1,

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -101,8 +101,6 @@ class FeaturesDriftTablePlot:
         """
         Produce the html code of the table plot with the given information and the stored configurations in the class.
 
-        :param features:              List of all the features names to include in the table. These names expected to be
-                                      in the statistics and metrics dictionaries.
         :param sample_set_statistics: The sample set calculated statistics dictionary.
         :param inputs_statistics:     The inputs calculated statistics dictionary.
         :param metrics:               The drift detection metrics calculated on the sample set and inputs.

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -84,7 +84,6 @@ def plot_produce(context: mlrun.MLClientCtx):
 
     # Plot:
     html_plot = FeaturesDriftTablePlot().produce(
-        features=list(sample_data.columns),
         sample_set_statistics=sample_data_statistics,
         inputs_statistics=inputs_statistics,
         metrics=metrics,


### PR DESCRIPTION
Fixes [ML-5265](https://jira.iguazeng.com/browse/ML-5265).

This change covers two cases:
- Extra features in the inputs (current data), as in the original issue.
- Missing keys, e.g. "mean", from existing features in the inputs. This happens when there's a placeholder for a label, but a new label name is used.