### PR TITLE
[Error handling] Do not populate exception string when error message is given

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -92,9 +92,7 @@ def raise_for_status(
     try:
         response.raise_for_status()
     except (requests.HTTPError, aiohttp.ClientResponseError) as exc:
-        error_message = err_to_str(exc)
-        if message:
-            error_message = f"{error_message}: {message}"
+        error_message = err_to_str(exc) if not message else message
         status_code = (
             response.status_code
             if hasattr(response, "status_code")

--- a/server/api/utils/clients/async_nuclio.py
+++ b/server/api/utils/clients/async_nuclio.py
@@ -222,9 +222,7 @@ class Client:
 
         self._logger.warning("Request to nuclio failed. Reason:", **log_kwargs)
 
-        raise mlrun.errors.STATUS_ERRORS[response.status](
-            error_message, response=response
-        )
+        mlrun.errors.raise_for_status(response, error_message)
 
     def _enrich_nuclio_api_gateway(
         self,

--- a/tests/integration/sdk_api/httpdb/test_exception_handling.py
+++ b/tests/integration/sdk_api/httpdb/test_exception_handling.py
@@ -35,9 +35,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         # This is practically verifies that log_and_raise puts the kwargs under the details
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError,
-            match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/"
-            rf"{mlrun.get_run_db().get_api_path_prefix()}\/projects\/some-project\/artifacts\/some-uid\/some-key: "
-            "details: {'reason': 'bad JSON body'}",
+            match="details: {'reason': 'bad JSON body'}",
         ):
             mlrun.get_run_db().api_call(
                 "POST",
@@ -54,9 +52,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         )
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError,
-            match=rf"400 Client Error: Bad Request for url: http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix()}"
-            r"\/projects(.*): Failed creating project some_p"
-            r"roject details: MLRunInvalidArgumentError\(\"Field \'project\.metadata\.name\' is malformed"
+            match=rf"Field \'project\.metadata\.name\' is malformed"
             rf"\. \'{invalid_project_name}\' does not match required pattern: (.*)\"\)",
         ):
             mlrun.get_run_db().create_project(project)
@@ -67,9 +63,7 @@ class TestExceptionHandling(tests.integration.sdk_api.base.TestMLRunIntegration)
         invalid_deletion_strategy = "some_strategy"
         with pytest.raises(
             mlrun.errors.MLRunHTTPError,
-            match=r"422 Client Error: Unprocessable Entity for url: "
-            rf"http:\/\/(.*)\/{mlrun.get_run_db().get_api_path_prefix(version='v2')}\/projects\/some-project-name(.*): "
-            r"Failed deleting project some-project-name details: \[{'loc':"
+            match=r"Failed deleting project some-project-name details: \[{'loc':"
             r" \['header', 'x-mlrun-deletion-strategy'], 'msg': \"value is not a valid enumeration member; "
             r"permitted: 'restrict', 'restricted', 'cascade', 'cascading', 'check'\", 'type': 'type_error.enum',"
             r" 'ctx': {'enum_values': \['restrict', 'restricted', 'cascade', 'cascading', 'check']}}]",


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-6636

Old message example:
<img width="1084" alt="image" src="https://github.com/mlrun/mlrun/assets/35141662/66a801d1-a708-48f3-ac43-31d276896131">


New format:
<img width="1081" alt="image" src="https://github.com/mlrun/mlrun/assets/35141662/8fa605ce-e041-45bc-af28-d87ac74e4809">
