### PR TITLE
[Artifacts] Persist db key when migrating to artifact v2 table

### DIFF
--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -581,9 +581,8 @@ def _migrate_artifacts_batch(
             or artifact_dict.get("spec", {}).get("db_key")
             or artifact_metadata.get("key", "")
         )
-        key_parts = key.split("-")
-        if len(key_parts) > 1 and iteration and key_parts[0] == str(iteration):
-            key = "-".join(key_parts[1:])
+        if iteration and key.startswith(f"{iteration}-"):
+            key = key[len(f"{iteration}-") :]
         new_artifact.key = key
 
         # best iteration

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -575,7 +575,9 @@ def _migrate_artifacts_batch(
         iteration = artifact_metadata.get("iter", None)
         new_artifact.iteration = int(iteration) if iteration else 0
 
-        # key - the artifact's key, without iteration if it is attached to it
+        # key - retain the db key to ensure BC of reading artifacts by the index key.
+        # if iteration is concatenated to the key, remove it as this was only handled in the backend,
+        # and now the iteration is saved in a separate column
         key = artifact.key
         if iteration and key.startswith(f"{iteration}-"):
             key = key[len(f"{iteration}-") :]

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -576,11 +576,7 @@ def _migrate_artifacts_batch(
         new_artifact.iteration = int(iteration) if iteration else 0
 
         # key - the artifact's key, without iteration if it is attached to it
-        key = (
-            artifact.key
-            or artifact_dict.get("spec", {}).get("db_key")
-            or artifact_metadata.get("key", "")
-        )
+        key = artifact.key
         if iteration and key.startswith(f"{iteration}-"):
             key = key[len(f"{iteration}-") :]
         new_artifact.key = key

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -571,13 +571,20 @@ def _migrate_artifacts_batch(
         # project - copy as is
         new_artifact.project = artifact_metadata.get("project", None)
 
-        # key - the artifact's key, without iteration if it is attached to it
-        key = artifact_metadata.get("key", "")
-        new_artifact.key = key
-
         # iteration - the artifact's iteration
         iteration = artifact_metadata.get("iter", None)
         new_artifact.iteration = int(iteration) if iteration else 0
+
+        # key - the artifact's key, without iteration if it is attached to it
+        key = (
+            artifact.key
+            or artifact_dict.get("spec", {}).get("db_key")
+            or artifact_metadata.get("key", "")
+        )
+        key_parts = key.split("-")
+        if len(key_parts) > 1 and iteration and key_parts[0] == str(iteration):
+            key = "-".join(key_parts[1:])
+        new_artifact.key = key
 
         # best iteration
         # if iteration == 0 it means it is from a single run since link artifacts were already

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -1322,7 +1322,7 @@ class TestArtifacts:
             assert artifacts[0]["metadata"]["project"] == project
             assert artifacts[0]["metadata"]["uid"] != artifact_uid
 
-    def test_migrate_artifact_v2_persist_db_key(
+    def test_migrate_artifact_v2_persist_db_key_with_iteration(
         self, db: DBInterface, db_session: Session
     ):
         artifact_key = "artifact"
@@ -1368,6 +1368,7 @@ class TestArtifacts:
         )
         new_artifact = query_all.one()
         assert new_artifact.key == db_key
+        assert new_artifact.iteration == iteration
 
     def test_update_model_spec(self, db: DBInterface, db_session: Session):
         artifact_key = "model1"

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -1075,16 +1075,7 @@ class TestArtifacts:
         artifact_tag = "artifact-tag-1"
         project = "project1"
 
-        # create project
-        db.create_project(
-            db_session,
-            mlrun.common.schemas.Project(
-                metadata=mlrun.common.schemas.ProjectMetadata(
-                    name=project,
-                ),
-                spec=mlrun.common.schemas.ProjectSpec(description="some-description"),
-            ),
-        )
+        self._create_project(db, db_session, project)
 
         # create an artifact in the old format
         artifact_key_1 = "artifact1"
@@ -1137,14 +1128,7 @@ class TestArtifacts:
             tag=legacy_artifact_tag,
         )
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # change the state file path to the temp directory for the test only
-            mlrun.config.config.artifacts.artifact_migration_state_file_path = (
-                temp_dir + "/_artifact_migration_state.json"
-            )
-
-            # perform the migration
-            server.api.initial_data._migrate_artifacts_table_v2(db, db_session)
+        self._run_artifacts_v2_migration(db, db_session)
 
         # validate the migration succeeded
         query_all = db._query(
@@ -1229,17 +1213,7 @@ class TestArtifacts:
         # create 10 artifacts in 10 projects
         for i in range(10):
             project_name = f"project-{i}"
-            db.create_project(
-                db_session,
-                mlrun.common.schemas.Project(
-                    metadata=mlrun.common.schemas.ProjectMetadata(
-                        name=project_name,
-                    ),
-                    spec=mlrun.common.schemas.ProjectSpec(
-                        description="some-description"
-                    ),
-                ),
-            )
+            self._create_project(db, db_session, project_name)
             for j in range(10):
                 artifact_key = f"artifact-{j}"
                 artifact_uid = f"uid-{j}"
@@ -1265,14 +1239,7 @@ class TestArtifacts:
         ).all()
         assert len(old_artifacts) == 100
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # change the state file path to the temp directory for the test only
-            mlrun.config.config.artifacts.artifact_migration_state_file_path = (
-                temp_dir + "/_artifact_migration_state.json"
-            )
-
-            # perform the migration
-            server.api.initial_data._migrate_artifacts_table_v2(db, db_session)
+        self._run_artifacts_v2_migration(db, db_session)
 
         # validate the migration succeeded
         old_artifacts = db._query(
@@ -1307,15 +1274,7 @@ class TestArtifacts:
         project = "project1"
 
         # create project
-        db.create_project(
-            db_session,
-            mlrun.common.schemas.Project(
-                metadata=mlrun.common.schemas.ProjectMetadata(
-                    name=project,
-                ),
-                spec=mlrun.common.schemas.ProjectSpec(description="some-description"),
-            ),
-        )
+        self._create_project(db, db_session, project)
 
         # create an artifact in the old format
         artifact_body = self._generate_artifact(artifact_key, artifact_uid, "artifact")
@@ -1338,14 +1297,7 @@ class TestArtifacts:
         old_artifacts = query_all.all()
         assert len(old_artifacts) == 1
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # change the state file path to the temp directory for the test only
-            mlrun.config.config.artifacts.artifact_migration_state_file_path = (
-                temp_dir + "/_artifact_migration_state.json"
-            )
-
-            # perform the migration
-            server.api.initial_data._migrate_artifacts_table_v2(db, db_session)
+        self._run_artifacts_v2_migration(db, db_session)
 
         # validate the migration succeeded
         query_all = db._query(
@@ -1369,6 +1321,53 @@ class TestArtifacts:
             assert artifacts[0]["metadata"]["key"] == artifact_key
             assert artifacts[0]["metadata"]["project"] == project
             assert artifacts[0]["metadata"]["uid"] != artifact_uid
+
+    def test_migrate_artifact_v2_persist_db_key(
+        self, db: DBInterface, db_session: Session
+    ):
+        artifact_key = "artifact"
+        artifact_tree = "some-tree"
+        artifact_tag = "artifact-tag-1"
+        project = "project1"
+        db_key = "db-key-1"
+        iteration = 2
+
+        # create project
+        self._create_project(db, db_session, project)
+
+        # create artifacts in the old format
+        artifact_body = self._generate_artifact(artifact_key, artifact_tree, "artifact")
+        artifact_body["metadata"]["key"] = artifact_key
+        artifact_body["metadata"]["iter"] = iteration
+        artifact_body["metadata"]["project"] = project
+        artifact_body["spec"]["db_key"] = db_key
+
+        # store the artifact with the db_key
+        db.store_artifact_v1(
+            db_session,
+            db_key,
+            artifact_body,
+            artifact_tree,
+            project=project,
+            tag=artifact_tag,
+            iter=iteration,
+        )
+
+        # validate the artifact was stored with the db_key
+        key = f"{iteration}-{db_key}"
+        artifact = db.read_artifact_v1(db_session, key, project=project)
+        assert artifact["metadata"]["key"] == artifact_key
+
+        # migrate the artifacts to v2
+        self._run_artifacts_v2_migration(db, db_session)
+
+        # validate the migration succeeded and the db_key was persisted
+        query_all = db._query(
+            db_session,
+            server.api.db.sqldb.models.ArtifactV2,
+        )
+        new_artifact = query_all.one()
+        assert new_artifact.key == db_key
 
     def test_update_model_spec(self, db: DBInterface, db_session: Session):
         artifact_key = "model1"
@@ -1471,3 +1470,24 @@ class TestArtifacts:
             project=project,
             producer_id=artifact_tree,
         )
+
+    @staticmethod
+    def _create_project(db: DBInterface, db_session: Session, project_name):
+        project = mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(
+                name=project_name,
+            ),
+            spec=mlrun.common.schemas.ProjectSpec(description="some-description"),
+        )
+        db.create_project(db_session, project)
+
+    @staticmethod
+    def _run_artifacts_v2_migration(db: DBInterface, db_session: Session):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # change the state file path to the temp directory for the test only
+            mlrun.config.config.artifacts.artifact_migration_state_file_path = (
+                temp_dir + "/_artifact_migration_state.json"
+            )
+
+            # perform the migration
+            server.api.initial_data._migrate_artifacts_table_v2(db, db_session)


### PR DESCRIPTION
We noticed that when migrating the artifacts table to the new v2 table, the new artifacts are saved with the `key` taken from `metadata.key` only.
However, some artifacts have different `db_keys`, meaning the key they are saved with in the DB can be different then the value in `metadata.key`.

Since we want to be backwards compatible, we want to persist the original key in the DB, **with a caveat**:
Artifacts from a hyper param run, with iterations, had a key in the DB that was a concatenation `{iter}-{key}`. We do not persist this behavior, but remove the `iter` part of the key, and save the iteration in a different column.
This should not affect reading/listing artifacts with iterations, as this concatenation was done behind the scenes.

Resolves https://jira.iguazeng.com/browse/ML-5799