### PR TITLE
[Project] Return not found status code when project not found

### DIFF
--- a/server/api/api/endpoints/projects_v2.py
+++ b/server/api/api/endpoints/projects_v2.py
@@ -63,7 +63,7 @@ async def delete_project(
         )
     except mlrun.errors.MLRunNotFoundError:
         logger.info("Project not found, nothing to delete", project=name)
-        return fastapi.Response(status_code=http.HTTPStatus.NO_CONTENT.value)
+        return fastapi.Response(status_code=http.HTTPStatus.NOT_FOUND.value)
 
     # usually the CRUD for delete project will check permissions, however, since we are running the crud in a background
     # task, we need to check permissions here. skip permission check if the request is from the leader.


### PR DESCRIPTION
The worker return **NO_CONTENT** status code instead of **NOT_FOUND** status code when a project deletion request is sent and the project cannot be found in the DB.
https://jira.iguazeng.com/browse/IG-22546