### PR TITLE
[Runs] Deprecate `state` arg

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -794,7 +794,7 @@ class HTTPRunDB(RunDBInterface):
         :param labels: A list of labels to filter by. Label filters work by either filtering a specific value
             of a label (i.e. list("key=value")) or by looking for the existence of a given
             key (i.e. "key").
-        :param state: List only runs whose state is specified.
+        :param state: Deprecated - List only runs whose state is specified (will be removed in 1.8.0)
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
             returned by their internal order in the DB (order will not be guaranteed).
@@ -828,6 +828,13 @@ class HTTPRunDB(RunDBInterface):
             # TODO: Remove this in 1.8.0
             warnings.warn(
                 "'last' is deprecated and will be removed in 1.8.0.",
+                FutureWarning,
+            )
+
+        if state:
+            # TODO: Remove this in 1.8.0
+            warnings.warn(
+                "'state' is deprecated and will be removed in 1.8.0. Use 'states' instead.",
                 FutureWarning,
             )
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -794,7 +794,7 @@ class HTTPRunDB(RunDBInterface):
         :param labels: A list of labels to filter by. Label filters work by either filtering a specific value
             of a label (i.e. list("key=value")) or by looking for the existence of a given
             key (i.e. "key").
-        :param state: Deprecated - List only runs whose state is specified (will be removed in 1.8.0)
+        :param state: Deprecated - List only runs whose state is specified (will be removed in 1.9.0)
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
             returned by their internal order in the DB (order will not be guaranteed).
@@ -832,9 +832,9 @@ class HTTPRunDB(RunDBInterface):
             )
 
         if state:
-            # TODO: Remove this in 1.8.0
+            # TODO: Remove this in 1.9.0
             warnings.warn(
-                "'state' is deprecated and will be removed in 1.8.0. Use 'states' instead.",
+                "'state' is deprecated and will be removed in 1.9.0. Use 'states' instead.",
                 FutureWarning,
             )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3731,7 +3731,7 @@ class MlrunProject(ModelObj):
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
             returned by their internal order in the DB (order will not be guaranteed).
-        :param last: Deprecated - currently not used (will be removed in 1.8.0).
+        :param last: Deprecated - currently not used (will be removed in 1.9.0).
         :param iter: If ``True`` return runs from all iterations. Otherwise, return only runs whose ``iter`` is 0.
         :param start_time_from: Filter by run start time in ``[start_time_from, start_time_to]``.
         :param start_time_to: Filter by run start time in ``[start_time_from, start_time_to]``.
@@ -3740,9 +3740,9 @@ class MlrunProject(ModelObj):
         :param last_update_time_to: Filter by run last update time in ``(last_update_time_from, last_update_time_to)``.
         """
         if state:
-            # TODO: Remove this in 1.8.0
+            # TODO: Remove this in 1.9.0
             warnings.warn(
-                "'state' is deprecated and will be removed in 1.8.0. Use 'states' instead.",
+                "'state' is deprecated and will be removed in 1.9.0. Use 'states' instead.",
                 FutureWarning,
             )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3727,7 +3727,7 @@ class MlrunProject(ModelObj):
         :param labels:  A list of labels to filter by. Label filters work by either filtering a specific value
                 of a label (i.e. list("key=value")) or by looking for the existence of a given
                 key (i.e. "key").
-        :param state: List only runs whose state is specified.
+        :param state: Deprecated - List only runs whose state is specified.
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
             returned by their internal order in the DB (order will not be guaranteed).
@@ -3739,6 +3739,13 @@ class MlrunProject(ModelObj):
             last_update_time_to)``.
         :param last_update_time_to: Filter by run last update time in ``(last_update_time_from, last_update_time_to)``.
         """
+        if state:
+            # TODO: Remove this in 1.8.0
+            warnings.warn(
+                "'state' is deprecated and will be removed in 1.8.0. Use 'states' instead.",
+                FutureWarning,
+            )
+
         db = mlrun.db.get_run_db(secrets=self._secrets)
         return db.list_runs(
             name,


### PR DESCRIPTION
Deprecate `state` field. The user should use `states` instead.
