### PR TITLE
[Artifacts] Fix producer uid not passed to artifact path template

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -72,6 +72,10 @@ class ArtifactProducer:
     def get_meta(self) -> dict:
         return {"kind": self.kind, "name": self.name, "tag": self.tag}
 
+    @property
+    def uid(self):
+        return None
+
 
 def dict_to_artifact(struct: dict) -> Artifact:
     kind = struct.get("kind", "")
@@ -262,7 +266,7 @@ class ArtifactManager:
         if target_path and item.is_dir and not target_path.endswith("/"):
             target_path += "/"
         target_path = template_artifact_path(
-            artifact_path=target_path, project=producer.project
+            artifact_path=target_path, project=producer.project, run_uid=producer.uid
         )
         item.target_path = target_path
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1183,7 +1183,7 @@ def calculate_dataframe_hash(dataframe: pandas.DataFrame):
     return hashlib.sha1(pandas.util.hash_pandas_object(dataframe).values).hexdigest()
 
 
-def template_artifact_path(artifact_path, project, run_uid="project"):
+def template_artifact_path(artifact_path, project, run_uid=None):
     """
     Replace {{run.uid}} with the run uid and {{project}} with the project name in the artifact path.
     If no run uid is provided, the word `project` will be used instead as it is assumed to be a project
@@ -1191,6 +1191,7 @@ def template_artifact_path(artifact_path, project, run_uid="project"):
     """
     if not artifact_path:
         return artifact_path
+    run_uid = run_uid or "project"
     artifact_path = artifact_path.replace("{{run.uid}}", run_uid)
     artifact_path = _fill_project_path_template(artifact_path, project)
     return artifact_path


### PR DESCRIPTION
Run UID wasn't passed to the artifact path template when logging an artifact, causing each `{{run.uid}}` to be resolved as `"project"` (the default).

Resolves https://iguazio.atlassian.net/browse/ML-6481