### PR TITLE
[Model Monitoring] Deploy the default app on the go

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -204,18 +204,10 @@ class PrometheusEndpoints(MonitoringStrEnum):
     MONITORING_DRIFT_STATUS = "/monitoring-drift-status"
 
 
-class MonitoringFunctionNames:
-    WRITER = "model-monitoring-writer"
-    APPLICATION_CONTROLLER = "model-monitoring-controller"
+class MonitoringFunctionNames(MonitoringStrEnum):
     STREAM = "model-monitoring-stream"
-
-    @staticmethod
-    def all():
-        return [
-            MonitoringFunctionNames.WRITER,
-            MonitoringFunctionNames.STREAM,
-            MonitoringFunctionNames.APPLICATION_CONTROLLER,
-        ]
+    APPLICATION_CONTROLLER = "model-monitoring-controller"
+    WRITER = "model-monitoring-writer"
 
 
 @dataclass

--- a/mlrun/common/types.py
+++ b/mlrun/common/types.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import enum
 
@@ -23,3 +22,10 @@ class StrEnum(str, enum.Enum):
 
     def __repr__(self):
         return self.value
+
+
+# Partial backport from Python 3.11
+# https://docs.python.org/3/library/http.html#http.HTTPMethod
+class HTTPMethod(StrEnum):
+    GET = "GET"
+    POST = "POST"

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -14,7 +14,7 @@
 
 import datetime
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 import mlrun.common.schemas
 import mlrun.model_monitoring

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -14,7 +14,7 @@
 
 import datetime
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import mlrun.common.schemas
 import mlrun.model_monitoring
@@ -722,9 +722,11 @@ class RunDBInterface(ABC):
         pass
 
     def enable_model_monitoring(
-        self,
-        project: str,
-        base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        self, project: str, base_period: int = 10, image: str = "mlrun/mlrun"
     ):
         pass
+
+    def deploy_histogram_data_drift_app(
+        self, project: str, image: str = "mlrun/mlrun"
+    ) -> dict[str, Any]:
+        raise NotImplementedError

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -723,10 +723,10 @@ class RunDBInterface(ABC):
 
     def enable_model_monitoring(
         self, project: str, base_period: int = 10, image: str = "mlrun/mlrun"
-    ) -> dict[str, Any]:
+    ) -> None:
         raise NotImplementedError
 
     def deploy_histogram_data_drift_app(
         self, project: str, image: str = "mlrun/mlrun"
-    ) -> dict[str, Any]:
+    ) -> None:
         raise NotImplementedError

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -722,7 +722,11 @@ class RunDBInterface(ABC):
         pass
 
     def enable_model_monitoring(
-        self, project: str, base_period: int = 10, image: str = "mlrun/mlrun"
+        self,
+        project: str,
+        base_period: int = 10,
+        image: str = "mlrun/mlrun",
+        deploy_histogram_data_drift_app: bool = True,
     ) -> None:
         raise NotImplementedError
 

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -723,8 +723,8 @@ class RunDBInterface(ABC):
 
     def enable_model_monitoring(
         self, project: str, base_period: int = 10, image: str = "mlrun/mlrun"
-    ):
-        pass
+    ) -> dict[str, Any]:
+        raise NotImplementedError
 
     def deploy_histogram_data_drift_app(
         self, project: str, image: str = "mlrun/mlrun"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3081,6 +3081,7 @@ class HTTPRunDB(RunDBInterface):
         project: str,
         base_period: int = 10,
         image: str = "mlrun/mlrun",
+        deploy_histogram_data_drift_app: bool = True,
     ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
@@ -3096,11 +3097,16 @@ class HTTPRunDB(RunDBInterface):
         :param image:       The image of the model monitoring controller, writer & monitoring
                             stream functions, which are real time nuclio functions.
                             By default, the image is mlrun/mlrun.
+        :param deploy_histogram_data_drift_app: If true, deploy the default histogram-based data drift application.
         """
         self.api_call(
             method=mlrun.common.types.HTTPMethod.POST,
             path=f"projects/{project}/model-monitoring/enable-model-monitoring",
-            params={"base_period": base_period, "image": image},
+            params={
+                "base_period": base_period,
+                "image": image,
+                "deploy_histogram_data_drift_app": deploy_histogram_data_drift_app,
+            },
         )
 
     def deploy_histogram_data_drift_app(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3081,7 +3081,7 @@ class HTTPRunDB(RunDBInterface):
         project: str,
         base_period: int = 10,
         image: str = "mlrun/mlrun",
-    ):
+    ) -> dict[str, typing.Any]:
         """
         Deploy model monitoring application controller, writer and stream functions.
         While the main goal of the controller function is to handle the monitoring processing and triggering

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3081,7 +3081,7 @@ class HTTPRunDB(RunDBInterface):
         project: str,
         base_period: int = 10,
         image: str = "mlrun/mlrun",
-    ) -> dict[str, typing.Any]:
+    ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
         While the main goal of the controller function is to handle the monitoring processing and triggering
@@ -3096,29 +3096,27 @@ class HTTPRunDB(RunDBInterface):
         :param image:       The image of the model monitoring controller, writer & monitoring
                             stream functions, which are real time nuclio functions.
                             By default, the image is mlrun/mlrun.
-        :returns:           A dictionary describing the different infra functions information.
         """
-        return self.api_call(
+        self.api_call(
             method=mlrun.common.types.HTTPMethod.POST,
             path=f"projects/{project}/model-monitoring/enable-model-monitoring",
             params={"base_period": base_period, "image": image},
-        ).json()
+        )
 
     def deploy_histogram_data_drift_app(
         self, project: str, image: str = "mlrun/mlrun"
-    ) -> dict[str, typing.Any]:
+    ) -> None:
         """
         Deploy the histogram data drift application.
 
         :param project: Project name.
         :param image:   The image on which the application will run.
-        :returns:       A dictionary describing the function information.
         """
-        return self.api_call(
+        self.api_call(
             method=mlrun.common.types.HTTPMethod.POST,
             path=f"projects/{project}/model-monitoring/deploy-histogram-data-drift-app",
             params={"image": image},
-        ).json()
+        )
 
     def create_hub_source(
         self, source: Union[dict, mlrun.common.schemas.IndexedHubSource]

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -22,8 +22,8 @@ import pandas as pd
 
 import mlrun.artifacts
 import mlrun.common.helpers
+import mlrun.common.schemas.model_monitoring.constants as mm_consts
 import mlrun.feature_store
-from mlrun.common.schemas.model_monitoring import EventFieldType, ModelMonitoringMode
 from mlrun.data_types.infer import InferOptions, get_df_stats
 from mlrun.utils import datetime_now, logger
 
@@ -46,7 +46,7 @@ def get_or_create_model_endpoint(
     sample_set_statistics: dict[str, typing.Any] = None,
     drift_threshold: float = None,
     possible_drift_threshold: float = None,
-    monitoring_mode: ModelMonitoringMode = ModelMonitoringMode.disabled,
+    monitoring_mode: mm_consts.ModelMonitoringMode = mm_consts.ModelMonitoringMode.disabled,
     db_session=None,
 ) -> ModelEndpoint:
     """
@@ -126,7 +126,7 @@ def record_results(
     context: typing.Optional[mlrun.MLClientCtx] = None,
     infer_results_df: typing.Optional[pd.DataFrame] = None,
     sample_set_statistics: typing.Optional[dict[str, typing.Any]] = None,
-    monitoring_mode: ModelMonitoringMode = ModelMonitoringMode.enabled,
+    monitoring_mode: mm_consts.ModelMonitoringMode = mm_consts.ModelMonitoringMode.enabled,
     # Deprecated arguments:
     drift_threshold: typing.Optional[float] = None,
     possible_drift_threshold: typing.Optional[float] = None,
@@ -280,7 +280,7 @@ def _model_endpoint_validations(
     # drift and possible drift thresholds
     if drift_threshold:
         current_drift_threshold = model_endpoint.spec.monitor_configuration.get(
-            EventFieldType.DRIFT_DETECTED_THRESHOLD,
+            mm_consts.EventFieldType.DRIFT_DETECTED_THRESHOLD,
             mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.drift_detected,
         )
         if current_drift_threshold != drift_threshold:
@@ -291,7 +291,7 @@ def _model_endpoint_validations(
 
     if possible_drift_threshold:
         current_possible_drift_threshold = model_endpoint.spec.monitor_configuration.get(
-            EventFieldType.POSSIBLE_DRIFT_THRESHOLD,
+            mm_consts.EventFieldType.POSSIBLE_DRIFT_THRESHOLD,
             mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.possible_drift,
         )
         if current_possible_drift_threshold != possible_drift_threshold:
@@ -330,14 +330,14 @@ def write_monitoring_df(
         )
 
     # Modify the DataFrame to the required structure that will be used later by the monitoring batch job
-    if EventFieldType.TIMESTAMP not in infer_results_df.columns:
+    if mm_consts.EventFieldType.TIMESTAMP not in infer_results_df.columns:
         # Initialize timestamp column with the current time
-        infer_results_df[EventFieldType.TIMESTAMP] = infer_datetime
+        infer_results_df[mm_consts.EventFieldType.TIMESTAMP] = infer_datetime
 
     # `endpoint_id` is the monitoring feature set entity and therefore it should be defined as the df index before
     # the ingest process
-    infer_results_df[EventFieldType.ENDPOINT_ID] = endpoint_id
-    infer_results_df.set_index(EventFieldType.ENDPOINT_ID, inplace=True)
+    infer_results_df[mm_consts.EventFieldType.ENDPOINT_ID] = endpoint_id
+    infer_results_df.set_index(mm_consts.EventFieldType.ENDPOINT_ID, inplace=True)
 
     monitoring_feature_set.ingest(source=infer_results_df, overwrite=False)
 
@@ -353,7 +353,7 @@ def _generate_model_endpoint(
     sample_set_statistics: dict[str, typing.Any],
     drift_threshold: float,
     possible_drift_threshold: float,
-    monitoring_mode: ModelMonitoringMode = ModelMonitoringMode.disabled,
+    monitoring_mode: mm_consts.ModelMonitoringMode = mm_consts.ModelMonitoringMode.disabled,
 ) -> ModelEndpoint:
     """
     Write a new model endpoint record.
@@ -392,11 +392,11 @@ def _generate_model_endpoint(
     model_endpoint.spec.model_class = "drift-analysis"
     if drift_threshold:
         model_endpoint.spec.monitor_configuration[
-            EventFieldType.DRIFT_DETECTED_THRESHOLD
+            mm_consts.EventFieldType.DRIFT_DETECTED_THRESHOLD
         ] = drift_threshold
     if possible_drift_threshold:
         model_endpoint.spec.monitor_configuration[
-            EventFieldType.POSSIBLE_DRIFT_THRESHOLD
+            mm_consts.EventFieldType.POSSIBLE_DRIFT_THRESHOLD
         ] = possible_drift_threshold
 
     model_endpoint.spec.monitoring_mode = monitoring_mode

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -350,7 +350,12 @@ class MonitoringApplicationController:
                     {
                         app.metadata.name
                         for app in monitoring_functions
-                        if app.status.state == "ready"
+                        if (
+                            app.status.state == "ready"
+                            # workaround for the default app, as its `status.state` is `None`
+                            or app.metadata.name
+                            == mm_constants.MLRUN_HISTOGRAM_DATA_DRIFT_APP_NAME
+                        )
                     }
                 )
             if not applications_names:
@@ -358,6 +363,10 @@ class MonitoringApplicationController:
                     "No monitoring functions found", project=self.project
                 )
                 return
+            self.context.logger.info(
+                "Starting to iterate over the applications",
+                applications=applications_names,
+            )
 
         except Exception as e:
             self.context.logger.error(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1868,16 +1868,6 @@ class MlrunProject(ModelObj):
             requirements_file,
             **application_kwargs,
         )
-        models_names = "all"
-        function_object.set_label(
-            mm_constants.ModelMonitoringAppLabel.KEY,
-            mm_constants.ModelMonitoringAppLabel.VAL,
-        )
-        function_object.set_label("models", models_names)
-
-        if not mlrun.mlconf.is_ce_mode():
-            function_object.apply(mlrun.mount_v3io())
-
         # save to project spec
         self.spec.set_function(resolved_function_name, function_object, func)
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1845,10 +1845,10 @@ class MlrunProject(ModelObj):
                                         monitoring application's constructor.
         """
 
-        if name in mm_constants.MonitoringFunctionNames.all():
+        if name in mm_constants.MonitoringFunctionNames.list():
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Application name can not be on of the following name : "
-                f"{mm_constants.MonitoringFunctionNames.all()}"
+                f"An application cannot have the following names: "
+                f"{mm_constants.MonitoringFunctionNames.list()}"
             )
         function_object: RemoteRuntime = None
         (

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -41,7 +41,6 @@ import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.db
 import mlrun.errors
 import mlrun.k8s_utils
-import mlrun.model_monitoring.api
 import mlrun.runtimes
 import mlrun.runtimes.nuclio.api_gateway
 import mlrun.runtimes.pod
@@ -1941,6 +1940,8 @@ class MlrunProject(ModelObj):
         requirements_file: str = "",
         **application_kwargs,
     ) -> tuple[str, mlrun.runtimes.BaseRuntime, dict]:
+        import mlrun.model_monitoring.api
+
         function_object: RemoteRuntime = None
         kind = None
         if (isinstance(func, str) or func is None) and application_class is not None:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1946,18 +1946,16 @@ class MlrunProject(ModelObj):
         kind = None
         if (isinstance(func, str) or func is None) and application_class is not None:
             kind = mlrun.run.RuntimeKinds.serving
-            function_object = (
-                mlrun.model_monitoring.api._create_model_monitoring_function_base(
-                    project=self.name,
-                    func=func,
-                    application_class=application_class,
-                    name=name,
-                    image=image,
-                    tag=tag,
-                    requirements=requirements,
-                    requirements_file=requirements_file,
-                    **application_kwargs,
-                )
+            func = mlrun.model_monitoring.api._create_model_monitoring_function_base(
+                project=self.name,
+                func=func,
+                application_class=application_class,
+                name=name,
+                image=image,
+                tag=tag,
+                requirements=requirements,
+                requirements_file=requirements_file,
+                **application_kwargs,
             )
         elif isinstance(func, str) and isinstance(handler, str):
             kind = mlrun.run.RuntimeKinds.nuclio

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2012,7 +2012,7 @@ class MlrunProject(ModelObj):
         base_period: int = 10,
         image: str = "mlrun/mlrun",
         deploy_histogram_data_drift_app: bool = True,
-    ) -> dict[str, typing.Any]:
+    ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
         While the main goal of the controller function is to handle the monitoring processing and triggering
@@ -2029,8 +2029,6 @@ class MlrunProject(ModelObj):
                                                 stream & histogram data drift functions, which are real time nuclio
                                                 functions. By default, the image is mlrun/mlrun.
         :param deploy_histogram_data_drift_app: If true, deploy the default histogram-based data drift application.
-
-        :returns:                               Model monitoring functions information as a dictionary.
         """
         if default_controller_image != "mlrun/mlrun":
             # TODO: Remove this in 1.9.0
@@ -2041,14 +2039,13 @@ class MlrunProject(ModelObj):
             )
             image = default_controller_image
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        result = db.enable_model_monitoring(
+        db.enable_model_monitoring(
             project=self.name,
             image=image,
             base_period=base_period,
         )
         if deploy_histogram_data_drift_app:
-            result |= db.deploy_histogram_data_drift_app(project=self.name, image=image)
-        return result
+            db.deploy_histogram_data_drift_app(project=self.name, image=image)
 
     def update_model_monitoring_controller(
         self,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1994,12 +1994,10 @@ class MlrunProject(ModelObj):
             requirements,
             requirements_file,
         )
-        models_names = "all"
         function_object.set_label(
             mm_constants.ModelMonitoringAppLabel.KEY,
             mm_constants.ModelMonitoringAppLabel.VAL,
         )
-        function_object.set_label("models", models_names)
 
         if not mlrun.mlconf.is_ce_mode():
             function_object.apply(mlrun.mount_v3io())

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2077,6 +2077,7 @@ class MlrunProject(ModelObj):
         self, *, delete_histogram_data_drift_app: bool = True
     ) -> None:
         """
+        Note: This method is currently not advised for use. See ML-3432.
         Disable model monitoring by deleting the underlying functions infrastructure from MLRun database.
 
         :param delete_histogram_data_drift_app: Whether to delete the histogram data drift app.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2073,20 +2073,10 @@ class MlrunProject(ModelObj):
             image=image,
         )
 
-    def disable_model_monitoring(self):
+    def disable_model_monitoring(self) -> None:
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        db.delete_function(
-            project=self.name,
-            name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-        )
-        db.delete_function(
-            project=self.name,
-            name=mm_constants.MonitoringFunctionNames.WRITER,
-        )
-        db.delete_function(
-            project=self.name,
-            name=mm_constants.MonitoringFunctionNames.STREAM,
-        )
+        for fn_name in mm_constants.MonitoringFunctionNames.list():
+            db.delete_function(project=self.name, name=fn_name)
 
     def set_function(
         self,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2021,10 +2021,11 @@ class MlrunProject(ModelObj):
             image = default_controller_image
         db = mlrun.db.get_run_db(secrets=self._secrets)
         db.enable_model_monitoring(
-            project=self.name, image=image, base_period=base_period
+            project=self.name,
+            image=image,
+            base_period=base_period,
+            deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
         )
-        if deploy_histogram_data_drift_app:
-            self.deploy_histogram_data_drift_app(image=image, db=db)
 
     def deploy_histogram_data_drift_app(
         self,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1926,14 +1926,16 @@ class MlrunProject(ModelObj):
 
     def _instantiate_model_monitoring_function(
         self,
-        func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,
-        application_class: typing.Union[str, ModelMonitoringApplicationBase] = None,
-        name: str = None,
-        image: str = None,
-        handler: str = None,
-        with_repo: bool = None,
-        tag: str = None,
-        requirements: typing.Union[str, list[str]] = None,
+        func: typing.Union[str, mlrun.runtimes.BaseRuntime, None] = None,
+        application_class: typing.Union[
+            str, ModelMonitoringApplicationBase, None
+        ] = None,
+        name: typing.Optional[str] = None,
+        image: typing.Optional[str] = None,
+        handler: typing.Optional[str] = None,
+        with_repo: typing.Optional[bool] = None,
+        tag: typing.Optional[str] = None,
+        requirements: typing.Union[str, list[str], None] = None,
         requirements_file: str = "",
         **application_kwargs,
     ) -> tuple[str, mlrun.runtimes.BaseRuntime, dict]:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2073,10 +2073,21 @@ class MlrunProject(ModelObj):
             image=image,
         )
 
-    def disable_model_monitoring(self) -> None:
+    def disable_model_monitoring(
+        self, *, delete_histogram_data_drift_app: bool = True
+    ) -> None:
+        """
+        Disable model monitoring by deleting the underlying functions infrastructure from MLRun database.
+
+        :param delete_histogram_data_drift_app: Whether to delete the histogram data drift app.
+        """
         db = mlrun.db.get_run_db(secrets=self._secrets)
         for fn_name in mm_constants.MonitoringFunctionNames.list():
             db.delete_function(project=self.name, name=fn_name)
+        if delete_histogram_data_drift_app:
+            db.delete_function(
+                project=self.name, name=mm_constants.MLRUN_HISTOGRAM_DATA_DRIFT_APP_NAME
+            )
 
     def set_function(
         self,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2040,12 +2040,26 @@ class MlrunProject(ModelObj):
             image = default_controller_image
         db = mlrun.db.get_run_db(secrets=self._secrets)
         db.enable_model_monitoring(
-            project=self.name,
-            image=image,
-            base_period=base_period,
+            project=self.name, image=image, base_period=base_period
         )
         if deploy_histogram_data_drift_app:
-            db.deploy_histogram_data_drift_app(project=self.name, image=image)
+            self.deploy_histogram_data_drift_app(image=image, db=db)
+
+    def deploy_histogram_data_drift_app(
+        self,
+        *,
+        image: str = "mlrun/mlrun",
+        db: Optional[mlrun.db.RunDBInterface] = None,
+    ) -> None:
+        """
+        Deploy the histogram data drift application.
+
+        :param image: The image on which the application will run.
+        :param db:    An optional DB object.
+        """
+        if db is None:
+            db = mlrun.db.get_run_db(secrets=self._secrets)
+        db.deploy_histogram_data_drift_app(project=self.name, image=image)
 
     def update_model_monitoring_controller(
         self,

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-import base64  # noqa: F401
+
 import os
 import traceback
 from distutils.util import strtobool
@@ -52,7 +51,6 @@ from mlrun.config import config
 from mlrun.errors import MLRunRuntimeError, err_to_str
 from mlrun.run import new_function
 from mlrun.runtimes import RuntimeKinds, ServingRuntime
-from mlrun.runtimes.utils import get_item_name
 from mlrun.utils import get_in, logger, update_in
 from server.api.api import deps
 from server.api.crud.secrets import Secrets, SecretsClientType
@@ -921,13 +919,6 @@ async def _get_function_status(data, auth_info: mlrun.common.schemas.AuthInfo):
             HTTPStatus.BAD_REQUEST.value,
             reason=f"Runtime error: {err_to_str(err)}",
         )
-
-
-def _get_function_env_var(fn: ServingRuntime, var_name: str):
-    for env_var in fn.spec.env:
-        if get_item_name(env_var) == var_name:
-            return env_var
-    return None
 
 
 def process_model_monitoring_secret(db_session, project_name: str, secret_key: str):

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -786,15 +786,12 @@ def _deploy_nuclio_runtime(
         else:
             model_monitoring_access_key = None
 
-        monitoring_deploy = (
-            server.api.crud.model_monitoring.deployment.MonitoringDeployment(
-                project=fn.metadata.project,
-                auth_info=auth_info,
-                db_session=db_session,
-                model_monitoring_access_key=model_monitoring_access_key,
-            )
-        )
-        fn = monitoring_deploy._apply_and_create_stream_trigger(
+        fn = server.api.crud.model_monitoring.deployment.MonitoringDeployment(
+            project=fn.metadata.project,
+            auth_info=auth_info,
+            db_session=db_session,
+            model_monitoring_access_key=model_monitoring_access_key,
+        )._apply_and_create_stream_trigger(
             function=fn,
             function_name=fn.metadata.name,
         )

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -97,7 +97,7 @@ async def enable_model_monitoring(
             mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
         )
 
-    return MonitoringDeployment(
+    MonitoringDeployment(
         project=commons.project,
         auth_info=commons.auth_info,
         db_session=commons.db_session,
@@ -165,7 +165,7 @@ async def update_model_monitoring_controller(
 def deploy_histogram_data_drift_app(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     image: str = "mlrun/mlrun",
-) -> dict[str, Any]:
+) -> None:
     """
     Deploy the histogram data drift app on the go.
 
@@ -181,7 +181,7 @@ def deploy_histogram_data_drift_app(
             mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
         )
 
-    return MonitoringDeployment(
+    MonitoringDeployment(
         project=commons.project,
         auth_info=commons.auth_info,
         db_session=commons.db_session,

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -71,6 +71,7 @@ async def enable_model_monitoring(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     base_period: int = 10,
     image: str = "mlrun/mlrun",
+    deploy_histogram_data_drift_app: bool = True,
 ):
     """
     Deploy model monitoring application controller, writer and stream functions.
@@ -86,6 +87,7 @@ async def enable_model_monitoring(
     :param image:       The image of the model monitoring controller, writer & monitoring
                         stream functions, which are real time nuclio functions.
                         By default, the image is mlrun/mlrun.
+    :param deploy_histogram_data_drift_app: If true, deploy the default histogram-based data drift application.
     """
 
     model_monitoring_access_key = None
@@ -105,6 +107,7 @@ async def enable_model_monitoring(
     ).deploy_monitoring_functions(
         image=image,
         base_period=base_period,
+        deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
     )
 
 

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -398,7 +398,7 @@ class MonitoringDeployment:
         :return: function runtime object with access key and access to system files.
         """
 
-        if function_name in mm_constants.MonitoringFunctionNames.all():
+        if function_name in mm_constants.MonitoringFunctionNames.list():
             # Set model monitoring access key for managing permissions
             function.set_env_from_secret(
                 mm_constants.ProjectSecretKeys.ACCESS_KEY,

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -14,6 +14,7 @@
 
 import json
 import typing
+from pathlib import Path
 
 import nuclio
 import sqlalchemy.orm
@@ -21,7 +22,7 @@ import sqlalchemy.orm
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.model_monitoring.application
-import mlrun.model_monitoring.applications.histogram_data_drift
+import mlrun.model_monitoring.applications
 import mlrun.model_monitoring.controller_handler
 import mlrun.model_monitoring.stream_processing
 import mlrun.model_monitoring.writer
@@ -42,8 +43,9 @@ _MONITORING_APPLICATION_CONTROLLER_FUNCTION_PATH = (
     mlrun.model_monitoring.controller_handler.__file__
 )
 _MONITORING_WRITER_FUNCTION_PATH = mlrun.model_monitoring.writer.__file__
-_HISTOGRAM_DATA_DRIFT_APP_PATH = (
-    mlrun.model_monitoring.applications.histogram_data_drift.__file__
+_HISTOGRAM_DATA_DRIFT_APP_PATH = str(
+    Path(mlrun.model_monitoring.applications.__file__).parent
+    / "histogram_data_drift.py"
 )
 
 
@@ -516,9 +518,7 @@ class MonitoringDeployment:
             logger.info("Ensured the histogram data drift function auth")
 
         graph = func.set_topology(mlrun.serving.states.StepKinds.flow)
-        first_step = graph.to(
-            class_name=mlrun.model_monitoring.applications.histogram_data_drift.HistogramDataDriftApplication.__name__
-        )
+        first_step = graph.to(class_name="HistogramDataDriftApplication")
         first_step.to(
             class_name=mlrun.model_monitoring.application.PushToMonitoringWriter(
                 project=self.project,

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -84,7 +84,10 @@ class MonitoringDeployment:
         self._max_parquet_save_interval = max_parquet_save_interval
 
     def deploy_monitoring_functions(
-        self, base_period: int = 10, image: str = "mlrun/mlrun"
+        self,
+        base_period: int = 10,
+        image: str = "mlrun/mlrun",
+        deploy_histogram_data_drift_app: bool = True,
     ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
@@ -94,12 +97,15 @@ class MonitoringDeployment:
         :param image:       The image of the model monitoring controller, writer & monitoring
                             stream functions, which are real time nuclio functino.
                             By default, the image is mlrun/mlrun.
+        :param deploy_histogram_data_drift_app: If true, deploy the default histogram-based data drift application.
         """
         self.deploy_model_monitoring_controller(
             controller_image=image, base_period=base_period
         )
         self.deploy_model_monitoring_writer_application(writer_image=image)
         self.deploy_model_monitoring_stream_processing(stream_image=image)
+        if deploy_histogram_data_drift_app:
+            self.deploy_histogram_data_drift_app(image=image)
 
     def deploy_model_monitoring_stream_processing(
         self, stream_image: str = "mlrun/mlrun"

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -84,27 +84,21 @@ class MonitoringDeployment:
 
     def deploy_monitoring_functions(
         self, base_period: int = 10, image: str = "mlrun/mlrun"
-    ) -> dict[str, typing.Any]:
+    ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
 
-        :param base_period:                 The time period in minutes in which the model monitoring controller function
-                                            triggers. By default, the base period is 10 minutes.
-        :param image:                       The image of the model monitoring controller, writer & monitoring
-                                            stream functions, which are real time nuclio functino.
-                                            By default, the image is mlrun/mlrun.
+        :param base_period: The time period in minutes in which the model monitoring controller function
+                            triggers. By default, the base period is 10 minutes.
+        :param image:       The image of the model monitoring controller, writer & monitoring
+                            stream functions, which are real time nuclio functino.
+                            By default, the image is mlrun/mlrun.
         """
-        controller_dict = self.deploy_model_monitoring_controller(
+        self.deploy_model_monitoring_controller(
             controller_image=image, base_period=base_period
         )
-
-        writer_dict = self.deploy_model_monitoring_writer_application(
-            writer_image=image
-        )
-
-        stream_dict = self.deploy_model_monitoring_stream_processing(stream_image=image)
-
-        return controller_dict | writer_dict | stream_dict
+        self.deploy_model_monitoring_writer_application(writer_image=image)
+        self.deploy_model_monitoring_stream_processing(stream_image=image)
 
     def deploy_model_monitoring_stream_processing(
         self, stream_image: str = "mlrun/mlrun"
@@ -487,12 +481,11 @@ class MonitoringDeployment:
                 pass
         logger.info(f"Deploying {function_name} function", project=self.project)
 
-    def deploy_histogram_data_drift_app(self, image: str) -> dict[str, typing.Any]:
+    def deploy_histogram_data_drift_app(self, image: str) -> None:
         """
         Deploy the histogram data drift application.
 
         :param image: The image on with the function will run.
-        :returns:     A dictionary describing the function and the deployment status.
         """
         logger.info("Preparing the histogram data drift function")
         func = typing.cast(
@@ -526,16 +519,12 @@ class MonitoringDeployment:
             )
         ).respond()
 
-        fn, ready = server.api.api.endpoints.functions._build_function(
+        server.api.api.endpoints.functions._build_function(
             db_session=self.db_session,
             auth_info=self.auth_info,
             function=func,
         )
         logger.info("Submitted the deployment")
-        return {
-            "histogram_app_data": fn.to_dict(),
-            "histogram_app_ready": ready,
-        }
 
 
 def get_endpoint_features(

--- a/tests/api/crud/model_monitoring/test_deployment.py
+++ b/tests/api/crud/model_monitoring/test_deployment.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from unittest.mock import Mock, patch
+
+import pytest
+
+import mlrun.runtimes
+import server.api.crud.model_monitoring.deployment as mm_dep
+
+
+@pytest.fixture()
+def monitoring_deployment() -> mm_dep.MonitoringDeployment:
+    return mm_dep.MonitoringDeployment(
+        project=Mock(spec=str),
+        auth_info=Mock(spec=mm_dep.mlrun.common.schemas.AuthInfo),
+        db_session=Mock(spec=mm_dep.sqlalchemy.orm.Session),
+        model_monitoring_access_key=None,
+    )
+
+
+class TestAppDeployment:
+    """Test nominal flow of the app deployment"""
+
+    @staticmethod
+    @pytest.fixture(autouse=True)
+    def _patch_build_function() -> Iterator[None]:
+        with patch(
+            "server.api.api.endpoints.functions._build_function",
+            new=Mock(return_value=(Mock(spec=mlrun.runtimes.ServingRuntime), True)),
+        ):
+            yield
+
+    @staticmethod
+    def test_app_dep(monitoring_deployment: mm_dep.MonitoringDeployment) -> None:
+        monitoring_deployment.deploy_histogram_data_drift_app(image="mlrun/mlrun")

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import os
 import os.path
 import pathlib
@@ -2070,3 +2070,50 @@ def test_load_project_dir(project_file_name, expectation):
             assert project.name == "pipe2"
     finally:
         shutil.rmtree(project_dir)
+
+
+class TestModelMonitoring:
+    """Test model monitoring project methods"""
+
+    @staticmethod
+    @pytest.fixture
+    def project() -> mlrun.projects.MlrunProject:
+        return unittest.mock.Mock()  # spec_set=mlrun.projects.MlrunProject)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("delete_app", "expected_deleted_fns"),
+        [
+            (
+                True,
+                mlrun.common.schemas.model_monitoring.constants.MonitoringFunctionNames.list()
+                + [
+                    mlrun.common.schemas.model_monitoring.constants.MLRUN_HISTOGRAM_DATA_DRIFT_APP_NAME
+                ],
+            ),
+            (
+                False,
+                mlrun.common.schemas.model_monitoring.constants.MonitoringFunctionNames.list(),
+            ),
+        ],
+    )
+    def test_disable(
+        project: mlrun.projects.MlrunProject,
+        delete_app: bool,
+        expected_deleted_fns: list[str],
+    ) -> None:
+        db_mock = unittest.mock.Mock(spec=mlrun.db.RunDBInterface)
+        with unittest.mock.patch(
+            "mlrun.db.get_run_db", unittest.mock.Mock(return_value=db_mock)
+        ):
+            mlrun.projects.MlrunProject.disable_model_monitoring(
+                project, delete_histogram_data_drift_app=delete_app
+            )
+
+        deleted_fns = [
+            call_args.kwargs["name"]
+            for call_args in db_mock.delete_function.call_args_list
+        ]
+        assert (
+            deleted_fns == expected_deleted_fns
+        ), "The deleted functions are different than expexted"


### PR DESCRIPTION
Resolves [ML-5865](https://iguazio.atlassian.net/browse/ML-5865).
Move the deployment to the backend in the background.
This enables a smoother and non-blocking experience with the `project.enable_model_monitoring()` call.

The relevant system tests passed.

[ML-5865]: https://iguazio.atlassian.net/browse/ML-5865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ