### PR TITLE
[CI] Optimize test integration runtime [part 2]

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -17,6 +17,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, Union
 
 import mlrun.alerts
+import mlrun.common
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.model_monitoring

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -31,9 +31,6 @@ results_dir = (pathlib.Path(conftest.results) / "artifacts").absolute()
 class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
     extra_env = {"MLRUN_HTTPDB__REAL_PATH": "/"}
 
-    def setup_method(self, method, extra_env=None):
-        super().setup_method(method, extra_env=self.extra_env)
-
     def test_artifacts(self):
         db = mlrun.get_run_db()
         prj, tree, key, body = "p9", "t19", "k802", "tomato"


### PR DESCRIPTION
This time, speeding up mlrun api by not rerunning it completely but simply restarting it

This would save a bit of a time (minutes), but enough to make it worth these line changes