### PR TITLE
[Model Monitoring] Add application metrics to V3IO tables and endpoints

### DIFF
--- a/mlrun/common/schemas/model_monitoring/__init__.py
+++ b/mlrun/common/schemas/model_monitoring/__init__.py
@@ -44,6 +44,7 @@ from .constants import (
 )
 from .grafana import (
     GrafanaColumn,
+    GrafanaColumnType,
     GrafanaDataPoint,
     GrafanaNumberColumn,
     GrafanaStringColumn,

--- a/mlrun/common/schemas/model_monitoring/grafana.py
+++ b/mlrun/common/schemas/model_monitoring/grafana.py
@@ -11,11 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from typing import Optional, Union
 
 from pydantic import BaseModel
+
+import mlrun.common.types
+
+
+class GrafanaColumnType(mlrun.common.types.StrEnum):
+    NUMBER = "number"
+    STRING = "string"
 
 
 class GrafanaColumn(BaseModel):
@@ -24,13 +30,11 @@ class GrafanaColumn(BaseModel):
 
 
 class GrafanaNumberColumn(GrafanaColumn):
-    text: str
-    type: str = "number"
+    type: str = GrafanaColumnType.NUMBER
 
 
 class GrafanaStringColumn(GrafanaColumn):
-    text: str
-    type: str = "string"
+    type: str = GrafanaColumnType.STRING
 
 
 class GrafanaTable(BaseModel):

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -298,6 +298,7 @@ class ModelEndpointList(BaseModel):
 
 class ModelEndpointMonitoringMetricType(mlrun.common.types.StrEnum):
     RESULT = "result"
+    METRIC = "metric"
 
 
 class ModelEndpointMonitoringMetric(BaseModel):
@@ -322,7 +323,7 @@ _FQN_PART_PATTERN = r"[a-zA-Z0-9_-]+"
 _FQN_PATTERN = (
     rf"^(?P<project>{_FQN_PART_PATTERN})\."
     rf"(?P<app>{_FQN_PART_PATTERN})\."
-    rf"(?P<type>{_FQN_PART_PATTERN})\."
+    rf"(?P<type>{ModelEndpointMonitoringMetricType.RESULT}|{ModelEndpointMonitoringMetricType.METRIC})\."
     rf"(?P<name>{_FQN_PART_PATTERN})$"
 )
 _FQN_REGEX = re.compile(_FQN_PATTERN)

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -338,27 +338,37 @@ def _parse_metric_fqn_to_monitoring_metric(fqn: str) -> ModelEndpointMonitoringM
     )
 
 
+class _MetricPoint(NamedTuple):
+    timestamp: datetime
+    value: float
+
+
 class _ResultPoint(NamedTuple):
     timestamp: datetime
     value: float
     status: ResultStatusApp
 
 
-class _ModelEndpointMonitoringResultValuesBase(BaseModel):
+class _ModelEndpointMonitoringMetricValuesBase(BaseModel):
     full_name: str
     type: ModelEndpointMonitoringMetricType
     data: bool
 
 
-class ModelEndpointMonitoringResultValues(_ModelEndpointMonitoringResultValuesBase):
-    full_name: str
-    type: ModelEndpointMonitoringMetricType
+class ModelEndpointMonitoringMetricValues(_ModelEndpointMonitoringMetricValuesBase):
+    type: ModelEndpointMonitoringMetricType = ModelEndpointMonitoringMetricType.METRIC
+    values: list[_MetricPoint]
+    data: bool = True
+
+
+class ModelEndpointMonitoringResultValues(_ModelEndpointMonitoringMetricValuesBase):
+    type: ModelEndpointMonitoringMetricType = ModelEndpointMonitoringMetricType.RESULT
     result_kind: ResultKindApp
     values: list[_ResultPoint]
     data: bool = True
 
 
-class ModelEndpointMonitoringResultNoData(_ModelEndpointMonitoringResultValuesBase):
+class ModelEndpointMonitoringMetricNoData(_ModelEndpointMonitoringMetricValuesBase):
     full_name: str
     type: ModelEndpointMonitoringMetricType
     data: bool = False

--- a/mlrun/model_monitoring/db/stores/base/store.py
+++ b/mlrun/model_monitoring/db/stores/base/store.py
@@ -116,7 +116,7 @@ class StoreBase(ABC):
         self,
         event: dict[str, typing.Any],
         kind: mm_constants.WriterEventKind = mm_constants.WriterEventKind.RESULT,
-    ):
+    ) -> None:
         """
         Write a new event in the target table.
 

--- a/mlrun/model_monitoring/db/stores/base/store.py
+++ b/mlrun/model_monitoring/db/stores/base/store.py
@@ -15,7 +15,7 @@
 import typing
 from abc import ABC, abstractmethod
 
-import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.common.schemas.model_monitoring as mm_schemas
 
 
 class StoreBase(ABC):
@@ -115,7 +115,7 @@ class StoreBase(ABC):
     def write_application_event(
         self,
         event: dict[str, typing.Any],
-        kind: mm_constants.WriterEventKind = mm_constants.WriterEventKind.RESULT,
+        kind: mm_schemas.WriterEventKind = mm_schemas.WriterEventKind.RESULT,
     ) -> None:
         """
         Write a new event in the target table.
@@ -157,3 +157,16 @@ class StoreBase(ABC):
 
         """
         pass
+
+    @abstractmethod
+    def get_model_endpoint_metrics(
+        self, endpoint_id: str, type: mm_schemas.ModelEndpointMonitoringMetricType
+    ) -> list[mm_schemas.ModelEndpointMonitoringMetric]:
+        """
+        Get the model monitoring results and metrics of the requested model endpoint.
+
+        :param: endpoint_id: The model endpoint identifier.
+        :param: type:        The type of the requested metrics ("result" or "metric").
+
+        :return:            A list of the available metrics.
+        """

--- a/mlrun/model_monitoring/db/stores/sqldb/sql_store.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/sql_store.py
@@ -339,7 +339,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         self,
         event: dict[str, typing.Any],
         kind: mm_constants.WriterEventKind = mm_constants.WriterEventKind.RESULT,
-    ):
+    ) -> None:
         """
         Write a new application event in the target table.
 

--- a/mlrun/model_monitoring/db/stores/sqldb/sql_store.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/sql_store.py
@@ -21,7 +21,7 @@ import pandas as pd
 import sqlalchemy
 
 import mlrun.common.model_monitoring.helpers
-import mlrun.common.schemas.model_monitoring as mm_constants
+import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.model_monitoring.db
 import mlrun.model_monitoring.db.stores.sqldb.models
 import mlrun.model_monitoring.helpers
@@ -71,7 +71,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
                 connection_string=self._sql_connection_string
             )
         )
-        self._tables[mm_constants.EventFieldType.MODEL_ENDPOINTS] = (
+        self._tables[mm_schemas.EventFieldType.MODEL_ENDPOINTS] = (
             self.ModelEndpointsTable
         )
 
@@ -81,7 +81,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
                 connection_string=self._sql_connection_string
             )
         )
-        self._tables[mm_constants.FileTargetKind.APP_RESULTS] = (
+        self._tables[mm_schemas.FileTargetKind.APP_RESULTS] = (
             self.ApplicationResultsTable
         )
 
@@ -89,7 +89,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         self.MonitoringSchedulesTable = mlrun.model_monitoring.db.stores.sqldb.models._get_monitoring_schedules_table(
             connection_string=self._sql_connection_string
         )
-        self._tables[mm_constants.FileTargetKind.MONITORING_SCHEDULES] = (
+        self._tables[mm_schemas.FileTargetKind.MONITORING_SCHEDULES] = (
             self.MonitoringSchedulesTable
         )
 
@@ -182,12 +182,12 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         """
 
         # Adjust timestamps fields
-        endpoint[mm_constants.EventFieldType.FIRST_REQUEST] = (endpoint)[
-            mm_constants.EventFieldType.LAST_REQUEST
+        endpoint[mm_schemas.EventFieldType.FIRST_REQUEST] = (endpoint)[
+            mm_schemas.EventFieldType.LAST_REQUEST
         ] = mlrun.utils.datetime_now()
 
         self._write(
-            table=mm_constants.EventFieldType.MODEL_ENDPOINTS,
+            table=mm_schemas.EventFieldType.MODEL_ENDPOINTS,
             event=endpoint,
         )
 
@@ -204,9 +204,9 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         """
         self._init_model_endpoints_table()
 
-        attributes.pop(mm_constants.EventFieldType.ENDPOINT_ID, None)
+        attributes.pop(mm_schemas.EventFieldType.ENDPOINT_ID, None)
 
-        filter_endpoint = {mm_constants.EventFieldType.UID: endpoint_id}
+        filter_endpoint = {mm_schemas.EventFieldType.UID: endpoint_id}
 
         self._update(
             attributes=attributes, table=self.ModelEndpointsTable, **filter_endpoint
@@ -220,7 +220,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         """
         self._init_model_endpoints_table()
 
-        filter_endpoint = {mm_constants.EventFieldType.UID: endpoint_id}
+        filter_endpoint = {mm_schemas.EventFieldType.UID: endpoint_id}
         # Delete the model endpoint record using sqlalchemy ORM
         self._delete(table=self.ModelEndpointsTable, **filter_endpoint)
 
@@ -240,7 +240,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         self._init_model_endpoints_table()
 
         # Get the model endpoint record using sqlalchemy ORM
-        filter_endpoint = {mm_constants.EventFieldType.UID: endpoint_id}
+        filter_endpoint = {mm_schemas.EventFieldType.UID: endpoint_id}
         endpoint_record = self._get(table=self.ModelEndpointsTable, **filter_endpoint)
 
         if not endpoint_record:
@@ -292,32 +292,32 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
                 query = self._filter_values(
                     query=query,
                     model_endpoints_table=model_endpoints_table,
-                    key_filter=mm_constants.EventFieldType.MODEL,
+                    key_filter=mm_schemas.EventFieldType.MODEL,
                     filtered_values=[model],
                 )
             if function:
                 query = self._filter_values(
                     query=query,
                     model_endpoints_table=model_endpoints_table,
-                    key_filter=mm_constants.EventFieldType.FUNCTION,
+                    key_filter=mm_schemas.EventFieldType.FUNCTION,
                     filtered_values=[function],
                 )
             if uids:
                 query = self._filter_values(
                     query=query,
                     model_endpoints_table=model_endpoints_table,
-                    key_filter=mm_constants.EventFieldType.UID,
+                    key_filter=mm_schemas.EventFieldType.UID,
                     filtered_values=uids,
                     combined=False,
                 )
             if top_level:
-                node_ep = str(mm_constants.EndpointType.NODE_EP.value)
-                router_ep = str(mm_constants.EndpointType.ROUTER.value)
+                node_ep = str(mm_schemas.EndpointType.NODE_EP.value)
+                router_ep = str(mm_schemas.EndpointType.ROUTER.value)
                 endpoint_types = [node_ep, router_ep]
                 query = self._filter_values(
                     query=query,
                     model_endpoints_table=model_endpoints_table,
-                    key_filter=mm_constants.EventFieldType.ENDPOINT_TYPE,
+                    key_filter=mm_schemas.EventFieldType.ENDPOINT_TYPE,
                     filtered_values=endpoint_types,
                     combined=False,
                 )
@@ -338,7 +338,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
     def write_application_event(
         self,
         event: dict[str, typing.Any],
-        kind: mm_constants.WriterEventKind = mm_constants.WriterEventKind.RESULT,
+        kind: mm_schemas.WriterEventKind = mm_schemas.WriterEventKind.RESULT,
     ) -> None:
         """
         Write a new application event in the target table.
@@ -349,16 +349,14 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         :param kind: The type of the event, can be either "result" or "metric".
         """
 
-        if kind == mm_constants.WriterEventKind.METRIC:
+        if kind == mm_schemas.WriterEventKind.METRIC:
             # TODO : Implement the logic for writing metrics to MySQL
             return
 
         self._init_application_results_table()
 
         application_filter_dict = {
-            mm_constants.EventFieldType.UID: self._generate_application_result_uid(
-                event
-            )
+            mm_schemas.EventFieldType.UID: self._generate_application_result_uid(event)
         }
 
         application_record = self._get(
@@ -367,11 +365,11 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         if application_record:
             self._convert_to_datetime(
                 event=event,
-                key=mm_constants.WriterEvent.START_INFER_TIME,
+                key=mm_schemas.WriterEvent.START_INFER_TIME,
             )
             self._convert_to_datetime(
                 event=event,
-                key=mm_constants.WriterEvent.END_INFER_TIME,
+                key=mm_schemas.WriterEvent.END_INFER_TIME,
             )
             # Update an existing application result
             self._update(
@@ -381,12 +379,12 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
             )
         else:
             # Write a new application result
-            event[mm_constants.EventFieldType.UID] = application_filter_dict[
-                mm_constants.EventFieldType.UID
+            event[mm_schemas.EventFieldType.UID] = application_filter_dict[
+                mm_schemas.EventFieldType.UID
             ]
 
             self._write(
-                table=mm_constants.FileTargetKind.APP_RESULTS,
+                table=mm_schemas.FileTargetKind.APP_RESULTS,
                 event=event,
             )
 
@@ -398,11 +396,11 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
     @staticmethod
     def _generate_application_result_uid(event: dict[str, typing.Any]) -> str:
         return (
-            event[mm_constants.WriterEvent.ENDPOINT_ID]
+            event[mm_schemas.WriterEvent.ENDPOINT_ID]
             + "_"
-            + event[mm_constants.WriterEvent.APPLICATION_NAME]
+            + event[mm_schemas.WriterEvent.APPLICATION_NAME]
             + "_"
-            + event[mm_constants.ResultData.RESULT_NAME]
+            + event[mm_schemas.ResultData.RESULT_NAME]
         )
 
     def get_last_analyzed(self, endpoint_id: str, application_name: str) -> int:
@@ -452,17 +450,17 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         if not monitoring_schedule_record:
             # Add a new record with empty last analyzed value
             self._write(
-                table=mm_constants.FileTargetKind.MONITORING_SCHEDULES,
+                table=mm_schemas.FileTargetKind.MONITORING_SCHEDULES,
                 event={
-                    mm_constants.SchedulingKeys.UID: uuid.uuid4().hex,
-                    mm_constants.SchedulingKeys.APPLICATION_NAME: application_name,
-                    mm_constants.SchedulingKeys.ENDPOINT_ID: endpoint_id,
-                    mm_constants.SchedulingKeys.LAST_ANALYZED: last_analyzed,
+                    mm_schemas.SchedulingKeys.UID: uuid.uuid4().hex,
+                    mm_schemas.SchedulingKeys.APPLICATION_NAME: application_name,
+                    mm_schemas.SchedulingKeys.ENDPOINT_ID: endpoint_id,
+                    mm_schemas.SchedulingKeys.LAST_ANALYZED: last_analyzed,
                 },
             )
 
         self._update(
-            attributes={mm_constants.SchedulingKeys.LAST_ANALYZED: last_analyzed},
+            attributes={mm_schemas.SchedulingKeys.LAST_ANALYZED: last_analyzed},
             table=self.MonitoringSchedulesTable,
             **application_filter_dict,
         )
@@ -558,7 +556,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
 
         # Convert endpoint labels into dictionary
         endpoint_labels = json.loads(
-            endpoint_dict.get(mm_constants.EventFieldType.LABELS)
+            endpoint_dict.get(mm_schemas.EventFieldType.LABELS)
         )
 
         for label in labels:
@@ -585,11 +583,9 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
             )
         application_filter_dict = {}
         if endpoint_id:
-            application_filter_dict[mm_constants.SchedulingKeys.ENDPOINT_ID] = (
-                endpoint_id
-            )
+            application_filter_dict[mm_schemas.SchedulingKeys.ENDPOINT_ID] = endpoint_id
         if application_name:
-            application_filter_dict[mm_constants.SchedulingKeys.APPLICATION_NAME] = (
+            application_filter_dict[mm_schemas.SchedulingKeys.APPLICATION_NAME] = (
                 application_name
             )
         return application_filter_dict
@@ -603,7 +599,7 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
         endpoints = self.list_model_endpoints()
 
         for endpoint_dict in endpoints:
-            endpoint_id = endpoint_dict[mm_constants.EventFieldType.UID]
+            endpoint_id = endpoint_dict[mm_schemas.EventFieldType.UID]
 
             # Delete last analyzed records
             self._delete_last_analyzed(endpoint_id=endpoint_id)
@@ -613,3 +609,8 @@ class SQLStoreBase(mlrun.model_monitoring.db.StoreBase):
 
             # Delete model endpoint record
             self.delete_model_endpoint(endpoint_id=endpoint_id)
+
+    def get_model_endpoint_metrics(
+        self, endpoint_id: str, type: mm_schemas.ModelEndpointMonitoringMetricType
+    ) -> list[mm_schemas.ModelEndpointMonitoringMetric]:
+        raise NotImplementedError

--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -619,12 +619,10 @@ class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
     def _extract_results_from_items(
         self, app_items: list[dict[str, str]]
     ) -> list[mm_schemas.ModelEndpointMonitoringMetric]:
+        """Assuming .#schema items are filtered out"""
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric] = []
         for app_item in app_items:
-            # See https://www.iguazio.com/docs/latest-release/services/data-layer/reference/system-attributes/#sys-attr-__name
             app_name = app_item.pop("__name")
-            if app_name == ".#schema":
-                continue
             for result_name in app_item:
                 metrics.append(
                     mm_schemas.ModelEndpointMonitoringMetric(
@@ -670,6 +668,7 @@ class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
                 container=container,
                 table_path=table_path,
                 marker=response.output.next_marker,
+                filter_expression='__name!=".#schema"',
             )
 
         return metrics

--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -321,6 +321,14 @@ class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
                 raise_for_status=v3io.dataplane.RaiseForStatus.never,
             )
 
+    @staticmethod
+    def _get_results_table_path(endpoint_id: str) -> str:
+        return endpoint_id
+
+    @staticmethod
+    def _get_metrics_table_path(endpoint_id: str) -> str:
+        return f"{endpoint_id}_metrics"
+
     def write_application_event(
         self,
         event: dict[str, typing.Any],
@@ -339,11 +347,11 @@ class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
         endpoint_id = event.pop(mm_schemas.WriterEvent.ENDPOINT_ID)
 
         if kind == mm_schemas.WriterEventKind.METRIC:
-            table_path = f"{endpoint_id}_metrics"
+            table_path = self._get_metrics_table_path(endpoint_id)
             key = f"{event[mm_schemas.WriterEvent.APPLICATION_NAME]}.{event[mm_schemas.MetricData.METRIC_NAME]}"
             attributes = {event_key: event[event_key] for event_key in _METRIC_FIELDS}
         elif kind == mm_schemas.WriterEventKind.RESULT:
-            table_path = endpoint_id
+            table_path = self._get_results_table_path(endpoint_id)
             key = event.pop(mm_schemas.WriterEvent.APPLICATION_NAME)
             metric_name = event.pop(mm_schemas.ResultData.RESULT_NAME)
             attributes = {metric_name: json.dumps(event)}

--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -33,6 +33,14 @@ fields_to_encode_decode = [
     mm_constants.EventFieldType.CURRENT_STATS,
 ]
 
+_METRIC_FIELDS: list[str] = [
+    mm_constants.WriterEvent.APPLICATION_NAME,
+    mm_constants.MetricData.METRIC_NAME,
+    mm_constants.MetricData.METRIC_VALUE,
+    mm_constants.WriterEvent.START_INFER_TIME,
+    mm_constants.WriterEvent.END_INFER_TIME,
+]
+
 
 class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
     """
@@ -287,7 +295,9 @@ class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
         endpoint_id = event.pop(mm_constants.WriterEvent.ENDPOINT_ID)
 
         if kind == mm_constants.WriterEventKind.METRIC:
-            raise NotImplementedError
+            table_path = f"{endpoint_id}_metrics"
+            key = f"{event[mm_constants.WriterEvent.APPLICATION_NAME]}.{event[mm_constants.MetricData.METRIC_NAME]}"
+            attributes = {event_key: event[event_key] for event_key in _METRIC_FIELDS}
         elif kind == mm_constants.WriterEventKind.RESULT:
             table_path = endpoint_id
             key = event.pop(mm_constants.WriterEvent.APPLICATION_NAME)

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -125,10 +125,9 @@ class TSDBConnector(ABC):
         """
         pass
 
-    def create_tsdb_application_tables(self):
+    def create_tsdb_application_tables(self) -> None:
         """
         Create the application tables using the TSDB connector. At the moment we support 2 types of application tables:
         - app_results: a detailed result that includes status, kind, extra data, etc.
         - metrics: a basic key value that represents a numeric metric.
         """
-        pass

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -57,13 +57,12 @@ class TSDBConnector(ABC):
         self,
         event: dict,
         kind: mm_constants.WriterEventKind = mm_constants.WriterEventKind.RESULT,
-    ):
+    ) -> None:
         """
         Write a single application or metric to TSDB.
 
         :raise mlrun.errors.MLRunRuntimeError: If an error occurred while writing the event.
         """
-        pass
 
     def delete_tsdb_resources(self):
         """

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -114,7 +114,7 @@ class V3IOTSDBConnector(TSDBConnector):
         )
         self.tables[mm_schemas.FileTargetKind.PREDICTIONS] = monitoring_predictions_path
 
-    def create_tsdb_application_tables(self):
+    def create_tsdb_application_tables(self) -> None:
         """
         Create the application tables using the TSDB connector. At the moment we support 2 types of application tables:
         - app_results: a detailed result that includes status, kind, extra data, etc.
@@ -124,11 +124,12 @@ class V3IOTSDBConnector(TSDBConnector):
             mm_schemas.MonitoringTSDBTables.APP_RESULTS,
             mm_schemas.MonitoringTSDBTables.METRICS,
         ]
-        for table in application_tables:
-            logger.info("Creating table in V3IO TSDB", table=table)
+        for table_name in application_tables:
+            logger.info("Creating table in V3IO TSDB", table_name=table_name)
+            table = self.tables[table_name]
             self._frames_client.create(
                 backend=_TSDB_BE,
-                table=self.tables[table],
+                table=table,
                 if_exists=IGNORE,
                 rate=_TSDB_RATE,
             )

--- a/mlrun/model_monitoring/db/v3io_tsdb_reader.py
+++ b/mlrun/model_monitoring/db/v3io_tsdb_reader.py
@@ -16,6 +16,7 @@
 
 from datetime import datetime
 from io import StringIO
+from typing import Union
 
 import pandas as pd
 
@@ -29,7 +30,6 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringResultNoData,
     ModelEndpointMonitoringResultValues,
     _compose_full_name,
-    _ModelEndpointMonitoringResultValuesBase,
 )
 from mlrun.model_monitoring.db.stores.v3io_kv.kv_store import KVStoreBase
 from mlrun.model_monitoring.db.tsdb.v3io.v3io_connector import _TSDB_BE
@@ -80,7 +80,9 @@ def read_data(
     start: datetime,
     end: datetime,
     metrics: list[ModelEndpointMonitoringMetric],
-) -> list[_ModelEndpointMonitoringResultValuesBase]:
+) -> list[
+    Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringResultNoData]
+]:
     client = mlrun.utils.v3io_clients.get_frames_client(
         address=mlrun.mlconf.v3io_framesd,
         container=KVStoreBase.get_v3io_monitoring_apps_container(project),
@@ -96,7 +98,9 @@ def read_data(
 
     metrics_without_data = {metric.full_name: metric for metric in metrics}
 
-    metrics_values: list[_ModelEndpointMonitoringResultValuesBase] = []
+    metrics_values: list[
+        Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringResultNoData]
+    ] = []
     if not df.empty:
         grouped = df.groupby(
             [mm_writer.WriterEvent.APPLICATION_NAME, mm_writer.ResultData.RESULT_NAME],

--- a/mlrun/model_monitoring/db/v3io_tsdb_reader.py
+++ b/mlrun/model_monitoring/db/v3io_tsdb_reader.py
@@ -102,6 +102,11 @@ def read_metrics_data(
         ],
     ],
 ]:
+    """
+    Read metrics OR results from the TSDB and return as a list.
+    Note: the type must match the actual metrics in the `metrics` parameter.
+    If the type is "results", pass only results in the `metrics` parameter.
+    """
     client = mlrun.utils.v3io_clients.get_frames_client(
         address=mlrun.mlconf.v3io_framesd,
         container=KVStoreBase.get_v3io_monitoring_apps_container(project),
@@ -146,6 +151,11 @@ def df_to_results_values(
 ) -> list[
     Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringMetricNoData]
 ]:
+    """
+    Parse a time-indexed data-frame of results from the TSDB into a list of
+    results values per distinct results.
+    When a result is not found in the data-frame, it is represented in no-data object.
+    """
     metrics_without_data = {metric.full_name: metric for metric in metrics}
 
     metrics_values: list[
@@ -193,6 +203,11 @@ def df_to_metrics_values(
 ) -> list[
     Union[ModelEndpointMonitoringMetricValues, ModelEndpointMonitoringMetricNoData]
 ]:
+    """
+    Parse a time-indexed data-frame of metrics from the TSDB into a list of
+    metrics values per distinct results.
+    When a metric is not found in the data-frame, it is represented in no-data object.
+    """
     metrics_without_data = {metric.full_name: metric for metric in metrics}
 
     metrics_values: list[

--- a/mlrun/model_monitoring/db/v3io_tsdb_reader.py
+++ b/mlrun/model_monitoring/db/v3io_tsdb_reader.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Move this module into the TSDB abstraction once it is in.
+# TODO: Move this module into the TSDB abstraction:
+# mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
 
 from datetime import datetime
 from io import StringIO

--- a/mlrun/model_monitoring/db/v3io_tsdb_reader.py
+++ b/mlrun/model_monitoring/db/v3io_tsdb_reader.py
@@ -37,10 +37,14 @@ from mlrun.model_monitoring.db.tsdb.v3io.v3io_connector import _TSDB_BE
 from mlrun.utils import logger
 
 
-def _get_sql_query(endpoint_id: str, names: list[tuple[str, str]]) -> str:
+def _get_sql_query(
+    endpoint_id: str,
+    names: list[tuple[str, str]],
+    table_name: str = mm_constants.MonitoringTSDBTables.APP_RESULTS,
+) -> str:
     with StringIO() as query:
         query.write(
-            f"SELECT * FROM '{mm_constants.MonitoringTSDBTables.APP_RESULTS}' "
+            f"SELECT * FROM '{table_name}' "
             f"WHERE {mm_writer.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"
         )
         if names:
@@ -74,7 +78,7 @@ def _get_result_kind(result_df: pd.DataFrame) -> mm_constants.ResultKindApp:
     return unique_kinds[0]
 
 
-def read_data(
+def read_metrics_data(
     *,
     project: str,
     endpoint_id: str,

--- a/mlrun/model_monitoring/db/v3io_tsdb_reader.py
+++ b/mlrun/model_monitoring/db/v3io_tsdb_reader.py
@@ -27,8 +27,8 @@ import mlrun.model_monitoring.writer as mm_writer
 import mlrun.utils.v3io_clients
 from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringMetric,
+    ModelEndpointMonitoringMetricNoData,
     ModelEndpointMonitoringMetricType,
-    ModelEndpointMonitoringResultNoData,
     ModelEndpointMonitoringResultValues,
     _compose_full_name,
 )
@@ -82,7 +82,7 @@ def read_data(
     end: datetime,
     metrics: list[ModelEndpointMonitoringMetric],
 ) -> list[
-    Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringResultNoData]
+    Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringMetricNoData]
 ]:
     client = mlrun.utils.v3io_clients.get_frames_client(
         address=mlrun.mlconf.v3io_framesd,
@@ -100,7 +100,7 @@ def read_data(
     metrics_without_data = {metric.full_name: metric for metric in metrics}
 
     metrics_values: list[
-        Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringResultNoData]
+        Union[ModelEndpointMonitoringResultValues, ModelEndpointMonitoringMetricNoData]
     ] = []
     if not df.empty:
         grouped = df.groupby(
@@ -115,7 +115,6 @@ def read_data(
         metrics_values.append(
             ModelEndpointMonitoringResultValues(
                 full_name=full_name,
-                type=ModelEndpointMonitoringMetricType.RESULT,
                 result_kind=result_kind,
                 values=list(
                     zip(
@@ -130,7 +129,7 @@ def read_data(
 
     for metric in metrics_without_data.values():
         metrics_values.append(
-            ModelEndpointMonitoringResultNoData(
+            ModelEndpointMonitoringMetricNoData(
                 full_name=metric.full_name,
                 type=ModelEndpointMonitoringMetricType.RESULT,
             )

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -138,7 +138,7 @@ class ModelMonitoringWriter(StepToDict):
         mlrun.get_run_db().generate_event(event_kind, event_data)
 
     @staticmethod
-    def _reconstruct_event(event: _RawEvent) -> tuple[_AppResultEvent, str]:
+    def _reconstruct_event(event: _RawEvent) -> tuple[_AppResultEvent, WriterEventKind]:
         """
         Modify the raw event into the expected monitoring application event
         schema as defined in `mlrun.common.schemas.model_monitoring.constants.WriterEvent`

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -184,7 +184,8 @@ class ModelMonitoringWriter(StepToDict):
         self._app_result_store.write_application_event(event=event.copy(), kind=kind)
         logger.info("Completed event DB writes")
 
-        _Notifier(event=event, notification_pusher=self._custom_notifier).notify()
+        if kind == WriterEventKind.RESULT:
+            _Notifier(event=event, notification_pusher=self._custom_notifier).notify()
 
         if (
             mlrun.mlconf.alerts.mode == mlrun.common.schemas.alert.AlertsModes.enabled

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -443,7 +443,7 @@ async def _get_metrics_values_data(
     response_model=list[
         Union[
             mm_endpoints.ModelEndpointMonitoringResultValues,
-            mm_endpoints.ModelEndpointMonitoringResultNoData,
+            mm_endpoints.ModelEndpointMonitoringMetricNoData,
         ]
     ],
 )
@@ -452,7 +452,7 @@ async def get_model_endpoint_monitoring_metrics_values(
 ) -> list[
     Union[
         mm_endpoints.ModelEndpointMonitoringResultValues,
-        mm_endpoints.ModelEndpointMonitoringResultNoData,
+        mm_endpoints.ModelEndpointMonitoringMetricNoData,
     ]
 ]:
     """

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -22,9 +22,8 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
-import mlrun.common.schemas
-import mlrun.common.schemas.model_monitoring.model_endpoints
-import mlrun.model_monitoring.db.stores.v3io_kv.kv_store
+import mlrun.common.schemas as schemas
+import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
 import mlrun.model_monitoring.db.v3io_tsdb_reader
 import mlrun.utils.helpers
 import server.api.api.deps
@@ -37,17 +36,15 @@ router = APIRouter(prefix="/projects/{project}/model-endpoints")
 
 @router.post(
     "/{endpoint_id}",
-    response_model=mlrun.common.schemas.ModelEndpoint,
+    response_model=schemas.ModelEndpoint,
 )
 async def create_model_endpoint(
     project: str,
     endpoint_id: str,
-    model_endpoint: mlrun.common.schemas.ModelEndpoint,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
+    model_endpoint: schemas.ModelEndpoint,
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
     db_session: Session = Depends(server.api.api.deps.get_db_session),
-) -> mlrun.common.schemas.ModelEndpoint:
+) -> schemas.ModelEndpoint:
     """
     Create a DB record of a given `ModelEndpoint` object.
 
@@ -63,10 +60,10 @@ async def create_model_endpoint(
     """
 
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.model_endpoint,
+        resource_type=schemas.AuthorizationResourceTypes.model_endpoint,
         project_name=project,
         resource_name=endpoint_id,
-        action=mlrun.common.schemas.AuthorizationAction.store,
+        action=schemas.AuthorizationAction.store,
         auth_info=auth_info,
     )
 
@@ -89,16 +86,14 @@ async def create_model_endpoint(
 
 @router.patch(
     "/{endpoint_id}",
-    response_model=mlrun.common.schemas.ModelEndpoint,
+    response_model=schemas.ModelEndpoint,
 )
 async def patch_model_endpoint(
     project: str,
     endpoint_id: str,
     attributes: str = None,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
-) -> mlrun.common.schemas.ModelEndpoint:
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
+) -> schemas.ModelEndpoint:
     """
     Update a DB record of a given `ModelEndpoint` object.
 
@@ -118,10 +113,10 @@ async def patch_model_endpoint(
     """
 
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.model_endpoint,
+        resource_type=schemas.AuthorizationResourceTypes.model_endpoint,
         project_name=project,
         resource_name=endpoint_id,
-        action=mlrun.common.schemas.AuthorizationAction.update,
+        action=schemas.AuthorizationAction.update,
         auth_info=auth_info,
     )
 
@@ -144,9 +139,7 @@ async def patch_model_endpoint(
 async def delete_model_endpoint(
     project: str,
     endpoint_id: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
 ):
     """
     Clears endpoint record from the DB based on endpoint_id.
@@ -158,10 +151,10 @@ async def delete_model_endpoint(
     """
 
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.model_endpoint,
+        resource_type=schemas.AuthorizationResourceTypes.model_endpoint,
         project_name=project,
         resource_name=endpoint_id,
-        action=mlrun.common.schemas.AuthorizationAction.delete,
+        action=schemas.AuthorizationAction.delete,
         auth_info=auth_info,
     )
 
@@ -174,7 +167,7 @@ async def delete_model_endpoint(
 
 @router.get(
     "",
-    response_model=mlrun.common.schemas.ModelEndpointList,
+    response_model=schemas.ModelEndpointList,
 )
 async def list_model_endpoints(
     project: str,
@@ -186,10 +179,8 @@ async def list_model_endpoints(
     metrics: list[str] = Query([], alias="metric"),
     top_level: bool = Query(False, alias="top-level"),
     uids: list[str] = Query(None, alias="uid"),
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
-) -> mlrun.common.schemas.ModelEndpointList:
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
+) -> schemas.ModelEndpointList:
     """
     Returns a list of endpoints of type 'ModelEndpoint', supports filtering by model, function, tag,
     labels or top level. By default, when no filters are applied, all available endpoints for the given project will be
@@ -234,7 +225,7 @@ async def list_model_endpoints(
 
     await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project_name=project,
-        action=mlrun.common.schemas.AuthorizationAction.read,
+        action=schemas.AuthorizationAction.read,
         auth_info=auth_info,
     )
 
@@ -252,7 +243,7 @@ async def list_model_endpoints(
         uids=uids,
     )
     allowed_endpoints = await server.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
-        mlrun.common.schemas.AuthorizationResourceTypes.model_endpoint,
+        schemas.AuthorizationResourceTypes.model_endpoint,
         endpoints.endpoints,
         lambda _endpoint: (
             _endpoint.metadata.project,
@@ -266,20 +257,20 @@ async def list_model_endpoints(
 
 
 async def _verify_model_endpoint_read_permission(
-    *, project: str, endpoint_id: str, auth_info: mlrun.common.schemas.AuthInfo
+    *, project: str, endpoint_id: str, auth_info: schemas.AuthInfo
 ) -> None:
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        mlrun.common.schemas.AuthorizationResourceTypes.model_endpoint,
+        schemas.AuthorizationResourceTypes.model_endpoint,
         project_name=project,
         resource_name=endpoint_id,
-        action=mlrun.common.schemas.AuthorizationAction.read,
+        action=schemas.AuthorizationAction.read,
         auth_info=auth_info,
     )
 
 
 @router.get(
     "/{endpoint_id}",
-    response_model=mlrun.common.schemas.ModelEndpoint,
+    response_model=schemas.ModelEndpoint,
 )
 async def get_model_endpoint(
     project: str,
@@ -288,10 +279,8 @@ async def get_model_endpoint(
     end: str = Query(default="now"),
     metrics: list[str] = Query([], alias="metric"),
     feature_analysis: bool = Query(default=False),
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
-) -> mlrun.common.schemas.ModelEndpoint:
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
+) -> schemas.ModelEndpoint:
     """Get a single model endpoint object. You can apply different time series metrics that will be added to the
        result.
 
@@ -335,18 +324,14 @@ async def get_model_endpoint(
 
 @router.get(
     "/{endpoint_id}/metrics",
-    response_model=list[
-        mlrun.common.schemas.model_monitoring.ModelEndpointMonitoringMetric
-    ],
+    response_model=list[mm_endpoints.ModelEndpointMonitoringMetric],
 )
 async def get_model_endpoint_monitoring_metrics(
     project: str,
     endpoint_id: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
     type: Literal["results", "metrics", "all"] = "all",
-) -> list[mlrun.common.schemas.model_monitoring.ModelEndpointMonitoringMetric]:
+) -> list[mm_endpoints.ModelEndpointMonitoringMetric]:
     """
     :param project:     The name of the project.
     :param endpoint_id: The unique id of the model endpoint.
@@ -362,10 +347,11 @@ async def get_model_endpoint_monitoring_metrics(
         project=project, endpoint_id=endpoint_id, auth_info=auth_info
     )
     return await run_in_threadpool(
-        mlrun.model_monitoring.db.stores.v3io_kv.kv_store.KVStoreBase(
+        mlrun.model_monitoring.get_store_object(
             project=project
         ).get_model_endpoint_metrics,
         endpoint_id=endpoint_id,
+        type=mm_endpoints.ModelEndpointMonitoringMetricType.RESULT,
     )
 
 
@@ -373,9 +359,7 @@ async def get_model_endpoint_monitoring_metrics(
 class _MetricsValuesParams:
     project: str
     endpoint_id: str
-    metrics: list[
-        mlrun.common.schemas.model_monitoring.model_endpoints.ModelEndpointMonitoringMetric
-    ]
+    metrics: list[mm_endpoints.ModelEndpointMonitoringMetric]
     start: datetime
     end: datetime
 
@@ -385,15 +369,11 @@ async def _get_metrics_values_data(
     endpoint_id: str,
     name: Annotated[
         list[str],
-        Query(
-            pattern=mlrun.common.schemas.model_monitoring.model_endpoints._FQN_PATTERN
-        ),
+        Query(pattern=mm_endpoints._FQN_PATTERN),
     ],
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        server.api.api.deps.authenticate_request
-    ),
+    auth_info: schemas.AuthInfo = Depends(server.api.api.deps.authenticate_request),
 ) -> _MetricsValuesParams:
     """
     Verify authorization, validate parameters and initialize the parameters.
@@ -426,12 +406,7 @@ async def _get_metrics_values_data(
         raise mlrun.errors.MLRunInvalidArgumentError(
             "Provided only one of start time, end time. Please provide both or neither."
         )
-    metrics = [
-        mlrun.common.schemas.model_monitoring.model_endpoints._parse_metric_fqn_to_monitoring_metric(
-            fqn
-        )
-        for fqn in name
-    ]
+    metrics = [mm_endpoints._parse_metric_fqn_to_monitoring_metric(fqn) for fqn in name]
     return _MetricsValuesParams(
         project=project,
         endpoint_id=endpoint_id,
@@ -445,8 +420,8 @@ async def _get_metrics_values_data(
     "/{endpoint_id}/metrics-values",
     response_model=list[
         Union[
-            mlrun.common.schemas.model_monitoring.model_endpoints.ModelEndpointMonitoringResultValues,
-            mlrun.common.schemas.model_monitoring.model_endpoints.ModelEndpointMonitoringResultNoData,
+            mm_endpoints.ModelEndpointMonitoringResultValues,
+            mm_endpoints.ModelEndpointMonitoringResultNoData,
         ]
     ],
 )
@@ -454,8 +429,8 @@ async def get_model_endpoint_monitoring_metrics_values(
     params: Annotated[_MetricsValuesParams, Depends(_get_metrics_values_data)],
 ) -> list[
     Union[
-        mlrun.common.schemas.model_monitoring.model_endpoints.ModelEndpointMonitoringResultValues,
-        mlrun.common.schemas.model_monitoring.model_endpoints.ModelEndpointMonitoringResultNoData,
+        mm_endpoints.ModelEndpointMonitoringResultValues,
+        mm_endpoints.ModelEndpointMonitoringResultNoData,
     ]
 ]:
     """

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -340,7 +340,7 @@ async def get_model_endpoint_monitoring_metrics(
     :param type:        The type of the metrics to return. "all" means "results"
                         and "metrics".
 
-    :returns:           A list of the application results for this model endpoint.
+    :returns:           A list of the application metrics or/and results for this model endpoint.
     """
     await _verify_model_endpoint_read_permission(
         project=project, endpoint_id=endpoint_id, auth_info=auth_info

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -345,17 +345,19 @@ async def get_model_endpoint_monitoring_metrics(
     auth_info: mlrun.common.schemas.AuthInfo = Depends(
         server.api.api.deps.authenticate_request
     ),
-    type: Literal["results"] = "results",
+    type: Literal["results", "metrics", "all"] = "all",
 ) -> list[mlrun.common.schemas.model_monitoring.ModelEndpointMonitoringMetric]:
     """
     :param project:     The name of the project.
     :param endpoint_id: The unique id of the model endpoint.
     :param auth_info:   The auth info of the request.
-    :param type:        The type of the metrics to return. Currently, only "results"
-                        is supported.
+    :param type:        The type of the metrics to return. "all" means "results"
+                        and "metrics".
 
     :returns:           A list of the application results for this model endpoint.
     """
+    if type != "results":
+        raise NotImplementedError
     await _verify_model_endpoint_read_permission(
         project=project, endpoint_id=endpoint_id, auth_info=auth_info
     )

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -461,7 +461,7 @@ async def get_model_endpoint_monitoring_metrics_values(
     :returns:      A list of the results values for this model endpoint.
     """
     return await run_in_threadpool(
-        mlrun.model_monitoring.db.v3io_tsdb_reader.read_data,
+        mlrun.model_monitoring.db.v3io_tsdb_reader.read_metrics_data,
         project=params.project,
         endpoint_id=params.endpoint_id,
         metrics=params.metrics,

--- a/tests/model_monitoring/test_schemas.py
+++ b/tests/model_monitoring/test_schemas.py
@@ -39,7 +39,19 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ),
             does_not_raise(),
         ),
+        (
+            "proj_j.app-123.metric.error-count",
+            ModelEndpointMonitoringMetric(
+                project="proj_j",
+                app="app-123",
+                type=ModelEndpointMonitoringMetricType.METRIC,
+                name="error-count",
+                full_name="proj_j.app-123.metric.error-count",
+            ),
+            does_not_raise(),
+        ),
         ("invalid..fqn", None, pytest.raises(ValueError)),
+        ("prj.a.non-type.name", None, pytest.raises(ValueError)),
     ],
 )
 def test_fqn_parsing(

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -51,7 +51,6 @@ def store(
     ("store", "items", "expected_metrics"),
     [
         ("", [], []),
-        ("default", [{"__name": ".#schema"}], []),
         (
             "default",
             [
@@ -84,8 +83,7 @@ def store(
                 {
                     "__name": "app1",
                     "drift-res": "{'d':0.4}",
-                },
-                {"__name": ".#schema"},
+                }
             ],
             [
                 ModelEndpointMonitoringMetric(
@@ -173,7 +171,6 @@ class TestGetModelEndpointMetrics:
         decoded_body=Entry.DecodedBody(LastItemIncluded="TRUE", NextMarker=_M0),
         items=[
             {"__name": "model-as-a-judge-app", "distance": ""},
-            {"__name": ".#schema"},
         ],
     )
     METRICS = [
@@ -201,6 +198,7 @@ class TestGetModelEndpointMetrics:
         container: str,
         table_path: str,
         marker: Optional[str] = None,
+        filter_expression: Optional[str] = None,
     ) -> v3io.dataplane.response.Response:
         if (
             container != cls.CONTAINER

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -98,12 +98,79 @@ def store(
     ],
     indirect=["store"],
 )
-def test_extract_metrics_from_items(
+def test_extract_results_from_items(
     store: KVStoreBase,
     items: list[dict[str, str]],
     expected_metrics: list[ModelEndpointMonitoringMetric],
 ) -> None:
     assert store._extract_results_from_items(items) == expected_metrics
+
+
+@pytest.mark.parametrize(
+    ("store", "items", "expected_metrics"),
+    [
+        ("", [], []),
+        (
+            "default",
+            [
+                {
+                    "__name": "histogram-data-drift.tvd_mean",
+                    "application_name": "histogram-data-drift",
+                    "metric_name": "tvd_mean",
+                    "metric_value": 1.0,
+                    "start_infer_time": "2024-05-15 17:25:28.000000+00:00",
+                    "end_infer_time": "2024-05-15 17:26:28.000000+00:00",
+                },
+                {
+                    "__name": "histogram-data-drift.kld_mean",
+                    "application_name": "histogram-data-drift",
+                    "metric_name": "kld_mean",
+                    "metric_value": 15.7973460213887,
+                    "start_infer_time": "2024-05-15 17:25:28.000000+00:00",
+                    "end_infer_time": "2024-05-15 17:26:28.000000+00:00",
+                },
+                {
+                    "__name": "histogram-data-drift.hellinger_mean",
+                    "application_name": "histogram-data-drift",
+                    "metric_name": "hellinger_mean",
+                    "metric_value": 1.0,
+                    "start_infer_time": "2024-05-15 17:25:28.000000+00:00",
+                    "end_infer_time": "2024-05-15 17:26:28.000000+00:00",
+                },
+            ],
+            [
+                ModelEndpointMonitoringMetric(
+                    project="default",
+                    app="histogram-data-drift",
+                    type=ModelEndpointMonitoringMetricType.METRIC,
+                    name="tvd_mean",
+                    full_name="default.histogram-data-drift.metric.tvd_mean",
+                ),
+                ModelEndpointMonitoringMetric(
+                    project="default",
+                    app="histogram-data-drift",
+                    type=ModelEndpointMonitoringMetricType.METRIC,
+                    name="kld_mean",
+                    full_name="default.histogram-data-drift.metric.kld_mean",
+                ),
+                ModelEndpointMonitoringMetric(
+                    project="default",
+                    app="histogram-data-drift",
+                    type=ModelEndpointMonitoringMetricType.METRIC,
+                    name="hellinger_mean",
+                    full_name="default.histogram-data-drift.metric.hellinger_mean",
+                ),
+            ],
+        ),
+    ],
+    indirect=["store"],
+)
+def test_extract_metrics_from_items(
+    store: KVStoreBase,
+    items: list[dict[str, str]],
+    expected_metrics: list[ModelEndpointMonitoringMetric],
+) -> None:
+    assert store._extract_metrics_from_items(items) == expected_metrics
 
 
 @pytest.fixture

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -35,7 +35,7 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringResultValues,
 )
 from mlrun.model_monitoring.db.stores.v3io_kv.kv_store import KVStoreBase
-from mlrun.model_monitoring.db.v3io_tsdb_reader import _get_sql_query, read_data
+from mlrun.model_monitoring.db.v3io_tsdb_reader import _get_sql_query, read_metrics_data
 
 
 @pytest.fixture(params=["default-project"])
@@ -419,8 +419,8 @@ def _mock_frames_client(tsdb_df: pd.DataFrame) -> Iterator[None]:
 
 
 @pytest.mark.usefixtures("_mock_frames_client")
-def test_read_data() -> None:
-    data = read_data(
+def test_read_results_data() -> None:
+    data = read_metrics_data(
         project="fictitious-one",
         endpoint_id="70450e1ef7cc9506d42369aeeb056eaaaa0bb8bd",
         start=datetime(2024, 4, 2, 18, 0, 0, tzinfo=timezone.utc),

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -105,7 +105,7 @@ def test_extract_metrics_from_items(
     items: list[dict[str, str]],
     expected_metrics: list[ModelEndpointMonitoringMetric],
 ) -> None:
-    assert store._extract_metrics_from_items(items) == expected_metrics
+    assert store._extract_results_from_items(items) == expected_metrics
 
 
 @pytest.fixture
@@ -257,13 +257,20 @@ class TestGetModelEndpointMetrics:
         endpoint_id: str,
         expected_metrics: list[ModelEndpointMonitoringMetric],
     ) -> None:
-        assert store.get_model_endpoint_metrics(endpoint_id) == expected_metrics
+        assert (
+            store.get_model_endpoint_metrics(
+                endpoint_id, type=ModelEndpointMonitoringMetricType.RESULT
+            )
+            == expected_metrics
+        )
 
     @classmethod
     def test_response_error(cls, store_with_err: KVStoreBase) -> None:
         """Test that non 404 errors are not silenced"""
         with pytest.raises(v3io.dataplane.response.HttpResponseError):
-            store_with_err.get_model_endpoint_metrics(cls.ENDPOINT)
+            store_with_err.get_model_endpoint_metrics(
+                cls.ENDPOINT, type=ModelEndpointMonitoringMetricType.RESULT
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -30,8 +30,8 @@ import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.utils.v3io_clients
 from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringMetric,
+    ModelEndpointMonitoringMetricNoData,
     ModelEndpointMonitoringMetricType,
-    ModelEndpointMonitoringResultNoData,
     ModelEndpointMonitoringResultValues,
 )
 from mlrun.model_monitoring.db.stores.v3io_kv.kv_store import KVStoreBase
@@ -452,4 +452,4 @@ def test_read_data() -> None:
     assert len(data) == 3
     counter = Counter([type(values) for values in data])
     assert counter[ModelEndpointMonitoringResultValues] == 2
-    assert counter[ModelEndpointMonitoringResultNoData] == 1
+    assert counter[ModelEndpointMonitoringMetricNoData] == 1

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -22,7 +22,7 @@ import semver
 import v3io.dataplane.kv
 import v3io_frames.client
 
-import mlrun.common.schemas.model_monitoring as mm_constants
+import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.model_monitoring
 import mlrun.model_monitoring.db.tsdb.v3io
 from mlrun.model_monitoring.writer import (
@@ -201,8 +201,8 @@ class TestTSDB:
             tsdb_connector._get_v3io_frames_client(V3IO_TABLE_CONTAINER)
         )
         tsdb_connector.tables = {
-            mm_constants.MonitoringTSDBTables.APP_RESULTS: mm_constants.MonitoringTSDBTables.APP_RESULTS,
-            mm_constants.MonitoringTSDBTables.METRICS: mm_constants.MonitoringTSDBTables.METRICS,
+            mm_schemas.MonitoringTSDBTables.APP_RESULTS: mm_schemas.MonitoringTSDBTables.APP_RESULTS,
+            mm_schemas.MonitoringTSDBTables.METRICS: mm_schemas.MonitoringTSDBTables.METRICS,
         }
         tsdb_connector.create_tsdb_application_tables()
 
@@ -235,7 +235,7 @@ class TestTSDB:
         event, kind = ModelMonitoringWriter._reconstruct_event(event)
         writer._tsdb_connector.write_application_event(event=event.copy(), kind=kind)
         record_from_tsdb = writer._tsdb_connector.get_records(
-            table=mm_constants.MonitoringTSDBTables.APP_RESULTS,
+            table=mm_schemas.MonitoringTSDBTables.APP_RESULTS,
             filter_query=f"endpoint_id=='{event[WriterEvent.ENDPOINT_ID]}'",
             start="now-1d",
             end="now+1d",
@@ -260,7 +260,7 @@ class TestTSDB:
 
         with pytest.raises(v3io_frames.errors.ReadError):
             writer._tsdb_connector.get_records(
-                table=mm_constants.MonitoringTSDBTables.APP_RESULTS,
+                table=mm_schemas.MonitoringTSDBTables.APP_RESULTS,
                 filter_query=f"endpoint_id=='{event[WriterEvent.ENDPOINT_ID]}'",
                 start="now-1d",
                 end="now+1d",

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -105,7 +105,7 @@ class _V3IORecordsChecker:
         cls._v3io_container = f"users/pipelines/{project_name}/monitoring-apps/"
 
     @classmethod
-    def _test_kv_record(cls, ep_id: str) -> None:
+    def _test_results_kv_record(cls, ep_id: str) -> None:
         for app_data in cls.apps_data:
             app_name = app_data.class_.NAME
             cls._logger.debug("Checking the KV record of app", app_name=app_name)
@@ -174,7 +174,7 @@ class _V3IORecordsChecker:
         cls, ep_id: str, inputs: set[str], outputs: set[str]
     ) -> None:
         cls._test_apps_parquet(ep_id, inputs, outputs)
-        cls._test_kv_record(ep_id)
+        cls._test_results_kv_record(ep_id)
         cls._test_tsdb_record(ep_id)
 
     @classmethod

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import concurrent
 import concurrent.futures
 import json
 import pickle
 import time
 import typing
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
@@ -292,7 +290,7 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
         )
 
     def _set_and_deploy_monitoring_apps(self) -> None:
-        with ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for app_data in self.apps_data:
                 if app_data.deploy:
                     fn = self.project.set_model_monitoring_function(
@@ -407,7 +405,7 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
         if not with_training_set and _DefaultDataDriftAppData in self.apps_data:
             self.apps_data.remove(_DefaultDataDriftAppData)
 
-        with ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             executor.submit(
                 self._submit_controller_and_deploy_writer,
                 deploy_histogram_data_drift_app=_DefaultDataDriftAppData
@@ -573,7 +571,7 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
     def test_inference_feature_set(self) -> None:
         self._log_model()
 
-        with ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             executor.submit(self._deploy_monitoring_app)
             executor.submit(self._deploy_monitoring_infra)
 
@@ -776,7 +774,7 @@ class TestAllKindOfServing(TestMLRunSystem):
             deploy_histogram_data_drift_app=False,
         )
         futures = []
-        with ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for model_name, model_dict in self.models.items():
                 self._log_model(
                     model_name,
@@ -790,7 +788,7 @@ class TestAllKindOfServing(TestMLRunSystem):
             future.result()
 
         futures_2 = []
-        with ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             self.db = mlrun.model_monitoring.get_store_object(project=self.project_name)
             endpoints = self.db.list_model_endpoints()
             for endpoint in endpoints:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -253,14 +253,16 @@ class _V3IORecordsChecker:
     def _test_api(cls, ep_id: str, app_data: _AppData) -> None:
         cls._logger.debug("Checking model endpoint monitoring APIs")
         run_db = mlrun.db.httpdb.HTTPRunDB(mlrun.mlconf.dbpath)
-        cls._test_api_get_metrics(
+        metrics_full_names = cls._test_api_get_metrics(
             ep_id=ep_id, app_data=app_data, run_db=run_db, type="metrics"
         )
         results_full_names = cls._test_api_get_metrics(
             ep_id=ep_id, app_data=app_data, run_db=run_db, type="results"
         )
         cls._test_api_get_values(
-            ep_id=ep_id, results_full_names=results_full_names, run_db=run_db
+            ep_id=ep_id,
+            results_full_names=metrics_full_names + results_full_names,
+            run_db=run_db,
         )
 
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -108,7 +108,9 @@ class _V3IORecordsChecker:
     def _test_results_kv_record(cls, ep_id: str) -> None:
         for app_data in cls.apps_data:
             app_name = app_data.class_.NAME
-            cls._logger.debug("Checking the KV record of app", app_name=app_name)
+            cls._logger.debug(
+                "Checking the results KV record of app", app_name=app_name
+            )
 
             resp = cls._kv_storage.client.kv.get(
                 container=cls._v3io_container, table_path=ep_id, key=app_name
@@ -120,6 +122,30 @@ class _V3IORecordsChecker:
                 assert (
                     data.keys() == app_data.results
                 ), "The KV saved metrics are different than expected"
+
+    @classmethod
+    def _test_metrics_kv_record(cls, ep_id: str) -> None:
+        for app_data in cls.apps_data:
+            if not app_data.metrics:
+                return
+
+            app_name = app_data.class_.NAME
+            table_path = f"{ep_id}_metrics"
+
+            for metric in app_data.metrics:
+                cls._logger.debug(
+                    "Checking a metric KV record of app",
+                    app_name=app_name,
+                    metric=metric,
+                )
+                resp = cls._kv_storage.client.kv.get(
+                    container=cls._v3io_container,
+                    table_path=table_path,
+                    key=f"{app_name}.{metric}",
+                )
+                assert (
+                    resp.output.item
+                ), f"V3IO KV app data is empty for app {app_name} and metric {metric}"
 
     @classmethod
     def _test_tsdb_record(cls, ep_id: str) -> None:
@@ -175,6 +201,7 @@ class _V3IORecordsChecker:
     ) -> None:
         cls._test_apps_parquet(ep_id, inputs, outputs)
         cls._test_results_kv_record(ep_id)
+        cls._test_metrics_kv_record(ep_id)
         cls._test_tsdb_record(ep_id)
 
     @classmethod

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -151,7 +151,7 @@ class _V3IORecordsChecker:
     def _test_tsdb_record(cls, ep_id: str) -> None:
         df: pd.DataFrame = cls._tsdb_storage.get_records(
             table=mm_constants.MonitoringTSDBTables.APP_RESULTS,
-            start=f"now-{5 * cls.app_interval}m",
+            start=f"now-{10 * cls.app_interval}m",
             end="now",
         )
         assert not df.empty, "No TSDB data"


### PR DESCRIPTION
Implements [ML-6430](https://iguazio.atlassian.net/browse/ML-6430).

Write the application metrics to V3IO KV and TSDB.
The KV store is per model endpoint, as done for results. Each key is per application + metric name, creating a schema that Grafana can consume.
The TSDB is implemented in its destined "metrics" table.

Support reading the metrics through the existing `/metrics` and `/metrics-values` API endpoints.

The testing is through some new unit tests and an extended test part in the primary system test.

[ML-6430]: https://iguazio.atlassian.net/browse/ML-6430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ