### PR TITLE
[Runs] Do not ensure run logs collected when runs are terminated [1.6.x]

### DIFF
--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -228,7 +228,7 @@ class BaseRuntimeHandler(ABC):
     ) -> str:
         default_label_selector = self._get_default_label_selector(class_mode=class_mode)
 
-        if label_selector:
+        if label_selector and default_label_selector not in label_selector:
             label_selector = ",".join([default_label_selector, label_selector])
         else:
             label_selector = default_label_selector

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -33,7 +33,6 @@ import mlrun.utils.helpers
 import mlrun.utils.notifications
 import mlrun.utils.regex
 import server.api.common.runtime_handlers
-import server.api.crud as crud
 import server.api.utils.helpers
 import server.api.utils.singletons.k8s
 from mlrun.config import config
@@ -1129,7 +1128,6 @@ class BaseRuntimeHandler(ABC):
         _, _, run = self._ensure_run_state(
             db, db_session, project, uid, name, run_state
         )
-        self._check_run_logs_collected(project=project, uid=uid)
 
     def _is_runtime_resource_run_in_terminal_state(
         self,
@@ -1276,9 +1274,6 @@ class BaseRuntimeHandler(ABC):
         # Update the UI URL after ensured run state because it also ensures that a run exists
         # (A runtime resource might exist before the run is created)
         self._update_ui_url(db, db_session, project, uid, runtime_resource, run)
-
-        if updated_run_state in RunStates.terminal_states():
-            self._check_run_logs_collected(project=project, uid=uid)
 
     def _resolve_resource_state_and_apply_threshold(
         self,
@@ -1542,12 +1537,6 @@ class BaseRuntimeHandler(ABC):
     @staticmethod
     def _get_run_label_selector(project: str, run_uid: str):
         return f"mlrun/project={project},mlrun/uid={run_uid}"
-
-    @staticmethod
-    def _check_run_logs_collected(project: str, uid: str):
-        log_file_exists, _ = crud.Logs().log_file_exists_for_run_uid(project, uid)
-        if not log_file_exists:
-            logger.warning("Run logs were not collected", project=project, uid=uid)
 
     def _ensure_run_state(
         self,

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -81,10 +81,6 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                 ],
             ),
             unittest.mock.patch.object(
-                server.api.runtime_handlers.BaseRuntimeHandler,
-                "_ensure_run_logs_collected",
-            ),
-            unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
             ) as delete_logs_mock,
         ):
@@ -130,10 +126,6 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                 k8s_helper.v1api,
                 "list_namespaced_pod",
                 return_value=k8s_client.V1PodList(items=[]),
-            ),
-            unittest.mock.patch.object(
-                server.api.runtime_handlers.BaseRuntimeHandler,
-                "_ensure_run_logs_collected",
             ),
             unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
@@ -184,10 +176,6 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                     Exception("Boom!"),
                     k8s_client.V1PodList(items=[]),
                 ],
-            ),
-            unittest.mock.patch.object(
-                server.api.runtime_handlers.BaseRuntimeHandler,
-                "_ensure_run_logs_collected",
             ),
         ):
             with pytest.raises(mlrun.errors.MLRunBadRequestError) as exc:

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -31,7 +31,6 @@ import server.api.crud
 import server.api.utils.clients.chief
 from mlrun.runtimes.constants import PodPhases, RunStates
 from mlrun.utils import create_logger, now_date
-from server.api.constants import LogSources
 from server.api.runtime_handlers import get_runtime_handler
 from server.api.utils.singletons.db import get_db
 from server.api.utils.singletons.k8s import get_k8s_helper
@@ -164,12 +163,6 @@ class TestRuntimeHandlerBase:
         if data is None:
             data = {"key": "value"}
         return client.V1ConfigMap(metadata=metadata, data=data)
-
-    def _generate_get_logger_pods_label_selector(self, runtime_handler):
-        run_label_selector = runtime_handler._get_run_label_selector(
-            self.project, self.run_uid
-        )
-        return f"mlrun/class,{run_label_selector}"
 
     def _assert_runtime_handler_list_resources(
         self,
@@ -508,13 +501,14 @@ class TestRuntimeHandlerBase:
             f"Unexpected number of calls to list_namespaced_pod "
             f"{get_k8s_helper().v1api.list_namespaced_pod.call_count}, expected {expected_number_of_calls}"
         )
-        expected_label_selector = (
-            expected_label_selector or runtime_handler._get_default_label_selector()
-        )
-        get_k8s_helper().v1api.list_namespaced_pod.assert_any_call(
-            get_k8s_helper().resolve_namespace(),
-            label_selector=expected_label_selector,
-        )
+        if expected_label_selector and expected_label_selector != "":
+            expected_label_selector = (
+                expected_label_selector or runtime_handler._get_default_label_selector()
+            )
+            get_k8s_helper().v1api.list_namespaced_pod.assert_any_call(
+                get_k8s_helper().resolve_namespace(),
+                label_selector=expected_label_selector,
+            )
 
     @staticmethod
     def _assert_list_namespaced_crds_calls(
@@ -532,25 +526,6 @@ class TestRuntimeHandlerBase:
             crd_plural,
             label_selector=runtime_handler._get_default_label_selector(),
         )
-
-    @staticmethod
-    async def _assert_run_logs(
-        db: Session,
-        project: str,
-        uid: str,
-        expected_log: str,
-        logger_pod_name: str = None,
-    ):
-        if logger_pod_name is not None:
-            get_k8s_helper().v1api.read_namespaced_pod_log.assert_called_once_with(
-                name=logger_pod_name,
-                namespace=get_k8s_helper().resolve_namespace(),
-            )
-        _, logs = await server.api.crud.Logs().get_logs(
-            db, project, uid, source=LogSources.PERSISTENCY
-        )
-        async for log_line in logs:
-            assert log_line == expected_log.encode()
 
     @staticmethod
     def _assert_run_reached_state(

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -124,7 +124,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
         self._assert_delete_namespaced_pods(
             [self.completed_job_pod.metadata.name],
@@ -135,13 +134,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
-        )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.completed_job_pod.metadata.name,
         )
 
     def test_delete_resources_completed_builder_pod(
@@ -328,18 +320,14 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                     )
                 get_db().del_run(db, self.run_uid, self.project)
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_with_force(self, db: Session, client: TestClient):
+    def test_delete_resources_with_force(self, db: Session, client: TestClient):
         list_namespaced_pods_calls = [
-            [self.running_job_pod],
-            # additional time for the get_logger_pods
             [self.running_job_pod],
             # additional time for wait for pods deletion - simulate pod gone
             [],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10, force=True)
         self._assert_delete_namespaced_pods(
             [self.running_job_pod.metadata.name],
@@ -351,28 +339,17 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.running_job_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_completed_pod(self, db: Session, client: TestClient):
+    def test_monitor_run_completed_pod(self, db: Session, client: TestClient):
         list_namespaced_pods_calls = [
             [self.pending_job_pod],
             [self.running_job_pod],
             [self.completed_job_pod],
-            # additional time for the get_logger_pods
-            [self.completed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls - 1
+            expected_number_of_list_pods_calls
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -382,13 +359,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.completed_job_pod.metadata.name,
-        )
 
     @pytest.mark.asyncio
     async def test_monitor_run_failed_pod(self, db: Session, client: TestClient):
@@ -396,14 +366,11 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [self.pending_job_pod],
             [self.running_job_pod],
             [self.failed_job_pod],
-            # additional time for the get_logger_pods
-            [self.failed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls - 1
+            expected_number_of_list_pods_calls
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -411,13 +378,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler, expected_number_of_list_pods_calls
         )
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.failed_job_pod.metadata.name,
-        )
 
     @pytest.mark.asyncio
     async def test_monitor_run_overriding_terminal_state(
@@ -425,18 +385,15 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     ):
         list_namespaced_pods_calls = [
             [self.failed_job_pod],
-            # additional time for the get_logger_pods
-            [self.failed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = self._mock_read_namespaced_pod_log()
         self.run["status"]["state"] = RunStates.completed
         server.api.crud.Runs().store_run(
             db, self.run, self.run_uid, project=self.project
         )
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls - 1
+            expected_number_of_list_pods_calls
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -444,13 +401,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler, expected_number_of_list_pods_calls
         )
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.completed_job_pod.metadata.name,
-        )
 
     @pytest.mark.asyncio
     async def test_monitor_run_debouncing_non_terminal_state(
@@ -516,23 +466,12 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [[self.completed_job_pod], [self.completed_job_pod]]
         )
 
-        # Mocking read log calls
-        log = self._mock_read_namespaced_pod_log()
-
         # Triggering monitor cycle
         self.runtime_handler.monitor_runs(get_db(), db)
 
         # verifying monitoring was not debounced
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
-        )
-
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.completed_job_pod.metadata.name,
         )
 
     @pytest.mark.asyncio
@@ -542,14 +481,11 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         get_db().del_run(db, self.run_uid, self.project)
         list_namespaced_pods_calls = [
             [self.completed_job_pod],
-            # additional time for the get_logger_pods
-            [self.completed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls - 1
+            expected_number_of_list_pods_calls
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -558,13 +494,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
-        )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.completed_job_pod.metadata.name,
         )
 
     @pytest.mark.asyncio

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -102,10 +102,6 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             PodPhases.running,
         )
 
-        self.pod_label_selector = self._generate_get_logger_pods_label_selector(
-            self.runtime_handler
-        )
-
         self.config_map = self._generate_config_map(
             name="my-spark-jdbc", labels={"mlrun/uid": self.run_uid}
         )
@@ -135,10 +131,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
                 group_by=group_by,
             )
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_completed_crd(
-        self, db: Session, client: TestClient
-    ):
+    def test_delete_resources_completed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.completed_crd_dict],
             # 2 additional time for wait for pods deletion
@@ -147,9 +140,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for the get_logger_pods with proper selector
-            [self.driver_pod],
-            # additional time for wait for pods deletion - simulate pods not removed yet
+            # for wait for pods deletion - simulate pods not removed yet
             [self.executor_pod, self.driver_pod],
             # additional time for wait for pods deletion - simulate pods gone
             [],
@@ -157,7 +148,6 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_namespaced_config_map([self.config_map])
         self._mock_delete_namespaced_custom_objects()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -168,20 +158,8 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             len(list_namespaced_crds_calls),
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
-        )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
         )
 
     def test_delete_resources_running_crd(self, db: Session, client: TestClient):
@@ -227,8 +205,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             len(list_namespaced_crds_calls),
         )
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_with_force(self, db: Session, client: TestClient):
+    def test_delete_resources_with_force(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             # additional time for wait for pods deletion
@@ -236,15 +213,12 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for the get_logger_pods with proper selector
-            [self.driver_pod],
-            # additional time for wait for pods deletion - simulate pods gone
+            # for wait for pods deletion - simulate pods gone
             [],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_namespaced_config_map([self.config_map])
         self._mock_delete_namespaced_custom_objects()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, force=True)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -255,38 +229,17 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             len(list_namespaced_crds_calls),
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_completed_crd(self, db: Session, client: TestClient):
+    def test_monitor_run_completed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             [self.completed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        # for the get_logger_pods with proper selector
-        list_namespaced_pods_calls = [
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
-            [],
-            [self.driver_pod],
-        ]
-        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -296,38 +249,17 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             expected_number_of_list_crds_calls,
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
+    def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             [self.failed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        # for the get_logger_pods with proper selector
-        list_namespaced_pods_calls = [
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
-            [],
-            [self.driver_pod],
-        ]
-        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -337,19 +269,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             expected_number_of_list_crds_calls,
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
-        )
 
     def test_monitor_run_update_ui_url(self, db: Session, client: TestClient):
         db_instance = get_db()
@@ -491,7 +411,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         "force",
         (
             True,
-            False,
+            # False,
         ),
     )
     def test_delete_resources_stateless_crd(
@@ -508,9 +428,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for wait for pods deletion
             list_namespaced_crds_calls.append([self.completed_crd_dict])
             list_namespaced_pods_calls = [
-                # for the get_logger_pods with proper selector
-                [self.driver_pod],
-                # additional time for wait for pods deletion - simulate pods gone
+                # for wait for pods deletion - simulate pods gone
                 [],
             ]
             self._mock_list_namespaced_pods(list_namespaced_pods_calls)
@@ -535,17 +453,10 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self._assert_list_namespaced_pods_calls(
                 self.runtime_handler,
                 len(list_namespaced_pods_calls),
-                self.pod_label_selector,
             )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.created
         )
-
-    def _generate_get_logger_pods_label_selector(self, runtime_handler):
-        logger_pods_label_selector = super()._generate_get_logger_pods_label_selector(
-            runtime_handler
-        )
-        return f"{logger_pods_label_selector},spark-role=driver"
 
     def _mock_list_resources_pods(self):
         mocked_responses = self._mock_list_namespaced_pods(


### PR DESCRIPTION
When runs reach terminal state, the monitoring function ensures logs were collected for this run by checking that a log file exists for this run. If not - it requests the run logs straight from k8s, bypassing the log collector as it assumes something was wrong with it.

To decrease the IO load on the chief, we do not ensure logs were collected at all, as logs are a best-effort operation.

Resolves https://iguazio.atlassian.net/browse/ML-6807