### PR TITLE
[Model Monitoring] Fix plotly artifact histogram

### DIFF
--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 from typing import Union
 
 import numpy as np

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -56,6 +56,7 @@ class FeaturesDriftTablePlot:
     # Histograms configurations:
     _SAMPLE_SET_HISTOGRAM_COLOR = "rgb(0,112,192)"  # Blue
     _INPUTS_HISTOGRAM_COLOR = "rgb(208,0,106)"  # Magenta
+    _HISTOGRAM_OPACITY = 0.75
 
     # Notification configurations:
     _NOTIFICATION_COLORS = {
@@ -366,13 +367,12 @@ class FeaturesDriftTablePlot:
             # Center the bins (leave the first one):
             bins = 0.5 * (bins[:-1] + bins[1:])
             # Plot the histogram as a line with filled background below it:
-            histogram_bar = go.Scatter(
+            histogram_bar = go.Bar(
                 x=bins,
                 y=counts,
-                fill="tozeroy",
                 name=name,
-                line_shape="spline",  # Make the line rounder.
-                line={"color": color},
+                marker_color=color,
+                opacity=self._HISTOGRAM_OPACITY,
                 legendgroup=name,
             )
             bars.append(histogram_bar)
@@ -579,6 +579,8 @@ class FeaturesDriftTablePlot:
                 "x": 1.0 - (self._NOTIFICATIONS_COLUMN_WIDTH / width) - 0.01,
                 "bgcolor": "rgba(0,0,0,0)",
             },
+            barmode="overlay",
+            bargap=0,
         )
         main_figure.update_xaxes(
             showticklabels=False,

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import sys
 from typing import Callable, Union
 
 import numpy as np
@@ -360,8 +361,15 @@ class FeaturesDriftTablePlot:
             counts, bins = histogram
             # Rescale the counts to be in percentages (between 0.0 to 1.0):
             counts = np.array(counts) / sum(counts)
+            hovertext = [""] * len(counts)
             # Convert to NumPy for vectorization:
             bins = np.array(bins)
+            if bins[0] == -sys.float_info.max:
+                bins[0] = bins[1] - (bins[2] - bins[1])
+                hovertext[0] = f"(-inf, {bins[1]})"
+            if bins[-1] == sys.float_info.max:
+                bins[-1] = bins[-2] + (bins[-2] - bins[-3])
+                hovertext[-1] = f"({bins[-2]}, inf)"
             # Center the bins (leave the first one):
             bins = 0.5 * (bins[:-1] + bins[1:])
             # Plot the histogram as a line with filled background below it:
@@ -372,6 +380,7 @@ class FeaturesDriftTablePlot:
                 marker_color=color,
                 opacity=self._HISTOGRAM_OPACITY,
                 legendgroup=name,
+                hovertext=hovertext,
                 showlegend=showlegend,
             )
             figure_add_trace(histogram_bar)

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -80,9 +80,6 @@ class FeaturesDriftTablePlot:
     _BACKGROUND_COLOR = "rgb(255,255,255)"  # White
     _SEPARATORS_COLOR = "rgb(240,240,240)"  # Light grey
 
-    # File name:
-    _FILE_NAME = "table_plot.html"
-
     def __init__(self):
         """
         Initialize the plot producer for later calling the `produce` method.

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -366,10 +366,10 @@ class FeaturesDriftTablePlot:
             bins = np.array(bins)
             if bins[0] == -sys.float_info.max:
                 bins[0] = bins[1] - (bins[2] - bins[1])
-                hovertext[0] = f"(-inf, {bins[1]})"
+                hovertext[0] = f"(-∞, {bins[1]})"
             if bins[-1] == sys.float_info.max:
                 bins[-1] = bins[-2] + (bins[-2] - bins[-3])
-                hovertext[-1] = f"({bins[-2]}, inf)"
+                hovertext[-1] = f"({bins[-2]}, ∞)"
             # Center the bins (leave the first one):
             bins = 0.5 * (bins[:-1] + bins[1:])
             # Plot the histogram as a line with filled background below it:

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -519,8 +519,10 @@ class FeaturesDriftTablePlot:
         main_figure.add_trace(sub_header_trace, row=2, col=1)
 
         # Start going over the features and plot each row, histogram and notification:
-        row = 3  # We are currently at row 3 counting the headers.
-        for feature in features:
+        for row, feature in enumerate(
+            features,
+            start=3,  # starting from row 3 after the headers
+        ):
             try:
                 # Add the feature values:
                 main_figure.add_trace(
@@ -559,7 +561,6 @@ class FeaturesDriftTablePlot:
                 row_height=row_height,
                 drift_result=drift_results[feature],
             )
-            row += 1
 
         # Configure the layout and axes for height and widths:
         main_figure.update_layout(

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -332,7 +332,7 @@ class FeaturesDriftTablePlot:
 
         return feature_row_table
 
-    def _plot_histogram_scatters(
+    def _plot_histogram_bars(
         self, sample_hist: tuple[list, list], input_hist: tuple[list, list]
     ) -> tuple[go.Scatter, go.Scatter]:
         """
@@ -348,8 +348,8 @@ class FeaturesDriftTablePlot:
                  [0] - Sample set histogram.
                  [1] - Input histogram.
         """
-        # Initialize a list to collect the scatters:
-        scatters = []
+        # Initialize a list to collect the bars:
+        bars = []
 
         # Plot the histograms:
         for name, color, histogram in zip(
@@ -366,7 +366,7 @@ class FeaturesDriftTablePlot:
             # Center the bins (leave the first one):
             bins = 0.5 * (bins[:-1] + bins[1:])
             # Plot the histogram as a line with filled background below it:
-            histogram_scatter = go.Scatter(
+            histogram_bar = go.Scatter(
                 x=bins,
                 y=counts,
                 fill="tozeroy",
@@ -375,9 +375,9 @@ class FeaturesDriftTablePlot:
                 line={"color": color},
                 legendgroup=name,
             )
-            scatters.append(histogram_scatter)
+            bars.append(histogram_bar)
 
-        return scatters[0], scatters[1]
+        return bars[0], bars[1]
 
     def _calculate_row_height(self, features: list[str]) -> int:
         """
@@ -543,7 +543,7 @@ class FeaturesDriftTablePlot:
                     f"{inputs_statistics.keys() = }\n"
                 )
             # Add the histograms (both traces are added to the same subplot figure):
-            sample_hist, input_hist = self._plot_histogram_scatters(
+            sample_hist, input_hist = self._plot_histogram_bars(
                 sample_hist=sample_set_statistics[feature]["hist"],
                 input_hist=inputs_statistics[feature]["hist"],
             )

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -20,6 +20,7 @@ import pytest
 
 import mlrun
 from mlrun.artifacts import Artifact
+from mlrun.common.model_monitoring.helpers import FeatureStats, pad_features_hist
 from mlrun.data_types.infer import DFDataInfer, default_num_bins
 from mlrun.model_monitoring.batch import VirtualDrift, calculate_inputs_statistics
 from mlrun.model_monitoring.features_drift_table import FeaturesDriftTablePlot
@@ -65,6 +66,7 @@ def plot_produce(context: mlrun.MLClientCtx):
         df=sample_data,
         options=mlrun.data_types.infer.InferOptions.Histogram,
     )
+    pad_features_hist(FeatureStats(sample_data_statistics))
     inputs_statistics = calculate_inputs_statistics(
         sample_set_statistics=sample_data_statistics,
         inputs=inputs,

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import json
 import os
 import tempfile
@@ -30,7 +30,7 @@ from mlrun.model_monitoring.features_drift_table import FeaturesDriftTablePlot
 def generate_data(
     n_samples: int,
     n_features: int,
-    loc_range: tuple[int, int] = (0.1, 1.1),
+    loc_range: tuple[float, float] = (0.1, 1.1),
     scale_range: tuple[int, int] = (1, 2),
     inputs_diff_range: tuple[int, int] = (0, 1),
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
@@ -96,7 +96,7 @@ def plot_produce(context: mlrun.MLClientCtx):
     )
 
 
-def test_plot_produce(rundb_mock):
+def test_plot_produce():
     # Create a temp directory:
     output_path = tempfile.TemporaryDirectory()
 

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 import tempfile
 
@@ -105,9 +104,6 @@ def test_plot_produce():
         artifact_path=output_path.name,
         handler=plot_produce,
     )
-
-    # Print the outputs for manual validation:
-    print(json.dumps(train_run.outputs, indent=4))
 
     # Validate the artifact was logged:
     assert len(train_run.status.artifacts) == 1

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from pathlib import Path
 
 import numpy as np
@@ -106,11 +105,11 @@ def test_plot_produce(tmp_path: Path) -> None:
     assert len(train_run.status.artifacts) == 1
 
     # Check the plot was saved properly (only the drift table plot should appear):
-    artifact_directory_content = os.listdir(
-        os.path.dirname(train_run.status.artifacts[0]["spec"]["target_path"])
+    artifact_directory_content = list(
+        Path(train_run.status.artifacts[0]["spec"]["target_path"]).parent.glob("*")
     )
     assert len(artifact_directory_content) == 1
-    assert artifact_directory_content[0] == "drift_table_plot.html"
+    assert artifact_directory_content[0].name == "drift_table_plot.html"
 
 
 class TestCalculateInputsStatistics:

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-import tempfile
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -95,13 +95,10 @@ def plot_produce(context: mlrun.MLClientCtx):
     )
 
 
-def test_plot_produce():
-    # Create a temp directory:
-    output_path = tempfile.TemporaryDirectory()
-
+def test_plot_produce(tmp_path: Path) -> None:
     # Run the plot production and logging:
     train_run = mlrun.new_function().run(
-        artifact_path=output_path.name,
+        artifact_path=str(tmp_path),
         handler=plot_produce,
     )
 
@@ -114,9 +111,6 @@ def test_plot_produce():
     )
     assert len(artifact_directory_content) == 1
     assert artifact_directory_content[0] == "drift_table_plot.html"
-
-    # Clean up the temporary directory:
-    output_path.cleanup()
 
 
 class TestCalculateInputsStatistics:


### PR DESCRIPTION
Fixes [ML-5790](https://jira.iguazeng.com/browse/ML-5790).

Before this PR, the histogram in plotly artifact suffered from two issues:
1. Background didn't match the scatter line:
  ![image](https://github.com/mlrun/mlrun/assets/36337649/2aba67c2-94b3-4ba1-a0d9-bd773b4a3972)
2. "Input" (current) data could be outside of the original range but was not shown:
  ![image](https://github.com/mlrun/mlrun/assets/36337649/824073a8-f211-4d1a-8b1d-5380e9a7e303)

Now the histograms are presented with bars, and the ±∞ bins are accounted for:
![image](https://github.com/mlrun/mlrun/assets/36337649/e07ac340-b461-42b0-831b-aae2dccfd9a6)