### PR TITLE
[API] Cache Get client-spec

### DIFF
--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -14,6 +14,7 @@
 #
 import collections
 import copy
+import functools
 import json
 import re
 import traceback
@@ -62,6 +63,11 @@ from server.api.utils.singletons.scheduler import get_scheduler
 def log_and_raise(status=HTTPStatus.BAD_REQUEST.value, **kw):
     logger.error(str(kw))
     raise HTTPException(status_code=status, detail=kw)
+
+
+@functools.lru_cache
+def expiring_lru_cache(ttl_seconds: int, func: typing.Callable, *args, **kwargs):
+    return func(*args, **kwargs)
 
 
 def log_path(project, uid) -> Path:

--- a/server/api/crud/client_spec.py
+++ b/server/api/crud/client_spec.py
@@ -24,7 +24,7 @@ class ClientSpec(
 ):
     def get_client_spec(
         self, client_version: str = None, client_python_version: str = None
-    ):
+    ) -> mlrun.common.schemas.ClientSpec:
         mpijob_crd_version = (
             server.api.runtime_handlers.mpijob.resolve_mpijob_crd_version()
         )


### PR DESCRIPTION
No reason to resolve it every time, enough to simply cache it for 60s per client version matrix.
the "ttl_seconds" is simply a way to invalidate cache based on time