### PR TITLE
[Model Monitoring] Fix default HTTP path when CE namespace is not `mlrun`[1.6.x]

### DIFF
--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -82,13 +82,15 @@ def parse_monitoring_stream_path(
         if application_name is None:
             stream_uri = (
                 mlrun.mlconf.model_endpoint_monitoring.default_http_sink.format(
-                    project=project
+                    project=project, namespace=mlrun.mlconf.namespace
                 )
             )
         else:
             stream_uri = (
                 mlrun.mlconf.model_endpoint_monitoring.default_http_sink_app.format(
-                    project=project, application_name=application_name
+                    project=project,
+                    application_name=application_name,
+                    namespace=mlrun.mlconf.namespace,
                 )
             )
     return stream_uri

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -487,8 +487,8 @@ default_config = {
         "offline_storage_path": "model-endpoints/{kind}",
         # Default http path that points to the monitoring stream nuclio function. Will be used as a stream path
         # when the user is working in CE environment and has not provided any stream path.
-        "default_http_sink": "http://nuclio-{project}-model-monitoring-stream.mlrun.svc.cluster.local:8080",
-        "default_http_sink_app": "http://nuclio-{project}-{application_name}.mlrun.svc.cluster.local:8080",
+        "default_http_sink": "http://nuclio-{project}-model-monitoring-stream.{namespace}.svc.cluster.local:8080",
+        "default_http_sink_app": "http://nuclio-{project}-{application_name}.{namespace}.svc.cluster.local:8080",
         "batch_processing_function_branch": "master",
         "parquet_batching_max_events": 10_000,
         "parquet_batching_timeout_secs": timedelta(minutes=1).total_seconds(),

--- a/mlrun/model_monitoring/batch.py
+++ b/mlrun/model_monitoring/batch.py
@@ -992,7 +992,7 @@ class BatchProcessor:
         """
         stream_http_path = (
             mlrun.mlconf.model_endpoint_monitoring.default_http_sink.format(
-                project=self.project
+                project=self.project, namespace=mlrun.mlconf.namespace
             )
         )
 

--- a/tests/model_monitoring/test_target_path.py
+++ b/tests/model_monitoring/test_target_path.py
@@ -67,7 +67,7 @@ def test_get_stream_path():
     stream_path = mlrun.model_monitoring.get_stream_path(project=TEST_PROJECT)
     assert (
         stream_path
-        == f"http://nuclio-{TEST_PROJECT}-model-monitoring-stream.mlrun.svc.cluster.local:8080"
+        == f"http://nuclio-{TEST_PROJECT}-model-monitoring-stream.{mlrun.mlconf.namespace}.svc.cluster.local:8080"
     )
 
     # kafka stream path from env


### PR DESCRIPTION
Backport for #5229   

