### PR TITLE
[Serving] Set event path to `/` when trigger is Kafka

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -383,6 +383,10 @@ def v2_serving_handler(context, event, get_body=False):
         if event.body == b"":
             event.body = None
 
+    # ML-6065 – workaround for NUC-178
+    if hasattr(event, "trigger") and event.trigger.kind in ("kafka", "kafka-cluster"):
+        event.path = "/"
+
     return context._server.run(event, context, get_body)
 
 

--- a/tests/system/runtimes/assets/child_function.py
+++ b/tests/system/runtimes/assets/child_function.py
@@ -18,6 +18,7 @@ class Identity:
 
 
 class Augment:
-    def do(self, x):
-        x["more_stuff"] = 5
-        return x
+    def do(self, event):
+        event.body["more_stuff"] = 5
+        event.body["path"] = event.path
+        return event

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -468,7 +468,11 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
         )
 
         graph.add_step(
-            name="other-child", class_name="Augment", after="q1", function="other-child"
+            name="other-child",
+            class_name="Augment",
+            after="q1",
+            function="other-child",
+            full_event=True,
         )
 
         graph["out"].after_step("other-child")
@@ -492,7 +496,7 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
         assert resp.status_code == 200
 
         expected_record = b'{"hello": "world"}'
-        expected_other_record = b'{"hello": "world", "more_stuff": 5}'
+        expected_other_record = b'{"hello": "world", "more_stuff": 5, "path": "/"}'
 
         self._logger.debug("Waiting for data to arrive in output topic")
         kafka_consumer.subscribe([self.topic_out])


### PR DESCRIPTION
[ML-6065](https://iguazio.atlassian.net/browse/ML-6065)

Workaround for [NUC-178](https://iguazio.atlassian.net/browse/NUC-178).

[ML-6065]: https://iguazio.atlassian.net/browse/ML-6065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NUC-178]: https://iguazio.atlassian.net/browse/NUC-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ