### PR TITLE
[API] Support Memray profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 23.2.1
 MLRUN_CACHE_DATE ?= $(shell date +%s)
+MLRUN_MEMRAY ?= 0
+MLRUN_MEMRAY_OUTPUT_FILE ?=
 # empty by default, can be set to something like "tag-name" which will cause to:
 # 1. docker pull the same image with the given tag (cache image) before the build
 # 2. add the --cache-from flag to the docker build
@@ -567,6 +569,8 @@ run-api: api ## Run mlrun api (dockerized)
 		--env MLRUN_LOG_LEVEL=$(MLRUN_LOG_LEVEL) \
 		--env MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS=$(MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS) \
 		--env MLRUN_HTTPDB__REAL_PATH=$(MLRUN_HTTPDB__REAL_PATH) \
+		--env MLRUN_MEMRAY=$(MLRUN_MEMRAY) \
+		--env MLRUN_MEMRAY_OUTPUT_FILE=$(MLRUN_MEMRAY_OUTPUT_FILE) \
 		$(MLRUN_API_IMAGE_NAME_TAGGED)
 
 .PHONY: run-test-db

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 23.2.1
 MLRUN_CACHE_DATE ?= $(shell date +%s)
-MLRUN_MEMRAY ?= 0
-MLRUN_MEMRAY_OUTPUT_FILE ?=
 # empty by default, can be set to something like "tag-name" which will cause to:
 # 1. docker pull the same image with the given tag (cache image) before the build
 # 2. add the --cache-from flag to the docker build
@@ -569,8 +567,6 @@ run-api: api ## Run mlrun api (dockerized)
 		--env MLRUN_LOG_LEVEL=$(MLRUN_LOG_LEVEL) \
 		--env MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS=$(MLRUN_SECRET_STORES__TEST_MODE_MOCK_SECRETS) \
 		--env MLRUN_HTTPDB__REAL_PATH=$(MLRUN_HTTPDB__REAL_PATH) \
-		--env MLRUN_MEMRAY=$(MLRUN_MEMRAY) \
-		--env MLRUN_MEMRAY_OUTPUT_FILE=$(MLRUN_MEMRAY_OUTPUT_FILE) \
 		$(MLRUN_API_IMAGE_NAME_TAGGED)
 
 .PHONY: run-test-db

--- a/automation/patch_igz/patch-api.yml
+++ b/automation/patch_igz/patch-api.yml
@@ -23,5 +23,7 @@ spec:
 #          value: "1"
 #        - name: MLRUN_MEMRAY_OUTPUT_FILE
 #          value: "/mlrun/db/api_memray.bin"
+#        - name: MLRUN_MEMRAY_EXTRA_FLAGS
+#          value: "--trace-python-allocators"
       - name: mlrun-log-collector
         imagePullPolicy: Always

--- a/automation/patch_igz/patch-api.yml
+++ b/automation/patch_igz/patch-api.yml
@@ -18,5 +18,10 @@ spec:
       containers:
       - name: mlrun-api
         imagePullPolicy: Always
+#        env:
+#        - name: MLRUN_MEMRAY
+#          value: "1"
+#        - name: MLRUN_MEMRAY_OUTPUT_FILE
+#          value: "/mlrun/db/api_memray.bin"
       - name: mlrun-log-collector
         imagePullPolicy: Always

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -84,10 +84,4 @@ VOLUME /mlrun/db
 # and avoid zombie processes
 ENTRYPOINT ["tini", "--"]
 
-CMD [ \
-    "uvicorn", \
-    "server.api.main:app", \
-    "--proxy-headers", \
-    "--host", "0.0.0.0", \
-    "--log-config", "server/api/uvicorn_log_config.yaml" \
-]
+CMD ["bash", "./dockerfiles/mlrun-api/start_api.sh"]

--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -12,3 +12,4 @@ sqlalchemy~=1.4
 pymysql~=1.0
 alembic~=1.9
 timelength~=1.1
+memray~=1.12

--- a/dockerfiles/mlrun-api/start_api.sh
+++ b/dockerfiles/mlrun-api/start_api.sh
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+:'       _\|/_
+         (o o)
+ +----oOO-{_}-OOo----------------------------------------------------------------------------------------------------+
+ |                                                                                                                   |
+ |  This script is run over tini to ensure capturing zombie processes and signal handling.                           |
+ |  It is important to run the API with exec so that the bash process will be replaced with                          |
+ |   the API process and for zombie processes reaping.                                                               |
+ |                                                                                                                   |
+ +-------------------------------------------------------------------------------------------------------------------+
+ '
+
 # Lower case the MLRUN_MEMRAY env var
 MLRUN_MEMRAY_LOWER=$(echo "$MLRUN_MEMRAY" | tr '[:upper:]' '[:lower:]')
 # Ensure 1 leading space

--- a/dockerfiles/mlrun-api/start_api.sh
+++ b/dockerfiles/mlrun-api/start_api.sh
@@ -16,7 +16,7 @@
          (o o)
  +----oOO-{_}-OOo----------------------------------------------------------------------------------------------------+
  |                                                                                                                   |
- |  This script is run over tini to ensure capturing zombie processes and signal handling.                           |
+ |  This script runs with tini to ensure capturing zombie processes and signal handling.                             |
  |  It is important to run the API with exec so that the bash process will be replaced with                          |
  |   the API process and for zombie processes reaping.                                                               |
  |                                                                                                                   |

--- a/dockerfiles/mlrun-api/start_api.sh
+++ b/dockerfiles/mlrun-api/start_api.sh
@@ -1,0 +1,34 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lower case the MLRUN_MEMRAY env var
+MLRUN_MEMRAY_LOWER=$(echo "$MLRUN_MEMRAY" | tr '[:upper:]' '[:lower:]')
+# Ensure 1 leading space
+MLRUN_MEMRAY_EXTRA_FLAGS=$(echo "${MLRUN_MEMRAY_EXTRA_FLAGS# }" | sed 's/^/ /')
+
+# Check if the mlrun memray is set to a true value
+if [[ -n "$MLRUN_MEMRAY_LOWER"  && ( "$MLRUN_MEMRAY_LOWER" == "1" || "$MLRUN_MEMRAY_LOWER" == "true" || "$MLRUN_MEMRAY_LOWER" == "yes" || "$MLRUN_MEMRAY_LOWER" == "on" )]]; then
+    if [[ -n "$MLRUN_MEMRAY_OUTPUT_FILE" ]]; then
+        echo "Starting API with memray profiling output file $MLRUN_MEMRAY_OUTPUT_FILE..."
+        exec python -m memray run${MLRUN_MEMRAY_EXTRA_FLAGS% } --output "$MLRUN_MEMRAY_OUTPUT_FILE" --force -m server.api.main
+    else
+        echo "Starting API with memray profiling..."
+        exec python -m memray run${MLRUN_MEMRAY_EXTRA_FLAGS% } -m server.api.main
+    fi
+else
+    exec uvicorn server.api.main:app \
+        --proxy-headers \
+        --host 0.0.0.0 \
+        --log-config server/api/uvicorn_log_config.yaml
+fi


### PR DESCRIPTION
## Memory profiling MLRun API with Memray
This PR basically ports #5570 but in bash instead of python because we want to run the API straight from uvicorn CLI instead of a wapper python process.
Also added support to specify extra flags as some may be useful e.g. `--trace-python-allocators` to help finding leaks.