### PR TITLE
[ModelObj] Filter warnings when using to_dict

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -71,6 +71,7 @@ class ModelObj:
             return new_type.from_dict(param)
         return param
 
+    @mlrun.utils.filter_warnings("ignore", FutureWarning)
     def to_dict(
         self, fields: list = None, exclude: list = None, strip: bool = False
     ) -> dict:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1405,6 +1405,18 @@ def as_number(field_name, field_value):
 
 
 def filter_warnings(action, category):
+    """
+    Decorator to filter warnings
+
+    Example::
+        @filter_warnings("ignore", FutureWarning)
+        def my_function():
+            pass
+
+    :param action:      one of "error", "ignore", "always", "default", "module", or "once"
+    :param category:    a class that the warning must be a subclass of
+    """
+
     def decorator(function):
         def wrapper(*args, **kwargs):
             # context manager that copies and, upon exit, restores the warnings filter and the showwarning() function.


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6034

When part of the spec fields are deprecated we may still be showing them as part of the object dictionary but they are not really used by the user.
The attribute `clone_target_dir` is a reference to `build.source_code_target_dir` and if the latter has a value, the former will warn when using `to_dict`.