### PR TITLE
[Project] Fix project creation in foreground

### DIFF
--- a/server/api/utils/projects/follower.py
+++ b/server/api/utils/projects/follower.py
@@ -110,25 +110,13 @@ class Member(
             )
             created_project = None
             if not is_running_in_background:
-                # as part of the store_project flow we encountered an error related to the isolation level we use.
-                # We use the default isolation level, I wasn't able to find exactly what is the default that sql alchemy
-                # sets but its serializable(once you SELECT a series of rows in a transaction, you will get the
-                # identical data back each time you re-emit that SELECT) or repeatable read isolation (you’ll see newly
-                # added rows (and no longer see deleted rows), but for rows that you’ve already loaded, you won’t see
-                # any change). Eventually, in the store_project flow, we already queried get_project and at the second
-                # time(below), after the project created, we failed because we got the same result from first query.
-                # Using session.commit ends the current transaction and start a new one which will result in a
-                # new query to the DB.
-                # for further read: https://docs-sqlalchemy.readthedocs.io/ko/latest/faq/sessions.html
-                # https://docs-sqlalchemy.readthedocs.io/ko/latest/dialects/mysql.html#transaction-isolation-level
-                # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html
-                # TODO: there are multiple isolation level we can choose, READ COMMITTED seems to solve our issue
-                #  but will require deeper investigation and more test coverage
-                if commit_before_get:
-                    db_session.commit()
-
-                created_project = self.get_project(
-                    db_session, project.metadata.name, leader_session
+                # not running in background means long-project creation operation might stale
+                # its db session, so we need to create a new one
+                # https://jira.iguazeng.com/browse/ML-5764
+                created_project = (
+                    server.api.db.session.run_function_with_new_db_session(
+                        self.get_project, project.metadata.name, leader_session
+                    )
                 )
             return created_project, is_running_in_background
 


### PR DESCRIPTION
long lived db session might stale during project creation with anomaly of mysql reject due to `BrokenPipeError`

fixes https://jira.iguazeng.com/browse/ML-5764

In addition to that, remove the old way of committing. anyway we create a new db session that would have the newly committed project to get on