### PR TITLE
[Nuclio] API Gateways minor improvements

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3433,7 +3433,7 @@ class HTTPRunDB(RunDBInterface):
             "PUT",
             endpoint_path,
             error,
-            json=api_gateway.dict(exclude_unset=True, exclude_none=True),
+            json=api_gateway.dict(exclude_none=True),
         )
         return mlrun.common.schemas.APIGateway(**response.json())
 

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -20,7 +20,7 @@ import requests
 import mlrun
 import mlrun.common.schemas
 
-from .function import RemoteRuntime
+from .function import RemoteRuntime, get_fullname
 from .serving import ServingRuntime
 
 NUCLIO_API_GATEWAY_AUTHENTICATION_MODE_BASIC_AUTH = "basicAuth"
@@ -258,7 +258,8 @@ class APIGateway:
                     f"input function {function_name} "
                     f"does not belong to this project"
                 )
-            function_names.append(func.uri)
+            nuclio_name = get_fullname(function_name, self.project, func.metadata.tag)
+            function_names.append(nuclio_name)
         return function_names
 
     @staticmethod

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -258,7 +258,7 @@ class APIGateway:
                     f"input function {function_name} "
                     f"does not belong to this project"
                 )
-            nuclio_name = get_fullname(function_name, self.project, func.metadata.tag)
+            nuclio_name = get_fullname(function_name, project, func.metadata.tag)
             function_names.append(nuclio_name)
         return function_names
 

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -141,6 +141,7 @@ class APIGateway:
             spec=mlrun.common.schemas.APIGatewaySpec(
                 name=self.name,
                 description=self.description,
+                host=self.host,
                 path=self.path,
                 authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.from_str(
                     self.authentication_mode

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -26,7 +26,6 @@ router = APIRouter()
     "/projects/{project}/api-gateways",
     response_model=mlrun.common.schemas.APIGatewaysOutput,
     response_model_exclude_none=True,
-    response_model_exclude_unset=True,
 )
 async def list_api_gateways(
     project: str,

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import copy
-import re
 import urllib.parse
 from http import HTTPStatus
 

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -39,7 +39,6 @@ class Client:
         self._auth = aiohttp.BasicAuth(auth_info.username, auth_info.session)
         self._logger = logger.get_child("nuclio-client")
         self._nuclio_dashboard_url = mlrun.mlconf.nuclio_dashboard_url
-        self._nuclio_domain = self._get_nuclio_external_host()
 
     async def __aenter__(self):
         await self._ensure_async_session()
@@ -93,7 +92,6 @@ class Client:
         self._enrich_nuclio_api_gateway(
             project_name=project_name,
             api_gateway=api_gateway,
-            api_gateway_name=api_gateway_name,
         )
 
         if project_name:
@@ -203,18 +201,7 @@ class Client:
     def _enrich_nuclio_api_gateway(
         self,
         project_name: str,
-        api_gateway_name: str,
         api_gateway: mlrun.common.schemas.APIGateway,
     ) -> mlrun.common.schemas.APIGateway:
         self._set_iguazio_labels(api_gateway, project_name)
-        if not api_gateway.spec.host:
-            api_gateway.spec.host = (
-                f"{api_gateway_name}-{project_name}."
-                f"{self._nuclio_domain[self._nuclio_domain.find('.') + 1:]}"
-            )
-
         return api_gateway
-
-    @staticmethod
-    def _get_nuclio_external_host():
-        return re.sub(r"^https?://\w+", "nuclio", mlrun.mlconf.resolve_ui_url())

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -98,7 +98,7 @@ class Client:
         if project_name:
             headers[NUCLIO_PROJECT_NAME_HEADER] = project_name
 
-        body = api_gateway.dict(exclude_unset=True, exclude_none=True)
+        body = api_gateway.dict(exclude_none=True)
         method = "POST" if create else "PUT"
         path = (
             NUCLIO_API_GATEWAYS_ENDPOINT_TEMPLATE.format(api_gateway=api_gateway_name)

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import copy
+import re
 import urllib.parse
 from http import HTTPStatus
 
@@ -38,7 +39,7 @@ class Client:
         self._auth = aiohttp.BasicAuth(auth_info.username, auth_info.session)
         self._logger = logger.get_child("nuclio-client")
         self._nuclio_dashboard_url = mlrun.mlconf.nuclio_dashboard_url
-        self._nuclio_domain = urllib.parse.urlparse(self._nuclio_dashboard_url).netloc
+        self._nuclio_domain = self._get_nuclio_external_host()
 
     async def __aenter__(self):
         await self._ensure_async_session()
@@ -213,3 +214,7 @@ class Client:
             )
 
         return api_gateway
+
+    @staticmethod
+    def _get_nuclio_external_host():
+        return re.sub(r"^https?://\w+", "nuclio", mlrun.mlconf.resolve_ui_url())

--- a/tests/api/api/test_nuclio.py
+++ b/tests/api/api/test_nuclio.py
@@ -70,11 +70,18 @@ def test_list_api_gateways(
     assert response.json() == {
         "api_gateways": {
             "new-gw": {
-                "metadata": {"name": "new-gw"},
+                "metadata": {"name": "new-gw", "labels": {}},
                 "spec": {
                     "name": "new-gw",
                     "path": "/",
-                    "upstreams": [{"nucliofunction": {"name": "test-func"}}],
+                    "authenticationMode": "none",
+                    "upstreams": [
+                        {
+                            "kind": "nucliofunction",
+                            "nucliofunction": {"name": "test-func"},
+                            "percentage": 0,
+                        }
+                    ],
                     "host": "http://my-api-gateway.com",
                 },
             }


### PR DESCRIPTION
Within this PR: 
* change pydantic model export parameters since we have some important default values which can be excluded with `exclude_unset` flag, so we need to remove it
* get rid of API gateway host generation, since it is done on Nuclio side (PR https://github.com/nuclio/nuclio/pull/3204)
* change the value how we get the nuclio function name from mlrun function name