### PR TITLE
[RemoteWorkflows] Fail fast when remote runner is failing [1.6.x]

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -624,6 +624,11 @@ class RunMetadata(ModelObj):
     def iteration(self, iteration):
         self._iteration = iteration
 
+    def is_workflow_runner(self):
+        if not self.labels:
+            return False
+        return self.labels.get("job-type", "") == "workflow-runner"
+
 
 class HyperParamStrategies:
     grid = "grid"
@@ -1067,6 +1072,14 @@ class RunStatus(ModelObj):
         self.ui_url = ui_url
         self.reason = reason
         self.notifications = notifications or {}
+
+    def is_failed(self):
+        if not self.state:
+            return None
+        return self.state.casefold() in [
+            mlrun.run.RunStatuses.failed.casefold(),
+            mlrun.run.RunStatuses.error.casefold(),
+        ]
 
 
 class RunTemplate(ModelObj):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1073,7 +1073,12 @@ class RunStatus(ModelObj):
         self.reason = reason
         self.notifications = notifications or {}
 
-    def is_failed(self):
+    def is_failed(self) -> Optional[bool]:
+        """
+        This method returns whether a run has failed.
+        Returns none if state has yet to be defined. callee is responsible for handling None.
+        (e.g wait for state to be defined)
+        """
         if not self.state:
             return None
         return self.state.casefold() in [

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import abc
 import builtins
+import http
 import importlib.util as imputil
 import os
 import tempfile
@@ -877,17 +878,33 @@ class _RemoteRunner(_PipelineRunner):
                 get_workflow_id_timeout=get_workflow_id_timeout,
             )
 
+            def _get_workflow_id_or_bail():
+                try:
+                    return run_db.get_workflow_id(
+                        project=project.name,
+                        name=workflow_response.name,
+                        run_id=workflow_response.run_id,
+                        engine=workflow_spec.engine,
+                    )
+                except mlrun.errors.MLRunHTTPStatusError as get_wf_exc:
+                    # fail fast on specific errors
+                    if get_wf_exc.error_status_code in [
+                        http.HTTPStatus.PRECONDITION_FAILED
+                    ]:
+                        raise mlrun.errors.MLRunFatalFailureError(
+                            original_exception=get_wf_exc
+                        )
+
+                    # raise for a retry (on other errors)
+                    raise
+
             # Getting workflow id from run:
             response = retry_until_successful(
                 1,
                 get_workflow_id_timeout,
                 logger,
                 False,
-                run_db.get_workflow_id,
-                project=project.name,
-                name=workflow_response.name,
-                run_id=workflow_response.run_id,
-                engine=workflow_spec.engine,
+                _get_workflow_id_or_bail,
             )
             workflow_id = response.workflow_id
             # After fetching the workflow_id the workflow executed successfully

--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -275,6 +275,19 @@ class WorkflowRunners(
 
         if workflow_id is None:
             if (
+                run_object.metadata.is_workflow_runner()
+                and run_object.status.is_failed()
+            ):
+                state = run_object.status.state
+                state_text = run_object.status.error
+                workflow_name = run_object.spec.parameters.get(
+                    "workflow_name", "<unknown>"
+                )
+                raise mlrun.errors.MLRunPreconditionFailedError(
+                    f"Failed to run workflow {workflow_name}, state: {state}, state_text: {state_text}"
+                )
+
+            elif (
                 engine == "local"
                 and state.casefold() == mlrun.run.RunStatuses.running.casefold()
             ):

--- a/tests/api/api/test_workflows.py
+++ b/tests/api/api/test_workflows.py
@@ -64,16 +64,14 @@ def test_get_workflow_fail_fast(db: Session, client: TestClient):
             },
         },
         "spec": {
-          "parameters": {
-              "workflow_name": "main"
-            },
+            "parameters": {"workflow_name": "main"},
         },
         "status": {
             "state": "failed",
             "error": "some dummy error",
-
             # workflow id is empty to simulate a failed remote runner
-            "results": {"workflow_id": None}},
+            "results": {"workflow_id": None},
+        },
     }
     server.api.crud.Runs().store_run(db, data, right_id, project=PROJECT_NAME)
     resp = client.get(

--- a/tests/api/api/test_workflows.py
+++ b/tests/api/api/test_workflows.py
@@ -52,6 +52,39 @@ def test_bad_schedule_format(db: Session, client: TestClient):
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
+def test_get_workflow_fail_fast(db: Session, client: TestClient):
+    _create_proj_with_workflow(client)
+
+    right_id = "".join(random.choices("0123456789abcdef", k=40))
+    data = {
+        "metadata": {
+            "name": "run-name",
+            "labels": {
+                "job-type": "workflow-runner",
+            },
+        },
+        "spec": {
+          "parameters": {
+              "workflow_name": "main"
+            },
+        },
+        "status": {
+            "state": "failed",
+            "error": "some dummy error",
+
+            # workflow id is empty to simulate a failed remote runner
+            "results": {"workflow_id": None}},
+    }
+    server.api.crud.Runs().store_run(db, data, right_id, project=PROJECT_NAME)
+    resp = client.get(
+        f"projects/{PROJECT_NAME}/workflows/{WORKFLOW_NAME}/runs/{right_id}"
+    )
+
+    # remote runner has failed, so the run should be failed
+    assert resp.status_code == HTTPStatus.PRECONDITION_FAILED
+    assert "some dummy error" in resp.json()["detail"]
+
+
 def test_get_workflow_bad_id(db: Session, client: TestClient):
     _create_proj_with_workflow(client)
 


### PR DESCRIPTION
When running a remote workflow, the configuration might be incorrect causing the remote runner (the pod that spins the remote workflow) to fail before it spins the workflow at all.
This would lead to needlessly wait for the workflow to come up the entire timeout (300 seconds by default)

This PR introduces a fail-fast mechanism for remote workflows where it detects the remote runner status and once it fails, it returns 412 to client (a-la SDK) which stops immediately waiting for the remote workflow to be finished

https://iguazio.atlassian.net/browse/ML-6188