### PR TITLE
[API] Use a common dependency in model monitoring endpoints

### DIFF
--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-import fastapi
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
@@ -23,16 +22,14 @@ from server.api.api import deps
 from server.api.api.endpoints.functions import process_model_monitoring_secret
 from server.api.crud.model_monitoring.deployment import MonitoringDeployment
 
-router = fastapi.APIRouter(prefix="/projects/{project}/model-monitoring")
+router = APIRouter(prefix="/projects/{project}/model-monitoring")
 
 
 @router.post("/enable-model-monitoring")
 async def enable_model_monitoring(
     project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
-        deps.authenticate_request
-    ),
-    db_session: Session = fastapi.Depends(deps.get_db_session),
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
+    db_session: Session = Depends(deps.get_db_session),
     base_period: int = 10,
     image: str = "mlrun/mlrun",
 ):
@@ -85,10 +82,8 @@ async def enable_model_monitoring(
 @router.post("/model-monitoring-controller")
 async def update_model_monitoring_controller(
     project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
-        deps.authenticate_request
-    ),
-    db_session: Session = fastapi.Depends(deps.get_db_session),
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
+    db_session: Session = Depends(deps.get_db_session),
     base_period: int = 10,
     image: str = "mlrun/mlrun",
 ):

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
+from typing import Annotated
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -25,11 +28,47 @@ from server.api.crud.model_monitoring.deployment import MonitoringDeployment
 router = APIRouter(prefix="/projects/{project}/model-monitoring")
 
 
+@dataclass
+class _CommonParams:
+    """Common parameters for model monitoring endpoints"""
+
+    project: str
+    auth_info: mlrun.common.schemas.AuthInfo
+    db_session: Session
+
+
+async def _common_parameters(
+    project: str,
+    auth_info: Annotated[
+        mlrun.common.schemas.AuthInfo, Depends(deps.authenticate_request)
+    ],
+    db_session: Annotated[Session, Depends(deps.get_db_session)],
+) -> _CommonParams:
+    """
+    Verify authorization and return common parameters.
+
+    :param project:    Project name.
+    :param auth_info:  The auth info of the request.
+    :param db_session: A session that manages the current dialog with the database.
+    :returns:          A `_CommonParameters` object that contains the input data.
+    """
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
+        project_name=project,
+        resource_name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.APPLICATION_CONTROLLER,
+        action=mlrun.common.schemas.AuthorizationAction.store,
+        auth_info=auth_info,
+    )
+    return _CommonParams(
+        project=project,
+        auth_info=auth_info,
+        db_session=db_session,
+    )
+
+
 @router.post("/enable-model-monitoring")
 async def enable_model_monitoring(
-    project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
-    db_session: Session = Depends(deps.get_db_session),
+    commons: Annotated[_CommonParams, Depends(_common_parameters)],
     base_period: int = 10,
     image: str = "mlrun/mlrun",
 ):
@@ -41,39 +80,28 @@ async def enable_model_monitoring(
     And the stream function goal is to monitor the log of the data stream. It is triggered when a new log entry
     is detected. It processes the new events into statistics that are then written to statistics databases.
 
-
-    :param project:                  Project name.
-    :param auth_info:                The auth info of the request.
-    :param db_session:               A session that manages the current dialog with the database.
-    :param base_period:              The time period in minutes in which the model monitoring controller function
-                                     triggers. By default, the base period is 10 minutes.
-    :param image:                    The image of the model monitoring controller, writer & monitoring
-                                     stream functions, which are real time nuclio functions.
-                                     By default, the image is mlrun/mlrun.
+    :param commons:     The common parameters of the request.
+    :param base_period: The time period in minutes in which the model monitoring controller function
+                        triggers. By default, the base period is 10 minutes.
+    :param image:       The image of the model monitoring controller, writer & monitoring
+                        stream functions, which are real time nuclio functions.
+                        By default, the image is mlrun/mlrun.
     """
-
-    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
-        project_name=project,
-        resource_name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-        action=mlrun.common.schemas.AuthorizationAction.store,
-        auth_info=auth_info,
-    )
 
     model_monitoring_access_key = None
     if not mlrun.mlconf.is_ce_mode():
         # Generate V3IO Access Key
         model_monitoring_access_key = process_model_monitoring_secret(
-            db_session,
-            project,
+            commons.db_session,
+            commons.project,
             mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
         )
 
     return MonitoringDeployment().deploy_monitoring_functions(
-        project=project,
+        project=commons.project,
         model_monitoring_access_key=model_monitoring_access_key,
-        db_session=db_session,
-        auth_info=auth_info,
+        db_session=commons.db_session,
+        auth_info=commons.auth_info,
         image=image,
         base_period=base_period,
     )
@@ -81,9 +109,7 @@ async def enable_model_monitoring(
 
 @router.post("/model-monitoring-controller")
 async def update_model_monitoring_controller(
-    project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
-    db_session: Session = Depends(deps.get_db_session),
+    commons: Annotated[_CommonParams, Depends(_common_parameters)],
     base_period: int = 10,
     image: str = "mlrun/mlrun",
 ):
@@ -91,39 +117,29 @@ async def update_model_monitoring_controller(
     Redeploy model monitoring application controller function.
     The main goal of the controller function is to handle the monitoring processing and triggering applications.
 
-    :param project:                  Project name.
-    :param auth_info:                The auth info of the request.
-    :param db_session:               A session that manages the current dialog with the database.
-    :param base_period:              The time period in minutes in which the model monitoring controller function
-                                     triggers. By default, the base period is 10 minutes.
-    :param image:                    The default image of the model monitoring controller job. Note that the writer
-                                     function, which is a real time nuclio functino, will be deployed with the same
-                                     image. By default, the image is mlrun/mlrun.
+    :param commons:     The common parameters of the request.
+    :param base_period: The time period in minutes in which the model monitoring controller function
+                        triggers. By default, the base period is 10 minutes.
+    :param image:       The default image of the model monitoring controller job. Note that the writer
+                        function, which is a real time nuclio functino, will be deployed with the same
+                        image. By default, the image is mlrun/mlrun.
     """
-
-    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
-        project_name=project,
-        resource_name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-        action=mlrun.common.schemas.AuthorizationAction.store,
-        auth_info=auth_info,
-    )
 
     model_monitoring_access_key = None
     if not mlrun.mlconf.is_ce_mode():
         # Generate V3IO Access Key
         model_monitoring_access_key = process_model_monitoring_secret(
-            db_session,
-            project,
+            commons.db_session,
+            commons.project,
             mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
         )
     try:
         # validate that the model monitoring stream has not yet been deployed
         mlrun.runtimes.nuclio.function.get_nuclio_deploy_status(
             name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-            project=project,
+            project=commons.project,
             tag="",
-            auth_info=auth_info,
+            auth_info=commons.auth_info,
         )
 
     except mlrun.errors.MLRunNotFoundError:
@@ -133,10 +149,10 @@ async def update_model_monitoring_controller(
         )
 
     return MonitoringDeployment().deploy_model_monitoring_controller(
-        project=project,
+        project=commons.project,
         model_monitoring_access_key=model_monitoring_access_key,
-        db_session=db_session,
-        auth_info=auth_info,
+        db_session=commons.db_session,
+        auth_info=commons.auth_info,
         controller_image=image,
         base_period=base_period,
         overwrite=True,


### PR DESCRIPTION
A mini-PR related to [ML-5865](https://iguazio.atlassian.net/browse/ML-5865) to allow neat code reuse.

Aggregate the following in common params:
* `project`
* `auth_info` (sub-dep)
* `db_session` (sub-dep)

For reference, see:
https://fastapi.tiangolo.com/tutorial/dependencies/
https://fastapi.tiangolo.com/tutorial/dependencies/sub-dependencies/

I verified that `enable_model_monitoring` works.

[ML-5865]: https://iguazio.atlassian.net/browse/ML-5865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ