### PR TITLE
[ProjectSummaries] Add runs_completed_recent_count

### DIFF
--- a/mlrun/common/schemas/project.py
+++ b/mlrun/common/schemas/project.py
@@ -110,6 +110,7 @@ class ProjectSummary(pydantic.BaseModel):
     files_count: int
     feature_sets_count: int
     models_count: int
+    runs_completed_recent_count: int
     runs_failed_recent_count: int
     runs_running_count: int
     schedules_count: int

--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -296,6 +296,7 @@ class Projects(
             project_to_schedule_count,
             project_to_feature_set_count,
             project_to_models_count,
+            project_to_recent_completed_runs_count,
             project_to_recent_failed_runs_count,
             project_to_running_runs_count,
             project_to_running_pipelines_count,
@@ -309,6 +310,9 @@ class Projects(
                     schedules_count=project_to_schedule_count.get(project, 0),
                     feature_sets_count=project_to_feature_set_count.get(project, 0),
                     models_count=project_to_models_count.get(project, 0),
+                    runs_completed_recent_count=project_to_recent_completed_runs_count.get(
+                        project, 0
+                    ),
                     runs_failed_recent_count=project_to_recent_failed_runs_count.get(
                         project, 0
                     ),
@@ -323,6 +327,7 @@ class Projects(
     async def _get_project_resources_counters(
         self,
     ) -> tuple[
+        dict[str, int],
         dict[str, int],
         dict[str, int],
         dict[str, int],
@@ -350,6 +355,7 @@ class Projects(
                 project_to_schedule_count,
                 project_to_feature_set_count,
                 project_to_models_count,
+                project_to_recent_completed_runs_count,
                 project_to_recent_failed_runs_count,
                 project_to_running_runs_count,
             ) = results[0]
@@ -359,6 +365,7 @@ class Projects(
                 project_to_schedule_count,
                 project_to_feature_set_count,
                 project_to_models_count,
+                project_to_recent_completed_runs_count,
                 project_to_recent_failed_runs_count,
                 project_to_running_runs_count,
                 project_to_running_pipelines_count,

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -428,6 +428,7 @@ class DBInterface(ABC):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
     ]:
         pass
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2302,7 +2302,11 @@ class SQLDB(DBInterface):
 
     def _calculate_runs_counters(
         self, session
-    ) -> tuple[dict[str, int], dict[str, int], dict[str, int],]:
+    ) -> tuple[
+        dict[str, int],
+        dict[str, int],
+        dict[str, int],
+    ]:
         running_runs_count_per_project = (
             session.query(Run.project, func.count(distinct(Run.name)))
             .filter(
@@ -2350,8 +2354,11 @@ class SQLDB(DBInterface):
         project_to_recent_completed_runs_count = {
             result[0]: result[1] for result in recent_completed_runs_count_per_project
         }
-        return (project_to_recent_completed_runs_count, project_to_recent_failed_runs_count,
-                project_to_running_runs_count)
+        return (
+            project_to_recent_completed_runs_count,
+            project_to_recent_failed_runs_count,
+            project_to_running_runs_count,
+        )
 
     async def generate_projects_summaries(
         self, session: Session, projects: list[str]

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2188,6 +2188,7 @@ class SQLDB(DBInterface):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
     ]:
         results = await asyncio.gather(
             fastapi.concurrency.run_in_threadpool(
@@ -2217,6 +2218,7 @@ class SQLDB(DBInterface):
             project_to_feature_set_count,
             project_to_models_count,
             (
+                project_to_recent_completed_runs_count,
                 project_to_recent_failed_runs_count,
                 project_to_running_runs_count,
             ),
@@ -2226,6 +2228,7 @@ class SQLDB(DBInterface):
             project_to_schedule_count,
             project_to_feature_set_count,
             project_to_models_count,
+            project_to_recent_completed_runs_count,
             project_to_recent_failed_runs_count,
             project_to_running_runs_count,
         )
@@ -2299,7 +2302,7 @@ class SQLDB(DBInterface):
 
     def _calculate_runs_counters(
         self, session
-    ) -> tuple[dict[str, int], dict[str, int]]:
+    ) -> tuple[dict[str, int], dict[str, int], dict[str, int],]:
         running_runs_count_per_project = (
             session.query(Run.project, func.count(distinct(Run.name)))
             .filter(
@@ -2330,7 +2333,25 @@ class SQLDB(DBInterface):
         project_to_recent_failed_runs_count = {
             result[0]: result[1] for result in recent_failed_runs_count_per_project
         }
-        return project_to_recent_failed_runs_count, project_to_running_runs_count
+
+        recent_completed_runs_count_per_project = (
+            session.query(Run.project, func.count(distinct(Run.name)))
+            .filter(
+                Run.state.in_(
+                    [
+                        mlrun.runtimes.constants.RunStates.completed,
+                    ]
+                )
+            )
+            .filter(Run.start_time >= one_day_ago)
+            .group_by(Run.project)
+            .all()
+        )
+        project_to_recent_completed_runs_count = {
+            result[0]: result[1] for result in recent_completed_runs_count_per_project
+        }
+        return (project_to_recent_completed_runs_count, project_to_recent_failed_runs_count,
+                project_to_running_runs_count)
 
     async def generate_projects_summaries(
         self, session: Session, projects: list[str]

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -322,7 +322,13 @@ def test_list_and_get_project_summaries(
 
     # create completed runs for the project to make sure we're not mistakenly counting them
     two_days_ago = datetime.datetime.now() - datetime.timedelta(hours=48)
-    _create_runs(client, project_name, 2, mlrun.runtimes.constants.RunStates.completed, two_days_ago)
+    _create_runs(
+        client,
+        project_name,
+        2,
+        mlrun.runtimes.constants.RunStates.completed,
+        two_days_ago,
+    )
 
     # create completed runs for the project for less than 24 hours ago
     runs_completed_recent_count = 10

--- a/tests/api/api/test_projects.py
+++ b/tests/api/api/test_projects.py
@@ -321,7 +321,19 @@ def test_list_and_get_project_summaries(
     )
 
     # create completed runs for the project to make sure we're not mistakenly counting them
-    _create_runs(client, project_name, 2, mlrun.runtimes.constants.RunStates.completed)
+    two_days_ago = datetime.datetime.now() - datetime.timedelta(hours=48)
+    _create_runs(client, project_name, 2, mlrun.runtimes.constants.RunStates.completed, two_days_ago)
+
+    # create completed runs for the project for less than 24 hours ago
+    runs_completed_recent_count = 10
+    one_hour_ago = datetime.datetime.now() - datetime.timedelta(hours=1)
+    _create_runs(
+        client,
+        project_name,
+        runs_completed_recent_count,
+        mlrun.runtimes.constants.RunStates.completed,
+        one_hour_ago,
+    )
 
     # create failed runs for the project for less than 24 hours ago
     recent_failed_runs_count = 6
@@ -371,13 +383,14 @@ def test_list_and_get_project_summaries(
     )
     for index, project_summary in enumerate(project_summaries_output.project_summaries):
         if project_summary.name == empty_project_name:
-            _assert_project_summary(project_summary, 0, 0, 0, 0, 0, 0, 0)
+            _assert_project_summary(project_summary, 0, 0, 0, 0, 0, 0, 0, 0)
         elif project_summary.name == project_name:
             _assert_project_summary(
                 project_summary,
                 files_count,
                 feature_sets_count,
                 models_count,
+                runs_completed_recent_count,
                 recent_failed_runs_count + recent_aborted_runs_count,
                 running_runs_count,
                 schedules_count,
@@ -394,6 +407,7 @@ def test_list_and_get_project_summaries(
         files_count,
         feature_sets_count,
         models_count,
+        runs_completed_recent_count,
         recent_failed_runs_count + recent_aborted_runs_count,
         running_runs_count,
         schedules_count,
@@ -438,6 +452,7 @@ def test_list_project_summaries_different_installation_modes(
         0,
         0,
         0,
+        0,
     )
 
     # Enterprise installation configuration pre 3.4.0
@@ -453,6 +468,7 @@ def test_list_project_summaries_different_installation_modes(
     _assert_project_summary(
         # accessing the zero index as there's only one project
         project_summaries_output.project_summaries[0],
+        0,
         0,
         0,
         0,
@@ -482,6 +498,7 @@ def test_list_project_summaries_different_installation_modes(
         0,
         0,
         0,
+        0,
     )
 
     # Docker installation configuration
@@ -497,6 +514,7 @@ def test_list_project_summaries_different_installation_modes(
     _assert_project_summary(
         # accessing the zero index as there's only one project
         project_summaries_output.project_summaries[0],
+        0,
         0,
         0,
         0,
@@ -1543,6 +1561,7 @@ def _assert_project_summary(
     files_count: int,
     feature_sets_count: int,
     models_count: int,
+    runs_completed_recent_count,
     runs_failed_recent_count: int,
     runs_running_count: int,
     schedules_count: int,
@@ -1551,6 +1570,7 @@ def _assert_project_summary(
     assert project_summary.files_count == files_count
     assert project_summary.feature_sets_count == feature_sets_count
     assert project_summary.models_count == models_count
+    assert project_summary.runs_completed_recent_count == runs_completed_recent_count
     assert project_summary.runs_failed_recent_count == runs_failed_recent_count
     assert project_summary.runs_running_count == runs_running_count
     assert project_summary.schedules_count == schedules_count

--- a/tests/api/utils/projects/test_follower_member.py
+++ b/tests/api/utils/projects/test_follower_member.py
@@ -414,6 +414,7 @@ async def test_list_project_summaries(
         runs_failed_recent_count=7,
         runs_running_count=8,
         schedules_count=1,
+        runs_completed_recent_count=9,
         pipelines_running_count=2,
     )
     server.api.crud.Projects().generate_projects_summaries = unittest.mock.Mock(
@@ -451,7 +452,7 @@ async def test_list_project_summaries_fails_to_list_pipeline_runs(
     )
 
     server.api.utils.singletons.db.get_db().get_project_resources_counters = (
-        unittest.mock.AsyncMock(return_value=tuple({project_name: i} for i in range(6)))
+        unittest.mock.AsyncMock(return_value=tuple({project_name: i} for i in range(7)))
     )
     project_summaries = await projects_follower.list_project_summaries(db)
     assert len(project_summaries.project_summaries) == 1


### PR DESCRIPTION
Adding new statistics to ProjectSummaries: 
**runs_completed_recent_count** - Number of completed runs in the last 24h

<img width="661" alt="image" src="https://github.com/mlrun/mlrun/assets/40743125/6f964b35-29e1-4dc3-885e-1c3c9c02a08d">


https://iguazio.atlassian.net/browse/ML-6120