### PR TITLE
[Pipelines] Add a boilerplate pipeline adapter package for KFPv2 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,19 +138,25 @@ jobs:
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
 
   package-tests:
-    name: Run package tests (Python ${{ matrix.python-version }})
+    name: Run package tests (Python ${{ matrix.python-version }}; Pipeline ${{ matrix.pipeline-adapter }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # 3.9 is the current >= 1.3.0 python version
         python-version: [3.9]
+        default-pipeline-adapter: ["kfp-v1-8"]
+        pipeline-adapter: ["kfp-v1-8", "kfp-v2"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        pipeline-adapter: ${{ matrix.pipeline-adapter }}
         cache: 'pip'
+    - name: Change default pipeline adapter for MLRun
+      if: matrix.default-pipeline-adapter != matrix.pipeline-adapter
+      run: sed -i -e 's/${{ matrix.default-pipeline-adapter }}/${{ matrix.pipeline-adapter }}/g' requirements.txt
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: pip install -r automation/requirements.txt && pip install -e .
     - name: Test package

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from setuptools import find_namespace_packages, setup
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mlrun-kfp-setup")
+
+setup(
+    name="mlrun-pipelines-kfp-v2-experiment",
+    version="0.1.2",
+    description="MLRun Pipelines package for providing KFP 2.* compatibility",
+    author="Yaron Haviv",
+    author_email="yaronh@iguazio.com",
+    license="Apache License 2.0",
+    url="https://github.com/mlrun/mlrun",
+    packages=find_namespace_packages(
+        where="src/",
+        include=[
+            "mlrun_pipelines",
+        ],
+    ),
+    package_dir={"": "src"},
+    keywords=[
+        "mlrun",
+        "kfp",
+    ],
+    python_requires=">=3.9, <3.12",
+    install_requires=[
+        "kfp[kubernetes]~=2.5.0",
+    ],
+)

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/helpers.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/helpers.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import typing
+
+
+def new_pipe_metadata(
+    artifact_path: str = None,
+    cleanup_ttl: int = None,
+    op_transformers: list[typing.Callable] = None,
+):
+    # This function is not required on a KFP 2.0 setup
+    # The definition is here for import compatibilty reasons
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mixins.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mixins.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class KfpAdapterMixin:
+    def apply(self, modify):
+        """
+        Apply a modifier to the runtime which is used to change the runtimes k8s object's spec.
+        Modifiers can be either KFP modifiers or MLRun modifiers (which are compatible with KFP)
+
+        :param modify: a modifier runnable object
+        :return: the runtime (self) after the modifications
+        """
+        raise NotImplementedError
+
+
+class PipelineProviderMixin:
+    def resolve_project_from_workflow_manifest(self, workflow_manifest):
+        raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/models.py
@@ -1,0 +1,100 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from kfp.dsl import PipelineTask
+from mlrun_pipelines.common.helpers import FlexibleMapper
+
+# class pointer for type checking on the main MLRun codebase
+PipelineNodeWrapper = PipelineTask
+
+
+class PipelineManifest(FlexibleMapper):
+    """
+    A Pipeline Manifest might have been created by an 1.8 SDK regardless of coming from a 2.0 API,
+    so this class tries to account for that
+    """
+
+    def get_schema_version(self) -> str:
+        raise NotImplementedError
+
+    def is_argo_compatible(self) -> bool:
+        raise NotImplementedError
+
+    def get_executors(self):
+        raise NotImplementedError
+
+
+class PipelineRun(FlexibleMapper):
+    @property
+    def id(self):
+        raise NotImplementedError
+
+    @property
+    def name(self):
+        raise NotImplementedError
+
+    @name.setter
+    def name(self, name):
+        raise NotImplementedError
+
+    @property
+    def status(self):
+        raise NotImplementedError
+
+    @status.setter
+    def status(self, status):
+        raise NotImplementedError
+
+    @property
+    def description(self):
+        raise NotImplementedError
+
+    @description.setter
+    def description(self, description):
+        raise NotImplementedError
+
+    @property
+    def created_at(self):
+        raise NotImplementedError
+
+    @created_at.setter
+    def created_at(self, created_at):
+        raise NotImplementedError
+
+    @property
+    def scheduled_at(self):
+        raise NotImplementedError
+
+    @scheduled_at.setter
+    def scheduled_at(self, scheduled_at):
+        raise NotImplementedError
+
+    @property
+    def finished_at(self):
+        raise NotImplementedError
+
+    @finished_at.setter
+    def finished_at(self, finished_at):
+        raise NotImplementedError
+
+    @property
+    def workflow_manifest(self) -> PipelineManifest:
+        raise NotImplementedError
+
+
+class PipelineExperiment(FlexibleMapper):
+    @property
+    def id(self):
+        raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
@@ -1,0 +1,172 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def v3io_cred(api="", user="", access_key=""):
+    """
+    Modifier function to copy local v3io env vars to container
+
+    Usage::
+
+        train = train_op(...)
+        train.apply(use_v3io_cred())
+    """
+    raise NotImplementedError
+
+
+def mount_v3io(
+    name="v3io",
+    remote="",
+    access_key="",
+    user="",
+    secret=None,
+    volume_mounts=None,
+):
+    """Modifier function to apply to a Container Op to volume mount a v3io path
+
+    :param name:            the volume name
+    :param remote:          the v3io path to use for the volume. ~/ prefix will be replaced with /users/<username>/
+    :param access_key:      the access key used to auth against v3io. if not given V3IO_ACCESS_KEY env var will be used
+    :param user:            the username used to auth against v3io. if not given V3IO_USERNAME env var will be used
+    :param secret:          k8s secret name which would be used to get the username and access key to auth against v3io.
+    :param volume_mounts:   list of VolumeMount. empty volume mounts & remote will default to mount /v3io & /User.
+    """
+    raise NotImplementedError
+
+
+def mount_v3iod(namespace, v3io_config_configmap):
+    raise NotImplementedError
+
+
+def mount_pvc(pvc_name=None, volume_name="pipeline", volume_mount_path="/mnt/pipeline"):
+    """
+    Modifier function to apply to a Container Op to simplify volume, volume mount addition and
+    enable better reuse of volumes, volume claims across container ops.
+
+    Usage::
+
+        train = train_op(...)
+        train.apply(mount_pvc('claim-name', 'pipeline', '/mnt/pipeline'))
+    """
+    raise NotImplementedError
+
+
+def set_env_variables(env_vars_dict: dict[str, str] = None, **kwargs):
+    """
+    Modifier function to apply a set of environment variables to a runtime. Variables may be passed
+    as either a dictionary of name-value pairs, or as arguments to the function.
+    See `KubeResource.apply` for more information on modifiers.
+
+    Usage::
+
+        function.apply(set_env_variables({"ENV1": "value1", "ENV2": "value2"}))
+        or
+        function.apply(set_env_variables(ENV1=value1, ENV2=value2))
+
+    :param env_vars_dict: dictionary of env. variables
+    :param kwargs: environment variables passed as args
+    """
+    raise NotImplementedError
+
+
+def mount_s3(
+    secret_name=None,
+    aws_access_key="",
+    aws_secret_key="",
+    endpoint_url=None,
+    prefix="",
+    aws_region=None,
+    non_anonymous=False,
+):
+    """Modifier function to add s3 env vars or secrets to container
+
+    **Warning:**
+    Using this function to configure AWS credentials will expose these credentials in the pod spec of the runtime
+    created. It is recommended to use the `secret_name` parameter, or set the credentials as project-secrets and avoid
+    using this function.
+
+    :param secret_name: kubernetes secret name (storing the access/secret keys)
+    :param aws_access_key: AWS_ACCESS_KEY_ID value. If this parameter is not specified and AWS_ACCESS_KEY_ID env.
+                            variable is defined, the value will be taken from the env. variable
+    :param aws_secret_key: AWS_SECRET_ACCESS_KEY value. If this parameter is not specified and AWS_SECRET_ACCESS_KEY
+                            env. variable is defined, the value will be taken from the env. variable
+    :param endpoint_url: s3 endpoint address (for non AWS s3)
+    :param prefix: string prefix to add before the env var name (for working with multiple s3 data stores)
+    :param aws_region: amazon region
+    :param non_anonymous: force the S3 API to use non-anonymous connection, even if no credentials are provided
+        (for authenticating externally, such as through IAM instance-roles)
+    """
+    raise NotImplementedError
+
+
+def mount_spark_conf():
+    raise NotImplementedError
+
+
+def mount_secret(secret_name, mount_path, volume_name="secret", items=None):
+    """Modifier function to mount kubernetes secret as files(s)
+
+    :param secret_name:  k8s secret name
+    :param mount_path:   path to mount inside the container
+    :param volume_name:  unique volume name
+    :param items:        If unspecified, each key-value pair in the Data field
+                         of the referenced Secret will be projected into the
+                         volume as a file whose name is the key and content is
+                         the value.
+                         If specified, the listed keys will be projected into
+                         the specified paths, and unlisted keys will not be
+                         present.
+    """
+    raise NotImplementedError
+
+
+def mount_configmap(configmap_name, mount_path, volume_name="configmap", items=None):
+    """Modifier function to mount kubernetes configmap as files(s)
+
+    :param configmap_name:  k8s configmap name
+    :param mount_path:      path to mount inside the container
+    :param volume_name:     unique volume name
+    :param items:           If unspecified, each key-value pair in the Data field
+                            of the referenced Configmap will be projected into the
+                            volume as a file whose name is the key and content is
+                            the value.
+                            If specified, the listed keys will be projected into
+                            the specified paths, and unlisted keys will not be
+                            present.
+    """
+    raise NotImplementedError
+
+
+def mount_hostpath(host_path, mount_path, volume_name="hostpath"):
+    """Modifier function to mount kubernetes configmap as files(s)
+
+    :param host_path:  host path
+    :param mount_path:   path to mount inside the container
+    :param volume_name:  unique volume name
+    """
+    raise NotImplementedError
+
+
+# auto_mount has to be moved to the mlrun_pipelines.common
+def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
+    """choose the mount based on env variables and params
+
+    volume will be selected by the following order:
+    - k8s PVC volume when both pvc_name and volume_mount_path are set
+    - k8s PVC volume when env var is set: MLRUN_PVC_MOUNT=<pvc-name>:<mount-path>
+    - k8s PVC volume if it's configured as the auto mount type
+    - iguazio v3io volume when V3IO_ACCESS_KEY and V3IO_USERNAME env vars are set
+    """
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
@@ -159,7 +159,6 @@ def mount_hostpath(host_path, mount_path, volume_name="hostpath"):
     raise NotImplementedError
 
 
-# auto_mount has to be moved to the mlrun_pipelines.common
 def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
     """choose the mount based on env variables and params
 

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
@@ -1,0 +1,84 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from kfp import dsl
+
+
+def generate_kfp_dag_and_resolve_project(run, project=None):
+    raise NotImplementedError
+
+
+def add_default_function_resources(
+    task: dsl.PipelineTask,
+) -> dsl.PipelineTask:
+    raise NotImplementedError
+
+
+def add_function_node_selection_attributes(
+    function, task: dsl.PipelineTask
+) -> dsl.PipelineTask:
+    raise NotImplementedError
+
+
+def add_annotations(
+    task: dsl.PipelineTask,
+    kind: str,
+    function,
+    func_url: str = None,
+    project: str = None,
+):
+    raise NotImplementedError
+
+
+def add_labels(task, function, scrape_metrics=False):
+    raise NotImplementedError
+
+
+def add_default_env(task):
+    raise NotImplementedError
+
+
+def generate_pipeline_node(
+    project_name: str,
+    name: str,
+    image: str,
+    command: list,
+    file_outputs: dict,
+    function,
+    func_url: str,
+    scrape_metrics: bool,
+    code_env: str,
+    registry: str,
+):
+    raise NotImplementedError
+
+
+def generate_image_builder_pipeline_node(
+    name,
+    function=None,
+    func_url=None,
+    cmd=None,
+):
+    raise NotImplementedError
+
+
+def generate_deployer_pipeline_node(
+    name,
+    function,
+    func_url=None,
+    cmd=None,
+):
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/patcher.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/patcher.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/utils.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/utils.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def compile_pipeline(pipeline, **kwargs):
+    raise NotImplementedError


### PR DESCRIPTION
[ML-4717](https://iguazio.atlassian.net/browse/ML-4717)

This PR adds `mlrun-pipelines-kfp-v2` as a new context to run the package tests.

An important caveat must be noted, however: since `mlrun-pipelines-kfp-v1-8` is part of the core set of dependencies for MLRun, it's not possible to add `mlrun-pipelines-kfp-v2` as a traditional extra dependency (think `pip install mlrun[kfp2]`). That's because the v1-8 and v2 packages have conflicting dependencies, and when an extra is installed, all dependencies are taken into account, as opposed to only the ones required by the extra.

Therefore, package tests for KFP v2 are implemented by changing the default KFP version of MLRun beforehand.

When MLRun becomes completely pipeline-independent, kfp v1 and v2 will be installable as package extras.

[ML-4717]: https://iguazio.atlassian.net/browse/ML-4717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ