### PR TITLE
[CI] Fix building jupyter image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@ kubeconfig
 **/patch_env.yml
 **/mlrun.env
 mlrun.egg-info
+
+# this is just a template
+!dockerfiles/jupyter/mlrun.env


### PR DESCRIPTION
mlrun.env is a template file for jupyer to include mlrun's default env for running it locally.