### PR TITLE
[Spark] Add streaming capabilities

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -43,14 +43,43 @@ from .utils import (
 )
 
 
-def load_spark_dataframe_with_options(session, spark_options, format=None):
+def load_spark_dataframe_with_options(
+    session, spark_options, format=None, streaming=None
+):
     non_hadoop_spark_options = spark_session_update_hadoop_options(
         session, spark_options
     )
-    if format:
-        df = session.read.format(format).load(**non_hadoop_spark_options)
+    if streaming:
+        # There are tons of messages like this one which are OK and we don't want to see them in the logs:
+        # WARN HDFSBackedStateStoreProvider: The state for version 1 doesn't exist in loadedMaps.
+        #       Reading snapshot file and delta files if needed...
+        #       Note that this is normal for the first batch of starting query.
+        # We'll suppress them by setting the log level to ERROR for the relevant logger.
+        # ToDo: we might consider disabling only this message by making a special .jar file
+        log4j = session._jvm.org.apache.log4j
+        logger = log4j.LogManager.getLogger(
+            "org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider"
+        )
+        logger.setLevel(log4j.Level.ERROR)
+
+        reader = session.read
+        if format:
+            reader = reader.format(format)
+        # if 'schema_infer_limit' in streaming:
+        #     df = reader.load(**non_hadoop_spark_options).limit(int(streaming['schema_infer_limit']))
+        # else:
+        df = reader.load(**non_hadoop_spark_options)
+        schema = df.schema
+        reader = session.readStream.schema(schema)
+        if format:
+            df = reader.format(format).load(**non_hadoop_spark_options)
+        else:
+            df = reader.load(**non_hadoop_spark_options)
     else:
-        df = session.read.load(**non_hadoop_spark_options)
+        if format:
+            df = session.read.format(format).load(**non_hadoop_spark_options)
+        else:
+            df = session.read.load(**non_hadoop_spark_options)
     return df
 
 
@@ -112,12 +141,14 @@ class BaseSourceDriver(DataSource):
             time_column=time_field or self.time_field,
         )
 
-    def to_spark_df(self, session, named_view=False, time_field=None, columns=None):
+    def to_spark_df(
+        self, session, named_view=False, time_field=None, columns=None, streaming=False
+    ):
         if self.support_spark:
             spark_options = self.get_spark_options()
             spark_format = spark_options.pop("format", None)
             df = load_spark_dataframe_with_options(
-                session, spark_options, format=spark_format
+                session, spark_options, format=spark_format, streaming=streaming
             )
             if named_view:
                 df.createOrReplaceTempView(self.name)
@@ -221,10 +252,14 @@ class CSVSource(BaseSourceDriver):
         )
         return spark_options
 
-    def to_spark_df(self, session, named_view=False, time_field=None, columns=None):
+    def to_spark_df(
+        self, session, named_view=False, time_field=None, columns=None, streaming=None
+    ):
         import pyspark.sql.functions as funcs
 
-        df = load_spark_dataframe_with_options(session, self.get_spark_options())
+        df = load_spark_dataframe_with_options(
+            session, self.get_spark_options(), streaming=streaming
+        )
 
         parse_dates = self._parse_dates or []
         if time_field and time_field not in parse_dates:
@@ -571,7 +606,9 @@ class BigQuerySource(BaseSourceDriver):
     def is_iterator(self):
         return bool(self.attributes.get("chunksize"))
 
-    def to_spark_df(self, session, named_view=False, time_field=None, columns=None):
+    def to_spark_df(
+        self, session, named_view=False, time_field=None, columns=None, streaming=None
+    ):
         options = copy(self.attributes.get("spark_options", {}))
         credentials, gcp_project = self._get_credentials_string()
         if credentials:
@@ -598,7 +635,9 @@ class BigQuerySource(BaseSourceDriver):
         elif table:
             options["path"] = table
 
-        df = load_spark_dataframe_with_options(session, options, "bigquery")
+        df = load_spark_dataframe_with_options(
+            session, options, "bigquery", streaming=streaming
+        )
         if named_view:
             df.createOrReplaceTempView(self.name)
         return self._filter_spark_df(df, time_field, columns)
@@ -983,7 +1022,9 @@ class KafkaSource(OnlineSource):
 
         return function
 
-    def to_spark_df(self, session, named_view=False, time_field=None, columns=None):
+    def to_spark_df(
+        self, session, named_view=False, time_field=None, columns=None, streaming=None
+    ):
         raise NotImplementedError(
             "Conversion of a source of type 'KafkaSource' "
             "to a Spark dataframe is not possible, as this operation is not supported by Spark"

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -1088,7 +1088,11 @@ def _ingest_with_spark(
         elif isinstance(source, pyspark.sql.DataFrame):
             df = source
         else:
-            df = source.to_spark_df(spark, time_field=timestamp_key)
+            df = source.to_spark_df(
+                spark,
+                time_field=timestamp_key,
+                streaming=bool(featureset.spec.checkpoint_path),
+            )
         if featureset.spec.graph and featureset.spec.graph.steps:
             df = run_spark_graph(df, featureset, namespace, spark)
 

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 import warnings
 from datetime import datetime
 from typing import Optional, Union
@@ -87,6 +88,7 @@ class FeatureSetSpec(ModelObj):
         engine=None,
         output_path=None,
         passthrough=None,
+        checkpoint_path=None,
     ):
         """Feature set spec object, defines the feature-set's configuration.
 
@@ -133,6 +135,7 @@ class FeatureSetSpec(ModelObj):
         self.engine = engine
         self.output_path = output_path or mlconf.artifact_path
         self.passthrough = passthrough
+        self.checkpoint_path = checkpoint_path
         self.with_default_targets = True
 
     @property
@@ -331,6 +334,7 @@ class FeatureSet(ModelObj):
         label_column: str = None,
         relations: dict[str, Union[Entity, str]] = None,
         passthrough: bool = None,
+        checkpoint_path: str = None,
     ):
         """Feature set object, defines a set of features and their data pipeline
 
@@ -366,6 +370,7 @@ class FeatureSet(ModelObj):
             label_column=label_column,
             relations=relations,
             passthrough=passthrough,
+            checkpoint_path=checkpoint_path,
         )
 
         if timestamp_key in self.spec.entities.keys():
@@ -814,6 +819,13 @@ class FeatureSet(ModelObj):
                 key_columns = []
                 if emit_policy:
                     class_args["emit_policy"] = emit_policy_to_dict(emit_policy)
+                if self.spec.checkpoint_path:
+                    checkpoint_path = (
+                        self.spec.checkpoint_path
+                        if self.spec.checkpoint_path.endswith("/")
+                        else self.spec.checkpoint_path + "/"
+                    )
+                    class_args["checkpoint_path"] = checkpoint_path + self.fullname
                 for entity in self.spec.entities:
                     key_columns.append(entity.name)
                 step = graph.add_step(
@@ -1188,11 +1200,13 @@ class SparkAggregateByKey(StepToDict):
         key_columns: list[str],
         time_column: str,
         aggregates: list[dict],
+        checkpoint_path: str = None,
         emit_policy: Union[EmitPolicy, dict] = None,
     ):
         self.key_columns = key_columns
         self.time_column = time_column
         self.aggregates = aggregates
+        self.checkpoint_path = checkpoint_path
         self.emit_policy_mode = None
         if emit_policy:
             if isinstance(emit_policy, EmitPolicy):
@@ -1277,18 +1291,76 @@ class SparkAggregateByKey(StepToDict):
                 for window in windows:
                     spark_window = self._duration_to_spark_format(window)
                     aggs = last_value_aggs
+                    all_aggs_names = ""
                     for operation in operations:
                         agg = self._get_aggr(operation, column)
                         agg_name = f"{name if name else column}_{operation}_{window}"
                         agg = agg.alias(agg_name)
                         aggs.append(agg)
+                        all_aggs_names = all_aggs_names + agg_name
                     window_column = funcs.window(
                         time_column, spark_window, spark_period
                     )
-                    df = input_df.groupBy(
-                        *self.key_columns,
-                        window_column.end.alias(time_column),
-                    ).agg(*aggs)
+                    if input_df.isStreaming:
+
+                        class MyBatchProcessor:
+                            def __init__(self):
+                                self.df = None
+
+                            def __call__(self, df, epoch_id):
+                                self.df = df
+
+                        batchProcessor = MyBatchProcessor()
+
+                        df = (
+                            input_df.withWatermark(time_column, spark_window)
+                            .groupBy(
+                                *self.key_columns,
+                                window_column.alias(time_column),
+                            )
+                            .agg(*aggs)
+                        )
+
+                        if self.checkpoint_path:
+                            checkpoint_path = (
+                                self.checkpoint_path
+                                if self.checkpoint_path.endswith("/")
+                                else self.checkpoint_path + "/"
+                            )
+                            local_dir = (
+                                time_column
+                                + spark_window
+                                + spark_period
+                                + all_aggs_names
+                            )
+                            local_dir = re.sub(r"[^a-zA-Z0-9]", "", local_dir)
+                            checkpoint_path = checkpoint_path + local_dir
+                            store, path, url = mlrun.store_manager.get_or_create_store(
+                                checkpoint_path
+                            )
+                            store.filesystem.makedirs(path, exist_ok=True)
+
+                            query = (
+                                df.writeStream.outputMode("update")
+                                .trigger(once=True)
+                                .foreachBatch(batchProcessor)
+                                .option("checkpointLocation", checkpoint_path)
+                                .start()
+                            )
+                            query.awaitTermination()
+                            df = batchProcessor.df.withColumn(
+                                time_column, funcs.col(f"{time_column}.end")
+                            )
+                        else:
+                            raise mlrun.errors.MLRunInvalidArgumentError(
+                                "checkpoint_path is required for streaming data"
+                            )
+                    else:
+                        df = input_df.groupBy(
+                            *self.key_columns,
+                            window_column.end.alias(time_column),
+                        ).agg(*aggs)
+
                     df = df.withColumn(f"{time_column}_window", funcs.lit(window))
                     dfs.append(df)
 

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -24,6 +24,14 @@ import pandas as pd
 import pytest
 import v3iofs
 from pandas._testing import assert_frame_equal
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
 from storey import EmitEveryEvent
 
 import mlrun
@@ -712,6 +720,241 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         resp = fstore.get_offline_features(vec)
         assert len(resp.to_dataframe() == 4)
         assert "uri" not in resp.to_dataframe() and "katya" not in resp.to_dataframe()
+
+    def test_stream_aggregation(self):
+        name = f"measurements_{uuid.uuid4()}"
+        test_base_time = datetime.fromisoformat("2020-07-21T21:40:00+00:00")
+
+        schema = StructType(
+            [
+                StructField("time", TimestampType(), True),
+                StructField("first_name", StringType(), True),
+                StructField("last_name", StringType(), True),
+                StructField("bid", IntegerType(), True),
+                StructField("mood", StringType(), True),
+            ]
+        )
+
+        data = (
+            {
+                "time": [
+                    test_base_time,
+                    test_base_time + pd.Timedelta(minutes=7),
+                    test_base_time + pd.Timedelta(minutes=14),
+                    test_base_time + pd.Timedelta(minutes=21),
+                    test_base_time + pd.Timedelta(minutes=28),
+                ],
+                "first_name": ["moshe", "yosi", "yosi", "moshe", "yosi"],
+                "last_name": ["cohen", "levi", "levi", "cohen", "levi"],
+                "bid": [2000, 10, 11, 12, 16],
+                "mood": ["bad", "good", "bad", "good", "good"],
+            },
+            {
+                "time": [
+                    test_base_time + pd.Timedelta(minutes=35),
+                    test_base_time + pd.Timedelta(minutes=42),
+                ],
+                "first_name": ["moshe", "yosi"],
+                "last_name": ["cohen", "levi"],
+                "bid": [20, 40],
+                "mood": ["bad", "good"],
+            },
+        )
+
+        checkpoint_path = "/tmp/checkpoints/"
+        path = f"{self.output_dir(url=False)}/test_aggregations_parquet/"
+        fsys = fsspec.filesystem(
+            "file" if self.run_local else v3iofs.fs.V3ioFS.protocol
+        )
+        try:
+            fsys.rm(checkpoint_path, recursive=True)
+        except FileNotFoundError:
+            pass
+
+        name_spark = f"{name}_spark"
+
+        for i in range(2):
+            # Cleanup parquet directory
+            try:
+                fsys.rm(path, recursive=True)
+            except FileNotFoundError:
+                pass
+            fsys.makedirs(path)
+
+            # Create Spark DataFrame
+            # Convert the dictionary to a list of rows
+            rows = list(
+                zip(
+                    data[i]["time"],
+                    data[i]["first_name"],
+                    data[i]["last_name"],
+                    data[i]["bid"],
+                    data[i]["mood"],
+                )
+            )
+            spark = SparkSession.builder.appName("test").getOrCreate()
+            spark_df = spark.createDataFrame(rows, schema)
+
+            # write the spark dataframe to parquet
+            spark_df.write.mode("append").parquet(path)
+
+            source = ParquetSource("myparquet", path=path)
+
+            data_set = fstore.FeatureSet(
+                name_spark,
+                entities=[Entity("first_name"), Entity("last_name")],
+                engine="spark",
+                checkpoint_path=checkpoint_path,
+            )
+
+            data_set.add_aggregation(
+                column="bid",
+                operations=["sum", "max", "sqr", "stdvar"],
+                windows="1h",
+                period="10m",
+            )
+            self.set_targets(data_set)
+            data_set.ingest(
+                source,
+                spark_context=self.spark_service,
+                run_config=fstore.RunConfig(local=self.run_local),
+            )
+
+        features = [
+            f"{name_spark}.*",
+        ]
+
+        vector = fstore.FeatureVector("my-vec", features)
+        resp = fstore.get_offline_features(vector, with_indexes=True)
+
+        df = resp.to_dataframe()
+        df = df.fillna("NaN-was-here")
+        # We can't count on the order when reading the results back
+        result_records = df.sort_values(["first_name", "last_name", "time"]).to_dict(
+            "records"
+        )
+        assert result_records == [
+            {
+                "bid_sum_1h": 2032,
+                "bid_max_1h": 2000,
+                "bid_sqr_1h": 4000544,
+                "bid_stdvar_1h": 1312101.3333333335,
+                "time": pd.Timestamp("2020-07-21 22:20:00"),
+                "bid": 20,
+                "mood": "bad",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 2032,
+                "bid_max_1h": 2000,
+                "bid_sqr_1h": 4000544,
+                "bid_stdvar_1h": 1312101.3333333335,
+                "time": pd.Timestamp("2020-07-21 22:30:00"),
+                "bid": 20,
+                "mood": "bad",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 2032,
+                "bid_max_1h": 2000,
+                "bid_sqr_1h": 4000544,
+                "bid_stdvar_1h": 1312101.3333333335,
+                "time": pd.Timestamp("2020-07-21 22:40:00"),
+                "bid": 20,
+                "mood": "bad",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 32,
+                "bid_max_1h": 20,
+                "bid_sqr_1h": 544,
+                "bid_stdvar_1h": 32.0,
+                "time": pd.Timestamp("2020-07-21 22:50:00"),
+                "bid": 20,
+                "mood": "bad",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 32,
+                "bid_max_1h": 20,
+                "bid_sqr_1h": 544,
+                "bid_stdvar_1h": 32.0,
+                "time": pd.Timestamp("2020-07-21 23:00:00"),
+                "bid": 20,
+                "mood": "bad",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 20,
+                "bid_max_1h": 20,
+                "bid_sqr_1h": 400,
+                "bid_stdvar_1h": "NaN-was-here",
+                "time": pd.Timestamp("2020-07-21 23:10:00"),
+                "bid": 20,
+                "mood": "bad",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 77,
+                "bid_max_1h": 40,
+                "bid_sqr_1h": 2077,
+                "bid_stdvar_1h": 198.24999999999997,
+                "time": pd.Timestamp("2020-07-21 22:30:00"),
+                "bid": 40,
+                "mood": "good",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 77,
+                "bid_max_1h": 40,
+                "bid_sqr_1h": 2077,
+                "bid_stdvar_1h": 198.24999999999997,
+                "time": pd.Timestamp("2020-07-21 22:40:00"),
+                "bid": 40,
+                "mood": "good",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 67,
+                "bid_max_1h": 40,
+                "bid_sqr_1h": 1977,
+                "bid_stdvar_1h": 240.33333333333334,
+                "time": pd.Timestamp("2020-07-21 22:50:00"),
+                "bid": 40,
+                "mood": "good",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 56,
+                "bid_max_1h": 40,
+                "bid_sqr_1h": 1856,
+                "bid_stdvar_1h": 288.0,
+                "time": pd.Timestamp("2020-07-21 23:00:00"),
+                "bid": 40,
+                "mood": "good",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 40,
+                "bid_max_1h": 40,
+                "bid_sqr_1h": 1600,
+                "bid_stdvar_1h": "NaN-was-here",
+                "time": pd.Timestamp("2020-07-21 23:10:00"),
+                "bid": 40,
+                "mood": "good",
+                "time_window": "1h",
+            },
+            {
+                "bid_sum_1h": 40,
+                "bid_max_1h": 40,
+                "bid_sqr_1h": 1600,
+                "bid_stdvar_1h": "NaN-was-here",
+                "time": pd.Timestamp("2020-07-21 23:20:00"),
+                "bid": 40,
+                "mood": "good",
+                "time_window": "1h",
+            },
+        ]
 
     def test_aggregations(self):
         name = f"measurements_{uuid.uuid4()}"


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-3892

This is an initial draft for integrating Spark Streaming into the Spark aggregation engine. As it is a preliminary version, there are several functionalities missing and numerous questions that remain unresolved:

1. **Schema Inferring**: Unlike other contexts where schema may be inferred automatically, Spark Streaming requires an explicit schema to be provided. The current implementation involves creating a static DataFrame just to deduce the schema on each iteration.
2. **Local Testing**: The functionality has been tested solely on a local environment. However, it is expected to function seamlessly on Spark's pods 'out of the box'.
3. **Checkpoint Path**: The compatibility of the checkpoint path with datastore profiles needs verification beyond just native URLs.
4. **Logging Warnings**: Utilizing Spark's streaming capabilities one iteration at a time generates numerous log warnings. Currently, I mitigate this by setting the log level of `org.apache.spark.sql.execution.streaming.state.HDFSBackedStateStoreProvider` to warning.
5. **Growing Checkpoint Directory**: The checkpoint directory size increases continuously; thus, it is imperative to establish provisioning guidelines for users.
