### PR TITLE
[Artifacts] Add `producer_uri` filter to list artifacts API [1.6.x]

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -944,6 +944,7 @@ class HTTPRunDB(RunDBInterface):
         kind: str = None,
         category: Union[str, mlrun.common.schemas.ArtifactCategories] = None,
         tree: str = None,
+        producer_uri: str = None,
     ) -> ArtifactList:
         """List artifacts filtered by various parameters.
 
@@ -970,9 +971,12 @@ class HTTPRunDB(RunDBInterface):
         :param best_iteration: Returns the artifact which belongs to the best iteration of a given run, in the case of
             artifacts generated from a hyper-param run. If only a single iteration exists, will return the artifact
             from that iteration. If using ``best_iter``, the ``iter`` parameter must not be used.
-        :param kind: Return artifacts of the requested kind.
-        :param category: Return artifacts of the requested category.
-        :param tree: Return artifacts of the requested tree.
+        :param kind:            Return artifacts of the requested kind.
+        :param category:        Return artifacts of the requested category.
+        :param tree:            Return artifacts of the requested tree.
+        :param producer_uri:    Return artifacts produced by the requested producer URI. Producer URI usually
+            points to a run and is used to filter artifacts by the run that produced them when the artifact producer id
+            is a workflow id (artifact was created as part of a workflow).
         """
 
         project = project or config.default_project
@@ -991,6 +995,7 @@ class HTTPRunDB(RunDBInterface):
             "category": category,
             "tree": tree,
             "format": mlrun.common.schemas.ArtifactsFormat.full.value,
+            "producer_uri": producer_uri,
         }
         error = "list artifacts"
         endpoint_path = f"projects/{project}/artifacts"

--- a/server/api/api/endpoints/artifacts_v2.py
+++ b/server/api/api/endpoints/artifacts_v2.py
@@ -150,7 +150,7 @@ async def list_artifacts(
     labels: List[str] = Query([], alias="label"),
     iter: int = Query(None, ge=0),
     tree: str = None,
-    run_uri: str = None,
+    producer_uri: str = None,
     best_iteration: bool = Query(False, alias="best-iteration"),
     format_: ArtifactsFormat = Query(ArtifactsFormat.full, alias="format"),
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
@@ -175,7 +175,7 @@ async def list_artifacts(
         best_iteration=best_iteration,
         format_=format_,
         producer_id=tree,
-        run_uri=run_uri,
+        producer_uri=producer_uri,
     )
 
     artifacts = await server.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(

--- a/server/api/api/endpoints/artifacts_v2.py
+++ b/server/api/api/endpoints/artifacts_v2.py
@@ -150,6 +150,7 @@ async def list_artifacts(
     labels: List[str] = Query([], alias="label"),
     iter: int = Query(None, ge=0),
     tree: str = None,
+    run_uri: str = None,
     best_iteration: bool = Query(False, alias="best-iteration"),
     format_: ArtifactsFormat = Query(ArtifactsFormat.full, alias="format"),
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
@@ -174,6 +175,7 @@ async def list_artifacts(
         best_iteration=best_iteration,
         format_=format_,
         producer_id=tree,
+        run_uri=run_uri,
     )
 
     artifacts = await server.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -148,7 +148,7 @@ class Artifacts(
         best_iteration: bool = False,
         format_: mlrun.common.schemas.artifact.ArtifactsFormat = mlrun.common.schemas.artifact.ArtifactsFormat.full,
         producer_id: str = None,
-        run_uri: str = None,
+        producer_uri: str = None,
     ) -> typing.List:
         project = project or mlrun.mlconf.default_project
         if labels is None:
@@ -166,7 +166,7 @@ class Artifacts(
             iter,
             best_iteration,
             producer_id=producer_id,
-            run_uri=run_uri,
+            producer_uri=producer_uri,
         )
         return artifacts
 

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -148,6 +148,7 @@ class Artifacts(
         best_iteration: bool = False,
         format_: mlrun.common.schemas.artifact.ArtifactsFormat = mlrun.common.schemas.artifact.ArtifactsFormat.full,
         producer_id: str = None,
+        run_uri: str = None,
     ) -> typing.List:
         project = project or mlrun.mlconf.default_project
         if labels is None:
@@ -165,6 +166,7 @@ class Artifacts(
             iter,
             best_iteration,
             producer_id=producer_id,
+            run_uri=run_uri,
         )
         return artifacts
 

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -209,7 +209,7 @@ class DBInterface(ABC):
         as_records: bool = False,
         uid: str = None,
         producer_id: str = None,
-        run_uri: str = None,
+        producer_uri: str = None,
     ):
         pass
 

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -207,8 +207,9 @@ class DBInterface(ABC):
         iter: int = None,
         best_iteration: bool = False,
         as_records: bool = False,
-        uid=None,
-        producer_id=None,
+        uid: str = None,
+        producer_id: str = None,
+        run_uri: str = None,
     ):
         pass
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -643,7 +643,7 @@ class SQLDB(DBInterface):
         as_records: bool = False,
         uid: str = None,
         producer_id: str = None,
-        run_uri: str = None,
+        producer_uri: str = None,
     ):
         project = project or config.default_project
 
@@ -666,7 +666,7 @@ class SQLDB(DBInterface):
             uid=uid,
             producer_id=producer_id,
             best_iteration=best_iteration,
-            run_uri=run_uri,
+            producer_uri=producer_uri,
         )
         if as_records:
             return artifact_records
@@ -1236,7 +1236,7 @@ class SQLDB(DBInterface):
         producer_id=None,
         best_iteration=False,
         most_recent=False,
-        run_uri=None,
+        producer_uri=None,
     ):
         if category and kind:
             message = "Category and Kind filters can't be given together"
@@ -1285,12 +1285,14 @@ class SQLDB(DBInterface):
         if most_recent:
             query = self._attach_most_recent_artifact_query(session, query)
 
-        if run_uri:
+        # Producer URI usually points to a run and is used to filter artifacts by the run that produced them when
+        # the artifact producer id is a workflow id (artifact was created as part of a workflow).
+        if producer_uri:
             artifacts = []
             for artifact in query:
                 artifact_struct = artifact.full_object
                 artifact_struct.setdefault("spec", {}).setdefault("producer", {})
-                if artifact_struct["spec"]["producer"].get("uri") == run_uri:
+                if artifact_struct["spec"]["producer"].get("uri") == producer_uri:
                     artifacts.append(artifact)
 
             return artifacts

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -641,8 +641,9 @@ class SQLDB(DBInterface):
         iter: int = None,
         best_iteration: bool = False,
         as_records: bool = False,
-        uid=None,
-        producer_id=None,
+        uid: str = None,
+        producer_id: str = None,
+        run_uri: str = None,
     ):
         project = project or config.default_project
 
@@ -665,6 +666,7 @@ class SQLDB(DBInterface):
             uid=uid,
             producer_id=producer_id,
             best_iteration=best_iteration,
+            run_uri=run_uri,
         )
         if as_records:
             return artifact_records
@@ -1234,6 +1236,7 @@ class SQLDB(DBInterface):
         producer_id=None,
         best_iteration=False,
         most_recent=False,
+        run_uri=None,
     ):
         if category and kind:
             message = "Category and Kind filters can't be given together"
@@ -1281,6 +1284,16 @@ class SQLDB(DBInterface):
                 query = query.filter(ArtifactV2.kind.in_(kinds))
         if most_recent:
             query = self._attach_most_recent_artifact_query(session, query)
+
+        if run_uri:
+            artifacts = []
+            for artifact in query:
+                artifact_struct = artifact.full_object
+                artifact_struct.setdefault("spec", {}).setdefault("producer", {})
+                if artifact_struct["spec"]["producer"].get("uri") == run_uri:
+                    artifacts.append(artifact)
+
+            return artifacts
 
         return query.all()
 

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -264,14 +264,14 @@ def test_list_artifacts(db: Session, client: TestClient) -> None:
     )
 
 
-def test_list_artifacts_with_run_uri(
+def test_list_artifacts_with_producer_uri(
     db: Session, unversioned_client: TestClient
 ) -> None:
     _create_project(unversioned_client, prefix="v1")
-    run_uri_1 = f"{PROJECT}/abc"
-    run_uri_2 = f"{PROJECT}/def"
-    run_uris = [run_uri_1, run_uri_1, run_uri_2, ""]
-    for run_uri in run_uris:
+    producer_uri_1 = f"{PROJECT}/abc"
+    producer_uri_2 = f"{PROJECT}/def"
+    producer_uris = [producer_uri_1, producer_uri_1, producer_uri_2, ""]
+    for producer_uri in producer_uris:
         data = {
             "kind": "artifact",
             "metadata": {
@@ -283,7 +283,7 @@ def test_list_artifacts_with_run_uri(
             },
             "spec": {
                 "db_key": "some-key",
-                "producer": {"kind": "api", "uri": run_uri},
+                "producer": {"kind": "api", "uri": producer_uri},
                 "target_path": "s3://aaa/aaa",
             },
             "status": {},
@@ -295,18 +295,18 @@ def test_list_artifacts_with_run_uri(
         assert resp.status_code == HTTPStatus.CREATED.value
 
     artifact_path = LIST_API_ARTIFACTS_V2_PATH.format(project=PROJECT)
-    resp = unversioned_client.get(f"{artifact_path}?run_uri={run_uri_1}")
+    resp = unversioned_client.get(f"{artifact_path}?producer_uri={producer_uri_1}")
     assert resp.status_code == HTTPStatus.OK.value
     artifacts = resp.json()["artifacts"]
     assert len(artifacts) == 2
     for artifact in artifacts:
-        assert artifact["spec"]["producer"]["uri"] == run_uri_1
+        assert artifact["spec"]["producer"]["uri"] == producer_uri_1
 
-    resp = unversioned_client.get(f"{artifact_path}?run_uri={run_uri_2}")
+    resp = unversioned_client.get(f"{artifact_path}?producer_uri={producer_uri_2}")
     assert resp.status_code == HTTPStatus.OK.value
     artifacts = resp.json()["artifacts"]
     assert len(artifacts) == 1
-    assert artifacts[0]["spec"]["producer"]["uri"] == run_uri_2
+    assert artifacts[0]["spec"]["producer"]["uri"] == producer_uri_2
 
     # Get all artifacts
     resp = unversioned_client.get(artifact_path)

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -96,7 +96,7 @@ class TestMLRunSystem:
 
     @staticmethod
     def _should_clean_resources():
-        return os.environ.get("MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES") != "false"
+        return False
 
     def _delete_test_project(self, name=None):
         if self._should_clean_resources():

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -96,7 +96,7 @@ class TestMLRunSystem:
 
     @staticmethod
     def _should_clean_resources():
-        return False
+        return os.environ.get("MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES") != "false"
 
     def _delete_test_project(self, name=None):
         if self._should_clean_resources():


### PR DESCRIPTION
Support filtering artifacts by the producer uri. This is useful for artifacts produced inside a workflow since their tree will be the workflow id and this allows to get the artifacts produced by a single run in the workflow.
https://iguazio.atlassian.net/browse/ML-6423