### PR TITLE
[Docs] Fix widths and alignments of published doc

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,5 +8,23 @@ div.navbar-brand-box {
 
 .bd-search {
     padding-top: 0.5rem !important;
-    padding-bottom: 0rem !important;
+    padding-bottom: 0rem !important; 
 }
+
+@media (min-width: 1200px){
+    .bd-main .bd-content .bd-article-container {
+    max-width: 100em;
+	width: 90%;
+    }	
+}
+@media(min-width: 1200px) {
+    .bd-page-width {
+    min-width: 75%;
+	max-width: 100%;
+	}
+    .bd-sidebar-primary {
+    flex-basis: 18%;
+    }
+}
+
+ 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,7 +8,7 @@ div.navbar-brand-box {
 
 .bd-search {
     padding-top: 0.5rem !important;
-    padding-bottom: 0rem !important; 
+    padding-bottom: 0rem !important;
 }
 
 @media (min-width: 1200px){
@@ -26,5 +26,3 @@ div.navbar-brand-box {
     flex-basis: 18%;
     }
 }
-
- 


### PR DESCRIPTION
The goal is to reduce the extensive white space on the right and left sides of the published docs while keeping the center (content) at a width that is easily readable. See the attached PDF for before and after on three different size monitors.
[fix white space.pdf](https://github.com/mlrun/mlrun/files/14549151/fix.white.space.pdf)
The proposed layout is about the same as the platform docs. 
For other possible distributions of white space etc., see:

- https://docs.databricks.com/en/getting-started/index.html
- https://docs.tecton.ai/docs/the-feature-development-workflow

Play with the zoom to see where the white space goes on a larger monitor
