### PR TITLE
[Artifacts] Ensure metadata dictionary when migrating legacy artifacts to v2

### DIFF
--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -577,7 +577,7 @@ def _migrate_artifacts_batch(
             link_artifact_ids.append(artifact.id)
             continue
 
-        artifact_metadata = artifact_dict.get("metadata", {})
+        artifact_metadata = artifact_dict.get("metadata", None) or {}
 
         # producer_id - the current uid value
         # uid can be in the metadata or in the artifact itself, or in the tree field

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -577,7 +577,7 @@ def _migrate_artifacts_batch(
             link_artifact_ids.append(artifact.id)
             continue
 
-        artifact_metadata = artifact_dict.get("metadata", None)
+        artifact_metadata = artifact_dict.get("metadata", {})
 
         # producer_id - the current uid value
         # uid can be in the metadata or in the artifact itself, or in the tree field
@@ -614,6 +614,7 @@ def _migrate_artifacts_batch(
 
         # to overcome issues with legacy artifacts with missing keys, we will set the key in the metadata
         if not artifact_metadata.get("key"):
+            artifact_dict.setdefault("metadata", {})
             artifact_dict["metadata"]["key"] = key
 
         # uid - calculate as the hash of the artifact object


### PR DESCRIPTION
If an old artifact is invalid in the db (doesn't have the expected fields in its `struct`), the `metadata` field can be empty even after converting it from legacy artifact.

Since we defaulted the metadata to `None` if doesn't exist, this can cause later `.get` calls to explode.
Defaulting to an empty dictionary fixes it.

Related to https://iguazio.atlassian.net/browse/ML-6795