### PR TITLE
[Auth] Fix httpdb init from env

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -142,8 +142,6 @@ class HTTPRunDB(RunDBInterface):
         self.base_url = base_url
         username = parsed_url.username or config.httpdb.user
         password = parsed_url.password or config.httpdb.password
-        self.user = username
-        self.password = password
         self.token_provider = None
 
         if config.auth_with_client_id.enabled:
@@ -160,6 +158,9 @@ class HTTPRunDB(RunDBInterface):
 
             if token:
                 self.token_provider = StaticTokenProvider(token)
+
+        self.user = username
+        self.password = password
 
     def __repr__(self):
         cls = self.__class__.__name__


### PR DESCRIPTION
Changes done in #5456 caused system tests to fail - as it seems when `httpdb` is initializing, the `ACCESS_KEY` gets into the `password` field of `httpdb` and the changes didn't update `self.password` and `self.user` after the call to `add_or_refresh_credentials` (which confusingly enough gets `user` and `password` and sets them to the results of itself).

With this fix, system tests are able to connect properly.