### PR TITLE
[Requirements] Bump igz-mgmt to 0.1.3

### DIFF
--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -4,7 +4,7 @@ dask-kubernetes~=0.11.0
 # 3.10.2 is bugged for python 3.9
 apscheduler>=3.10.3,<4
 objgraph~=3.6
-igz-mgmt~=0.1.1
+igz-mgmt~=0.1.3
 humanfriendly~=10.0
 fastapi~=0.110.0
 # in sqlalchemy>=2.0 there is breaking changes (such as in Table class autoload argument is removed)

--- a/server/api/utils/events/iguazio.py
+++ b/server/api/utils/events/iguazio.py
@@ -44,12 +44,11 @@ class Client(base_events.BaseEventClient):
                 self.access_key, event
             )
         except Exception as exc:
-            if self.verbose:
-                logger.warning(
-                    "Failed to emit event",
-                    event=event,
-                    exc_info=exc,
-                )
+            logger.warning(
+                "Failed to emit event",
+                event=event,
+                exc_info=exc,
+            )
 
     def generate_auth_secret_event(
         self,


### PR DESCRIPTION
system tests `test_audit_project_secret_events` and `test_delete_project_secret_events` fails while trying to use igz-mgmt version 0.1.2 because emit events fail due to schema instantiation errors. 
It was resolved in igz-mgmt version 0.1.3

Additionally, we can now view the error when an exception is raised.
