### PR TITLE
[API] Verify log collections stopped on startup only on currently collected logs

### DIFF
--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -70,6 +70,7 @@ class DBInterface(ABC):
         only_uids: bool = False,
         last_update_time_from: datetime.datetime = None,
         states: list[str] = None,
+        specific_uids: list[str] = None,
     ):
         pass
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -252,6 +252,7 @@ class SQLDB(DBInterface):
         only_uids=True,
         last_update_time_from: datetime = None,
         states: list[str] = None,
+        specific_uids: list[str] = None,
     ) -> typing.Union[list[str], RunList]:
         """
         List all runs uids in the DB
@@ -281,6 +282,9 @@ class SQLDB(DBInterface):
 
         if requested_logs_modes is not None:
             query = query.filter(Run.requested_logs.in_(requested_logs_modes))
+
+        if specific_uids:
+            query = query.filter(Run.uid.in_(specific_uids))
 
         if not only_uids:
             # group_by allows us to have a row per uid with the whole record rather than just the uid (as distinct does)

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -519,12 +519,36 @@ async def _start_periodic_stop_logs():
 
 async def _verify_log_collection_stopped_on_startup():
     """
-    Pulls runs from DB that are in terminal state and have logs requested, and call stop logs for them.
+    First, list runs that are currently being collected in the log collector.
+    Second, query the DB for those runs that are also in terminal state and have logs requested.
+    Lastly, call stop logs for the runs that met all of the above conditions.
     This is done so that the log collector won't keep trying to collect logs for runs that are already
     in terminal state.
     """
+    logger.debug("Listing runs currently being log collected")
+    log_collector_client = server.api.utils.clients.log_collector.LogCollectorClient()
+    run_uids_in_progress = []
+    failed_listing = False
+    try:
+        runs_in_progress_response_stream = log_collector_client.list_runs_in_progress()
+        # collate the run uids from the response stream to a list
+        async for run_uids in runs_in_progress_response_stream:
+            run_uids_in_progress.extend(run_uids)
+    except Exception as exc:
+        failed_listing = True
+        logger.warning(
+            "Failed listing runs currently being log collected",
+            exc=err_to_str(exc),
+            traceback=traceback.format_exc(),
+        )
+
+    if len(run_uids_in_progress) == 0 and not failed_listing:
+        logger.debug("No runs currently being log collected")
+        return
+
     logger.debug(
-        "Getting all runs which have reached terminal state and already have logs requested",
+        "Getting current log collected runs which have reached terminal state and already have logs requested",
+        run_uids_in_progress_count=len(run_uids_in_progress),
     )
     db_session = await fastapi.concurrency.run_in_threadpool(create_session)
     try:
@@ -539,6 +563,7 @@ async def _verify_log_collection_stopped_on_startup():
                 # usually it happens when run pods get preempted
                 mlrun.runtimes.constants.RunStates.unknown,
             ],
+            specific_uids=run_uids_in_progress,
         )
 
         if len(runs) > 0:

--- a/server/log-collector/pkg/services/logcollector/logcollector_test.go
+++ b/server/log-collector/pkg/services/logcollector/logcollector_test.go
@@ -816,10 +816,10 @@ func (suite *LogCollectorTestSuite) TestListRunsInProgress() {
 		// remove projects from state manifest and current state when test is done to avoid conflicts with other tests
 		for project := range projectToRuns {
 			err := suite.logCollectorServer.stateManifest.RemoveProject(project)
-			suite.Require().NoError(err, "Failed to remove project from state manifest")
+			suite.Assert().NoError(err, "Failed to remove project from state manifest")
 
 			err = suite.logCollectorServer.currentState.RemoveProject(project)
-			suite.Require().NoError(err, "Failed to remove project from current state")
+			suite.Assert().NoError(err, "Failed to remove project from current state")
 		}
 	}()
 

--- a/server/log-collector/pkg/services/logcollector/server.go
+++ b/server/log-collector/pkg/services/logcollector/server.go
@@ -696,7 +696,6 @@ func (s *Server) ListRunsInProgress(request *protologcollector.ListRunsRequest, 
 		s.Logger.DebugWithCtx(ctx, "No runs in progress to list")
 		if err := responseStream.Send(&protologcollector.ListRunsResponse{
 			RunUIDs: []string{},
-			Success: true,
 		}); err != nil {
 			return errors.Wrapf(err, "Failed to send empty response to stream")
 		}
@@ -712,7 +711,6 @@ func (s *Server) ListRunsInProgress(request *protologcollector.ListRunsRequest, 
 
 		if err := responseStream.Send(&protologcollector.ListRunsResponse{
 			RunUIDs: runsInProgress[i:endIndex],
-			Success: true,
 		}); err != nil {
 			return errors.Wrapf(err, "Failed to send runs in progress to stream")
 		}

--- a/server/log-collector/proto/log_collector.proto
+++ b/server/log-collector/proto/log_collector.proto
@@ -78,7 +78,6 @@ message ListRunsRequest {
 
 message ListRunsResponse {
   repeated string runUIDs = 1;
-  bool success = 2;
 }
 
 // StringArray is a wrapper around a repeated string field, used in map values.

--- a/tests/api/utils/clients/test_log_collector.py
+++ b/tests/api/utils/clients/test_log_collector.py
@@ -65,9 +65,8 @@ class GetLogSizeResponse:
 
 
 class ListRunsResponse:
-    def __init__(self, success, run_uids=None, total_calls=1):
-        self.success = success
-        self.runUIDs = run_uids
+    def __init__(self, run_uids=None, total_calls=1):
+        self.runUIDs = run_uids or []
         self.total_calls = total_calls
         self.current_calls = 0
 
@@ -266,7 +265,7 @@ class TestLogCollector:
         # mock a short response for ListRunsInProgress
         run_uids = [f"{str(i)}" for i in range(10)]
         log_collector._call_stream = unittest.mock.MagicMock(
-            return_value=ListRunsResponse(success=True, run_uids=run_uids)
+            return_value=ListRunsResponse(run_uids=run_uids)
         )
         run_uids_stream = log_collector.list_runs_in_progress(project=project_name)
         await _verify_runs(run_uids_stream)


### PR DESCRIPTION
Followup to https://github.com/mlrun/mlrun/pull/5314 - ‼️ please merge this after ‼️ 

## Background:
When the API starts, it sends a `stop_logs` request to the log collector on **all** runs that have reached a terminal state and have logs requested.
That condition can apply for > 90% of the runs in the system, and results in large delays in the API startup, as the requests to the log collector are done in small chunks (due to GRPC message size limitation).

## Fix:
To mitigate that, we use the new log collector endpoint - `ListRunsInProgress` (see #5314), and do the following flow:

1. List runs in progress from log collector - we'll only get the runs that the log collector wants to collect logs for
2. Query the DB for runs from the above list, which also reached terminal state and have logs already requested
3. Call stop logs only for the runs that meet the above conditions

This will majorly decrease the number of `stop_logs` requests, and the API start time.

Related tickets:
- https://iguazio.atlassian.net/browse/ML-5971
- https://iguazio.atlassian.net/browse/ML-5975