### PR TITLE
[Projects] Make store_project async and refresh cached result

### DIFF
--- a/server/api/api/endpoints/projects.py
+++ b/server/api/api/endpoints/projects.py
@@ -72,7 +72,7 @@ def create_project(
         http.HTTPStatus.ACCEPTED.value: {},
     },
 )
-def store_project(
+async def store_project(
     project: mlrun.common.schemas.Project,
     name: str,
     # TODO: we're in a http request context here, therefore it doesn't make sense that by default it will hold the
@@ -85,7 +85,8 @@ def store_project(
         server.api.api.deps.get_db_session
     ),
 ):
-    project, is_running_in_background = get_project_member().store_project(
+    project, is_running_in_background = await run_in_threadpool(
+        get_project_member().store_project,
         db_session,
         name,
         project,

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2375,6 +2375,9 @@ class SQLDB(DBInterface):
         project_record.source = project.spec.source
         project_record.owner = project.spec.owner
         project_record.state = project.status.state
+        project_record.default_function_node_selector = (
+            project.spec.default_function_node_selector
+        )
         labels = project.metadata.labels or {}
         update_labels(project_record, labels)
         self._upsert(session, [project_record])
@@ -3901,6 +3904,7 @@ class SQLDB(DBInterface):
                 spec=mlrun.common.schemas.ProjectSpec(
                     description=project_record.description,
                     source=project_record.source,
+                    default_function_node_selector=project_record.default_function_node_selector,
                 ),
                 status=mlrun.common.schemas.ObjectStatus(
                     state=project_record.state,

--- a/server/api/utils/clients/iguazio.py
+++ b/server/api/utils/clients/iguazio.py
@@ -755,6 +755,13 @@ class Client(
             )
         if project.spec.owner:
             body["data"]["attributes"]["owner_username"] = project.spec.owner
+
+        if project.spec.default_function_node_selector is not None:
+            body["data"]["attributes"]["default_function_node_selector"] = (
+                Client._transform_mlrun_labels_to_iguazio_labels(
+                    project.spec.default_function_node_selector
+                )
+            )
         return body
 
     @staticmethod

--- a/server/api/utils/projects/follower.py
+++ b/server/api/utils/projects/follower.py
@@ -150,7 +150,9 @@ class Member(
                 )
             else:
                 self._leader_client.update_project(leader_session, name, project)
-                return self.get_project(db_session, name, leader_session), False
+                return server.api.db.session.run_function_with_new_db_session(
+                    self.get_project, name, leader_session
+                ), False
 
     def patch_project(
         self,

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -1088,10 +1088,15 @@ def _generate_project(
     annotations=None,
     created=None,
     owner="project-owner",
+    default_function_node_selector=None,
 ) -> mlrun.common.schemas.Project:
     if labels is None:
         labels = {
             "some-label": "some-label-value",
+        }
+    if default_function_node_selector is None:
+        default_function_node_selector = {
+            "zone": "us-west-1"
         }
     if annotations is None:
         annotations = {
@@ -1110,6 +1115,7 @@ def _generate_project(
             desired_state=mlrun.common.schemas.ProjectState.online,
             owner=owner,
             some_extra_field="some value",
+            default_function_node_selector=default_function_node_selector,
         ),
         status=mlrun.common.schemas.ProjectStatus(
             some_extra_field="some value",
@@ -1135,6 +1141,7 @@ def _build_project_response(
             "updated_at": datetime.datetime.utcnow().isoformat(),
             "admin_status": project.spec.desired_state
             or mlrun.common.schemas.ProjectState.online,
+            "default_function_node_selector": [],
         },
     }
     if with_mlrun_project:
@@ -1153,6 +1160,12 @@ def _build_project_response(
         body["attributes"]["labels"] = (
             iguazio_client._transform_mlrun_labels_to_iguazio_labels(
                 project.metadata.labels
+            )
+        )
+    if project.spec.default_function_node_selector:
+        body["attributes"]["default_function_node_selector"] = (
+            iguazio_client._transform_mlrun_labels_to_iguazio_labels(
+                project.spec.default_function_node_selector
             )
         )
     if project.metadata.annotations:

--- a/tests/api/utils/clients/test_iguazio.py
+++ b/tests/api/utils/clients/test_iguazio.py
@@ -1095,9 +1095,7 @@ def _generate_project(
             "some-label": "some-label-value",
         }
     if default_function_node_selector is None:
-        default_function_node_selector = {
-            "zone": "us-west-1"
-        }
+        default_function_node_selector = {"zone": "us-west-1"}
     if annotations is None:
         annotations = {
             "some-annotation": "some-annotation-value",


### PR DESCRIPTION
Fixes in this PR:
- Refactor `store_project` to be asynchronous
- Update the return value to use a new DB session; ensuring it captures the latest changes and updated fields.
- Fix support for default function node selector
