### PR TITLE
[Dependabot] Add a basic Dependabot config to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
See:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

Depedanbot is an automatic dependency updater.
Start for now with GitHub Actions updates.

For example, consider the CI workflow: `.github/workflows/ci.yaml`. The following marketplace actions are used in it:

* `actions/checkout@v3` - v4 is available.
* `actions/setup-python@v4` - v5 is available.

Dependabot will detect these outdated dependencies and will create PRs to update them.

In the future, we may extend Dependabot to update also Python dependencies. Such controlled and automatic updates will prevent complex bulk updates, such as https://github.com/mlrun/mlrun/pull/5664.