### PR TITLE
[Runtimes] Fix Pickling in MLRun Function Due to Improper Dynamic Import

### DIFF
--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -384,6 +384,7 @@ def load_module(file_name, handler, context):
         if spec is None:
             raise RunError(f"Cannot import from {file_name!r}")
         module = imputil.module_from_spec(spec)
+        sys.modules[mod_name] = module
         spec.loader.exec_module(module)
 
     class_args = {}


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-2872

According to https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly, we were missing a step in how we dynamically import the function handler in the local runtime.
After adding the missing step, Pickle works properly within the MLRun Function:
![Screenshot 2024-05-27 at 12 12 17](https://github.com/mlrun/mlrun/assets/12761913/8a96157f-dff0-48d4-bb52-40e9c019b8c5)
