### PR TITLE
[Linting] Check copyright notice in Python file in `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,10 +610,10 @@ lint-imports: ## Validates import dependencies
 	lint-imports
 
 .PHONY: lint
-lint: fmt-check lint-imports ## Run lint on the code
+lint: lint-check lint-imports ## Run lint on the code
 
-.PHONY: fmt-check
-fmt-check: ## Check the code (using ruff)
+.PHONY: lint-check
+lint-check: ## Check the code (using ruff)
 	@echo "Running ruff checks..."
 	python -m ruff check --exit-non-zero-on-fix
 	python -m ruff format --check

--- a/Makefile
+++ b/Makefile
@@ -616,6 +616,7 @@ lint: lint-check lint-imports ## Run lint on the code
 lint-check: ## Check the code (using ruff)
 	@echo "Running ruff checks..."
 	python -m ruff check --exit-non-zero-on-fix
+	python -m ruff check --preview --select=CPY001 --exit-non-zero-on-fix
 	python -m ruff format --check
 
 .PHONY: lint-go

--- a/automation/deployment/__init__.py
+++ b/automation/deployment/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/automation/deployment/ce.py
+++ b/automation/deployment/ce.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/automation/deployment/deployer.py
+++ b/automation/deployment/deployer.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dependencies.py
+++ b/dependencies.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/db/factory.py
+++ b/mlrun/db/factory.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/launcher/__init__.py
+++ b/mlrun/launcher/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/launcher/factory.py
+++ b/mlrun/launcher/factory.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages.py
+++ b/packages.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ extend-include = ["*.ipynb"]
 target-version = "py39"
 
 [tool.ruff.lint]
-select = [
+extend-select = [
     "F",  # pyflakes
     "W",  # pycodestyle
     "E",  # pycodestyle
@@ -15,7 +15,7 @@ exclude = ["*.ipynb"]
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120
 
-[tool.ruff.lint.per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,25 @@ target-version = "py39"
 
 [tool.ruff.lint]
 extend-select = [
-    "F",  # pyflakes
-    "W",  # pycodestyle
-    "E",  # pycodestyle
-    "I",  # isort
-    "UP", # pyupgrade
+    "F",   # pyflakes
+    "W",   # pycodestyle
+    "E",   # pycodestyle
+    "I",   # isort
+    "UP",  # pyupgrade
+    "CPY", # flake8-copyright
 ]
 exclude = ["*.ipynb"]
+explicit-preview-rules = true
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 120
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
+"docs/**.py" = ["CPY001"]
+
+[tool.ruff.lint.flake8-copyright]
+author = "Iguazio"
 
 [tool.pytest.ini_options]
 addopts = "-v -rf --disable-warnings"

--- a/server/api/launcher.py
+++ b/server/api/launcher.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/server/api/rundb/__init__.py
+++ b/server/api/rundb/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/integration/sdk_api/httpdb/runs/__init__.py
+++ b/tests/integration/sdk_api/httpdb/runs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#

--- a/tests/integration/sdk_api/httpdb/runs/test_dask.py
+++ b/tests/integration/sdk_api/httpdb/runs/test_dask.py
@@ -1,4 +1,4 @@
-# Copyright 2023 MLRun Authors
+# Copyright 2023 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import pytest
 


### PR DESCRIPTION
Opt-in the preview flake8-copyright CPY001 rule:
* https://docs.astral.sh/ruff/rules/#flake8-copyright-cpy
* https://docs.astral.sh/ruff/settings/#lintflake8-copyright

This allows faster feedback on missing copyright notice at the top of Python source files.

Note:
* Checks only Python files.
* It checks only for a generic header, not the full one.
* This is a preview rule.