### PR TITLE
[Tests] Remove unique project name suffix

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -19,7 +19,7 @@ import typing
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -127,9 +127,6 @@ class _V3IORecordsChecker:
 @pytest.mark.enterprise
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
     project_name = "test-app-flow"
-    project_name += datetime.now().strftime(  # remove when ML-5588 is fixed
-        "%y%m%d%H%M"
-    )
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
 


### PR DESCRIPTION
[ML-5588](https://jira.iguazeng.com/browse/ML-5588) is fixed, and the same project name works when running this system test multiple times - verified.