### PR TITLE
[Nuclio] Delete Nuclio function when removing function of Nuclio runtime

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -196,6 +196,7 @@ default_config = {
                 "run_abortion": "600",
                 "abort_grace_period": "10",
                 "delete_project": "900",
+                "delete_function": "900",
             },
             "runtimes": {"dask": "600"},
         },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -188,6 +188,7 @@ default_config = {
     "background_tasks": {
         # enabled / disabled
         "timeout_mode": "enabled",
+        "function_deletion_batch_size": 10,
         # timeout in seconds to wait for background task to be updated / finished by the worker responsible for the task
         "default_timeouts": {
             "operations": {

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1149,7 +1149,7 @@ class HTTPRunDB(RunDBInterface):
             )
             background_task = mlrun.common.schemas.BackgroundTask(**response.json())
             background_task = self._wait_for_background_task_to_reach_terminal_state(
-                background_task.metadata.name
+                background_task.metadata.name, project=project
             )
             if (
                 background_task.status.state

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1142,7 +1142,23 @@ class HTTPRunDB(RunDBInterface):
         project = project or config.default_project
         path = f"projects/{project}/functions/{name}"
         error_message = f"Failed deleting function {project}/{name}"
-        self.api_call("DELETE", path, error_message)
+        response = self.api_call("DELETE", path, error_message, version="v2")
+        if response.status_code == http.HTTPStatus.ACCEPTED:
+            logger.info(
+                "Function is being deleted", project_name=project, function_name=name
+            )
+            background_task = mlrun.common.schemas.BackgroundTask(**response.json())
+            background_task = self._wait_for_background_task_to_reach_terminal_state(
+                background_task.metadata.name
+            )
+            if (
+                background_task.status.state
+                == mlrun.common.schemas.BackgroundTaskState.succeeded
+            ):
+                logger.info(
+                    "Function deleted", project_name=project, function_name=name
+                )
+                return
 
     def list_functions(self, name=None, project=None, tag=None, labels=None):
         """Retrieve a list of functions, filtered by specific criteria.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1158,7 +1158,13 @@ class HTTPRunDB(RunDBInterface):
                 logger.info(
                     "Function deleted", project_name=project, function_name=name
                 )
-                return
+            elif (
+                background_task.status.state
+                == mlrun.common.schemas.BackgroundTaskState.failed
+            ):
+                logger.info(
+                    "Function deletion failed", project_name=project, function_name=name
+                )
 
     def list_functions(self, name=None, project=None, tag=None, labels=None):
         """Retrieve a list of functions, filtered by specific criteria.

--- a/server/api/api/api.py
+++ b/server/api/api/api.py
@@ -29,6 +29,7 @@ from server.api.api.endpoints import (
     files,
     frontend_spec,
     functions,
+    functions_v2,
     grafana_proxy,
     healthz,
     hub,
@@ -194,5 +195,10 @@ api_v2_router.include_router(
 api_v2_router.include_router(
     projects_v2.router,
     tags=["projects"],
+    dependencies=[Depends(deps.authenticate_request)],
+)
+api_v2_router.include_router(
+    functions_v2.router,
+    tags=["functions"],
     dependencies=[Depends(deps.authenticate_request)],
 )

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -141,7 +141,7 @@ async def get_function(
     "/projects/{project}/functions/{name}",
     status_code=HTTPStatus.NO_CONTENT.value,
     deprecated=True,
-    description="'/projects/{project}/functions/{name}' will be removed in 1.9.0, "
+    description="'/v1/projects/{project}/functions/{name}' will be removed in 1.9.0, "
     "use '/v2/projects/{project}/functions/{name}' instead.",
 )
 async def delete_function(

--- a/server/api/api/endpoints/functions_v2.py
+++ b/server/api/api/endpoints/functions_v2.py
@@ -1,0 +1,117 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import http
+
+import fastapi
+from fastapi import (
+    APIRouter,
+    Depends,
+    Request,
+)
+from fastapi.concurrency import run_in_threadpool
+from sqlalchemy.orm import Session
+
+import mlrun.common.model_monitoring
+import mlrun.common.model_monitoring.helpers
+import mlrun.common.schemas
+import server.api.api.utils
+import server.api.crud.model_monitoring.deployment
+import server.api.crud.runtimes.nuclio.function
+import server.api.db.session
+import server.api.launcher
+import server.api.utils.auth.verifier
+import server.api.utils.background_tasks
+import server.api.utils.clients.chief
+import server.api.utils.functions
+import server.api.utils.pagination
+import server.api.utils.singletons.k8s
+import server.api.utils.singletons.project_member
+from mlrun.utils import logger
+from server.api.api import deps
+from server.api.utils.singletons.scheduler import get_scheduler
+
+router = APIRouter()
+
+
+@router.delete(
+    "/projects/{project}/functions/{name}",
+    responses={
+        http.HTTPStatus.NO_CONTENT.value: {},
+        http.HTTPStatus.ACCEPTED.value: {"model": mlrun.common.schemas.BackgroundTask},
+    },
+)
+async def delete_function(
+    background_tasks: fastapi.BackgroundTasks,
+    response: fastapi.Response,
+    request: Request,
+    project: str,
+    name: str,
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
+    db_session: Session = Depends(deps.get_db_session),
+):
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.function,
+        project,
+        name,
+        mlrun.common.schemas.AuthorizationAction.delete,
+        auth_info,
+    )
+    #  If the requested function has a schedule, we must delete it before deleting the function
+    try:
+        function_schedule = await run_in_threadpool(
+            get_scheduler().get_schedule,
+            db_session,
+            project,
+            name,
+        )
+    except mlrun.errors.MLRunNotFoundError:
+        function_schedule = None
+
+    if function_schedule:
+        # when deleting a function, we should also delete its schedules if exists
+        # schedules are only supposed to be run by the chief, therefore, if the function has a schedule,
+        # and we are running in worker, we send the request to the chief client
+        if (
+            mlrun.mlconf.httpdb.clusterization.role
+            != mlrun.common.schemas.ClusterizationRole.chief
+        ):
+            logger.info(
+                "Function has a schedule, deleting",
+                function=name,
+                project=project,
+            )
+            chief_client = server.api.utils.clients.chief.Client()
+            await chief_client.delete_schedule(
+                project=project, name=name, request=request
+            )
+        else:
+            await run_in_threadpool(
+                get_scheduler().delete_schedule, db_session, project, name
+            )
+    task, task_name = await run_in_threadpool(
+        server.api.api.utils.create_function_deletion_background_task,
+        db_session,
+        project,
+        name,
+        auth_info,
+    )
+    if task:
+        background_tasks.add_task(task)
+
+    response.status_code = http.HTTPStatus.ACCEPTED.value
+    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
+        task_name
+    )

--- a/server/api/api/endpoints/functions_v2.py
+++ b/server/api/api/endpoints/functions_v2.py
@@ -101,7 +101,7 @@ async def delete_function(
             await run_in_threadpool(
                 get_scheduler().delete_schedule, db_session, project, name
             )
-    task, task_name = await run_in_threadpool(
+    task = await run_in_threadpool(
         server.api.api.utils.create_function_deletion_background_task,
         background_tasks,
         db_session,
@@ -109,10 +109,6 @@ async def delete_function(
         name,
         auth_info,
     )
-    if task:
-        background_tasks.add_task(task)
 
     response.status_code = http.HTTPStatus.ACCEPTED.value
-    return server.api.utils.background_tasks.InternalBackgroundTasksHandler().get_background_task(
-        task_name
-    )
+    return task

--- a/server/api/api/endpoints/functions_v2.py
+++ b/server/api/api/endpoints/functions_v2.py
@@ -103,6 +103,7 @@ async def delete_function(
             )
     task, task_name = await run_in_threadpool(
         server.api.api.utils.create_function_deletion_background_task,
+        background_tasks,
         db_session,
         project,
         name,

--- a/server/api/api/endpoints/functions_v2.py
+++ b/server/api/api/endpoints/functions_v2.py
@@ -49,7 +49,6 @@ router = APIRouter()
 @router.delete(
     "/projects/{project}/functions/{name}",
     responses={
-        http.HTTPStatus.NO_CONTENT.value: {},
         http.HTTPStatus.ACCEPTED.value: {"model": mlrun.common.schemas.BackgroundTask},
     },
 )

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1288,14 +1288,16 @@ def create_function_deletion_background_task(
 ):
     # create the background task for function deletion
     return server.api.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task(
-        db_session=db_session,
-        project=project_name,
-        background_tasks=background_tasks,
-        function=_delete_function,
-        timeout=mlrun.mlconf.background_tasks.default_timeouts.operations.delete_function,
-        name=None,
-        function_name=function_name,
-        auth_info=auth_info,
+        db_session,
+        project_name,
+        background_tasks,
+        _delete_function,
+        mlrun.mlconf.background_tasks.default_timeouts.operations.delete_function,
+        None,
+        db_session,
+        project_name,
+        function_name,
+        auth_info,
     )
 
 
@@ -1316,10 +1318,7 @@ async def _delete_function(
         # Since we request functions by a specific name and project,
         # in MLRun terminology, they are all just versions of the same function
         # therefore, it's enough to check the kind of the first one only
-        if (
-            functions[0].get("kind")
-            in mlrun.runtimes.RuntimeKindsRuntimeKinds.nuclio_runtimes()
-        ):
+        if functions[0].get("kind") in mlrun.runtimes.RuntimeKinds.nuclio_runtimes():
             # generate Nuclio function names based on function tags
             nuclio_function_names = [
                 mlrun.runtimes.nuclio.function.get_fullname(
@@ -1345,7 +1344,9 @@ async def _delete_function(
 
 
 async def delete_nuclio_functions_in_batches(
-    auth_info: mlrun.common.schemas.AuthInfo, project_name: str, function_names: str
+    auth_info: mlrun.common.schemas.AuthInfo,
+    project_name: str,
+    function_names: list[str],
 ):
     async def delete_function(
         nuclio_client: server.api.utils.clients.iguazio.AsyncClient,

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import kubernetes.client
 import semver
 import sqlalchemy.orm
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
@@ -1280,18 +1280,12 @@ def verify_project_is_deleted(project_name, auth_info):
 
 
 def create_function_deletion_background_task(
-    background_tasks: fastapi.BackgroundTasks,
+    background_tasks: BackgroundTasks,
     db_session: sqlalchemy.orm.Session,
     project_name: str,
     function_name: str,
     auth_info: mlrun.common.schemas.AuthInfo,
 ):
-    background_task_kind_format = (
-        server.api.utils.background_tasks.BackgroundTaskKinds.function_deletion
-    )
-    background_task_kind = background_task_kind_format.format(function_name)
-    background_task_name = str(uuid.uuid4())
-
     # create the background task for function deletion
     return server.api.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task(
         db_session=db_session,
@@ -1299,7 +1293,7 @@ def create_function_deletion_background_task(
         background_tasks=background_tasks,
         function=_delete_function,
         timeout=mlrun.mlconf.background_tasks.default_timeouts.operations.delete_function,
-        name=background_task_name,
+        name=None,
         function_name=function_name,
         auth_info=auth_info,
     )

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import collections
 import copy
 import functools
@@ -1320,11 +1321,14 @@ async def _delete_function(
         # Since we request functions by a specific name and project,
         # in MLRun terminology, they are all just versions of the same function
         # therefore, it's enough to check the kind of the first one only
-        if functions[0].get("kind") in RuntimeKinds.nuclio_runtimes():
+        if (
+            functions[0].get("kind")
+            in mlrun.runtimes.RuntimeKindsRuntimeKinds.nuclio_runtimes()
+        ):
             # generate Nuclio function names based on function tags
             nuclio_function_names = [
                 mlrun.runtimes.nuclio.function.get_fullname(
-                    name, project, function.get("metadata", {}).get("tag")
+                    function_name, project_name, function.get("metadata", {}).get("tag")
                 )
                 for function in functions
             ]

--- a/server/api/utils/background_tasks/kinds.py
+++ b/server/api/utils/background_tasks/kinds.py
@@ -18,3 +18,4 @@ class BackgroundTaskKinds:
     db_migrations = "db.migrations"
     project_deletion = "project.deletion.{0}"
     project_deletion_wrapper = "project.deletion.wrapper.{0}"
+    function_deletion = "project.deletion.{0}"

--- a/server/api/utils/background_tasks/kinds.py
+++ b/server/api/utils/background_tasks/kinds.py
@@ -18,4 +18,4 @@ class BackgroundTaskKinds:
     db_migrations = "db.migrations"
     project_deletion = "project.deletion.{0}"
     project_deletion_wrapper = "project.deletion.wrapper.{0}"
-    function_deletion = "project.deletion.{0}"
+    function_deletion = "function.deletion.{0}"

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -48,9 +48,6 @@ PROJECT = "project-name"
 ORIGINAL_VERSIONED_API_PREFIX = server.api.main.BASE_VERSIONED_API_PREFIX
 FUNCTIONS_API = "projects/{project}/functions/{name}"
 
-# V2 endpoints
-V2_PREFIX = "v2/"
-
 
 def test_build_status_pod_not_found(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient

--- a/tests/api/api/utils.py
+++ b/tests/api/api/utils.py
@@ -32,11 +32,12 @@ def create_project(
     artifact_path=None,
     source="source",
     load_source_on_run=False,
+    endpoint_prefix="",
 ):
     project = _create_project_obj(
         project_name, artifact_path, source, load_source_on_run
     )
-    resp = client.post("projects", json=project.dict())
+    resp = client.post(f"{endpoint_prefix}projects", json=project.dict())
     assert resp.status_code == HTTPStatus.CREATED.value
     return resp
 


### PR DESCRIPTION
This PR addresses a bug where deleting an MLRun function from the Nuclio runtime only removed the function from the database, leaving the associated Nuclio pod running.

Since an MLRun function can be mapped to multiple Nuclio functions with different tags, the deletion process first checks if the function is associated with Nuclio. Then, it retrieves all tags belonging to this function, generates Nuclio function names, and sends requests to the Nuclio API to delete each Nuclio function mapped to the given MLRun function.

Jira - https://iguazio.atlassian.net/browse/ML-3432
https://iguazio.atlassian.net/browse/ML-6293