### PR TITLE
[FeatureStore] Fix additional filters with passthrough

### DIFF
--- a/mlrun/feature_store/retrieval/spark_merger.py
+++ b/mlrun/feature_store/retrieval/spark_merger.py
@@ -241,6 +241,7 @@ class SparkFeatureMerger(BaseMerger):
             source_kind = feature_set.spec.source.kind
             source_path = feature_set.spec.source.path
             source_kwargs.update(feature_set.spec.source.attributes)
+            source_kwargs.pop("additional_filters")
         else:
             target = get_offline_target(feature_set)
             if not target:

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -4822,6 +4822,10 @@ class TestFeatureStore(TestMLRunSystem):
     @pytest.mark.parametrize("engine", ["local", "dask"])
     @pytest.mark.parametrize("passthrough", [True, False])
     def test_parquet_filters(self, engine, local, passthrough):
+        if passthrough and engine == "dask":
+            pytest.skip(
+                "Dask engine with passthrough=True is not supported. Open issue ML-6684"
+            )
         config_parameters = {} if local else {"image": "mlrun/mlrun"}
         run_config = fstore.RunConfig(local=local, **config_parameters)
         parquet_path = os.path.relpath(str(self.assets_path / "testdata.parquet"))


### PR DESCRIPTION
1) Block additional_filters from source attributes while using spark_merger - `_get_engine_df`.
2) Add tests.

[ML-6673](https://iguazio.atlassian.net/browse/ML-6673)


[ML-6673]: https://iguazio.atlassian.net/browse/ML-6673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ