### PR TITLE
[Versioning] Fix package version for dev feature branches

### DIFF
--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import logging
 import os
-import os.path
 import pathlib
 import re
 import subprocess
@@ -83,11 +82,9 @@ def main():
         print(next_version)
 
     elif args.command == "ensure":
-        repo_root = os.path.dirname(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        )
-        version_file_path = os.path.join(
-            repo_root, "mlrun", "utils", "version", "version.json"
+        repo_root = pathlib.Path(__file__).parents[2]
+        version_file_path = str(
+            (repo_root / "mlrun/utils/version/version.json").absolute()
         )
         logger.debug(f"{args.mlrun_version = }")
         create_or_update_version_file(args.mlrun_version, version_file_path)

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -15,6 +15,7 @@
 import argparse
 import json
 import logging
+import os
 import os.path
 import pathlib
 import re
@@ -23,8 +24,11 @@ import typing
 
 import packaging.version
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("version_file")
+logger.setLevel(os.getenv("LOG_LEVEL", logging.INFO))
+ch = logging.StreamHandler()
+ch.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+logger.addHandler(ch)
 
 
 def main():

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -89,6 +89,7 @@ def main():
         version_file_path = os.path.join(
             repo_root, "mlrun", "utils", "version", "version.json"
         )
+        logger.debug(f"{args.mlrun_version = }")
         create_or_update_version_file(args.mlrun_version, version_file_path)
 
     elif args.command == "is-stable":
@@ -279,6 +280,7 @@ def create_or_update_version_file(mlrun_version: str, version_file_path: str):
         feature_name = resolve_feature_name(git_branch)
         if not mlrun_version.endswith(feature_name):
             mlrun_version = f"{mlrun_version}+{feature_name}"
+            logger.debug(f"With feature_name: {mlrun_version = }")
 
     # Check if the provided version is a semver and followed by a "-"
     semver_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+"  # e.g. 0.6.0-
@@ -302,7 +304,9 @@ def create_or_update_version_file(mlrun_version: str, version_file_path: str):
         "git_commit": git_commit,
     }
 
-    logger.info(f"Writing version info to file: {str(version_info)}")
+    logger.info(
+        f"Writing version info to file: {str(version_info)}, {version_file_path = }"
+    )
     with open(version_file_path, "w+") as version_file:
         json.dump(version_info, version_file, sort_keys=True, indent=2)
 

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 import argparse
 import json
@@ -24,10 +23,6 @@ import typing
 
 import packaging.version
 
-# NOTE
-# this script is being used in all build flows before building to add version information to the code
-# therefore it needs to be runnable in several environments - GH action, Jenkins, etc...
-# therefore this script should be kept python 2 and 3 compatible, and should not require external dependencies
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("version_file")
 

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -38,7 +38,7 @@ def main():
         "ensure", help="ensure the version file is up to date"
     )
     ensure_parser.add_argument(
-        "--mlrun-version", type=str, required=False, default="0.0.0+unstable"
+        "--mlrun-version", type=str, required=False, default="unstable"
     )
 
     subparsers.add_parser(

--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -272,7 +272,7 @@ def create_or_update_version_file(mlrun_version: str, version_file_path: str):
 
     # Enrich the version with the feature name (unless version is unstable)
     if (
-        "+unstable" not in mlrun_version
+        "unstable" not in mlrun_version
         and git_branch
         and git_branch.startswith("feature/")
     ):


### PR DESCRIPTION
The main flaw was here:
https://github.com/mlrun/mlrun/blob/cb22edcffad43bc0a042c224b449eee4f209299f/automation/version/version_file.py#L276
Where we pass:
https://github.com/mlrun/mlrun/blob/cb22edcffad43bc0a042c224b449eee4f209299f/Makefile#L16

In
```sh
make update-version-file
```
https://github.com/mlrun/mlrun/blob/cb22edcffad43bc0a042c224b449eee4f209299f/Makefile#L142-L144

It results in wrong semver versions in `mlrun/utils/version/version.json`.

For example, on a branch named `feature/x-y-z` atop dev:
```json
{
  "git_commit": "cb22edcffad43bc0a042c224b449eee4f209299f",
  "version": "0.0.0+unstable+x-y-z"
}
```
The version contains two pluses - `+`, and therefore, invalid.
It fails basic dev flows, such as `make api`.

After this change, on the `feature/x-y-z` branch:
```sh
make update-version-file
```
--> `0.0.0+unstable`

```sh
MLRUN_VERSION=1.7.0 make update-version-file
```
--> `1.7.0+x-y-z`

In addition to the fix, I did some housekeeping - see the commit messages.