### PR TITLE
[Model Monitoring] Delete pipelines `access_key` from SERVING_SPEC_ENV [1.6.x]

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -350,7 +350,6 @@ class EventStreamProcessor:
                     rate="10/m",
                     time_col=EventFieldType.TIMESTAMP,
                     container=self.tsdb_container,
-                    access_key=self.v3io_access_key,
                     v3io_frames=self.v3io_framesd,
                     infer_columns_from_data=True,
                     index_cols=[


### PR DESCRIPTION
#5423 

(cherry picked from commit 8e801eb0972eaf167381777c219c1b792bbd7fa5)