### PR TITLE
[Project] Use job kind by default if not specified

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -505,6 +505,8 @@ def build(
         if kfp:
             print("Runtime:")
             pprint(runtime)
+        # use kind = "job" by default if not specified
+        runtime.setdefault("kind", "job")
         func = new_function(runtime=runtime)
 
     elif func_url:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2086,7 +2086,7 @@ class MlrunProject(ModelObj):
         self,
         func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,
         name: str = "",
-        kind: str = "",
+        kind: str = "job",
         image: str = None,
         handler: str = None,
         with_repo: bool = None,

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -389,6 +389,9 @@ def import_function_to_dict(url, secrets=None):
     code = get_in(runtime, "spec.build.functionSourceCode")
     update_in(runtime, "metadata.build.code_origin", url)
     cmd = code_file = get_in(runtime, "spec.command", "")
+    # use kind = "job" by default if not specified
+    if "kind" not in runtime:
+        runtime["kind"] = "job"
     if " " in cmd:
         code_file = cmd[: cmd.find(" ")]
     if runtime["kind"] in ["", "local"]:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -390,8 +390,7 @@ def import_function_to_dict(url, secrets=None):
     update_in(runtime, "metadata.build.code_origin", url)
     cmd = code_file = get_in(runtime, "spec.command", "")
     # use kind = "job" by default if not specified
-    if "kind" not in runtime:
-        runtime["kind"] = "job"
+    runtime.setdefault("kind", "job")
     if " " in cmd:
         code_file = cmd[: cmd.find(" ")]
     if runtime["kind"] in ["", "local"]:

--- a/tests/system/runtimes/assets/function_without_kind.yaml
+++ b/tests/system/runtimes/assets/function_without_kind.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+metadata:
+  name: test-func
+spec:
+  command: ''
+  args: []
+  image_pull_policy: Always
+  build:
+    commands: []
+    base_image: mlrun/mlrun

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -27,8 +27,8 @@ import tests.system.base
 from mlrun.runtimes.function_reference import FunctionReference
 
 
-def exec_run(args):
-    cmd = [executable, "-m", "mlrun", "run"] + args
+def exec_cli(args, action="run"):
+    cmd = [executable, "-m", "mlrun", action] + args
     process = os.popen(" ".join(cmd))
     out = process.read()
     ret_code = process.close()
@@ -375,7 +375,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             "handler",
         ]
         start_time = datetime.datetime.now()
-        exec_run(args)
+        exec_cli(args)
         end_time = datetime.datetime.now()
 
         assert (
@@ -406,8 +406,19 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             "--handler",
             "handler",
         ]
-        _, ret_code = exec_run(args)
+        _, ret_code = exec_cli(args)
         assert ret_code is None
+
+    def test_cli_build_function_without_kind(self):
+        # kind='job' should be used by default, the user is not required to specify it
+        function = str(self.assets_path / "function_without_kind.yaml")
+        args = [
+            "--name",
+            "test",
+            function,
+        ]
+        out, _ = exec_cli(args, action="build")
+        assert "Function built, state=ready" in out
 
     @pytest.mark.parametrize("local", [True, False])
     def test_df_as_params(self, local):


### PR DESCRIPTION
when using project.set_function(), or when running CLI build command with a source function, 
use kind="job" if the user did not specify it.

Resolves:
https://iguazio.atlassian.net/browse/ML-886