### PR TITLE
[Runs] Do not enrich runs in server side launcher [1.6.x]

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -156,7 +156,7 @@ from .project import (
     ProjectSummary,
 )
 from .regex import RegexMatchModes
-from .runs import RunIdentifier
+from .runs import RunIdentifier, RunsFormat
 from .runtime_resource import (
     GroupedByJobRuntimeResourcesOutput,
     GroupedByProjectRuntimeResourcesOutput,

--- a/mlrun/common/schemas/runs.py
+++ b/mlrun/common/schemas/runs.py
@@ -27,6 +27,7 @@ class RunIdentifier(pydantic.BaseModel):
 
 # In 1.7 should be moved to mlrun.common.formatters.run.py
 class RunsFormat(mlrun.common.types.StrEnum):
+    # No enrichment, data is pulled as-is from the database.
     standard = "standard"
 
     # Performs run enrichment, including the run's artifacts. Only available for the `get` run API.

--- a/mlrun/common/schemas/runs.py
+++ b/mlrun/common/schemas/runs.py
@@ -25,9 +25,9 @@ class RunIdentifier(pydantic.BaseModel):
     iter: typing.Optional[int]
 
 
-# In 1.7 should be moved ro mlrun.common.formatters.run.py
+# In 1.7 should be moved to mlrun.common.formatters.run.py
 class RunsFormat(mlrun.common.types.StrEnum):
-    full = "full"
+    standard = "standard"
 
     # Performs run enrichment, including the run's artifacts. Only available for the `get` run API.
-    enriched = "enriched"
+    full = "full"

--- a/mlrun/common/schemas/runs.py
+++ b/mlrun/common/schemas/runs.py
@@ -16,8 +16,18 @@ import typing
 
 import pydantic
 
+import mlrun.common.types
+
 
 class RunIdentifier(pydantic.BaseModel):
     kind: typing.Literal["run"] = "run"
     uid: typing.Optional[str]
     iter: typing.Optional[int]
+
+
+# In 1.7 should be moved ro mlrun.common.formatters.run.py
+class RunsFormat(mlrun.common.types.StrEnum):
+    full = "full"
+
+    # Performs run enrichment, including the run's artifacts. Only available for the `get` run API.
+    enriched = "enriched"

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -53,7 +53,13 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def read_run(self, uid, project="", iter=0):
+    def read_run(
+        self,
+        uid: str,
+        project: str = "",
+        iter: int = 0,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -58,7 +58,7 @@ class RunDBInterface(ABC):
         uid: str,
         project: str = "",
         iter: int = 0,
-        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.full,
     ):
         pass
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -651,7 +651,7 @@ class HTTPRunDB(RunDBInterface):
         uid,
         project="",
         iter=0,
-        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.full,
     ):
         """Read the details of a stored run from the DB.
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -646,16 +646,26 @@ class HTTPRunDB(RunDBInterface):
             )
         return None
 
-    def read_run(self, uid, project="", iter=0):
+    def read_run(
+        self,
+        uid,
+        project="",
+        iter=0,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+    ):
         """Read the details of a stored run from the DB.
 
-        :param uid: The run's unique ID.
-        :param project: Project name.
-        :param iter: Iteration within a specific execution.
+        :param uid:         The run's unique ID.
+        :param project:     Project name.
+        :param iter:        Iteration within a specific execution.
+        :param format_:     The format in which to return the run details.
         """
 
         path = self._path_of("runs", project, uid)
-        params = {"iter": iter}
+        params = {
+            "iter": iter,
+            "format": format_.value,
+        }
         error = f"get run {project}/{uid}"
         resp = self.api_call("GET", path, error, params=params)
         return resp.json()["data"]

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -75,7 +75,7 @@ class NopDB(RunDBInterface):
         uid,
         project="",
         iter=0,
-        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.full,
     ):
         pass
 

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -70,7 +70,13 @@ class NopDB(RunDBInterface):
     def abort_run(self, uid, project="", iter=0, timeout=45, status_text=""):
         pass
 
-    def read_run(self, uid, project="", iter=0):
+    def read_run(
+        self,
+        uid,
+        project="",
+        iter=0,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+    ):
         pass
 
     def list_runs(

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -417,7 +417,7 @@ class BaseRuntime(ModelObj):
     def _get_db_run(
         self,
         task: RunObject = None,
-        run_format: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+        run_format: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.full,
     ):
         if self._get_db() and task:
             project = task.metadata.project
@@ -544,7 +544,7 @@ class BaseRuntime(ModelObj):
         resp: dict = None,
         task: RunObject = None,
         err: Union[Exception, str] = None,
-        run_format: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+        run_format: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.full,
     ) -> typing.Optional[dict]:
         """update the task state in the DB"""
         was_none = False

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -414,13 +414,19 @@ class BaseRuntime(ModelObj):
             state_thresholds=state_thresholds,
         )
 
-    def _get_db_run(self, task: RunObject = None):
+    def _get_db_run(
+        self,
+        task: RunObject = None,
+        run_format: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+    ):
         if self._get_db() and task:
             project = task.metadata.project
             uid = task.metadata.uid
             iter = task.metadata.iteration
             try:
-                return self._get_db().read_run(uid, project, iter=iter)
+                return self._get_db().read_run(
+                    uid, project, iter=iter, format_=run_format
+                )
             except mlrun.db.RunDBError:
                 return None
         if task:
@@ -537,13 +543,14 @@ class BaseRuntime(ModelObj):
         self,
         resp: dict = None,
         task: RunObject = None,
-        err=None,
+        err: Union[Exception, str] = None,
+        run_format: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
     ) -> typing.Optional[dict]:
         """update the task state in the DB"""
         was_none = False
         if resp is None and task:
             was_none = True
-            resp = self._get_db_run(task)
+            resp = self._get_db_run(task, run_format)
 
             if not resp:
                 self.store_run(task)

--- a/server/api/api/endpoints/runs.py
+++ b/server/api/api/endpoints/runs.py
@@ -135,7 +135,7 @@ async def get_run(
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
     format_: mlrun.common.schemas.RunsFormat = Query(
-        mlrun.common.schemas.RunsFormat.enriched, alias="format"
+        mlrun.common.schemas.RunsFormat.full, alias="format"
     ),
 ):
     data = await run_in_threadpool(

--- a/server/api/api/endpoints/runs.py
+++ b/server/api/api/endpoints/runs.py
@@ -134,9 +134,12 @@ async def get_run(
     iter: int = 0,
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
+    format_: mlrun.common.schemas.RunsFormat = Query(
+        mlrun.common.schemas.RunsFormat.enriched, alias="format"
+    ),
 ):
     data = await run_in_threadpool(
-        server.api.crud.Runs().get_run, db_session, uid, iter, project
+        server.api.crud.Runs().get_run, db_session, uid, iter, project, format_
     )
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.run,

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -142,14 +142,14 @@ class Runs(
         uid: str,
         iter: int,
         project: str = None,
-        format_: mlrun.common.schemas.RunsFormat = mlrun.common.schemas.RunsFormat.enriched,
+        format_: mlrun.common.schemas.RunsFormat = mlrun.common.schemas.RunsFormat.full,
     ) -> dict:
         project = project or mlrun.mlconf.default_project
         run = server.api.utils.singletons.db.get_db().read_run(
             db_session, uid, project, iter
         )
 
-        if format_ == mlrun.common.schemas.RunsFormat.enriched:
+        if format_ == mlrun.common.schemas.RunsFormat.full:
             self._enrich_run(db_session, iter, project, run, uid)
 
         return run

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -150,7 +150,7 @@ class Runs(
         )
 
         if format_ == mlrun.common.schemas.RunsFormat.full:
-            self._enrich_run(db_session, iter, project, run, uid)
+            self._enrich_run_artifacts(db_session, iter, project, run, uid)
 
         return run
 
@@ -489,7 +489,7 @@ class Runs(
             )
         return artifacts
 
-    def _enrich_run(
+    def _enrich_run_artifacts(
         self,
         db_session: sqlalchemy.orm.Session,
         iteration: int,

--- a/server/api/launcher.py
+++ b/server/api/launcher.py
@@ -162,7 +162,11 @@ class ServerSideLauncher(launcher.BaseLauncher):
                 last_err = err
 
             finally:
-                result = runtime._update_run_state(task=run, err=last_err)
+                result = runtime._update_run_state(
+                    task=run,
+                    err=last_err,
+                    run_format=mlrun.common.schemas.RunsFormat.full,
+                )
 
         self._save_notifications(run)
 

--- a/server/api/launcher.py
+++ b/server/api/launcher.py
@@ -165,7 +165,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
                 result = runtime._update_run_state(
                     task=run,
                     err=last_err,
-                    run_format=mlrun.common.schemas.RunsFormat.full,
+                    run_format=mlrun.common.schemas.RunsFormat.standard,
                 )
 
         self._save_notifications(run)

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -96,13 +96,20 @@ class SQLRunDB(RunDBInterface):
     def abort_run(self, uid, project="", iter=0, timeout=45, status_text=""):
         raise NotImplementedError()
 
-    def read_run(self, uid, project=None, iter=None):
+    def read_run(
+        self,
+        uid: str,
+        project: str = None,
+        iter: int = None,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+    ):
         return self._transform_db_error(
             server.api.crud.Runs().get_run,
             self.session,
             uid,
             iter,
             project,
+            format_,
         )
 
     def list_runs(

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -101,7 +101,7 @@ class SQLRunDB(RunDBInterface):
         uid: str,
         project: str = None,
         iter: int = None,
-        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.enriched,
+        format_: mlrun.common.schemas.runs.RunsFormat = mlrun.common.schemas.runs.RunsFormat.full,
     ):
         return self._transform_db_error(
             server.api.crud.Runs().get_run,

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -642,8 +642,8 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
     @pytest.mark.parametrize(
         "run_format",
         [
-            mlrun.common.schemas.RunsFormat.enriched,
             mlrun.common.schemas.RunsFormat.full,
+            mlrun.common.schemas.RunsFormat.standard,
         ],
     )
     def test_run_formats(
@@ -678,7 +678,7 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
         )
 
         expected_artifacts = artifacts
-        if run_format == mlrun.common.schemas.RunsFormat.full:
+        if run_format == mlrun.common.schemas.RunsFormat.standard:
             expected_artifacts = []
         self._validate_run_artifacts(
             expected_artifacts, db, project, run_uid, run_format=run_format
@@ -736,7 +736,7 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
             run_uid,
             iter,
             project,
-            format_=run_format or mlrun.common.schemas.RunsFormat.enriched,
+            format_=run_format or mlrun.common.schemas.RunsFormat.full,
         )
 
         enriched_artifacts = []

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -298,7 +298,7 @@ class RunDBMock:
 
         self._runs[uid] = struct
 
-    def read_run(self, uid, project, iter=0):
+    def read_run(self, uid, project, iter=0, format_=None):
         return self._runs.get(uid, {})
 
     def list_runs(


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6817

Artifacts are not required on the server side.
To decide whether enrichment is necessary, we have two formats for runs:

* Standard - no enrichment; data is pulled as-is from the database.
* Full - includes enriched artifacts.

Clients must use the Full format for backward compatibility.
