### PR TITLE
[API Reference] Add `mlrun.model_monitoring` docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Dockerfile.mlrun-test-nb
 docs/_build
 docs/external/*.html
 docs/external/*.md
+docs/api/generated_rsts/
 iteration_results.csv
 mlrun.egg-info/
 model.txt

--- a/docs/api/mlrun.model_monitoring.rst
+++ b/docs/api/mlrun.model_monitoring.rst
@@ -1,0 +1,12 @@
+mlrun.model_monitoring
+======================
+
+.. automodule:: mlrun.model_monitoring.api
+   :members:
+
+.. autoclass:: mlrun.model_monitoring.application.ModelMonitoringApplicationResult
+   :members:
+
+.. autoclass:: mlrun.model_monitoring.application.ModelMonitoringApplicationBase
+   :members:
+   :exclude-members: do


### PR DESCRIPTION
Resolves [ML-5526](https://iguazio.atlassian.net/browse/ML-5526).

Add generated RSTs to gitignore.

I verified that it shows in the docs with `make html-docs`.

[ML-5526]: https://iguazio.atlassian.net/browse/ML-5526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ