### PR TITLE
[Model Monitoring] Fix metric existence query performance

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -177,19 +177,6 @@ class TSDBConnector(ABC):
         :return:                   Metric values object or no data object.
         """
 
-    @abstractmethod
-    def read_prediction_metric_for_endpoint_if_exists(
-        self, endpoint_id: str
-    ) -> typing.Optional[mm_schemas.ModelEndpointMonitoringMetric]:
-        """
-        Read the "invocations" metric for the provided model endpoint, and return the metric object
-        if it exists.
-
-        :param endpoint_id: The model endpoint identifier.
-        :return:            `None` if the invocations metric does not exist, otherwise return the
-                            corresponding metric object.
-        """
-
     @staticmethod
     def df_to_metrics_values(
         *,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -22,7 +22,7 @@ import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.schemas as tdengine_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.stream_graph_steps
 from mlrun.model_monitoring.db import TSDBConnector
-from mlrun.model_monitoring.helpers import get_invocations_fqn
+from mlrun.model_monitoring.helpers import get_invocations_fqn, get_invocations_metric
 from mlrun.utils import logger
 
 
@@ -388,10 +388,4 @@ class TDEngineConnector(TSDBConnector):
             limit=1,
         )
         if predictions:
-            return mm_schemas.ModelEndpointMonitoringMetric(
-                project=self.project,
-                app=mm_schemas.SpecialApps.MLRUN_INFRA,
-                type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
-                name=mm_schemas.PredictionsQueryConstants.INVOCATIONS,
-                full_name=get_invocations_fqn(self.project),
-            )
+            return get_invocations_metric(self.project)

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -22,7 +22,7 @@ import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.schemas as tdengine_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.stream_graph_steps
 from mlrun.model_monitoring.db import TSDBConnector
-from mlrun.model_monitoring.helpers import get_invocations_fqn, get_invocations_metric
+from mlrun.model_monitoring.helpers import get_invocations_fqn
 from mlrun.utils import logger
 
 
@@ -377,15 +377,25 @@ class TDEngineConnector(TSDBConnector):
             ),  # pyright: ignore[reportArgumentType]
         )
 
-    def read_prediction_metric_for_endpoint_if_exists(
-        self, endpoint_id: str
-    ) -> typing.Optional[mm_schemas.ModelEndpointMonitoringMetric]:
-        # Read just one record, because we just want to check if there is any data for this endpoint_id
-        predictions = self.read_predictions(
-            endpoint_id=endpoint_id,
-            start=datetime.min,
-            end=mlrun.utils.now_date(),
-            limit=1,
-        )
-        if predictions:
-            return get_invocations_metric(self.project)
+    # Note: this function serves as a reference for checking the TSDB for the existence of a metric.
+    #
+    # def read_prediction_metric_for_endpoint_if_exists(
+    #     self, endpoint_id: str
+    # ) -> typing.Optional[mm_schemas.ModelEndpointMonitoringMetric]:
+    #     """
+    #     Read the "invocations" metric for the provided model endpoint, and return the metric object
+    #     if it exists.
+    #
+    #     :param endpoint_id: The model endpoint identifier.
+    #     :return:            `None` if the invocations metric does not exist, otherwise return the
+    #                         corresponding metric object.
+    #     """
+    #     # Read just one record, because we just want to check if there is any data for this endpoint_id
+    #     predictions = self.read_predictions(
+    #         endpoint_id=endpoint_id,
+    #         start=datetime.min,
+    #         end=mlrun.utils.now_date(),
+    #         limit=1,
+    #     )
+    #     if predictions:
+    #         return get_invocations_metric(self.project)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -161,7 +161,7 @@ class V3IOTSDBConnector(TSDBConnector):
             time_col=mm_schemas.EventFieldType.TIMESTAMP,
             container=self.container,
             v3io_frames=self.v3io_framesd,
-            columns=["latency"],
+            columns=[mm_schemas.EventFieldType.LATENCY],
             index_cols=[
                 mm_schemas.EventFieldType.ENDPOINT_ID,
             ],

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -536,11 +536,17 @@ class V3IOTSDBConnector(TSDBConnector):
         table_path: str,
         name: str = mm_schemas.ResultData.RESULT_NAME,
         metric_and_app_names: Optional[list[tuple[str, str]]] = None,
+        columns: Optional[list[str]] = None,
     ) -> str:
         """Get the SQL query for the results/metrics table"""
+        if columns:
+            selection = ",".join(columns)
+        else:
+            selection = "*"
+
         with StringIO() as query:
             query.write(
-                f"SELECT * FROM '{table_path}' "
+                f"SELECT {selection} FROM '{table_path}' "
                 f"WHERE {mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"
             )
             if metric_and_app_names:

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -376,7 +376,6 @@ class V3IOTSDBConnector(TSDBConnector):
         filter_query: str = "",
         interval: typing.Optional[str] = None,
         agg_funcs: typing.Optional[list] = None,
-        limit: typing.Optional[int] = None,
         sliding_window_step: typing.Optional[str] = None,
         **kwargs,
     ) -> pd.DataFrame:
@@ -400,7 +399,6 @@ class V3IOTSDBConnector(TSDBConnector):
         :param agg_funcs:             The aggregation functions to apply on the columns. Note that if `agg_funcs` is
                                       provided, `interval` must bg provided as well. Provided as a list of strings in
                                       the format of ['sum', 'avg', 'count', ...].
-        :param limit:                 The maximum number of records to return.
         :param sliding_window_step:   The time step for which the time window moves forward. Note that if
                                       `sliding_window_step` is provided, interval must be provided as well. Provided
                                       as a string in the format of '1m', '1h', etc.
@@ -437,8 +435,6 @@ class V3IOTSDBConnector(TSDBConnector):
             else:
                 raise err
 
-        if limit:
-            df = df.head(limit)
         return df
 
     def _get_v3io_source_directory(self) -> str:
@@ -572,7 +568,6 @@ class V3IOTSDBConnector(TSDBConnector):
         end: Union[datetime, str],
         aggregation_window: Optional[str] = None,
         agg_funcs: Optional[list[str]] = None,
-        limit: Optional[int] = None,
     ) -> Union[
         mm_schemas.ModelEndpointMonitoringMetricNoData,
         mm_schemas.ModelEndpointMonitoringMetricValues,
@@ -591,7 +586,6 @@ class V3IOTSDBConnector(TSDBConnector):
             filter_query=f"endpoint_id=='{endpoint_id}'",
             interval=aggregation_window,
             agg_funcs=agg_funcs,
-            limit=limit,
             sliding_window_step=aggregation_window,
         )
 
@@ -624,7 +618,7 @@ class V3IOTSDBConnector(TSDBConnector):
     ) -> Optional[mm_schemas.ModelEndpointMonitoringMetric]:
         # Read just one record, because we just want to check if there is any data for this endpoint_id
         predictions = self.read_predictions(
-            endpoint_id=endpoint_id, start="0", end="now", limit=1
+            endpoint_id=endpoint_id, start="0", end="now"
         )
         if predictions.data:
             return mm_schemas.ModelEndpointMonitoringMetric(

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing
 from datetime import datetime
 from io import StringIO
 from typing import Literal, Optional, Union
@@ -47,7 +46,7 @@ class V3IOTSDBConnector(TSDBConnector):
         self,
         project: str,
         container: str = _CONTAINER,
-        v3io_framesd: typing.Optional[str] = None,
+        v3io_framesd: Optional[str] = None,
         create_table: bool = False,
     ) -> None:
         super().__init__(project=project)
@@ -291,7 +290,7 @@ class V3IOTSDBConnector(TSDBConnector):
                 f"Failed to write application result to TSDB: {err}"
             )
 
-    def delete_tsdb_resources(self, table: typing.Optional[str] = None):
+    def delete_tsdb_resources(self, table: Optional[str] = None):
         if table:
             # Delete a specific table
             tables = [table]
@@ -372,11 +371,11 @@ class V3IOTSDBConnector(TSDBConnector):
         table: str,
         start: Union[datetime, str],
         end: Union[datetime, str],
-        columns: typing.Optional[list[str]] = None,
+        columns: Optional[list[str]] = None,
         filter_query: str = "",
-        interval: typing.Optional[str] = None,
-        agg_funcs: typing.Optional[list[str]] = None,
-        sliding_window_step: typing.Optional[str] = None,
+        interval: Optional[str] = None,
+        agg_funcs: Optional[list[str]] = None,
+        sliding_window_step: Optional[str] = None,
         **kwargs,
     ) -> pd.DataFrame:
         """

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -504,8 +504,8 @@ class V3IOTSDBConnector(TSDBConnector):
             raise ValueError(f"Invalid {type = }")
 
         query = self._get_sql_query(
-            endpoint_id,
-            [(metric.app, metric.name) for metric in metrics],
+            endpoint_id=endpoint_id,
+            names=[(metric.app, metric.name) for metric in metrics],
             table_path=table_path,
             name=name,
         )
@@ -531,6 +531,7 @@ class V3IOTSDBConnector(TSDBConnector):
 
     @staticmethod
     def _get_sql_query(
+        *,
         endpoint_id: str,
         names: list[tuple[str, str]],
         table_path: str,

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -636,7 +636,7 @@ class V3IOTSDBConnector(TSDBConnector):
         query = self._get_sql_query(
             endpoint_id=endpoint_id,
             table_path=self.tables[mm_schemas.FileTargetKind.PREDICTIONS],
-            columns=[f"COUNT({mm_schemas.EventFieldType.LATENCY})"],
+            columns=[f"count({mm_schemas.EventFieldType.LATENCY})"],
         )
         try:
             logger.debug("Checking TSDB", project=self.project, query=query)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -25,7 +25,7 @@ import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.feature_store.steps
 import mlrun.utils.v3io_clients
 from mlrun.model_monitoring.db import TSDBConnector
-from mlrun.model_monitoring.helpers import get_invocations_fqn
+from mlrun.model_monitoring.helpers import get_invocations_fqn, get_invocations_metric
 from mlrun.utils import logger
 
 _TSDB_BE = "tsdb"
@@ -653,10 +653,4 @@ class V3IOTSDBConnector(TSDBConnector):
                 raise
 
         if not df.empty:
-            return mm_schemas.ModelEndpointMonitoringMetric(
-                project=self.project,
-                app=mm_schemas.SpecialApps.MLRUN_INFRA,
-                type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
-                name=mm_schemas.PredictionsQueryConstants.INVOCATIONS,
-                full_name=get_invocations_fqn(self.project),
-            )
+            return get_invocations_metric(self.project)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -375,7 +375,7 @@ class V3IOTSDBConnector(TSDBConnector):
         columns: typing.Optional[list[str]] = None,
         filter_query: str = "",
         interval: typing.Optional[str] = None,
-        agg_funcs: typing.Optional[list] = None,
+        agg_funcs: typing.Optional[list[str]] = None,
         sliding_window_step: typing.Optional[str] = None,
         **kwargs,
     ) -> pd.DataFrame:
@@ -414,7 +414,7 @@ class V3IOTSDBConnector(TSDBConnector):
 
         if agg_funcs:
             # Frames client expects the aggregators to be a comma-separated string
-            agg_funcs = ",".join(agg_funcs)
+            aggregators = ",".join(agg_funcs)
         table_path = self.tables[table]
         try:
             df = self._frames_client.read(
@@ -425,7 +425,7 @@ class V3IOTSDBConnector(TSDBConnector):
                 columns=columns,
                 filter=filter_query,
                 aggregation_window=interval,
-                aggregators=agg_funcs,
+                aggregators=aggregators,
                 step=sliding_window_step,
                 **kwargs,
             )

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -505,7 +505,7 @@ class V3IOTSDBConnector(TSDBConnector):
 
         query = self._get_sql_query(
             endpoint_id=endpoint_id,
-            names=[(metric.app, metric.name) for metric in metrics],
+            metric_and_app_names=[(metric.app, metric.name) for metric in metrics],
             table_path=table_path,
             name=name,
         )
@@ -533,9 +533,9 @@ class V3IOTSDBConnector(TSDBConnector):
     def _get_sql_query(
         *,
         endpoint_id: str,
-        names: list[tuple[str, str]],
         table_path: str,
         name: str = mm_schemas.ResultData.RESULT_NAME,
+        metric_and_app_names: Optional[list[tuple[str, str]]] = None,
     ) -> str:
         """Get the SQL query for the results/metrics table"""
         with StringIO() as query:
@@ -543,10 +543,10 @@ class V3IOTSDBConnector(TSDBConnector):
                 f"SELECT * FROM '{table_path}' "
                 f"WHERE {mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"
             )
-            if names:
+            if metric_and_app_names:
                 query.write(" AND (")
 
-                for i, (app_name, result_name) in enumerate(names):
+                for i, (app_name, result_name) in enumerate(metric_and_app_names):
                     sub_cond = (
                         f"({mm_schemas.WriterEvent.APPLICATION_NAME}='{app_name}' "
                         f"AND {name}='{result_name}')"

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -25,6 +25,7 @@ from mlrun.common.schemas.model_monitoring import (
     EventFieldType,
 )
 from mlrun.common.schemas.model_monitoring.model_endpoints import (
+    ModelEndpointMonitoringMetric,
     ModelEndpointMonitoringMetricType,
     _compose_full_name,
 )
@@ -304,4 +305,20 @@ def get_invocations_fqn(project: str) -> str:
         app=mm_constants.SpecialApps.MLRUN_INFRA,
         name=mm_constants.PredictionsQueryConstants.INVOCATIONS,
         type=ModelEndpointMonitoringMetricType.METRIC,
+    )
+
+
+def get_invocations_metric(project: str) -> ModelEndpointMonitoringMetric:
+    """
+    Return the invocations metric of any model endpoint in the given project.
+
+    :param project: The project name.
+    :returns:       The model monitoring metric object.
+    """
+    return ModelEndpointMonitoringMetric(
+        project=project,
+        app=mm_constants.SpecialApps.MLRUN_INFRA,
+        type=ModelEndpointMonitoringMetricType.METRIC,
+        name=mm_constants.PredictionsQueryConstants.INVOCATIONS,
+        full_name=get_invocations_fqn(project),
     )

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -455,11 +455,7 @@ async def _get_metrics_values_params(
 
 
 async def _wrap_coroutine_in_list(x):
-    result = await x
-    if result is None:
-        return []
-    else:
-        return [result]
+    return [await x]
 
 
 @router.get(

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -375,7 +375,7 @@ def test_tsdb_query(
 ) -> None:
     assert (
         V3IOTSDBConnector._get_sql_query(
-            endpoint_id=endpoint_id, names=names, table_path=table_path
+            endpoint_id=endpoint_id, metric_and_app_names=names, table_path=table_path
         )
         == expected_query
     )

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -410,8 +410,8 @@ def test_tsdb_predictions_existence_query() -> None:
         table_path="pipelines/metrics-data-v2/model-endpoints/predictions/",
         endpoint_id="d4b50a7727d65c7f73c33590f6fe87a40d93af2a",
     ) == (
-        "SELECT count(latency) FROM 'pipelines/metrics-data-v2/model-endpoints/predictions/'"
-        " WHERE endpoint_id='d4b50a7727d65c7f73c33590f6fe87a40d93af2a';"
+        "SELECT count(latency) FROM 'pipelines/metrics-data-v2/model-endpoints/predictions/' "
+        "WHERE endpoint_id='d4b50a7727d65c7f73c33590f6fe87a40d93af2a';"
     )
 
 

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -381,6 +381,17 @@ def test_tsdb_query(
     )
 
 
+def test_tsdb_predictions_existence_query() -> None:
+    assert V3IOTSDBConnector._get_sql_query(
+        columns=["count(latency)"],
+        table_path="pipelines/metrics-data-v2/model-endpoints/predictions/",
+        endpoint_id="d4b50a7727d65c7f73c33590f6fe87a40d93af2a",
+    ) == (
+        "SELECT count(latency) FROM 'pipelines/metrics-data-v2/model-endpoints/predictions/'"
+        " WHERE endpoint_id='d4b50a7727d65c7f73c33590f6fe87a40d93af2a';"
+    )
+
+
 @pytest.fixture
 def tsdb_df() -> pd.DataFrame:
     return pd.DataFrame.from_records(

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -374,7 +374,9 @@ def test_tsdb_query(
     endpoint_id: str, names: list[tuple[str, str]], table_path: str, expected_query: str
 ) -> None:
     assert (
-        V3IOTSDBConnector._get_sql_query(endpoint_id, names, table_path)
+        V3IOTSDBConnector._get_sql_query(
+            endpoint_id=endpoint_id, names=names, table_path=table_path
+        )
         == expected_query
     )
 

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -25,6 +25,7 @@ import pytest
 import v3io.dataplane.kv
 import v3io.dataplane.output
 import v3io.dataplane.response
+import v3io_frames
 
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.utils.v3io_clients
@@ -36,7 +37,10 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
     _MetricPoint,
 )
 from mlrun.model_monitoring.db.stores.v3io_kv.kv_store import KVStoreBase
-from mlrun.model_monitoring.db.tsdb.v3io.v3io_connector import V3IOTSDBConnector
+from mlrun.model_monitoring.db.tsdb.v3io.v3io_connector import (
+    V3IOTSDBConnector,
+    _is_no_schema_error,
+)
 
 
 @pytest.fixture(params=["default-project"])
@@ -172,6 +176,25 @@ def test_extract_metrics_from_items(
     expected_metrics: list[ModelEndpointMonitoringMetric],
 ) -> None:
     assert store._extract_metrics_from_items(items) == expected_metrics
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_is_no_schema"),
+    [
+        (v3io_frames.ReadError("Another read error"), False),
+        (
+            v3io_frames.ReadError(
+                "can't query: failed to create adapter: No TSDB schema file found at "
+                "'v3io-webapi:8081/users/pipelines/mm-serving-no-data/model-endpoints/predictions/'."
+            ),
+            True,
+        ),
+    ],
+)
+def test_is_no_schema_error(
+    exc: v3io_frames.ReadError, expected_is_no_schema: bool
+) -> None:
+    assert _is_no_schema_error(exc) == expected_is_no_schema
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes [ML-6726](https://iguazio.atlassian.net/browse/ML-6726).

Remove `read_prediction_metric_for_endpoint_if_exists` - always return the invocations metric.
In addition, remove the `limit` argument from the V3IO TSDB method, as it's not supported.

[ML-6726]: https://iguazio.atlassian.net/browse/ML-6726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ