### PR TITLE
[Nuclio] Allow having api gateways with the same name in different projects

### DIFF
--- a/mlrun/common/helpers.py
+++ b/mlrun/common/helpers.py
@@ -42,6 +42,6 @@ def generate_api_gateway_name(project: str, name: str) -> str:
     :param project: project name
     :param name: api gateway name
 
-    :return: "{project}-{name}" if project name is given else name
+    :return: the resolved api gateway name
     """
     return f"{project}-{name}" if project else name

--- a/mlrun/common/helpers.py
+++ b/mlrun/common/helpers.py
@@ -34,3 +34,14 @@ def parse_versioned_object_uri(
         uri = uri[:loc]
 
     return project, uri, tag, hash_key
+
+
+def generate_api_gateway_name(project: str, name: str) -> str:
+    """
+    Generate a unique (within project) api gateway name
+    :param project: project name
+    :param name: api gateway name
+
+    :return: "{project}-{name}" if project name is given else name
+    """
+    return f"{project}-{name}" if project else name

--- a/mlrun/common/schemas/api_gateway.py
+++ b/mlrun/common/schemas/api_gateway.py
@@ -20,6 +20,7 @@ import pydantic
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.types
 from mlrun.common.constants import MLRUN_FUNCTIONS_ANNOTATION
+from mlrun.common.helpers import generate_api_gateway_name
 
 
 class APIGatewayAuthenticationMode(mlrun.common.types.StrEnum):
@@ -113,6 +114,8 @@ class APIGateway(_APIGatewayBaseModel):
 
     def _replace_nuclio_function_names_with_mlrun_names(self):
         # replace function names from nuclio names to mlrun names
+        # and adds mlrun function URI's to an api gateway annotations
+        # so when we then get api gateway entity from nuclio, we are able to get mlrun function names
         mlrun_functions = self.metadata.annotations.get(MLRUN_FUNCTIONS_ANNOTATION)
         if mlrun_functions:
             mlrun_function_uris = (
@@ -177,7 +180,7 @@ class APIGateway(_APIGatewayBaseModel):
             mlrun_constants.MLRunInternalLabels.nuclio_project_name
         )
         if project_name:
-            self.spec.name = f"{project_name}-{self.spec.name}"
+            self.spec.name = generate_api_gateway_name(project_name, self.spec.name)
             self.metadata.name = self.spec.name
         return self
 

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -128,10 +128,7 @@ async def store_api_gateway(
             project_name=project,
         )
         await client.store_api_gateway(
-            project_name=project,
-            api_gateway_name=gateway,
-            api_gateway=api_gateway,
-            create=create,
+            project_name=project, api_gateway=api_gateway, create=create
         )
         api_gateway = await client.get_api_gateway(
             name=gateway,

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -100,13 +100,13 @@ async def get_api_gateway(
 
 
 @router.put(
-    "/projects/{project}/api-gateways/{gateway}",
+    "/projects/{project}/api-gateways/{name}",
     response_model=mlrun.common.schemas.APIGateway,
     response_model_exclude_none=True,
 )
 async def store_api_gateway(
     project: str,
-    gateway: str,
+    name: str,
     api_gateway: mlrun.common.schemas.APIGateway,
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
 ):
@@ -118,31 +118,31 @@ async def store_api_gateway(
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.api_gateway,
         project,
-        gateway,
+        name,
         mlrun.common.schemas.AuthorizationAction.store,
         auth_info,
     )
     async with server.api.utils.clients.async_nuclio.Client(auth_info) as client:
         create = not await client.api_gateway_exists(
-            name=gateway,
+            name=name,
             project_name=project,
         )
         await client.store_api_gateway(
             project_name=project, api_gateway=api_gateway, create=create
         )
         api_gateway = await client.get_api_gateway(
-            name=gateway,
+            name=name,
             project_name=project,
         )
     return api_gateway
 
 
 @router.delete(
-    "/projects/{project}/api-gateways/{gateway}",
+    "/projects/{project}/api-gateways/{name}",
 )
 async def delete_api_gateway(
     project: str,
-    gateway: str,
+    name: str,
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
 ):
     await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
@@ -153,13 +153,13 @@ async def delete_api_gateway(
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.api_gateway,
         project,
-        gateway,
+        name,
         mlrun.common.schemas.AuthorizationAction.delete,
         auth_info,
     )
 
     async with server.api.utils.clients.async_nuclio.Client(auth_info) as client:
-        return await client.delete_api_gateway(project_name=project, name=gateway)
+        return await client.delete_api_gateway(project_name=project, name=name)
 
 
 @router.post("/projects/{project}/nuclio/{name}/deploy")

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -85,14 +85,11 @@ class Client:
         if project_name:
             headers[NUCLIO_PROJECT_NAME_HEADER] = project_name
 
-        logger.debug("Getting API Gateway", name=name, project_name=project_name)
-
         api_gateway = await self._send_request_to_api(
             method="GET",
             path=NUCLIO_API_GATEWAYS_ENDPOINT_TEMPLATE.format(api_gateway=name),
             headers=headers,
         )
-        logger.debug("Got API Gateway", api_gateway=api_gateway)
         return mlrun.common.schemas.APIGateway.parse_obj(
             api_gateway
         ).replace_nuclio_names_with_mlrun_names()

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -22,6 +22,7 @@ import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils
+from mlrun.common.helpers import generate_api_gateway_name
 from mlrun.utils import logger
 
 NUCLIO_API_SESSIONS_ENDPOINT = "/api/sessions/"
@@ -70,8 +71,7 @@ class Client:
 
     async def api_gateway_exists(self, name: str, project_name: str = None):
         # enrich api gateway name with project prefix
-        if project_name:
-            name = f"{project_name}-{name}"
+        name = generate_api_gateway_name(project_name, name)
 
         return name in await self.list_api_gateways(project_name=project_name)
 
@@ -79,8 +79,7 @@ class Client:
         headers = {}
 
         # enrich api gateway name with project prefix
-        if project_name:
-            name = f"{project_name}-{name}"
+        name = generate_api_gateway_name(project_name, name)
 
         if project_name:
             headers[NUCLIO_PROJECT_NAME_HEADER] = project_name
@@ -130,8 +129,7 @@ class Client:
         headers = {}
 
         # enrich api gateway name with project prefix
-        if project_name:
-            name = f"{project_name}-{name}"
+        name = generate_api_gateway_name(project_name, name)
 
         if project_name:
             headers[NUCLIO_PROJECT_NAME_HEADER] = project_name

--- a/tests/api/api/test_nuclio.py
+++ b/tests/api/api/test_nuclio.py
@@ -193,9 +193,7 @@ def test_mlrun_function_translation_to_nuclio(
             functions=functions, project=project_name
         ),
     )
-    api_gateway_server_side = (
-        api_gateway_client_side.to_scheme().enrich_mlrun_function_names()
-    )
+    api_gateway_server_side = api_gateway_client_side.to_scheme().enrich_mlrun_names()
     assert (
         api_gateway_server_side.get_function_names() == expected_nuclio_function_names
     )
@@ -205,7 +203,7 @@ def test_mlrun_function_translation_to_nuclio(
         == expected_mlrun_functions_label
     )
     api_gateway_with_replaced_nuclio_names_to_mlrun = (
-        api_gateway_server_side.replace_nuclio_names_with_mlrun_uri()
+        api_gateway_server_side.replace_nuclio_names_with_mlrun_names()
     )
     assert (
         api_gateway_with_replaced_nuclio_names_to_mlrun.get_function_names()

--- a/tests/api/utils/clients/test_async_nuclio.py
+++ b/tests/api/utils/clients/test_async_nuclio.py
@@ -99,13 +99,15 @@ async def test_nuclio_delete_api_gateway(
     nuclio_client,
     mock_aioresponse,
 ):
+    project_name = "default"
+    api_gateway_name = "test-basic"
     request_url = f"{api_url}/api/api_gateways/"
     mock_aioresponse.delete(
         request_url,
-        payload={"metadata": {"name": "test-basic"}},
+        payload={"metadata": {"name": f"{project_name}-{api_gateway_name}"}},
         status=http.HTTPStatus.NO_CONTENT,
     )
-    await nuclio_client.delete_api_gateway("test-basic", "default")
+    await nuclio_client.delete_api_gateway(api_gateway_name, project_name)
 
 
 @pytest.mark.asyncio
@@ -114,14 +116,16 @@ async def test_nuclio_store_api_gateway(
     nuclio_client,
     mock_aioresponse,
 ):
-    request_url = f"{api_url}/api/api_gateways/new-gw"
+    project_name = "default"
+    api_gateway_name = "new-gw"
+    request_url = f"{api_url}/api/api_gateways/{project_name}-{api_gateway_name}"
     api_gateway = mlrun.runtimes.nuclio.api_gateway.APIGateway(
         metadata=mlrun.runtimes.nuclio.api_gateway.APIGatewayMetadata(
-            name="new-gw",
+            name=api_gateway_name,
         ),
         spec=mlrun.runtimes.nuclio.api_gateway.APIGatewaySpec(
             functions=["test-func"],
-            project="default",
+            project=project_name,
         ),
     )
 
@@ -130,10 +134,10 @@ async def test_nuclio_store_api_gateway(
         status=http.HTTPStatus.ACCEPTED,
         payload=mlrun.common.schemas.APIGateway(
             metadata=mlrun.common.schemas.APIGatewayMetadata(
-                name="new-gw",
+                name=api_gateway_name,
             ),
             spec=mlrun.common.schemas.APIGatewaySpec(
-                name="new-gw",
+                name=api_gateway_name,
                 path="/",
                 host="test.host",
                 upstreams=[
@@ -145,7 +149,7 @@ async def test_nuclio_store_api_gateway(
         ).dict(),
     )
     await nuclio_client.store_api_gateway(
-        project_name="default", api_gateway=api_gateway.to_scheme()
+        project_name=project_name, api_gateway=api_gateway.to_scheme()
     )
 
 


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-6784

The goal of this PR is to unblock creation of api gateways with the same names, but in different project. I implemented this by populating a project name to an api gateway name on server side. 

BC tests failed because of changing the `gateway` to `name`, but it doesn't really break anything, because that's the 1st release when we introduce this feature.