### PR TITLE
[Dask] Enhance extending env vars to avoid memory leak [1.6.x]

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1012,12 +1012,12 @@ class KubeResource(BaseRuntime):
 
     def _set_env(self, name, value=None, value_from=None):
         new_var = k8s_client.V1EnvVar(name=name, value=value, value_from=value_from)
-        i = 0
-        for v in self.spec.env:
-            if get_item_name(v) == name:
-                self.spec.env[i] = new_var
+
+        # ensure we don't have duplicate env vars with the same name
+        for env_index, value_item in enumerate(self.spec.env):
+            if get_item_name(value_item) == name:
+                self.spec.env[env_index] = new_var
                 return self
-            i += 1
         self.spec.env.append(new_var)
         return self
 

--- a/server/api/runtime_handlers/daskjob.py
+++ b/server/api/runtime_handlers/daskjob.py
@@ -328,8 +328,16 @@ def enrich_dask_cluster(
     # leaving no room for human mistakes
     env.extend(
         filter(
-            lambda spec_env: not any(
-                [True for _env in env if _env["name"] == spec_env["name"]]
+            lambda spec_env: isinstance(spec_env, dict)
+            and not any(
+                [
+                    True
+                    for _env in env
+                    # spec_env might be V1EnvVar or a dict
+                    # _env is just a dict
+                    if getattr(spec_env, "name", spec_env.get("name", ""))
+                    == _env["name"]
+                ]
             ),
             spec.env,
         )

--- a/server/api/runtime_handlers/daskjob.py
+++ b/server/api/runtime_handlers/daskjob.py
@@ -326,17 +326,20 @@ def enrich_dask_cluster(
     # in other words, dont let spec.env override env (or not even duplicate it)
     # we dont want to override env to ensure k8s runtime envs are enforced and correct
     # leaving no room for human mistakes
+    def get_env_name(env_: Union[client.V1EnvVar, Dict]) -> str:
+        if isinstance(env_, client.V1EnvVar):
+            return env_.name
+        return env_.get("name", "")
+
     env.extend(
         filter(
-            lambda spec_env: isinstance(spec_env, dict)
-            and not any(
+            lambda spec_env: not any(
                 [
                     True
                     for _env in env
                     # spec_env might be V1EnvVar or a dict
                     # _env is just a dict
-                    if getattr(spec_env, "name", spec_env.get("name", ""))
-                    == _env["name"]
+                    if get_env_name(spec_env) == get_env_name(_env)
                 ]
             ),
             spec.env,

--- a/server/api/runtime_handlers/daskjob.py
+++ b/server/api/runtime_handlers/daskjob.py
@@ -321,7 +321,20 @@ def enrich_dask_cluster(
         or "daskdev/dask:latest"
     )
     env = spec.env
-    env.extend(function.generate_runtime_k8s_env())
+    for i, runtime_env in enumerate(function.generate_runtime_k8s_env()):
+        found = False
+        for j, function_env in enumerate(env):
+            if runtime_env["name"] == function_env["name"]:
+                # gc
+                del env[j]
+
+                # prioritize the function runtime env var over the given one
+                env[j] = function_env
+                found = True
+                break
+        if not found:
+            env.append(runtime_env)
+
     namespace = meta.namespace or config.namespace
     if spec.extra_pip:
         env.append(spec.extra_pip)

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 import mlrun
 import mlrun.common.schemas
 import server.api.api.endpoints.functions
+import server.api.runtime_handlers.daskjob
 from mlrun import mlconf
 from mlrun.platforms import auto_mount
 from mlrun.runtimes.utils import generate_resources
@@ -431,6 +432,89 @@ class TestDaskRuntime(TestRuntimeBase):
         runtime.with_security_context(other_security_context)
         _ = runtime.client
         self.assert_security_context(other_security_context)
+
+    def test_enrich_dask_cluster(self):
+        function = mlrun.runtimes.DaskCluster(
+            metadata=dict(
+                name="test",
+                project="project",
+                labels={"label1": "val1"},
+                annotations={"annotation1": "val1"},
+            ),
+            spec=dict(
+                nthreads=1,
+                worker_resources={"limits": {"memory": "1Gi"}},
+                scheduler_resources={"limits": {"memory": "1Gi"}},
+                env=[],
+            ),
+        )
+
+        function.generate_runtime_k8s_env = unittest.mock.Mock(
+            return_value=[
+                {"name": "MLRUN_DEFAULT_PROJECT", "value": "project"},
+                {"name": "MLRUN_NAMESPACE", "value": "test-namespace"},
+            ]
+        )
+
+        # add default envvars that expected to be on enriched pods
+        # do it to verify later on it is not duplicated and appears only once
+        function.spec.env.extend(function.generate_runtime_k8s_env())
+
+        secrets = []
+        client_version = "1.6.0"
+        client_python_version = "3.8"
+        scheduler_pod, worker_pod, function, namespace = (
+            server.api.runtime_handlers.daskjob.enrich_dask_cluster(
+                function, secrets, client_version, client_python_version
+            )
+        )
+
+        assert scheduler_pod.metadata.namespace == namespace
+        assert worker_pod.metadata.namespace == namespace
+        assert scheduler_pod.metadata.labels == {
+            "mlrun/project": "project",
+            "mlrun/class": "dask",
+            "mlrun/function": "test",
+            "label1": "val1",
+            "mlrun/scrape-metrics": "True",
+            "mlrun/tag": "latest",
+        }
+        assert worker_pod.metadata.labels == {
+            "mlrun/project": "project",
+            "mlrun/class": "dask",
+            "mlrun/function": "test",
+            "label1": "val1",
+            "mlrun/scrape-metrics": "True",
+            "mlrun/tag": "latest",
+        }
+        assert scheduler_pod.spec.containers[0].args == ["dask", "scheduler"]
+        assert worker_pod.spec.containers[0].args == [
+            "dask",
+            "worker",
+            "--nthreads",
+            "1",
+            "--memory-limit",
+            "1Gi",
+        ]
+        assert worker_pod.spec.containers[0].resources == {
+            "limits": {"memory": "1Gi"},
+            "requests": {},
+        }
+        assert scheduler_pod.spec.containers[0].resources == {
+            "limits": {"memory": "1Gi"},
+            "requests": {},
+        }
+        assert worker_pod.spec.containers[0].env == [
+            {"name": "MLRUN_DEFAULT_PROJECT", "value": "project"},
+            {"name": "MLRUN_NAMESPACE", "value": "test-namespace"},
+        ]
+        assert scheduler_pod.spec.containers[0].env == [
+            {"name": "MLRUN_DEFAULT_PROJECT", "value": "project"},
+            {"name": "MLRUN_NAMESPACE", "value": "test-namespace"},
+        ]
+
+        # used once by test, once by enrich_dask_cluster
+        assert function.generate_runtime_k8s_env.call_count == 2
 
     def test_deploy_dask_function_with_enriched_security_context(
         self, db: Session, client: TestClient, k8s_secrets_mock: K8sSecretsMock

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -20,6 +20,7 @@ import unittest.mock
 
 from dask import distributed
 from fastapi.testclient import TestClient
+from kubernetes import client as k8s_client
 from sqlalchemy.orm import Session
 
 import mlrun
@@ -447,6 +448,7 @@ class TestDaskRuntime(TestRuntimeBase):
                 scheduler_resources={"limits": {"memory": "1Gi"}},
                 env=[
                     {"name": "MLRUN_NAMESPACE", "value": "other-namespace"},
+                    k8s_client.V1EnvVar(name="MLRUN_TAG", value="latest"),
                 ],
             ),
         )
@@ -469,6 +471,7 @@ class TestDaskRuntime(TestRuntimeBase):
         expected_env = [
             {"name": "MLRUN_DEFAULT_PROJECT", "value": "project"},
             {"name": "MLRUN_NAMESPACE", "value": "test-namespace"},
+            k8s_client.V1EnvVar(name="MLRUN_TAG", value="latest"),
         ]
         expected_labels = {
             "mlrun/project": "project",


### PR DESCRIPTION
Function spec may already include some of the envvars generated by `generate_runtime_k8s_env` causing the extend list items to include them again. every scheduled cycle of such dask function would extend its env var list to infinity

https://iguazio.atlassian.net/browse/ML-6317
