### PR TITLE
[Project] Increase nuclio project deletion verification timeout

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -408,7 +408,7 @@ default_config = {
             "iguazio_access_key": "",
             "iguazio_list_projects_default_page_size": 200,
             "iguazio_client_job_cache_ttl": "20 minutes",
-            "nuclio_project_deletion_verification_timeout": "60 seconds",
+            "nuclio_project_deletion_verification_timeout": "150 seconds",
             "nuclio_project_deletion_verification_interval": "5 seconds",
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -408,7 +408,7 @@ default_config = {
             "iguazio_access_key": "",
             "iguazio_list_projects_default_page_size": 200,
             "iguazio_client_job_cache_ttl": "20 minutes",
-            "nuclio_project_deletion_verification_timeout": "150 seconds",
+            "nuclio_project_deletion_verification_timeout": "300 seconds",
             "nuclio_project_deletion_verification_interval": "5 seconds",
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates

--- a/server/api/api/endpoints/projects.py
+++ b/server/api/api/endpoints/projects.py
@@ -241,7 +241,7 @@ async def delete_project(
     except mlrun.errors.MLRunNotFoundError as exc:
         if not server.api.utils.helpers.is_request_from_leader(auth_info.projects_role):
             logger.debug(
-                "Project no found in leader, ensuring project deleted in mlrun",
+                "Project not found in leader, ensuring project deleted in mlrun",
                 err=mlrun.errors.err_to_str(exc),
             )
             force_delete = True


### PR DESCRIPTION
When deleting a project, the project deletion in Nuclio takes some time to start, and even after Nuclio deletes the functions' deployment, it might take some time for the actual function pods to be deleted (due to kubernetes' graceful termination, which defaults to 60s).

Thus, increasing the timeout for project and function pods deletion verification from a minute to 5 minutes

Fixes https://jira.iguazeng.com/browse/ML-5758 