### PR TITLE
[Application] Don't use `http` as sidecar port name

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -994,11 +994,11 @@ class RemoteRuntime(KubeResource):
         ports = mlrun.utils.helpers.as_list(ports)
         sidecar["ports"] = [
             {
-                "name": "http",
+                "name": f"{name}-{i}",
                 "containerPort": port,
                 "protocol": "TCP",
             }
-            for port in ports
+            for i, port in enumerate(ports)
         ]
 
         if command:

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -95,7 +95,7 @@ def test_consecutive_deploy_application_runtime(rundb_mock):
             [
                 {
                     "image": "my/web-app:latest",
-                    "ports": [{"containerPort": 8080, "name": "http"}],
+                    "ports": [{"containerPort": 8080, "name": "sidecar-port"}],
                     "args": ["--help"],
                 }
             ],
@@ -105,7 +105,7 @@ def test_consecutive_deploy_application_runtime(rundb_mock):
             [
                 {
                     "image": "my/web-app:latest",
-                    "ports": [{"containerPort": 8080, "name": "http"}],
+                    "ports": [{"containerPort": 8080, "name": "sidecar-port"}],
                 }
             ],
             None,
@@ -114,7 +114,7 @@ def test_consecutive_deploy_application_runtime(rundb_mock):
             [
                 {
                     "image": "my/web-app:latest",
-                    "ports": [{"containerPort": 8080, "name": "http"}],
+                    "ports": [{"containerPort": 8080, "name": "sidecar-port"}],
                     "command": ["echo"],
                 }
             ],
@@ -124,7 +124,7 @@ def test_consecutive_deploy_application_runtime(rundb_mock):
             [
                 {
                     "image": "my/web-app:latest",
-                    "ports": [{"containerPort": 8080, "name": "http"}],
+                    "ports": [{"containerPort": 8080, "name": "sidecar-port"}],
                     "command": ["echo"],
                     "args": ["--help"],
                 }
@@ -195,7 +195,13 @@ def _assert_application_post_deploy_spec(fn, image):
         {
             "image": image,
             "name": "application-test-sidecar",
-            "ports": [{"containerPort": 8080, "name": "http", "protocol": "TCP"}],
+            "ports": [
+                {
+                    "containerPort": 8080,
+                    "name": "application-test-sidecar-0",
+                    "protocol": "TCP",
+                }
+            ],
         }
     ]
     assert fn.get_env("SIDECAR_PORT") == "8080"


### PR DESCRIPTION
Following https://github.com/nuclio/nuclio/pull/3238 - The application sidecar's port name cannot be `http`, as this is a reserved name in Nuclio for the function service.
Thus, name the ports dynamically using the sidecar name instead.