### PR TITLE
[Pagination] Phase III - Paginator Logic & Finalize Pagination Cache Lifecycle

### DIFF
--- a/server/api/crud/pagination_cache.py
+++ b/server/api/crud/pagination_cache.py
@@ -31,11 +31,12 @@ class PaginationCache(metaclass=mlrun.utils.singleton.Singleton):
         user: str,
         method: typing.Callable,
         current_page: int,
+        page_size: int,
         kwargs: dict,
     ):
         db = server.api.utils.singletons.db.get_db()
         return db.store_paginated_query_cache_record(
-            session, user, method.__name__, current_page, kwargs
+            session, user, method.__name__, current_page, page_size, kwargs
         )
 
     @staticmethod

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -768,6 +768,7 @@ class DBInterface(ABC):
         user: str,
         function: str,
         current_page: int,
+        page_size: int,
         kwargs: dict,
     ):
         raise NotImplementedError

--- a/server/api/db/sqldb/models/models_mysql.py
+++ b/server/api/db/sqldb/models/models_mysql.py
@@ -633,6 +633,7 @@ with warnings.catch_warnings():
         user = Column(String(255, collation=SQLCollationUtil.collation()))
         function = Column(String(255, collation=SQLCollationUtil.collation()))
         current_page = Column(Integer)
+        page_size = Column(Integer)
         kwargs = Column(JSON)
         last_accessed = Column(
             sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3),

--- a/server/api/db/sqldb/models/models_sqlite.py
+++ b/server/api/db/sqldb/models/models_sqlite.py
@@ -580,6 +580,7 @@ with warnings.catch_warnings():
         user = Column(String(255, collation=SQLCollationUtil.collation()))
         function = Column(String(255, collation=SQLCollationUtil.collation()))
         current_page = Column(Integer)
+        page_size = Column(Integer)
         kwargs = Column(JSON)
         last_accessed = Column(TIMESTAMP, default=datetime.now(timezone.utc))
 

--- a/server/api/migrations_mysql/versions/3e81ad4e5ebf_add_pagination_cache.py
+++ b/server/api/migrations_mysql/versions/3e81ad4e5ebf_add_pagination_cache.py
@@ -41,6 +41,7 @@ def upgrade():
             "function", sa.String(length=255, collation="utf8_bin"), nullable=True
         ),
         sa.Column("current_page", sa.Integer(), nullable=True),
+        sa.Column("page_size", sa.Integer(), nullable=True),
         sa.Column("kwargs", sa.JSON(), nullable=True),
         sa.Column("last_accessed", mysql.TIMESTAMP(fsp=3), nullable=True),
         sa.PrimaryKeyConstraint("key"),

--- a/server/api/migrations_sqlite/versions/51e944e8884f_add_pagination_cache.py
+++ b/server/api/migrations_sqlite/versions/51e944e8884f_add_pagination_cache.py
@@ -38,6 +38,7 @@ def upgrade():
         sa.Column("user", sa.String(length=255), nullable=True),
         sa.Column("function", sa.String(length=255), nullable=True),
         sa.Column("current_page", sa.Integer(), nullable=True),
+        sa.Column("page_size", sa.Integer(), nullable=True),
         sa.Column("kwargs", sa.JSON(), nullable=True),
         sa.Column("last_accessed", sa.TIMESTAMP(), nullable=True),
         sa.PrimaryKeyConstraint("key"),

--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -40,10 +40,6 @@ class PaginatedMethods:
     def get_method(cls, method_name: str) -> typing.Callable:
         return cls._method_map[method_name]
 
-    @staticmethod
-    def get_name(method: typing.Callable) -> str:
-        return method.__name__
-
 
 class Paginator(metaclass=mlrun.utils.singleton.Singleton):
     def __init__(self):

--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -1,0 +1,148 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import typing
+
+import sqlalchemy.orm
+
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.utils.singleton
+import server.api.crud
+from mlrun.utils import logger
+
+
+class PaginatedMethods:
+    _methods: list[typing.Callable] = [
+        # TODO: add methods when they implement pagination
+        # server.api.crud.Runs().list_runs,
+    ]
+    _method_map = {method.__name__: method for method in _methods}
+
+    @classmethod
+    def method_is_supported(cls, method: typing.Union[str, typing.Callable]) -> bool:
+        if isinstance(method, str):
+            return method in cls._method_map
+        return method in cls._methods
+
+    @classmethod
+    def get_method(cls, method_name: str) -> typing.Callable:
+        return cls._method_map[method_name]
+
+    @staticmethod
+    def get_name(method: typing.Callable) -> str:
+        return method.__name__
+
+
+class Paginator(metaclass=mlrun.utils.singleton.Singleton):
+    def __init__(self):
+        self._logger = logger.get_child("paginator")
+        self._pagination_cache = server.api.crud.PaginationCache()
+
+    def paginate_request(
+        self,
+        session: sqlalchemy.orm.Session,
+        method: typing.Callable,
+        auth_info: typing.Optional[mlrun.common.schemas.AuthInfo] = None,
+        token: typing.Optional[str] = None,
+        page: typing.Optional[int] = None,
+        page_size: typing.Optional[int] = None,
+        **method_kwargs,
+    ) -> tuple[typing.Any, dict[str, typing.Union[str, int]]]:
+        if not PaginatedMethods.method_is_supported(method):
+            raise NotImplementedError(
+                f"Pagination is not supported for method {method}"
+            )
+
+        if page_size is None and token is None:
+            self._logger.debug("No token or page size provided, returning all records")
+            return method(**method_kwargs), {}
+
+        token, page, page_size, method, method_kwargs = (
+            self._create_or_update_pagination_cache_record(
+                session,
+                method,
+                auth_info,
+                token,
+                page,
+                page_size,
+                **method_kwargs,
+            )
+        )
+
+        try:
+            self._logger.debug(
+                "Retrieving page",
+                page=page,
+                page_size=page_size,
+                method=method.__name__,
+            )
+            return method(**method_kwargs, page=page, page_size=page_size), {
+                "token": token,
+                "page": page,
+                "page_size": page_size,
+            }
+        except StopIteration:
+            self._logger.debug("End of pagination", token=token, method=method.__name__)
+            self._pagination_cache.delete_pagination_cache_record(session, key=token)
+            return [], {}
+
+    def _create_or_update_pagination_cache_record(
+        self,
+        session: sqlalchemy.orm.Session,
+        method: typing.Callable,
+        auth_info: typing.Optional[mlrun.common.schemas.AuthInfo] = None,
+        token: typing.Optional[str] = None,
+        page: typing.Optional[int] = None,
+        page_size: typing.Optional[int] = None,
+        **method_kwargs,
+    ) -> tuple[str, int, int, typing.Callable, dict]:
+        if token:
+            self._logger.debug(
+                "Token provided, updating pagination cache record", token=token
+            )
+            pagination_cache_record = (
+                self._pagination_cache.get_pagination_cache_record(session, key=token)
+            )
+            if pagination_cache_record is None:
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Token {token} not found in pagination cache"
+                )
+            method = PaginatedMethods.get_method(pagination_cache_record.function)
+            method_kwargs = pagination_cache_record.kwargs
+            page = page or pagination_cache_record.current_page + 1
+            page_size = pagination_cache_record.page_size
+            user = pagination_cache_record.user
+
+            if user and (not auth_info or auth_info.user_id != user):
+                raise mlrun.errors.MLRunAccessDeniedError(
+                    "User is not allowed to access this token"
+                )
+
+        # upsert pagination cache record to update last_accessed time or create a new record
+        self._logger.debug(
+            "Storing pagination cache record",
+            method=method.__name__,
+            page=page,
+            page_size=page_size,
+        )
+        token = self._pagination_cache.store_pagination_cache_record(
+            session,
+            user=auth_info.user_id if auth_info else None,
+            method=method,
+            current_page=page,
+            page_size=page_size,
+            kwargs=method_kwargs,
+        )
+        return token, page, page_size, method, method_kwargs

--- a/tests/api/crud/test_pagination_cache.py
+++ b/tests/api/crud/test_pagination_cache.py
@@ -32,12 +32,13 @@ def test_pagination_cache_monitor_ttl(db: sqlalchemy.orm.Session):
 
     method = server.api.crud.Projects().list_projects
     page = 1
+    page_size = 10
     kwargs = {}
 
     logger.debug("Creating paginated cache records")
     for i in range(3):
         server.api.crud.PaginationCache().store_pagination_cache_record(
-            db, f"user{i}", method, page, kwargs
+            db, f"user{i}", method, page, page_size, kwargs
         )
 
     assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 3
@@ -49,7 +50,7 @@ def test_pagination_cache_monitor_ttl(db: sqlalchemy.orm.Session):
 
     logger.debug("Creating new paginated cache record that won't be expired")
     new_key = server.api.crud.PaginationCache().store_pagination_cache_record(
-        db, "user3", method, page, kwargs
+        db, "user3", method, page, page_size, kwargs
     )
 
     logger.debug("Monitoring pagination cache")
@@ -73,11 +74,12 @@ def test_pagination_cache_monitor_max_table_size(db: sqlalchemy.orm.Session):
 
     method = server.api.crud.Projects().list_projects
     page = 1
+    page_size = 10
     kwargs = {}
 
     logger.debug("Creating old paginated cache record")
     old_key = server.api.crud.PaginationCache().store_pagination_cache_record(
-        db, "user0", method, page, kwargs
+        db, "user0", method, page, page_size, kwargs
     )
 
     logger.debug("Sleeping for 1 second to create time difference between records")
@@ -88,7 +90,7 @@ def test_pagination_cache_monitor_max_table_size(db: sqlalchemy.orm.Session):
     )
     for i in range(1, max_size):
         server.api.crud.PaginationCache().store_pagination_cache_record(
-            db, f"user{i}", method, page, kwargs
+            db, f"user{i}", method, page, page_size, kwargs
         )
 
     assert (
@@ -98,7 +100,7 @@ def test_pagination_cache_monitor_max_table_size(db: sqlalchemy.orm.Session):
 
     logger.debug("Creating new paginated cache record to replace the old one")
     new_key = server.api.crud.PaginationCache().store_pagination_cache_record(
-        db, "user3", method, page, kwargs
+        db, "user3", method, page, page_size, kwargs
     )
 
     logger.debug("Monitoring pagination cache")
@@ -127,12 +129,13 @@ def test_pagination_cleanup(db: sqlalchemy.orm.Session):
     """
     method = server.api.crud.Projects().list_projects
     page = 1
+    page_size = 10
     kwargs = {}
 
     logger.debug("Creating paginated cache records")
     for i in range(3):
         server.api.crud.PaginationCache().store_pagination_cache_record(
-            db, f"user{i}", method, page, kwargs
+            db, f"user{i}", method, page, page_size, kwargs
         )
 
     assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 3

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -135,7 +135,7 @@ def test_paginate_request(mock_paginated_method, db: sqlalchemy.orm.Session):
         cache_record, auth_info.user_id, paginated_method, 2, page_size
     )
 
-    logger.info("Saving token for next test")
+    logger.info("Saving token for next assert")
     token = pagination_info["token"]
 
     logger.info(
@@ -200,9 +200,9 @@ def test_paginate_other_users_token(mock_paginated_method, db: sqlalchemy.orm.Se
 def test_paginate_no_auth(mock_paginated_method, db: sqlalchemy.orm.Session):
     """
     Test pagination with no auth info.
-    Request paginated method with page and page size, and verify that the correct items are returned.
+    Request paginated method without auth info, verify that the correct items are returned.
     Check the db for the pagination cache record.
-    Request the next page without auth info, and verify that a AccessDeniedError is raised.
+    Request the next page with auth info of some user, and verify that the request is successful.
     """
     page_size = 3
     method_kwargs = {"total_amount": 5}

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -54,6 +54,12 @@ def mock_paginated_method(monkeypatch):
     yield paginated_method
 
 
+@pytest.fixture()
+def cleanup_pagination_cache_on_teardown(db: sqlalchemy.orm.Session):
+    yield
+    server.api.crud.PaginationCache().cleanup_pagination_cache(db)
+
+
 def test_paginated_method():
     """
     Test the above paginated_method function, which is used as a mock for the paginated methods
@@ -88,7 +94,11 @@ def test_paginated_method():
         paginated_method(total_amount, 5, page_size)
 
 
-def test_paginate_request(mock_paginated_method, db: sqlalchemy.orm.Session):
+def test_paginate_request(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
     """
     Test pagination happy flow.
     Request paginated method with page and page size, and verify that the correct items are returned.
@@ -154,7 +164,11 @@ def test_paginate_request(mock_paginated_method, db: sqlalchemy.orm.Session):
     assert cache_record is None
 
 
-def test_paginate_other_users_token(mock_paginated_method, db: sqlalchemy.orm.Session):
+def test_paginate_other_users_token(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
     """
     Test pagination with a token that was created by a different user.
     Request paginated method with page and page size, and verify that the correct items are returned.
@@ -197,7 +211,11 @@ def test_paginate_other_users_token(mock_paginated_method, db: sqlalchemy.orm.Se
         paginator.paginate_request(db, paginated_method, None, pagination_info["token"])
 
 
-def test_paginate_no_auth(mock_paginated_method, db: sqlalchemy.orm.Session):
+def test_paginate_no_auth(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
     """
     Test pagination with no auth info.
     Request paginated method without auth info, verify that the correct items are returned.
@@ -241,7 +259,11 @@ def test_paginate_no_auth(mock_paginated_method, db: sqlalchemy.orm.Session):
     )
 
 
-def test_no_pagination(mock_paginated_method, db: sqlalchemy.orm.Session):
+def test_no_pagination(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
     """
     Test pagination with no page and page size.
     Request paginated method with no page and page size, and verify that all items are returned.
@@ -268,7 +290,11 @@ def test_no_pagination(mock_paginated_method, db: sqlalchemy.orm.Session):
     assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 0
 
 
-def test_pagination_not_supported(mock_paginated_method, db: sqlalchemy.orm.Session):
+def test_pagination_not_supported(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
     """
     Test pagination with a method that is not supported.
     Request a method that is not supported for pagination, and verify that a NotImplementedError is raised.
@@ -291,7 +317,11 @@ def test_pagination_not_supported(mock_paginated_method, db: sqlalchemy.orm.Sess
         )
 
 
-def test_pagination_cache_cleanup(mock_paginated_method, db: sqlalchemy.orm.Session):
+def test_pagination_cache_cleanup(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
     """
     Test pagination cache cleanup.
     Create paginated cache records and check that they are removed when calling cleanup_pagination_cache.

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -264,7 +264,7 @@ def test_no_pagination(mock_paginated_method, db: sqlalchemy.orm.Session):
     assert len(response) == 5
     assert not pagination_info
 
-    logger.debug("Checking that no cache record was created")
+    logger.info("Checking that no cache record was created")
     assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 0
 
 
@@ -325,7 +325,7 @@ def test_pagination_cache_cleanup(mock_paginated_method, db: sqlalchemy.orm.Sess
     logger.info("Checking that all records were removed")
     assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 0
 
-    logger.debug("Try to get page with token")
+    logger.info("Try to get page with token")
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
         paginator.paginate_request(
             db,

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -1,0 +1,363 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import typing
+
+import pytest
+import sqlalchemy.orm
+
+import mlrun.common.schemas
+import server.api.crud
+import server.api.db.sqldb.models
+import server.api.utils.pagination
+from mlrun.utils import logger
+
+
+def paginated_method(
+    total_amount: int,
+    page: typing.Optional[int] = None,
+    page_size: typing.Optional[int] = None,
+):
+    items = [{"name": f"item{i}"} for i in range(total_amount)]
+    if not page_size:
+        return items
+
+    page = page or 1
+    if page < 1 or (page - 1) * page_size >= total_amount:
+        raise StopIteration
+
+    return items[(page - 1) * page_size : page * page_size]
+
+
+@pytest.fixture()
+def mock_paginated_method(monkeypatch):
+    monkeypatch.setattr(
+        server.api.utils.pagination.PaginatedMethods, "_methods", [paginated_method]
+    )
+    monkeypatch.setattr(
+        server.api.utils.pagination.PaginatedMethods,
+        "_method_map",
+        {"paginated_method": paginated_method},
+    )
+    yield paginated_method
+
+
+def test_paginated_method():
+    """
+    Test the above paginated_method function, which is used as a mock for the paginated methods
+    in the following tests.
+    """
+    total_amount = 10
+    page_size = 3
+
+    items = paginated_method(total_amount, 1, page_size)
+    assert len(items) == page_size
+    assert items[0]["name"] == "item0"
+    assert items[1]["name"] == "item1"
+    assert items[2]["name"] == "item2"
+
+    items = paginated_method(total_amount, 2, page_size)
+    assert len(items) == page_size
+    assert items[0]["name"] == "item3"
+    assert items[1]["name"] == "item4"
+    assert items[2]["name"] == "item5"
+
+    items = paginated_method(total_amount, 3, page_size)
+    assert len(items) == page_size
+    assert items[0]["name"] == "item6"
+    assert items[1]["name"] == "item7"
+    assert items[2]["name"] == "item8"
+
+    items = paginated_method(total_amount, 4, page_size)
+    assert len(items) == 1
+    assert items[0]["name"] == "item9"
+
+    with pytest.raises(StopIteration):
+        paginated_method(total_amount, 5, page_size)
+
+
+def test_paginate_request(mock_paginated_method, db: sqlalchemy.orm.Session):
+    """
+    Test pagination happy flow.
+    Request paginated method with page and page size, and verify that the correct items are returned.
+    Check the db for the pagination cache record.
+    Continue requesting the next page until the end of the items. Meanwhile, check the db for the pagination
+    cache record updates.
+    Once response is empty, verify that the cache record was removed.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    page_size = 3
+    method_kwargs = {"total_amount": 5}
+
+    paginator = server.api.utils.pagination.Paginator()
+
+    logger.info("Requesting first page")
+    response, pagination_info = paginator.paginate_request(
+        db, paginated_method, auth_info, None, 1, page_size, **method_kwargs
+    )
+    _assert_paginated_response(
+        response, pagination_info, 1, page_size, ["item0", "item1", "item2"]
+    )
+
+    logger.info("Checking db cache record")
+    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
+        db, pagination_info["token"]
+    )
+    _assert_cache_record(
+        cache_record, auth_info.user_id, paginated_method, 1, page_size
+    )
+
+    logger.info("Requesting second page")
+    response, pagination_info = paginator.paginate_request(
+        db, paginated_method, auth_info, pagination_info["token"]
+    )
+    _assert_paginated_response(
+        response, pagination_info, 2, page_size, ["item3", "item4"]
+    )
+
+    logger.info("Checking db cache record")
+    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
+        db, pagination_info["token"]
+    )
+    _assert_cache_record(
+        cache_record, auth_info.user_id, paginated_method, 2, page_size
+    )
+
+    logger.info("Saving token for next test")
+    token = pagination_info["token"]
+
+    logger.info(
+        "Requesting third page, which is the end of the items and should return empty response"
+    )
+    response, pagination_info = paginator.paginate_request(
+        db, paginated_method, auth_info, pagination_info["token"]
+    )
+    assert len(response) == 0
+    assert not pagination_info
+
+    logger.info("Checking db cache record was removed")
+    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
+        db, token
+    )
+    assert cache_record is None
+
+
+def test_paginate_other_users_token(mock_paginated_method, db: sqlalchemy.orm.Session):
+    """
+    Test pagination with a token that was created by a different user.
+    Request paginated method with page and page size, and verify that the correct items are returned.
+    Check the db for the pagination cache record.
+    Request the next page with the token, and with different user, and verify that a AccessDeniedError is raised.
+    """
+    auth_info_1 = mlrun.common.schemas.AuthInfo(user_id="user1")
+    auth_info_2 = mlrun.common.schemas.AuthInfo(user_id="user2")
+    page_size = 3
+    method_kwargs = {"total_amount": 5}
+
+    paginator = server.api.utils.pagination.Paginator()
+
+    logger.info("Requesting first page with user1")
+    response, pagination_info = paginator.paginate_request(
+        db, paginated_method, auth_info_1, None, 1, page_size, **method_kwargs
+    )
+    _assert_paginated_response(
+        response, pagination_info, 1, page_size, ["item0", "item1", "item2"]
+    )
+
+    logger.info("Checking db cache record")
+    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
+        db, pagination_info["token"]
+    )
+    _assert_cache_record(
+        cache_record, auth_info_1.user_id, paginated_method, 1, page_size
+    )
+
+    logger.info("Requesting second page with user2, should raise AccessDeniedError")
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        paginator.paginate_request(
+            db, paginated_method, auth_info_2, pagination_info["token"]
+        )
+
+    logger.info(
+        "Requesting second page without auth info, should raise AccessDeniedError"
+    )
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        paginator.paginate_request(db, paginated_method, None, pagination_info["token"])
+
+
+def test_paginate_no_auth(mock_paginated_method, db: sqlalchemy.orm.Session):
+    """
+    Test pagination with no auth info.
+    Request paginated method with page and page size, and verify that the correct items are returned.
+    Check the db for the pagination cache record.
+    Request the next page without auth info, and verify that a AccessDeniedError is raised.
+    """
+    page_size = 3
+    method_kwargs = {"total_amount": 5}
+
+    paginator = server.api.utils.pagination.Paginator()
+
+    logger.info("Requesting first page")
+    response, pagination_info = paginator.paginate_request(
+        db, paginated_method, None, None, 1, page_size, **method_kwargs
+    )
+    _assert_paginated_response(
+        response, pagination_info, 1, page_size, ["item0", "item1", "item2"]
+    )
+
+    logger.info("Checking db cache record")
+    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
+        db, pagination_info["token"]
+    )
+    _assert_cache_record(cache_record, None, paginated_method, 1, page_size)
+
+    logger.info("Requesting second page with auth info of some user")
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="any-user")
+    response, pagination_info = paginator.paginate_request(
+        db, paginated_method, auth_info, pagination_info["token"]
+    )
+    _assert_paginated_response(
+        response, pagination_info, 2, page_size, ["item3", "item4"]
+    )
+
+    logger.info("Checking db cache record")
+    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
+        db, pagination_info["token"]
+    )
+    _assert_cache_record(
+        cache_record, auth_info.user_id, paginated_method, 2, page_size
+    )
+
+
+def test_no_pagination(mock_paginated_method, db: sqlalchemy.orm.Session):
+    """
+    Test pagination with no page and page size.
+    Request paginated method with no page and page size, and verify that all items are returned.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    method_kwargs = {"total_amount": 5}
+
+    paginator = server.api.utils.pagination.Paginator()
+
+    logger.info("Requesting all items")
+    response, pagination_info = paginator.paginate_request(
+        db,
+        paginated_method,
+        auth_info,
+        token=None,
+        page=None,
+        page_size=None,
+        **method_kwargs,
+    )
+    assert len(response) == 5
+    assert not pagination_info
+
+    logger.debug("Checking that no cache record was created")
+    assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 0
+
+
+def test_pagination_not_supported(mock_paginated_method, db: sqlalchemy.orm.Session):
+    """
+    Test pagination with a method that is not supported.
+    Request a method that is not supported for pagination, and verify that a NotImplementedError is raised.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    method_kwargs = {"total_amount": 5}
+
+    paginator = server.api.utils.pagination.Paginator()
+
+    logger.info("Requesting a method that is not supported for pagination")
+    with pytest.raises(NotImplementedError):
+        paginator.paginate_request(
+            db,
+            lambda: paginated_method(5, 1, 3),
+            auth_info,
+            token=None,
+            page=1,
+            page_size=3,
+            **method_kwargs,
+        )
+
+
+def test_pagination_cache_cleanup(mock_paginated_method, db: sqlalchemy.orm.Session):
+    """
+    Test pagination cache cleanup.
+    Create paginated cache records and check that they are removed when calling cleanup_pagination_cache.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    method_kwargs = {"total_amount": 5}
+    page_size = 3
+    token = None
+
+    paginator = server.api.utils.pagination.Paginator()
+
+    logger.info("Creating paginated cache records")
+    for i in range(3):
+        _, pagination_info = paginator.paginate_request(
+            db,
+            paginated_method,
+            auth_info,
+            None,
+            1,
+            page_size + i,
+            **method_kwargs,
+        )
+        token = pagination_info["token"]
+
+    assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 3
+
+    logger.info("Cleaning up pagination cache")
+    paginator._pagination_cache.cleanup_pagination_cache(db)
+    db.commit()
+
+    logger.info("Checking that all records were removed")
+    assert len(server.api.crud.PaginationCache().list_pagination_cache_records(db)) == 0
+
+    logger.debug("Try to get page with token")
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        paginator.paginate_request(
+            db,
+            paginated_method,
+            auth_info,
+            token,
+            1,
+            page_size,
+            **method_kwargs,
+        )
+
+
+def _assert_paginated_response(
+    response, pagination_info, page, page_size, expected_items
+):
+    assert len(response) == len(expected_items)
+    for i, item in enumerate(expected_items):
+        assert response[i]["name"] == item
+    assert pagination_info["token"] is not None
+    assert pagination_info["page"] == page
+    assert pagination_info["page_size"] == page_size
+
+
+def _assert_cache_record(
+    cache_record: server.api.db.sqldb.models.PaginationCache,
+    user: typing.Optional[str],
+    method: typing.Callable,
+    current_page: int,
+    page_size: int,
+):
+    assert cache_record is not None
+    assert cache_record.user == user
+    assert cache_record.function == method.__name__
+    assert cache_record.current_page == current_page
+    assert cache_record.page_size == page_size


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-5803

Implement paginator wrapper logic that wraps paginated functions with handling the cached record CRUD.

When requesting to paginate a request:
- If the method isn't supported raise NotImplemented
- If no page size or token is given, return all items - no pagination
- If token was given, check db cache records
  - Record doesn't exist? - 404
  - Record belongs to other user? - 403
  - Update record's last_access time and current page
- Call supported method with page number, page size
  - method raised StopIteration? - Clear cache record from db
- return response with pagination info (token, page number, page size)
