### PR TITLE
[API] Make healthz endpoint async [1.6.x]

### DIFF
--- a/server/api/api/endpoints/healthz.py
+++ b/server/api/api/endpoints/healthz.py
@@ -26,7 +26,7 @@ router = APIRouter()
     "/healthz",
     status_code=http.HTTPStatus.OK.value,
 )
-def health():
+async def health():
     # offline is the initial state
     # waiting for chief is set for workers waiting for chief to be ready and then clusterize against it
     if mlconfig.httpdb.state in [


### PR DESCRIPTION
fastapi spin a thread for any non-async endpoint. under high load, healthz endpoint will start failing very often waiting for threads availability from its pool.

https://iguazio.atlassian.net/issues/ML-6803