### PR TITLE
[Project] Support loading project from files with both `yaml` and `yml` extensions

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -585,8 +585,8 @@ def _load_project_dir(context, name="", subpath=""):
     project_file_path = path.join(context, subpath_str, "project.y*ml")
     function_file_path = path.join(context, subpath_str, "function.y*ml")
     setup_file_path = path.join(context, subpath_str, "project_setup.py")
-    project_files = glob.glob(project_file_path)
-    if len(project_files) > 0:
+
+    if project_files := glob.glob(project_file_path):
         # if there are multiple project files, use the first one
         project_file_path = project_files[0]
         with open(project_file_path) as fp:
@@ -594,7 +594,6 @@ def _load_project_dir(context, name="", subpath=""):
             struct = yaml.load(data, Loader=yaml.FullLoader)
             project = _project_instance_from_struct(struct, name)
             project.spec.context = context
-
     elif function_files := glob.glob(function_file_path):
         function_path = function_files[0]
         func = import_function(function_path)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -580,24 +580,37 @@ def _run_project_setup(
 
 def _load_project_dir(context, name="", subpath=""):
     subpath_str = subpath or ""
-    fpath = path.join(context, subpath_str, "project.yaml")
+
+    # support both .yaml and .yml file extensions
+    project_file_path = path.join(context, subpath_str, "project.y*ml")
+    function_file_path = path.join(context, subpath_str, "function.y*ml")
     setup_file_path = path.join(context, subpath_str, "project_setup.py")
-    if path.isfile(fpath):
-        with open(fpath) as fp:
+    project_files = glob.glob(project_file_path)
+    if len(project_files) > 0:
+        # if there are multiple project files, use the first one
+        project_file_path = project_files[0]
+        with open(project_file_path) as fp:
             data = fp.read()
             struct = yaml.load(data, Loader=yaml.FullLoader)
             project = _project_instance_from_struct(struct, name)
             project.spec.context = context
 
-    elif path.isfile(path.join(context, subpath_str, "function.yaml")):
-        func = import_function(path.join(context, subpath_str, "function.yaml"))
+    elif function_files := glob.glob(function_file_path):
+        function_path = function_files[0]
+        func = import_function(function_path)
+        function_file_name = path.basename(path.normpath(function_path))
         project = MlrunProject.from_dict(
             {
                 "metadata": {
                     "name": func.metadata.project,
                 },
                 "spec": {
-                    "functions": [{"url": "function.yaml", "name": func.metadata.name}],
+                    "functions": [
+                        {
+                            "url": function_file_name,
+                            "name": func.metadata.name,
+                        },
+                    ],
                 },
             }
         )

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1633,3 +1633,26 @@ def test_project_labels_validation(project_labels, valid):
     assert valid == mlrun.projects.ProjectMetadata.validate_project_labels(
         project_labels, raise_on_failure=False
     )
+
+
+@pytest.mark.parametrize(
+    "project_file_name",
+    [
+        "project.yaml",
+        "project.yml",
+    ],
+)
+def test_load_project_dir(project_file_name):
+    project_dir = "project-dir"
+    os.makedirs(project_dir, exist_ok=True)
+    try:
+        # copy project.yaml from assets to project_dir
+        shutil.copy(
+            str(assets_path() / "project.yaml"),
+            str(pathlib.Path(project_dir) / project_file_name),
+        )
+        project = mlrun.load_project(project_dir, save=False)
+        # just to make sure the project was loaded correctly from the file
+        assert project.name == "pipe2"
+    finally:
+        shutil.rmtree(project_dir)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1636,13 +1636,14 @@ def test_project_labels_validation(project_labels, valid):
 
 
 @pytest.mark.parametrize(
-    "project_file_name",
+    "project_file_name, expected_failure",
     [
-        "project.yaml",
-        "project.yml",
+        ("project.yaml", False),
+        ("project.yml", False),
+        ("non-valid-file.yamrt", True),
     ],
 )
-def test_load_project_dir(project_file_name):
+def test_load_project_dir(project_file_name, expected_failure):
     project_dir = "project-dir"
     os.makedirs(project_dir, exist_ok=True)
     try:
@@ -1651,8 +1652,12 @@ def test_load_project_dir(project_file_name):
             str(assets_path() / "project.yaml"),
             str(pathlib.Path(project_dir) / project_file_name),
         )
-        project = mlrun.load_project(project_dir, save=False)
-        # just to make sure the project was loaded correctly from the file
-        assert project.name == "pipe2"
+        if not expected_failure:
+            project = mlrun.load_project(project_dir, save=False)
+            # just to make sure the project was loaded correctly from the file
+            assert project.name == "pipe2"
+        else:
+            with pytest.raises(mlrun.errors.MLRunNotFoundError):
+                mlrun.load_project(project_dir)
     finally:
         shutil.rmtree(project_dir)

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1636,14 +1636,14 @@ def test_project_labels_validation(project_labels, valid):
 
 
 @pytest.mark.parametrize(
-    "project_file_name, expected_failure",
+    "project_file_name, expectation",
     [
-        ("project.yaml", False),
-        ("project.yml", False),
-        ("non-valid-file.yamrt", True),
+        ("project.yaml", does_not_raise()),
+        ("project.yml", does_not_raise()),
+        ("non-valid-file.yamrt", pytest.raises(mlrun.errors.MLRunNotFoundError)),
     ],
 )
-def test_load_project_dir(project_file_name, expected_failure):
+def test_load_project_dir(project_file_name, expectation):
     project_dir = "project-dir"
     os.makedirs(project_dir, exist_ok=True)
     try:
@@ -1652,12 +1652,9 @@ def test_load_project_dir(project_file_name, expected_failure):
             str(assets_path() / "project.yaml"),
             str(pathlib.Path(project_dir) / project_file_name),
         )
-        if not expected_failure:
+        with expectation:
             project = mlrun.load_project(project_dir, save=False)
             # just to make sure the project was loaded correctly from the file
             assert project.name == "pipe2"
-        else:
-            with pytest.raises(mlrun.errors.MLRunNotFoundError):
-                mlrun.load_project(project_dir)
     finally:
         shutil.rmtree(project_dir)


### PR DESCRIPTION
If a `project.yml` file exists, there is no reason for `mlrun.load_project` to fail.

As an improvement, support both `yaml` and `yml` extensions for project and function files.