### PR TITLE
[Artifacts] Verify artifact permissions when listing artifact tags [1.6.x]

### DIFF
--- a/server/api/api/endpoints/artifacts.py
+++ b/server/api/api/endpoints/artifacts.py
@@ -98,6 +98,15 @@ async def list_artifact_tags(
         mlrun.common.schemas.AuthorizationAction.read,
         auth_info,
     )
+    # verify that the user has permissions to read the project's artifacts
+    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+        mlrun.common.schemas.AuthorizationResourceTypes.artifact,
+        project,
+        "",
+        mlrun.common.schemas.AuthorizationAction.read,
+        auth_info,
+    )
+
     tags = await run_in_threadpool(
         server.api.crud.Artifacts().list_artifact_tags, db_session, project, category
     )


### PR DESCRIPTION
Query permissions on the artifacts as well as on the project.
This is required since users with project security admin policies shouldn't get the artifact tags.

Resolves https://iguazio.atlassian.net/browse/ML-6669