### PR TITLE
[Model Monitoring] Fix invalid current_stats in `MonitoringApplicationContext`

### DIFF
--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import json
 import typing
 from typing import Optional
@@ -138,7 +137,7 @@ class _PrepareMonitoringEvent(StepToDict):
         if not event.get("mlrun_context"):
             application_context = MonitoringApplicationContext().from_dict(
                 event,
-                context=copy.deepcopy(self.context),
+                context=self.context,
                 model_endpoint_dict=self.model_endpoints,
             )
         else:

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -113,7 +113,7 @@ class MonitoringApplicationContext(MLClientCtx):
             attrs.get(mm_constants.ApplicationEvent.FEATURE_STATS, "{}")
         )
         self._sample_df_stats = json.loads(
-            attrs.get(mm_constants.ApplicationEvent.FEATURE_STATS, "{}")
+            attrs.get(mm_constants.ApplicationEvent.CURRENT_STATS, "{}")
         )
 
         self.endpoint_id = attrs.get(mm_constants.ApplicationEvent.ENDPOINT_ID)

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1142,18 +1142,15 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
 
         assert not df.empty, "No TSDB data"
         assert (
-            len(df) == 4
-        ), "Expects four results of the histogram data drift app in the TSDB"
+            len(df) == 1
+        ), "Expects a single result from the histogram data drift app in the TSDB"
         assert set(df.application_name) == {
             "histogram-data-drift"
-        }, "The application names are different than expected"
+        }, "The application name is different than expected"
         assert df.endpoint_id.nunique() == 1, "Expects a single model endpoint"
         assert set(df.result_name) == {
             "general_drift",
-            "hellinger_mean",
-            "kld_mean",
-            "tvd_mean",
-        }, "The results are different than expected"
+        }, "The result is different than expected"
 
     def test_record(self) -> None:
         self.project.enable_model_monitoring(


### PR DESCRIPTION

- Fix the calculation of `current_stats` as part of the `MonitoringApplicationContext`.
- Remove unnecessary use of `deepcopy` as part of the `_PrepareMonitoringEvent` step. 

A fix for [ML-6425](https://iguazio.atlassian.net/browse/ML-6425 )

[ML-6425]: https://iguazio.atlassian.net/browse/ML-6425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ