### PR TITLE
[Runs] Enrich run with artifacts when getting a single run [1.6.x]

### DIFF
--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -148,11 +148,14 @@ class Runs(
             db_session, uid, project, iter
         )
 
+        # Since we don't store the artifacts in the run body, we need to fetch them separately
+        # The client may be using them as in pipeline as input for the next step
         producer_uri = None
         producer_id = run["metadata"]["labels"].get("workflow")
         if not producer_id:
             producer_id = run["metadata"]["uid"]
         else:
+            # Producer URI is the URI of the MLClientCtx object that produced the artifact
             producer_uri = f"{project}/{run['metadata']['uid']}"
 
         artifacts = server.api.crud.Artifacts().list_artifacts(

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -164,8 +164,10 @@ class Runs(
             producer_uri=producer_uri,
             project=project,
         )
-        run.setdefault("status", {})
-        run["status"]["artifacts"] = artifacts
+
+        if artifacts or "artifacts" in run.get("status", {}):
+            run.setdefault("status", {})
+            run["status"]["artifacts"] = artifacts
 
         return run
 

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -151,9 +151,9 @@ class Runs(
         # Since we don't store the artifacts in the run body, we need to fetch them separately
         # The client may be using them as in pipeline as input for the next step
         producer_uri = None
-        producer_id = run["metadata"]["labels"].get("workflow")
+        producer_id = run["metadata"].get("labels", {}).get("workflow")
         if not producer_id:
-            producer_id = run["metadata"]["uid"]
+            producer_id = uid
         else:
             # Producer URI is the URI of the MLClientCtx object that produced the artifact
             producer_uri = f"{project}/{run['metadata']['uid']}"

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -465,22 +465,25 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
         artifacts = []
         i = 0
         while len(artifacts) < artifacts_len:
-            artifacts.append(
-                {
-                    "kind": "artifact",
-                    "metadata": {
-                        "key": f"key{i}",
-                        "tree": workflow_uid or run_uid,
-                        "uid": f"uid{i}",
-                        "project": project,
-                        "iter": None,
-                    },
-                    "spec": {
-                        "db_key": f"db_key{i}",
-                    },
-                    "status": {},
+            artifact = {
+                "kind": "artifact",
+                "metadata": {
+                    "key": f"key{i}",
+                    "tree": workflow_uid or run_uid,
+                    "uid": f"uid{i}",
+                    "project": project,
+                    "iter": None,
+                },
+                "spec": {
+                    "db_key": f"db_key{i}",
+                },
+                "status": {},
+            }
+            if workflow_uid:
+                artifact["spec"]["producer"] = {
+                    "uri": f"{project}/{run_uid}",
                 }
-            )
+            artifacts.append(artifact)
             i += 1
         return artifacts
 


### PR DESCRIPTION
When we run a remote job we get the run response from the server. Since we removed the artifacts from the run body, the client will not be able to use the runs' outputs and thus it breaks BC and in particular it breaks pipelines that are dependent on previous runs artifacts.
The fix is solely for getting a single run, there we will enrich it with its artifacts.

Jira - https://iguazio.atlassian.net/browse/ML-6441