### PR TITLE
[Requirements] Force installing mlrun pipelines >= 0.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,5 @@ deprecated~=1.2
 jinja2~=3.1, >=3.1.3
 orjson>=3.9.15, <4
 # mlrun pipeline adapters
-mlrun-pipelines-kfp-common~=0.1.0
-mlrun-pipelines-kfp-v1-8~=0.1.0
+mlrun-pipelines-kfp-common~=0.1.1, >0.1.0
+mlrun-pipelines-kfp-v1-8~=0.1.1, >0.1.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -108,6 +108,9 @@ def test_requirement_specifiers_convention():
                 continue
 
     ignored_invalid_map = {
+        # 0.1.0 is not compatible with mlrun >=1.7.0rc19
+        "mlrun-pipelines-kfp-common": {"~=0.1.1, >0.1.0"},
+        "mlrun-pipelines-kfp-v1-8": {"~=0.1.1, >0.1.0"},
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "aiobotocore": {">=2.5.0,<2.8"},
         "storey": {"~=1.7.17"},


### PR DESCRIPTION
0.1.0 is not compatible with recent 1.7.0-rc19 changes

https://iguazio.atlassian.net/issues/ML-6685