### PR TITLE
[Application] Fix the application runtime min nuclio versions error message

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -19,6 +19,7 @@ import warnings
 from datetime import datetime
 from time import sleep
 
+import inflection
 import nuclio
 import nuclio.utils
 import requests
@@ -65,7 +66,14 @@ def min_nuclio_versions(*versions):
             if validate_nuclio_version_compatibility(*versions):
                 return function(*args, **kwargs)
 
-            message = f"'{function.__qualname__}' function requires Nuclio v{' or v'.join(versions)} or higher"
+            if function.__name__ == "__init__":
+                name = inflection.titleize(function.__qualname__.split(".")[0])
+            else:
+                name = function.__qualname__
+
+            message = (
+                f"'{name}' function requires Nuclio v{' or v'.join(versions)} or higher"
+            )
             raise mlrun.errors.MLRunIncompatibleVersionError(message)
 
         return wrapper

--- a/tests/api/runtimes/test_application.py
+++ b/tests/api/runtimes/test_application.py
@@ -73,7 +73,7 @@ class TestApplicationRuntime(TestRuntimeBase):
             self._generate_runtime(self.runtime_kind)
         assert (
             str(exc.value)
-            == "'ApplicationRuntime.__init__' function requires Nuclio v1.13.1 or higher"
+            == "'Application Runtime' function requires Nuclio v1.13.1 or higher"
         )
 
     def _execute_run(self, runtime, **kwargs):


### PR DESCRIPTION
Now the error message will be `'Application Runtime' function requires Nuclio v1.13.1 or higher`

https://iguazio.atlassian.net/browse/ML-6539
related pr - https://github.com/mlrun/mlrun/pull/5618