### PR TITLE
[API] Check the artifact kind while attempting to remove artifact data

### DIFF
--- a/mlrun/artifacts/__init__.py
+++ b/mlrun/artifacts/__init__.py
@@ -17,7 +17,13 @@
 # Don't remove this, used by sphinx documentation
 __all__ = ["get_model", "update_model"]
 
-from .base import Artifact, ArtifactMetadata, ArtifactSpec, get_artifact_meta
+from .base import (
+    Artifact,
+    ArtifactMetadata,
+    ArtifactSpec,
+    DirArtifact,
+    get_artifact_meta,
+)
 from .dataset import DatasetArtifact, TableArtifact, update_dataset_meta
 from .manager import (
     ArtifactManager,

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -183,7 +183,7 @@ class MLRunInternalServerError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
 
 
-class MLRunNotImplementServerError(MLRunHTTPStatusError):
+class MLRunNotImplementedServerError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.NOT_IMPLEMENTED.value
 
 
@@ -238,5 +238,5 @@ STATUS_ERRORS = {
     HTTPStatus.PRECONDITION_FAILED.value: MLRunPreconditionFailedError,
     HTTPStatus.INTERNAL_SERVER_ERROR.value: MLRunInternalServerError,
     HTTPStatus.SERVICE_UNAVAILABLE.value: MLRunServiceUnavailableError,
-    HTTPStatus.NOT_IMPLEMENTED.value: MLRunNotImplementServerError,
+    HTTPStatus.NOT_IMPLEMENTED.value: MLRunNotImplementedServerError,
 }

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -183,6 +183,10 @@ class MLRunInternalServerError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.INTERNAL_SERVER_ERROR.value
 
 
+class MLRunNotImplementServerError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.NOT_IMPLEMENTED.value
+
+
 class MLRunServiceUnavailableError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.SERVICE_UNAVAILABLE.value
 
@@ -234,4 +238,5 @@ STATUS_ERRORS = {
     HTTPStatus.PRECONDITION_FAILED.value: MLRunPreconditionFailedError,
     HTTPStatus.INTERNAL_SERVER_ERROR.value: MLRunInternalServerError,
     HTTPStatus.SERVICE_UNAVAILABLE.value: MLRunServiceUnavailableError,
+    HTTPStatus.NOT_IMPLEMENTED.value: MLRunNotImplementServerError,
 }

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -277,7 +277,7 @@ class Artifacts(
             # TODO: must be removed once it is supported
             artifact_kind = artifact["kind"]
             if artifact_kind in ["model", "dataset", "dir"]:
-                raise mlrun.errors.MLRunNotImplementServerError(
+                raise mlrun.errors.MLRunNotImplementedServerError(
                     f"Deleting artifact data kind: {artifact_kind} is currently not supported"
                 )
             path = artifact["spec"]["target_path"]
@@ -297,9 +297,4 @@ class Artifacts(
                 deletion_strategy
                 == mlrun.common.schemas.artifact.ArtifactsDeletionStrategies.data_force
             ):
-                if isinstance(exc, mlrun.errors.MLRunNotImplementServerError):
-                    raise
-                else:
-                    raise mlrun.errors.MLRunInternalServerError(
-                        "Failed to delete artifact data"
-                    ) from exc
+                raise

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -282,7 +282,7 @@ class Artifacts(
                 )
             path = artifact["spec"]["target_path"]
             server.api.crud.Files().delete_artifact_data(
-                auth_info, project, path, secrets
+                auth_info, project, path, secrets=secrets
             )
         except Exception as exc:
             logger.debug(
@@ -297,7 +297,7 @@ class Artifacts(
                 deletion_strategy
                 == mlrun.common.schemas.artifact.ArtifactsDeletionStrategies.data_force
             ):
-                if type(exc) is mlrun.errors.MLRunNotImplementServerError:
+                if isinstance(exc, mlrun.errors.MLRunNotImplementServerError):
                     raise
                 else:
                     raise mlrun.errors.MLRunInternalServerError(

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -271,6 +271,11 @@ class Artifacts(
                 producer_id=producer_id,
                 object_uid=object_uid,
             )
+            artifact_kind = artifact["kind"]
+            if artifact_kind in ["model", "dataset", "dir"]:
+                raise mlrun.errors.MLRunNotImplementServerError(
+                    f"Deleting artifact data kind: {artifact_kind} is currently not supported"
+                )
             path = artifact["spec"]["target_path"]
             server.api.crud.Files().delete_artifact_data(
                 auth_info, project, path, secrets
@@ -288,6 +293,9 @@ class Artifacts(
                 deletion_strategy
                 == mlrun.common.schemas.artifact.ArtifactsDeletionStrategies.data_force
             ):
-                raise mlrun.errors.MLRunInternalServerError(
-                    "Failed to delete artifact data"
-                ) from exc
+                if type(exc) is mlrun.errors.MLRunNotImplementServerError:
+                    raise
+                else:
+                    raise mlrun.errors.MLRunInternalServerError(
+                        "Failed to delete artifact data"
+                    ) from exc

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -271,6 +271,10 @@ class Artifacts(
                 producer_id=producer_id,
                 object_uid=object_uid,
             )
+
+            # Data artifacts that are ModelArtifact, DirArtifact, or DatasetArtifact
+            # must not be removed because we do not yet support the deletion of artifacts that contain multiple files
+            # TODO: must be removed once it is supported
             artifact_kind = artifact["kind"]
             if artifact_kind in ["model", "dataset", "dir"]:
                 raise mlrun.errors.MLRunNotImplementServerError(

--- a/tests/api/api/test_artifacts.py
+++ b/tests/api/api/test_artifacts.py
@@ -274,7 +274,7 @@ def test_fails_deleting_artifact_data(
 
     with unittest.mock.patch(
         "server.api.crud.files.Files.delete_artifact_data",
-        side_effect=Exception("some error"),
+        side_effect=mlrun.errors.MLRunInternalServerError("some error"),
     ):
         resp = unversioned_client.delete(
             url_with_deletion_strategy.format(deletion_strategy=deletion_strategy)


### PR DESCRIPTION
Data artifacts that are `ModelArtifact`, `DirArtifact`, or `DatasetArtifact` must not be removed because we do not yet support the deletion of artifacts that contain multiple files.

If the `deletion strategy` is `"data-force"` and one of these artifact kinds is attempted to be deleted, the error `MLRunNotImplementServerError` will be raised.

https://iguazio.atlassian.net/browse/ML-6432