### PR TITLE
[Nuclio] Disable project creation on deploy

### DIFF
--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -78,7 +78,7 @@ def deploy_nuclio_function(
             project=project_name,
             tag=function.metadata.tag,
             verbose=function.verbose,
-            create_new=True,
+            create_new=False,
             watch=False,
             return_address_mode=nuclio.deploy.ReturnAddressModes.all,
             auth_info=auth_info.to_nuclio_auth_info() if auth_info else None,

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -78,7 +78,7 @@ def deploy_nuclio_function(
             project=project_name,
             tag=function.metadata.tag,
             verbose=function.verbose,
-            create_new=False,
+            create_new=mlrun.mlconf.httpdb.projects.leader == "mlrun",
             watch=False,
             return_address_mode=nuclio.deploy.ReturnAddressModes.all,
             auth_info=auth_info.to_nuclio_auth_info() if auth_info else None,


### PR DESCRIPTION
If the project doesn't exist than something else went wrong.
When mlrun is not leader, nuclio will go to the leader to create the project but the project already exists there so it will fail.