### PR TITLE
[Model Monitoring] Fix passing training stats instead of current stats

### DIFF
--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -193,7 +193,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
             status=status,
             extra_data={
                 EventFieldType.CURRENT_STATS: json.dumps(
-                    monitoring_context.feature_stats
+                    monitoring_context.sample_df_stats
                 ),
                 EventFieldType.DRIFT_MEASURES: metrics_per_feature.T.to_json(),
                 EventFieldType.DRIFT_STATUS: status.value,

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -492,11 +492,18 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
     def _test_model_endpoint_stats(cls, ep_id: str) -> None:
         cls._logger.debug("Checking model endpoint", ep_id=ep_id)
         ep = cls.run_db.get_model_endpoint(project=cls.project_name, endpoint_id=ep_id)
-        assert (
-            ep.status.current_stats.keys()
-            == ep.status.feature_stats.keys()
-            == set(ep.spec.feature_names)
-        ), "The endpoint current stats keys are not the same as feature stats and feature names"
+        assert ep.status.feature_stats.keys() == set(
+            ep.spec.feature_names
+        ), "The endpoint's feature stats keys are not the same as the feature names"
+        assert set(ep.status.current_stats.keys()) == set(
+            ep.status.feature_stats.keys()
+        ) | {
+            "timestamp",
+            "latency",
+            "error_count",
+            "metrics",
+            "p0",
+        }, "The endpoint's current stats is different than expected"
         assert ep.status.drift_status, "The general drift status is empty"
         assert ep.status.drift_measures, "The drift measures are empty"
 


### PR DESCRIPTION
Fixes [ML-6691](https://iguazio.atlassian.net/browse/ML-6691).

Add coverage in the unit tests and the system test. The system test passed.

[ML-6691]: https://iguazio.atlassian.net/browse/ML-6691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ