### PR TITLE
[K8s] Fix validating label keys

### DIFF
--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -165,6 +165,11 @@ def verify_label_key(key: str):
     mlrun.utils.helpers.verify_field_regex(
         f"project.metadata.labels.'{key}'",
         name,
+        mlrun.utils.regex.k8s_character_limit,
+    )
+    mlrun.utils.helpers.verify_field_regex(
+        f"project.metadata.labels.'{key}'",
+        name,
         mlrun.utils.regex.qualified_name,
     )
 

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -141,17 +141,6 @@ def verify_label_key(key: str):
     if not key:
         raise mlrun.errors.MLRunInvalidArgumentError("label key cannot be empty")
 
-    mlrun.utils.helpers.verify_field_regex(
-        f"project.metadata.labels.'{key}'",
-        key,
-        mlrun.utils.regex.k8s_character_limit,
-    )
-
-    if key.startswith("k8s.io/") or key.startswith("kubernetes.io/"):
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            "Labels cannot start with 'k8s.io/' or 'kubernetes.io/'"
-        )
-
     parts = key.split("/")
     if len(parts) == 1:
         name = parts[0]
@@ -178,6 +167,11 @@ def verify_label_key(key: str):
         name,
         mlrun.utils.regex.qualified_name,
     )
+
+    if key.startswith("k8s.io/") or key.startswith("kubernetes.io/"):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Labels cannot start with 'k8s.io/' or 'kubernetes.io/'"
+        )
 
 
 def verify_label_value(value, label_key):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -181,8 +181,12 @@ def verify_field_regex(
             )
             if mode == mlrun.common.schemas.RegexMatchModes.all:
                 if raise_on_failure:
+                    if len(field_name) > max_chars:
+                        field_name = field_name[:max_chars] + "...truncated"
+                    if len(field_value) > max_chars:
+                        field_value = field_value[:max_chars] + "...truncated"
                     raise mlrun.errors.MLRunInvalidArgumentError(
-                        f"Field '{field_name[:max_chars]}' is malformed. '{field_value[:max_chars]}' "
+                        f"Field '{field_name}' is malformed. '{field_value}' "
                         f"does not match required pattern: {pattern}"
                     )
                 return False

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -40,10 +40,9 @@ def test_sanitize_label_value(value: str, expected: str):
     "label_key, exception",
     [
         # valid
-        (
-            "a" * 253 + "/key",
-            does_not_raise(),
-        ),
+        ("a/" + "b" * 63, does_not_raise()),
+        ("a" * 253 + "/b", does_not_raise()),
+        ("a" * 253 + "/" + "b" * 63, does_not_raise()),
         ("my-key", does_not_raise()),
         ("a/b", does_not_raise()),
         ("prefix/valid-key", does_not_raise()),
@@ -52,32 +51,37 @@ def test_sanitize_label_value(value: str, expected: str):
         # preserved
         ("k8s.io/a", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         ("kubernetes.io/a", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        # Prefix too long
+        # prefix too long
         (
             "toolong" + "a" * 248 + "/key",
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
-        # Prefix has invalid character - '_'
+        # name too long
+        (
+            "a/" + "b" * 64,
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        # prefix has invalid character - '_'
         (
             "prefix_with_underscores/valid-key",
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
-        # Invalid prefix
+        # invalid prefix
         (
             "invalid-prefix-.com/key",
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
-        # Trailing slash in key
+        # trailing slash in key
         ("invalid-prefix/key/", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        # Leading slash in key
+        # leading slash in key
         ("/invalid-key", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        # Empty key
+        # empty key
         ("", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        # Trailing dash
+        # trailing dash
         ("invalid-key-", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        # Trailing underscore
+        # trailing underscore
         ("invalid-key_", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
-        # Trailing dot
+        # trailing dot
         ("invalid-key.", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
     ],
 )

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from contextlib import nullcontext as does_not_raise
+
 import pytest
 
-from mlrun.k8s_utils import sanitize_label_value
+import mlrun.errors
+import mlrun.k8s_utils
 
 
 @pytest.mark.parametrize(
@@ -30,4 +33,54 @@ from mlrun.k8s_utils import sanitize_label_value
     ],
 )
 def test_sanitize_label_value(value: str, expected: str):
-    assert sanitize_label_value(value) == expected
+    assert mlrun.k8s_utils.sanitize_label_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    "label_key, exception",
+    [
+        # valid
+        (
+            "a" * 253 + "/key",
+            does_not_raise(),
+        ),
+        ("my-key", does_not_raise()),
+        ("a/b", does_not_raise()),
+        ("prefix/valid-key", does_not_raise()),
+        ("prefix.with.dots/valid-key", does_not_raise()),
+        ("prefix-with-dashes/valid-key", does_not_raise()),
+        # preserved
+        ("k8s.io/a", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        ("kubernetes.io/a", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        # Prefix too long
+        (
+            "toolong" + "a" * 248 + "/key",
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        # Prefix has invalid character - '_'
+        (
+            "prefix_with_underscores/valid-key",
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        # Invalid prefix
+        (
+            "invalid-prefix-.com/key",
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        # Trailing slash in key
+        ("invalid-prefix/key/", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        # Leading slash in key
+        ("/invalid-key", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        # Empty key
+        ("", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        # Trailing dash
+        ("invalid-key-", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        # Trailing underscore
+        ("invalid-key_", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        # Trailing dot
+        ("invalid-key.", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+    ],
+)
+def test_verify_label_key(label_key, exception):
+    with exception:
+        mlrun.k8s_utils.verify_label_key(label_key)


### PR DESCRIPTION
Previously we have validated for max length of the entire key which is wrong according to k8s spec https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set whereas the key can be split into 2 segments in case of a "/" delimiter. prefix and name. the name is indeed limited to 64 chars while the prefix can be longer and up to 254 chars. 

This PR also indicating the key has been truncated in error in case it exceeds the default 64 chars.

https://iguazio.atlassian.net/browse/ML-5872