### PR TITLE
[Datastore] Revert 'kind' prefix for default and v3io stores

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -548,11 +548,10 @@ default_config = {
     },
     "feature_store": {
         "data_prefixes": {
-            "default": "v3io:///projects/{project}/FeatureStore/{name}/nosql",
+            "default": "v3io:///projects/{project}/FeatureStore/{name}/{kind}",
             "nosql": "v3io:///projects/{project}/FeatureStore/{name}/nosql",
             # "authority" is optional and generalizes [userinfo "@"] host [":" port]
             "redisnosql": "redis://{authority}/projects/{project}/FeatureStore/{name}/nosql",
-            "dsnosql": "ds://{ds_profile_name}/projects/{project}/FeatureStore/{name}/nosql",
         },
         "default_targets": "parquet,nosql",
         "default_job_image": "mlrun/mlrun",


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6228
https://github.com/mlrun/mlrun/pull/5441

Revert the modification of the 'kind' suffix in the default path, as there are v3io-based targets such as streams and parquet that do not belong to the 'nosql' category. Also remove the kind suffix from 'ds' targets