### PR TITLE
[Datastore] Improve error on invalid URL in `get_store_resource()`

### DIFF
--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -146,7 +146,11 @@ def get_store_resource(
 
     db = db or mlrun.get_run_db(secrets=secrets)
     kind, uri = parse_store_uri(uri)
-    if kind == StorePrefix.FeatureSet:
+    if not kind:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Cannot get store resource from invalid URI: {uri}"
+        )
+    elif kind == StorePrefix.FeatureSet:
         project, name, tag, uid = parse_versioned_object_uri(
             uri, project or config.default_project
         )


### PR DESCRIPTION
Relates to [ML-6520](https://iguazio.atlassian.net/browse/ML-6520).

The new check is added to avoid this error on an invalid URL:
```
mlrun.errors.MLRunInvalidArgumentError: Field 'model_endpoint.spec.model_uri' should be of type 'ModelArtifact' (got: DataItem with value: ).
```

[ML-6520]: https://iguazio.atlassian.net/browse/ML-6520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ