### PR TITLE
[Model Monitoring] Update model endpoint's current stats and drift measures in the writer

### DIFF
--- a/docs/api/mlrun.model_monitoring.rst
+++ b/docs/api/mlrun.model_monitoring.rst
@@ -22,3 +22,6 @@ mlrun.model_monitoring
    :members:
    :exclude-members: do
 
+.. automodule:: mlrun.model_monitoring.applications.histogram_data_drift
+   :members:
+

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -555,7 +555,7 @@ class RunDBInterface(ABC):
         end: Optional[str] = None,
         metrics: Optional[list[str]] = None,
         features: bool = False,
-    ):
+    ) -> "mlrun.model_monitoring.model_endpoint.ModelEndpoint":
         pass
 
     @abstractmethod

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -555,7 +555,7 @@ class RunDBInterface(ABC):
         end: Optional[str] = None,
         metrics: Optional[list[str]] = None,
         features: bool = False,
-    ) -> "mlrun.model_monitoring.model_endpoint.ModelEndpoint":
+    ) -> mlrun.model_monitoring.ModelEndpoint:
         pass
 
     @abstractmethod

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -248,7 +248,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
             mm_drift_table.FeaturesDriftTablePlot().produce(
                 sample_set_statistics=sample_set_statistics,
                 inputs_statistics=inputs_statistics,
-                metrics=metrics_per_feature.T.to_dict(),
+                metrics=metrics_per_feature.T.to_dict(),  # pyright: ignore[reportArgumentType]
                 drift_results=drift_results,
             )
         )

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -168,6 +168,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
             value=value,
             kind=ResultKindApp.data_drift,
             status=status,
+            extra_data={},
         )
 
     def _get_metrics(

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -150,16 +150,19 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
         self, metrics: list[mm_results.ModelMonitoringApplicationMetric]
     ) -> mm_results.ModelMonitoringApplicationResult:
         """Get the general drift result from the metrics list"""
-        value = np.mean(
-            [
-                metric.value
-                for metric in metrics
-                if metric.name
-                in [
-                    f"{HellingerDistance.NAME}_mean",
-                    f"{TotalVarianceDistance.NAME}_mean",
+        value = cast(
+            float,
+            np.mean(
+                [
+                    metric.value
+                    for metric in metrics
+                    if metric.name
+                    in [
+                        f"{HellingerDistance.NAME}_mean",
+                        f"{TotalVarianceDistance.NAME}_mean",
+                    ]
                 ]
-            ]
+            ),
         )
 
         status = self._value_classifier.value_to_status(value)

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -91,9 +91,27 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
     """
     MLRun's default data drift application for model monitoring.
 
-    The application calculates the metrics over the features' histograms.
-    Each metric is calculated over all the features, the mean is taken,
-    and the status is returned.
+    The application expects tabular numerical data, and calculates three metrics over the features' histograms.
+    The three metrics are:
+
+    * Hellinger distance.
+    * Total variance distance.
+    * Kullback-Leibler divergence.
+
+    Each metric is calculated over all the features individually and the mean is taken as the metric value.
+    The average of Hellinger and total variance distance is taken as the result.
+
+    The application logs two artifacts:
+
+    * A JSON with the general drift per feature.
+    * A plotly table different metrics per feature.
+
+    This application is deployed by default when calling:
+
+    .. code-block:: python
+
+        project.enable_model_monitoring()
+
     """
 
     NAME: Final[str] = HistogramDataDriftApplicationConstants.NAME
@@ -108,8 +126,6 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
 
     def __init__(self, value_classifier: Optional[ValueClassifier] = None) -> None:
         """
-        Initialize the data drift application.
-
         :param value_classifier: Classifier object that adheres to the `ValueClassifier` protocol.
                                  If not provided, the default `DataDriftClassifier()` is used.
         """

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -184,8 +184,9 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
             },
         )
 
+    @staticmethod
     def _get_metrics(
-        self, metrics_per_feature: DataFrame
+        metrics_per_feature: DataFrame,
     ) -> list[mm_results.ModelMonitoringApplicationMetric]:
         """Average the metrics over the features and add the status"""
         metrics: list[mm_results.ModelMonitoringApplicationMetric] = []
@@ -217,8 +218,8 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
             del sample_set_statistics[EventFieldType.TIMESTAMP]
         return sample_set_statistics
 
+    @staticmethod
     def _log_json_artifact(
-        self,
         drift_per_feature_values: Series,
         monitoring_context: mm_context.MonitoringApplicationContext,
     ) -> None:

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -19,7 +19,6 @@ import mlrun.common.model_monitoring
 import mlrun.common.schemas
 import mlrun.common.schemas.alert as alert_constants
 import mlrun.model_monitoring
-import mlrun.model_monitoring.db.stores
 from mlrun.common.schemas.model_monitoring.constants import (
     EventFieldType,
     HistogramDataDriftApplicationConstants,
@@ -228,7 +227,7 @@ class ModelMonitoringWriter(StepToDict):
                 "data drift app",
                 endpoint_id=endpoint_id,
             )
-            store = mlrun.model_monitoring.db.get_store_object(project=self.project)
+            store = mlrun.model_monitoring.get_store_object(project=self.project)
             store.update_model_endpoint(
                 endpoint_id=endpoint_id,
                 attributes=json.loads(event[ResultData.RESULT_EXTRA_DATA]),

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -221,8 +221,12 @@ class ModelMonitoringWriter(StepToDict):
             and event[ResultData.RESULT_NAME]
             == HistogramDataDriftApplicationConstants.GENERAL_RESULT_NAME
         ):
-            # Update the model endpoint with metadata specific to the
-            # histogram data drift app
+            endpoint_id = event[WriterEvent.ENDPOINT_ID]
+            logger.info(
+                "Updating the model endpoint with metadata specific to the histogram "
+                "data drift app",
+                endpoint_id=endpoint_id,
+            )
             store = mlrun.model_monitoring.db.get_store_object(project=self.project)
             store.update_model_endpoint(
                 endpoint_id=endpoint_id,

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -127,11 +127,11 @@ class ModelMonitoringWriter(StepToDict):
             or drift_status == ResultStatusApp.potential_detection.value
         ):
             logger.info("Sending an alert")
-            entity = {
-                "kind": alert_constants.EventEntityKind.MODEL,
-                "project": project_name,
-                "ids": [model_endpoint],
-            }
+            entity = mlrun.common.schemas.alert.EventEntities(
+                kind=alert_constants.EventEntityKind.MODEL,
+                project=project_name,
+                ids=[model_endpoint],
+            )
             event_kind = (
                 alert_constants.EventKind.DRIFT_DETECTED
                 if drift_status == ResultStatusApp.detected.value

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -22,6 +22,7 @@ import mlrun.model_monitoring
 import mlrun.model_monitoring.db.stores
 from mlrun.common.schemas.model_monitoring.constants import (
     EventFieldType,
+    HistogramDataDriftApplicationConstants,
     MetricData,
     ResultData,
     ResultStatusApp,
@@ -211,4 +212,19 @@ class ModelMonitoringWriter(StepToDict):
                 event[ResultData.RESULT_STATUS],
                 event_value,
                 self.project,
+            )
+
+        if (
+            kind == WriterEventKind.RESULT
+            and event[WriterEvent.APPLICATION_NAME]
+            == HistogramDataDriftApplicationConstants.NAME
+            and event[ResultData.RESULT_NAME]
+            == HistogramDataDriftApplicationConstants.GENERAL_RESULT_NAME
+        ):
+            # Update the model endpoint with metadata specific to the
+            # histogram data drift app
+            store = mlrun.model_monitoring.db.get_store_object(project=self.project)
+            store.update_model_endpoint(
+                endpoint_id=endpoint_id,
+                attributes=json.loads(event[ResultData.RESULT_EXTRA_DATA]),
             )

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import datetime
 import json
 import os
@@ -101,6 +102,8 @@ def event(request: pytest.FixtureRequest) -> _AppResultEvent:
                 ),
             }
         )
+    else:
+        raise ValueError
 
 
 @pytest.fixture

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -15,10 +15,11 @@
 import datetime
 import json
 import os
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import semver
+import v3io.dataplane.kv
 import v3io_frames.client
 
 import mlrun.common.schemas.model_monitoring as mm_constants
@@ -36,6 +37,7 @@ from mlrun.model_monitoring.writer import (
     _WriterEventValueError,
 )
 from mlrun.utils.notifications.notification_pusher import CustomNotificationPusher
+from mlrun.utils.v3io_clients import V3IOClient
 
 TEST_PROJECT = "test-application-results"
 V3IO_TABLE_CONTAINER = f"bigdata/{TEST_PROJECT}"
@@ -122,6 +124,59 @@ def notification_pusher() -> CustomNotificationPusher:
 def test_reconstruct_event_error(event: _RawEvent, exception: type[Exception]) -> None:
     with pytest.raises(exception):
         ModelMonitoringWriter._reconstruct_event(event)
+
+
+class TestHistogramGeneralDriftResultEvent:
+    @staticmethod
+    @pytest.fixture
+    def mock_v3io_client() -> V3IOClient:
+        mock_client = Mock(spec=V3IOClient)
+        mock_client.kv = Mock(spec=v3io.dataplane.kv.Model)
+        return mock_client
+
+    @staticmethod
+    @pytest.fixture
+    def general_drift_event() -> _RawEvent:
+        return _RawEvent(
+            {
+                "application_name": "histogram-data-drift",
+                "end_infer_time": "2024-05-12 14:53:26.000000+00:00",
+                "endpoint_id": "fc96fcd22935343586ce32c5d4614f5dca816405",
+                "current_stats": {},  # Don't rely on current stats
+                "result_extra_data": '{"current_stats": "{\\"sepal_length_cm\\": {\\"count\\": 150.0, \\"mean\\": 5.843333333333334, \\"std\\": 0.828066127977863, \\"min\\": 4.3, \\"25%\\": 5.1, \\"50%\\": 5.8, \\"75%\\": 6.4, \\"max\\": 7.9, \\"hist\\": [[0, 4, 5, 7, 16, 9, 5, 13, 14, 10, 6, 10, 16, 7, 11, 4, 2, 4, 1, 5, 1, 0], [-1.7976931348623157e+308, 4.3, 4.4799999999999995, 4.66, 4.84, 5.02, 5.2, 5.38, 5.5600000000000005, 5.74, 5.92, 6.1, 6.28, 6.46, 6.640000000000001, 6.82, 7.0, 7.18, 7.36, 7.54, 7.720000000000001, 7.9, 1.7976931348623157e+308]]}, \\"sepal_width_cm\\": {\\"count\\": 150.0, \\"mean\\": 3.0573333333333337, \\"std\\": 0.4358662849366982, \\"min\\": 2.0, \\"25%\\": 2.8, \\"50%\\": 3.0, \\"75%\\": 3.3, \\"max\\": 4.4, \\"hist\\": [[0, 1, 3, 4, 3, 8, 14, 14, 10, 26, 11, 19, 12, 6, 4, 9, 2, 1, 1, 1, 1, 0], [-1.7976931348623157e+308, 2.0, 2.12, 2.24, 2.3600000000000003, 2.48, 2.6, 2.72, 2.8400000000000003, 2.96, 3.08, 3.2, 3.3200000000000003, 3.4400000000000004, 3.5600000000000005, 3.6800000000000006, 3.8000000000000003, 3.9200000000000004, 4.040000000000001, 4.16, 4.28, 4.4, 1.7976931348623157e+308]]}, \\"petal_length_cm\\": {\\"count\\": 150.0, \\"mean\\": 3.7580000000000005, \\"std\\": 1.7652982332594662, \\"min\\": 1.0, \\"25%\\": 1.6, \\"50%\\": 4.35, \\"75%\\": 5.1, \\"max\\": 6.9, \\"hist\\": [[0, 4, 33, 11, 2, 0, 0, 1, 2, 3, 5, 12, 14, 12, 17, 6, 12, 7, 4, 2, 3, 0], [-1.7976931348623157e+308, 1.0, 1.295, 1.59, 1.8850000000000002, 2.18, 2.475, 2.7700000000000005, 3.0650000000000004, 3.3600000000000003, 3.6550000000000002, 3.95, 4.245000000000001, 4.540000000000001, 4.835000000000001, 5.130000000000001, 5.425000000000001, 5.720000000000001, 6.015000000000001, 6.3100000000000005, 6.605, 6.9, 1.7976931348623157e+308]]}, \\"petal_width_cm\\": {\\"count\\": 150.0, \\"mean\\": 1.1993333333333336, \\"std\\": 0.7622376689603465, \\"min\\": 0.1, \\"25%\\": 0.3, \\"50%\\": 1.3, \\"75%\\": 1.8, \\"max\\": 2.5, \\"hist\\": [[0, 34, 7, 7, 1, 1, 0, 0, 7, 3, 5, 21, 12, 4, 2, 12, 11, 6, 3, 8, 6, 0], [-1.7976931348623157e+308, 0.1, 0.22, 0.33999999999999997, 0.45999999999999996, 0.58, 0.7, 0.82, 0.94, 1.06, 1.1800000000000002, 1.3, 1.42, 1.54, 1.6600000000000001, 1.78, 1.9, 2.02, 2.14, 2.2600000000000002, 2.38, 2.5, 1.7976931348623157e+308]]}}", "drift_measures": "{\\"sepal_length_cm\\":{\\"hellinger\\":0.0,\\"kld\\":0.0,\\"tvd\\":0.0},\\"sepal_width_cm\\":{\\"hellinger\\":0.0,\\"kld\\":0.0,\\"tvd\\":0.0},\\"petal_length_cm\\":{\\"hellinger\\":0.0000000105,\\"kld\\":0.0,\\"tvd\\":0.0},\\"petal_width_cm\\":{\\"hellinger\\":0.0,\\"kld\\":0.0,\\"tvd\\":0.0}}", "drift_status": 0}',  # noqa: E501
+                "result_kind": 0,
+                "result_name": "general_drift",
+                "result_status": 0,
+                "result_value": 1.3170890159654386e-9,
+                "start_infer_time": "2024-05-12 14:52:26.000000+00:00",
+            }
+        )
+
+    @staticmethod
+    @patch("mlrun.utils.v3io_clients.get_client")  # patch frames client
+    def test_update_model_endpoint(
+        _, general_drift_event: _RawEvent, mock_v3io_client: V3IOClient
+    ) -> None:
+        with patch(
+            "mlrun.utils.v3io_clients.get_v3io_client",
+            Mock(return_value=mock_v3io_client),
+        ):
+            ModelMonitoringWriter(project=TEST_PROJECT).do(general_drift_event)
+        update_mock = mock_v3io_client.kv.update
+        assert update_mock.call_count == 2, (
+            "Expects two update calls - one for the results KV, "
+            "and one for the model endpoint"
+        )
+        update_mock.assert_called_with(
+            container="users",
+            table_path="pipelines/test-application-results/model-endpoints/endpoints/",
+            key="fc96fcd22935343586ce32c5d4614f5dca816405",
+            attributes={
+                "current_stats": b'{"sepal_length_cm": {"count": 150.0, "mean": 5.843333333333334, "std": 0.828066127977863, "min": 4.3, "25%": 5.1, "50%": 5.8, "75%": 6.4, "max": 7.9, "hist": [[0, 4, 5, 7, 16, 9, 5, 13, 14, 10, 6, 10, 16, 7, 11, 4, 2, 4, 1, 5, 1, 0], [-1.7976931348623157e+308, 4.3, 4.4799999999999995, 4.66, 4.84, 5.02, 5.2, 5.38, 5.5600000000000005, 5.74, 5.92, 6.1, 6.28, 6.46, 6.640000000000001, 6.82, 7.0, 7.18, 7.36, 7.54, 7.720000000000001, 7.9, 1.7976931348623157e+308]]}, "sepal_width_cm": {"count": 150.0, "mean": 3.0573333333333337, "std": 0.4358662849366982, "min": 2.0, "25%": 2.8, "50%": 3.0, "75%": 3.3, "max": 4.4, "hist": [[0, 1, 3, 4, 3, 8, 14, 14, 10, 26, 11, 19, 12, 6, 4, 9, 2, 1, 1, 1, 1, 0], [-1.7976931348623157e+308, 2.0, 2.12, 2.24, 2.3600000000000003, 2.48, 2.6, 2.72, 2.8400000000000003, 2.96, 3.08, 3.2, 3.3200000000000003, 3.4400000000000004, 3.5600000000000005, 3.6800000000000006, 3.8000000000000003, 3.9200000000000004, 4.040000000000001, 4.16, 4.28, 4.4, 1.7976931348623157e+308]]}, "petal_length_cm": {"count": 150.0, "mean": 3.7580000000000005, "std": 1.7652982332594662, "min": 1.0, "25%": 1.6, "50%": 4.35, "75%": 5.1, "max": 6.9, "hist": [[0, 4, 33, 11, 2, 0, 0, 1, 2, 3, 5, 12, 14, 12, 17, 6, 12, 7, 4, 2, 3, 0], [-1.7976931348623157e+308, 1.0, 1.295, 1.59, 1.8850000000000002, 2.18, 2.475, 2.7700000000000005, 3.0650000000000004, 3.3600000000000003, 3.6550000000000002, 3.95, 4.245000000000001, 4.540000000000001, 4.835000000000001, 5.130000000000001, 5.425000000000001, 5.720000000000001, 6.015000000000001, 6.3100000000000005, 6.605, 6.9, 1.7976931348623157e+308]]}, "petal_width_cm": {"count": 150.0, "mean": 1.1993333333333336, "std": 0.7622376689603465, "min": 0.1, "25%": 0.3, "50%": 1.3, "75%": 1.8, "max": 2.5, "hist": [[0, 34, 7, 7, 1, 1, 0, 0, 7, 3, 5, 21, 12, 4, 2, 12, 11, 6, 3, 8, 6, 0], [-1.7976931348623157e+308, 0.1, 0.22, 0.33999999999999997, 0.45999999999999996, 0.58, 0.7, 0.82, 0.94, 1.06, 1.1800000000000002, 1.3, 1.42, 1.54, 1.6600000000000001, 1.78, 1.9, 2.02, 2.14, 2.2600000000000002, 2.38, 2.5, 1.7976931348623157e+308]]}}',  # noqa: E501
+                "drift_measures": '{"sepal_length_cm":{"hellinger":0.0,"kld":0.0,"tvd":0.0},"sepal_width_cm":{"hellinger":0.0,"kld":0.0,"tvd":0.0},"petal_length_cm":{"hellinger":0.0000000105,"kld":0.0,"tvd":0.0},"petal_width_cm":{"hellinger":0.0,"kld":0.0,"tvd":0.0}}',  # noqa: E501
+                "drift_status": 0,
+            },
+        )
 
 
 class TestTSDB:

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -156,7 +156,7 @@ class TestTSDB:
     @staticmethod
     @pytest.fixture
     def writer(
-        tsdb_connector: tsdb_connector,
+        tsdb_connector: mlrun.model_monitoring.db.tsdb.v3io.V3IOTSDBConnector,
     ) -> ModelMonitoringWriter:
         writer = Mock(spec=ModelMonitoringWriter)
         writer.project = TEST_PROJECT


### PR DESCRIPTION
Resolves [ML-5767](https://iguazio.atlassian.net/browse/ML-5767).

It is tested with a unit test and a new part in the primary system test.

The "extra data" of the default app's result is populated with the relevant data, and the writer treats this result in the new part.

[ML-5767]: https://iguazio.atlassian.net/browse/ML-5767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ