### PR TITLE
[Docs] Enable automodule for mlrun.comon.schemas.artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,8 +587,12 @@ run-test-db:
 		--collation-server=utf8_bin \
 		--sql_mode=""
 
+.PHONY: clean-html-docs
+clean-html-docs: ## Clean html docs
+	cd docs && make clean && cd ..
+
 .PHONY: html-docs
-html-docs: ## Build html docs
+html-docs: clean-html-docs ## Build html docs
 	rm -f docs/external/*.md
 	cd docs && make html
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ MLRun is organized into the following modules. The most common functions are exp
   :glob:
 
   mlrun.frameworks/index
+  mlrun.common/index
   *
 
 See also the :ref:`index of all functions and classes <genindex>`.

--- a/docs/api/mlrun.common/index.rst
+++ b/docs/api/mlrun.common/index.rst
@@ -1,0 +1,10 @@
+.. _mlrun.common:
+
+mlrun.common
+============
+
+.. toctree::
+  :maxdepth: 1
+  :glob:
+
+  mlrun.common.schemas/index

--- a/docs/api/mlrun.common/mlrun.common.schemas/index.rst
+++ b/docs/api/mlrun.common/mlrun.common.schemas/index.rst
@@ -1,0 +1,10 @@
+.. _mlrun.common.schemas:
+
+mlrun.common.schemas
+====================
+
+.. toctree::
+  :maxdepth: 1
+  :glob:
+
+  mlrun.common.schemas.artifact

--- a/docs/api/mlrun.common/mlrun.common.schemas/mlrun.common.schemas.artifact.rst
+++ b/docs/api/mlrun.common/mlrun.common.schemas/mlrun.common.schemas.artifact.rst
@@ -1,0 +1,7 @@
+mlrun.common.schemas.artifact
+=============================
+
+.. automodule:: mlrun.common.schemas.artifact
+   :members:
+   :show-inheritance:
+   :undoc-members:


### PR DESCRIPTION
When running `make html-docs` to generate the mlrun documentation, it takes all of the docstrings and compiles them into docs, but it does not compile the entire code inside the `mlrun.common` module. 
It will now compile `mlrun.common.schemas.artifact.py` as well, thus the link to the enum `ArtifactsDeletionStrategies` will work as expected.
We need to activate that for all files under `mlrun.common` and create `rst` files for each Python file in that module. 
