### PR TITLE
[Serving] Revert #5322

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -295,9 +295,7 @@ class ServingRuntime(RemoteRuntime):
                         "provided class is not a router step, must provide a router class in router topology"
                     )
             else:
-                step = RouterStep(
-                    class_name=class_name, class_args=class_args, engine=engine
-                )
+                step = RouterStep(class_name=class_name, class_args=class_args)
             self.spec.graph = step
         elif topology == StepKinds.flow:
             self.spec.graph = RootFlowStep(engine=engine)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -590,7 +590,7 @@ class RouterStep(TaskStep):
 
     kind = "router"
     default_shape = "doubleoctagon"
-    _dict_fields = _task_step_fields + ["routes", "engine"]
+    _dict_fields = _task_step_fields + ["routes"]
     _default_class = "mlrun.serving.ModelRouter"
 
     def __init__(
@@ -603,7 +603,6 @@ class RouterStep(TaskStep):
         function: str = None,
         input_path: str = None,
         result_path: str = None,
-        engine: str = None,
     ):
         super().__init__(
             class_name,
@@ -616,8 +615,6 @@ class RouterStep(TaskStep):
         )
         self._routes: ObjectDict = None
         self.routes = routes
-        self.engine = engine
-        self._controller = None
 
     def get_children(self):
         """get child steps (routes)"""
@@ -686,33 +683,6 @@ class RouterStep(TaskStep):
 
         self._set_error_handler()
         self._post_init(mode)
-
-        if self.engine == "async":
-            self._build_async_flow()
-            self._run_async_flow()
-
-    def _build_async_flow(self):
-        """initialize and build the async/storey DAG"""
-
-        self.respond()
-        source, self._wait_for_result = _init_async_objects(self.context, [self])
-        source.to(self.async_object)
-
-        self._async_flow = source
-
-    def _run_async_flow(self):
-        self._controller = self._async_flow.run()
-
-    def run(self, event, *args, **kwargs):
-        if self._controller:
-            # async flow (using storey)
-            event._awaitable_result = None
-            resp = self._controller.emit(
-                event, return_awaitable_result=self._wait_for_result
-            )
-            return resp.await_result()
-
-        return super().run(event, *args, **kwargs)
 
     def __getitem__(self, name):
         return self._routes[name]

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -247,8 +247,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
     image: Optional[str] = None
 
     @pytest.mark.timeout(270)
-    @pytest.mark.parametrize("engine", ["sync", "async"])
-    def test_basic_model_monitoring(self, engine) -> None:
+    def test_basic_model_monitoring(self) -> None:
         # Main validations:
         # 1 - a single model endpoint is created
         # 2 - stream metrics are recorded as expected under the model endpoint
@@ -271,11 +270,6 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         serving_fn = mlrun.import_function(
             "hub://v2-model-server", project=self.project_name
         ).apply(mlrun.auto_mount())
-
-        serving_fn.set_topology(
-            "router",
-            engine=engine,
-        )
 
         # enable model monitoring
         serving_fn.set_tracking()


### PR DESCRIPTION
The original change was a first step in implementing [ML-5136](https://iguazio.atlassian.net/browse/ML-5136), but is no longer necessary because we have decided to direct users to flow topology instead, and ultimately deprecate router topology.

[ML-5136]: https://iguazio.atlassian.net/browse/ML-5136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ