### PR TITLE
Revert "[API] Make healthz endpoint async [1.6.x]"

### DIFF
--- a/server/api/api/endpoints/healthz.py
+++ b/server/api/api/endpoints/healthz.py
@@ -26,7 +26,7 @@ router = APIRouter()
     "/healthz",
     status_code=http.HTTPStatus.OK.value,
 )
-async def health():
+def health():
     # offline is the initial state
     # waiting for chief is set for workers waiting for chief to be ready and then clusterize against it
     if mlconfig.httpdb.state in [


### PR DESCRIPTION
Reverts mlrun/mlrun#5763

seems like healthz failing more often when running on main eventloop rather than threadpool
to be investigated. for now, rolling back