### PR TITLE
[Tests] Fix "basic model monitoring" system test

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -187,7 +187,7 @@ class TestMLRunSystem:
         )
 
     @property
-    def assets_path(self):
+    def assets_path(self) -> pathlib.Path:
         """Returns the test file directory "assets" directory."""
         return (
             pathlib.Path(sys.modules[self.__module__].__file__).absolute().parent

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import json
 import os
 import pickle
@@ -275,7 +275,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         # Upload the model through the projects API so that it is available to the serving function
         project.log_model(
             model_name,
-            model_dir=os.path.relpath(self.assets_path),
+            model_dir=str(self.assets_path),
             model_file="model.pkl",
             training_set=train_set,
             artifact_path=f"v3io:///projects/{project.metadata.name}",
@@ -294,7 +294,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         # Simulating valid requests
         iris_data = iris["data"].tolist()
 
-        for i in range(102):
+        for _ in range(102):
             data_point = choice(iris_data)
             serving_fn.invoke(
                 f"v2/models/{model_name}/infer", json.dumps({"inputs": [data_point]})

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -301,13 +301,8 @@ class TestBasicModelMonitoring(TestMLRunSystem):
             sleep(choice([0.01, 0.04]))
 
         # Test metrics
-        mlrun.utils.helpers.retry_until_successful(
-            3,
-            10,
-            self._logger,
-            False,
-            self._assert_model_endpoint_metrics,
-        )
+        sleep(5)
+        self._assert_model_endpoint_metrics()
 
     def _assert_model_endpoint_metrics(self):
         endpoints_list = mlrun.get_run_db().list_model_endpoints(

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -235,7 +235,6 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         )
 
 
-@pytest.mark.skip(reason="Chronically fails, see ML-5820")
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestBasicModelMonitoring(TestMLRunSystem):
@@ -321,7 +320,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         assert len(endpoint.status.metrics) > 0
         self._logger.debug("Model endpoint metrics", endpoint.status.metrics)
 
-        assert endpoint.status.metrics["generic"]["predictions_count_5m"] == 101
+        assert endpoint.status.metrics["generic"]["predictions_count_5m"] == 102
 
         predictions_per_second = endpoint.status.metrics["real_time"][
             "predictions_per_second"


### PR DESCRIPTION
1/3 of [ML-5820](https://jira.iguazeng.com/browse/ML-5820).

Since we invoke the serving function 102 times, it's okay to expect 102 "predictions_count_5m" 🙂 

For reference, see:
https://github.com/mlrun/mlrun/actions/runs/7628699879/job/20793969478#step:9:1358