### PR TITLE
[Alerts] Set criteria to defaults if not provided

### DIFF
--- a/mlrun/common/schemas/alert.py
+++ b/mlrun/common/schemas/alert.py
@@ -104,7 +104,7 @@ class AlertCriteria(pydantic.BaseModel):
         pydantic.Field(
             description="Number of events to wait until notification is sent"
         ),
-    ] = 0
+    ] = 1
     period: Annotated[
         str,
         pydantic.Field(

--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -45,6 +45,9 @@ class Alerts(
 
         self._validate_alert(alert_data, name, project)
 
+        if alert_data.criteria is None:
+            alert_data.criteria = mlrun.common.schemas.alert.AlertCriteria()
+
         if alert is not None:
             self._delete_notifications(alert)
         else:

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -74,6 +74,8 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         # get alert and validate params
         alert = self._get_alerts(project_name, created_alert.name)
         self._validate_alert(alert, project_name, alert1["name"])
+        assert alert.criteria["count"] == 1
+        assert alert.criteria["period"] is None
 
         # try to get non existent alert ID
         with pytest.raises(mlrun.errors.MLRunNotFoundError):


### PR DESCRIPTION
https://iguazio.atlassian.net/issues/ML-6857

When user does not provide criteria, set it to defaults in order to be more explicit when user gets the object back