### PR TITLE
[API] Fix get run with artifacts and iterations [1.6.x]

### DIFF
--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -157,9 +157,18 @@ class Runs(
         else:
             # Producer URI is the URI of the MLClientCtx object that produced the artifact
             producer_uri = f"{project}/{run['metadata']['uid']}"
+            if iter:
+                producer_uri += f"-{iter}"
+
+        best_iteration = False
+        if not iter:
+            iter = None
+            best_iteration = True
 
         artifacts = server.api.crud.Artifacts().list_artifacts(
             db_session,
+            iter=iter,
+            best_iteration=best_iteration,
             producer_id=producer_id,
             producer_uri=producer_uri,
             project=project,

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -96,7 +96,7 @@ class TestMLRunSystem:
 
     @staticmethod
     def _should_clean_resources():
-        return os.environ.get("MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES") != "false"
+        return False
 
     def _delete_test_project(self, name=None):
         if self._should_clean_resources():

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -96,7 +96,7 @@ class TestMLRunSystem:
 
     @staticmethod
     def _should_clean_resources():
-        return False
+        return os.environ.get("MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES") != "false"
 
     def _delete_test_project(self, name=None):
         if self._should_clean_resources():


### PR DESCRIPTION
Enriching artifacts for a run is coupled with the runs iteration.
If the iteration is 0 it is the parent run so we get the best iteration.
Otherwise, the iteration is part of the producer uri so we append it.