### PR TITLE
[Function] Optimise an error when function deletion is failed

### DIFF
--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1397,7 +1397,7 @@ async def _delete_nuclio_functions_in_batches(
                 nuclio_name, error_message = result
                 if error_message:
                     failed_requests.append(
-                        f"Failed to delete nuclio function {nuclio_name}: {error_message}"
+                        error_message
                     )
 
     return failed_requests

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1396,8 +1396,6 @@ async def _delete_nuclio_functions_in_batches(
             if isinstance(result, tuple):
                 nuclio_name, error_message = result
                 if error_message:
-                    failed_requests.append(
-                        error_message
-                    )
+                    failed_requests.append(error_message)
 
     return failed_requests

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1315,7 +1315,7 @@ async def _delete_function(
             auth_info, project, nuclio_function_names
         )
         if failed_requests:
-            error_message = f"Failed to delete function {function_name}. Errors: {' '.join(failed_requests)}"
+            error_message = f"Failed to delete function {function_name}. Errors: {';'.join(failed_requests)}"
             await _update_functions_with_deletion_info(
                 functions, project, {"status.deletion_error": error_message}
             )

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -212,7 +212,9 @@ class Client:
 
         self._logger.warning("Request to nuclio failed. Reason:", **log_kwargs)
 
-        mlrun.errors.raise_for_status(response, error_message)
+        raise mlrun.errors.STATUS_ERRORS[response.status](
+            error_message, response=response
+        )
 
     def _enrich_nuclio_api_gateway(
         self,


### PR DESCRIPTION
Currently, the error string can be too long, so I have removed the additional string about failure for every Nuclio function. There will still be a message indicating that the deletion failed, including the MLRun function name.

So, instead of this 

```
Failed to delete function func-nuclio. Errors: Failed to delete nuclio function run-nuclio-hello-world-func-nuclio: 412, message='Precondition Failed', url=URL('http://nuclio-dashboard.default-tenant.svc.cluster.local:8070/api/functions/'): : Function is "
```

we will have:

```
Failed to delete function func-nuclio. Errors: Function is used by api gateways"
```

Jira - https://iguazio.atlassian.net/browse/ML-6552