### PR TITLE
[Requirements] Align scikit-learn version [1.6.x]

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -27,6 +27,6 @@ avro~=1.11
 sqlalchemy-utils~=0.39.0
 
 # frameworks tests
-scikit-learn~=1.4
+scikit-learn~=1.4.0
 lightgbm~=3.0; platform_machine != 'arm64'
 xgboost~=1.1

--- a/dockerfiles/base/mlrun_requirements.txt
+++ b/dockerfiles/base/mlrun_requirements.txt
@@ -4,6 +4,6 @@
 # TODO: delete me once we delete models entirely
 matplotlib~=3.5
 scipy~=1.11
-scikit-learn~=1.4
+scikit-learn~=1.4.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib~=3.5
 scipy~=1.11
-scikit-learn~=1.4
+scikit-learn~=1.4.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 xgboost~=1.1

--- a/dockerfiles/mlrun/requirements.txt
+++ b/dockerfiles/mlrun/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib~=3.5
 scipy~=1.11
-scikit-learn~=1.4
+scikit-learn~=1.4.0
 seaborn~=0.11.0
 scikit-plot~=0.3.7
 mpi4py~=3.1

--- a/docs/tutorials/01-mlrun-basics.ipynb
+++ b/docs/tutorials/01-mlrun-basics.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "**Before you start, make sure the MLRun client package is installed and configured properly:**\n",
     "\n",
-    "This notebook uses sklearn and numpy. If it is not installed in your environment run `!pip install scikit-learn~=1.4 numpy~=1.26`."
+    "This notebook uses sklearn and numpy. If it is not installed in your environment run `!pip install scikit-learn~=1.4.0 numpy~=1.26`."
    ]
   },
   {
@@ -82,7 +82,7 @@
    "outputs": [],
    "source": [
     "# Install MLRun and sklearn, run this only once (restart the notebook after the install !!!)\n",
-    "%pip install mlrun scikit-learn~=1.4 numpy~=1.26"
+    "%pip install mlrun scikit-learn~=1.4.0 numpy~=1.26"
    ]
   },
   {

--- a/docs/tutorials/colab/01-mlrun-basics-colab.ipynb
+++ b/docs/tutorials/colab/01-mlrun-basics-colab.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "**Before you start, make sure the MLRun client package is installed and configured properly !**\n",
     "\n",
-    "This notebook uses sklearn. If it is not installed in your environment run `!pip install scikit-learn~=1.4`."
+    "This notebook uses sklearn. If it is not installed in your environment run `!pip install scikit-learn~=1.4.0`."
    ]
   },
   {
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "# install MLRun and sklearn, run this only once (restart the notebook after the install !!!)\n",
-    "%pip install mlrun scikit-learn~=1.4"
+    "%pip install mlrun scikit-learn~=1.4.0"
    ]
   },
   {
@@ -120,9 +120,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "%pip install uvicorn~=0.17.0 dask-kubernetes~=0.11.0 apscheduler~=3.6 sqlite3-to-mysql~=1.4 scikit-learn~=1.4"
-   ]
+   "source": "%pip install uvicorn~=0.17.0 dask-kubernetes~=0.11.0 apscheduler~=3.6 sqlite3-to-mysql~=1.4 scikit-learn~=1.4.0"
   },
   {
    "cell_type": "markdown",

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -144,6 +144,7 @@ def test_requirement_specifiers_convention():
         # conda requirements since conda does not support ~= operator
         "lightgbm": {">=3.0"},
         "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
+        "scikit-learn": {"~=1.4.0"},
     }
 
     for (


### PR DESCRIPTION
From a mix of `scikit-learn~=1.4.0` and `scikit-learn~=1.4` to just the former.

Backport of #5626 / c58f85d.

[ML-6549](https://iguazio.atlassian.net/browse/ML-6549)

[ML-6549]: https://iguazio.atlassian.net/browse/ML-6549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ