### PR TITLE
[Functions] Update function with deletion task id

### DIFF
--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1351,13 +1351,13 @@ async def _delete_function(
                 error_message = f"Failed to delete function {function_name}. Errors: {' '.join(failed_requests)}"
                 raise mlrun.errors.MLRunInternalServerError(error_message)
 
-    # delete the function from the database
-    await run_in_threadpool(
-        server.api.crud.Functions().delete_function,
-        db_session,
-        project,
-        function_name,
-    )
+        # delete the function from the database
+        await run_in_threadpool(
+            server.api.crud.Functions().delete_function,
+            db_session,
+            project,
+            function_name,
+        )
 
 
 async def _update_functions_with_deletion_task_ids(

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1318,6 +1318,14 @@ async def _delete_function(
         project,
         function_name,
     )
+
+    logger.debug(
+        "Updating functions with deletion task id",
+        function_name=function_name,
+        functions_count=len(functions),
+        project=project,
+    )
+
     # update functions with deletion task id
     await _update_functions_with_deletion_task_ids(
         db_session, functions, project, background_task_name

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1318,20 +1318,19 @@ async def _delete_function(
         project,
         function_name,
     )
-
-    logger.debug(
-        "Updating functions with deletion task id",
-        function_name=function_name,
-        functions_count=len(functions),
-        project=project,
-    )
-
-    # update functions with deletion task id
-    await _update_functions_with_deletion_task_ids(
-        db_session, functions, project, background_task_name
-    )
-
     if len(functions) > 0:
+        logger.debug(
+            "Updating functions with deletion task id",
+            function_name=function_name,
+            functions_count=len(functions),
+            project=project,
+        )
+
+        # update functions with deletion task id
+        await _update_functions_with_deletion_task_ids(
+            db_session, functions, project, background_task_name
+        )
+
         # Since we request functions by a specific name and project,
         # in MLRun terminology, they are all just versions of the same function
         # therefore, it's enough to check the kind of the first one only
@@ -1357,6 +1356,10 @@ async def _delete_function(
             db_session,
             project,
             function_name,
+        )
+    else:
+        logger.debug(
+            "No functions to delete found", function_name=function_name, project=project
         )
 
 

--- a/server/api/crud/functions.py
+++ b/server/api/crud/functions.py
@@ -134,3 +134,17 @@ class Functions(
             client_python_version=client_python_version,
         )
         function.save(versioned=False)
+
+    def set_function_deletion_task_id(
+        self, db_session: sqlalchemy.orm.Session, function, project, deletion_task_id
+    ):
+        deleting_updates = {
+            "status.deletion_task_id": deletion_task_id,
+        }
+        return server.api.utils.singletons.db.get_db().update_function(
+            session=db_session,
+            name=function["metadata"]["name"],
+            tag=function["metadata"]["tag"],
+            project=project,
+            updates=deleting_updates,
+        )

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -311,6 +311,18 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
+    def update_function(
+        self,
+        session,
+        name,
+        updates: dict,
+        project: str = None,
+        tag: str = None,
+        hash_key: str = None,
+    ):
+        pass
+
+    @abstractmethod
     def create_schedule(
         self,
         session,

--- a/tests/api/api/test_utils.py
+++ b/tests/api/api/test_utils.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import kubernetes.client
 import pytest
+import sqlalchemy.orm
 from deepdiff import DeepDiff
 from fastapi.testclient import TestClient
 from kubernetes.client.models import V1ConfigMap, V1ObjectMeta
@@ -41,6 +42,7 @@ from server.api.api.utils import (
     _generate_function_and_task_from_submit_run_body,
     _mask_v3io_access_key_env_var,
     _mask_v3io_volume_credentials,
+    _update_functions_with_deletion_task_ids,
     ensure_function_has_auth_set,
     ensure_function_security_context,
     get_scheduler,
@@ -1690,3 +1692,26 @@ async def test_delete_function_calls_k8s_helper_methods():
         assert len(failed_requests) == 0
         k8s_helper_mock.get_configmap.assert_called_with("function1", "model-conf")
         k8s_helper_mock.delete_configmap.assert_called_with("config-map-1")
+
+
+@pytest.mark.asyncio
+async def test_update_functions_with_deletion_task_ids(db: sqlalchemy.orm.Session):
+    project = "my_project"
+    deletion_task_id = "12345"
+    function_name = "test_function"
+    function_tag = "latest"
+    function = {
+        "metadata": {"name": function_name, "tag": function_tag},
+    }
+    server.api.crud.Functions().store_function(
+        db, project=project, function=function, name=function_name, tag=function_tag
+    )
+    functions = [function]
+
+    await _update_functions_with_deletion_task_ids(
+        db, functions, project, deletion_task_id
+    )
+    function = server.api.crud.Functions().get_function(
+        db, name=function_name, project=project, tag=function_tag
+    )
+    assert function["status"]["deletion_task_id"] == deletion_task_id

--- a/tests/api/crud/test_functions.py
+++ b/tests/api/crud/test_functions.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sqlalchemy.orm
+
+import server.api.crud
+
+
+def test_set_function_deletion_task_id_updates_correctly(db: sqlalchemy.orm.Session):
+    function_name = "test_function"
+    function_tag = "latest"
+    function = {
+        "metadata": {"name": function_name, "tag": function_tag},
+    }
+    project = "test_project"
+    deletion_task_id = "12345"
+
+    server.api.crud.Functions().store_function(
+        db, project=project, function=function, name=function_name, tag=function_tag
+    )
+
+    function = server.api.crud.Functions().get_function(
+        db, name=function_name, project=project, tag=function_tag
+    )
+
+    result = server.api.crud.Functions().set_function_deletion_task_id(
+        db_session=db,
+        function=function,
+        project=project,
+        deletion_task_id=deletion_task_id,
+    )
+
+    assert result["status"]["deletion_task_id"] == deletion_task_id


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-6422

This task is a small part of  https://iguazio.atlassian.net/browse/ML-3432 during which function deletion api of v2 was implemented. In the new implementation, we've introduced a background task that handles function deletion and returns a task name to the user.

During the initial implementation, we overlooked how the UI would recognize that a function is being deleted. This task addresses that oversight by ensuring that function["status"]["deletion_task_id"] is set to deletion_task_id before the function is deleted. This way, the UI can accurately indicate that the function is in the process of being deleted.