### PR TITLE
[Nuclio] API Gateway authentication improvements

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3404,7 +3404,7 @@ class HTTPRunDB(RunDBInterface):
         :param project: Project name
         """
         project = project or config.default_project
-        error = "get api gateway"
+        error = "delete api gateway"
         endpoint_path = f"projects/{project}/api-gateways/{name}"
         self.api_call("DELETE", endpoint_path, error)
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3756,7 +3756,7 @@ class MlrunProject(ModelObj):
         """
         Deletes an API gateway by name.
 
-        :param name: The name of the API gateway to retrieve.
+        :param name: The name of the API gateway to delete.
         """
 
         mlrun.db.get_run_db().delete_api_gateway(name=name, project=self.name)

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -187,7 +187,7 @@ class APIGateway:
                 name=self.name,
                 description=self.description,
                 path=self.path,
-                authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.from_str(
+                authenticationMode=mlrun.common.schemas.APIGatewayAuthenticationMode.from_str(
                     self.authentication.authentication_mode
                 ),
                 upstreams=upstreams,

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -133,6 +133,7 @@ class Client:
     async def _ensure_async_session(self):
         if not self._session:
             self._session = mlrun.utils.AsyncClientWithRetry(
+                raise_for_status=False,
                 retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
                 == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
                 logger=logger,

--- a/tests/api/utils/clients/test_async_nuclio.py
+++ b/tests/api/utils/clients/test_async_nuclio.py
@@ -54,9 +54,11 @@ async def test_nuclio_get_api_gateway(
     mock_aioresponse,
 ):
     api_gateway = mlrun.runtimes.nuclio.api_gateway.APIGateway(
-        functions=["test"], name="test-basic", project="default-project"
+        functions=["test"],
+        name="test-basic",
+        project="default-project",
     )
-
+    api_gateway.with_basic_auth("test", "test")
     request_url = f"{api_url}/api/api_gateways/test-basic"
     mock_aioresponse.get(
         request_url,
@@ -67,7 +69,10 @@ async def test_nuclio_get_api_gateway(
     received_api_gateway = mlrun.runtimes.nuclio.api_gateway.APIGateway.from_scheme(r)
     assert received_api_gateway.name == api_gateway.name
     assert received_api_gateway.description == api_gateway.description
-    assert received_api_gateway.authentication_mode == api_gateway.authentication_mode
+    assert (
+        received_api_gateway.authentication.authentication_mode
+        == api_gateway.authentication.authentication_mode
+    )
     assert received_api_gateway.functions == api_gateway.functions
     assert received_api_gateway.canary == api_gateway.canary
 


### PR DESCRIPTION
This PR implements part of https://iguazio.atlassian.net/browse/ML-5372: 
* Implements `with_basic_auth`
* Use HTTPBasicAuth instead of custom header generation when invoke gateway
* Pass authentication interface instead of (authmode, authentication)