### PR TITLE
[Feature Store] Restore ds default template path

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -552,6 +552,7 @@ default_config = {
             "nosql": "v3io:///projects/{project}/FeatureStore/{name}/nosql",
             # "authority" is optional and generalizes [userinfo "@"] host [":" port]
             "redisnosql": "redis://{authority}/projects/{project}/FeatureStore/{name}/nosql",
+            "dsnosql": "ds://{ds_profile_name}/projects/{project}/FeatureStore/{name}/nosql",
         },
         "default_targets": "parquet,nosql",
         "default_job_image": "mlrun/mlrun",


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6228


Reinstate the default path template for the ds type of datastore, which was initially introduced in https://github.com/mlrun/mlrun/pull/5441 and mistakenly removed in https://github.com/mlrun/mlrun/pull/5450