### PR TITLE
[Hack] Delete comment that is no longer relevant from notebook

### DIFF
--- a/hack/benchmarks/model_serving_benchmark.ipynb
+++ b/hack/benchmarks/model_serving_benchmark.ipynb
@@ -122,10 +122,7 @@
    "execution_count": 9,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Support added in https://github.com/mlrun/mlrun/pull/5322\n",
-    "# fn.set_topology(\"router\", engine=\"async\")"
-   ]
+   "source": ""
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Since the idea of supporting router topology with async engine has been scrapped.