### PR TITLE
[Artifacts] Fix artifact name missing in metadata during migration [1.6.x]

### DIFF
--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -592,6 +592,10 @@ def _migrate_artifacts_batch(
         else:
             new_artifact.best_iteration = False
 
+        # to overcome issues with legacy artifacts with missing keys, we will set the key in the metadata
+        if not artifact_metadata.get("key"):
+            artifact_dict["metadata"]["key"] = key
+
         # uid - calculate as the hash of the artifact object
         uid = fill_artifact_object_hash(
             artifact_dict, new_artifact.iteration, new_artifact.producer_id

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -1370,6 +1370,53 @@ class TestArtifacts:
         assert new_artifact.key == db_key
         assert new_artifact.iteration == iteration
 
+    def test_migrate_artifact_without_metadata_key(
+        self, db: DBInterface, db_session: Session
+    ):
+        # empty key on purpose
+        artifact_key = ""
+        artifact_tree = "some-tree"
+        artifact_tag = "artifact-tag-1"
+        project = "project1"
+        db_key = "db-key-1"
+
+        # create project
+        self._create_project(db, db_session, project)
+
+        # create artifacts in the old format
+        artifact_body = self._generate_artifact(artifact_key, artifact_tree, "artifact")
+        artifact_body["metadata"]["project"] = project
+        artifact_body["spec"]["db_key"] = db_key
+
+        # store the artifact with the db_key
+        db.store_artifact_v1(
+            db_session,
+            db_key,
+            artifact_body,
+            artifact_tree,
+            project=project,
+            tag=artifact_tag,
+        )
+
+        # validate the artifact was stored with the db_key
+        artifact = db.read_artifact_v1(db_session, db_key, project=project)
+        assert artifact["metadata"]["key"] == ""
+        assert artifact["spec"]["db_key"] == db_key
+
+        # migrate the artifacts to v2
+        self._run_artifacts_v2_migration(db, db_session)
+
+        # validate the migration succeeded and the metadata key is the db_key
+        query_all = db._query(
+            db_session,
+            server.api.db.sqldb.models.ArtifactV2,
+        )
+        new_artifact = query_all.one()
+
+        assert new_artifact.key == db_key
+        artifact = new_artifact.full_object
+        assert artifact["metadata"]["key"] == db_key
+
     def test_update_model_spec(self, db: DBInterface, db_session: Session):
         artifact_key = "model1"
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -286,7 +286,7 @@ def test_validate_tag_name(tag_name, expected):
             "artifact-name\\test",
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
-        ("", mlrun.errors.MLRunInvalidArgumentError),
+        ("", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         # Valid names
         ("artifact-name2.0", does_not_raise()),
         ("artifact-name", does_not_raise()),

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -286,6 +286,7 @@ def test_validate_tag_name(tag_name, expected):
             "artifact-name\\test",
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
+        ("", mlrun.errors.MLRunInvalidArgumentError),
         # Valid names
         ("artifact-name2.0", does_not_raise()),
         ("artifact-name", does_not_raise()),


### PR DESCRIPTION
The `key` of the artifact is used for creating its uid, which is a hash on the artifact dictionary, but must contain `key`, `iteration` and `producer_id` as they determine the artifact's uniqueness.

We saw a bug where a legacy artifact had no `key` in the artifact dictionary, only a `db_key`.
While migrating all artifacts to the new `artifacts_v2` table, an exception was raised about `key` not being populated in the artifacts dictionary.

To overcome this, we populate the key with the artifact's `db_key`. This shouldn't cause issues because when reading artifacts from the DB you need to provide the db_key and not the key.

Resolves https://iguazio.atlassian.net/browse/IG-22883