### PR TITLE
[Feature Store] Fix quadratic result size of `/features` API

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -99,6 +99,7 @@ from .feature_store import (
     FeatureSetSpec,
     FeatureSetsTagsOutput,
     FeaturesOutput,
+    FeaturesOutputV2,
     FeatureVector,
     FeatureVectorRecord,
     FeatureVectorsOutput,

--- a/mlrun/common/schemas/feature_store.py
+++ b/mlrun/common/schemas/feature_store.py
@@ -46,6 +46,16 @@ class Feature(FeatureStoreBaseModel):
         extra = pydantic.Extra.allow
 
 
+class QualifiedFeature(FeatureStoreBaseModel):
+    name: str
+    value_type: str
+    feature_set_index: int
+    labels: Optional[dict] = {}
+
+    class Config:
+        extra = pydantic.Extra.allow
+
+
 class Entity(FeatureStoreBaseModel):
     name: str
     value_type: str
@@ -143,6 +153,11 @@ class FeatureListOutput(FeatureStoreBaseModel):
 
 class FeaturesOutput(FeatureStoreBaseModel):
     features: list[FeatureListOutput]
+
+
+class FeaturesOutputV2(FeatureStoreBaseModel):
+    features: list[QualifiedFeature]
+    feature_set_digests: list[FeatureSetDigestOutputV2]
 
 
 class EntityListOutput(FeatureStoreBaseModel):

--- a/mlrun/common/schemas/feature_store.py
+++ b/mlrun/common/schemas/feature_store.py
@@ -14,7 +14,7 @@
 #
 from typing import Optional
 
-from pydantic import BaseModel, Extra, Field
+import pydantic
 
 from .auth import AuthorizationResourceTypes, Credentials
 from .object import (
@@ -27,42 +27,52 @@ from .object import (
 )
 
 
-class Feature(BaseModel):
+class FeatureStoreBaseModel(pydantic.BaseModel):
+    """
+    Intermediate base class, in order to override pydantic's configuration, as per
+    https://docs.pydantic.dev/1.10/usage/model_config/#change-behaviour-globally
+    """
+
+    class Config:
+        copy_on_model_validation = "none"
+
+
+class Feature(FeatureStoreBaseModel):
     name: str
     value_type: str
     labels: Optional[dict] = {}
 
     class Config:
-        extra = Extra.allow
+        extra = pydantic.Extra.allow
 
 
-class Entity(BaseModel):
+class Entity(FeatureStoreBaseModel):
     name: str
     value_type: str
     labels: Optional[dict] = {}
 
     class Config:
-        extra = Extra.allow
+        extra = pydantic.Extra.allow
 
 
-class QualifiedEntity(BaseModel):
+class QualifiedEntity(FeatureStoreBaseModel):
     name: str
     value_type: str
     feature_set_index: int
     labels: Optional[dict] = {}
 
     class Config:
-        extra = Extra.allow
+        extra = pydantic.Extra.allow
 
 
 class FeatureSetSpec(ObjectSpec):
     entities: list[Entity] = []
     features: list[Feature] = []
-    engine: Optional[str] = Field(default="storey")
+    engine: Optional[str] = pydantic.Field(default="storey")
 
 
-class FeatureSet(BaseModel):
-    kind: ObjectKind = Field(ObjectKind.feature_set, const=True)
+class FeatureSet(FeatureStoreBaseModel):
+    kind: ObjectKind = pydantic.Field(ObjectKind.feature_set, const=True)
     metadata: ObjectMetadata
     spec: FeatureSetSpec
     status: ObjectStatus
@@ -72,7 +82,7 @@ class FeatureSet(BaseModel):
         return AuthorizationResourceTypes.feature_set
 
 
-class EntityRecord(BaseModel):
+class EntityRecord(FeatureStoreBaseModel):
     name: str
     value_type: str
     labels: list[LabelRecord]
@@ -81,7 +91,7 @@ class EntityRecord(BaseModel):
         orm_mode = True
 
 
-class FeatureRecord(BaseModel):
+class FeatureRecord(FeatureStoreBaseModel):
     name: str
     value_type: str
     labels: list[LabelRecord]
@@ -98,62 +108,59 @@ class FeatureSetRecord(ObjectRecord):
         orm_mode = True
 
 
-class FeatureSetsOutput(BaseModel):
+class FeatureSetsOutput(FeatureStoreBaseModel):
     feature_sets: list[FeatureSet]
 
 
-class FeatureSetsTagsOutput(BaseModel):
+class FeatureSetsTagsOutput(FeatureStoreBaseModel):
     tags: list[str] = []
 
 
-class FeatureSetDigestSpec(BaseModel):
+class FeatureSetDigestSpec(FeatureStoreBaseModel):
     entities: list[Entity]
     features: list[Feature]
 
 
-class FeatureSetDigestOutput(BaseModel):
+class FeatureSetDigestOutput(FeatureStoreBaseModel):
     metadata: ObjectMetadata
     spec: FeatureSetDigestSpec
 
-    class Config:
-        copy_on_model_validation = False
 
-
-class FeatureSetDigestSpecV2(BaseModel):
+class FeatureSetDigestSpecV2(FeatureStoreBaseModel):
     entities: list[Entity]
 
 
-class FeatureSetDigestOutputV2(BaseModel):
+class FeatureSetDigestOutputV2(FeatureStoreBaseModel):
     feature_set_index: int
     metadata: ObjectMetadata
     spec: FeatureSetDigestSpecV2
 
 
-class FeatureListOutput(BaseModel):
+class FeatureListOutput(FeatureStoreBaseModel):
     feature: Feature
     feature_set_digest: FeatureSetDigestOutput
 
 
-class FeaturesOutput(BaseModel):
+class FeaturesOutput(FeatureStoreBaseModel):
     features: list[FeatureListOutput]
 
 
-class EntityListOutput(BaseModel):
+class EntityListOutput(FeatureStoreBaseModel):
     entity: Entity
     feature_set_digest: FeatureSetDigestOutput
 
 
-class EntitiesOutputV2(BaseModel):
+class EntitiesOutputV2(FeatureStoreBaseModel):
     entities: list[QualifiedEntity]
     feature_set_digests: list[FeatureSetDigestOutputV2]
 
 
-class EntitiesOutput(BaseModel):
+class EntitiesOutput(FeatureStoreBaseModel):
     entities: list[EntityListOutput]
 
 
-class FeatureVector(BaseModel):
-    kind: ObjectKind = Field(ObjectKind.feature_vector, const=True)
+class FeatureVector(FeatureStoreBaseModel):
+    kind: ObjectKind = pydantic.Field(ObjectKind.feature_vector, const=True)
     metadata: ObjectMetadata
     spec: ObjectSpec
     status: ObjectStatus
@@ -167,39 +174,39 @@ class FeatureVectorRecord(ObjectRecord):
     pass
 
 
-class FeatureVectorsOutput(BaseModel):
+class FeatureVectorsOutput(FeatureStoreBaseModel):
     feature_vectors: list[FeatureVector]
 
 
-class FeatureVectorsTagsOutput(BaseModel):
+class FeatureVectorsTagsOutput(FeatureStoreBaseModel):
     tags: list[str] = []
 
 
-class DataSource(BaseModel):
+class DataSource(FeatureStoreBaseModel):
     kind: str
     name: str
     path: str
 
     class Config:
-        extra = Extra.allow
+        extra = pydantic.Extra.allow
 
 
-class DataTarget(BaseModel):
+class DataTarget(FeatureStoreBaseModel):
     kind: str
     name: str
     path: Optional[str]
 
     class Config:
-        extra = Extra.allow
+        extra = pydantic.Extra.allow
 
 
-class FeatureSetIngestInput(BaseModel):
+class FeatureSetIngestInput(FeatureStoreBaseModel):
     source: Optional[DataSource]
     targets: Optional[list[DataTarget]]
     infer_options: Optional[int]
     credentials: Credentials = Credentials()
 
 
-class FeatureSetIngestOutput(BaseModel):
+class FeatureSetIngestOutput(FeatureStoreBaseModel):
     feature_set: FeatureSet
     run_object: dict

--- a/server/api/api/endpoints/feature_store_v2.py
+++ b/server/api/api/endpoints/feature_store_v2.py
@@ -26,10 +26,36 @@ from mlrun.common.schemas.feature_store import (
     FeatureSetDigestOutputV2,
     FeatureSetDigestSpecV2,
     QualifiedEntity,
+    QualifiedFeature,
 )
 from server.api.api import deps
 
 router = APIRouter(prefix="/v2/projects/{project}")
+
+
+def _dedup_feature_set(
+    feature_set_digest, feature_set_digest_id_to_index, feature_set_digests_v2
+):
+    # dedup feature set list
+    # we can rely on the object ID because SQLAlchemy already avoids duplication at the object
+    # level, and the conversion from "model" to "schema" retains this property
+    feature_set_digest_obj_id = id(feature_set_digest)
+    feature_set_index = feature_set_digest_id_to_index.get(
+        feature_set_digest_obj_id, None
+    )
+    if feature_set_index is None:
+        feature_set_index = len(feature_set_digest_id_to_index)
+        feature_set_digest_id_to_index[feature_set_digest_obj_id] = feature_set_index
+        feature_set_digests_v2.append(
+            FeatureSetDigestOutputV2(
+                feature_set_index=feature_set_index,
+                metadata=feature_set_digest.metadata,
+                spec=FeatureSetDigestSpecV2(
+                    entities=feature_set_digest.spec.entities,
+                ),
+            )
+        )
+    return feature_set_index
 
 
 @router.get("/entities", response_model=mlrun.common.schemas.EntitiesOutputV2)
@@ -57,27 +83,9 @@ async def list_entities(
     for entity_v1 in entities.entities:
         feature_set_digest = entity_v1.feature_set_digest
 
-        # dedup feature set list
-        # we can rely on the object ID because SQLAlchemy already avoids duplication at the object
-        # level, and the conversion from "model" to "schema" retains this property
-        feature_set_digest_obj_id = id(feature_set_digest)
-        feature_set_index = feature_set_digest_id_to_index.get(
-            feature_set_digest_obj_id, None
+        feature_set_index = _dedup_feature_set(
+            feature_set_digest, feature_set_digest_id_to_index, feature_set_digests_v2
         )
-        if feature_set_index is None:
-            feature_set_index = len(feature_set_digest_id_to_index)
-            feature_set_digest_id_to_index[feature_set_digest_obj_id] = (
-                feature_set_index
-            )
-            feature_set_digests_v2.append(
-                FeatureSetDigestOutputV2(
-                    feature_set_index=feature_set_index,
-                    metadata=feature_set_digest.metadata,
-                    spec=FeatureSetDigestSpecV2(
-                        entities=feature_set_digest.spec.entities,
-                    ),
-                )
-            )
 
         entity = entity_v1.entity
         entities_v2.append(
@@ -91,4 +99,50 @@ async def list_entities(
 
     return mlrun.common.schemas.EntitiesOutputV2(
         entities=entities_v2, feature_set_digests=feature_set_digests_v2
+    )
+
+
+@router.get("/features", response_model=mlrun.common.schemas.FeaturesOutputV2)
+async def list_features(
+    project: str,
+    name: str = None,
+    tag: str = None,
+    entities: list[str] = Query(None, alias="entity"),
+    labels: list[str] = Query(None, alias="label"),
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
+    db_session: Session = Depends(deps.get_db_session),
+):
+    features = await server.api.api.endpoints.feature_store.list_features(
+        project,
+        name,
+        tag,
+        labels,
+        entities,
+        auth_info,
+        db_session,
+    )
+
+    features_v2: list[QualifiedFeature] = []
+    feature_set_digests_v2: list[FeatureSetDigestOutputV2] = []
+    feature_set_digest_id_to_index: dict[int, int] = {}
+
+    for feature_v1 in features.features:
+        feature_set_digest = feature_v1.feature_set_digest
+
+        feature_set_index = _dedup_feature_set(
+            feature_set_digest, feature_set_digest_id_to_index, feature_set_digests_v2
+        )
+
+        feature = feature_v1.feature
+        features_v2.append(
+            QualifiedFeature(
+                name=feature.name,
+                value_type=feature.value_type,
+                feature_set_index=feature_set_index,
+                labels=feature.labels,
+            )
+        )
+
+    return mlrun.common.schemas.FeaturesOutputV2(
+        features=features_v2, feature_set_digests=feature_set_digests_v2
     )

--- a/tests/integration/sdk_api/httpdb/test_feature_store.py
+++ b/tests/integration/sdk_api/httpdb/test_feature_store.py
@@ -132,6 +132,18 @@ class TestFeatureStore(tests.integration.sdk_api.base.TestMLRunIntegration):
         assert len(results["features"]) == 1
 
         response = await async_client.get(
+            f"v2/projects/{project_name}/features?name=bid"
+        )
+        assert response.status_code == HTTPStatus.OK.value
+        results = response.json()
+        assert len(results["features"]) == 1
+        assert len(results["feature_set_digests"]) == 1
+        assert (
+            results["features"][0]["feature_set_index"]
+            == results["feature_set_digests"][0]["feature_set_index"]
+        )
+
+        response = await async_client.get(
             f"v1/projects/{project_name}/entities?name=ticker"
         )
         assert response.status_code == HTTPStatus.OK.value


### PR DESCRIPTION
in a new, v2 implementation.

Also eliminates duplication of feature set digest objects to further improve performance.

[ML-6765](https://iguazio.atlassian.net/browse/ML-6765)

Based on the same changes for `/entities` in https://github.com/mlrun/mlrun/pull/5729.

Contains the changes in https://github.com/mlrun/mlrun/pull/5748 which as of now is still open.

[ML-6765]: https://iguazio.atlassian.net/browse/ML-6765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ