### PR TITLE
[Go] Fix buffer pool race condition

### DIFF
--- a/server/log-collector/pkg/common/bufferpool/bufferpool.go
+++ b/server/log-collector/pkg/common/bufferpool/bufferpool.go
@@ -26,5 +26,5 @@ type Pool interface {
 	NumPooled() int
 
 	// PoolSize returns the maximum number of buffers in the pool.
-	PoolSize() int
+	CurrentPoolSize() int
 }

--- a/server/log-collector/pkg/common/bufferpool/bufferpool.go
+++ b/server/log-collector/pkg/common/bufferpool/bufferpool.go
@@ -22,9 +22,9 @@ type Pool interface {
 	// Put returns a buffer to the pool.
 	Put([]byte)
 
-	// NumPooled returns the number of buffers currently in the pool.
+	// NumPooled returns the number of currently available buffers in the pool.
 	NumPooled() int
 
-	// PoolSize returns the maximum number of buffers in the pool.
-	CurrentPoolSize() int
+	// PoolSize returns the number of already allocated buffers in the pool.
+	PoolSize() int
 }

--- a/server/log-collector/pkg/common/bufferpool/bufferpool_test.go
+++ b/server/log-collector/pkg/common/bufferpool/bufferpool_test.go
@@ -54,7 +54,7 @@ func (suite *sizedBytePoolTestSuite) TestByteBufferPoolBlocking() {
 	}
 
 	suite.Require().Equal(0, pool.NumPooled(), "Pool should be empty")
-	suite.Require().Equal(numOfBuffers, pool.PoolSize(), "Pool size should be %d", numOfBuffers)
+	suite.Require().Equal(numOfBuffers, pool.CurrentPoolSize(), "Pool size should be %d", numOfBuffers)
 
 	// try to get another buffer in a go routine, should block
 	var newBuffer []byte
@@ -66,7 +66,7 @@ func (suite *sizedBytePoolTestSuite) TestByteBufferPoolBlocking() {
 
 	// make sure new buffer is not set yet, and the pool is still full
 	suite.Require().Nil(newBuffer, "New buffer should not be set yet")
-	suite.Require().Equal(numOfBuffers, pool.PoolSize(), "Pool should be full")
+	suite.Require().Equal(numOfBuffers, pool.CurrentPoolSize(), "Pool should be full")
 	suite.Require().Equal(0, pool.NumPooled(), "Pool should not have pooled buffers")
 
 	// put the buffers back

--- a/server/log-collector/pkg/common/bufferpool/bufferpool_test.go
+++ b/server/log-collector/pkg/common/bufferpool/bufferpool_test.go
@@ -86,6 +86,6 @@ func (suite *sizedBytePoolTestSuite) TestByteBufferPoolBlocking() {
 	suite.Require().Equal(numOfBuffers, pool.NumPooled(), "Pool should have 4 pooled buffers")
 }
 
-func TestLogCollectorTestSuite(t *testing.T) {
+func TestSizedBytePoolTestSuite(t *testing.T) {
 	suite.Run(t, new(sizedBytePoolTestSuite))
 }

--- a/server/log-collector/pkg/common/bufferpool/bufferpool_test.go
+++ b/server/log-collector/pkg/common/bufferpool/bufferpool_test.go
@@ -54,7 +54,7 @@ func (suite *sizedBytePoolTestSuite) TestByteBufferPoolBlocking() {
 	}
 
 	suite.Require().Equal(0, pool.NumPooled(), "Pool should be empty")
-	suite.Require().Equal(numOfBuffers, pool.CurrentPoolSize(), "Pool size should be %d", numOfBuffers)
+	suite.Require().Equal(numOfBuffers, pool.PoolSize(), "Pool size should be %d", numOfBuffers)
 
 	// try to get another buffer in a go routine, should block
 	var newBuffer []byte
@@ -66,7 +66,7 @@ func (suite *sizedBytePoolTestSuite) TestByteBufferPoolBlocking() {
 
 	// make sure new buffer is not set yet, and the pool is still full
 	suite.Require().Nil(newBuffer, "New buffer should not be set yet")
-	suite.Require().Equal(numOfBuffers, pool.CurrentPoolSize(), "Pool should be full")
+	suite.Require().Equal(numOfBuffers, pool.PoolSize(), "Pool should be full")
 	suite.Require().Equal(0, pool.NumPooled(), "Pool should not have pooled buffers")
 
 	// put the buffers back

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -771,12 +771,6 @@ func (s *Server) startLogStreaming(ctx context.Context,
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	s.Logger.DebugWithCtx(ctx,
-		"Finished log streaming",
-		"runUID", runUID,
-		"projectName", projectName,
-		"podName", podName)
-
 	// remove run from state file
 	if err := s.stateManifest.RemoveLogItem(ctx, runUID, projectName); err != nil {
 		s.Logger.WarnWithCtx(ctx, "Failed to remove log item from state file")
@@ -784,6 +778,7 @@ func (s *Server) startLogStreaming(ctx context.Context,
 
 	s.Logger.DebugWithCtx(ctx,
 		"Finished log streaming",
+		"projectName", projectName,
 		"runUID", runUID,
 		"podName", podName)
 }


### PR DESCRIPTION
We have seen tests failing on data race condition between go routines writing to and reading from the `sizedBufferPool`'s `currentSize` property simultaneously.

To fix that, added a mutex for reading and writing to the `currentSize` property, so it won't change while different goroutines want to create new buffers. 
