### PR TITLE
[Nuclio] Fix nuclio-name when mlrun name passed as a string

### DIFF
--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -214,7 +214,7 @@ class APIGatewaySpec(ModelObj):
 
     def enrich_and_validate(
         self,
-        project,
+        project: str,
         functions: Union[
             list[
                 Union[

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -284,7 +284,9 @@ class APIGatewaySpec(ModelObj):
         function_names = []
         for func in functions:
             if isinstance(func, str):
-                function_names.append(func)
+                # if mlrun name is passed as string we assume that tag is latest
+                nuclio_name = f"{project}-{func}"
+                function_names.append(nuclio_name)
                 continue
 
             function_name = (

--- a/tests/api/utils/clients/test_async_nuclio.py
+++ b/tests/api/utils/clients/test_async_nuclio.py
@@ -79,7 +79,7 @@ async def test_nuclio_get_api_gateway(
         received_api_gateway.authentication.authentication_mode
         == api_gateway.spec.authentication.authentication_mode
     )
-    assert received_api_gateway.spec.functions == ["test", "test2"]
+    assert received_api_gateway.spec.functions == ["default-test", "default-test2"]
     assert received_api_gateway.spec.canary == [20, 80]
 
 

--- a/tests/api/utils/clients/test_async_nuclio.py
+++ b/tests/api/utils/clients/test_async_nuclio.py
@@ -79,7 +79,10 @@ async def test_nuclio_get_api_gateway(
         received_api_gateway.authentication.authentication_mode
         == api_gateway.spec.authentication.authentication_mode
     )
-    assert received_api_gateway.spec.functions == ["default-test", "default-test2"]
+    assert received_api_gateway.spec.functions == [
+        "default-project-test",
+        "default-project-test2",
+    ]
     assert received_api_gateway.spec.canary == [20, 80]
 
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1976,7 +1976,7 @@ def test_list_api_gateways(patched_list_api_gateways, context):
 
     assert gateways[0].name == "test"
     assert gateways[0].host == "http://gateway-f1-f2-project-name.some-domain.com"
-    assert gateways[0].spec.functions == ["project-name-my-func1"]
+    assert gateways[0].spec.functions == ["my-func1"]
 
     assert gateways[1].invoke_url == "http://test-basic-default.domain.com/"
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1976,7 +1976,7 @@ def test_list_api_gateways(patched_list_api_gateways, context):
 
     assert gateways[0].name == "test"
     assert gateways[0].host == "http://gateway-f1-f2-project-name.some-domain.com"
-    assert gateways[0].spec.functions == ["my-func1"]
+    assert gateways[0].spec.functions == ["project-name-my-func1"]
 
     assert gateways[1].invoke_url == "http://test-basic-default.domain.com/"
 


### PR DESCRIPTION
Generates proper nuclio name if MLRun function name is given as a string