### PR TITLE
[Linting] Upgrade Ruff

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ twine~=3.1
 build~=1.0
 
 # formatting & linting
-ruff==0.3.0
+ruff==0.4.2
 import-linter~=2.0
 
 # testing

--- a/mlrun/data_types/to_pandas.py
+++ b/mlrun/data_types/to_pandas.py
@@ -65,10 +65,10 @@ def toPandas(spark_df):
                 msg = (
                     "toPandas attempted Arrow optimization because "
                     "'spark.sql.execution.arrow.pyspark.enabled' is set to true; however, "
-                    "failed by the reason below:\n  %s\n"
+                    f"failed by the reason below:\n  {str(e)}\n"
                     "Attempting non-optimization as "
                     "'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to "
-                    "true." % str(e)
+                    "true."
                 )
                 warnings.warn(msg)
                 use_arrow = False
@@ -78,7 +78,7 @@ def toPandas(spark_df):
                     "'spark.sql.execution.arrow.pyspark.enabled' is set to true, but has "
                     "reached the error below and will not continue because automatic fallback "
                     "with 'spark.sql.execution.arrow.pyspark.fallback.enabled' has been set to "
-                    "false.\n  %s" % str(e)
+                    f"false.\n  {str(e)}"
                 )
                 warnings.warn(msg)
                 raise
@@ -144,7 +144,7 @@ def toPandas(spark_df):
                     "reached the error below and can not continue. Note that "
                     "'spark.sql.execution.arrow.pyspark.fallback.enabled' does not have an "
                     "effect on failures in the middle of "
-                    "computation.\n  %s" % str(e)
+                    f"computation.\n  {str(e)}"
                 )
                 warnings.warn(msg)
                 raise

--- a/mlrun/data_types/to_pandas.py
+++ b/mlrun/data_types/to_pandas.py
@@ -65,7 +65,7 @@ def toPandas(spark_df):
                 msg = (
                     "toPandas attempted Arrow optimization because "
                     "'spark.sql.execution.arrow.pyspark.enabled' is set to true; however, "
-                    f"failed by the reason below:\n  {str(e)}\n"
+                    f"failed by the reason below:\n  {e}\n"
                     "Attempting non-optimization as "
                     "'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to "
                     "true."
@@ -78,7 +78,7 @@ def toPandas(spark_df):
                     "'spark.sql.execution.arrow.pyspark.enabled' is set to true, but has "
                     "reached the error below and will not continue because automatic fallback "
                     "with 'spark.sql.execution.arrow.pyspark.fallback.enabled' has been set to "
-                    f"false.\n  {str(e)}"
+                    f"false.\n  {e}"
                 )
                 warnings.warn(msg)
                 raise
@@ -144,7 +144,7 @@ def toPandas(spark_df):
                     "reached the error below and can not continue. Note that "
                     "'spark.sql.execution.arrow.pyspark.fallback.enabled' does not have an "
                     "effect on failures in the middle of "
-                    f"computation.\n  {str(e)}"
+                    f"computation.\n  {e}"
                 )
                 warnings.warn(msg)
                 raise

--- a/mlrun/feature_store/retrieval/conversion.py
+++ b/mlrun/feature_store/retrieval/conversion.py
@@ -79,7 +79,7 @@ class PandasConversionMixin:
                     msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.pyspark.enabled' is set to true; however, "
-                        f"failed by the reason below:\n  {str(e)}\n"
+                        f"failed by the reason below:\n  {e}\n"
                         "Attempting non-optimization as "
                         "'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to "
                         "true."
@@ -92,7 +92,7 @@ class PandasConversionMixin:
                         "'spark.sql.execution.arrow.pyspark.enabled' is set to true, but has "
                         "reached the error below and will not continue because automatic fallback "
                         "with 'spark.sql.execution.arrow.pyspark.fallback.enabled' has been set to "
-                        f"false.\n  {str(e)}"
+                        f"false.\n  {e}"
                     )
                     warnings.warn(msg)
                     raise
@@ -158,7 +158,7 @@ class PandasConversionMixin:
                         "reached the error below and can not continue. Note that "
                         "'spark.sql.execution.arrow.pyspark.fallback.enabled' does not have an "
                         "effect on failures in the middle of "
-                        f"computation.\n  {str(e)}"
+                        f"computation.\n  {e}"
                     )
                     warnings.warn(msg)
                     raise

--- a/mlrun/feature_store/retrieval/conversion.py
+++ b/mlrun/feature_store/retrieval/conversion.py
@@ -79,10 +79,10 @@ class PandasConversionMixin:
                     msg = (
                         "toPandas attempted Arrow optimization because "
                         "'spark.sql.execution.arrow.pyspark.enabled' is set to true; however, "
-                        "failed by the reason below:\n  %s\n"
+                        f"failed by the reason below:\n  {str(e)}\n"
                         "Attempting non-optimization as "
                         "'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to "
-                        "true." % str(e)
+                        "true."
                     )
                     warnings.warn(msg)
                     use_arrow = False
@@ -92,7 +92,7 @@ class PandasConversionMixin:
                         "'spark.sql.execution.arrow.pyspark.enabled' is set to true, but has "
                         "reached the error below and will not continue because automatic fallback "
                         "with 'spark.sql.execution.arrow.pyspark.fallback.enabled' has been set to "
-                        "false.\n  %s" % str(e)
+                        f"false.\n  {str(e)}"
                     )
                     warnings.warn(msg)
                     raise
@@ -158,7 +158,7 @@ class PandasConversionMixin:
                         "reached the error below and can not continue. Note that "
                         "'spark.sql.execution.arrow.pyspark.fallback.enabled' does not have an "
                         "effect on failures in the middle of "
-                        "computation.\n  %s" % str(e)
+                        f"computation.\n  {str(e)}"
                     )
                     warnings.warn(msg)
                     raise

--- a/mlrun/frameworks/_dl_common/loggers/tensorboard_logger.py
+++ b/mlrun/frameworks/_dl_common/loggers/tensorboard_logger.py
@@ -547,7 +547,10 @@ class TensorboardLogger(Logger, Generic[DLTypes.WeightType]):
                     "inputs",
                     "parameters",
                 ]:
-                    text += f"\n  * **{property_name.capitalize()}**: {self._markdown_print(value=property_value, tabs=2)}"
+                    text += (
+                        f"\n  * **{property_name.capitalize()}**: "
+                        f"{self._markdown_print(value=property_value, tabs=2)}"
+                    )
         else:
             for property_name, property_value in self._extract_epoch_results().items():
                 text += f"\n  * **{property_name.capitalize()}**: {self._markdown_print(value=property_value, tabs=2)}"
@@ -610,7 +613,10 @@ class TensorboardLogger(Logger, Generic[DLTypes.WeightType]):
 
         :return: The generated link.
         """
-        return f'<a href="{config.resolve_ui_url()}/{config.ui.projects_prefix}/{context.project}/jobs/monitor/{context.uid}/overview" target="_blank">{link_text}</a>'
+        return (
+            f'<a href="{config.resolve_ui_url()}/{config.ui.projects_prefix}/{context.project}'
+            f'/jobs/monitor/{context.uid}/overview" target="_blank">{link_text}</a>'
+        )
 
     @staticmethod
     def _extract_properties_from_context(context: mlrun.MLClientCtx) -> dict[str, Any]:

--- a/mlrun/frameworks/_dl_common/loggers/tensorboard_logger.py
+++ b/mlrun/frameworks/_dl_common/loggers/tensorboard_logger.py
@@ -547,10 +547,7 @@ class TensorboardLogger(Logger, Generic[DLTypes.WeightType]):
                     "inputs",
                     "parameters",
                 ]:
-                    text += "\n  * **{}**: {}".format(
-                        property_name.capitalize(),
-                        self._markdown_print(value=property_value, tabs=2),
-                    )
+                    text += f"\n  * **{property_name.capitalize()}**: {self._markdown_print(value=property_value, tabs=2)}"
         else:
             for property_name, property_value in self._extract_epoch_results().items():
                 text += f"\n  * **{property_name.capitalize()}**: {self._markdown_print(value=property_value, tabs=2)}"
@@ -613,15 +610,7 @@ class TensorboardLogger(Logger, Generic[DLTypes.WeightType]):
 
         :return: The generated link.
         """
-        return (
-            '<a href="{}/{}/{}/jobs/monitor/{}/overview" target="_blank">{}</a>'.format(
-                config.resolve_ui_url(),
-                config.ui.projects_prefix,
-                context.project,
-                context.uid,
-                link_text,
-            )
-        )
+        return f'<a href="{config.resolve_ui_url()}/{config.ui.projects_prefix}/{context.project}/jobs/monitor/{context.uid}/overview" target="_blank">{link_text}</a>'
 
     @staticmethod
     def _extract_properties_from_context(context: mlrun.MLClientCtx) -> dict[str, Any]:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1018,7 +1018,10 @@ def get_ui_url(project, uid=None):
 def get_workflow_url(project, id=None):
     url = ""
     if mlrun.mlconf.resolve_ui_url():
-        url = f"{mlrun.mlconf.resolve_ui_url()}/{mlrun.mlconf.ui.projects_prefix}/{project}/jobs/monitor-workflows/workflow/{id}"
+        url = (
+            f"{mlrun.mlconf.resolve_ui_url()}/{mlrun.mlconf.ui.projects_prefix}"
+            f"/{project}/jobs/monitor-workflows/workflow/{id}"
+        )
     return url
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1018,9 +1018,7 @@ def get_ui_url(project, uid=None):
 def get_workflow_url(project, id=None):
     url = ""
     if mlrun.mlconf.resolve_ui_url():
-        url = "{}/{}/{}/jobs/monitor-workflows/workflow/{}".format(
-            mlrun.mlconf.resolve_ui_url(), mlrun.mlconf.ui.projects_prefix, project, id
-        )
+        url = f"{mlrun.mlconf.resolve_ui_url()}/{mlrun.mlconf.ui.projects_prefix}/{project}/jobs/monitor-workflows/workflow/{id}"
     return url
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.ruff]
 extend-include = ["*.ipynb"]
 target-version = "py39"
+required-version = ">=0.4.2"
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
Upgrade Ruff to the latest version - 0.4.2, which is [even faster](https://astral.sh/blog/ruff-v0.4.0).
In addition, set the minimal required version so that devs get an informative error message when running with an older version locally.