### PR TITLE
[Linting] Use a fixed Ruff version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ build~=1.0
 
 # formatting & linting
 ruff==0.3.0
-import-linter~=1.8
+import-linter~=2.0
 
 # testing
 pytest~=7.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ twine~=3.1
 build~=1.0
 
 # formatting & linting
-ruff~=0.3.0
+ruff==0.3.0
 import-linter~=1.8
 
 # testing


### PR DESCRIPTION
We required `ruff~=0.3.0`. A recent release of 0.3.1 introduced some errors:
https://github.com/mlrun/mlrun/actions/runs/8184734938/job/22379726933?pr=5255#step:5:14

Fix the version to avoid such unsolicited upgrades.

In addition, upgrade import-linter version - no changes.