### PR TITLE
[Retryer] Fix retryer not keeping last exception

### DIFF
--- a/mlrun/utils/retryer.py
+++ b/mlrun/utils/retryer.py
@@ -138,6 +138,7 @@ class Retryer:
         except mlrun.errors.MLRunFatalFailureError as exc:
             raise exc.original_exception
         except Exception as exc:
+            self.last_exception = exc
             return (
                 None,
                 self.last_exception,


### PR DESCRIPTION
This caused the retryer to not raise any exception when waiting for pipeline times out