### PR TITLE
[Pipelines] Add KFPv2 functionalities to MLRun

### DIFF
--- a/mlrun/platforms/__init__.py
+++ b/mlrun/platforms/__init__.py
@@ -17,6 +17,19 @@ import json
 from pprint import pprint
 from time import sleep
 
+from mlrun_pipelines.common.mounts import VolumeMount
+from mlrun_pipelines.mounts import (
+    auto_mount,
+    mount_configmap,
+    mount_hostpath,
+    mount_pvc,
+    mount_s3,
+    mount_secret,
+    mount_v3io,
+    set_env_variables,
+    v3io_cred,
+)
+
 from .iguazio import (
     V3ioStreamClient,
     add_or_refresh_credentials,

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/models.py
@@ -106,6 +106,9 @@ class PipelineRun(FlexibleMapper):
     def finished_at(self, finished_at):
         self._external_data["finished_at"] = finished_at
 
+    def workflow_manifest(self) -> PipelineManifest:
+        return self._workflow_manifest
+
 
 class PipelineExperiment(FlexibleMapper):
     @property

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py
@@ -245,7 +245,7 @@ def add_function_node_selection_attributes(
 
 
 def generate_kfp_dag_and_resolve_project(run, project=None):
-    workflow = run._workflow_manifest
+    workflow = run.workflow_manifest()
     if not workflow:
         return None, project, None
 

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mixins.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mixins.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 #
 
+from mlrun_pipelines.common.helpers import PROJECT_ANNOTATION
+
+import mlrun
+
 
 class KfpAdapterMixin:
     def apply(self, modify):
@@ -23,9 +27,54 @@ class KfpAdapterMixin:
         :param modify: a modifier runnable object
         :return: the runtime (self) after the modifications
         """
-        raise NotImplementedError
+        return modify(self)
 
 
 class PipelineProviderMixin:
     def resolve_project_from_workflow_manifest(self, workflow_manifest):
-        raise NotImplementedError
+        for _, executor in workflow_manifest.get_executors():
+            project_from_annotation = (
+                executor.get("metadata", {})
+                .get("annotations", {})
+                .get(PROJECT_ANNOTATION)
+            )
+            if project_from_annotation:
+                return project_from_annotation
+            command = executor.get("container", {}).get("command", [])
+            action = None
+            for index, argument in enumerate(command):
+                if argument == "mlrun" and index + 1 < len(command):
+                    action = command[index + 1]
+                    break
+            if action:
+                if action == "deploy":
+                    project = self._resolve_project_from_command(
+                        command,
+                        hyphen_p_is_also_project=True,
+                        has_func_url_flags=True,
+                        has_runtime_flags=False,
+                    )
+                    if project:
+                        return project
+                elif action == "run":
+                    project = self._resolve_project_from_command(
+                        command,
+                        hyphen_p_is_also_project=False,
+                        has_func_url_flags=True,
+                        has_runtime_flags=True,
+                    )
+                    if project:
+                        return project
+                elif action == "build":
+                    project = self._resolve_project_from_command(
+                        command,
+                        hyphen_p_is_also_project=False,
+                        has_func_url_flags=False,
+                        has_runtime_flags=True,
+                    )
+                    if project:
+                        return project
+                else:
+                    raise NotImplementedError(f"Unknown action: {action}")
+
+        return mlrun.mlconf.default_project

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/models.py
@@ -27,74 +27,85 @@ class PipelineManifest(FlexibleMapper):
     """
 
     def get_schema_version(self) -> str:
-        raise NotImplementedError
+        try:
+            return self._external_data["schemaVersion"]
+        except KeyError:
+            return self._external_data["apiVersion"]
 
     def is_argo_compatible(self) -> bool:
-        raise NotImplementedError
+        if self.get_schema_version().startswith("argoproj.io"):
+            return True
+        return False
 
     def get_executors(self):
-        raise NotImplementedError
+        if self.is_argo_compatible():
+            yield from [
+                (t.get("name"), t) for t in self._external_data["spec"]["templates"]
+            ]
+        else:
+            yield from self._external_data["deploymentSpec"]["executors"].items()
 
 
 class PipelineRun(FlexibleMapper):
     @property
     def id(self):
-        raise NotImplementedError
+        return self._external_data["run_id"]
 
     @property
     def name(self):
-        raise NotImplementedError
+        return self._external_data["display_name"]
 
     @name.setter
     def name(self, name):
-        raise NotImplementedError
+        self._external_data["display_name"] = name
 
     @property
     def status(self):
-        raise NotImplementedError
+        return self._external_data["state"]
 
     @status.setter
     def status(self, status):
-        raise NotImplementedError
+        self._external_data["state"] = status
 
     @property
     def description(self):
-        raise NotImplementedError
+        return self._external_data["description"]
 
     @description.setter
     def description(self, description):
-        raise NotImplementedError
+        self._external_data["description"] = description
 
     @property
     def created_at(self):
-        raise NotImplementedError
+        return self._external_data["created_at"]
 
     @created_at.setter
     def created_at(self, created_at):
-        raise NotImplementedError
+        self._external_data["created_at"] = created_at
 
     @property
     def scheduled_at(self):
-        raise NotImplementedError
+        return self._external_data["scheduled_at"]
 
     @scheduled_at.setter
     def scheduled_at(self, scheduled_at):
-        raise NotImplementedError
+        self._external_data["scheduled_at"] = scheduled_at
 
     @property
     def finished_at(self):
-        raise NotImplementedError
+        return self._external_data["finished_at"]
 
     @finished_at.setter
     def finished_at(self, finished_at):
-        raise NotImplementedError
+        self._external_data["finished_at"] = finished_at
 
-    @property
     def workflow_manifest(self) -> PipelineManifest:
-        raise NotImplementedError
+        return PipelineManifest(
+            self._external_data["pipeline_spec"],
+        )
 
 
 class PipelineExperiment(FlexibleMapper):
     @property
     def id(self):
-        raise NotImplementedError
+        return self._external_data["experiment_id"]

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
+
+import mlrun
+from mlrun.config import config
+from mlrun.errors import MLRunInvalidArgumentError
+from mlrun.utils import logger
 
 
 def v3io_cred(api="", user="", access_key=""):
@@ -52,15 +58,36 @@ def mount_v3iod(namespace, v3io_config_configmap):
 
 def mount_pvc(pvc_name=None, volume_name="pipeline", volume_mount_path="/mnt/pipeline"):
     """
-    Modifier function to apply to a Container Op to simplify volume, volume mount addition and
-    enable better reuse of volumes, volume claims across container ops.
+    Modifier function to apply to a PipelineTask to simplify volume, volume mount addition and
+    enable better reuse of volumes, volume claims across pipelinetasks.
 
     Usage::
 
         train = train_op(...)
         train.apply(mount_pvc('claim-name', 'pipeline', '/mnt/pipeline'))
     """
-    raise NotImplementedError
+    if "MLRUN_PVC_MOUNT" in os.environ:
+        mount = os.environ.get("MLRUN_PVC_MOUNT")
+        items = mount.split(":")
+        if len(items) != 2:
+            raise MLRunInvalidArgumentError(
+                "MLRUN_PVC_MOUNT should include <pvc-name>:<mount-path>"
+            )
+        pvc_name = items[0]
+        volume_mount_path = items[1]
+
+    if not pvc_name:
+        raise MLRunInvalidArgumentError(
+            "No PVC name: use the pvc_name parameter or configure the MLRUN_PVC_MOUNT environment variable"
+        )
+
+    def _mount_pvc(runtime):
+        runtime.spec.update_vols_and_mounts(
+            volumes=[{"PVC": {"name": pvc_name}, "name": volume_name}],
+            volume_mounts=[{"mountPath": volume_mount_path, "name": volume_name}],
+        )
+
+    return _mount_pvc
 
 
 def set_env_variables(env_vars_dict: dict[str, str] = None, **kwargs):
@@ -78,7 +105,16 @@ def set_env_variables(env_vars_dict: dict[str, str] = None, **kwargs):
     :param env_vars_dict: dictionary of env. variables
     :param kwargs: environment variables passed as args
     """
-    raise NotImplementedError
+    env_data = env_vars_dict.copy() if env_vars_dict else {}
+    for key, value in kwargs.items():
+        env_data[key] = value
+
+    def _set_env_variables(runtime):
+        for _key, _value in env_data.items():
+            runtime.set_env(_key, _value)
+        return runtime
+
+    return _set_env_variables
 
 
 def mount_s3(
@@ -108,7 +144,53 @@ def mount_s3(
     :param non_anonymous: force the S3 API to use non-anonymous connection, even if no credentials are provided
         (for authenticating externally, such as through IAM instance-roles)
     """
-    raise NotImplementedError
+    if secret_name and (aws_access_key or aws_secret_key):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "can use k8s_secret for credentials or specify them (aws_access_key, aws_secret_key) not both"
+        )
+
+    if not secret_name and (
+        aws_access_key
+        or os.environ.get(prefix + "AWS_ACCESS_KEY_ID")
+        or aws_secret_key
+        or os.environ.get(prefix + "AWS_SECRET_ACCESS_KEY")
+    ):
+        logger.warning(
+            "it is recommended to use k8s secret (specify secret_name), "
+            "specifying the aws_access_key/aws_secret_key directly is unsafe"
+        )
+
+    def _use_s3_cred(runtime):
+        from os import environ
+
+        _access_key = aws_access_key or environ.get(prefix + "AWS_ACCESS_KEY_ID")
+        _secret_key = aws_secret_key or environ.get(prefix + "AWS_SECRET_ACCESS_KEY")
+        _endpoint_url = endpoint_url or environ.get(prefix + "S3_ENDPOINT_URL")
+
+        if _endpoint_url:
+            runtime.set_env(prefix + "S3_ENDPOINT_URL", endpoint_url)
+        if aws_region:
+            runtime.set_env(prefix + "AWS_REGION", aws_region)
+        if non_anonymous:
+            runtime.set_env(prefix + "S3_NON_ANONYMOUS", "true")
+
+        if secret_name:
+            runtime.set_env_from_secret(
+                prefix + "AWS_ACCESS_KEY_ID",
+                secret=secret_name,
+                secret_key="AWS_ACCESS_KEY_ID",
+            )
+            runtime.set_env_from_secret(
+                prefix + "AWS_SECRET_ACCESS_KEY",
+                secret=secret_name,
+                secret_key="AWS_SECRET_ACCESS_KEY",
+            )
+        else:
+            runtime.set_env(prefix + "AWS_ACCESS_KEY_ID", _access_key)
+            runtime.set_env(prefix + "AWS_SECRET_ACCESS_KEY", _secret_key)
+        return runtime
+
+    return _use_s3_cred
 
 
 def mount_spark_conf():
@@ -121,15 +203,18 @@ def mount_secret(secret_name, mount_path, volume_name="secret", items=None):
     :param secret_name:  k8s secret name
     :param mount_path:   path to mount inside the container
     :param volume_name:  unique volume name
-    :param items:        If unspecified, each key-value pair in the Data field
-                         of the referenced Secret will be projected into the
-                         volume as a file whose name is the key and content is
-                         the value.
-                         If specified, the listed keys will be projected into
-                         the specified paths, and unlisted keys will not be
-                         present.
+    :param items:        unused due to lack of support on KFPv2 SDK
+                         kept for backwards compatibility
     """
-    raise NotImplementedError
+
+    def _mount_secret(runtime):
+        runtime.spec.update_vols_and_mounts(
+            volumes=[{"secret": {"name": secret_name}, "name": volume_name}],
+            volume_mounts=[{"mountPath": mount_path, "name": volume_name}],
+        )
+        return runtime
+
+    return _mount_secret
 
 
 def mount_configmap(configmap_name, mount_path, volume_name="configmap", items=None):
@@ -138,15 +223,18 @@ def mount_configmap(configmap_name, mount_path, volume_name="configmap", items=N
     :param configmap_name:  k8s configmap name
     :param mount_path:      path to mount inside the container
     :param volume_name:     unique volume name
-    :param items:           If unspecified, each key-value pair in the Data field
-                            of the referenced Configmap will be projected into the
-                            volume as a file whose name is the key and content is
-                            the value.
-                            If specified, the listed keys will be projected into
-                            the specified paths, and unlisted keys will not be
-                            present.
+    :param items:           unused due to lack of support on KFPv2 SDK
+                            kept for backwards compatibility
     """
-    raise NotImplementedError
+
+    def _mount_configmap(runtime):
+        runtime.spec.update_vols_and_mounts(
+            volumes=[{"configMap": {"name": configmap_name}, "name": volume_name}],
+            volume_mounts=[{"mountPath": mount_path, "name": volume_name}],
+        )
+        return runtime
+
+    return _mount_configmap
 
 
 def mount_hostpath(host_path, mount_path, volume_name="hostpath"):
@@ -156,7 +244,9 @@ def mount_hostpath(host_path, mount_path, volume_name="hostpath"):
     :param mount_path:   path to mount inside the container
     :param volume_name:  unique volume name
     """
-    raise NotImplementedError
+    raise NotImplementedError(
+        "Support for hostPath mounting is not yet available on the KFP 2 engine"
+    )
 
 
 def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
@@ -168,4 +258,21 @@ def auto_mount(pvc_name="", volume_mount_path="", volume_name=None):
     - k8s PVC volume if it's configured as the auto mount type
     - iguazio v3io volume when V3IO_ACCESS_KEY and V3IO_USERNAME env vars are set
     """
-    raise NotImplementedError
+    if pvc_name and volume_mount_path:
+        return mount_pvc(
+            pvc_name=pvc_name,
+            volume_mount_path=volume_mount_path,
+            volume_name=volume_name or "shared-persistency",
+        )
+    if "MLRUN_PVC_MOUNT" in os.environ:
+        return mount_pvc(
+            volume_name=volume_name or "shared-persistency",
+        )
+    # In the case of MLRun-kit when working remotely, no env variables will be defined but auto-mount
+    # parameters may still be declared - use them in that case.
+    if config.storage.auto_mount_type == "pvc":
+        return mount_pvc(**config.get_storage_auto_mount_params())
+    if "V3IO_ACCESS_KEY" in os.environ:
+        return mount_v3io(name=volume_name or "v3io")
+
+    raise ValueError("failed to auto mount, need to set env vars")

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
@@ -13,24 +13,132 @@
 # limitations under the License.
 #
 
+import os
 
 from kfp import dsl
+from kfp import kubernetes as kfp_k8s
+from mlrun_pipelines.common.helpers import (
+    FUNCTION_ANNOTATION,
+    PROJECT_ANNOTATION,
+    RUN_ANNOTATION,
+)
+from mlrun_pipelines.common.ops import PipelineRunType
+
+import mlrun
+from mlrun.config import config
+from mlrun.utils import get_in, logger
 
 
 def generate_kfp_dag_and_resolve_project(run, project=None):
-    raise NotImplementedError
+    workflow = run.workflow_manifest()
+    if not workflow:
+        return None, project, None
+
+    templates = {}
+    for name, template in workflow.get_executors():
+        project = project or get_in(
+            template, ["metadata", "annotations", PROJECT_ANNOTATION], ""
+        )
+        templates[name] = {
+            "run_type": get_in(
+                template, ["metadata", "annotations", RUN_ANNOTATION], ""
+            ),
+            "function": get_in(
+                template, ["metadata", "annotations", FUNCTION_ANNOTATION], ""
+            ),
+        }
+
+    dag = {}
+    nodes = []
+    if run["run_details"]:
+        nodes = run["run_details"].get("task_details", [])
+    for node in nodes:
+        name = (
+            node["display_name"]
+            if not node["child_tasks"]
+            else node["child_tasks"][0]["pod_name"]
+        )
+        if not name:
+            continue
+        record = {
+            "phase": node["state"],
+            "started_at": node["create_time"],
+            "finished_at": node["end_time"],
+            "id": node["task_id"],
+            "parent": node.get("parent_task_id", ""),
+            "name": node["display_name"],
+            "type": "DAG" if node["child_tasks"] else "Pod",
+            "children": [c["pod_name"] for c in node["child_tasks"] or []],
+        }
+
+        if name in templates:
+            record["function"] = templates[name].get("function")
+            record["run_type"] = templates[name].get("run_type")
+        dag[name] = record
+
+    return dag, project, run["state"]
 
 
 def add_default_function_resources(
     task: dsl.PipelineTask,
 ) -> dsl.PipelineTask:
-    raise NotImplementedError
+    __set_task_requests = {
+        "cpu": task.set_cpu_request,
+        "memory": task.set_memory_request,
+    }
+    __set_task_limits = {
+        "cpu": task.set_cpu_limit,
+        "memory": task.set_memory_limit,
+    }
+
+    default_resources = config.get_default_function_pod_resources()
+    for resource_name, resource_value in default_resources["requests"].items():
+        if resource_value:
+            __set_task_requests[resource_name](resource_value)
+
+    for resource_name, resource_value in default_resources["limits"].items():
+        if resource_value:
+            __set_task_limits[resource_name](resource_value)
+
+    return task
 
 
 def add_function_node_selection_attributes(
     function, task: dsl.PipelineTask
 ) -> dsl.PipelineTask:
-    raise NotImplementedError
+    if not mlrun.runtimes.RuntimeKinds.is_local_runtime(function.kind):
+        if getattr(function.spec, "node_selector"):
+            for k, v in function.spec.node_selector.items():
+                task = kfp_k8s.add_node_selector(task, k, v)
+
+    if getattr(function.spec, "tolerations"):
+        if hasattr(kfp_k8s, "add_toleration"):
+            for t in function.spec.tolerations:
+                task = kfp_k8s.add_toleration(
+                    task,
+                    t.key,
+                    t.operator,
+                    t.value,
+                    t.effect,
+                    t.toleration_seconds,
+                )
+        else:
+            # TODO: remove this warning as soon as KFP SDK >=2.7.0 is available for MLRun SDK
+            logger.warning(
+                "Support for Pod tolerations is not yet available on the KFP 2 engine",
+                project=function.metadata.project,
+                function_name=function.metadata.name,
+            )
+
+    # TODO: remove this warning as soon as KFP SDK provides support for affinity management
+    if getattr(function.spec, "affinity"):
+        logger.warning(
+            "Support for Pod affinity is not yet available on the KFP 2 engine",
+            project=function.metadata.project,
+            function_name=function.metadata.name,
+        )
+
+    return task
 
 
 def add_annotations(
@@ -40,15 +148,118 @@ def add_annotations(
     func_url: str = None,
     project: str = None,
 ):
-    raise NotImplementedError
+    # TODO: remove this warning as soon as KFP SDK >=2.7.0 is available for MLRun SDK
+    if not hasattr(kfp_k8s, "add_pod_annotation"):
+        logger.warning(
+            "Support for Pod annotations is not yet available on the KFP 2 engine",
+            project=project,
+            function_name=function.metadata.name,
+        )
+        return
+
+    if func_url and func_url.startswith("db://"):
+        func_url = func_url[len("db://") :]
+    kfp_k8s.add_pod_annotation(task, RUN_ANNOTATION, kind)
+    kfp_k8s.add_pod_annotation(
+        task, PROJECT_ANNOTATION, project or function.metadata.project
+    )
+    kfp_k8s.add_pod_annotation(task, FUNCTION_ANNOTATION, func_url or function.uri)
+    return task
 
 
 def add_labels(task, function, scrape_metrics=False):
-    raise NotImplementedError
+    # TODO: remove this warning as soon as KFP SDK >=2.7.0 is available for MLRun SDK
+    if not hasattr(kfp_k8s, "add_pod_label"):
+        logger.warning(
+            "Support for Pod labels is not yet available on the KFP 2 engine",
+            project=function.metadata.project,
+            function_name=function.metadata.name,
+        )
+        return
+
+    prefix = mlrun.runtimes.utils.mlrun_key
+    kfp_k8s.add_pod_label(task, prefix + "class", function.kind)
+    kfp_k8s.add_pod_label(task, prefix + "function", function.metadata.name)
+    kfp_k8s.add_pod_label(task, prefix + "name", task.name)
+    kfp_k8s.add_pod_label(task, prefix + "project", function.metadata.project)
+    kfp_k8s.add_pod_label(task, prefix + "tag", function.metadata.tag or "latest")
+    kfp_k8s.add_pod_label(
+        task, prefix + "scrape-metrics", "True" if scrape_metrics else "False"
+    )
 
 
 def add_default_env(task):
-    raise NotImplementedError
+    if hasattr(kfp_k8s, "use_field_path_as_env"):
+        kfp_k8s.use_field_path_as_env(task, "MLRUN_NAMESPACE", "metadata.namespace")
+    else:
+        # TODO: remove this warning as soon as "use_field_path_as_env" is available for MLRun SDK
+        logger.warning(
+            "Support for field paths as Pod environment variables is not yet available for the KFP 2 engine."
+            'Functions tentatively default to "MLRUN_NAMESPACE: mlrun"',
+        )
+        task.set_env_variable(name="MLRUN_NAMESPACE", value="mlrun")
+
+    if config.httpdb.api_url:
+        task.set_env_variable(name="MLRUN_DBPATH", value=config.httpdb.api_url)
+
+    if config.mpijob_crd_version:
+        task.set_env_variable(
+            name="MLRUN_MPIJOB_CRD_VERSION", value=config.mpijob_crd_version
+        )
+
+    auth_env_var = mlrun.runtimes.constants.FunctionEnvironmentVariables.auth_session
+    if auth_env_var in os.environ or "V3IO_ACCESS_KEY" in os.environ:
+        task.set_env_variable(
+            name=auth_env_var,
+            value=os.environ.get(auth_env_var) or os.environ.get("V3IO_ACCESS_KEY"),
+        )
+    return task
+
+
+def sync_environment_variables(function, task):
+    function_env = {var.name: var.value for var in function.spec.env}
+    for k in function_env:
+        task.set_env_variable(name=k, value=function_env[k])
+    return task
+
+
+def sync_mounts(function, task):
+    supported_mounts = {
+        "configMap": __sync_mount_config_map,
+        "secret": __sync_mount_secret,
+        "PVC": __sync_pvc,
+    }
+    for volume in function.spec.volumes:
+        for key in volume:
+            if isinstance(volume[key], dict):
+                mount_path = ""
+                for m in function.spec.volume_mounts:
+                    if m["name"] == volume["name"]:
+                        mount_path = m["mountPath"]
+                        break
+                supported_mounts[key](task, volume, mount_path)
+    return task
+
+
+def __sync_mount_config_map(task, volume, mount_path):
+    # TODO: remove this warning as soon as KFP SDK >=2.7.0 is available for MLRun SDK
+    if not hasattr(kfp_k8s, "use_config_map_as_volume"):
+        logger.warning(
+            "Support for using a ConfigMap as a volume is not yet available on the KFP 2 engine",
+        )
+        return
+    kfp_k8s.use_config_map_as_volume(task, volume["configMap"]["name"], mount_path)
+    return task
+
+
+def __sync_mount_secret(task, volume, mount_path):
+    kfp_k8s.use_secret_as_volume(task, volume["secret"]["name"], mount_path)
+    return task
+
+
+def __sync_pvc(task, volume, mount_path):
+    kfp_k8s.mount_pvc(task, volume["PVC"]["name"], mount_path)
+    return task
 
 
 def generate_pipeline_node(
@@ -63,7 +274,37 @@ def generate_pipeline_node(
     code_env: str,
     registry: str,
 ):
-    raise NotImplementedError
+    def mlrun_function():
+        return dsl.ContainerSpec(
+            image=image,
+            command=command,
+        )
+
+    container_component = dsl.component_factory.create_container_component_from_func(
+        mlrun_function
+    )
+
+    task = container_component()
+    task.set_display_name(name)
+
+    add_default_function_resources(task)
+    add_function_node_selection_attributes(function, task)
+    add_annotations(task, PipelineRunType.run, function, func_url, project_name)
+    add_labels(task, function, scrape_metrics)
+    task.set_env_variable(
+        name="MLRUN_ARTIFACT_PATH",
+        value=mlrun.pipeline_context.project._enrich_artifact_path_with_workflow_uid(),
+    )
+    if code_env:
+        task.set_env_variable(name="MLRUN_EXEC_CODE", value=code_env)
+    if registry:
+        task.set_env_variable(
+            name="MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY", value=registry
+        )
+    add_default_env(task)
+    sync_mounts(function, task)
+    sync_environment_variables(function, task)
+    return task
 
 
 def generate_image_builder_pipeline_node(
@@ -72,7 +313,43 @@ def generate_image_builder_pipeline_node(
     func_url=None,
     cmd=None,
 ):
-    raise NotImplementedError
+    def build_mlrun_function(state: dsl.OutputPath(str), image: dsl.OutputPath(str)):
+        runtime_args = ["--state-file-path", state, "--image-file-path", image]
+        return dsl.ContainerSpec(
+            image=config.kfp_image,
+            command=cmd + runtime_args,
+        )
+
+    container_component = dsl.component_factory.create_container_component_from_func(
+        build_mlrun_function
+    )
+    task = container_component()
+    task.set_display_name(name)
+
+    add_default_function_resources(task)
+    add_function_node_selection_attributes(function, task)
+    add_annotations(task, PipelineRunType.build, function, func_url)
+
+    if config.httpdb.builder.docker_registry:
+        task.set_env_variable(
+            name="MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY",
+            value=config.httpdb.builder.docker_registry,
+        )
+    if "IGZ_NAMESPACE_DOMAIN" in os.environ:
+        task.set_env_variable(
+            name="IGZ_NAMESPACE_DOMAIN",
+            value=os.environ.get("IGZ_NAMESPACE_DOMAIN"),
+        )
+
+    is_v3io = function.spec.build.source and function.spec.build.source.startswith(
+        "v3io"
+    )
+    if "V3IO_ACCESS_KEY" in os.environ and is_v3io:
+        task.set_env_variable(
+            name="V3IO_ACCESS_KEY", value=os.environ.get("V3IO_ACCESS_KEY")
+        )
+    add_default_env(task)
+    return task
 
 
 def generate_deployer_pipeline_node(
@@ -81,4 +358,21 @@ def generate_deployer_pipeline_node(
     func_url=None,
     cmd=None,
 ):
-    raise NotImplementedError
+    def deploy_function():
+        return dsl.ContainerSpec(
+            image=config.kfp_image,
+            command=cmd,
+        )
+
+    container_component = dsl.component_factory.create_container_component_from_func(
+        deploy_function
+    )
+    task = container_component()
+    task.set_display_name(name)
+
+    add_default_function_resources(task)
+    add_function_node_selection_attributes(function, task)
+    add_annotations(task, PipelineRunType.deploy, function, func_url)
+
+    add_default_env(task)
+    return task

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/utils.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/utils.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 #
 
+import tempfile
+
+from kfp.compiler import Compiler
+
 
 def compile_pipeline(pipeline, **kwargs):
-    raise NotImplementedError
+    pipe_file = tempfile.NamedTemporaryFile(suffix=".yaml", delete=False).name
+    Compiler().compile(pipeline, pipe_file, type_check=False)
+    return pipe_file

--- a/server/api/crud/pipelines.py
+++ b/server/api/crud/pipelines.py
@@ -385,7 +385,7 @@ class Pipelines(
         return None
 
     def resolve_project_from_pipeline(self, pipeline: PipelineRun):
-        return self.resolve_project_from_workflow_manifest(pipeline._workflow_manifest)
+        return self.resolve_project_from_workflow_manifest(pipeline.workflow_manifest())
 
     @staticmethod
     def _get_experiment_id_from_run(run: dict) -> str:


### PR DESCRIPTION
[ML-4717](https://iguazio.atlassian.net/browse/ML-4717)

This PR adds KFPv2 compatibility to MLRun, making it possible for it to deploy pipelines while using its new APIs (both on the SDK and the API server levels).



fixes https://iguazio.atlassian.net/browse/ML-6241

[ML-4717]: https://iguazio.atlassian.net/browse/ML-4717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ