### PR TITLE
[Model Monitoring] Fix to use sync handler

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -188,7 +188,10 @@ class GraphServer(ModelObj):
 
     def init_object(self, namespace):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
-        return v2_serving_handler if self.context.is_mock else v2_serving_async_handler
+        if self.graph.kind == "router" or self.context.is_mock:
+            return v2_serving_handler
+        else:
+            return v2_serving_async_handler
 
     def test(
         self,

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -188,9 +188,6 @@ class GraphServer(ModelObj):
 
     def init_object(self, namespace):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
-        if self.graph.kind in ("router", "task") or self.context.is_mock:
-            return v2_serving_handler
-        return v2_serving_async_handler
 
     def test(
         self,
@@ -341,9 +338,9 @@ def v2_serving_init(context, namespace=None):
         **kwargs,
     )
     context.logger.info("Initializing graph steps")
-    serving_handler = server.init_object(namespace or get_caller_globals())
+    server.init_object(namespace or get_caller_globals())
     # set the handler hook to point to our handler
-    setattr(context, "mlrun_handler", serving_handler)
+    setattr(context, "mlrun_handler", v2_serving_handler)
     setattr(context, "_server", server)
     context.logger.info_with("Serving was initialized", verbose=server.verbose)
     if server.verbose:
@@ -389,11 +386,6 @@ def v2_serving_handler(context, event, get_body=False):
             event.body = None
 
     return context._server.run(event, context, get_body)
-
-
-async def v2_serving_async_handler(context, event, get_body=False):
-    """hook for nuclio handler()"""
-    return await context._server.run(event, context, get_body)
 
 
 def create_graph_server(

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -190,8 +190,7 @@ class GraphServer(ModelObj):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
         if self.graph.kind == "router" or self.context.is_mock:
             return v2_serving_handler
-        else:
-            return v2_serving_async_handler
+        return v2_serving_async_handler
 
     def test(
         self,

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -188,7 +188,7 @@ class GraphServer(ModelObj):
 
     def init_object(self, namespace):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
-        if self.graph.kind == "router" or self.context.is_mock:
+        if self.graph.kind in ("router", "task") or self.context.is_mock:
             return v2_serving_handler
         return v2_serving_async_handler
 


### PR DESCRIPTION
[ML-5801](https://jira.iguazeng.com/browse/ML-5801)

Fixes error(*) introduced in #4724. It turns out that model monitoring doesn't use storey at all (which also explains why `V2ModelServer` doesn't use any of storey's facilities). #4724 didn't take this into account.

Fixes `TestMonitoringAppFlow::test_app_flow` and other model monitoring tests, as well as `TestProject::test_local_cli` and `TestArchiveSources::test_serving_deploy`.

(*) The actual error as it occurs in the pod:
```
  File "/opt/nuclio/_nuclio_wrapper.py", line 151, in serve_requests
    await self._handle_event(event)
  File "/opt/nuclio/_nuclio_wrapper.py", line 441, in _handle_event
    entrypoint_output = await entrypoint_output
  File "/opt/conda/lib/python3.9/site-packages/mlrun/serving/server.py", line 394, in v2_serving_async_handler
    return await context._server.run(event, context, get_body)
TypeError: object Response can't be used in 'await' expression
```