### PR TITLE
[Nuclio] List only functions with status when deleting Nuclio functions

### DIFF
--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1303,7 +1303,6 @@ async def _delete_function(
     # in MLRun terminology, they are all just versions of the same function
     # therefore, it's enough to check the kind of the first one only
     if functions[0].get("kind") in mlrun.runtimes.RuntimeKinds.nuclio_runtimes():
-
         # filter functions which doesn't have status
         # it means that they aren't attached to the actual nuclio function
         nuclio_functions = [function for function in functions if function["status"]]

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1303,7 +1303,7 @@ async def _delete_function(
     # in MLRun terminology, they are all just versions of the same function
     # therefore, it's enough to check the kind of the first one only
     if functions[0].get("kind") in mlrun.runtimes.RuntimeKinds.nuclio_runtimes():
-        # filter functions which doesn't have status
+        # filter functions which don't have a status
         # it means that they aren't attached to the actual nuclio function
         nuclio_functions = [function for function in functions if function["status"]]
 


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-6744

The problem with duplicated error happened because `list_functions()` returns 2 copies of the same functions. One of tag `latest` and another one of an empty tag. The one with empty tag is the same with latest, but without status, so them both point to the same Nuclio function. In order to avoid duplicated deletion of nuclio functions, we need to filter out those without status. 