### PR TITLE
[Automation] Fix patch remote script docker registry

### DIFF
--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -36,7 +36,7 @@ DOCKER_REPO:
 
 # Optional - Use when your registry is connected to a DNS which is accessible from the cluster
 # For iguazio datanode registry use:
-# datanode-registry.iguazio-platform.app.<system-name>.<lab.iguazeng/cloud-cd>.com:80/mlrun
+# datanode-registry.iguazio-platform.app.<system-name>.<lab.iguazeng/cloud-cd>.com:80
 OVERWRITE_IMAGE_REGISTRY:
 
 # Optional - will attempt docker login if defined, need to login manually otherwise

--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -27,8 +27,12 @@ SSH_PASSWORD:
 
 # Docker registry you can push to. Make sure you are logged into it before running the script (required)
 # e.g. docker.io/my_user
-# For iguazio datanode registry use <data-node-ip>:8009/mlrun
+# For iguazio datanode registry use <data-node-ip>:8009
 DOCKER_REGISTRY:
+
+# Docker repository to push to
+# If you are using the iguazio datanode registry, use "mlrun"
+DOCKER_REPO:
 
 # Optional - Use when your registry is connected to a DNS which is accessible from the cluster
 # For iguazio datanode registry use:

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -226,9 +226,10 @@ class MLRunPatcher:
     def _replace_deployment_images(self, container, built_image):
         logger.info("Replace mlrun-api-chief")
         if self._config.get("OVERWRITE_IMAGE_REGISTRY"):
+            docker_registry, overwrite_registry = self._resolve_overwrite_registry()
             built_image = built_image.replace(
-                self._config["DOCKER_REGISTRY"],
-                self._config["OVERWRITE_IMAGE_REGISTRY"],
+                docker_registry,
+                overwrite_registry,
             )
 
         self._exec_remote(
@@ -507,6 +508,16 @@ class MLRunPatcher:
             )
 
         return stdout
+
+    def _resolve_overwrite_registry(self):
+        docker_registry = self._config["DOCKER_REGISTRY"]
+        overwrite_registry = self._config["OVERWRITE_IMAGE_REGISTRY"]
+        if docker_registry.endswith("/"):
+            docker_registry = docker_registry[:-1]
+        if overwrite_registry.endswith("/"):
+            overwrite_registry = overwrite_registry[:-1]
+
+        return docker_registry, overwrite_registry
 
 
 @click.command(help="mlrun-api deployer to remote system")

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -152,9 +152,11 @@ class MLRunPatcher:
 
     def _make_mlrun(self, target, image_tag, image_name) -> str:
         logger.info(f"Building mlrun docker image: {target}:{image_tag}")
+        mlrun_docker_registry = self._resolve_mlrun_docker_registry()
         env = {
             "MLRUN_VERSION": image_tag,
-            "MLRUN_DOCKER_REPO": self._config["DOCKER_REGISTRY"],
+            "MLRUN_DOCKER_REPO": "mlrun",
+            "MLRUN_DOCKER_REGISTRY": mlrun_docker_registry,
         }
         cmd = ["make", target]
         self._exec_local(cmd, live=True, env=env)
@@ -447,6 +449,19 @@ class MLRunPatcher:
     @staticmethod
     def _get_image_tag(tag) -> str:
         return f"{tag}"
+
+    def _resolve_mlrun_docker_registry(self):
+        mlrun_docker_registry = self._config["DOCKER_REGISTRY"]
+
+        # remove "mlrun" as it will be added via the docker repo env var
+        if mlrun_docker_registry.endswith("mlrun"):
+            mlrun_docker_registry = mlrun_docker_registry[:-5]
+
+        # ensure we have a trailing slash
+        if not mlrun_docker_registry.endswith("/"):
+            mlrun_docker_registry += "/"
+
+        return mlrun_docker_registry
 
     @staticmethod
     def _execute_local_proc_interactive(cmd, env=None):

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -457,16 +457,6 @@ class MLRunPatcher:
     def _get_image_tag(tag) -> str:
         return f"{tag}"
 
-    def _resolve_mlrun_docker_registry(self):
-        mlrun_docker_registry = self._config["DOCKER_REGISTRY"]
-
-        # ensure we have a trailing slash, unless we are using the an mlrun registry
-        if not mlrun_docker_registry.endswith(
-            "/"
-        ) and not mlrun_docker_registry.endswith("mlrun"):
-            mlrun_docker_registry += "/"
-        return mlrun_docker_registry
-
     @staticmethod
     def _execute_local_proc_interactive(cmd, env=None):
         env = os.environ | (env or {})

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -153,21 +153,19 @@ class MLRunPatcher:
     def _make_mlrun(self, target, image_tag, image_name) -> str:
         logger.info(f"Building mlrun docker image: {target}:{image_tag}")
         mlrun_docker_registry = self._config["DOCKER_REGISTRY"]
-        ends_with_mlrun = mlrun_docker_registry.endswith("mlrun")
+        mlrun_docker_repo = self._config.get("DOCKER_REPO", "")
 
-        # ensure we have a trailing slash, unless a "mlrun" specific repo is used
-        if not mlrun_docker_registry.endswith("/") and not ends_with_mlrun:
+        if not mlrun_docker_registry.endswith("/"):
             mlrun_docker_registry += "/"
 
         env = {
             "MLRUN_VERSION": image_tag,
             "MLRUN_DOCKER_REGISTRY": mlrun_docker_registry,
-            # unless set to an empty string, the makefile will add "mlrun" as the repo
-            "MLRUN_DOCKER_REPO": "" if ends_with_mlrun else "mlrun",
+            "MLRUN_DOCKER_REPO": mlrun_docker_repo,
         }
         cmd = ["make", target]
         self._exec_local(cmd, live=True, env=env)
-        return f"{self._config['DOCKER_REGISTRY']}/{image_name}:{image_tag}"
+        return f"{mlrun_docker_registry}{mlrun_docker_repo}/{image_name}:{image_tag}"
 
     def _connect_to_node(self, node):
         logger.debug(f"Connecting to {node}")


### PR DESCRIPTION
Following https://github.com/mlrun/mlrun/pull/5690, the `MLRUN_DOCKER_REGISTRY` env var defaults to `registry.hub.docker.com`.
The patch script only sets the `MLRUN_DOCKER_REPO` env var, causing weird behavior such as resolving the image name to:
```
registry.hub.docker.com/<datanode-ip>:8009/mlrun/mlrun-api:1.7.0-rc21
```

This PR fixes this by:
1. Populating `MLRUN_DOCKER_REGISTRY` with the `DOCKER_REGISTRY` config value, ensuring it ends with a `/` .
2. Setting `MLRUN_DOCKER_REPO=mlrun` or to an empty string, conditioned on the docker registry. This is done because the makefile concatenates "mlrun" to `MLRUN_DOCKER_REGISTRY` value by default.