### PR TITLE
[Artifacts] Improve list artifact tags db query

### DIFF
--- a/server/api/api/endpoints/artifacts.py
+++ b/server/api/api/endpoints/artifacts.py
@@ -110,15 +110,17 @@ async def list_artifact_tags(
         ),
         auth_info,
     )
-    tags = [
+
+    # create a tags set to remove duplicates
+    tags = {
         tag_tuple[2]
         for tag_tuple in tag_tuples
         if tag_tuple[1] in allowed_artifact_keys
-    ]
+    }
+
     return {
         "project": project,
-        # Remove duplicities
-        "tags": list(set(tags)),
+        "tags": list(tags),
     }
 
 

--- a/server/api/api/endpoints/artifacts.py
+++ b/server/api/api/endpoints/artifacts.py
@@ -97,30 +97,13 @@ async def list_artifact_tags(
         mlrun.common.schemas.AuthorizationAction.read,
         auth_info,
     )
-    tag_tuples = await run_in_threadpool(
+    tags = await run_in_threadpool(
         server.api.crud.Artifacts().list_artifact_tags, db_session, project, category
     )
-    artifact_key_to_tag = {tag_tuple[1]: tag_tuple[2] for tag_tuple in tag_tuples}
-    allowed_artifact_keys = await server.api.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
-        mlrun.common.schemas.AuthorizationResourceTypes.artifact,
-        list(artifact_key_to_tag.keys()),
-        lambda artifact_key: (
-            project,
-            artifact_key,
-        ),
-        auth_info,
-    )
-
-    # create a tags set to remove duplicates
-    tags = {
-        tag_tuple[2]
-        for tag_tuple in tag_tuples
-        if tag_tuple[1] in allowed_artifact_keys
-    }
 
     return {
         "project": project,
-        "tags": list(tags),
+        "tags": tags,
     }
 
 

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -1062,9 +1062,9 @@ class TestArtifacts:
         artifacts = db.list_artifacts(db_session, project=project, tag="latest")
         assert len(artifacts) == 5
 
-        # query all artifacts tags, should return 15+5=20 tags
+        # query all artifacts tags, should return 4 tags = 3 tags + latest
         tags = db.list_artifact_tags(db_session, project=project)
-        assert len(tags) == 20
+        assert len(tags) == 4
 
         # files counters should return the most recent artifacts, for each key -> 5 artifacts
         project_to_files_count = db._calculate_files_counters(db_session)

--- a/tests/api/db/test_sqldb.py
+++ b/tests/api/db/test_sqldb.py
@@ -57,11 +57,10 @@ def test_list_artifact_tags(db: SQLDB, db_session: Session):
 
     tags = db.list_artifact_tags(db_session, "p1")
     expected_tags = [
-        ("p1", "k1", "t1"),
-        ("p1", "k1", "latest"),
-        ("p1", "k1", "t2"),
-        ("p1", "k2", "t3"),
-        ("p1", "k2", "latest"),
+        "t1",
+        "latest",
+        "t2",
+        "t3",
     ]
     assert deepdiff.DeepDiff(tags, expected_tags, ignore_order=True) == {}
 
@@ -69,13 +68,13 @@ def test_list_artifact_tags(db: SQLDB, db_session: Session):
     model_tags = db.list_artifact_tags(
         db_session, "p1", mlrun.common.schemas.ArtifactCategories.model
     )
-    expected_tags = [("p1", "k2", "t3"), ("p1", "k2", "latest")]
+    expected_tags = ["t3", "latest"]
     assert deepdiff.DeepDiff(expected_tags, model_tags, ignore_order=True) == {}
 
     model_tags = db.list_artifact_tags(
         db_session, "p2", mlrun.common.schemas.ArtifactCategories.dataset
     )
-    expected_tags = [("p2", "k3", "t4"), ("p2", "k3", "latest")]
+    expected_tags = ["t4", "latest"]
     assert deepdiff.DeepDiff(expected_tags, model_tags, ignore_order=True) == {}
 
 


### PR DESCRIPTION
When listing artifact tags, we first loaded all of the artifacts in the project to the API's memory, then iterated over them and looked for tags in their metadata.
This resulted with a major load on the API and in systems with a large number of artifacts, requests to `GET /artifact-tags` were stuck and timing out.

To fix it, instead of loading the entire artifacts table then iterating over it, we use a simple join on the artifact tags table and query only the artifact key (needed for permission filtering) and the tag name.
This results with a much quicker query and simpler code.

Resolves https://iguazio.atlassian.net/browse/ML-6611