### PR TITLE
[Application] Populate resource configuration to sidecar

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -436,6 +436,42 @@ class ApplicationRuntime(RemoteRuntime):
             **http_client_kwargs,
         )
 
+    def with_limits(
+        self,
+        mem: str = None,
+        cpu: str = None,
+        gpus: int = None,
+        gpu_type: str = "nvidia.com/gpu",
+        patch: bool = False,
+    ):
+        # set the nuclio function limits
+        super().with_limits(mem, cpu, gpus, gpu_type, patch)
+
+        # set the sidecar limits
+        sidecars = self.spec.config.get("spec.sidecars", [])
+        for sidecar in sidecars:
+            sidecar["resources"] = sidecar.get("resources", {})
+            sidecar["resources"]["limits"] = sidecar["resources"].get("limits", {})
+            sidecar["resources"]["limits"]["cpu"] = cpu
+            sidecar["resources"]["limits"]["memory"] = mem
+
+    def with_requests(
+        self,
+        mem: str = None,
+        cpu: str = None,
+        patch: bool = False,
+    ):
+        # set the nuclio function requests
+        super().with_requests(mem, cpu, patch)
+
+        # set the sidecar requests
+        sidecars = self.spec.config.get("spec.sidecars", [])
+        for sidecar in sidecars:
+            sidecar["resources"] = sidecar.get("resources", {})
+            sidecar["resources"]["requests"] = sidecar["resources"].get("requests", {})
+            sidecar["resources"]["requests"]["cpu"] = cpu
+            sidecar["resources"]["requests"]["memory"] = mem
+
     def _build_application_image(
         self,
         builder_env: dict = None,

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -436,42 +436,6 @@ class ApplicationRuntime(RemoteRuntime):
             **http_client_kwargs,
         )
 
-    def with_limits(
-        self,
-        mem: str = None,
-        cpu: str = None,
-        gpus: int = None,
-        gpu_type: str = "nvidia.com/gpu",
-        patch: bool = False,
-    ):
-        # set the nuclio function limits
-        super().with_limits(mem, cpu, gpus, gpu_type, patch)
-
-        # set the sidecar limits
-        sidecars = self.spec.config.get("spec.sidecars", [])
-        for sidecar in sidecars:
-            sidecar["resources"] = sidecar.get("resources", {})
-            sidecar["resources"]["limits"] = sidecar["resources"].get("limits", {})
-            sidecar["resources"]["limits"]["cpu"] = cpu
-            sidecar["resources"]["limits"]["memory"] = mem
-
-    def with_requests(
-        self,
-        mem: str = None,
-        cpu: str = None,
-        patch: bool = False,
-    ):
-        # set the nuclio function requests
-        super().with_requests(mem, cpu, patch)
-
-        # set the sidecar requests
-        sidecars = self.spec.config.get("spec.sidecars", [])
-        for sidecar in sidecars:
-            sidecar["resources"] = sidecar.get("resources", {})
-            sidecar["resources"]["requests"] = sidecar["resources"].get("requests", {})
-            sidecar["resources"]["requests"]["cpu"] = cpu
-            sidecar["resources"]["requests"]["memory"] = mem
-
     def _build_application_image(
         self,
         builder_env: dict = None,

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -984,6 +984,9 @@ class RemoteRuntime(KubeResource):
         if args and sidecar["command"]:
             sidecar["args"] = mlrun.utils.helpers.as_list(args)
 
+        # populate the sidecar resources from the function spec
+        sidecar["resources"] = self.spec.resources
+
     def _set_sidecar(self, name: str) -> dict:
         self.spec.config.setdefault("spec.sidecars", [])
         sidecars = self.spec.config["spec.sidecars"]

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -985,7 +985,8 @@ class RemoteRuntime(KubeResource):
             sidecar["args"] = mlrun.utils.helpers.as_list(args)
 
         # populate the sidecar resources from the function spec
-        sidecar["resources"] = self.spec.resources
+        if self.spec.resources:
+            sidecar["resources"] = self.spec.resources
 
     def _set_sidecar(self, name: str) -> dict:
         self.spec.config.setdefault("spec.sidecars", [])

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -190,6 +190,28 @@ def test_application_api_gateway(rundb_mock):
     assert function_name in api_gateway.spec.functions[0]
 
 
+def test_application_runtime_resources(rundb_mock):
+    mlrun.mlconf.igz_version = "3.6.0"
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+    )
+    cpu_requests = "0.7"
+    memory_requests = "1.2Gi"
+    cpu_limits = "2"
+    memory_limits = "4Gi"
+    fn.with_requests(cpu=cpu_requests, mem=memory_requests)
+    fn.with_limits(cpu=cpu_limits, mem=memory_limits)
+
+    fn.deploy()
+
+    assert fn.spec.resources == mlrun.k8s.ResourceRequirements(
+        limits={"cpu": "1", "memory": "2Gi"},
+        requests={"cpu": "0.5", "memory": "1Gi"},
+    )
+
+
 def _assert_function_code(fn, file_path=None):
     file_path = (
         file_path or mlrun.runtimes.ApplicationRuntime.get_filename_and_handler()[0]

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -22,6 +22,16 @@ import mlrun.common.schemas
 import mlrun.utils
 
 
+@pytest.fixture
+def igz_version_mock():
+    """Application runtime uses access key api gateway which requires igz version >= 3.5.5,
+    so we need to mock the igz version to be 3.6.0 to pass the validation in the tests."""
+    original_igz_version = mlrun.mlconf.igz_version
+    mlrun.mlconf.igz_version = "3.6.0"
+    yield
+    mlrun.mlconf.igz_version = original_igz_version
+
+
 def test_create_application_runtime():
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test", kind="application", image="mlrun/mlrun"
@@ -33,8 +43,7 @@ def test_create_application_runtime():
     # _assert_function_handler(fn)
 
 
-def test_create_application_runtime_with_command(rundb_mock):
-    mlrun.mlconf.igz_version = "3.6.0"
+def test_create_application_runtime_with_command(rundb_mock, igz_version_mock):
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
         "application-test", kind="application", image="mlrun/mlrun", command="echo"
     )
@@ -47,8 +56,7 @@ def test_create_application_runtime_with_command(rundb_mock):
     # _assert_function_handler(fn)
 
 
-def test_deploy_application_runtime(rundb_mock):
-    mlrun.mlconf.igz_version = "3.6.0"
+def test_deploy_application_runtime(rundb_mock, igz_version_mock):
     image = "my/web-app:latest"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test", kind="application", image=image
@@ -57,8 +65,7 @@ def test_deploy_application_runtime(rundb_mock):
     _assert_application_post_deploy_spec(fn, image)
 
 
-def test_consecutive_deploy_application_runtime(rundb_mock):
-    mlrun.mlconf.igz_version = "3.6.0"
+def test_consecutive_deploy_application_runtime(rundb_mock, igz_version_mock):
     image = "my/web-app:latest"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test", kind="application", image=image
@@ -160,8 +167,7 @@ def test_image_enriched_on_build_application_image(remote_builder_mock):
     assert fn.status.state == mlrun.common.schemas.FunctionState.ready
 
 
-def test_application_image_build(remote_builder_mock):
-    mlrun.mlconf.igz_version = "3.6.0"
+def test_application_image_build(remote_builder_mock, igz_version_mock):
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test",
         kind="application",
@@ -174,8 +180,7 @@ def test_application_image_build(remote_builder_mock):
     )
 
 
-def test_application_api_gateway(rundb_mock):
-    mlrun.mlconf.igz_version = "3.6.0"
+def test_application_api_gateway(rundb_mock, igz_version_mock):
     function_name = "application-test"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(
         "application-test",
@@ -190,8 +195,7 @@ def test_application_api_gateway(rundb_mock):
     assert function_name in api_gateway.spec.functions[0]
 
 
-def test_application_runtime_resources(rundb_mock):
-    mlrun.mlconf.igz_version = "3.6.0"
+def test_application_runtime_resources(rundb_mock, igz_version_mock):
     image = "my/web-app:latest"
     app_name = "application-test"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.code_to_function(


### PR DESCRIPTION
When setting requests / limits on an application runtime, we expect these resources to be applied on the sidecar container as well.
In this PR we populate the sidecar with the application resources before deploying.

Resolves https://iguazio.atlassian.net/browse/ML-6526