### PR TITLE
[Build] Fix `clone_target_dir` backwards compatibility

### DIFF
--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -317,7 +317,7 @@ async def build_function(
     # clone_target_dir is deprecated but needs to remain for backward compatibility
     func_dict = fn.to_dict()
     func_dict["spec"]["clone_target_dir"] = get_in(
-        data, "data.spec.build.source_code_target_dir"
+        func_dict, "spec.build.source_code_target_dir"
     )
 
     return {

--- a/tests/api/utils/test_builder.py
+++ b/tests/api/utils/test_builder.py
@@ -1129,52 +1129,6 @@ def test_mlrun_base_image_no_requirements():
         assert with_mlrun is False
 
 
-def _get_target_image_from_create_pod_mock():
-    return _create_pod_mock_pod_spec().containers[0].args[5]
-
-
-def _create_pod_mock_pod_spec():
-    return (
-        server.api.utils.singletons.k8s.get_k8s_helper()
-        .create_pod.call_args[0][0]
-        .pod.spec
-    )
-
-
-def _patch_k8s_helper(monkeypatch):
-    get_k8s_helper_mock = unittest.mock.Mock()
-    get_k8s_helper_mock.create_pod = unittest.mock.Mock(
-        side_effect=lambda pod: (pod, "some-namespace")
-    )
-    get_k8s_helper_mock.get_project_secret_name = unittest.mock.Mock(
-        side_effect=lambda name: "name"
-    )
-    get_k8s_helper_mock.get_project_secret_keys = unittest.mock.Mock(
-        side_effect=lambda project, filter_internal: ["KEY"]
-    )
-    get_k8s_helper_mock.get_project_secret_data = unittest.mock.Mock(
-        side_effect=lambda project, keys: {"KEY": "val"}
-    )
-    monkeypatch.setattr(
-        server.api.utils.singletons.k8s,
-        "get_k8s_helper",
-        lambda *args, **kwargs: get_k8s_helper_mock,
-    )
-
-
-def _mock_default_service_account(monkeypatch, service_account):
-    resolve_project_default_service_account_mock = unittest.mock.MagicMock()
-    resolve_project_default_service_account_mock.return_value = (
-        [],
-        service_account,
-    )
-    monkeypatch.setattr(
-        server.api.api.utils,
-        "resolve_project_default_service_account",
-        resolve_project_default_service_account_mock,
-    )
-
-
 @pytest.mark.parametrize(
     "builder_env,source,commands,extra_args,expected_in_stage",
     [
@@ -1614,4 +1568,50 @@ def test_resolve_function_image_secret(
         == server.api.utils.builder._resolve_function_image_secret(
             resolved_image_target, secret_name
         )
+    )
+
+
+def _get_target_image_from_create_pod_mock():
+    return _create_pod_mock_pod_spec().containers[0].args[5]
+
+
+def _create_pod_mock_pod_spec():
+    return (
+        server.api.utils.singletons.k8s.get_k8s_helper()
+        .create_pod.call_args[0][0]
+        .pod.spec
+    )
+
+
+def _patch_k8s_helper(monkeypatch):
+    get_k8s_helper_mock = unittest.mock.Mock()
+    get_k8s_helper_mock.create_pod = unittest.mock.Mock(
+        side_effect=lambda pod: (pod, "some-namespace")
+    )
+    get_k8s_helper_mock.get_project_secret_name = unittest.mock.Mock(
+        side_effect=lambda name: "name"
+    )
+    get_k8s_helper_mock.get_project_secret_keys = unittest.mock.Mock(
+        side_effect=lambda project, filter_internal: ["KEY"]
+    )
+    get_k8s_helper_mock.get_project_secret_data = unittest.mock.Mock(
+        side_effect=lambda project, keys: {"KEY": "val"}
+    )
+    monkeypatch.setattr(
+        server.api.utils.singletons.k8s,
+        "get_k8s_helper",
+        lambda *args, **kwargs: get_k8s_helper_mock,
+    )
+
+
+def _mock_default_service_account(monkeypatch, service_account):
+    resolve_project_default_service_account_mock = unittest.mock.MagicMock()
+    resolve_project_default_service_account_mock.return_value = (
+        [],
+        service_account,
+    )
+    monkeypatch.setattr(
+        server.api.api.utils,
+        "resolve_project_default_service_account",
+        resolve_project_default_service_account_mock,
     )


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-5873

The build flow is enriching the `source_code_target_dir` on the function so we need to take it from there and not from the request data.