### PR TITLE
[Application] Log a warning when building image without command entrypoint

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -27,6 +27,7 @@ from mlrun.runtimes.nuclio.api_gateway import (
     APIGatewaySpec,
 )
 from mlrun.runtimes.nuclio.function import NuclioSpec, NuclioStatus
+from mlrun.utils import logger
 
 
 class ApplicationSpec(NuclioSpec):
@@ -447,6 +448,14 @@ class ApplicationRuntime(RemoteRuntime):
         mlrun_version_specifier=None,
         show_on_failure: bool = False,
     ):
+        if not self.spec.command:
+            logger.warning(
+                "Building the application image without a command. "
+                "Use spec.command and spec.args to specify the application entrypoint",
+                command=self.spec.command,
+                args=self.spec.args,
+            )
+
         with_mlrun = self._resolve_build_with_mlrun(with_mlrun)
         return self._build_image(
             builder_env=builder_env,


### PR DESCRIPTION
There seems to be a confusion on having to explicitly set the entrypoint as mlrun does it automatically for other runtimes with "code to function" though for application runtime it is not supported. mlrun currently provides no indication for why the application may be unhealthy if the user didn't specify an entrypoint. This is a mitigation, we should also log the actual error which can be done with listing the pod events.