### PR TITLE
[Helpers] Ignore pre-release in `min_iguazio_version`

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1572,13 +1572,19 @@ def validate_component_version_compatibility(
     component_current_version = None
     try:
         if component_name == "iguazio":
-            parsed_current_version = mlrun.mlconf.get_parsed_igz_version()
             component_current_version = mlrun.mlconf.igz_version
+            parsed_current_version = mlrun.mlconf.get_parsed_igz_version()
+
+            # ignore pre-release versions and build metadata, as iguazio version is not semver compliant
+            # (we will always have a "pre-release" version even on GA releases)
+            parsed_current_version = semver.VersionInfo.parse(
+                f"{parsed_current_version.major}.{parsed_current_version.minor}.{parsed_current_version.patch}"
+            )
         if component_name == "nuclio":
+            component_current_version = mlrun.mlconf.nuclio_version
             parsed_current_version = semver.VersionInfo.parse(
                 mlrun.mlconf.nuclio_version
             )
-            component_current_version = mlrun.mlconf.nuclio_version
         if not parsed_current_version:
             return True
     except ValueError:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1575,8 +1575,8 @@ def validate_component_version_compatibility(
             component_current_version = mlrun.mlconf.igz_version
             parsed_current_version = mlrun.mlconf.get_parsed_igz_version()
 
-            # ignore pre-release versions and build metadata, as iguazio version is not semver compliant
-            # (we will always have a "pre-release" version even on GA releases)
+            # ignore pre-release and build metadata, as iguazio version always has them, and we only care about the
+            # major, minor, and patch versions
             parsed_current_version = semver.VersionInfo.parse(
                 f"{parsed_current_version.major}.{parsed_current_version.minor}.{parsed_current_version.patch}"
             )

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -278,7 +278,7 @@ def test_min_iguazio_version_fail(min_versions):
     ],
 )
 def test_min_iguazio_versions_success(min_versions):
-    mlconf.igz_version = "3.8.0+b953.20240321124232"
+    mlconf.igz_version = "3.8.0-b953.20240321124232"
 
     logger.debug(f"Testing case: {min_versions}")
 

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -278,7 +278,9 @@ def test_min_iguazio_version_fail(min_versions):
     ],
 )
 def test_min_iguazio_versions_success(min_versions):
-    mlconf.igz_version = "3.8.0"
+    mlconf.igz_version = "3.8.0+b953.20240321124232"
+
+    logger.debug(f"Testing case: {min_versions}")
 
     @min_iguazio_versions(*min_versions)
     def success():

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -30,6 +30,7 @@ import mlrun
 import mlrun.artifacts
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring as mm_consts
+import mlrun.db.nopdb
 import mlrun.errors
 import mlrun.projects.project
 import mlrun.runtimes.base

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1813,6 +1813,7 @@ def test_create_api_gateway_valid(
     upstreams,
     authentication_mode,
 ):
+    mlrun.mlconf.igz_version = "3.6.0"
     patched_create_api_gateway.return_value = mlrun.common.schemas.APIGateway(
         metadata=mlrun.common.schemas.APIGatewayMetadata(
             name="new-gw",

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -34,6 +34,7 @@ def test_create_application_runtime():
 
 
 def test_create_application_runtime_with_command(rundb_mock):
+    mlrun.mlconf.igz_version = "3.6.0"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
         "application-test", kind="application", image="mlrun/mlrun", command="echo"
     )
@@ -47,6 +48,7 @@ def test_create_application_runtime_with_command(rundb_mock):
 
 
 def test_deploy_application_runtime(rundb_mock):
+    mlrun.mlconf.igz_version = "3.6.0"
     image = "my/web-app:latest"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test", kind="application", image=image
@@ -56,6 +58,7 @@ def test_deploy_application_runtime(rundb_mock):
 
 
 def test_consecutive_deploy_application_runtime(rundb_mock):
+    mlrun.mlconf.igz_version = "3.6.0"
     image = "my/web-app:latest"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test", kind="application", image=image
@@ -158,6 +161,7 @@ def test_image_enriched_on_build_application_image(remote_builder_mock):
 
 
 def test_application_image_build(remote_builder_mock):
+    mlrun.mlconf.igz_version = "3.6.0"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test",
         kind="application",
@@ -171,6 +175,7 @@ def test_application_image_build(remote_builder_mock):
 
 
 def test_application_api_gateway(rundb_mock):
+    mlrun.mlconf.igz_version = "3.6.0"
     function_name = "application-test"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test",


### PR DESCRIPTION
Iguazio versions are named `<major>.<minor>.<patch>-bXX-YYYYY`, even when it is a GA release.
According to semver, this version is marked as a "pre-release", although it is not necessarily the case.

Thus, in the `min_iguazio_version` wrapper we can safely ignore the pre-release and build version when comparing versions.