### PR TITLE
[Tests] Reduce the example size generated by Hypothesis in the CI

### DIFF
--- a/tests/model_monitoring/test_metrics.py
+++ b/tests/model_monitoring/test_metrics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+import os
 from typing import Union
 
 import numpy as np
@@ -113,7 +114,8 @@ def _norm_arr(arr: np.ndarray) -> np.ndarray:
     return arr / arr_sum.sum()
 
 
-_length_strategy = st.integers(min_value=1, max_value=500)
+_max_value = 100 if os.getenv("CI") == "true" else 500
+_length_strategy = st.integers(min_value=1, max_value=_max_value)
 
 
 def distribution_strategy(


### PR DESCRIPTION
We received a few "too slow" data generation health check errors from Hypothesis:
https://hypothesis.readthedocs.io/en/latest/settings.html#hypothesis.HealthCheck.too_slow

We address it here by reducing the distribution array length in the GitHub CI job.

For the "CI" env var, see:
https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables