### PR TITLE
[Logger] Fix populating log formatter [1.6.x]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1346,12 +1346,21 @@ def read_env(env=None, prefix=env_prefix):
         if igz_domain:
             config["ui_url"] = f"https://mlrun-ui.{igz_domain}"
 
-    if config.get("log_level"):
+    if log_level := config.get("log_level"):
         import mlrun.utils.logger
 
         # logger created (because of imports mess) before the config is loaded (in tests), therefore we're changing its
         # level manually
-        mlrun.utils.logger.set_logger_level(config["log_level"])
+        mlrun.utils.logger.set_logger_level(log_level)
+
+    if log_formatter_name := config.get("log_formatter"):
+        import mlrun.utils.logger
+
+        log_formatter = mlrun.utils.create_formatter_instance(
+            mlrun.utils.FormatterKinds(log_formatter_name)
+        )
+        mlrun.utils.logger.get_handler("default").setFormatter(log_formatter)
+
     # The default function pod resource values are of type str; however, when reading from environment variable numbers,
     # it converts them to type int if contains only number, so we want to convert them to str.
     _convert_resources_to_str(config)

--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -186,7 +186,7 @@ class FormatterKinds(Enum):
     JSON = "json"
 
 
-def _create_formatter_instance(formatter_kind: FormatterKinds) -> logging.Formatter:
+def create_formatter_instance(formatter_kind: FormatterKinds) -> logging.Formatter:
     return {
         FormatterKinds.HUMAN: HumanReadableFormatter(),
         FormatterKinds.HUMAN_EXTENDED: HumanReadableExtendedFormatter(),
@@ -208,7 +208,7 @@ def create_logger(
     logger_instance = Logger(level, name=name, propagate=False)
 
     # resolve formatter
-    formatter_instance = _create_formatter_instance(
+    formatter_instance = create_formatter_instance(
         FormatterKinds(formatter_kind.lower())
     )
 


### PR DESCRIPTION
Ensure logger formatter is set. since `config.py` is populated after the logger is created, it is required to set it explicitly as provided within this pr

https://iguazio.atlassian.net/browse/ML-5763