### PR TITLE
[Git] Add `project.yaml` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ tests/project.yaml
 *venv*
 mlrun/utils/version/version.json
 tests/system/env.yml
+project.yaml
+
 # pyenv file for working with several python versions
 .python-version
 *.bak


### PR DESCRIPTION
This file is generated each time a system test is run.
It pollutes the index and might be committed by mistake.