### PR TITLE
[Datastore] Fix `S3Store.rm()`

### DIFF
--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -198,11 +198,6 @@ class S3Store(DataStore):
         bucket = self.s3.Bucket(bucket)
         return [obj.key[key_length:] for obj in bucket.objects.filter(Prefix=key)]
 
-    def rm(self, path, recursive=False, maxdepth=None):
-        bucket, key = self.get_bucket_and_key(path)
-        path = f"{bucket}/{key}"
-        self.filesystem.rm(path=path, recursive=recursive, maxdepth=maxdepth)
-
 
 def parse_s3_bucket_and_key(s3_path):
     try:

--- a/tests/system/datastore/test_aws_s3.py
+++ b/tests/system/datastore/test_aws_s3.py
@@ -30,6 +30,7 @@ from mlrun.datastore.datastore_profile import (
 )
 from mlrun.datastore.sources import ParquetSource
 from mlrun.datastore.targets import ParquetTarget, get_default_prefix_for_target
+from mlrun.utils import logger
 from tests.system.base import TestMLRunSystem
 
 test_environment = TestMLRunSystem._get_env_from_file()
@@ -125,7 +126,7 @@ class TestAwsS3(TestMLRunSystem):
             "s3", key=self._access_key_id, secret=self._secret_access_key
         )
         param = self.s3[url_type]
-        print(f"Using URL {param['parquet_url']}\n")
+        logger.info(f"Using URL {param['parquet_url']}")
         data = {"Column1": [1, 2, 3], "Column2": ["A", "B", "C"]}
         df = pd.DataFrame(data)
         source_path = param["parquet_url"]
@@ -137,13 +138,13 @@ class TestAwsS3(TestMLRunSystem):
 
         # ingest
         target_path = f"{os.path.dirname(param['parquet_url'])}/target_{uuid.uuid4()}"
-        targets = [ParquetTarget(path=target_path)]
+        target = ParquetTarget(path=target_path)
         fset = fstore.FeatureSet(
             name="test_fs",
             entities=[fstore.Entity("Column1")],
         )
 
-        fset.ingest(source=parquet_source, targets=targets)
+        fset.ingest(source=parquet_source, targets=[target])
         result = ParquetSource(path=target_path).to_dataframe(
             columns=("Column1", "Column2")
         )
@@ -153,12 +154,15 @@ class TestAwsS3(TestMLRunSystem):
             df.sort_index(axis=1), result.sort_index(axis=1), check_like=True
         )
 
+        # Check for ML-6587 regression
+        target.purge()
+
     def test_ingest_ds_default_target(self):
         s3_fs = fsspec.filesystem(
             "s3", key=self._access_key_id, secret=self._secret_access_key
         )
         param = self.s3["ds_with_bucket"]
-        print(f"Using URL {param['parquet_url']}\n")
+        logger.info(f"Using URL {param['parquet_url']}")
         data = {"Column1": [1, 2, 3], "Column2": ["A", "B", "C"]}
         df = pd.DataFrame(data)
         source_path = param["parquet_url"]
@@ -169,20 +173,20 @@ class TestAwsS3(TestMLRunSystem):
 
         parquet_source = ParquetSource(name="test", path=source_path)
 
-        targets = [ParquetTarget(path="ds://s3ds_profile_with_bucket")]
+        target = ParquetTarget(path="ds://s3ds_profile_with_bucket")
         fset = fstore.FeatureSet(
             name="test_fs",
             entities=[fstore.Entity("Column1")],
         )
 
-        fset.ingest(source=parquet_source, targets=targets)
+        fset.ingest(source=parquet_source, targets=[target])
 
         expected_default_ds_data_prefix = get_default_prefix_for_target(
             "dsnosql"
         ).format(
             ds_profile_name="s3ds_profile_with_bucket",
             project=fset.metadata.project,
-            kind=targets[0].kind,
+            kind=target.kind,
             name=fset.metadata.name,
         )
 
@@ -196,3 +200,6 @@ class TestAwsS3(TestMLRunSystem):
         assert_frame_equal(
             df.sort_index(axis=1), result.sort_index(axis=1), check_like=True
         )
+
+        # Check for ML-6587 regression
+        target.purge()


### PR DESCRIPTION
[ML-6587](https://iguazio.atlassian.net/browse/ML-6587)

Following breakage in 1.7.8-rc18, introduced by #5582.

[ML-6587]: https://iguazio.atlassian.net/browse/ML-6587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ