### PR TITLE
[Docs] Fix text block formatting

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2669,17 +2669,20 @@ class MlrunProject(ModelObj):
         file_path: str = None,
         provider: typing.Union[str, mlrun.common.schemas.SecretProviderName] = None,
     ):
-        """set project secrets from dict or secrets env file
+        """
+        Set project secrets from dict or secrets env file
         when using a secrets file it should have lines in the form KEY=VALUE, comment line start with "#"
         V3IO paths/credentials and MLrun service API address are dropped from the secrets
 
-        example secrets file::
+        example secrets file:
+
+        .. code-block:: text
 
             # this is an env file
-            AWS_ACCESS_KEY_ID = XXXX
-            AWS_SECRET_ACCESS_KEY = YYYY
+            AWS_ACCESS_KEY_ID=XXXX
+            AWS_SECRET_ACCESS_KEY=YYYY
 
-        usage::
+        usage:
 
             # read env vars from dict or file and set as project secrets
             project.set_secrets({"SECRET1": "value"})

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2676,7 +2676,7 @@ class MlrunProject(ModelObj):
 
         example secrets file:
 
-        .. code-block:: text
+        .. code-block:: shell
 
             # this is an env file
             AWS_ACCESS_KEY_ID=XXXX


### PR DESCRIPTION
Fix the spaces `ENV_VAR = VAL` --> `ENV_VAR=VAL` in the docstrings introduced in https://github.com/mlrun/mlrun/pull/5420.
Remove the spaces in the text code block by specifying the language.

The API reference after this change:
![image](https://github.com/mlrun/mlrun/assets/36337649/c1687576-ae06-450c-9797-cef0cc188758)
