### PR TITLE
[Tests] Allow running tests after previous failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -556,6 +556,7 @@ run-api-undockerized: ## Run mlrun api locally (un-dockerized)
 
 .PHONY: run-api
 run-api: api ## Run mlrun api (dockerized)
+	docker rm mlrun-api --force || true
 	docker run \
 		--name mlrun-api \
 		--detach \


### PR DESCRIPTION
Sometimes we have leftovers from previous runs
that prevent integration tests from running.