### PR TITLE
[Spark] Enable support for non-aggregation operations in Spark using the streaming interface

### DIFF
--- a/mlrun/data_types/__init__.py
+++ b/mlrun/data_types/__init__.py
@@ -30,7 +30,7 @@ class BaseDataInfer:
 
 
 def get_infer_interface(df) -> BaseDataInfer:
-    if hasattr(df, "rdd"):
+    if "rdd" in dir(df):
         from .spark import SparkDataInfer
 
         return SparkDataInfer

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -68,6 +68,18 @@ def load_spark_dataframe_with_options(
         # if 'schema_infer_limit' in streaming:
         #     df = reader.load(**non_hadoop_spark_options).limit(int(streaming['schema_infer_limit']))
         # else:
+
+        # Spark streaming expects either directory or file path with wildcard. Single file path is not supported
+        # So we trick it making it by adding a wildcard to the end of the path: file.parquet -> file.parque[t]
+        if "path" in non_hadoop_spark_options and (
+            non_hadoop_spark_options["path"].endswith(".parquet")
+            or non_hadoop_spark_options["path"].endswith(".csv")
+        ):
+            last_char = non_hadoop_spark_options["path"][-1]
+            non_hadoop_spark_options["path"] = (
+                non_hadoop_spark_options["path"][:-1] + f"[{last_char}]"
+            )
+
         df = reader.load(**non_hadoop_spark_options)
         schema = df.schema
         reader = session.readStream.schema(schema)

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -500,7 +500,7 @@ class BaseStoreTarget(DataTargetBase):
         chunk_id=0,
         **kwargs,
     ) -> Optional[int]:
-        if hasattr(df, "rdd"):
+        if "rdd" in dir(df):
             options = self.get_spark_options(key_column, timestamp_key)
             options.update(kwargs)
             df = self.prepare_spark_df(df, key_column, timestamp_key, options)
@@ -540,9 +540,9 @@ class BaseStoreTarget(DataTargetBase):
                 or isinstance(file_system.protocol, (tuple, list))
                 and "file" in file_system.protocol
             ):
-                dir = os.path.dirname(target_path)
-                if dir:
-                    os.makedirs(dir, exist_ok=True)
+                directory = os.path.dirname(target_path)
+                if directory:
+                    os.makedirs(directory, exist_ok=True)
             target_df = df
             partition_cols = None  # single parquet file
             if not target_path.endswith(".parquet") and not target_path.endswith(
@@ -1325,7 +1325,7 @@ class NoSqlBaseTarget(BaseStoreTarget):
     def write_dataframe(
         self, df, key_column=None, timestamp_key=None, chunk_id=0, **kwargs
     ):
-        if hasattr(df, "rdd"):
+        if "rdd" in dir(df):
             options = self.get_spark_options(key_column, timestamp_key)
             options.update(kwargs)
             df = self.prepare_spark_df(df)
@@ -2078,7 +2078,7 @@ class SQLTarget(BaseStoreTarget):
 
         self._create_sql_table()
 
-        if hasattr(df, "rdd"):
+        if "rdd" in dir(df):
             raise ValueError("Spark is not supported")
         else:
             (

--- a/mlrun/feature_store/retrieval/spark_merger.py
+++ b/mlrun/feature_store/retrieval/spark_merger.py
@@ -305,6 +305,6 @@ class SparkFeatureMerger(BaseMerger):
         )
 
     def _convert_entity_rows_to_engine_df(self, entity_rows):
-        if entity_rows is not None and not hasattr(entity_rows, "rdd"):
+        if entity_rows is not None and "rdd" not in dir(entity_rows):
             return self.spark.createDataFrame(entity_rows)
         return entity_rows

--- a/mlrun/feature_store/steps.py
+++ b/mlrun/feature_store/steps.py
@@ -32,7 +32,7 @@ def get_engine(first_event):
         first_event = first_event.body
     if isinstance(first_event, pd.DataFrame):
         return "pandas"
-    if hasattr(first_event, "rdd"):
+    if "rdd" in dir(first_event):
         return "spark"
     return "storey"
 


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6474

- Enable support for non-aggregation operations in Spark using the streaming interface.
- Replace `hasattr(obj, 'rdd')` with `'rdd' in dir(obj)` since `hasattr()` evaluates the property, which can lead to unintended behavior.
- Update the system to handle single Parquet and CSV files.

