### PR TITLE
[Project] ensure_project: instead of list all projects, get project by name

### DIFF
--- a/server/api/utils/projects/member.py
+++ b/server/api/utils/projects/member.py
@@ -44,6 +44,7 @@ class Member(abc.ABC):
             db_session,
             format_=mlrun.common.formatters.ProjectFormat.name_only,
             leader_session=auth_info.session,
+            names=[name],
         )
         if name not in project_names.projects:
             raise mlrun.errors.MLRunNotFoundError(f"Project {name} does not exist")

--- a/server/api/utils/projects/member.py
+++ b/server/api/utils/projects/member.py
@@ -40,13 +40,18 @@ class Member(abc.ABC):
         wait_for_completion: bool = True,
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ):
-        project = self.get_project(
-            db_session,
-            format_=mlrun.common.formatters.ProjectFormat.name_only,
-            leader_session=auth_info.session,
-            from_leader=False,
-            name=name,
-        )
+        try:
+            project = self.get_project(
+                db_session,
+                format_=mlrun.common.formatters.ProjectFormat.name_only,
+                leader_session=auth_info.session,
+                from_leader=False,
+                name=name,
+            )
+        except mlrun.errors.MLRunNotFoundError:
+            project = None
+
+        # for custom description and for sanity check
         if not project:
             raise mlrun.errors.MLRunNotFoundError(f"Project {name} does not exist")
 

--- a/server/api/utils/projects/member.py
+++ b/server/api/utils/projects/member.py
@@ -40,13 +40,14 @@ class Member(abc.ABC):
         wait_for_completion: bool = True,
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ):
-        project_names = self.list_projects(
+        project = self.get_project(
             db_session,
             format_=mlrun.common.formatters.ProjectFormat.name_only,
             leader_session=auth_info.session,
-            names=[name],
+            from_leader=False,
+            name=name,
         )
-        if name not in project_names.projects:
+        if not project:
             raise mlrun.errors.MLRunNotFoundError(f"Project {name} does not exist")
 
     @abc.abstractmethod

--- a/server/api/utils/projects/remotes/nop_follower.py
+++ b/server/api/utils/projects/remotes/nop_follower.py
@@ -70,9 +70,9 @@ class Member(project_follower.Member):
     def get_project(
         self, session: sqlalchemy.orm.Session, name: str
     ) -> mlrun.common.schemas.Project:
-        # deep copy so we won't accidentally get changes from tests
         if name not in self._projects:
             raise mlrun.errors.MLRunNotFoundError(f"Project {name} does not exist")
+        # deep copy so we won't accidentally get changes from tests
         return self._projects[name].copy(deep=True)
 
     def list_projects(

--- a/server/api/utils/projects/remotes/nop_follower.py
+++ b/server/api/utils/projects/remotes/nop_follower.py
@@ -71,6 +71,8 @@ class Member(project_follower.Member):
         self, session: sqlalchemy.orm.Session, name: str
     ) -> mlrun.common.schemas.Project:
         # deep copy so we won't accidentally get changes from tests
+        if name not in self._projects:
+            raise mlrun.errors.MLRunNotFoundError(f"Project {name} does not exist")
         return self._projects[name].copy(deep=True)
 
     def list_projects(


### PR DESCRIPTION
In the ensure_project function, instead of getting all project names and then check programmatically if the project name exists,  add it to the sql query.

https://iguazio.atlassian.net/browse/ML-6840