### PR TITLE
[Datastore] Fix delete method in filestore and s3

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -223,12 +223,9 @@ class StoreManager:
             subpath = url[len("memory://") :]
             return in_memory_store, subpath, url
 
-        elif schema == "":
+        elif schema in get_local_file_schema():
             # parse_url() will drop the windows drive-letter from the path for url like "c:\a\b".
             # As a workaround, we set subpath to the url.
-            subpath = url
-
-        elif schema == "file://":
             subpath = url.replace("file://", "", 1)
 
         if not schema and endpoint:

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -223,6 +223,14 @@ class StoreManager:
             subpath = url[len("memory://") :]
             return in_memory_store, subpath, url
 
+        elif schema == "":
+            # parse_url() will drop the windows drive-letter from the path for url like "c:\a\b".
+            # As a workaround, we set subpath to the url.
+            subpath = url
+
+        elif schema == "file://":
+            subpath = url.replace("file://", "", 1)
+
         if not schema and endpoint:
             if endpoint in self._stores.keys():
                 return self._stores[endpoint], subpath, url
@@ -241,9 +249,6 @@ class StoreManager:
         )
         if not secrets and not mlrun.config.is_running_as_api():
             self._stores[store_key] = store
-        # in file stores in windows path like c:\a\b the drive letter is dropped from the path, so we return the url
-        if store.kind == "file" and isinstance(url, str):
-            subpath = url.replace("file://", "", 1)
         return store, subpath, url
 
     def reset_secrets(self):

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -242,7 +242,7 @@ class StoreManager:
         if not secrets and not mlrun.config.is_running_as_api():
             self._stores[store_key] = store
         # in file stores in windows path like c:\a\b the drive letter is dropped from the path, so we return the url
-        if store.kind == "file":
+        if store.kind == "file" and isinstance(url, str):
             subpath = url.replace("file://", "", 1)
         return store, subpath, url
 

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -242,7 +242,9 @@ class StoreManager:
         if not secrets and not mlrun.config.is_running_as_api():
             self._stores[store_key] = store
         # in file stores in windows path like c:\a\b the drive letter is dropped from the path, so we return the url
-        return store, url if store.kind == "file" else subpath, url
+        if store.kind == "file":
+            subpath = url.replace("file://", "", 1)
+        return store, subpath, url
 
     def reset_secrets(self):
         self._secrets = {}

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -198,6 +198,11 @@ class S3Store(DataStore):
         bucket = self.s3.Bucket(bucket)
         return [obj.key[key_length:] for obj in bucket.objects.filter(Prefix=key)]
 
+    def rm(self, path, recursive=False, maxdepth=None):
+        bucket, key = self.get_bucket_and_key(path)
+        path = f"{bucket}/{key}"
+        self.filesystem.rm(path=path, recursive=recursive, maxdepth=maxdepth)
+
 
 def parse_s3_bucket_and_key(s3_path):
     try:

--- a/tests/datastore/test_filestore.py
+++ b/tests/datastore/test_filestore.py
@@ -37,7 +37,6 @@ class TestFileStore:
                 with pytest.raises(FileNotFoundError):
                     data_item.stat()
                 assert not os.path.exists(temp_file.name)
-        except Exception as e:
+        finally:
             if os.path.exists(temp_file.name):
                 os.remove(temp_file.name)
-            raise e

--- a/tests/datastore/test_filestore.py
+++ b/tests/datastore/test_filestore.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os.path
+import tempfile
+
+import pytest
+
+import mlrun
+
+
+class TestFileStore:
+    @pytest.mark.parametrize(
+        "prefix",
+        ["", "file://"],
+    )
+    def test_put_stat_delete(self, prefix):
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as temp_file:
+                object_url = f"{prefix}{temp_file.name}"
+                data_item = mlrun.run.get_dataitem(object_url)
+                test_text = "test string"
+                data_item.put(test_text)
+                assert data_item.stat().size == len(test_text)
+                data_item.delete()
+                with pytest.raises(FileNotFoundError):
+                    data_item.stat()
+                assert not os.path.exists(temp_file.name)
+        except Exception as e:
+            if os.path.exists(temp_file.name):
+                os.remove(temp_file.name)
+            raise e

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -21,6 +21,7 @@ import fsspec
 import pandas as pd
 import pytest
 import yaml
+from botocore.exceptions import ClientError
 
 import mlrun
 import mlrun.errors
@@ -144,6 +145,10 @@ class TestAwsS3:
         upload_data_item.upload(self.test_file)
         response = upload_data_item.get()
         assert response.decode() == self.test_string
+        upload_data_item.delete()
+        with pytest.raises(ClientError) as client_exception:
+            upload_data_item.stat()
+        assert client_exception.value.response["Error"]["Code"] == "404"
 
         # Verify as_df() creates a proper DF. Note that the AWS case as_df() works through the fsspec interface, that's
         # why it's important to test it as well.


### PR DESCRIPTION
1) Fix s3 path issue - in custom `rm` implementation.
2) Fix the usage of `file://` schema.
3) Add tests to each fix.

[ML-6393](https://iguazio.atlassian.net/browse/ML-6393)

[ML-6393]: https://iguazio.atlassian.net/browse/ML-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ