### PR TITLE
[SQLAlchemy] Recycle & ping connection prior using them

### DIFF
--- a/mlrun/common/db/sql_session.py
+++ b/mlrun/common/db/sql_session.py
@@ -63,20 +63,11 @@ def _init_engine(dsn=None):
         if max_overflow is None:
             max_overflow = config.httpdb.max_workers
 
-        # tests connections for liveness upon each checkout
-        pool_pre_ping = config.httpdb.db.connections_pool_pre_ping
-        if pool_pre_ping is None:
-            pool_pre_ping = True
-
-        # his setting causes the pool to recycle connections after the given number of seconds has passed
-        pool_recycle = config.httpdb.db.connections_pool_recycle
-        if pool_recycle is None:
-            pool_recycle = 60 * 60
         kwargs = {
             "pool_size": pool_size,
             "max_overflow": max_overflow,
-            "pool_pre_ping": pool_pre_ping,
-            "pool_recycle": pool_recycle,
+            "pool_pre_ping": config.httpdb.db.connections_pool_pre_ping,
+            "pool_recycle": config.httpdb.db.connections_pool_recycle,
         }
     engine = create_engine(dsn, **kwargs)
     _engines[dsn] = engine

--- a/mlrun/common/db/sql_session.py
+++ b/mlrun/common/db/sql_session.py
@@ -62,9 +62,21 @@ def _init_engine(dsn=None):
         max_overflow = config.httpdb.db.connections_pool_max_overflow
         if max_overflow is None:
             max_overflow = config.httpdb.max_workers
+
+        # tests connections for liveness upon each checkout
+        pool_pre_ping = config.httpdb.db.connections_pool_pre_ping
+        if pool_pre_ping is None:
+            pool_pre_ping = True
+
+        # his setting causes the pool to recycle connections after the given number of seconds has passed
+        pool_recycle = config.httpdb.db.connections_pool_recycle
+        if pool_recycle is None:
+            pool_recycle = 60 * 60
         kwargs = {
             "pool_size": pool_size,
             "max_overflow": max_overflow,
+            "pool_pre_ping": pool_pre_ping,
+            "pool_recycle": pool_recycle,
         }
     engine = create_engine(dsn, **kwargs)
     _engines[dsn] = engine

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -306,7 +306,9 @@ default_config = {
                 # default is 16MB, max 1G, for more info https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
                 "max_allowed_packet": 64000000,  # 64MB
             },
-            # None will set this to be equal to the httpdb.max_workers
+            "connections_pool_pre_ping": None,
+            "connections_pool_recycle": None,
+            # None defaults to httpdb.max_workers
             "connections_pool_size": None,
             "connections_pool_max_overflow": None,
             # below is a db-specific configuration

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -306,8 +306,10 @@ default_config = {
                 # default is 16MB, max 1G, for more info https://dev.mysql.com/doc/refman/8.0/en/packet-too-large.html
                 "max_allowed_packet": 64000000,  # 64MB
             },
-            "connections_pool_pre_ping": None,
-            "connections_pool_recycle": None,
+            # tests connections for liveness upon each checkout
+            "connections_pool_pre_ping": True,
+            # this setting causes the pool to recycle connections after the given number of seconds has passed
+            "connections_pool_recycle": 60 * 60,
             # None defaults to httpdb.max_workers
             "connections_pool_size": None,
             "connections_pool_max_overflow": None,


### PR DESCRIPTION
It has been observed that not using mlrun for very long of period forcing mysql to stale the connection, later on discovering it while using connection to perform db operations. this pr ensure sqlalchemy recycle the connection pool in a default of 1 hour + perform a pre-ping prior using the connection to perform db operation

https://jira.iguazeng.com/browse/ML-5772