### PR TITLE
[Docs] Remove double function parameter

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -661,7 +661,6 @@ def code_to_function(
     :param embed_code:   indicates whether or not to inject the code directly into the function runtime spec,
                          defaults to True
     :param description:  short function description, defaults to ''
-    :param requirements: list of python packages or pip requirements file path, defaults to None
     :param requirements: a list of python packages
     :param requirements_file: path to a python requirements file
     :param categories:   list of categories for mlrun Function Hub, defaults to None


### PR DESCRIPTION
Remove double function param 'requirements' for 'code_to_function'