### PR TITLE
Revert "[Makefile] Specify docker repository explicitly (#5690)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ MLRUN_VERSION ?= unstable
 # if the provided version includes a "+" we replace it with "-" for the docker tag
 MLRUN_DOCKER_TAG ?= $(shell echo "$(MLRUN_VERSION)" | sed -E 's/\+/\-/g')
 MLRUN_DOCKER_REPO ?= mlrun
+# empty by default (dockerhub), can be set to something like "quay.io/".
 # This will be used to tag the images built using this makefile
-DOCKER_HUB ?= registry.hub.docker.com
-MLRUN_DOCKER_REGISTRY ?= $(DOCKER_HUB)/
+MLRUN_DOCKER_REGISTRY ?=
 # empty by default (use cache), set it to anything to disable caching (will add flags to pip and docker commands to
 # disable caching)
 MLRUN_NO_CACHE ?=
@@ -574,7 +574,7 @@ run-test-db:
 		--env MYSQL_ROOT_HOST=% \
 		--env MYSQL_DATABASE="mlrun" \
 		--detach \
-		$(DOCKER_HUB)/mysql/mysql-server:8.0 \
+		mysql/mysql-server:8.0 \
 		--character-set-server=utf8 \
 		--collation-server=utf8_bin
 


### PR DESCRIPTION
This reverts commit af02b489ea5bbc2822f191cc202847f48997e82e.

Now it's possible to pull images as usual without the explicit Docker hub registry specification.
This also makes the locally-built images have a friendlier repository name that can be pushed without retagging (e.g. `make mlrun`).