### PR TITLE
[Runs] Give precedence to artifact target path over URI in result HTML [1.6.x]

### DIFF
--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -134,7 +134,7 @@ def artifacts_html(
 
         if not attribute_value:
             mlrun.utils.logger.warning(
-                "Artifact is incomplete, omitting from output (most likely due to a failed artifact logging)",
+                f"Artifact required attribute {attribute_name} is missing, omitting from output",
                 artifact_key=key,
             )
             continue
@@ -408,14 +408,14 @@ def runs_to_html(
     else:
         df["labels"] = df["labels"].apply(dict_html)
         df["inputs"] = df["inputs"].apply(inputs_html)
-        if df["artifact_uris"][0]:
-            df["artifact_uris"] = df["artifact_uris"].apply(dict_html)
-            df.drop("artifacts", axis=1, inplace=True)
-        else:
+        if df["artifacts"][0]:
             df["artifacts"] = df["artifacts"].apply(
                 lambda artifacts: artifacts_html(artifacts, "target_path"),
             )
             df.drop("artifact_uris", axis=1, inplace=True)
+        else:
+            df["artifact_uris"] = df["artifact_uris"].apply(dict_html)
+            df.drop("artifacts", axis=1, inplace=True)
 
     def expand_error(x):
         if x["state"] == "error":

--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -413,9 +413,12 @@ def runs_to_html(
                 lambda artifacts: artifacts_html(artifacts, "target_path"),
             )
             df.drop("artifact_uris", axis=1, inplace=True)
-        else:
+        elif df["artifact_uris"][0]:
             df["artifact_uris"] = df["artifact_uris"].apply(dict_html)
             df.drop("artifacts", axis=1, inplace=True)
+        else:
+            df.drop("artifacts", axis=1, inplace=True)
+            df.drop("artifact_uris", axis=1, inplace=True)
 
     def expand_error(x):
         if x["state"] == "error":


### PR DESCRIPTION
Show the artifacts (on the far left) ahead of showing the artifact URIs if available
![Screenshot 2024-05-19 at 16 37 10](https://github.com/mlrun/mlrun/assets/48641682/1785f84a-ebeb-44ed-a2c3-456316871b80)


https://iguazio.atlassian.net/browse/ML-6490