### PR TITLE
[Function] Validate tag name before deploying

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -544,6 +544,8 @@ class RemoteRuntime(KubeResource):
         if tag:
             self.metadata.tag = tag
 
+        mlrun.utils.validate_tag_name(self.metadata.tag, "function.metadata.tag")
+
         # Attempt auto-mounting, before sending to remote build
         self.try_auto_mount_based_on_config()
         self._fill_credentials()

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -263,7 +263,8 @@ class RemoteRuntime(KubeResource):
         self._status = self._verify_dict(status, "status", NuclioStatus)
 
     def pre_deploy_validation(self):
-        pass
+        if self.metadata.tag:
+            mlrun.utils.validate_tag_name(self.metadata.tag, "function.metadata.tag")
 
     def set_config(self, key, value):
         self.spec.config[key] = value
@@ -543,8 +544,6 @@ class RemoteRuntime(KubeResource):
             self.metadata.project = project
         if tag:
             self.metadata.tag = tag
-
-        mlrun.utils.validate_tag_name(self.metadata.tag, "function.metadata.tag")
 
         # Attempt auto-mounting, before sending to remote build
         self.try_auto_mount_based_on_config()

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -216,6 +216,6 @@ def test_update_credentials_from_remote_build(function_kind):
     ],
 )
 def test_invalid_tags(tag, expected, rundb_mock):
-    function = mlrun.new_function("test", kind="nuclio")
+    function = mlrun.new_function("test", kind="nuclio", tag=tag)
     with expected:
-        function.deploy(tag=tag)
+        function.pre_deploy_validation()

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -20,6 +20,7 @@ import pytest
 from deepdiff import DeepDiff
 
 import mlrun
+import mlrun.errors
 from mlrun import code_to_function
 from mlrun.utils.helpers import resolve_git_reference_from_source
 from tests.runtimes.test_base import TestAutoMount
@@ -204,3 +205,17 @@ def test_update_credentials_from_remote_build(function_kind):
 
     assert function.metadata.credentials.access_key == secret_name
     assert function.spec.env == remote_data["spec"]["env"]
+
+
+@pytest.mark.parametrize(
+    "tag,expected",
+    [
+        ("valid_tag", does_not_raise()),
+        ("invalid%$tag", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        ("too-long-tag" * 10, pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+    ],
+)
+def test_invalid_tags(tag, expected, rundb_mock):
+    function = mlrun.new_function("test", kind="nuclio")
+    with expected:
+        function.deploy(tag=tag)


### PR DESCRIPTION
Validate tag adheres to k8s limitations before we get to the DB.

Resolves https://iguazio.atlassian.net/browse/ML-6567