### PR TITLE
[Model] Replace yaml dump with safe_dump

### DIFF
--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -509,7 +509,7 @@ def _get_extra(target, extra_data, is_dir=False):
 def _remove_tag_from_spec_yaml(model_spec):
     spec_dict = model_spec.to_dict()
     spec_dict["metadata"].pop("tag", None)
-    return yaml.dump(spec_dict)
+    return yaml.safe_dump(spec_dict)
 
 
 def update_model(

--- a/mlrun/track/tracker.py
+++ b/mlrun/track/tracker.py
@@ -31,8 +31,9 @@ class Tracker(ABC):
     * Offline: Manually importing models and artifacts into an MLRun project using the `import_x` methods.
     """
 
+    @staticmethod
     @abstractmethod
-    def is_enabled(self) -> bool:
+    def is_enabled() -> bool:
         """
         Checks if tracker is enabled.
 

--- a/tests/track/test_tracker_manager.py
+++ b/tests/track/test_tracker_manager.py
@@ -25,7 +25,8 @@ class TrackerExample(Tracker):
     # just some random module
     TRACKED_MODULE_NAME = "os"
 
-    def is_enabled(self):
+    @staticmethod
+    def is_enabled():
         return True
 
     def pre_run(self, context) -> dict:


### PR DESCRIPTION
The `yaml.dump` causes issues in some cases, look at ticket:
https://iguazio.atlassian.net/browse/ML-6452?atlOrigin=eyJpIjoiMDY1ZDhjNGVmZmNjNDAwNWI1MmU1NjYyYjgzZmU0NTciLCJwIjoiamlyYS1zbGFjay1pbnQifQ


This is a first and simple fix for a specific location that affects our work.