### PR TITLE
[Alerts] Populate event cache upon api restart

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -701,7 +701,10 @@ default_config = {
     "grafana_url": "",
     "alerts": {
         # supported modes: "enabled", "disabled".
-        "mode": "enabled"
+        "mode": "enabled",
+        # maximum number of alerts we allow to be configured.
+        # user will get an error when exceeding this
+        "max_allowed": 1000,
     },
     "auth_with_client_id": {
         "enabled": False,

--- a/server/api/api/endpoints/alerts.py
+++ b/server/api/api/endpoints/alerts.py
@@ -172,6 +172,8 @@ async def delete_alert(
             project=project, name=name, request=request
         )
 
+    logger.debug("Deleting alert", project=project, name=name)
+
     await run_in_threadpool(
         server.api.crud.Alerts().delete_alert, db_session, project, name
     )

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -746,6 +746,14 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
+    def get_all_alerts(self, session) -> list[mlrun.common.schemas.AlertConfig]:
+        pass
+
+    @abstractmethod
+    def get_num_configured_alerts(self, session) -> int:
+        pass
+
+    @abstractmethod
     def store_alert_notifications(
         self,
         session,

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -29,6 +29,7 @@ import mergedeep
 import pytz
 from sqlalchemy import MetaData, and_, distinct, func, or_, text
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Session
 
 import mlrun
@@ -3781,6 +3782,9 @@ class SQLDB(DBInterface):
         kw = {k: v for k, v in kw.items() if v is not None}
         return session.query(cls).filter_by(**kw)
 
+    def _get_count(self, session, cls):
+        return session.query(func.count(inspect(cls).primary_key[0])).scalar()
+
     def _find_or_create_users(self, session, user_names):
         users = list(self._query(session, User).filter(User.name.in_(user_names)))
         new = set(user_names) - {user.name for user in users}
@@ -4389,6 +4393,13 @@ class SQLDB(DBInterface):
         return self._transform_alert_template_record_to_schema(
             self._get_alert_template_record(session, name)
         )
+
+    def get_all_alerts(self, session) -> list[mlrun.common.schemas.AlertConfig]:
+        query = self._query(session, AlertConfig)
+        return list(map(self._transform_alert_config_record_to_schema, query.all()))
+
+    def get_num_configured_alerts(self, session) -> int:
+        return self._get_count(session, AlertConfig)
 
     def store_alert(
         self, session, alert: mlrun.common.schemas.AlertConfig

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -141,6 +141,10 @@ latest_data_version = 5
 
 
 def update_default_configuration_data():
+    server.api.db.session.run_function_with_new_db_session(
+        server.api.crud.Alerts().populate_event_cache
+    )
+
     logger.debug("Updating default configuration data")
     db_session = create_session()
     try:


### PR DESCRIPTION
We need to handle a case where alert was created and mlrun-api was restarted after that. Need to populate event cache from DB in such case

https://iguazio.atlassian.net/issues/ML-6616