### PR TITLE
[Serving] Undo code simplification that breaks with older nuclio

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -190,7 +190,11 @@ class GraphServer(ModelObj):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
         # v2_serving_async_handler is only required to support nuclio<1.12.10
         # TODO: delete v2_serving_async_handler and always use v2_serving_handler once nuclio<1.12.10 support is dropped
-        if self.graph.kind in ("router", "task") or self.context.is_mock:
+        if (
+            self.context.is_mock
+            or hasattr(self.graph, "controller")
+            and asyncio.iscoroutine(self.graph.controller.emit)
+        ):
             return v2_serving_handler
         return v2_serving_async_handler
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -188,6 +188,8 @@ class GraphServer(ModelObj):
 
     def init_object(self, namespace):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
+        # v2_serving_async_handler is only required to support nuclio<1.12.10
+        # TODO: delete v2_serving_async_handler and always use v2_serving_handler once nuclio<1.12.10 support is dropped
         if self.graph.kind in ("router", "task") or self.context.is_mock:
             return v2_serving_handler
         return v2_serving_async_handler

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -191,12 +191,12 @@ class GraphServer(ModelObj):
         # v2_serving_async_handler is only required to support nuclio<1.12.10
         # TODO: delete v2_serving_async_handler and always use v2_serving_handler once nuclio<1.12.10 support is dropped
         if (
-            self.context.is_mock
-            or hasattr(self.graph, "controller")
+            not self.context.is_mock
+            and hasattr(self.graph, "controller")
             and asyncio.iscoroutine(self.graph.controller.emit)
         ):
-            return v2_serving_handler
-        return v2_serving_async_handler
+            return v2_serving_async_handler
+        return v2_serving_handler
 
     def test(
         self,

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -188,6 +188,9 @@ class GraphServer(ModelObj):
 
     def init_object(self, namespace):
         self.graph.init_object(self.context, namespace, self.load_mode, reset=True)
+        if self.graph.kind in ("router", "task") or self.context.is_mock:
+            return v2_serving_handler
+        return v2_serving_async_handler
 
     def test(
         self,
@@ -338,9 +341,9 @@ def v2_serving_init(context, namespace=None):
         **kwargs,
     )
     context.logger.info("Initializing graph steps")
-    server.init_object(namespace or get_caller_globals())
+    serving_handler = server.init_object(namespace or get_caller_globals())
     # set the handler hook to point to our handler
-    setattr(context, "mlrun_handler", v2_serving_handler)
+    setattr(context, "mlrun_handler", serving_handler)
     setattr(context, "_server", server)
     context.logger.info_with("Serving was initialized", verbose=server.verbose)
     if server.verbose:
@@ -386,6 +389,11 @@ def v2_serving_handler(context, event, get_body=False):
             event.body = None
 
     return context._server.run(event, context, get_body)
+
+
+async def v2_serving_async_handler(context, event, get_body=False):
+    """hook for nuclio handler()"""
+    return await context._server.run(event, context, get_body)
 
 
 def create_graph_server(

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -193,7 +193,7 @@ class GraphServer(ModelObj):
         if (
             not self.context.is_mock
             and hasattr(self.graph, "controller")
-            and asyncio.iscoroutine(self.graph.controller.emit)
+            and asyncio.iscoroutinefunction(self.graph.controller.emit)
         ):
             return v2_serving_async_handler
         return v2_serving_handler


### PR DESCRIPTION
Changing the handler to a regular method that may still return a coroutine object as part of #5203 is correct, but older (<1.12.10) nuclio versions explicitly check whether the handler method itself is a coroutine, rather than whether it returned a coroutine object.

This PR effectively reverts the last commit ([23be466](https://github.com/mlrun/mlrun/pull/5203/commits/23be466b3ff62882be5e724acf8623e8a755bdce)) in #5203, which aimed to simplify the code, not taking older nuclio versions into account.

For reference, the nuclio code in question is [here](https://github.com/nuclio/nuclio/commit/af713bc4e65a6b7324dabf5c354f532cacab9d78#diff-725534bace834296150d3e0c0525fd5ef3ec7b57ddaa193e5cc98ed5d062e2eaL425).