### PR TITLE
[Model Monitoring] Fix redeploy a model with monitoring

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -312,15 +312,18 @@ class ServingRuntime(RemoteRuntime):
         sample: Optional[int] = None,
         stream_args: Optional[dict] = None,
         tracking_policy: Optional[Union["TrackingPolicy", dict]] = None,
+        enable_tracking: bool = True,
     ) -> None:
         """apply on your serving function to monitor a deployed model, including real-time dashboards to detect drift
            and analyze performance.
 
-        :param stream_path:     Path/url of the tracking stream e.g. v3io:///users/mike/mystream
-                                you can use the "dummy://" path for test/simulation.
-        :param batch:           Micro batch size (send micro batches of N records at a time).
-        :param sample:          Sample size (send only one of N records).
-        :param stream_args:     Stream initialization parameters, e.g. shards, retention_in_hours, ..
+        :param stream_path:         Path/url of the tracking stream e.g. v3io:///users/mike/mystream
+                                    you can use the "dummy://" path for test/simulation.
+        :param batch:               Micro batch size (send micro batches of N records at a time).
+        :param sample:              Sample size (send only one of N records).
+        :param stream_args:         Stream initialization parameters, e.g. shards, retention_in_hours, ..
+        :param enable_tracking:     Enabled/ Disable tracking on current serving runtime.
+                                    Default True (enabling tracking).
 
                                 example::
 
@@ -331,7 +334,7 @@ class ServingRuntime(RemoteRuntime):
 
         """
         # Applying model monitoring configurations
-        self.spec.track_models = True
+        self.spec.track_models = enable_tracking
 
         if stream_path:
             self.spec.parameters["log_stream"] = stream_path

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -322,8 +322,8 @@ class ServingRuntime(RemoteRuntime):
         :param batch:               Micro batch size (send micro batches of N records at a time).
         :param sample:              Sample size (send only one of N records).
         :param stream_args:         Stream initialization parameters, e.g. shards, retention_in_hours, ..
-        :param enable_tracking:     Enabled/ Disable tracking on current serving runtime.
-                                    Default True (enabling tracking).
+        :param enable_tracking:     Enabled/Disable model-monitoring tracking.
+                                    Default True (tracking enabled).
 
                                 example::
 

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -604,7 +604,5 @@ def _init_endpoint_record(
                 else mlrun.common.schemas.model_monitoring.ModelMonitoringMode.disabled
             },
         )
-        logger.info("Model monitoring is disabled for this model endpoint")
-        return None
 
     return uid

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -899,7 +899,12 @@ class TestAllKindOfServing(TestMLRunSystem):
 
     @classmethod
     def _deploy_model_serving(
-        cls, name: str, model_name: str, class_name: str, **kwargs
+        cls,
+        name: str,
+        model_name: str,
+        class_name: str,
+        enable_tracking: bool = True,
+        **kwargs,
     ) -> mlrun.runtimes.nuclio.serving.ServingRuntime:
         serving_fn = mlrun.code_to_function(
             project=cls.project_name,
@@ -912,7 +917,7 @@ class TestAllKindOfServing(TestMLRunSystem):
             model_path=f"store://models/{cls.project_name}/{model_name}:latest",
             class_name=class_name,
         )
-        serving_fn.set_tracking()
+        serving_fn.set_tracking(enable_tracking=enable_tracking)
         if cls.image is not None:
             serving_fn.spec.image = serving_fn.spec.build.image = cls.image
 
@@ -999,3 +1004,85 @@ class TestAllKindOfServing(TestMLRunSystem):
             assert res_dict[
                 "has_all_the_events"
             ], f"For {res_dict['model_name']} Not all the events were saved"
+
+
+class TestTracking(TestAllKindOfServing):
+    project_name = "test-tracking"
+    # Set image to "<repo>/mlrun:<tag>" for local testing
+    image: typing.Optional[str] = "docker.io/davesh0812/mlrun:1.7.0"
+
+    @classmethod
+    def custom_setup_class(cls) -> None:
+        cls.models = {
+            "int_one_to_one": {
+                "name": "serving_1",
+                "model_name": "int_one_to_one",
+                "class_name": "OneToOne",
+                "data_point": [1, 2, 3],
+                "schema": ["f0", "f1", "f2", "p0"],
+            },
+        }
+
+    def test_tracking(self) -> None:
+        self.project.enable_model_monitoring(
+            image=self.image or "mlrun/mlrun",
+            base_period=1,
+            deploy_histogram_data_drift_app=False,
+        )
+
+        for model_name, model_dict in self.models.items():
+            self._log_model(
+                model_name,
+                training_set=model_dict.get("training_set"),
+                label_column=model_dict.get("label_column"),
+            )
+            self._deploy_model_serving(**model_dict, enable_tracking=False)
+
+        self.db = mlrun.model_monitoring.get_store_object(project=self.project_name)
+        endpoints = self.db.list_model_endpoints()
+        assert len(endpoints) == 0
+
+        for model_name, model_dict in self.models.items():
+            self._deploy_model_serving(**model_dict, enable_tracking=True)
+
+        self.db = mlrun.model_monitoring.get_store_object(project=self.project_name)
+        endpoints = self.db.list_model_endpoints()
+        assert len(endpoints) == 1
+        endpoint = endpoints[0]
+        assert (
+            endpoint["monitoring_mode"]
+            == mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled
+        )
+
+        res_dict = self._test_endpoint(
+            model_name=endpoint[mm_constants.EventFieldType.MODEL].split(":")[0],
+            feature_set_uri=endpoint[mm_constants.EventFieldType.FEATURE_SET_URI],
+        )
+        assert res_dict[
+            "is_schema_saved"
+        ], f"For {res_dict['model_name']} the schema of parquet is missing columns"
+
+        assert res_dict[
+            "has_all_the_events"
+        ], f"For {res_dict['model_name']} Not all the events were saved"
+
+        for model_name, model_dict in self.models.items():
+            self._deploy_model_serving(**model_dict, enable_tracking=False)
+
+        self.db = mlrun.model_monitoring.get_store_object(project=self.project_name)
+        endpoints = self.db.list_model_endpoints()
+        assert len(endpoints) == 1
+        endpoint = endpoints[0]
+        assert (
+            endpoint["monitoring_mode"]
+            == mlrun.common.schemas.model_monitoring.ModelMonitoringMode.disabled
+        )
+
+        res_dict = self._test_endpoint(
+            model_name=endpoint[mm_constants.EventFieldType.MODEL].split(":")[0],
+            feature_set_uri=endpoint[mm_constants.EventFieldType.FEATURE_SET_URI],
+        )
+
+        assert res_dict[
+            "has_all_the_events"
+        ], f"For {res_dict['model_name']}, Despite tracking being disabled, there is new data in the parquet."

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1009,7 +1009,7 @@ class TestAllKindOfServing(TestMLRunSystem):
 class TestTracking(TestAllKindOfServing):
     project_name = "test-tracking"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "docker.io/davesh0812/mlrun:1.7.0"
+    image: typing.Optional[str] = None
 
     @classmethod
     def custom_setup_class(cls) -> None:


### PR DESCRIPTION
We will create MEP only when tracking is enabled. This is because MEP creation requires running set_model_monitoring_credentials(), and doing so beforehand could cause data store conflicts. 

Tracking can be enabled or disabled using set_tracking(enable_tracking=True/False), and redeployed accordingly.

https://iguazio.atlassian.net/browse/ML-4442