### PR TITLE
[SQL] Setting all default mysql modes

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -324,7 +324,14 @@ default_config = {
                 # optional values (as per https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-full):
                 #
                 # if set to "nil" or "none", nothing would be set
-                "modes": "STRICT_TRANS_TABLES",
+                "modes": (
+                    "ONLY_FULL_GROUP_BY"
+                    ",STRICT_TRANS_TABLES"
+                    ",NO_ZERO_IN_DATE"
+                    ",NO_ZERO_DATE"
+                    ",ERROR_FOR_DIVISION_BY_ZERO"
+                    ",NO_ENGINE_SUBSTITUTION",
+                )
             },
         },
         "jobs": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -325,8 +325,7 @@ default_config = {
                 #
                 # if set to "nil" or "none", nothing would be set
                 "modes": (
-                    "ONLY_FULL_GROUP_BY"
-                    ",STRICT_TRANS_TABLES"
+                    "STRICT_TRANS_TABLES"
                     ",NO_ZERO_IN_DATE"
                     ",NO_ZERO_DATE"
                     ",ERROR_FOR_DIVISION_BY_ZERO"


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-3834
https://iguazio.atlassian.net/browse/ML-5959

Dropped the default `ONLY_FULL_GROUP_BY` as it caused "Getting all runs which are in non terminal state and require logs collection" to fail with

```
pymysql.err.OperationalError: (1055, "Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'mlrun.runs.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
```
