### PR TITLE
[Httpdb] Use normalized name in URL when get_nuclio_deploy_status

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1531,9 +1531,7 @@ class HTTPRunDB(RunDBInterface):
                 "last_log_timestamp": str(last_log_timestamp),
                 "verbose": bool2str(verbose),
             }
-            _path = (
-                f"projects/{func.metadata.project}/nuclio/{normalized_name}/deploy"
-            )
+            _path = f"projects/{func.metadata.project}/nuclio/{normalized_name}/deploy"
             resp = self.api_call("GET", _path, params=params)
         except OSError as err:
             logger.error(f"error getting deploy status: {err_to_str(err)}")

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1523,15 +1523,16 @@ class HTTPRunDB(RunDBInterface):
         """
 
         try:
+            normalized_name = normalize_name(func.metadata.name)
             params = {
-                "name": normalize_name(func.metadata.name),
+                "name": normalized_name,
                 "project": func.metadata.project,
                 "tag": func.metadata.tag,
                 "last_log_timestamp": str(last_log_timestamp),
                 "verbose": bool2str(verbose),
             }
             _path = (
-                f"projects/{func.metadata.project}/nuclio/{func.metadata.name}/deploy"
+                f"projects/{func.metadata.project}/nuclio/{normalized_name}/deploy"
             )
             resp = self.api_call("GET", _path, params=params)
         except OSError as err:


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-6328

This PR addresses the bug where function isn't found because name wasn't normalized. The name was only normalized in `params`, but not in the url. 