### PR TITLE
[FeatureStore] Avoid raising error in dict pop

### DIFF
--- a/mlrun/feature_store/retrieval/spark_merger.py
+++ b/mlrun/feature_store/retrieval/spark_merger.py
@@ -243,7 +243,7 @@ class SparkFeatureMerger(BaseMerger):
             source_kind = feature_set.spec.source.kind
             source_path = feature_set.spec.source.path
             source_kwargs.update(feature_set.spec.source.attributes)
-            source_kwargs.pop("additional_filters")
+            source_kwargs.pop("additional_filters", None)
         else:
             target = get_offline_target(feature_set)
             if not target:


### PR DESCRIPTION
`source_kwargs` does not always contain additional_filters.
Avoid raising an error.

part of [ML-6673](https://iguazio.atlassian.net/browse/ML-6673) solution.

[ML-6673]: https://iguazio.atlassian.net/browse/ML-6673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ