### PR TITLE
[API] Fix logging headers for incoming/responding requests

### DIFF
--- a/server/api/middlewares/request_logger.py
+++ b/server/api/middlewares/request_logger.py
@@ -132,4 +132,4 @@ class RequestLoggerMiddleware:
         for name, values in headers.items():
             if name in headers_to_omit:
                 del headers_to_log[name]
-        return headers_to_log
+        return dict(headers_to_log.items())


### PR DESCRIPTION
See differences below, note `MutableHeaders` on `before` does not exists on `after`

before

```
{"datetime":"2024-04-10 07:51:36,967","level":"debug","message":"Received request","with":{"client_address":"127.0.0.1:63807","headers":"MutableHeaders({'host': '0.0.0.0:8080', 'accept-encoding': 'gzip, deflate', 'accept': '*/*', 'connection': 'keep-alive', 'user-agent': 'HTTPie/3.2.2', 'x-v3io-username': 'admin'})","http_version":"1.1","method":"GET","request_id":"0c9a88d7-64af-4a54-b0c1-94a19fefcc3d","uri":"/api/projects?format=name_only"}}
```

after

```
{"datetime":"2024-04-10 07:49:14,346","level":"debug","message":"Received request","with":{"client_address":"127.0.0.1:63707","headers":{"accept":"*/*","accept-encoding":"gzip, deflate","connection":"keep-alive","host":"0.0.0.0:8080","user-agent":"HTTPie/3.2.2","x-v3io-username":"admin"},"http_version":"1.1","method":"GET","request_id":"510d1914-c0a4-42e2-8281-19b999a0796f","uri":"/api/projects?format=name_only"}}
```
