### PR TITLE
[Serving] Keep `event.path` and create new `event.target_path`

### DIFF
--- a/mlrun/runtimes/nuclio/nuclio.py
+++ b/mlrun/runtimes/nuclio/nuclio.py
@@ -44,7 +44,7 @@ def nuclio_jobs_init(context, data):
 
 
 def nuclio_jobs_handler(context, event):
-    paths = event.path.strip("/").split("/")
+    paths = event.target_path.strip("/").split("/")
 
     if not paths or paths[0] not in context.globals:
         return context.Response(

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -69,7 +69,7 @@ class RemoteStep(storey.SendToHttp):
 
 
         :param url:     http(s) url or function [project/]name to call
-        :param subpath: path (which follows the url), use `$path` to use the event.path
+        :param subpath: path (which follows the url), use `$path` to use the event.target_path
         :param method:  HTTP method (GET, POST, ..), default to POST
         :param headers: dictionary with http header values
         :param url_expression: an expression for getting the url from the event, e.g. "event['url']"
@@ -210,11 +210,11 @@ class RemoteStep(storey.SendToHttp):
             url = self._url_function_handler(body)
         else:
             url = self._endpoint
-            striped_path = event.path.lstrip("/")
+            striped_path = event.target_path.lstrip("/")
             if self._append_event_path:
                 url = url + "/" + striped_path
             if striped_path:
-                headers[event_path_key] = event.path
+                headers[event_path_key] = event.target_path
 
         if event.id:
             headers[event_id_key] = event.id

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -198,7 +198,7 @@ class ModelRouter(BaseModelRouter):
         return model, self.routes[model], subpath
 
     def _handle_event(self, event):
-        name, route, subpath = self._resolve_route(event.body, event.path)
+        name, route, subpath = self._resolve_route(event.body, event.target_path)
         if not route:
             # if model wasn't specified return model list
             setattr(event, "terminated", True)
@@ -206,7 +206,7 @@ class ModelRouter(BaseModelRouter):
             return event
 
         self.context.logger.debug(f"router run model {name}, op={subpath}")
-        event.path = subpath
+        event.target_path = subpath
         response = route.run(event)
         event.body = response.body if response else None
         return event
@@ -841,9 +841,9 @@ class VotingEnsemble(ParallelRun):
             return event
 
         # Extract route information
-        name, route, subpath = self._resolve_route(event.body, event.path)
+        name, route, subpath = self._resolve_route(event.body, event.target_path)
         self.context.logger.debug(f"router run model {name}, op={subpath}")
-        event.path = subpath
+        event.target_path = subpath
 
         # Return the correct response
         # If no model name was given and no operation

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -254,7 +254,7 @@ class GraphServer(ModelObj):
             if event_id_key in event.headers:
                 event.id = event.headers.get(event_id_key)
             if event_path_key in event.headers:
-                event.path = event.headers.get(event_path_key)
+                event.target_path = event.headers.get(event_path_key)
 
         if isinstance(event.body, (str, bytes)) and (
             not event.content_type or event.content_type in ["json", "application/json"]
@@ -384,8 +384,14 @@ def v2_serving_handler(context, event, get_body=False):
             event.body = None
 
     # ML-6065 – workaround for NUC-178
-    if hasattr(event, "trigger") and event.trigger.kind in ("kafka", "kafka-cluster"):
-        event.path = "/"
+    if hasattr(event, "trigger") and event.trigger.kind in (
+        "kafka",
+        "kafka-cluster",
+        "v3ioStream",
+    ):
+        event.target_path = "/"
+    else:
+        event.target_path = event.path
 
     return context._server.run(event, context, get_body)
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -838,7 +838,7 @@ class QueueStep(BaseStep):
             return event
 
         if self._stream:
-            self._stream.push({"id": event.id, "body": data, "path": event.path})
+            self._stream.push({"id": event.id, "body": data, "path": event.target_path})
             event.terminated = True
             event.body = None
         return event

--- a/mlrun/serving/v1_serving.py
+++ b/mlrun/serving/v1_serving.py
@@ -167,12 +167,15 @@ def nuclio_serving_handler(context, event):
             model_name = next(iter(context.models))
             route = "predict"
         else:
-            model_name, route = event.path.strip("/").split("/")
+            model_name, route = event.target_path.strip("/").split("/")
         route = context.router[route]
     except Exception:
         actions = "|".join(context.router.keys())
         models = "|".join(context.models.keys())
-        body = f"Got path: {event.path} \n Path must be <model-name>/<action> \nactions: {actions} \nmodels: {models}"
+        body = (
+            f"Got path: {event.target_path} \n "
+            f"Path must be <model-name>/<action> \nactions: {actions} \nmodels: {models}"
+        )
         return context.Response(
             body=body,
             content_type="text/plain",

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -231,7 +231,7 @@ class V2ModelServer(StepToDict):
         original_body = event.body
         event_body = _extract_input_data(self._input_path, event.body)
         event_id = event.id
-        op = event.path.strip("/")
+        op = event.target_path.strip("/")
         if event_body and isinstance(event_body, dict):
             op = op or event_body.get("operation")
             event_id = event_body.get("id", event_id)


### PR DESCRIPTION
This fixes explicit ack following #5771 ([ML-6863](https://iguazio.atlassian.net/browse/ML-6863)), and also fixes [ML-6868](https://iguazio.atlassian.net/browse/ML-6868).

[ML-6863]: https://iguazio.atlassian.net/browse/ML-6863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-6868]: https://iguazio.atlassian.net/browse/ML-6868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ