### PR TITLE
[Artifacts] Reorder db operations when marking best iteration artifact [1.6.x]

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1068,8 +1068,10 @@ class SQLDB(DBInterface):
         if link_key:
             key = link_key
 
-        # use no_autoflush to avoid the session flushing between the 2 select queries, which can possibly
-        # cause deadlocks
+        # We perform two consecutive SELECT queries and modify the two artifact records that are returned.
+        # Without no_autoflush, SQLAlchemy offloads the transaction data to the DB during the second SELECT query,
+        # which can result in a deadlock due to assumed conflicts between the transactions.
+        # Using no_autoflush ensures that all modifications don't arrive to the DB until the transaction is committed.
         with session.no_autoflush:
             # get the best iteration artifact record
             query = self._query(session, ArtifactV2).filter(

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1057,6 +1057,8 @@ class SQLDB(DBInterface):
         link_artifact,
         uid=None,
     ):
+        artifacts_to_commit = []
+
         # get the artifact record from the db
         link_iteration = link_artifact.get("spec", {}).get("link_iteration")
         link_tree = link_artifact.get("spec", {}).get("link_tree") or link_artifact.get(
@@ -1065,45 +1067,50 @@ class SQLDB(DBInterface):
         link_key = link_artifact.get("spec", {}).get("link_key")
         if link_key:
             key = link_key
-        query = self._query(session, ArtifactV2).filter(
-            ArtifactV2.project == project,
-            ArtifactV2.key == key,
-            ArtifactV2.iteration == link_iteration,
-        )
-        if link_tree:
-            query = query.filter(ArtifactV2.producer_id == link_tree)
-        if uid:
-            query = query.filter(ArtifactV2.uid == uid)
 
-        artifact_record = query.one_or_none()
-        if not artifact_record:
-            raise mlrun.errors.MLRunNotFoundError(
-                f"Best iteration artifact not found - {project}/{key}:{link_iteration}",
+        # use no_autoflush to avoid the session flushing between the 2 select queries, which can possibly
+        # cause deadlocks
+        with session.no_autoflush:
+            # get the best iteration artifact record
+            query = self._query(session, ArtifactV2).filter(
+                ArtifactV2.project == project,
+                ArtifactV2.key == key,
+                ArtifactV2.iteration == link_iteration,
             )
+            if link_tree:
+                query = query.filter(ArtifactV2.producer_id == link_tree)
+            if uid:
+                query = query.filter(ArtifactV2.uid == uid)
 
-        # update the artifact record with best iteration
-        artifact_record.best_iteration = True
+            best_iteration_artifact_record = query.one_or_none()
+            if not best_iteration_artifact_record:
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Best iteration artifact not found - {project}/{key}:{link_iteration}",
+                )
 
-        artifacts_to_commit = [artifact_record]
+            # get the previous best iteration artifact
+            query = self._query(session, ArtifactV2).filter(
+                ArtifactV2.project == project,
+                ArtifactV2.key == key,
+                ArtifactV2.best_iteration,
+                ArtifactV2.iteration != link_iteration,
+            )
+            if link_tree:
+                query = query.filter(ArtifactV2.producer_id == link_tree)
 
-        # remove the best iteration flag from the previous best iteration artifact
-        query = self._query(session, ArtifactV2).filter(
-            ArtifactV2.project == project,
-            ArtifactV2.key == key,
-            ArtifactV2.best_iteration,
-            ArtifactV2.iteration != link_iteration,
-        )
-        if link_tree:
-            query = query.filter(ArtifactV2.producer_id == link_tree)
+            previous_best_iteration_artifacts = query.one_or_none()
+            if previous_best_iteration_artifacts:
+                # remove the previous best iteration flag
+                previous_best_iteration_artifacts.best_iteration = False
+                artifacts_to_commit.append(previous_best_iteration_artifacts)
 
-        previous_best_iteration_artifacts = query.one_or_none()
-        if previous_best_iteration_artifacts:
-            previous_best_iteration_artifacts.best_iteration = False
-            artifacts_to_commit.append(previous_best_iteration_artifacts)
+            # update the artifact record with best iteration
+            best_iteration_artifact_record.best_iteration = True
+            artifacts_to_commit.append(best_iteration_artifact_record)
 
         self._upsert(session, artifacts_to_commit)
 
-        return artifact_record.uid
+        return best_iteration_artifact_record.uid
 
     def _update_artifact_record_from_dict(
         self,


### PR DESCRIPTION
Previously, marking a best iteration artifact was done in the following flow:

1. Fetch the new best iteration artifact from the DB
2. Mark it with `best_iteration = True`
3. Fetch the previous best iteration artifact from the DB
4. Mark it with `best_iteration = False`
5. Commit the changes

We have seen cases where the query in (3) fails with the following DB error:
```
line 1099, in _mark_best_iteration_artifact\n    previous_best_iteration_artifacts = query.one_or_none()
sqlalchemy.exc.OperationalError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)\n(pymysql.err.OperationalError) (1213, \'Deadlock found when trying to get lock; try restarting transaction\')\n[SQL: UPDATE artifacts_v2 SET best_iteration=%(best_iteration)s WHERE artifacts_v2.id = %(artifacts_v2_id)s]\n[parameters: {\'best_iteration\': 1, \'artifacts_v2_id\': 189657}]\n(Background on this error at: https://sqlalche.me/e/14/e3q8)
```

This means that even when the change in (2) was not committed, the session has this information and tries to auto flush it before the next select - and causes a deadlock.

To fix it, we do the following in this PR:
1. Change the order - first fetch both artifacts from the DB, then update both of them, then commit.
2. We use `with session.no_autoflush` to make sure all changes will only happen when the session is committed.

Resolves https://iguazio.atlassian.net/browse/ML-6869