### PR TITLE
[Runs] Block deleting run in aborting state

### DIFF
--- a/mlrun/runtimes/constants.py
+++ b/mlrun/runtimes/constants.py
@@ -185,7 +185,7 @@ class RunStates:
         return [
             RunStates.running,
             RunStates.pending,
-            # TODO: add aborting state once we have it
+            RunStates.aborting,
         ]
 
 

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -193,8 +193,11 @@ class Runs(
             run_state
             in mlrun.runtimes.constants.RunStates.not_allowed_for_deletion_states()
         ):
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Can not delete run in {run_state} state, consider aborting the run first"
+            message = "consider aborting the run first"
+            if run_state == mlrun.runtimes.constants.RunStates.aborting:
+                message = "wait for the run to finish aborting first"
+            raise mlrun.errors.MLRunPreconditionFailedError(
+                f"Can not delete run in {run_state} state, {message}"
             )
 
         runtime_kind = run.get("metadata", {}).get("labels", {}).get("kind")


### PR DESCRIPTION
Currently we don't allow deleting runs in pending or running states.
Once runtime resources were deleted, the run can be deleted safely without the worry of the run being recreated by monitoring.
We know that the runtime resources were deleted only after the abortion job has finished and the run state changed to aborted.