### PR TITLE
[Coding Conventions] Enforce sending self as first arg of instance methods

### DIFF
--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -104,6 +104,7 @@ class ModelEndpointSpec(ObjectSpec):
         )
 
     @validator("monitor_configuration")
+    @classmethod
     def set_name(cls, monitor_configuration):
         return monitor_configuration or {
             EventFieldType.DRIFT_DETECTED_THRESHOLD: (
@@ -115,6 +116,7 @@ class ModelEndpointSpec(ObjectSpec):
         }
 
     @validator("model_uri")
+    @classmethod
     def validate_model_uri(cls, model_uri):
         """Validate that the model uri includes the required prefix"""
         prefix, uri = mlrun.datastore.parse_store_uri(model_uri)

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -37,6 +37,7 @@ class DatastoreProfile(pydantic.BaseModel):
         extra = pydantic.Extra.forbid
 
     @pydantic.validator("name")
+    @classmethod
     def lower_case(cls, v):
         return v.lower()
 
@@ -304,6 +305,7 @@ class DatastoreProfileGCS(DatastoreProfile):
         return v
 
     @pydantic.validator("gcp_credentials", pre=True, always=True)
+    @classmethod
     def convert_dict_to_json(cls, v):
         if isinstance(v, dict):
             return json.dumps(v)

--- a/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
@@ -60,7 +60,7 @@ class _ApplicationResultOrMetric:
     )
 
     @declared_attr
-    def endpoint_id(cls):
+    def endpoint_id(self):
         return Column(
             String(40),
             ForeignKey(f"{EventFieldType.MODEL_ENDPOINTS}.{EventFieldType.UID}"),
@@ -81,7 +81,7 @@ class ApplicationMetricsTable(
 
 class MonitoringSchedulesTable(Base, MonitoringSchedulesBaseTable):
     @declared_attr
-    def endpoint_id(cls):
+    def endpoint_id(self):
         return Column(
             String(40),
             ForeignKey(f"{EventFieldType.MODEL_ENDPOINTS}.{EventFieldType.UID}"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ extend-select = [
     "I",   # isort
     "UP",  # pyupgrade
     "CPY", # flake8-copyright
+    "N805", # first argument of instance method should be 'self'
     "N806", # lowercase variable names
     "N816", # snake_case for global variable names
     "N999", # snake_case for module names

--- a/tests/model_monitoring/test_stores/test_sql.py
+++ b/tests/model_monitoring/test_stores/test_sql.py
@@ -49,6 +49,7 @@ class TestSQLStore:
     def store_connection(tmp_path: Path) -> str:
         return f"sqlite:///{tmp_path / 'test.db'}"
 
+    @classmethod
     @pytest.fixture()
     def _mock_random_endpoint(
         cls,


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6626

This PR addresses  the 3rd python coding convention rule of the conventions that we defined:
"Use self as the first parameter in instance methods."