### PR TITLE
[Model Monitoring] Fix v3io tsdb_client in`test_app` 

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -115,6 +115,8 @@ class _V3IORecordsChecker:
                     mm_constants.ProjectSecretKeys.TSDB_CONNECTION
                 ),
             )
+        else:
+            cls._tsdb_storage = mlrun.model_monitoring.get_tsdb_connector(project=project_name)
         cls._kv_storage = mlrun.model_monitoring.get_store_object(project=project_name)
         cls._v3io_container = f"users/pipelines/{project_name}/monitoring-apps/"
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -116,7 +116,9 @@ class _V3IORecordsChecker:
                 ),
             )
         else:
-            cls._tsdb_storage = mlrun.model_monitoring.get_tsdb_connector(project=project_name)
+            cls._tsdb_storage = mlrun.model_monitoring.get_tsdb_connector(
+                project=project_name
+            )
         cls._kv_storage = mlrun.model_monitoring.get_store_object(project=project_name)
         cls._v3io_container = f"users/pipelines/{project_name}/monitoring-apps/"
 


### PR DESCRIPTION
fix a bug in which the `_tsdb_storage` wasn't created during the test when using the default `v3io-tsdb` 