### PR TITLE
[Automation] Don't rollout deployment before purging DB

### DIFF
--- a/.run/Patch remote.run.xml
+++ b/.run/Patch remote.run.xml
@@ -24,7 +24,7 @@
       </ENTRIES>
     </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/automation/patch_igz/patch_remote.py" />
-    <option name="PARAMETERS" value="-v" />
+    <option name="PARAMETERS" value="-v -r" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.run/Patch remote.run.xml
+++ b/.run/Patch remote.run.xml
@@ -24,7 +24,7 @@
       </ENTRIES>
     </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/automation/patch_igz/patch_remote.py" />
-    <option name="PARAMETERS" value="-v -r" />
+    <option name="PARAMETERS" value="-v" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -84,11 +84,13 @@ class MLRunPatcher:
                     self.Consts.log_collector_container, built_log_collector_image
                 )
 
-            self._rollout_deployment()
-            self._wait_deployment_ready()
             if self._reset_db:
                 self._reset_mlrun_db()
                 self._wait_deployment_ready()
+            else:
+                self._rollout_deployment()
+                self._wait_deployment_ready()
+
         finally:
             out = self._exec_remote(
                 [


### PR DESCRIPTION
There is no need to rollout the deployment since we scale it down before purging the DB and scale up when purge is done