### PR TITLE
[Logger] Enhance formatter creation [1.6.x]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1383,7 +1383,7 @@ def read_env(env=None, prefix=env_prefix):
         current_formatter_name = current_handler.formatter.__class__.__name__
         desired_formatter_name = log_formatter.__name__
         if current_formatter_name != desired_formatter_name:
-            current_handler.setFormatter(log_formatter)
+            current_handler.setFormatter(log_formatter())
 
     # The default function pod resource values are of type str; however, when reading from environment variable numbers,
     # it converts them to type int if contains only number, so we want to convert them to str.

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1376,12 +1376,12 @@ def read_env(env=None, prefix=env_prefix):
     if log_formatter_name := config.get("log_formatter"):
         import mlrun.utils.logger
 
-        log_formatter = mlrun.utils.create_formatter_instance(
+        log_formatter = mlrun.utils.resolve_formatter_by_kind(
             mlrun.utils.FormatterKinds(log_formatter_name)
         )
         current_handler = mlrun.utils.logger.get_handler("default")
         current_formatter_name = current_handler.formatter.__class__.__name__
-        desired_formatter_name = log_formatter.__class__.__name__
+        desired_formatter_name = log_formatter.__name__
         if current_formatter_name != desired_formatter_name:
             current_handler.setFormatter(log_formatter)
 

--- a/mlrun/utils/logger.py
+++ b/mlrun/utils/logger.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import typing
 from enum import Enum
 from sys import stdout
 from traceback import format_exception
@@ -186,11 +187,15 @@ class FormatterKinds(Enum):
     JSON = "json"
 
 
-def create_formatter_instance(formatter_kind: FormatterKinds) -> logging.Formatter:
+def resolve_formatter_by_kind(
+    formatter_kind: FormatterKinds,
+) -> typing.Type[
+    typing.Union[HumanReadableFormatter, HumanReadableExtendedFormatter, JSONFormatter]
+]:
     return {
-        FormatterKinds.HUMAN: HumanReadableFormatter(),
-        FormatterKinds.HUMAN_EXTENDED: HumanReadableExtendedFormatter(),
-        FormatterKinds.JSON: JSONFormatter(),
+        FormatterKinds.HUMAN: HumanReadableFormatter,
+        FormatterKinds.HUMAN_EXTENDED: HumanReadableExtendedFormatter,
+        FormatterKinds.JSON: JSONFormatter,
     }[formatter_kind]
 
 
@@ -208,11 +213,11 @@ def create_logger(
     logger_instance = Logger(level, name=name, propagate=False)
 
     # resolve formatter
-    formatter_instance = create_formatter_instance(
+    formatter_instance = resolve_formatter_by_kind(
         FormatterKinds(formatter_kind.lower())
     )
 
     # set handler
-    logger_instance.set_handler("default", stream or stdout, formatter_instance)
+    logger_instance.set_handler("default", stream or stdout, formatter_instance())
 
     return logger_instance

--- a/server/api/runtime_handlers/daskjob.py
+++ b/server/api/runtime_handlers/daskjob.py
@@ -350,6 +350,9 @@ def enrich_dask_cluster(
     if spec.extra_pip:
         env.append(spec.extra_pip)
 
+    # remove duplicates by name
+    env = list({get_env_name(spec_env): spec_env for spec_env in env}.values())
+
     pod_labels = get_resource_labels(function, scrape_metrics=config.scrape_metrics)
 
     worker_args = ["dask", "worker"]

--- a/tests/api/runtimes/test_dask.py
+++ b/tests/api/runtimes/test_dask.py
@@ -449,6 +449,8 @@ class TestDaskRuntime(TestRuntimeBase):
                 env=[
                     {"name": "MLRUN_NAMESPACE", "value": "other-namespace"},
                     k8s_client.V1EnvVar(name="MLRUN_TAG", value="latest"),
+                    {"name": "TEST_DUP", "value": "A"},
+                    {"name": "TEST_DUP", "value": "B"},
                 ],
             ),
         )
@@ -472,6 +474,7 @@ class TestDaskRuntime(TestRuntimeBase):
             {"name": "MLRUN_DEFAULT_PROJECT", "value": "project"},
             {"name": "MLRUN_NAMESPACE", "value": "test-namespace"},
             k8s_client.V1EnvVar(name="MLRUN_TAG", value="latest"),
+            {"name": "TEST_DUP", "value": "A"},
         ]
         expected_labels = {
             "mlrun/project": "project",


### PR DESCRIPTION
Potentially reduce the creation of formatter instance creation every time configmap is loaded.
Now, create the instance only if really needed

In addition, ensured that dask-job has no duplicate envvar by name to mitigate cases where function was prone to https://github.com/mlrun/mlrun/commit/dbb53dc1e528cfa04c02960e9de29fcad530c9ed issue