### PR TITLE
[Model Monitoring] Support endpoint connection string based on project secret

### DIFF
--- a/mlrun/model_monitoring/db/stores/__init__.py
+++ b/mlrun/model_monitoring/db/stores/__init__.py
@@ -31,17 +31,12 @@ class ObjectStoreFactory(enum.Enum):
     def to_object_store(
         self,
         project: str,
-        access_key: str = None,
-        secret_provider: typing.Callable = None,
+        **kwargs,
     ) -> StoreBase:
         """
         Return a StoreBase object based on the provided enum value.
 
         :param project:                   The name of the project.
-        :param access_key:                Access key with permission to the DB table. Note that if access key is None
-                                          and the endpoint target is from type KV then the access key will be
-                                          retrieved from the environment variable.
-        :param secret_provider:           An optional secret provider to get the connection string secret.
 
         :return: `StoreBase` object.
 
@@ -50,10 +45,7 @@ class ObjectStoreFactory(enum.Enum):
         if self == self.v3io_nosql:
             from mlrun.model_monitoring.db.stores.v3io_kv.kv_store import KVStoreBase
 
-            # Get V3IO access key from env
-            access_key = access_key or mlrun.mlconf.get_v3io_access_key()
-
-            return KVStoreBase(project=project, access_key=access_key)
+            return KVStoreBase(project=project)
 
         # Assuming SQL store target if store type is not KV.
         # Update these lines once there are more than two store target types.
@@ -62,7 +54,7 @@ class ObjectStoreFactory(enum.Enum):
 
         return SQLStoreBase(
             project=project,
-            secret_provider=secret_provider,
+            **kwargs,
         )
 
     @classmethod
@@ -95,24 +87,40 @@ def get_model_endpoint_store(
 
 def get_store_object(
     project: str,
-    access_key: str = None,
+    store_type: typing.Optional[str] = None,
     secret_provider: typing.Callable = None,
+    **kwargs,
 ) -> StoreBase:
     """
     Getting the DB target type based on mlrun.config.model_endpoint_monitoring.store_type.
 
     :param project:         The name of the project.
-    :param access_key:      Access key with permission to the DB table.
+    :param store_type:      The type of the store target. See mlrun.model_monitoring.db.stores.ObjectStoreFactory
+                            for available store types.
     :param secret_provider: An optional secret provider to get the connection string secret.
 
     :return: `StoreBase` object. Using this object, the user can apply different operations on the
              model monitoring record such as write, update, get and delete a model endpoint.
     """
 
+    store_connection_string = mlrun.model_monitoring.helpers.get_connection_string(
+        secret_provider=secret_provider
+    )
+
+    if store_connection_string and (
+        store_connection_string.startswith("mysql")
+        or store_connection_string.startswith("sqlite")
+    ):
+        store_type = mlrun.common.schemas.model_monitoring.ModelEndpointTarget.SQL
+        kwargs["store_connection_string"] = store_connection_string
+
+    # Set the default store type if no connection has been set
+    store_type = store_type or mlrun.mlconf.model_endpoint_monitoring.store_type
+
     # Get store type value from ObjectStoreFactory enum class
-    store_type = ObjectStoreFactory(mlrun.mlconf.model_endpoint_monitoring.store_type)
+    store_type = ObjectStoreFactory(store_type)
 
     # Convert into store target object
     return store_type.to_object_store(
-        project=project, access_key=access_key, secret_provider=secret_provider
+        project=project, secret_provider=secret_provider, **kwargs
     )

--- a/mlrun/model_monitoring/db/stores/__init__.py
+++ b/mlrun/model_monitoring/db/stores/__init__.py
@@ -92,7 +92,8 @@ def get_store_object(
     **kwargs,
 ) -> StoreBase:
     """
-    Getting the DB target type based on mlrun.config.model_endpoint_monitoring.store_type.
+    Generate a store object based on the provided store type. If a connection string is provided, the store type will
+    be updated according to the connection string.
 
     :param project:         The name of the project.
     :param store_type:      The type of the store target. See mlrun.model_monitoring.db.stores.ObjectStoreFactory

--- a/mlrun/model_monitoring/db/stores/base/store.py
+++ b/mlrun/model_monitoring/db/stores/base/store.py
@@ -19,7 +19,7 @@ import mlrun.common.schemas.model_monitoring as mm_schemas
 
 
 class StoreBase(ABC):
-    type: str = ""
+    type: typing.ClassVar[str]
     """
     An abstract class to handle the store object in the DB target.
     """

--- a/mlrun/model_monitoring/db/stores/base/store.py
+++ b/mlrun/model_monitoring/db/stores/base/store.py
@@ -19,6 +19,7 @@ import mlrun.common.schemas.model_monitoring as mm_schemas
 
 
 class StoreBase(ABC):
+    type: str = ""
     """
     An abstract class to handle the store object in the DB target.
     """

--- a/mlrun/model_monitoring/db/stores/sqldb/sql_store.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/sql_store.py
@@ -33,7 +33,7 @@ from mlrun.utils import datetime_now, logger
 
 
 class SQLStoreBase(StoreBase):
-    type: str = mm_schemas.ModelEndpointTarget.SQL
+    type: typing.ClassVar[str] = mm_schemas.ModelEndpointTarget.SQL
     """
     Handles the DB operations when the DB target is from type SQL. For the SQL operations, we use SQLAlchemy, a Python
     SQL toolkit that handles the communication with the database.  When using SQL for storing the model monitoring

--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -24,8 +24,8 @@ import v3io.dataplane.response
 
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring as mm_schemas
-import mlrun.model_monitoring.db
 import mlrun.utils.v3io_clients
+from mlrun.model_monitoring.db import StoreBase
 from mlrun.utils import logger
 
 # Fields to encode before storing in the KV table or to decode after retrieving
@@ -89,16 +89,20 @@ _KIND_TO_SCHEMA_PARAMS: dict[mm_schemas.WriterEventKind, SchemaParams] = {
 _EXCLUDE_SCHEMA_FILTER_EXPRESSION = '__name!=".#schema"'
 
 
-class KVStoreBase(mlrun.model_monitoring.db.StoreBase):
+class KVStoreBase(StoreBase):
+    type: str = mm_schemas.ModelEndpointTarget.V3IO_NOSQL
     """
     Handles the DB operations when the DB target is from type KV. For the KV operations, we use an instance of V3IO
     client and usually the KV table can be found under v3io:///users/pipelines/project-name/model-endpoints/endpoints/.
     """
 
-    def __init__(self, project: str, access_key: typing.Optional[str] = None) -> None:
+    def __init__(
+        self,
+        project: str,
+    ) -> None:
         super().__init__(project=project)
         # Initialize a V3IO client instance
-        self.access_key = access_key or os.environ.get("V3IO_ACCESS_KEY")
+        self.access_key = os.environ.get("V3IO_ACCESS_KEY")
         self.client = mlrun.utils.v3io_clients.get_v3io_client(
             endpoint=mlrun.mlconf.v3io_api, access_key=self.access_key
         )

--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import os
 import typing
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -90,7 +89,7 @@ _EXCLUDE_SCHEMA_FILTER_EXPRESSION = '__name!=".#schema"'
 
 
 class KVStoreBase(StoreBase):
-    type: str = mm_schemas.ModelEndpointTarget.V3IO_NOSQL
+    type: typing.ClassVar[str] = "v3io-nosql"
     """
     Handles the DB operations when the DB target is from type KV. For the KV operations, we use an instance of V3IO
     client and usually the KV table can be found under v3io:///users/pipelines/project-name/model-endpoints/endpoints/.
@@ -102,9 +101,8 @@ class KVStoreBase(StoreBase):
     ) -> None:
         super().__init__(project=project)
         # Initialize a V3IO client instance
-        self.access_key = os.environ.get("V3IO_ACCESS_KEY")
         self.client = mlrun.utils.v3io_clients.get_v3io_client(
-            endpoint=mlrun.mlconf.v3io_api, access_key=self.access_key
+            endpoint=mlrun.mlconf.v3io_api,
         )
         # Get the KV table path and container
         self.path, self.container = self._get_path_and_container()
@@ -190,7 +188,6 @@ class KVStoreBase(StoreBase):
             table_path=self.path,
             key=endpoint_id,
             raise_for_status=v3io.dataplane.RaiseForStatus.never,
-            access_key=self.access_key,
         )
         endpoint = endpoint.output.item
 
@@ -503,7 +500,6 @@ class KVStoreBase(StoreBase):
 
     def _get_frames_client(self):
         return mlrun.utils.v3io_clients.get_frames_client(
-            token=self.access_key,
             address=mlrun.mlconf.v3io_framesd,
             container=self.container,
         )

--- a/mlrun/model_monitoring/db/tsdb/__init__.py
+++ b/mlrun/model_monitoring/db/tsdb/__init__.py
@@ -65,7 +65,7 @@ class ObjectTSDBFactory(enum.Enum):
 def get_tsdb_connector(
     project: str,
     tsdb_connector_type: str = "",
-    secret_provider: typing.Optional[typing.Callable] = None,
+    secret_provider: typing.Optional[typing.Callable[[str], str]] = None,
     **kwargs,
 ) -> TSDBConnector:
     """

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -25,7 +25,7 @@ from mlrun.utils import logger
 
 
 class TSDBConnector(ABC):
-    type: str = ""
+    type: typing.ClassVar[str]
 
     def __init__(self, project: str):
         """

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -97,7 +97,7 @@ def get_monitoring_parquet_path(
     return parquet_path
 
 
-def get_connection_string(secret_provider: typing.Callable = None) -> str:
+def get_connection_string(secret_provider: typing.Callable[[str], str] = None) -> str:
     """Get endpoint store connection string from the project secret. If wasn't set, take it from the system
     configurations.
 
@@ -117,7 +117,7 @@ def get_connection_string(secret_provider: typing.Callable = None) -> str:
 
 
 def get_tsdb_connection_string(
-    secret_provider: typing.Optional[typing.Callable] = None,
+    secret_provider: typing.Optional[typing.Callable[[str], str]] = None,
 ) -> str:
     """Get TSDB connection string from the project secret. If wasn't set, take it from the system
     configurations.
@@ -281,7 +281,7 @@ def calculate_inputs_statistics(
 def get_endpoint_record(
     project: str,
     endpoint_id: str,
-    secret_provider: typing.Optional[typing.Callable] = None,
+    secret_provider: typing.Optional[typing.Callable[[str], str]] = None,
 ) -> dict[str, typing.Any]:
     model_endpoint_store = mlrun.model_monitoring.get_store_object(
         project=project, secret_provider=secret_provider

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -278,9 +278,13 @@ def calculate_inputs_statistics(
     return inputs_statistics
 
 
-def get_endpoint_record(project: str, endpoint_id: str):
+def get_endpoint_record(
+    project: str,
+    endpoint_id: str,
+    secret_provider: typing.Optional[typing.Callable] = None,
+) -> dict[str, typing.Any]:
     model_endpoint_store = mlrun.model_monitoring.get_store_object(
-        project=project,
+        project=project, secret_provider=secret_provider
     )
     return model_endpoint_store.get_model_endpoint(endpoint_id=endpoint_id)
 

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -66,10 +66,6 @@ class EventStreamProcessor:
         self.parquet_batching_max_events = parquet_batching_max_events
         self.parquet_batching_timeout_secs = parquet_batching_timeout_secs
 
-        self.model_endpoint_store_target = (
-            mlrun.mlconf.model_endpoint_monitoring.store_type
-        )
-
         logger.info(
             "Initializing model monitoring event stream processor",
             parquet_path=self.parquet_path,
@@ -139,7 +135,7 @@ class EventStreamProcessor:
     def apply_monitoring_serving_graph(
         self,
         fn: mlrun.runtimes.ServingRuntime,
-        tsdb_service_provider: typing.Optional[typing.Callable] = None,
+        secret_provider: typing.Optional[typing.Callable] = None,
     ) -> None:
         """
         Apply monitoring serving graph to a given serving function. The following serving graph includes about 4 main
@@ -167,7 +163,8 @@ class EventStreamProcessor:
            using CE, the parquet target path is based on the defined MLRun artifact path.
 
         :param fn: A serving function.
-        :param tsdb_service_provider: An optional callable function that provides the TSDB connection string.
+        :param secret_provider: An optional callable function that provides the connection string from the project
+                                secret.
         """
 
         graph = typing.cast(
@@ -293,7 +290,6 @@ class EventStreamProcessor:
                 name="UpdateEndpoint",
                 after="ProcessBeforeEndpointUpdate",
                 project=self.project,
-                model_endpoint_store_target=self.model_endpoint_store_target,
             )
 
         apply_update_endpoint()
@@ -310,7 +306,10 @@ class EventStreamProcessor:
                 table=self.kv_path,
             )
 
-        if self.model_endpoint_store_target == ModelEndpointTarget.V3IO_NOSQL:
+        store_object = mlrun.model_monitoring.get_store_object(
+            project=self.project, secret_provider=secret_provider
+        )
+        if store_object.type == ModelEndpointTarget.V3IO_NOSQL:
             apply_infer_schema()
 
         # Emits the event in window size of events based on sample_window size (10 by default)
@@ -328,7 +327,7 @@ class EventStreamProcessor:
         # TSDB branch (skip to Prometheus if in CE env)
         if not mlrun.mlconf.is_ce_mode():
             tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-                project=self.project, secret_provider=tsdb_service_provider
+                project=self.project, secret_provider=secret_provider
             )
             tsdb_connector.apply_monitoring_stream_steps(graph=graph)
 
@@ -904,7 +903,7 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
 
 
 class UpdateEndpoint(mlrun.feature_store.steps.MapClass):
-    def __init__(self, project: str, model_endpoint_store_target: str, **kwargs):
+    def __init__(self, project: str, **kwargs):
         """
         Update the model endpoint record in the DB. Note that the event at this point includes metadata and stats about
         the average latency and the amount of predictions over time. This data will be used in the monitoring dashboards
@@ -914,7 +913,6 @@ class UpdateEndpoint(mlrun.feature_store.steps.MapClass):
         """
         super().__init__(**kwargs)
         self.project = project
-        self.model_endpoint_store_target = model_endpoint_store_target
 
     def do(self, event: dict):
         # Remove labels from the event

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -135,7 +135,7 @@ class EventStreamProcessor:
     def apply_monitoring_serving_graph(
         self,
         fn: mlrun.runtimes.ServingRuntime,
-        secret_provider: typing.Optional[typing.Callable] = None,
+        secret_provider: typing.Optional[typing.Callable[[str], str]] = None,
     ) -> None:
         """
         Apply monitoring serving graph to a given serving function. The following serving graph includes about 4 main

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from typing import Any, NewType
+from typing import Any, Callable, NewType
 
 import mlrun.common.model_monitoring
 import mlrun.common.schemas
@@ -102,7 +102,11 @@ class ModelMonitoringWriter(StepToDict):
 
     kind = "monitoring_application_stream_pusher"
 
-    def __init__(self, project: str, secret_provider=None) -> None:
+    def __init__(
+        self,
+        project: str,
+        secret_provider: Callable = None,
+    ) -> None:
         self.project = project
         self.name = project  # required for the deployment process
 

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -30,7 +30,7 @@ from mlrun.common.schemas.model_monitoring.constants import (
     WriterEventKind,
 )
 from mlrun.common.schemas.notification import NotificationKind, NotificationSeverity
-from mlrun.model_monitoring.helpers import get_endpoint_record, get_result_instance_fqn
+from mlrun.model_monitoring.helpers import get_result_instance_fqn
 from mlrun.serving.utils import StepToDict
 from mlrun.utils import logger
 from mlrun.utils.notifications.notification_pusher import CustomNotificationPusher
@@ -102,7 +102,7 @@ class ModelMonitoringWriter(StepToDict):
 
     kind = "monitoring_application_stream_pusher"
 
-    def __init__(self, project: str, tsdb_secret_provider=None) -> None:
+    def __init__(self, project: str, secret_provider=None) -> None:
         self.project = project
         self.name = project  # required for the deployment process
 
@@ -111,10 +111,10 @@ class ModelMonitoringWriter(StepToDict):
         )
 
         self._app_result_store = mlrun.model_monitoring.get_store_object(
-            project=self.project
+            project=self.project, secret_provider=secret_provider
         )
         self._tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-            project=self.project, secret_provider=tsdb_secret_provider
+            project=self.project, secret_provider=secret_provider
         )
         self._endpoints_records = {}
 
@@ -223,7 +223,7 @@ class ModelMonitoringWriter(StepToDict):
             endpoint_id = event[WriterEvent.ENDPOINT_ID]
             endpoint_record = self._endpoints_records.setdefault(
                 endpoint_id,
-                get_endpoint_record(project=self.project, endpoint_id=endpoint_id),
+                self._app_result_store.get_model_endpoint(endpoint_id=endpoint_id),
             )
             event_value = {
                 "app_name": event[WriterEvent.APPLICATION_NAME],

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3192,7 +3192,8 @@ class MlrunProject(ModelObj):
         tsdb_connection: Optional[str] = None,
     ):
         """Set the credentials that will be used by the project's model monitoring
-        infrastructure functions.
+        infrastructure functions. Important to note that you have to set the credentials before deploying any
+        model monitoring or serving function.
 
         :param access_key:                Model Monitoring access key for managing user permissions
         :param endpoint_store_connection: Endpoint store connection string

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -348,12 +348,11 @@ async def get_model_endpoint_monitoring_metrics(
         project=project, endpoint_id=endpoint_id, auth_info=auth_info
     )
 
-    get_model_endpoint_metrics = mlrun.model_monitoring.get_store_object(
-        project=project,
-        secret_provider=server.api.crud.secrets.get_project_secret_provider(
+    get_model_endpoint_metrics = (
+        server.api.crud.model_monitoring.helpers.get_store_object(
             project=project
-        ),
-    ).get_model_endpoint_metrics
+        ).get_model_endpoint_metrics
+    )
     metrics: list[mm_endpoints.ModelEndpointMonitoringMetric] = []
     tasks: list[asyncio.Task] = []
     if type == "results" or type == "all":

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -234,7 +234,6 @@ async def list_model_endpoints(
 
     endpoints = await run_in_threadpool(
         server.api.crud.ModelEndpoints().list_model_endpoints,
-        auth_info=auth_info,
         project=project,
         model=model,
         function=function,
@@ -315,7 +314,6 @@ async def get_model_endpoint(
 
     return await run_in_threadpool(
         server.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
         project=project,
         endpoint_id=endpoint_id,
         metrics=metrics,

--- a/server/api/api/endpoints/model_endpoints.py
+++ b/server/api/api/endpoints/model_endpoints.py
@@ -349,7 +349,10 @@ async def get_model_endpoint_monitoring_metrics(
     )
 
     get_model_endpoint_metrics = mlrun.model_monitoring.get_store_object(
-        project=project
+        project=project,
+        secret_provider=server.api.crud.secrets.get_project_secret_provider(
+            project=project
+        ),
     ).get_model_endpoint_metrics
     metrics: list[mm_endpoints.ModelEndpointMonitoringMetric] = []
     tasks: list[asyncio.Task] = []

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -376,7 +376,7 @@ class MonitoringDeployment:
         # Create monitoring serving graph
         stream_processor.apply_monitoring_serving_graph(
             function,
-            tsdb_service_provider=server.api.crud.secrets.get_project_secret_provider(
+            secret_provider=server.api.crud.secrets.get_project_secret_provider(
                 project=self.project
             ),
         )
@@ -495,7 +495,7 @@ class MonitoringDeployment:
         graph.to(
             ModelMonitoringWriter(
                 project=self.project,
-                tsdb_secret_provider=server.api.crud.secrets.get_project_secret_provider(
+                secret_provider=server.api.crud.secrets.get_project_secret_provider(
                     project=self.project
                 ),
             )

--- a/server/api/crud/model_monitoring/helpers.py
+++ b/server/api/crud/model_monitoring/helpers.py
@@ -22,6 +22,8 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.schedule
 import mlrun.errors
+import mlrun.model_monitoring
+import mlrun.model_monitoring.db.stores
 import server.api.crud.secrets
 
 
@@ -140,3 +142,13 @@ def get_stream_path(
             stream_uri=stream_uri, project=project, function_name=function_name
         )
     ]
+
+
+def get_store_object(project: str) -> mlrun.model_monitoring.db.stores.StoreBase:
+    """Handle the get store object function for the server side, using the project secret provider."""
+    return mlrun.model_monitoring.get_store_object(
+        project=project,
+        secret_provider=server.api.crud.secrets.get_project_secret_provider(
+            project=project
+        ),
+    )

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -376,7 +376,6 @@ class ModelEndpoints:
         # Generate a model endpoint store object and get the model endpoint record as a dictionary
         model_endpoint_store = mlrun.model_monitoring.get_store_object(
             project=project,
-            access_key=auth_info.data_session,
             secret_provider=server.api.crud.secrets.get_project_secret_provider(
                 project=project
             ),
@@ -472,7 +471,6 @@ class ModelEndpoints:
 
         # Generate a model endpoint store object and get a list of model endpoint dictionaries
         endpoint_store = mlrun.model_monitoring.get_store_object(
-            access_key=auth_info.data_session,
             project=project,
             secret_provider=server.api.crud.secrets.get_project_secret_provider(
                 project=project
@@ -538,22 +536,23 @@ class ModelEndpoints:
             data_session=os.getenv("V3IO_ACCESS_KEY")
         )
 
-        # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,
-        # we're using the igz version heuristic
-        if (
-            mlrun.mlconf.model_endpoint_monitoring.store_type
-            == mlrun.common.schemas.model_monitoring.ModelEndpointTarget.V3IO_NOSQL
-            and (not mlrun.mlconf.igz_version or not mlrun.mlconf.v3io_api)
-        ):
-            return
         # Delete model monitoring store resources
         endpoint_store = mlrun.model_monitoring.get_store_object(
-            access_key=auth_info.data_session,
             project=project_name,
             secret_provider=server.api.crud.secrets.get_project_secret_provider(
                 project=project_name
             ),
         )
+
+        # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,
+        # we're using the igz version heuristic
+        if (
+            endpoint_store.type
+            == mlrun.common.schemas.model_monitoring.ModelEndpointTarget.V3IO_NOSQL
+            and (not mlrun.mlconf.igz_version or not mlrun.mlconf.v3io_api)
+        ):
+            return
+
         endpoint_store.delete_model_endpoints_resources()
 
         # Delete model monitoring TSDB resources

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -510,19 +510,19 @@ class ModelEndpoints:
         :param project_name: The name of the project.
         """
 
-        # Delete model monitoring store resources
-        endpoint_store = server.api.crud.model_monitoring.helpers.get_store_object(
-            project=project_name
-        )
-
         # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,
         # we're using the igz version heuristic
         if (
-            endpoint_store.type
+            mlrun.mlconf.model_endpoint_monitoring.store_type
             == mlrun.common.schemas.model_monitoring.ModelEndpointTarget.V3IO_NOSQL
             and (not mlrun.mlconf.igz_version or not mlrun.mlconf.v3io_api)
         ):
             return
+
+        # Delete model monitoring store resources
+        endpoint_store = server.api.crud.model_monitoring.helpers.get_store_object(
+            project=project_name
+        )
 
         endpoint_store.delete_model_endpoints_resources()
 

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -41,8 +41,8 @@ class ModelEndpoints:
         model_endpoint: mlrun.common.schemas.ModelEndpoint,
     ) -> mlrun.common.schemas.ModelEndpoint:
         """
-        Creates model endpoint record in DB. The DB target type is defined under
-        `mlrun.config.model_endpoint_monitoring.store_type` (V3IO-NOSQL by default).
+        Creates model endpoint record in DB. The DB store target is defined either by a provided connection string
+        or by the default store target that is defined in MLRun configuration.
 
         :param db_session:             A session that manages the current dialog with the database.
         :param model_endpoint:         Model endpoint object to update.
@@ -140,11 +140,10 @@ class ModelEndpoints:
         # system
         logger.info("Creating model endpoint", endpoint_id=model_endpoint.metadata.uid)
         # Write the new model endpoint
-        model_endpoint_store = mlrun.model_monitoring.get_store_object(
-            project=model_endpoint.metadata.project,
-            secret_provider=server.api.crud.secrets.get_project_secret_provider(
+        model_endpoint_store = (
+            server.api.crud.model_monitoring.helpers.get_store_object(
                 project=model_endpoint.metadata.project
-            ),
+            )
         )
         model_endpoint_store.write_model_endpoint(endpoint=model_endpoint.flat_dict())
 
@@ -172,11 +171,8 @@ class ModelEndpoints:
         """
 
         # Generate a model endpoint store object and apply the update process
-        model_endpoint_store = mlrun.model_monitoring.get_store_object(
-            project=project,
-            secret_provider=server.api.crud.secrets.get_project_secret_provider(
-                project=project
-            ),
+        model_endpoint_store = (
+            server.api.crud.model_monitoring.helpers.get_store_object(project=project)
         )
         model_endpoint_store.update_model_endpoint(
             endpoint_id=endpoint_id, attributes=attributes
@@ -321,11 +317,8 @@ class ModelEndpoints:
         :param project:     The name of the project.
         :param endpoint_id: The id of the endpoint.
         """
-        model_endpoint_store = mlrun.model_monitoring.get_store_object(
-            project=project,
-            secret_provider=server.api.crud.secrets.get_project_secret_provider(
-                project=project
-            ),
+        model_endpoint_store = (
+            server.api.crud.model_monitoring.helpers.get_store_object(project=project)
         )
 
         model_endpoint_store.delete_model_endpoint(endpoint_id=endpoint_id)
@@ -371,11 +364,8 @@ class ModelEndpoints:
         )
 
         # Generate a model endpoint store object and get the model endpoint record as a dictionary
-        model_endpoint_store = mlrun.model_monitoring.get_store_object(
-            project=project,
-            secret_provider=server.api.crud.secrets.get_project_secret_provider(
-                project=project
-            ),
+        model_endpoint_store = (
+            server.api.crud.model_monitoring.helpers.get_store_object(project=project)
         )
 
         model_endpoint_record = model_endpoint_store.get_model_endpoint(
@@ -464,11 +454,8 @@ class ModelEndpoints:
         endpoint_list = mlrun.common.schemas.ModelEndpointList(endpoints=[])
 
         # Generate a model endpoint store object and get a list of model endpoint dictionaries
-        endpoint_store = mlrun.model_monitoring.get_store_object(
-            project=project,
-            secret_provider=server.api.crud.secrets.get_project_secret_provider(
-                project=project
-            ),
+        endpoint_store = server.api.crud.model_monitoring.helpers.get_store_object(
+            project=project
         )
 
         endpoint_dictionary_list = endpoint_store.list_model_endpoints(
@@ -524,11 +511,8 @@ class ModelEndpoints:
         """
 
         # Delete model monitoring store resources
-        endpoint_store = mlrun.model_monitoring.get_store_object(
-            project=project_name,
-            secret_provider=server.api.crud.secrets.get_project_secret_provider(
-                project=project_name
-            ),
+        endpoint_store = server.api.crud.model_monitoring.helpers.get_store_object(
+            project=project_name
         )
 
         # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,

--- a/tests/api/api/test_model_endpoints.py
+++ b/tests/api/api/test_model_endpoints.py
@@ -48,7 +48,7 @@ def test_build_kv_cursor_filter_expression():
     store_type_object = mlrun.model_monitoring.db.ObjectStoreFactory(value="v3io-nosql")
 
     endpoint_store: KVmodelType = store_type_object.to_object_store(
-        project=TEST_PROJECT, access_key=V3IO_ACCESS_KEY
+        project=TEST_PROJECT,
     )
 
     with pytest.raises(MLRunInvalidArgumentError):
@@ -281,7 +281,7 @@ def test_generating_tsdb_paths():
     # Initialize endpoint store target object
     store_type_object = mlrun.model_monitoring.db.ObjectStoreFactory(value="v3io-nosql")
     endpoint_store: KVmodelType = store_type_object.to_object_store(
-        project=TEST_PROJECT, access_key=V3IO_ACCESS_KEY
+        project=TEST_PROJECT,
     )
 
     # Generating the required tsdb paths

--- a/tests/api/crud/model_monitoring/test_model_endpoints.py
+++ b/tests/api/crud/model_monitoring/test_model_endpoints.py
@@ -66,7 +66,18 @@ def mock_kv() -> Iterator[None]:
         yield
 
 
-@pytest.mark.usefixtures("_patch_external_resources", "mock_kv")
+@pytest.fixture()
+def mock_get_connection_string() -> Iterator[None]:
+    with patch(
+        "mlrun.model_monitoring.helpers.get_connection_string",
+        return_value=None,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures(
+    "_patch_external_resources", "mock_kv", "mock_get_connection_string"
+)
 def test_create_with_empty_feature_stats(
     db_session: DBSession,
     model_endpoint: mlrun.common.schemas.ModelEndpoint,

--- a/tests/model_monitoring/test_stores/test_sql.py
+++ b/tests/model_monitoring/test_stores/test_sql.py
@@ -137,14 +137,13 @@ class TestSQLStore:
     @pytest.fixture
     def new_sql_store(cls, store_connection: str) -> Iterator[SQLStoreBase]:
         # Generate store object target
-        store_type_object = mlrun.model_monitoring.db.ObjectStoreFactory(value="sql")
         with unittest.mock.patch(
             "mlrun.model_monitoring.helpers.get_connection_string",
             return_value=store_connection,
         ):
             sql_store = cast(
                 SQLStoreBase,
-                store_type_object.to_object_store(project=cls._TEST_PROJECT),
+                mlrun.model_monitoring.get_store_object(project=cls._TEST_PROJECT),
             )
             yield sql_store
             sql_store.delete_model_endpoints_resources()

--- a/tests/model_monitoring/test_stores/test_sql.py
+++ b/tests/model_monitoring/test_stores/test_sql.py
@@ -330,7 +330,7 @@ class TestMonitoringSchedules:
             mp_ctx.setenv(
                 ProjectSecretKeys.ENDPOINT_STORE_CONNECTION, in_mem_connection
             )
-            store = SQLStoreBase(project="tmp_proj")
+            store = mlrun.model_monitoring.get_store_object(project="tmp_proj")
         store._create_tables_if_not_exist()
         return store
 

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -44,6 +44,8 @@ from mlrun.runtimes import BaseRuntime
 from mlrun.utils.v3io_clients import get_frames_client
 from tests.system.base import TestMLRunSystem
 
+_MLRUN_MODEL_MONITORING_DB = "mysql+pymysql://root@mlrun-db:3306/mlrun_model_monitoring"
+
 
 # Marked as enterprise because of v3io mount and pipelines
 @TestMLRunSystem.skip_test_if_env_not_configured
@@ -246,15 +248,22 @@ class TestBasicModelMonitoring(TestMLRunSystem):
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: Optional[str] = None
 
-    @pytest.mark.timeout(270)
-    def test_basic_model_monitoring(self) -> None:
+    @pytest.mark.timeout(540)
+    @pytest.mark.parametrize("with_sql_target", [True, False])
+    def test_basic_model_monitoring(self, with_sql_target: bool) -> None:
         # Main validations:
         # 1 - a single model endpoint is created
         # 2 - model name, tag and values are recorded as expected under the model endpoint
         # 3 - stream metrics are recorded as expected under the model endpoint
+        # 4 - test on both SQL and KV store targets
 
         # Deploy Model Servers
         project = self.project
+
+        if with_sql_target:
+            project.set_model_monitoring_credentials(
+                endpoint_store_connection=_MLRUN_MODEL_MONITORING_DB
+            )
 
         iris = load_iris()
         train_set = pd.DataFrame(


### PR DESCRIPTION
Until now, if a user wished to define a SQL target for storing the model monitoring data instead of V3IO KV, he had to apply configmap to update MLRun configurations, particularly the `model_endpoint_monitoring.store_type` value. Afterwards he had to provide a SQL connection string either through configmap or by using the  `set_model_monitoring_credentials` API.

In this PR, we improve this behaviour so that users can provide the connection string using the   `set_model_monitoring_credentials` method, without applying any configmap to update MLRun model monitoring configurations. It's important to note that this API is project=specific, meaning that the user will have to apply this API to each project. For example:

`project.set_model_monitoring_credentials(endpoint_store_connection="mysql+pymysql://root@my-db:3306/mlrun_model_monitoring")`
JIRA: https://iguazio.atlassian.net/browse/ML-6747