### PR TITLE
[Automation] Fix patch remote reset DB

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ on:
         type: choice
         options: [ 'bump-rc', 'stable' ]
       skip_images:
-        description: 'Comma separated list of images to skip building, example with all possible images: mlrun,mlrun-gpu,ui,api,base,models,jupyter,test'
+        description: 'Comma separated list of images to skip building, example with all possible images: mlrun,mlrun-gpu,ui,api,base,jupyter,test'
         required: false
         default: ''
       skip_publish_pypi:

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -238,8 +238,6 @@ jobs:
           --username "${{ secrets.LATEST_SYSTEM_TEST_USERNAME }}" \
           --access-key "${{ secrets.LATEST_SYSTEM_TEST_ACCESS_KEY }}" \
           --iguazio-version "${{ steps.computed_params.outputs.iguazio_version }}" \
-          --mysql-user "${{ secrets.LATEST_SYSTEM_TEST_MYSQL_USER }}" \
-          --mysql-password "${{ secrets.LATEST_SYSTEM_TEST_MYSQL_PASSWORD }}" \
           --mlrun-version "${{ steps.computed_params.outputs.mlrun_version }}" \
           --mlrun-ui-version "${{ steps.computed_params.outputs.mlrun_ui_version }}" \
           --mlrun-commit "${{ steps.computed_params.outputs.mlrun_hash }}" \

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -309,17 +309,21 @@ class MLRunPatcher:
         )
 
     def _reset_mlrun_db(self):
-        curr_worker_replicas = self._exec_remote(
-            [
-                "kubectl",
-                "-n",
-                "default-tenant",
-                "get",
-                "deployment",
-                "mlrun-api-worker",
-                "-o=jsonpath='{.spec.replicas}'",
-            ]
-        ).strip()
+        curr_worker_replicas = (
+            self._exec_remote(
+                [
+                    "kubectl",
+                    "-n",
+                    "default-tenant",
+                    "get",
+                    "deployment",
+                    "mlrun-api-worker",
+                    "-o=jsonpath='{.spec.replicas}'",
+                ]
+            )
+            .strip()
+            .strip("'")
+        )
         logger.info("Detected current worker replicas: %s", curr_worker_replicas)
 
         logger.info("Scaling down mlrun-api-chief")
@@ -392,6 +396,8 @@ class MLRunPatcher:
                 "exec",
                 "-it",
                 mlrun_db_pod,
+                "-c",
+                "mlrun-db",
                 "--",
                 "mysql",
                 "-u",
@@ -399,7 +405,7 @@ class MLRunPatcher:
                 "-S",
                 "/var/run/mysqld/mysql.sock",
                 "-e",
-                "'DROP DATABASE mlrun; CREATE DATABASE mlrun'",
+                "DROP DATABASE mlrun; CREATE DATABASE mlrun",
             ],
             live=True,
         )


### PR DESCRIPTION
A few fixes:
1. my-sql user and password secrets are no longer used in system test deployer.
2. Fix reset db on patch remote script