### PR TITLE
[Tensorflow] Fix import

### DIFF
--- a/mlrun/frameworks/tf_keras/callbacks/logging_callback.py
+++ b/mlrun/frameworks/tf_keras/callbacks/logging_callback.py
@@ -17,7 +17,7 @@ from typing import Callable, Union
 import numpy as np
 import tensorflow as tf
 from tensorflow import Tensor, Variable
-from tensorflow.keras.callbacks import Callback
+from tensorflow.python.keras.callbacks import Callback
 
 import mlrun
 

--- a/mlrun/frameworks/tf_keras/callbacks/logging_callback.py
+++ b/mlrun/frameworks/tf_keras/callbacks/logging_callback.py
@@ -15,9 +15,14 @@
 from typing import Callable, Union
 
 import numpy as np
+import semver
 import tensorflow as tf
 from tensorflow import Tensor, Variable
-from tensorflow.python.keras.callbacks import Callback
+
+if semver.VersionInfo.parse(tf.__version__) < semver.VersionInfo(2, 6):
+    from tensorflow.keras.callbacks import Callback
+else:
+    from keras.callbacks import Callback
 
 import mlrun
 

--- a/mlrun/frameworks/tf_keras/mlrun_interface.py
+++ b/mlrun/frameworks/tf_keras/mlrun_interface.py
@@ -19,7 +19,8 @@ from typing import Union
 
 import tensorflow as tf
 from tensorflow import keras
-from tensorflow.keras.callbacks import (
+from tensorflow.keras.optimizers import Optimizer
+from tensorflow.python.keras.callbacks import (
     BaseLogger,
     Callback,
     CSVLogger,
@@ -27,7 +28,6 @@ from tensorflow.keras.callbacks import (
     ProgbarLogger,
     TensorBoard,
 )
-from tensorflow.keras.optimizers import Optimizer
 
 import mlrun
 

--- a/mlrun/frameworks/tf_keras/mlrun_interface.py
+++ b/mlrun/frameworks/tf_keras/mlrun_interface.py
@@ -17,17 +17,29 @@ import os
 from abc import ABC
 from typing import Union
 
+import semver
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras.optimizers import Optimizer
-from tensorflow.python.keras.callbacks import (
-    BaseLogger,
-    Callback,
-    CSVLogger,
-    ModelCheckpoint,
-    ProgbarLogger,
-    TensorBoard,
-)
+
+if semver.VersionInfo.parse(tf.__version__) < semver.VersionInfo(2, 6):
+    from tensorflow.keras.callbacks import (
+        BaseLogger,
+        Callback,
+        CSVLogger,
+        ModelCheckpoint,
+        ProgbarLogger,
+        TensorBoard,
+    )
+else:
+    from keras.callbacks import (
+        BaseLogger,
+        Callback,
+        CSVLogger,
+        ModelCheckpoint,
+        ProgbarLogger,
+        TensorBoard,
+    )
 
 import mlrun
 


### PR DESCRIPTION
[ML-5916](https://iguazio.atlassian.net/browse/ML-5916)

tensorflow 2.16.1 breaks `tensorflow.keras.callbacks`.

`tensorflow.python.keras.callbacks` works with tensorflow 2.16.1 as well as with previous versions.

[ML-5916]: https://iguazio.atlassian.net/browse/ML-5916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ