### PR TITLE
[Requirements] Bump v3io to 0.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pyyaml~=5.1
 requests~=2.31
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6
-v3io~=0.6.2
+v3io~=0.6.4
 # pydantic 1.10.8 fixes a bug with literal and typing-extension 4.6.0
 # https://docs.pydantic.dev/latest/changelog/#v1108-2023-05-23
 pydantic~=1.10, >=1.10.8
@@ -32,7 +32,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec==2023.9.2
 v3iofs~=0.1.17
-storey~=1.7.5
+storey~=1.7.6
 inflection~=0.5.0
 python-dotenv~=0.17.0
 # older version of setuptools contains vulnerabilities, see `GHSA-r9hx-vwmv-q579`, so we limit to 65.5 and above

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -110,7 +110,7 @@ def test_requirement_specifiers_convention():
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "aiobotocore": {">=2.5.0,<2.8"},
-        "storey": {"~=1.7.5"},
+        "storey": {"~=1.7.6"},
         "nuclio-sdk": {">=0.5"},
         "bokeh": {"~=2.4, >=2.4.2"},
         # protobuf is limited just for docs


### PR DESCRIPTION
bump v3io to 0.6.4.
bump storey to 1.7.6.

Part of [ML-5926](https://iguazio.atlassian.net/browse/ML-5926)

[ML-5926]: https://iguazio.atlassian.net/browse/ML-5926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ