### PR TITLE
[Linting] Check syntax and format code blocks in markdown with blacken-docs 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,7 @@ For example:
 import pytest
 from tests.system.base import TestMLRunSystem
 
+
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestSomeFunctionality(TestMLRunSystem):
@@ -199,6 +200,7 @@ Example of a suite with two tests, one of them meant for enterprise only
 ```python
 import pytest
 from tests.system.base import TestMLRunSystem
+
 
 @TestMLRunSystem.skip_test_if_env_not_configured
 class TestSomeFunctionality(TestMLRunSystem):
@@ -216,15 +218,16 @@ If some setup or teardown is required for the tests in the suite, add these foll
 ```python
 from tests.system.base import TestMLRunSystem
 
+
 @TestMLRunSystem.skip_test_if_env_not_configured
 class TestSomeFunctionality(TestMLRunSystem):
-    
+
     def custom_setup(self):
         pass
-    
+
     def custom_teardown(self):
         pass
-    
+
     def test_the_functionality(self):
         pass
 ```

--- a/Makefile
+++ b/Makefile
@@ -601,13 +601,18 @@ fmt: ## Format the code using Ruff
 	python -m ruff check --fix-only
 	python -m ruff format
 
+.PHONY: fmt-docs
+fmt-docs: ## Format the code blocks in markdown files
+	@echo "Formatting the docs"
+	git ls-files -z -- '*.md' | xargs -0 blacken-docs -t=py39
+
 .PHONY: lint-imports
 lint-imports: ## Validates import dependencies
 	@echo "Running import linter"
 	lint-imports
 
 .PHONY: lint
-lint: lint-check lint-imports ## Run lint on the code
+lint: lint-check lint-imports fmt-docs ## Run lint on the code
 
 .PHONY: lint-check
 lint-check: ## Check the code (using ruff)

--- a/Makefile
+++ b/Makefile
@@ -596,14 +596,17 @@ html-docs-dockerized: build-test ## Build html docs dockerized
 		make html-docs
 
 .PHONY: fmt
-fmt: ## Format the code using Ruff
+fmt: ## Format the code using Ruff and blacken-docs
 	@echo "Running ruff checks and fixes..."
 	python -m ruff check --fix-only
 	python -m ruff format
+	@echo "Formatting the code blocks with blacken-docs..."
+	git ls-files -z -- '*.md' | xargs -0 blacken-docs -t=py39
 
-.PHONY: fmt-docs
-fmt-docs: ## Format the code blocks in markdown files
-	@echo "Formatting the docs"
+.PHONY: lint-docs
+lint-docs: ## Format the code blocks in markdown files
+# TODO: use the `--check` flag when blacken-docs 1.17 is released
+	@echo "Checking the code blocks with blacken-docs"
 	git ls-files -z -- '*.md' | xargs -0 blacken-docs -t=py39
 
 .PHONY: lint-imports
@@ -612,7 +615,7 @@ lint-imports: ## Validates import dependencies
 	lint-imports
 
 .PHONY: lint
-lint: lint-check lint-imports fmt-docs ## Run lint on the code
+lint: lint-check lint-imports lint-docs ## Run lint on the code
 
 .PHONY: lint-check
 lint-check: ## Check the code (using ruff)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ build~=1.0
 # formatting & linting
 ruff==0.4.2
 import-linter~=2.0
+blacken-docs~=1.16
 
 # testing
 pytest~=8.2

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -72,10 +72,12 @@ Docs: [Create, save, and use projects](./projects/create-project.html)
 project = mlrun.get_or_create_project(name="my-project", context="./")
 
 # Add a function to the project
-project.set_function(name='train_model', func='train_model.py', kind='job', image='mlrun/mlrun')
+project.set_function(
+    name="train_model", func="train_model.py", kind="job", image="mlrun/mlrun"
+)
 
 # Add aworkflow (pipeline) to the project
-project.set_workflow(name='training_pipeline', workflow_path='straining_pipeline.py')
+project.set_workflow(name="training_pipeline", workflow_path="straining_pipeline.py")
 
 # Save the project and generate the project.yaml file
 project.save()
@@ -95,8 +97,11 @@ An MLRun project can be backed by a Git repo. Functions consume the repo and pul
 project.set_source(source="git://github.com/mlrun/project-archive.git")
 
 fn = project.set_function(
-    name="myjob", handler="job_func.job_handler",
-    image="mlrun/mlrun", kind="job", with_repo=True,
+    name="myjob",
+    handler="job_func.job_handler",
+    image="mlrun/mlrun",
+    kind="job",
+    with_repo=True,
 )
 
 project.build_function(fn)
@@ -105,11 +110,16 @@ project.build_function(fn)
 #### Pull the repo code at runtime
 
 ```python
-project.set_source(source="git://github.com/mlrun/project-archive.git", pull_at_runtime=True)
+project.set_source(
+    source="git://github.com/mlrun/project-archive.git", pull_at_runtime=True
+)
 
 fn = project.set_function(
-    name="nuclio", handler="nuclio_func:nuclio_handler",
-    image="mlrun/mlrun", kind="nuclio", with_repo=True,
+    name="nuclio",
+    handler="nuclio_func:nuclio_handler",
+    image="mlrun/mlrun",
+    kind="nuclio",
+    with_repo=True,
 )
 ```
 
@@ -167,7 +177,7 @@ Docs: [Working with secrets](./secrets.html)
 
 ```python
 # Add secrets to the project
-project.set_secrets(secrets={'AWS_KEY': '111222333'}, provider="kubernetes")
+project.set_secrets(secrets={"AWS_KEY": "111222333"}, provider="kubernetes")
 
 # Run the job with all secrets (automatically injects all project secrets for non-local runtimes)
 project.run_function(fn)
@@ -185,7 +195,9 @@ Docs: [Kinds of functions (runtimes)](./concepts/functions-overview.html)
 
 ```python
 # Job - run once to completion
-job = project.set_function(name="my-job", func="my_job.py", kind="job", image="mlrun/mlrun", handler="handler")
+job = project.set_function(
+    name="my-job", func="my_job.py", kind="job", image="mlrun/mlrun", handler="handler"
+)
 project.run_function(job)
 ```
 
@@ -193,7 +205,13 @@ project.run_function(job)
 
 ```python
 # Nuclio - generic real-time function to do something when triggered
-nuclio = project.set_function(name="my-nuclio", func="my_nuclio.py", kind="nuclio", image="mlrun/mlrun", handler="handler")
+nuclio = project.set_function(
+    name="my-nuclio",
+    func="my_nuclio.py",
+    kind="nuclio",
+    image="mlrun/mlrun",
+    handler="handler",
+)
 project.deploy_function(nuclio)
 ```
 
@@ -201,8 +219,18 @@ project.deploy_function(nuclio)
 
 ```python
 # Serving - specialized Nuclio function specifically for model serving
-serving = project.set_function(name="my-serving", func="my_serving.py", kind="serving", image="mlrun/mlrun", handler="handler")
-serving.add_model(key="iris", model_path="https://s3.wasabisys.com/iguazio/models/iris/model.pkl", model_class="ClassifierModel")
+serving = project.set_function(
+    name="my-serving",
+    func="my_serving.py",
+    kind="serving",
+    image="mlrun/mlrun",
+    handler="handler",
+)
+serving.add_model(
+    key="iris",
+    model_path="https://s3.wasabisys.com/iguazio/models/iris/model.pkl",
+    model_class="ClassifierModel",
+)
 project.deploy_function(serving)
 ```
 
@@ -212,7 +240,13 @@ Docs: [Kinds of functions (runtimes)](./concepts/functions-overview.html)
 #### MPIJob (Horovod)
 
 ```python
-mpijob = mlrun.code_to_function(name="my-mpijob", filename="my_mpijob.py", kind="mpijob", image="mlrun/mlrun", handler="handler")
+mpijob = mlrun.code_to_function(
+    name="my-mpijob",
+    filename="my_mpijob.py",
+    kind="mpijob",
+    image="mlrun/mlrun",
+    handler="handler",
+)
 mpijob.spec.replicas = 3
 mpijob.run()
 ```
@@ -223,7 +257,7 @@ mpijob.run()
 dask = mlrun.new_function(name="my-dask", kind="dask", image="mlrun/ml-base")
 dask.spec.remote = True
 dask.spec.replicas = 5
-dask.spec.service_type = 'NodePort'
+dask.spec.service_type = "NodePort"
 dask.with_worker_limits(mem="6G")
 dask.with_scheduler_limits(mem="1G")
 dask.spec.nthreads = 5
@@ -235,18 +269,19 @@ dask.client
 
 ```python
 import os
-read_csv_filepath = os.path.join(os.path.abspath('.'), 'spark_read_csv.py')
 
-spark = mlrun.new_function(kind='spark', command=read_csv_filepath, name='sparkreadcsv') 
+read_csv_filepath = os.path.join(os.path.abspath("."), "spark_read_csv.py")
+
+spark = mlrun.new_function(kind="spark", command=read_csv_filepath, name="sparkreadcsv")
 spark.with_driver_limits(cpu="1300m")
-spark.with_driver_requests(cpu=1, mem="512m") 
+spark.with_driver_requests(cpu=1, mem="512m")
 spark.with_executor_limits(cpu="1400m")
 spark.with_executor_requests(cpu=1, mem="512m")
-spark.with_igz_spark() 
-spark.spec.replicas = 2 
+spark.with_igz_spark()
+spark.spec.replicas = 2
 
-spark.deploy() # build image
-spark.run(artifact_path='/User') # run spark job
+spark.deploy()  # build image
+spark.run(artifact_path="/User")  # run spark job
 ```
 
 ### Resource management
@@ -275,14 +310,20 @@ fn.spec.max_replicas = 4
 
 ```python
 # Nuclio/serving scaling
-fn.spec.min_replicas = 0    # zero value is mandatory for scale to zero
+fn.spec.min_replicas = 0  # zero value is mandatory for scale to zero
 fn.spec.max_replicas = 2
 
 # Scaling to zero in case of 30 minutes (idle-time duration)
-fn.set_config(key="spec.scaleToZero.scaleResources",
-              value=[{"metricName":"nuclio_processor_handled_events_total",
-                      "windowSize" : "30m",     # default values are 1m, 2m, 5m, 10m, 30m
-                      "threshold" : 0}])
+fn.set_config(
+    key="spec.scaleToZero.scaleResources",
+    value=[
+        {
+            "metricName": "nuclio_processor_handled_events_total",
+            "windowSize": "30m",  # default values are 1m, 2m, 5m, 10m, 30m
+            "threshold": 0,
+        }
+    ],
+)
 ```
 
 #### Mount persistent storage
@@ -292,7 +333,11 @@ fn.set_config(key="spec.scaleToZero.scaleResources",
 fn.apply(mlrun.mount_v3io())
 
 # Mount PVC
-fn.apply(mlrun.platforms.mount_pvc(pvc_name="data-claim", volume_name="data", volume_mount_path="/data"))
+fn.apply(
+    mlrun.platforms.mount_pvc(
+        pvc_name="data-claim", volume_name="data", volume_mount_path="/data"
+    )
+)
 ```
 
 #### Pod priority
@@ -304,7 +349,7 @@ fn.with_priority_class(name="igz-workload-medium")
 #### Node selection
 
 ```python
-fn.with_node_selection(node_selector={"app.iguazio.com/lifecycle" : "non-preemptible"})
+fn.with_node_selection(node_selector={"app.iguazio.com/lifecycle": "non-preemptible"})
 ```
 
 ### Serving/Nuclio triggers
@@ -323,18 +368,31 @@ If you didn't set this parameter explicitly, the value is taken from [Nuclio pla
 
 ```python
 import nuclio
-serve = mlrun.import_function('hub://v2_model_server')
 
-# Set amount of workers 
+serve = mlrun.import_function("hub://v2_model_server")
+
+# Set amount of workers
 serve.with_http(workers=8, worker_timeout=10)
 
 # V3IO stream trigger
-serve.add_v3io_stream_trigger(stream_path='v3io:///projects/myproj/stream1', name='stream', group='serving', seek_to='earliest', shards=1)
+serve.add_v3io_stream_trigger(
+    stream_path="v3io:///projects/myproj/stream1",
+    name="stream",
+    group="serving",
+    seek_to="earliest",
+    shards=1,
+)
 
 # Kafka stream trigger
 serve.add_trigger(
     name="kafka",
-    spec=nuclio.KafkaTrigger(brokers=["192.168.1.123:39092"], topics=["TOPIC"], partitions=4, consumer_group="serving", initial_offset="earliest")
+    spec=nuclio.KafkaTrigger(
+        brokers=["192.168.1.123:39092"],
+        topics=["TOPIC"],
+        partitions=4,
+        consumer_group="serving",
+        initial_offset="earliest",
+    ),
 )
 
 # Cron trigger
@@ -354,8 +412,12 @@ Docs: [Build function image](./runtimes/image-build.html), [Images and their usa
 
 ```python
 project.set_function(
-   "train_code.py", name="trainer", kind="job",
-   image="mlrun/mlrun", handler="train_func", requirements=["pandas==1.3.5"]
+    "train_code.py",
+    name="trainer",
+    kind="job",
+    image="mlrun/mlrun",
+    handler="train_func",
+    requirements=["pandas==1.3.5"],
 )
 
 project.build_function(
@@ -363,10 +425,10 @@ project.build_function(
     # Specify base image
     base_image="myrepo/base_image:latest",
     # Run arbitrary commands
-    commands= [
+    commands=[
         "pip install git+https://github.com/myusername/myrepo.git@mybranch",
-        "mkdir -p /some/path && chmod 0777 /some/path",    
-    ]
+        "mkdir -p /some/path && chmod 0777 /some/path",
+    ],
 )
 ```
 
@@ -374,11 +436,15 @@ project.build_function(
 
 ```python
 project.set_function(
-   "train_code.py", name="trainer", kind="job",
-   image="mlrun/mlrun", handler="train_func", requirements=["pandas==1.3.5"]
+    "train_code.py",
+    name="trainer",
+    kind="job",
+    image="mlrun/mlrun",
+    handler="train_func",
+    requirements=["pandas==1.3.5"],
 )
 
-# auto_build will trigger building the image before running, 
+# auto_build will trigger building the image before running,
 # due to the additional requirements.
 project.run_function("trainer", auto_build=True)
 ```
@@ -395,32 +461,33 @@ from kfp import dsl
 import mlrun
 import nuclio
 
+
 # Create a Kubeflow Pipelines pipeline
 @dsl.pipeline(
     name="batch-pipeline",
-    description="Example of batch pipeline for heart disease dataset"
+    description="Example of batch pipeline for heart disease dataset",
 )
 def pipeline(source_url, label_column):
-    
+
     # Get current project
     project = mlrun.get_current_project()
-    
+
     # Ingest the data set
     ingest = mlrun.run_function(
-        'get-data',
-        handler='prep_data',
-        inputs={'source_url': source_url},
-        params={'label_column': label_column},
-        outputs=["cleaned_data"]
+        "get-data",
+        handler="prep_data",
+        inputs={"source_url": source_url},
+        params={"label_column": label_column},
+        outputs=["cleaned_data"],
     )
-    
-    # Train a model   
+
+    # Train a model
     train = mlrun.run_function(
         "train",
         handler="train_model",
         inputs={"dataset": ingest.outputs["cleaned_data"]},
         params={"label_column": label_column},
-        outputs=['model']
+        outputs=["model"],
     )
 ```
 
@@ -428,11 +495,13 @@ def pipeline(source_url, label_column):
 
 ```python
 # Functions within the workflow
-project.set_function(name='get-data', func='get_data.py', kind='job', image='mlrun/mlrun')
-project.set_function(name='train', func='train.py', kind='job', image='mlrun/mlrun')
+project.set_function(
+    name="get-data", func="get_data.py", kind="job", image="mlrun/mlrun"
+)
+project.set_function(name="train", func="train.py", kind="job", image="mlrun/mlrun")
 
 # Workflow
-project.set_workflow(name='main', workflow_path='pipeline.py')
+project.set_workflow(name="main", workflow_path="pipeline.py")
 
 project.save()
 ```
@@ -444,9 +513,9 @@ Python SDK
 run_id = project.run(
     name="main",
     arguments={
-        "source_url" : "store://feature-vectors/heart-disease-classifier/heart-disease-vec:latest",
-        "label_column" : "target"
-    }
+        "source_url": "store://feature-vectors/heart-disease-classifier/heart-disease-vec:latest",
+        "label_column": "target",
+    },
 )
 ```
 
@@ -463,10 +532,10 @@ mlrun project --run main \
 run_id = project.run(
     name="main",
     arguments={
-        "source_url" : "store://feature-vectors/heart-disease-classifier/heart-disease-vec:latest",
-        "label_column" : "target"
+        "source_url": "store://feature-vectors/heart-disease-classifier/heart-disease-vec:latest",
+        "label_column": "target",
     },
-    schedule="0 * * * *"
+    schedule="0 * * * *",
 )
 ```
 
@@ -475,10 +544,12 @@ run_id = project.run(
 Docs: [MLRun execution context](./concepts/mlrun-execution-context.html)
 
 ```python
-context.logger.debug(message="Debugging info")              # logging all (debug, info, warning, error)
-context.logger.info(message="Something happened")           # logging info, warning and error
+context.logger.debug(
+    message="Debugging info"
+)  # logging all (debug, info, warning, error)
+context.logger.info(message="Something happened")  # logging info, warning and error
 context.logger.warning(message="Something might go wrong")  # logging warning and error
-context.logger.error(message="Something went wrong")        # logging only error
+context.logger.error(message="Something went wrong")  # logging only error
 ```
 
 ```{admonition} Note
@@ -527,14 +598,14 @@ from mlrun.frameworks.sklearn import apply_mlrun
 apply_mlrun(model=model, model_name="my_model", x_test=X_test, y_test=y_test)
 model.fit(X_train, y_train)
 
+
 # MLRun decorator for input/output parsing
-@mlrun.handler(labels={'framework':'scikit-learn'},
-               outputs=['prediction:dataset'],
-               inputs={"train_data": pd.DataFrame,
-                       "predict_input": pd.DataFrame})
-def train_and_predict(train_data,
-                      predict_input,
-                      label_column='label'):
+@mlrun.handler(
+    labels={"framework": "scikit-learn"},
+    outputs=["prediction:dataset"],
+    inputs={"train_data": pd.DataFrame, "predict_input": pd.DataFrame},
+)
+def train_and_predict(train_data, predict_input, label_column="label"):
 
     x = train_data.drop(label_column, axis=1)
     y = train_data[label_column]
@@ -553,8 +624,10 @@ Docs: [Deploy models and applications](./deployment/index.html)
 Docs: [Using built-in model serving classes](./serving/built-in-model-serving.html), [Build your own model serving class](./serving/custom-model-serving-class.html), [Model serving API](./serving/model-api.html)
 
 ```python
-serve = mlrun.import_function('hub://v2_model_server')
-serve.add_model(key="iris", model_path="https://s3.wasabisys.com/iguazio/models/iris/model.pkl")
+serve = mlrun.import_function("hub://v2_model_server")
+serve.add_model(
+    key="iris", model_path="https://s3.wasabisys.com/iguazio/models/iris/model.pkl"
+)
 
 # Deploy to local mock server (Development testing)
 mock_server = serve.to_mock_server()
@@ -586,8 +659,12 @@ Docs: [Model monitoring overview](./monitoring/model-monitoring-deployment.html)
 context.log_model("model", model_file="model.pkl", training_set=X_train)
 
 # Enable tracking for the model server
-serving_fn = import_function('hub://v2_model_server', project=project_name).apply(auto_mount())
-serving_fn.add_model("model", model_path="store://models/project-name/model:latest") # Model path comes from experiment tracking DB
+serving_fn = import_function("hub://v2_model_server", project=project_name).apply(
+    auto_mount()
+)
+serving_fn.add_model(
+    "model", model_path="store://models/project-name/model:latest"
+)  # Model path comes from experiment tracking DB
 serving_fn.set_tracking()
 
 # Deploy the model server
@@ -600,15 +677,12 @@ serving_fn.deploy()
 batch_inference = mlrun.import_function("hub://batch_inference")
 batch_run = project.run_function(
     batch_inference,
-    inputs={
-        "dataset": prediction_set_path,
-        "sample_set": training_set_path
-    },
+    inputs={"dataset": prediction_set_path, "sample_set": training_set_path},
     params={
         "model": model_artifact.uri,
         "label_columns": "label",
-        "perform_drift_analysis" : True
-    }
+        "perform_drift_analysis": True,
+    },
 )
 ```
 
@@ -623,7 +697,12 @@ Docs: [Ingest data using the feature store](./data-prep/ingest-data-fs.html)
 Docs: [Sources](./feature-store/sources-targets.html#sources)
 
 ```python
-from mlrun.datastore.sources import CSVSource, ParquetSource, BigQuerySource, KafkaSource
+from mlrun.datastore.sources import (
+    CSVSource,
+    ParquetSource,
+    BigQuerySource,
+    KafkaSource,
+)
 
 # CSV
 csv_source = CSVSource(name="read", path="/User/getting_started/examples/demo.csv")
@@ -633,20 +712,24 @@ csv_df = csv_source.to_dataframe()
 from pyspark.sql import SparkSession
 
 session = SparkSession.builder.master("local").getOrCreate()
-parquet_source = ParquetSource(name="read", path="v3io:///users/admin/getting_started/examples/userdata1.parquet")
+parquet_source = ParquetSource(
+    name="read", path="v3io:///users/admin/getting_started/examples/userdata1.parquet"
+)
 spark_df = parquet_source.to_spark_df(session=session)
 
 # BigQuery
-bq_source = BigQuerySource(name="read", table="the-psf.pypi.downloads20210328", gcp_project="my_project")
+bq_source = BigQuerySource(
+    name="read", table="the-psf.pypi.downloads20210328", gcp_project="my_project"
+)
 bq_df = bq_source.to_dataframe()
 
 # Kafka
 kafka_source = KafkaSource(
     name="read",
-    brokers='localhost:9092',
-    topics='topic',
-    group='serving',
-    initial_offset='earliest'
+    brokers="localhost:9092",
+    topics="topic",
+    group="serving",
+    initial_offset="earliest",
 )
 kafka_source.add_nuclio_trigger(function=fn)
 
@@ -680,7 +763,7 @@ pq_target = ParquetTarget(
     name="write",
     path="/User/test.parquet",
     partitioned=True,
-    partition_cols=["country"]
+    partition_cols=["country"],
 )
 pq_target.write_dataframe(df=pq_df, key_column="id")
 
@@ -732,10 +815,11 @@ from mlrun.datastore.sources import ParquetSource
 categorical_fset = fstore.FeatureSet(
     name="heart-disease-categorical",
     entities=[fstore.Entity("patient_id")],
-    description="Categorical columns for heart disease dataset"
+    description="Categorical columns for heart disease dataset",
 )
 
-categorical_fset.ingest(source=ParquetSource(path="./data/heart_disease_categorical.parquet")
+categorical_fset.ingest(
+    source=ParquetSource(path="./data/heart_disease_categorical.parquet")
 )
 ```
 
@@ -749,7 +833,7 @@ storey_set = fstore.FeatureSet(
     name="heart-disease-storey",
     entities=[fstore.Entity("patient_id")],
     description="Heart disease data via storey engine",
-    engine="storey"
+    engine="storey",
 )
 storey_set.ingest(source=DataFrameSource(df=data))
 
@@ -758,19 +842,20 @@ pandas_set = fstore.FeatureSet(
     name="heart-disease-pandas",
     entities=[fstore.Entity("patient_id")],
     description="Heart disease data via pandas engine",
-    engine="pandas"
+    engine="pandas",
 )
 pandas_set.ingest(source=DataFrameSource(df=data))
 
 # Spark engine
 from pyspark.sql import SparkSession
+
 spark = SparkSession.builder.appName("Spark function").getOrCreate()
 
 spark_set = fstore.FeatureSet(
     name="heart-disease-spark",
     entities=[fstore.Entity("patient_id")],
     description="Heart disease data via spark engine",
-    engine="spark"
+    engine="spark",
 )
 spark_set.ingest(source=CSVSource(path=v3io_data_path), spark_context=spark)
 ```
@@ -783,19 +868,17 @@ Docs: [Ingest data locally](./data-prep/ingest-data-fs.html#ingest-data-locally)
 # Local
 from mlrun.datastore.sources import CSVSource
 
-fs=fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
-df = fs.ingest(    
-    source=CSVSource("mycsv", path="stocks.csv")
-)
+fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
+df = fs.ingest(source=CSVSource("mycsv", path="stocks.csv"))
 
 # Job
 from mlrun.datastore.sources import ParquetSource
 
 fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
-df = fs.ingest(    
-    source=ParquetSource("mypq", path="stocks.parquet")
-    run_config=fstore.RunConfig(image='mlrun/mlrun')
-	)
+df = fs.ingest(
+    source=ParquetSource("mypq", path="stocks.parquet"),
+    run_config=fstore.RunConfig(image="mlrun/mlrun"),
+)
 
 # Real-Time
 from mlrun.datastore.sources import HttpSource
@@ -803,15 +886,17 @@ from mlrun.datastore.sources import HttpSource
 fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
 url, _ = fs.deploy_ingestion_service(
     source=HttpSource(key_field="ticker"),
-    run_config=fstore.RunConfig(image='mlrun/mlrun', kind="serving")
+    run_config=fstore.RunConfig(image="mlrun/mlrun", kind="serving"),
 )
 
 # Incremental
-cron_trigger = "* */1 * * *" # will run every hour
+cron_trigger = "* */1 * * *"  # will run every hour
 fs = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")])
 fset.ingest(
-    source=ParquetSource("mypq", path="stocks.parquet", time_field="time", schedule=cron_trigger),
-    run_config=fstore.RunConfig(image='mlrun/mlrun')
+    source=ParquetSource(
+        "mypq", path="stocks.parquet", time_field="time", schedule=cron_trigger
+    ),
+    run_config=fstore.RunConfig(image="mlrun/mlrun"),
 )
 ```
 
@@ -848,6 +933,7 @@ class MyMapStorey(MapClass):
         event["multi"] = event["bid"] * self._multiplier
         return event
 
+
 # Pandas
 class MyMapPandas:
     def __init__(self, multiplier=1, **kwargs):
@@ -856,6 +942,7 @@ class MyMapPandas:
     def do(self, df):
         df["multi"] = df["bid"] * self._multiplier
         return df
+
 
 # Spark
 class MyMapSpark:
@@ -889,20 +976,20 @@ fvec = fstore.FeatureVector(
 )
 fvec.save()
 
-# Instantiate feature-vector from mlrun DB 
+# Instantiate feature-vector from mlrun DB
 fvec = fstore.get_feature_vector("iguazio-academy/heart-disease-vector")
 
 # Offline features for training
 df = fvec.get_offline_features().to_dataframe()
-..
+
 # Materialize offline features to parquet
 fvec.get_offline_features(target=ParquetTarget())
-..
+
 # Online features for serving
-feature_service = fvec.get_online_feature_service()feature_service.get(
+feature_service = fvec.get_online_feature_service().feature_service.get(
     [
-        {"patient_id" : "e443544b-8d9e-4f6c-9623-e24b6139aae0"},
-        {"patient_id" : "8227d3df-16ab-4452-8ea5-99472362d982"}
+        {"patient_id": "e443544b-8d9e-4f6c-9623-e24b6139aae0"},
+        {"patient_id": "8227d3df-16ab-4452-8ea5-99472362d982"},
     ]
 )
 ```
@@ -931,8 +1018,10 @@ Define Python file(s) to orchestrate
 def inc(x):
     return x + 1
 
+
 def mul(x):
     return x * 2
+
 
 class WithState:
     def __init__(self, name, context, init_val=0):
@@ -949,16 +1038,16 @@ class WithState:
 Define MLRun function and graph
 ```python
 import mlrun
+
 fn = project.set_function(
-    name="simple-graph", func="graph.py",
-    kind="serving", image="mlrun/mlrun"
+    name="simple-graph", func="graph.py", kind="serving", image="mlrun/mlrun"
 )
 graph = fn.set_topology("flow")
 
 # inc, mul, and WithState are all defined in graph.py
-graph.to(name="+1", handler='inc')\
-     .to(name="*2", handler='mul')\
-     .to(name="(X+counter)", class_name='WithState').respond()
+graph.to(name="+1", handler="inc").to(name="*2", handler="mul").to(
+    name="(X+counter)", class_name="WithState"
+).respond()
 
 # Local testing
 server = fn.to_mock_server()
@@ -974,8 +1063,8 @@ project.deploy_function(fn)
 Docs: [Example of a simple model serving router](./serving/use-cases.html#example-of-a-simple-model-serving-router)
 
 ```python
-# load the sklearn model serving function and add models to it  
-fn = mlrun.import_function('hub://v2_model_server')
+# load the sklearn model serving function and add models to it
+fn = mlrun.import_function("hub://v2_model_server")
 fn.add_model("model1", model_path="s3://...")
 fn.add_model("model2", model_path="store://...")
 
@@ -983,7 +1072,7 @@ fn.add_model("model2", model_path="store://...")
 project.deploy_function(fn)
 
 # test the live model endpoint
-fn.invoke('/v2/models/model1/infer', body={"inputs": [5]})
+fn.invoke("/v2/models/model1/infer", body={"inputs": [5]})
 ```
 ![](./_static/images/simple_model_serving.png)
 
@@ -997,6 +1086,7 @@ from typing import List
 import numpy as np
 
 import mlrun
+
 
 class ClassifierModel(mlrun.serving.V2ModelServer):
     def load(self):
@@ -1017,18 +1107,20 @@ Docs: {ref}`graph-example`
 
 ```python
 fn = project.set_function(
-    name="advanced", func="demo.py", 
-    kind="serving", image="mlrun/mlrun"
+    name="advanced", func="demo.py", kind="serving", image="mlrun/mlrun"
 )
 graph = function.set_topology("flow", engine="async")
 
-# use built-in storey class or our custom Echo class to create and link Task steps. Add an error 
+# use built-in storey class or our custom Echo class to create and link Task steps. Add an error
 # handling step that runs only if the "Echo" step fails
-graph.to("storey.Extend", name="enrich", _fn='({"tag": "something"})') \
-     .to(class_name="Echo", name="pre-process", some_arg='abc').error_handler(name='catcher', handler='handle_error', full_event=True)
+graph.to("storey.Extend", name="enrich", _fn='({"tag": "something"})').to(
+    class_name="Echo", name="pre-process", some_arg="abc"
+).error_handler(name="catcher", handler="handle_error", full_event=True)
 
 # add an Ensemble router with two child models (routes), the "*" prefix marks it as router class
-router = graph.add_step("*mlrun.serving.VotingEnsemble", name="ensemble", after="pre-process")
+router = graph.add_step(
+    "*mlrun.serving.VotingEnsemble", name="ensemble", after="pre-process"
+)
 router.add_route("m1", class_name="ClassifierModel", model_path=path1)
 router.add_route("m2", class_name="ClassifierModel", model_path=path2)
 
@@ -1047,13 +1139,10 @@ def hyper_func(context, p1, p2):
     print(f"p1={p1}, p2={p2}, result={p1 * p2}")
     context.log_result("multiplier", p1 * p2)
 
+
 # MLRun function in project
 fn = project.set_function(
-    name="hp",
-    func="hp.py",
-    image="mlrun/mlrun",
-    kind="job",
-    handler="hyper_func"
+    name="hp", func="hp.py", image="mlrun/mlrun", kind="job", handler="hyper_func"
 )
 ```
 ```{admonition} Note
@@ -1068,9 +1157,7 @@ Docs: [Grid Search](./hyper-params.html#grid-search-default)
 Runs all parameter combinations
 ```python
 hp_tuning_run = project.run_function(
-    "hp", 
-    hyperparams={"p1": [2,4,1], "p2": [10,20]}, 
-    selector="max.multiplier"
+    "hp", hyperparams={"p1": [2, 4, 1], "p2": [10, 20]}, selector="max.multiplier"
 )
 ```
 
@@ -1141,10 +1228,7 @@ Docs: [Running the workers using Nuclio](./hyper-params.html#running-the-workers
 ```python
 # Create nuclio:mlrun function
 fn = project.set_function(
-    name='hyper-tst2',
-    func="hp.py",
-    kind='nuclio:mlrun',
-    image='mlrun/mlrun'
+    name="hyper-tst2", func="hp.py", kind="nuclio:mlrun", image="mlrun/mlrun"
 )
 # (replicas * workers) must be equal to or greater than parallel_runs
 fn.spec.replicas = 2
@@ -1157,10 +1241,8 @@ hp_tuning_run_dask = project.run_function(
     hyperparams={"p1": [2, 4, 1], "p2": [10, 20, 30]},
     selector="max.multiplier",
     hyper_param_options=mlrun.model.HyperParamOptions(
-        strategy="grid",
-        parallel_runs=4,
-        max_errors=3
+        strategy="grid", parallel_runs=4, max_errors=3
     ),
-    handler="hyper_func"
+    handler="hyper_func",
 )
 ```

--- a/docs/concepts/auto-logging-mlops.md
+++ b/docs/concepts/auto-logging-mlops.md
@@ -20,8 +20,7 @@ In addition it handles automation of various MLOps tasks like scaling runs over 
 `apply_mlrun()` accepts the model object and various optional parameters. For example:
 
 ```python
-apply_mlrun(model=model, model_name="my_model", 
-            x_test=x_test, y_test=y_test)
+apply_mlrun(model=model, model_name="my_model", x_test=x_test, y_test=y_test)
 ```
 
 When specifying the `x_test` and `y_test` data it generates various plots and calculations to evaluate the model.

--- a/docs/concepts/decorators-and-auto-logging.md
+++ b/docs/concepts/decorators-and-auto-logging.md
@@ -11,9 +11,8 @@ Assume you have the following code in `train.py`
 import pandas as pd
 from sklearn.svm import SVC
 
-def train_and_predict(train_data,
-                      predict_input,
-                      label_column='label'):
+
+def train_and_predict(train_data, predict_input, label_column="label"):
 
     x = train_data.drop(label_column, axis=1)
     y = train_data[label_column]
@@ -31,13 +30,13 @@ import pandas as pd
 from sklearn.svm import SVC
 import mlrun
 
-@mlrun.handler(labels={'framework':'scikit-learn'},
-               outputs=['prediction:dataset'],
-               inputs={"train_data": pd.DataFrame,
-                       "predict_input": pd.DataFrame})
-def train_and_predict(train_data,
-                      predict_input,
-                      label_column='label'):
+
+@mlrun.handler(
+    labels={"framework": "scikit-learn"},
+    outputs=["prediction:dataset"],
+    inputs={"train_data": pd.DataFrame, "predict_input": pd.DataFrame},
+)
+def train_and_predict(train_data, predict_input, label_column="label"):
 
     x = train_data.drop(label_column, axis=1)
     y = train_data[label_column]
@@ -52,15 +51,23 @@ To run the code, use the following example:
 
 ``` python
 import mlrun
+
 project = mlrun.get_or_create_project("mlrun-example", context="./", user_project=True)
 
-trainer = project.set_function("train.py", name="train_and_predict", kind="job", image="mlrun/mlrun", handler="train_and_predict")
+trainer = project.set_function(
+    "train.py",
+    name="train_and_predict",
+    kind="job",
+    image="mlrun/mlrun",
+    handler="train_and_predict",
+)
 
 trainer_run = project.run_function(
-    "train_and_predict", 
-    inputs={"train_data": mlrun.get_sample_path('data/iris/iris_dataset.csv'),
-            "predict_input": mlrun.get_sample_path('data/iris/iris_to_predict.csv')
-           }
+    "train_and_predict",
+    inputs={
+        "train_data": mlrun.get_sample_path("data/iris/iris_dataset.csv"),
+        "predict_input": mlrun.get_sample_path("data/iris/iris_to_predict.csv"),
+    },
 )
 ```
 
@@ -78,13 +85,10 @@ The decorator gives you the option to set labels for the run. The `labels` param
 The `mlrun.handler` decorator can also parse the input types, if they are specified. An equivalent definition is as follows:
 
 ``` python
-@mlrun.handler(labels={'framework':'scikit-learn'},
-               outputs=['prediction:dataset'])
-def train_and_predict(train_data: pd.DataFrame,
-                      predict_input: pd.DataFrame,
-                      label_column='label'):
-
-...
+@mlrun.handler(labels={"framework": "scikit-learn"}, outputs=["prediction:dataset"])
+def train_and_predict(
+    train_data: pd.DataFrame, predict_input: pd.DataFrame, label_column="label"
+): ...
 ```
 
 **Notice**: Type hints from the `typing` module (e.g. `typing.Optional`, `typing.Union`, `typing.List` etc.) are 

--- a/docs/concepts/mlrun-execution-context.md
+++ b/docs/concepts/mlrun-execution-context.md
@@ -27,6 +27,7 @@ Example function and usage of the context object:
 from mlrun.artifacts import PlotlyArtifact
 import pandas as pd
 
+
 def my_job(context, p1=1, p2="x"):
     # load MLRUN runtime context (will be set by the runtime framework)
 
@@ -56,14 +57,14 @@ def my_job(context, p1=1, p2="x"):
         "html_result", body=b"<b> Some HTML <b>", local_path="result.html"
     )
 
-     # create a plotly output (will show in the pipelines UI)
+    # create a plotly output (will show in the pipelines UI)
     x = np.arange(10)
     fig = go.Figure(data=go.Scatter(x=x, y=x**2))
 
     # Create a PlotlyArtifact using the figure and log it
     plotly_artifact = PlotlyArtifact(figure=fig, key="plotly")
     context.log_artifact(plotly_artifact)
-    
+
     raw_data = {
         "first_name": ["Jason", "Molly", "Tina", "Jake", "Amy"],
         "last_name": ["Miller", "Jacobson", "Ali", "Milner", "Cooze"],
@@ -78,9 +79,9 @@ Example of creating the context objects from the environment:
 
 ```python
 if __name__ == "__main__":
-    context = mlrun.get_or_create_ctx('train')
-    p1 = context.get_param('p1', 1)
-    p2 = context.get_param('p2', 'a-string')
+    context = mlrun.get_or_create_ctx("train")
+    p1 = context.get_param("p1", 1)
+    p2 = context.get_param("p2", "a-string")
     # do something
     context.log_result("accuracy", p1 * 2)
 ```

--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -81,7 +81,7 @@ In any `run` method you can configure the notifications via their model. For exa
 ```python
 notification = mlrun.model.Notification(
     kind="webhook",
-    when=["completed","error"],
+    when=["completed", "error"],
     name="notification-1",
     message="completed",
     severity="info",
@@ -97,7 +97,7 @@ For example:
 ```python
 notification = mlrun.model.Notification(
     kind="webhook",
-    when=["completed","error"],
+    when=["completed", "error"],
     name="notification-1",
     message="completed",
     severity="info",
@@ -117,8 +117,13 @@ This is a fallback to the old notification behavior, therefore not all of the ne
 In these engines the old way of setting project notifiers is still supported:
 
 ```python
-project.notifiers.add_notification(notification_type="slack",params={"webhook":"<slack webhook url>"})
-project.notifiers.add_notification(notification_type="git", params={"repo": "<repo>", "issue": "<issue>", "token": "<token>"})
+project.notifiers.add_notification(
+    notification_type="slack", params={"webhook": "<slack webhook url>"}
+)
+project.notifiers.add_notification(
+    notification_type="git",
+    params={"repo": "<repo>", "issue": "<issue>", "token": "<token>"},
+)
 ```
 Instead of passing the webhook in the notification `params`, it is also possible in a Jupyter notebook to use the ` %env` 
 magic command:
@@ -128,7 +133,9 @@ magic command:
 
 Editing and removing notifications is done similarly with the following methods:
 ```python
-project.notifiers.edit_notification(notification_type="slack",params={"webhook":"<new slack webhook url>"})
+project.notifiers.edit_notification(
+    notification_type="slack", params={"webhook": "<new slack webhook url>"}
+)
 project.notifiers.remove_notification(notification_type="slack")
 ```
 
@@ -138,7 +145,9 @@ You can set notifications on live runs via the `set_run_notifications` method. F
 ```python
 import mlrun
 
-mlrun.get_run_db().set_run_notifications("<project-name>", "<run-uid>", [notification1, notification2])
+mlrun.get_run_db().set_run_notifications(
+    "<project-name>", "<run-uid>", [notification1, notification2]
+)
 ```
 
 Using the `set_run_notifications` method overrides any existing notifications on the run. To delete all notifications, pass an empty list.
@@ -149,7 +158,9 @@ You can set notifications on scheduled runs via the `set_schedule_notifications`
 ```python
 import mlrun
 
-mlrun.get_run_db().set_schedule_notifications("<project-name>", "<schedule-name>", [notification1, notification2])
+mlrun.get_run_db().set_schedule_notifications(
+    "<project-name>", "<schedule-name>", [notification1, notification2]
+)
 ```
 
 Using the `set_schedule_notifications` method overrides any existing notifications on the schedule. To delete all notifications, pass an empty list.
@@ -167,11 +178,11 @@ if the drift is above a certain threshold:
 ```python
 notification = mlrun.model.Notification(
     kind="slack",
-    when=["completed","error"],
+    when=["completed", "error"],
     name="notification-1",
     message="completed",
     severity="info",
     secret_params={"webhook": "<slack webhook url>"},
-    condition='{{ run["status"]["results"]["drift"] > 0.1 }}'
+    condition='{{ run["status"]["results"]["drift"] > 0.1 }}',
 )
 ```

--- a/docs/concepts/scheduled-jobs.md
+++ b/docs/concepts/scheduled-jobs.md
@@ -18,11 +18,11 @@ To create the job, use the `code_to_function` syntax and specify the `kind` like
 import mlrun
 
 job = mlrun.code_to_function(
-    name="my-scheduled-job",      # Name of the job (displayed in console and UI)
-    filename="schedule.py",       # Python file or Jupyter notebook to run
-    kind="job",                   # Run as a job
-    image="mlrun/mlrun",          # Use this Docker image
-    handler="hello"               # Execute the function hello() within code.py
+    name="my-scheduled-job",  # Name of the job (displayed in console and UI)
+    filename="schedule.py",  # Python file or Jupyter notebook to run
+    kind="job",  # Run as a job
+    image="mlrun/mlrun",  # Use this Docker image
+    handler="hello",  # Execute the function hello() within code.py
 )
 ```
 

--- a/docs/concepts/workflow-overview.md
+++ b/docs/concepts/workflow-overview.md
@@ -48,7 +48,11 @@ def newpipe():
     train = mlrun.run_function(
         "train",
         name="train",
-        params={"sample": -1, "label_column": project.get_param("label", "label"), "test_size": 0.10},
+        params={
+            "sample": -1,
+            "label_column": project.get_param("label", "label"),
+            "test_size": 0.10,
+        },
         hyperparams={
             "model_pkg_class": [
                 "sklearn.ensemble.RandomForestClassifier",

--- a/docs/data-prep/ingest-data-fs.md
+++ b/docs/data-prep/ingest-data-fs.md
@@ -86,12 +86,12 @@ metadata/stats and once for the actual ingest. This is normal behavior.
 Use a feature set to create the basic feature-set definition and then an ingest method to run a simple ingestion "locally" in the Jupyter Notebook pod.
 
 ```python
-# Simple feature set that reads a csv file as a dataframe and ingests it "as is" 
+# Simple feature set that reads a csv file as a dataframe and ingests it "as is"
 stocks_set = FeatureSet("stocks", entities=[Entity("ticker")])
 stocks = pd.read_csv("stocks.csv")
 df = stocks_set.ingest(stocks)
 
-# Specify a csv file as source, specify a custom CSV target 
+# Specify a csv file as source, specify a custom CSV target
 source = CSVSource("mycsv", path="stocks.csv")
 targets = [CSVTarget("mycsv", path="./new_stocks.csv")]
 measurements.ingest(source, targets)
@@ -101,6 +101,7 @@ To append data you need to reuse the feature set that was used in previous inges
 that was saved in the DB (and not create a new feature set on every ingest).<br>
 For example:
 ```python
+try:
     my_fset = fstore.get_feature_set("my_fset")
 except mlrun.errors.MLRunNotFoundError:
     my_fset = FeatureSet("my_fset", entities=[Entity("key")])
@@ -120,7 +121,7 @@ It also enables you to schedule the job or use bigger/faster resources.
 ```python
 # Running as a remote job
 stocks_set = FeatureSet("stocks", entities=[Entity("ticker")])
-config = RunConfig(image='mlrun/mlrun')
+config = RunConfig(image="mlrun/mlrun")
 df = stocks_set.ingest(stocks, run_config=config)
 ```
 

--- a/docs/data-prep/ingesting_data.md
+++ b/docs/data-prep/ingesting_data.md
@@ -11,7 +11,7 @@ data-stores framework to connect to various types of data sources and download c
 data which is stored on S3 and load it into a `DataFrame`, use the following code:
 
 ```python
-# Access object in AWS S3, in the "input-data" bucket 
+# Access object in AWS S3, in the "input-data" bucket
 import mlrun
 
 # Access credentials
@@ -39,12 +39,12 @@ data ingestion function:
 def ingest_data(context, source_url: mlrun.DataItem):
     # Load the data from its source, and convert to a DataFrame
     df = source_url.as_df()
-    
+
     # Perform data cleaning and processing
     # ...
-    
+
     # Save the processed data to the artifact store
-    context.log_dataset('cleaned_data', df=df, format='csv')
+    context.log_dataset("cleaned_data", df=df, format="csv")
 ```
 
 This code can be placed in a python file, or as a cell in the Python notebook. For example, if the code above was saved
@@ -52,22 +52,25 @@ to a file, the following code creates an MLRun function from it and executes it 
 
 ```python
 # create a function from py or notebook (ipynb) file, specify the default function handler
-ingest_func = mlrun.code_to_function(name='ingest_data', filename='./ingest_data.py', 
-                                     kind='job', image='mlrun/mlrun')
+ingest_func = mlrun.code_to_function(
+    name="ingest_data", filename="./ingest_data.py", kind="job", image="mlrun/mlrun"
+)
 
 source_url = "s3://input-data/input_data.csv"
 
-ingest_data_run = ingest_func.run(name='ingest_data',
-                                  handler=ingest_data,
-                                  inputs={'source_url': source_url},
-                                  local=False)
+ingest_data_run = ingest_func.run(
+    name="ingest_data",
+    handler=ingest_data,
+    inputs={"source_url": source_url},
+    local=False,
+)
 ```
 
 As the `source_url` is part of the function's `inputs`, MLRun automatically wraps it up with a `DataItem`. The output
 is logged to the function's `artifact_path`, and can be obtained from the run result:
 
 ```python
-cleaned_data_frame = ingest_data_run.artifact('cleaned_data').as_df()
+cleaned_data_frame = ingest_data_run.artifact("cleaned_data").as_df()
 ```
 
 Note that running the function remotely may require attaching storage to the function, as well as passing storage

--- a/docs/data-prep/logging_datasets.md
+++ b/docs/data-prep/logging_datasets.md
@@ -8,7 +8,7 @@ only stores the DataFrame, but it also provides information about the data, such
 The simplest way to store a dataset is with the following code:
 
 ``` python
-context.log_dataset(key='my_data', df=df)
+context.log_dataset(key="my_data", df=df)
 ```
 
 Where `key` is the name of the artifact and `df` is the DataFrame. By default, MLRun stores a short preview of 20 lines.
@@ -26,18 +26,24 @@ from os import path
 from mlrun.execution import MLClientCtx
 from mlrun.datastore import DataItem
 
+
 # Ingest a data set into the platform
-def get_data(context: MLClientCtx, source_url: DataItem, format: str = 'csv'):
+def get_data(context: MLClientCtx, source_url: DataItem, format: str = "csv"):
 
     iris_dataset = source_url.as_df()
 
-    target_path = path.join(context.artifact_path, 'data')
+    target_path = path.join(context.artifact_path, "data")
     # Optionally print data to your logger
-    context.logger.info('Saving Iris data set to {} ...'.format(target_path))
+    context.logger.info("Saving Iris data set to {} ...".format(target_path))
 
     # Store the data set in your artifacts database
-    context.log_dataset('iris_dataset', df=iris_dataset, format=format,
-                        index=False, artifact_path=target_path)
+    context.log_dataset(
+        "iris_dataset",
+        df=iris_dataset,
+        format=format,
+        index=False,
+        artifact_path=target_path,
+    )
 ```
 
 This code can be placed in a python file, or as a cell in the Python notebook.
@@ -46,28 +52,29 @@ You can run this function locally or as a job. For example, to run it locally:
 from os import path
 from mlrun import new_project, mlconf
 
-project_name = 'my-project'
-project_path = path.abspath('conf')
+project_name = "my-project"
+project_path = path.abspath("conf")
 project = new_project(project_name, project_path, init_git=True)
 
 # Target location for storing pipeline artifacts
-artifact_path = path.abspath('jobs')
+artifact_path = path.abspath("jobs")
 # MLRun DB path or API service URL
-mlconf.dbpath = mlconf.dbpath or 'http://mlrun-api:8080'
+mlconf.dbpath = mlconf.dbpath or "http://mlrun-api:8080"
 
-source_url = 'https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv'
+source_url = "https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv"
 
 # Create a function from py or notebook (ipynb) file
-get_data_func = project.set_function('./get_data.py'
-    name='get_data'
-    kind='job', 
-    image='mlrun/mlrun')
-    
+get_data_func = project.set_function(
+    "./get_data.py", name="get_data", kind="job", image="mlrun/mlrun"
+)
+
 # Run get-data function locally
-get_data_run = get_data_func.run(handler="get_data",
-    inputs={'source_url': source_url},
+get_data_run = get_data_func.run(
+    handler="get_data",
+    inputs={"source_url": source_url},
     artifact_path=artifact_path,
-    local=True)
+    local=True,
+)
 ```
 
 The dataset location is returned in the `outputs` field, therefore you can get the location by calling
@@ -76,10 +83,10 @@ The dataset location is returned in the `outputs` field, therefore you can get t
 
 ``` python
 # Read your data set
-get_data_run.artifact('iris_dataset').as_df()
+get_data_run.artifact("iris_dataset").as_df()
 
 # Visualize an artifact in Jupyter (image, html, df, ..)
-get_data_run.artifact('confusion-matrix').show()
+get_data_run.artifact("confusion-matrix").show()
 ```
 
 The dataset returned from the run result is of the `DataItem` type. It allows access to the data itself as a Pandas 

--- a/docs/feature-store/feature-sets.md
+++ b/docs/feature-store/feature-sets.md
@@ -51,7 +51,7 @@ Avoid using timestamps or bool as entities.
    
 Example:
 ```python
-#Create a basic feature set example
+# Create a basic feature set example
 stocks_set = FeatureSet("stocks", entities=[Entity("ticker")])
 ```
 
@@ -105,11 +105,15 @@ in the Iguazio NoSQL DB (`NoSqlTarget`). You can use the default targets or add/
 Graph example (storey engine):
 ```python
 import mlrun.feature_store as fstore
-feature_set = fstore.FeatureSet("measurements", entities=[Entity(key)], timestamp_key="timestamp")
+
+feature_set = fstore.FeatureSet(
+    "measurements", entities=[Entity(key)], timestamp_key="timestamp"
+)
 # Define the computational graph including the custom functions
-feature_set.graph.to(DropColumns(drop_columns))\
-                 .to(RenameColumns(mapping={'bad': 'bed'}))
-feature_set.add_aggregation('hr', ['avg'], ["1h"])
+feature_set.graph.to(DropColumns(drop_columns)).to(
+    RenameColumns(mapping={"bad": "bed"})
+)
+feature_set.add_aggregation("hr", ["avg"], ["1h"])
 feature_set.plot()
 feature_set.ingest(data_df)
 ```
@@ -119,6 +123,7 @@ Graph example (pandas engine):
 def myfunc1(df, context=None):
     df = df.drop(columns=["exchange"])
     return df
+
 
 stocks_set = fstore.FeatureSet("stocks", entities=[Entity("ticker")], engine="pandas")
 stocks_set.graph.to(name="s1", handler="myfunc1")

--- a/docs/feature-store/feature-vectors.md
+++ b/docs/feature-store/feature-vectors.md
@@ -35,19 +35,23 @@ Example of creating a feature vector:
 import mlrun.feature_store as fstore
 
 # Feature vector definitions
-feature_vector_name = 'example-fv'
-feature_vector_description = 'Example feature vector'
-features = ['data_source_1.*', 
-            'data_source_2.feature_1', 
-            'data_source_2.feature_2',
-            'data_source_3.*']
-label_feature = 'label_source_1.label_feature'
+feature_vector_name = "example-fv"
+feature_vector_description = "Example feature vector"
+features = [
+    "data_source_1.*",
+    "data_source_2.feature_1",
+    "data_source_2.feature_2",
+    "data_source_3.*",
+]
+label_feature = "label_source_1.label_feature"
 
 # Feature vector creation
-fv = fstore.FeatureVector(name=feature_vector_name,
-                          features=features,
-                          label_feature=label_feature,
-                          description=feature_vector_description)
+fv = fstore.FeatureVector(
+    name=feature_vector_name,
+    features=features,
+    label_feature=label_feature,
+    description=feature_vector_description,
+)
 
 # Save the feature vector in the MLRun DB
 # so it can be referenced by the `store://`
@@ -137,13 +141,14 @@ as a function input using `store://feature-vectors/{project}/{feature_vector_nam
 For example:
 
 ```python
-fn = mlrun.import_function('hub://sklearn-classifier').apply(auto_mount())
+fn = mlrun.import_function("hub://sklearn-classifier").apply(auto_mount())
 
 # Define the training task, including the feature vector and label
-task = mlrun.new_task('training', 
-                      inputs={'dataset': f'store://feature-vectors/{project}/{feature_vector_name}'},
-                      params={'label_column': 'label'}
-                     )
+task = mlrun.new_task(
+    "training",
+    inputs={"dataset": f"store://feature-vectors/{project}/{feature_vector_name}"},
+    params={"label_column": "label"},
+)
 
 # Run the function
 run = fn.run(task)
@@ -246,7 +251,7 @@ To create the {py:class}`~mlrun.feature_store.OnlineVectorService` you only need
 import mlrun.feature_store as fstore
 
 # Create the Feature Vector Online Service
-feature_vector = 'store://feature-vectors/{project}/{feature_vector_name}'
+feature_vector = "store://feature-vectors/{project}/{feature_vector_name}"
 fvec = fstore.get_feature_vector(feature_vector)
 svc = fvec.get_online_feature_service()
 ```
@@ -268,7 +273,7 @@ For example:
 
 ```python
 # Define the wanted entities
-entities = [{<feature-vector-entity-column-name>: <entity>}]
+entities = [{"<feature-vector-entity-column-name>": "<entity>"}]
 
 # Get the feature vectors from the service
 svc.get(entities)

--- a/docs/feature-store/retrieve-offline-data.md
+++ b/docs/feature-store/retrieve-offline-data.md
@@ -18,7 +18,7 @@ You can add a time-based filter condition when running `get_offline_feature` wit
 ```python
 import mlrun.feature_store as fstore
 
-feature_vector = '<feature_vector_name>'
+feature_vector = "<feature_vector_name>"
 fvec = fstore.get_feature_vector(feature_vector)
 offline_fv = fvec.get_offline_features(target=ParquetTarget())
 ```
@@ -39,7 +39,9 @@ To retrieve a feature vector's offline dataset, use MLRun's data item mechanism,
 specifying to receive it as a DataFrame.
 
 ```python
-df = mlrun.get_dataitem(f'store://feature-vectors/{project}/patient-deterioration').as_df()
+df = mlrun.get_dataitem(
+    f"store://feature-vectors/{project}/patient-deterioration"
+).as_df()
 ```
 
 When trying to retrieve the dataset in your training function, you can put the feature vector reference as an input to 
@@ -47,10 +49,12 @@ the function and use the `as_df()` function to retrieve it automatically.
 
 ```python
 # A sample MLRun training function
-def my_training_function(context, # MLRun context
-                         dataset, # our feature vector reference
-                         **kwargs):
-    
+def my_training_function(
+    context,  # MLRun context
+    dataset,  # our feature vector reference
+    **kwargs,
+):
+
     # retrieve the dataset
     df = dataset.as_df()
 
@@ -61,14 +65,14 @@ And now you can create the MLRun function and run it locally or over the kuberne
 
 ```python
 # Creating the training MLRun function with the code
-fn = mlrun.code_to_function('training', 
-                            kind='job',
-                            handler='my_training_function')
+fn = mlrun.code_to_function("training", kind="job", handler="my_training_function")
 
 # Creating the task to run the function with its dataset
-task = mlrun.new_task('training', 
-                      inputs={'dataset': f'store://feature-vectors/{project}/{feature_vector_name}'}) # The feature vector is given as an input to the function
+task = mlrun.new_task(
+    "training",
+    inputs={"dataset": f"store://feature-vectors/{project}/{feature_vector_name}"},
+)  # The feature vector is given as an input to the function
 
 # Running the function over the kubernetes cluster
-fn.run(task) # Set local=True to run locally
+fn.run(task)  # Set local=True to run locally
 ```

--- a/docs/feature-store/sources-targets.md
+++ b/docs/feature-store/sources-targets.md
@@ -37,7 +37,9 @@ Confluent Kafka source is Tech Preview
 ## Kafka source
 
 ```python
-profile = DatastoreProfileKafkaSource(name="profile-name",bootstrap_servers="localhost", topic="topic_name")
+profile = DatastoreProfileKafkaSource(
+    name="profile-name", bootstrap_servers="localhost", topic="topic_name"
+)
 target = KafkaSource(path="ds://profile-name")
 ```
 
@@ -146,7 +148,9 @@ NFS, S3, Azure blob storage, Redis, SQL, and on Iguazio DB/FS.
 ## Kafka target
 
 ```python
-profile = DatastoreProfileKafkaTarget(name="profile-name",bootstrap_servers="localhost", topic="topic_name")
+profile = DatastoreProfileKafkaTarget(
+    name="profile-name", bootstrap_servers="localhost", topic="topic_name"
+)
 target = KafkaTarget(path="ds://profile-name")
 ```
 
@@ -233,7 +237,12 @@ explicitly each time with the path parameter, for example:</br>
 
 ### RedisNoSql data store profile
 ```python
-profile = DatastoreProfileRedis(name="profile-name", endpoint_url="redis://11.22.33.44:6379", username="user", password="password")
+profile = DatastoreProfileRedis(
+    name="profile-name",
+    endpoint_url="redis://11.22.33.44:6379",
+    username="user",
+    password="password",
+)
 RedisNoSqlTarget(path="ds://profile-name/a/b")
 ```
 

--- a/docs/feature-store/training-serving.md
+++ b/docs/feature-store/training-serving.md
@@ -15,16 +15,16 @@ To use it, first create an online feature service with the feature vector.
 import mlrun.feature_store as fstore
 
 # Create the Feature Vector Online Service
-feature_vector = 'store://feature-vectors/{project}/{feature_vector_name}'
+feature_vector = "store://feature-vectors/{project}/{feature_vector_name}"
 fvec = fstore.get_feature_vector(feature_vector)
 svc = fvec.get_online_feature_service()
 ```
 
 After creating the service, you can use the feature vector's entity to get the latest feature vector for it.
-Pass a list of `{<key name>: <key value>}` pairs to receive a batch of feature vectors.
+Pass a list of `{"<key name>": "<key value>"}` pairs to receive a batch of feature vectors.
 
 ```python
-fv = svc.get([{<key name>: <key value>}])
+fv = svc.get([{"<key name>": "<key value>"}])
 ```
 
 ## Incorporating to the serving model
@@ -44,24 +44,29 @@ import numpy as np
 import mlrun
 import os
 
+
 class ClassifierModel(mlrun.serving.V2ModelServer):
-    
+
     def load(self):
         """load and initialize the model and/or other elements"""
-        model_file, extra_data = self.get_model('.pkl')
-        self.model = load(open(model_file, 'rb'))
-        
+        model_file, extra_data = self.get_model(".pkl")
+        self.model = load(open(model_file, "rb"))
+
         # Setup FS Online service
-        self.feature_service = mlrun.feature_store.get_online_feature_service('patient-deterioration')
-        
+        self.feature_service = mlrun.feature_store.get_online_feature_service(
+            "patient-deterioration"
+        )
+
         # Get feature vector statistics for imputing
         self.feature_stats = self.feature_service.vector.get_stats_table()
-        
+
     def preprocess(self, body: dict, op) -> list:
-        # Get patient feature vector 
+        # Get patient feature vector
         # from the patient_id given in the request
-        vectors = self.feature_service.get([{'patient_id': patient_id} for patient_id in body['inputs']])
-        
+        vectors = self.feature_service.get(
+            [{"patient_id": patient_id} for patient_id in body["inputs"]]
+        )
+
         # Impute inf's in the data to the feature's mean value
         # using the collected statistics from the Feature store
         feature_vectors = []
@@ -69,19 +74,19 @@ class ClassifierModel(mlrun.serving.V2ModelServer):
             new_vec = []
             for f, v in fv.items():
                 if np.isinf(v):
-                    new_vec.append(self.feature_stats.loc[f, 'mean'])
+                    new_vec.append(self.feature_stats.loc[f, "mean"])
                 else:
                     new_vec.append(v)
             feature_vectors.append(new_vec)
-            
+
         # Set the final feature vector as the inputs
         # to pass to the predict function
-        body['inputs'] = feature_vectors
+        body["inputs"] = feature_vectors
         return body
 
     def predict(self, body: dict) -> list:
         """Generate model predictions from sample"""
-        feats = np.asarray(body['inputs'])
+        feats = np.asarray(body["inputs"])
         result: np.ndarray = self.model.predict(feats)
         return result.tolist()
 ```
@@ -90,13 +95,14 @@ Which you can deploy with:
 
 ```python
 # Create the serving function from the code above
-fn = mlrun.code_to_function(<function_name>, 
-                            kind='serving')
+fn = mlrun.code_to_function("<function_name>", kind="serving")
 
 # Add a specific model to the serving function
-fn.add_model(<model_name>, 
-             class_name='ClassifierModel',
-             model_path=<store_model_file_reference>)
+fn.add_model(
+    "<model_name>",
+    class_name="ClassifierModel",
+    model_path="<store_model_file_reference>",
+)
 
 # Enable MLRun's model monitoring
 fn.set_tracking()
@@ -112,5 +118,5 @@ fn.deploy()
 And test using:
 
 ```python
-fn.invoke('/v2/models/infer', body={<key name>: <key value>})
+fn.invoke("/v2/models/infer", body={"<key name>": "<key value>"})
 ```

--- a/docs/feature-store/transformations.md
+++ b/docs/feature-store/transformations.md
@@ -117,6 +117,7 @@ All time windows are aligned to the epoch (1970-01-01T00:00:00Z).
 
    ```python
    import mlrun.feature_store as fstore
+
    # create a new feature set
    quotes_set = fstore.FeatureSet("stock-quotes", entities=[fstore.Entity("ticker")])
    quotes_set.add_aggregation("bid", ["min", "max"], ["1h"], "10m", name="price")
@@ -138,9 +139,10 @@ All time windows are aligned to the epoch (1970-01-01T00:00:00Z).
    
    ```python
    import mlrun.feature_store as fstore
+
    # create a new feature set
    quotes_set = fstore.FeatureSet("stock-quotes", entities=[fstore.Entity("ticker")])
-   quotes_set.add_aggregation("bid", ["min", "max"], ["1h"] name="price")
+   quotes_set.add_aggregation("bid", ["min", "max"], ["1h"], name="price")
    ```
    This code generates two new features: `bid_min_1h` and `bid_max_1h` once per hour.  
 
@@ -255,7 +257,7 @@ class MultiplyFeature(StepToDict, MLRunStep):
 
     def _do_storey(self, event):
         # event is a single row represented by a dictionary
-        event[self._new_feature] = event[self._feature] * self._value  
+        event[self._new_feature] = event[self._feature] * self._value
         return event
 
     def _do_pandas(self, event):
@@ -265,9 +267,9 @@ class MultiplyFeature(StepToDict, MLRunStep):
 
     def _do_spark(self, event):
         # event is a pyspark.sql.DataFrame
-        return event.withColumn(self._new_feature, 
-                                col(self._feature) * lit(self._value)
-                                )
+        return event.withColumn(
+            self._new_feature, col(self._feature) * lit(self._value)
+        )
 ```
 
 The following example uses this step in a feature-set graph with the `pandas` engine. This example adds a feature called 
@@ -277,10 +279,11 @@ when creating the graph step:
 ```python
 import mlrun.feature_store as fstore
 
-feature_set = fstore.FeatureSet("fs-new", 
-                                entities=[fstore.Entity("id")], 
-                                engine="pandas",
-                                )
+feature_set = fstore.FeatureSet(
+    "fs-new",
+    entities=[fstore.Entity("id")],
+    engine="pandas",
+)
 # Adding multiply step, with specific class parameters passed as kwargs
 feature_set.graph.to(class_name="MultiplyFeature", feature="number1", value=4)
 df_pandas = feature_set.ingest(data)

--- a/docs/feature-store/using-spark-engine.md
+++ b/docs/feature-store/using-spark-engine.md
@@ -12,7 +12,9 @@ When constructing the {py:class}`~mlrun.feature_store.FeatureSet` object, pass a
    to `spark`. For example:
    
 ```python
-feature_set = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")], engine="spark")
+feature_set = fstore.FeatureSet(
+    "stocks", entities=[fstore.Entity("ticker")], engine="spark"
+)
 ```
 To use a remote execution engine, pass a `RunConfig` object as the `run_config` parameter for 
 the `ingest` API. The actual remote function to execute depends on the object passed:
@@ -51,7 +53,9 @@ import mlrun.feature_store as fstore
 from pyspark.sql import SparkSession
 
 mlrun.get_or_create_project(name="stocks")
-feature_set = fstore.FeatureSet("stocks", entities=[fstore.Entity("ticker")], engine="spark")
+feature_set = fstore.FeatureSet(
+    "stocks", entities=[fstore.Entity("ticker")], engine="spark"
+)
 
 # add_aggregation can be used in conjunction with Spark
 feature_set.add_aggregation("price", ["min", "max"], ["1h"], "10m")
@@ -73,6 +77,7 @@ It may take a few minutes to prepare the image.
 
 ```python
 from mlrun.runtimes import RemoteSparkRuntime
+
 RemoteSparkRuntime.deploy_default_image()
 ```
 
@@ -82,13 +87,17 @@ Remote ingestion:
 ```
 ```python
 from mlrun.feature_store.api import ingest
+
+
 def ingest_handler(context):
-    ingest(mlrun_context=context) # The handler function must call ingest with the mlrun_context
+    ingest(
+        mlrun_context=context
+    )  # The handler function must call ingest with the mlrun_context
 ```
 You can run your PySpark code for ingesting data into the feature store by adding:
 ```python
 def my_spark_func(df, context=None):
-    return df.filter("bid>55") # PySpark code
+    return df.filter("bid>55")  # PySpark code
 ```
 ```python
 # mlrun: end-code
@@ -98,11 +107,15 @@ from mlrun.datastore.sources import CSVSource
 from mlrun import code_to_function
 import mlrun.feature_store as fstore
 
-feature_set = fstore.FeatureSet("stock-quotes", entities=[fstore.Entity("ticker")], engine="spark")
+feature_set = fstore.FeatureSet(
+    "stock-quotes", entities=[fstore.Entity("ticker")], engine="spark"
+)
 
 source = CSVSource("mycsv", path="v3io:///projects/quotes.csv")
 
-spark_service_name = "iguazio-spark-service" # As configured & shown in the Iguazio dashboard
+spark_service_name = (
+    "iguazio-spark-service"  # As configured & shown in the Iguazio dashboard
+)
 
 feature_set.graph.to(name="s1", handler="my_spark_func")
 my_func = code_to_function("func", kind="remote-spark")
@@ -117,6 +130,7 @@ The following code should be executed only once to build the spark job image bef
 It may take a few minutes to prepare the image.
 ```python
 from mlrun.runtimes import Spark3Runtime
+
 Spark3Runtime.deploy_default_image()
 ```
 
@@ -126,12 +140,17 @@ Spark operator ingestion:
 
 from mlrun.feature_store.api import ingest
 
+
 def ingest_handler(context):
-    ingest(mlrun_context=context) # The handler function must call ingest with the mlrun_context
+    ingest(
+        mlrun_context=context
+    )  # The handler function must call ingest with the mlrun_context
+
 
 # You can add your own PySpark code as a graph step:
 def my_spark_func(df, context=None):
-    return df.filter("bid>55") # PySpark code
+    return df.filter("bid>55")  # PySpark code
+
 
 # mlrun: end-code
 ```
@@ -141,7 +160,9 @@ from mlrun.datastore.sources import CSVSource
 from mlrun import code_to_function
 import mlrun.feature_store as fstore
 
-feature_set = fstore.FeatureSet("stock-quotes", entities=[fstore.Entity("ticker")], engine="spark")
+feature_set = fstore.FeatureSet(
+    "stock-quotes", entities=[fstore.Entity("ticker")], engine="spark"
+)
 
 source = CSVSource("mycsv", path="v3io:///projects/quotes.csv")
 
@@ -200,16 +221,18 @@ One-time setup:
 1. Deploy the default image for your job (this takes several minutes but should be executed only once per cluster for any MLRun/Iguazio upgrade):
    ```python
    from mlrun.runtimes import RemoteSparkRuntime
+
    RemoteSparkRuntime.deploy_default_image()
    ```
 2. Store your S3 credentials in a k8s [secret](../secrets.html#kubernetes-project-secrets):
    ```python
    import mlrun
-   secrets = {'s3_access_key': AWS_ACCESS_KEY, 's3_secret_key': AWS_SECRET_KEY}
+
+   secrets = {"s3_access_key": AWS_ACCESS_KEY, "s3_secret_key": AWS_SECRET_KEY}
    mlrun.get_run_db().create_project_secrets(
-       project = "uhuh-proj",
+       project="uhuh-proj",
        provider=mlrun.common.schemas.SecretProviderName.kubernetes,
-       secrets=secrets
+       secrets=secrets,
    )
    ```
 
@@ -222,22 +245,27 @@ from pyspark.sql import SparkSession
 
 
 from mlrun.feature_store.api import ingest
+
+
 def ingest_handler(context):
-    conf = (SparkConf()
-            .set("spark.hadoop.fs.s3a.path.style.access", True)
-            .set("spark.hadoop.fs.s3a.access.key", context.get_secret('s3_access_key'))
-            .set("spark.hadoop.fs.s3a.secret.key", context.get_secret('s3_secret_key'))
-            .set("spark.hadoop.fs.s3a.endpoint", context.get_param("s3_endpoint"))
-            .set("spark.hadoop.fs.s3a.region", context.get_param("s3_region"))
-            .set("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-            .set("com.amazonaws.services.s3.enableV4", True)
-            .set("spark.driver.extraJavaOptions", "-Dcom.amazonaws.services.s3.enableV4=true"))
-    spark = (
-        SparkSession.builder.config(conf=conf).appName("S3 app").getOrCreate()
+    conf = (
+        SparkConf()
+        .set("spark.hadoop.fs.s3a.path.style.access", True)
+        .set("spark.hadoop.fs.s3a.access.key", context.get_secret("s3_access_key"))
+        .set("spark.hadoop.fs.s3a.secret.key", context.get_secret("s3_secret_key"))
+        .set("spark.hadoop.fs.s3a.endpoint", context.get_param("s3_endpoint"))
+        .set("spark.hadoop.fs.s3a.region", context.get_param("s3_region"))
+        .set("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+        .set("com.amazonaws.services.s3.enableV4", True)
+        .set(
+            "spark.driver.extraJavaOptions", "-Dcom.amazonaws.services.s3.enableV4=true"
+        )
     )
-    
+    spark = SparkSession.builder.config(conf=conf).appName("S3 app").getOrCreate()
+
     ingest(mlrun_context=context, spark_context=spark)
-    
+
+
 # mlrun: end-code
 ```
 
@@ -248,27 +276,31 @@ from mlrun.datastore.targets import ParquetTarget
 from mlrun import code_to_function
 import mlrun.feature_store as fstore
 
-feature_set = fstore.FeatureSet("stock-quotes", entities=[fstore.Entity("ticker")], engine="spark")
+feature_set = fstore.FeatureSet(
+    "stock-quotes", entities=[fstore.Entity("ticker")], engine="spark"
+)
 
 source = CSVSource("mycsv", path="v3io:///projects/quotes.csv")
 
-spark_service_name = "spark" # As configured & shown in the Iguazio dashboard
+spark_service_name = "spark"  # As configured & shown in the Iguazio dashboard
 
-fn = code_to_function(kind='remote-spark',  name='func')
+fn = code_to_function(kind="remote-spark", name="func")
 
 run_config = fstore.RunConfig(local=False, function=fn, handler="ingest_handler")
-run_config.with_secret('kubernetes', ['s3_access_key', 's3_secret_key'])
+run_config.with_secret("kubernetes", ["s3_access_key", "s3_secret_key"])
 run_config.parameters = {
-    "s3_endpoint" : "s3.us-east-2.amazonaws.com",
-    "s3_region" : "us-east-2"
+    "s3_endpoint": "s3.us-east-2.amazonaws.com",
+    "s3_region": "us-east-2",
 }
 
 target = ParquetTarget(
-    path = "s3://my-s3-bucket/some/path",
-    partitioned = False,
+    path="s3://my-s3-bucket/some/path",
+    partitioned=False,
 )
 
-feature_set.ingest(source, targets=[target], run_config=run_config, spark_context=spark_service_name)
+feature_set.ingest(
+    source, targets=[target], run_config=run_config, spark_context=spark_service_name
+)
 ```
 
 ## Spark ingestion from Snowflake example

--- a/docs/genai/data-mgmt/unstructured-data.md
+++ b/docs/genai/data-mgmt/unstructured-data.md
@@ -94,7 +94,7 @@ workflow_run = project.run(
         "transcribe_model": "openai/whisper-large-v3",
         "translate_to_english": True,
         "pii_recognition_model": "whole",
-        "pii_recognition_entities": ['PERSON', "EMAIL", "PHONE"],
+        "pii_recognition_entities": ["PERSON", "EMAIL", "PHONE"],
         "pii_recognition_entity_operator_map": {
             "PERSON": ("replace", {"new_value": "John Doe"}),
             "EMAIL": ("replace", {"new_value": "john_doe@email.com"}),

--- a/docs/genai/data-mgmt/vector-databases.md
+++ b/docs/genai/data-mgmt/vector-databases.md
@@ -16,27 +16,27 @@ To use a vector database, you can create a function that stores the text data in
 For example, the following function adds data to a ChromaDB vector database:
 
 ```python
-def handler_chroma(context:MLClientCtx,
-                   vector_db_data: DataItem,
-                   cache_dir: str,
-                   collection-name: str):
-    
+def handler_chroma(
+    context: MLClientCtx, vector_db_data: DataItem, cache_dir: str, collection_name: str
+):
+
     df = vector_db_data.as_df()
 
     # Create chroma client
     chroma_client = chromadb.PersistentClient(path=cache_dir)
-    
+
     if collection_name in [c.name for c in chroma_client.list_collections()]:
         chroma_client.delete_collection(name=collection_name)
-    
-	# Add data to the collection 
+
+    # Add data to the collection
     collection = chroma_client.create_collection(name=collection_name)
 
     collection.add(
         documents=df["title"].tolist(),
         metadatas=[{"topic": topic} for topic in df["topic"].tolist()],
-        ids=[f"id{x}" for x in range(len(documents)])
-    
+        ids=[f"id{x}" for x in range(len(documents))],
+    )
+
     context.logger.info("Vector DB was created")
 ```
 
@@ -48,7 +48,6 @@ results = collection.query(query_texts=[topic], n_results=10)
 collection.query(query_texts=[topic], n_results=10)
 q_context = " ".join([f"#{str(i)}" for i in results["documents"][0]])
 prompt_template = f"Relevant context: {q_context}\n\n The user's question: {question}"
-
 ```
 
 ## Supported vector databases

--- a/docs/genai/deployment/genai_serving.md
+++ b/docs/genai/deployment/genai_serving.md
@@ -17,12 +17,10 @@ hugging_face_serving = project.set_function("hub://hugging_face_serving")
 Next, you can add a model to the function using this code:
 
 ```python
-
 hugging_face_serving.add_model(
-    'mymodel',
-    class_name='HuggingFaceModelServer',
-    model_path='123',  # This is not used, just for enabling the process.
-    
+    "mymodel",
+    class_name="HuggingFaceModelServer",
+    model_path="123",  # This is not used, just for enabling the process.
     task="text-generation",
     model_class="AutoModelForCausalLM",
     model_name="openai-community/gpt2",
@@ -35,8 +33,7 @@ And test the model:
 ```python
 hugging_face_mock_server = hugging_face_serving.to_mock_server()
 result = hugging_face_mock_server.test(
-    "/v2/models/mymodel",
-    body={"inputs": ["write a short poem"]}
+    "/v2/models/mymodel", body={"inputs": ["write a short poem"]}
 )
 print(f"Output: {result['outputs']}")
 ```
@@ -101,16 +98,19 @@ class OnnxGenaiModelServer(mlrun.serving.v2_serving.V2ModelServer):
     def load(self):
         # Download the model snapshot and save it to the model folder
         self.model_folder = snapshot_download(self.model_name)
-        
+
         # Load the model from the model folder
         self.model = og.Model(os.path.join(self.model_folder, self.model_path))
-        
+
         # Create a tokenizer using the loaded model
         self.tokenizer = og.Tokenizer(self.model)
-        
+
     def predict(self, request: Dict[str, Any]) -> list:
         # Get prompts from inputs::
-        prompts = [f'{self.chat_template.format(prompt=input.get("prompt"))}' for input in request["inputs"]]
+        prompts = [
+            f'{self.chat_template.format(prompt=input.get("prompt"))}'
+            for input in request["inputs"]
+        ]
 
         # Tokenize:
         input_tokens = self.tokenizer.encode_batch(prompts)
@@ -119,12 +119,15 @@ class OnnxGenaiModelServer(mlrun.serving.v2_serving.V2ModelServer):
         params = og.GeneratorParams(self.model)
         params.set_search_options(**self.search_options)
         params.input_ids = input_tokens
-        
+
         # Generate output tokens:
         output_tokens = self.model.generate(params)
-        
+
         # Decode output tokens to text:
-        response = [{"prediction": self.tokenizer.decode(output), "prompt": prompt} for (output, prompt) in zip(output_tokens, prompts)]
+        response = [
+            {"prediction": self.tokenizer.decode(output), "prompt": prompt}
+            for (output, prompt) in zip(output_tokens, prompts)
+        ]
 
         return response
 ```
@@ -139,20 +142,24 @@ Save the code above to `src/onnx_genai_serving.ay` and then create a model servi
 import os
 import mlrun
 
-project = mlrun.get_or_create_project("genai-deployment", context = "./", user_project=True)
+project = mlrun.get_or_create_project(
+    "genai-deployment", context="./", user_project=True
+)
 
-genai_serving = project.set_function("src/onnx_genai_serving.py",
-                                     name="genai-serving",
-                                     kind="serving",
-                                     image="mlrun/mlrun",
-                                     requirements=["huggingface_hub", "onnxruntime_genai"])
+genai_serving = project.set_function(
+    "src/onnx_genai_serving.py",
+    name="genai-serving",
+    kind="serving",
+    image="mlrun/mlrun",
+    requirements=["huggingface_hub", "onnxruntime_genai"],
+)
 
-genai_serving.add_model("mymodel",
-                        model_name="microsoft/Phi-3-mini-4k-instruct-onnx",
-                        model_path=os.path.join("cpu_and_mobile", "cpu-int4-rtn-block-32-acc-level-4"),
-                        class_name="OnnxGenaiModelServer"
-                       )
-
+genai_serving.add_model(
+    "mymodel",
+    model_name="microsoft/Phi-3-mini-4k-instruct-onnx",
+    model_path=os.path.join("cpu_and_mobile", "cpu-int4-rtn-block-32-acc-level-4"),
+    class_name="OnnxGenaiModelServer",
+)
 ```
 
 The code loads a Phi-3 model. This example uses the CPU version so it's easy to test and run, but you can just as easily provide a GPU-based model.
@@ -163,8 +170,7 @@ Test the model with the following code:
 mock_server = genai_serving.to_mock_server()
 
 result = mock_server.test(
-    "/v2/models/mymodel",
-    body={"inputs": [{"prompt":"What is 1+1?"}]}
+    "/v2/models/mymodel", body={"inputs": [{"prompt": "What is 1+1?"}]}
 )
 print(f"Output: {result['outputs']}")
 ```
@@ -184,7 +190,6 @@ This builds a docker images with the required dependencies and deploys a Nuclio 
 To test the model, use the HTTP trigger:
 ```python
 genai_serving.invoke(
-    "/v2/models/mymodel",
-    body={"inputs": [{"prompt":"What is 1+1?"}]}
+    "/v2/models/mymodel", body={"inputs": [{"prompt": "What is 1+1?"}]}
 )
 ```

--- a/docs/genai/deployment/genai_serving_graph.md
+++ b/docs/genai/deployment/genai_serving_graph.md
@@ -36,7 +36,6 @@ To run a model as part of a larger pipeline, you can use the {py:method}`~mlrun.
 Store the code above to `src/serve-llm.py`. Then, to create the serving function, run the following code:
 
 ```python
-
 serving_fn = project.set_function(
     name="serve-llm",
     func="src/serve_llm.py",
@@ -62,20 +61,20 @@ The following code shows how to set up an multi-step inference pipeline using ML
 graph = serving_function.set_topology("flow", engine="async")
 
 # Add the steps:
-graph.to(handler="preprocess", name="preprocess") \
-     .to("LLMModelServer",
-         name="infer",
-         model_args={"load_in_8bit": True,
-                     "device_map": "cuda:0",
-                     "trust_remote_code": True},
-         tokenizer_name="tiiuae/falcon-7b",
-         model_name="tiiuae/falcon-7b",
-         peft_model=project.get_artifact_uri("falcon-7b-mlrun")) \
-     .to(handler="postprocess", name="postprocess") \
-     .to("ToxicityClassifierModelServer",
-         name="toxicity-classifier",
-         threshold=0.7).respond()
-
+graph.to(handler="preprocess", name="preprocess").to(
+    "LLMModelServer",
+    name="infer",
+    model_args={
+        "load_in_8bit": True,
+        "device_map": "cuda:0",
+        "trust_remote_code": True,
+    },
+    tokenizer_name="tiiuae/falcon-7b",
+    model_name="tiiuae/falcon-7b",
+    peft_model=project.get_artifact_uri("falcon-7b-mlrun"),
+).to(handler="postprocess", name="postprocess").to(
+    "ToxicityClassifierModelServer", name="toxicity-classifier", threshold=0.7
+).respond()
 ```
 
 This flow is illustrated as follows:
@@ -100,8 +99,16 @@ Once you have the serving pipeline, it behaves just like any other serving funct
 An example of calling the pipeline:
 
 ```python
-generate_kwargs = {"max_length": 150, "temperature": 0.9, "top_p": 0.5, "top_k": 25, "repetition_penalty": 1.0}
-response = serving_function.invoke(path='/predict', body={"prompt": "What is MLRun?", **generate_kwargs})
+generate_kwargs = {
+    "max_length": 150,
+    "temperature": 0.9,
+    "top_p": 0.5,
+    "top_k": 25,
+    "repetition_penalty": 1.0,
+}
+response = serving_function.invoke(
+    path="/predict", body={"prompt": "What is MLRun?", **generate_kwargs}
+)
 print(response["outputs"])
 ```
 

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -358,7 +358,7 @@ of following ways:
   after this command:
     ```python
     from mlrun.config import config as mlconf
-    
+
     mlconf.storage.auto_mount_type = "none"
     ```
 * If running MLRun from an IDE, the configuration can be overridden using an environment variable. Set the following
@@ -375,7 +375,7 @@ of following ways:
 
 The artifact path needs to be modified since the bucket name is set to `mlrun` by default. It is recommended to keep 
 the same path structure as the default, while modifying the bucket name. For example:
-```python
+```text
 s3://<bucket name>/projects/{{run.project}}/artifacts
 ```
 

--- a/docs/monitoring/model-monitoring.md
+++ b/docs/monitoring/model-monitoring.md
@@ -42,6 +42,7 @@ project.log_model(
     model_file="./assets/model.pkl",
     training_set=train_set,
     framework="sklearn",
+)
 ```
 
 ## Import, enable monitoring, and deploy the serving function

--- a/docs/projects/create-project.md
+++ b/docs/projects/create-project.md
@@ -39,8 +39,10 @@ The `user_project=True` add the current username to the provided project name (m
 
 ```python
 import mlrun
-project = mlrun.new_project("myproj", "./", user_project=True, 
-                            init_git=True, description="my new project")
+
+project = mlrun.new_project(
+    "myproj", "./", user_project=True, init_git=True, description="my new project"
+)
 ```
  
 Projects can also be created from a template (yaml file, zip file, or git repo), allowing users to create reusable skeletons. 
@@ -50,9 +52,14 @@ Example of creating a new project from a zip template:
 
 ```python
 # create a project from zip, initialize a local git, and register the git remote path
-project = mlrun.new_project("myproj", "./", init_git=True, user_project=True,
-                            remote="git://github.com/myorg/some-project.git",
-                            from_template="http://mysite/proj.zip")
+project = mlrun.new_project(
+    "myproj",
+    "./",
+    init_git=True,
+    user_project=True,
+    remote="git://github.com/myorg/some-project.git",
+    from_template="http://mysite/proj.zip",
+)
 ```
 
 
@@ -71,15 +78,29 @@ Functions can be created from a single code/notebook file or have access to the 
 
 ```python
 # register a (single) python file as a function
-project.set_function('src/data_prep.py', 'data-prep', image='mlrun/mlrun', handler='prep', kind="job")
+project.set_function(
+    "src/data_prep.py", "data-prep", image="mlrun/mlrun", handler="prep", kind="job"
+)
 
-# register a notebook file as a function, specify custom image and extra requirements 
-project.set_function('src/mynb.ipynb', name='test-function', image="my-org/my-image",
-                      handler="run_test", requirements="requirements.txt", kind="job")
+# register a notebook file as a function, specify custom image and extra requirements
+project.set_function(
+    "src/mynb.ipynb",
+    name="test-function",
+    image="my-org/my-image",
+    handler="run_test",
+    requirements="requirements.txt",
+    kind="job",
+)
 
 # register a module.handler as a function (requires defining the default sources/work dir, if it's not root)
 project.spec.workdir = "src"
-project.set_function(name="train", handler="training.train",  image="mlrun/mlrun", kind="job", with_repo=True)
+project.set_function(
+    name="train",
+    handler="training.train",
+    image="mlrun/mlrun",
+    kind="job",
+    with_repo=True,
+)
 ```
 
 See details and examples on how to [**create and register functions**](../runtimes/create-and-use-functions.html), 
@@ -92,16 +113,18 @@ Users can define artifact files or objects in the project spec, which are regist
 To register artifacts use the {py:meth}`~mlrun.projects.MlrunProject.set_artifact`) method. See the examples:
 
 ```python
-# register a simple file artifact in the project (point to remote object)  
-data_url = 'https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv'
-project.set_artifact('data', target_path=data_url)
+# register a simple file artifact in the project (point to remote object)
+data_url = "https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv"
+project.set_artifact("data", target_path=data_url)
 
 # register a model artifact
-project.set_artifact('model', ModelArtifact(model_file="model.pkl"), target_path=model_dir_url)
+project.set_artifact(
+    "model", ModelArtifact(model_file="model.pkl"), target_path=model_dir_url
+)
 
 # register local or remote artifact object (yaml or zip), will be imported on project load
 # to generate such a package use `artifact.export(zip_path)`
-project.set_artifact('model', 'https://mystuff.com/models/mymodel.zip')
+project.set_artifact("model", "https://mystuff.com/models/mymodel.zip")
 ```
 
 ```{admonition} Note
@@ -114,8 +137,8 @@ Projects contain one or more workflows (pipelines). The workflows can be registe
 Project workflows are executed using the {py:meth}`~mlrun.projects.MlrunProject.run`) method. See [**building and running workflows**](./build-run-workflows-pipelines.html) for details.
 
 ```python
-# Add a multi-stage workflow (./myflow.py) to the project with the name 'main' and save the project 
-project.set_workflow('main', "./src/workflow.py")
+# Add a multi-stage workflow (./myflow.py) to the project with the name 'main' and save the project
+project.set_workflow("main", "./src/workflow.py")
 ```
 
 **Set project wide parameters and secrets:**
@@ -246,10 +269,12 @@ and run `get_or_create_project` to load changes made by others.
 Example:
 
 ```python
-    # load project from the DB (if exists) or the source repo
-    project = mlrun.get_or_create_project("myproj", "./", "git://github.com/mlrun/demo-xgb-project.git")
-    project.pull("development")  # pull the latest code from git
-    project.run("main", arguments={'data': data_url})  # run the workflow "main"
+# load project from the DB (if exists) or the source repo
+project = mlrun.get_or_create_project(
+    "myproj", "./", "git://github.com/mlrun/demo-xgb-project.git"
+)
+project.pull("development")  # pull the latest code from git
+project.run("main", arguments={"data": data_url})  # run the workflow "main"
 ```
 
 ## Deleting a project

--- a/docs/projects/load-project.md
+++ b/docs/projects/load-project.md
@@ -32,7 +32,7 @@ Example of loading a project from git, using the default `context` dir,  and run
 ```python
 # load the project and run the 'main' workflow
 project = load_project(name="myproj", url="git://github.com/mlrun/project-archive.git")
-project.run("main", arguments={'data': data_url})
+project.run("main", arguments={"data": data_url})
 ```
 
 ```{admonition} Note

--- a/docs/projects/project-setup.md
+++ b/docs/projects/project-setup.md
@@ -13,7 +13,9 @@ Upon loading an MLRun project via {py:meth}`~mlrun.projects.get_or_create_projec
 import mlrun
 
 # Load or create an MLRun project
-project = mlrun.get_or_create_project("my-project") # project_setup.py called while loading project
+project = mlrun.get_or_create_project(
+    "my-project"
+)  # project_setup.py called while loading project
 ```
 
 ## Format
@@ -96,12 +98,12 @@ The project can then be loaded using the following code snippet:
 ```python
 project = mlrun.get_or_create_project(
     name="my-project",
-    context="./src", # project_setup.py should be in this directory
+    context="./src",  # project_setup.py should be in this directory
     parameters={
-        "source" : "https://github.com/mlrun/my-repo#main",
-        "secrets_file" : ".env",
-        "default_image" : "mlrun/mlrun"
-    }
+        "source": "https://github.com/mlrun/my-repo#main",
+        "secrets_file": ".env",
+        "default_image": "mlrun/mlrun",
+    },
 )
 ```
 
@@ -115,7 +117,7 @@ Some common operations that can be added to the `project_setup.py` script includ
 Set the project source and enable pulling at runtime if specified. See {py:meth}`~mlrun.projects.MlrunProject.set_source` for more info.
 
 ```python
-source = project.get_param("source") # https://github.com/mlrun/my-repo#main
+source = project.get_param("source")  # https://github.com/mlrun/my-repo#main
 
 project.set_source(source, pull_at_runtime=True)
 ```
@@ -126,7 +128,7 @@ Export the local project directory contents to a zip file archive. Use this in c
 **Note:** This requires using the Iguazio `v3io` data layer or some `s3` compliant object storage such as `minio`.
 
 ```python
-source = project.get_param("source") # v3io:///bigdata/my_project.zip
+source = project.get_param("source")  # v3io:///bigdata/my_project.zip
 
 project.set_source(source, pull_at_runtime=True)
 if ".zip" in source:
@@ -138,7 +140,7 @@ if ".zip" in source:
 Define the default Docker image for the project. It will be used for functions without a specified image. See {py:meth}`~mlrun.projects.MlrunProject.set_default_image` for more info.
 
 ```python
-default_image = project.get_param("default_image") # mlrun/mlrun
+default_image = project.get_param("default_image")  # mlrun/mlrun
 
 if default_image:
     project.set_default_image(default_image)
@@ -148,13 +150,11 @@ if default_image:
 Build a Docker image and optionally set it as the project default. See {py:meth}`~mlrun.projects.MlrunProject.build_image` for more info.
 
 ```python
-base_image = project.get_param("base_image") # mlrun/mlrun
-requirements_file = project.get_param("requirements_file") # requirements.txt
+base_image = project.get_param("base_image")  # mlrun/mlrun
+requirements_file = project.get_param("requirements_file")  # requirements.txt
 
 project.build_image(
-    base_image=base_image,
-    requirements_file=requirements_file,
-    set_as_default=True
+    base_image=base_image, requirements_file=requirements_file, set_as_default=True
 )
 ```
 
@@ -181,7 +181,7 @@ project.set_workflow("main", "main_workflow.py")
 Create project secrets by setting them from a specified file path and load them as environment variables in the local environment. See {py:meth}`~mlrun.projects.MlrunProject.set_secrets` and {py:meth}`~mlrun.set_env_from_file` for more info.
 
 ```python
-secrets_file = project.get_param("secrets_file") # .env
+secrets_file = project.get_param("secrets_file")  # .env
 
 if secrets_file and os.path.exists(secrets_file):
     project.set_secrets(file_path=secrets_file)
@@ -194,8 +194,8 @@ Register artifacts like models or datasets in the project. Useful for version co
 ```python
 project.set_artifact(
     key="model",
-    artifact="artifacts/model:challenger.yaml", # YAML file in project directory
-    tag="challenger"
+    artifact="artifacts/model:challenger.yaml",  # YAML file in project directory
+    tag="challenger",
 )
 project.register_artifacts()
 ```

--- a/docs/projects/run-build-deploy.md
+++ b/docs/projects/run-build-deploy.md
@@ -24,7 +24,7 @@ Use these methods as `project` methods. For example:
 
 ```python
 # run the "train" function in myproject
-run = myproject.run_function("train", inputs={"data": data_url})  
+run = myproject.run_function("train", inputs={"data": data_url})
 ```
     
 The first parameter in all three methods is either the function name (in the project), or a function object, used if you want to 
@@ -35,8 +35,8 @@ specify functions that you imported/created ad hoc, or to modify a function spec
 serving = import_function("hub://v2_model_server", new_name="serving")
 serving.spec.replicas = 2
 deploy = deploy_function(
-  serving,
-  models=[{"key": "mymodel", "model_path": train.outputs["model"]}],
+    serving,
+    models=[{"key": "mymodel", "model_path": train.outputs["model"]}],
 )
 ```
     
@@ -45,7 +45,7 @@ You can use the {py:meth}`~mlrun.projects.MlrunProject.get_function` method to g
 ```python
 trainer = project.get_function("train")
 trainer.with_limits(mem="2G", cpu=2, gpus=1)
-run = project.run_function("train", inputs={"data": data_url}) 
+run = project.run_function("train", inputs={"data": data_url})
 ```
 
 <a id="run"></a>
@@ -81,31 +81,37 @@ project.set_function("mycode.py", "prep", image="mlrun/mlrun")
 project.set_function("hub://auto_trainer", "train")
 
 # run functions (refer to them by name)
-run1 = project.run_function("prep", params={"x": 7}, inputs={'data': data_url})
+run1 = project.run_function("prep", params={"x": 7}, inputs={"data": data_url})
 run2 = project.run_function("train", inputs={"dataset": run1.outputs["data"]})
-run2.artifact('confusion-matrix').show()
+run2.artifact("confusion-matrix").show()
 ```
 
 Example with `new_task`:
 
 ```python
 import mlrun
-project = mlrun.get_or_create_project('example-project')
----
+
+project = mlrun.get_or_create_project("example-project")
 
 from mlrun import RunTemplate, new_task, mlconf
 from os import path
-artifact_path = path.join(mlconf.artifact_path, '{{run.uid}}')
+
+artifact_path = path.join(mlconf.artifact_path, "{{run.uid}}")
+
+
 def handler(context, param, model_names):
     context.logger.info("Running handler")
-    context.set_label('category', 'tests')
+    context.set_label("category", "tests")
     for model_name, file_name in model_names:
         context.log_artifact(model_name, body=param.encode(), local_path=file_name)
-----
+
+
 func = project.set_function("my-func", kind="job", image="mlrun/mlrun")
 func.save()
----
-task = new_task(name='mytask', handler=handler, artifact_path=artifact_path, project='project-name')
+
+task = new_task(
+    name="mytask", handler=handler, artifact_path=artifact_path, project="project-name"
+)
 run_object = project.run_function("my-func", local=True, base_task=task)
 ```
 
@@ -141,7 +147,7 @@ Basic example:
 # Deploy a real-time nuclio function ("myapi")
 deployment = project.deploy_function("myapi")
 
-# invoke the deployed function (using HTTP request) 
+# invoke the deployed function (using HTTP request)
 resp = deployment.function.invoke("/do")
 ```
 
@@ -154,14 +160,14 @@ Example of using `deploy_function` inside a pipeline, after the `train` step, to
 # Deploy the trained model (from the "train" step) as a serverless serving function
 serving_fn = mlrun.new_function("serving", image="mlrun/mlrun", kind="serving")
 mlrun.deploy_function(
-  serving_fn,
-  models=[
-      {
-          "key": model_name,
-          "model_path": train.outputs["model"],
-          "class_name": 'mlrun.frameworks.sklearn.SklearnModelServer',
-      }
-  ],
+    serving_fn,
+    models=[
+        {
+            "key": model_name,
+            "model_path": train.outputs["model"],
+            "class_name": "mlrun.frameworks.sklearn.SklearnModelServer",
+        }
+    ],
 )
 ```
 
@@ -184,21 +190,21 @@ image that was set when the function was added to the project.
 For example:
 
 ```python
- project = mlrun.new_project(project_name, "./proj")
- # use v1 of a pre-built image as default
- project.set_default_image("myrepo/my-prebuilt-image:v1")
- # set function without an image, will use the project's default image
- project.set_function("mycode.py", "prep")
+project = mlrun.new_project(project_name, "./proj")
+# use v1 of a pre-built image as default
+project.set_default_image("myrepo/my-prebuilt-image:v1")
+# set function without an image, will use the project's default image
+project.set_function("mycode.py", "prep")
 
- # function will run with the "myrepo/my-prebuilt-image:v1" image
- run1 = project.run_function("prep", params={"x": 7}, inputs={'data': data_url})
+# function will run with the "myrepo/my-prebuilt-image:v1" image
+run1 = project.run_function("prep", params={"x": 7}, inputs={"data": data_url})
 
- ...
+...
 
- # replace the default image with a newer v2
- project.set_default_image("myrepo/my-prebuilt-image:v2")
- # function will now run using the v2 version of the image 
- run2 = project.run_function("prep", params={"x": 7}, inputs={'data': data_url})
+# replace the default image with a newer v2
+project.set_default_image("myrepo/my-prebuilt-image:v2")
+# function will now run using the v2 version of the image
+run2 = project.run_function("prep", params={"x": 7}, inputs={"data": data_url})
 ```
 Read more about {ref}`images-usage`.
 
@@ -226,32 +232,32 @@ based on the project configuration and provided parameters:
 For example:
 
 ```python
- # Set image config for current project object, using base mlrun image with additional requirements. 
- image_name = ".my-project-image"
- project.build_config(
-     image=image_name,
-     set_as_default=True,
-     with_mlrun=False,
-     base_image="mlrun/mlrun",
-     requirements=["vaderSentiment"],
- )
+# Set image config for current project object, using base mlrun image with additional requirements.
+image_name = ".my-project-image"
+project.build_config(
+    image=image_name,
+    set_as_default=True,
+    with_mlrun=False,
+    base_image="mlrun/mlrun",
+    requirements=["vaderSentiment"],
+)
 
- # Export the project configuration. The yaml file will contain the build configuration
- proj_file_path = "~/mlrun/my-project/project.yaml"
- project.export(proj_file_path)
+# Export the project configuration. The yaml file will contain the build configuration
+proj_file_path = "~/mlrun/my-project/project.yaml"
+project.export(proj_file_path)
 ```
  
 This project can then be imported and the default image can be built:
 
 ```python
- # Import the project as a new project with a different name
- new_project = mlrun.load_project("~/mlrun/my-project", name="my-other-project")
- # Build the default image for the project, based on project build config
- new_project.build_image()
+# Import the project as a new project with a different name
+new_project = mlrun.load_project("~/mlrun/my-project", name="my-other-project")
+# Build the default image for the project, based on project build config
+new_project.build_image()
 
- # Set a new function and run it (new function uses the my-project-image image built previously)
- new_project.set_function("sentiment.py", name="scores", kind="job", handler="handler")
- new_project.run_function("scores")
+# Set a new function and run it (new function uses the my-project-image image built previously)
+new_project.set_function("sentiment.py", name="scores", kind="job", handler="handler")
+new_project.run_function("scores")
 ```
 
 <a id="build_image"></a>
@@ -264,14 +270,9 @@ If you set a source for the project (for example, git source) and set `pull_at_r
 the generated image contains the project source in it. For example, this code builds `.some-project-image` 
 image with the source in it.
 ```python
-project = mlrun.get_or_create_project(
-    name="project-name", context="./"
-)
+project = mlrun.get_or_create_project(name="project-name", context="./")
 
-project.set_source(
-    "git://some/repo",
-    pull_at_runtime=False
-)
+project.set_source("git://some/repo", pull_at_runtime=False)
 
 project.build_image(image=".some-project-image")
 ```
@@ -290,6 +291,8 @@ image_name = ".temporary-image"
 project.build_image(image=image_name, set_as_default=False)
 
 # Create a function using the temp image name
-project.set_function("sentiment.py", name="scores", kind="job", handler="handler", image=image_name)
+project.set_function(
+    "sentiment.py", name="scores", kind="job", handler="handler", image=image_name
+)
 ```
    

--- a/docs/runtimes/configuring-job-resources.md
+++ b/docs/runtimes/configuring-job-resources.md
@@ -29,7 +29,7 @@ Environment variables can be added individually, from a Python dictionary, or a 
 fn.set_env(name="MY_ENV", value="MY_VAL")
 
 # Multiple variables
-fn.set_envs(env_vars={"MY_ENV" : "MY_VAL", "SECOND_ENV" : "SECOND_VAL"})
+fn.set_envs(env_vars={"MY_ENV": "MY_VAL", "SECOND_ENV": "SECOND_VAL"})
 
 # Multiple variables from file
 fn.set_envs(file_path="env.txt")
@@ -39,8 +39,13 @@ fn.set_envs(file_path="env.txt")
 
 Some runtimes can scale horizontally, configured either as a number of replicas:
 ```python
-training_function = mlrun.code_to_function("training.py", name="training", handler="train", 
-                                           kind="mpijob", image="mlrun/mlrun-gpu")
+training_function = mlrun.code_to_function(
+    "training.py",
+    name="training",
+    handler="train",
+    kind="mpijob",
+    image="mlrun/mlrun-gpu",
+)
 training_function.spec.replicas = 2
 ```
 or a range (for auto-scaling in Dask or Nuclio):
@@ -74,10 +79,15 @@ See more details in the [Kubernetes documentation: Resource Management for Pods 
 Examples of {py:meth}`~mlrun.runtimes.KubeResource.with_requests` and  {py:meth}`~mlrun.runtimes.KubeResource.with_limits`:
 
 ```python
-training_function = mlrun.code_to_function("training.py", name="training", handler="train", 
-                                           kind="mpijob", image="mlrun/mlrun-gpu")
-training_function.with_requests(mem="1G", cpu=1) #lower bound
-training_function.with_limits(mem="2G", cpu=2, gpus=1) #upper bound
+training_function = mlrun.code_to_function(
+    "training.py",
+    name="training",
+    handler="train",
+    kind="mpijob",
+    image="mlrun/mlrun-gpu",
+)
+training_function.with_requests(mem="1G", cpu=1)  # lower bound
+training_function.with_limits(mem="2G", cpu=2, gpus=1)  # upper bound
 ```
 
 ```{admonition} Note
@@ -352,7 +362,11 @@ In some instances, you might need to mount a file-system to your container to pe
 fn.apply(mlrun.mount_v3io())
 
 # Mount persistent storage - PVC
-fn.apply(mlrun.platforms.mount_pvc(pvc_name="data-claim", volume_name="data", volume_mount_path="/data"))
+fn.apply(
+    mlrun.platforms.mount_pvc(
+        pvc_name="data-claim", volume_name="data", volume_mount_path="/data"
+    )
+)
 ```
 
 ## Preventing stuck pods
@@ -375,11 +389,13 @@ To configure to infinity, use `-1`.
 
 To change the state thresholds, use:
 ```python
-func.set_state_thresholds({"pending_not_scheduled": "1 min"}) 
+func.set_state_thresholds({"pending_not_scheduled": "1 min"})
 ```
 For just the run, use:
 ```python
-func.run(state_thresholds={"running": "1 min", "image_pull_backoff": "1 minute and 30s"}) 
+func.run(
+    state_thresholds={"running": "1 min", "image_pull_backoff": "1 minute and 30s"}
+)
 ```
 
 See {py:meth}`~mlrun.runtimes.KubeResource.set_state_thresholds`

--- a/docs/runtimes/image-build.md
+++ b/docs/runtimes/image-build.md
@@ -34,15 +34,15 @@ will require building of the image:
 project = mlrun.new_project(project_name, "./proj")
 
 project.set_function(
-   "train_code.py", 
-   name="trainer",
-   kind="job",
-   image="mlrun/mlrun",
-   handler="train_func",
-   requirements=["pandas"]
+    "train_code.py",
+    name="trainer",
+    kind="job",
+    image="mlrun/mlrun",
+    handler="train_func",
+    requirements=["pandas"],
 )
 
-# auto_build will trigger building the image before running, 
+# auto_build will trigger building the image before running,
 # due to the additional requirements.
 project.run_function("trainer", auto_build=True)
 ```
@@ -69,8 +69,8 @@ resulting image name, as specified in the `image` parameter.
 
 ```python
 project.build_function(
-   "trainer",
-   base_image="myrepo/my_base_image:latest",
+    "trainer",
+    base_image="myrepo/my_base_image:latest",
 )
 ```
 
@@ -82,12 +82,12 @@ To run arbitrary commands during the image build, pass them in the `commands` pa
 github_repo = "myusername/myrepo.git@mybranch"
 
 project.build_function(
-   "trainer",
-   base_image="myrepo/base_image:latest",
-   commands= [
+    "trainer",
+    base_image="myrepo/base_image:latest",
+    commands=[
         "pip install git+https://github.com/" + github_repo,
-        "mkdir -p /some/path && chmod 0777 /some/path",    
-   ]
+        "mkdir -p /some/path && chmod 0777 /some/path",
+    ],
 )
 ```
 
@@ -104,11 +104,7 @@ of the specified version instead.
 For example:
 
 ```python
-project.build_function(
-   "trainer",
-   with_mlrun=True,
-   mlrun_version_specifier="1.0.0"
-)
+project.build_function("trainer", with_mlrun=True, mlrun_version_specifier="1.0.0")
 ```
 
 ### Working with code repository
@@ -167,7 +163,7 @@ Only use this flag in trusted environments or with private registries where you 
 To use this flag, pass it in the extra_args parameter, for example:
 ```python
 project.build_function(
-    ...
+    "<function-name>",
     extra_args="--skip-tls-verify",
 )
 ```
@@ -179,8 +175,8 @@ the `builder_env` parameter, for example:
 
 ```python
 project.build_function(
-   ...
-   builder_env={"GIT_TOKEN": token},
+    "<function-name>",
+    builder_env={"GIT_TOKEN": token},
 )
 ```
 
@@ -195,7 +191,7 @@ Kaniko directly, for example:
 
 ```python
 project.build_function(
-    ...
+    "<function-name>",
     extra_args="--build arg GIT_TOKEN=token --skip-tls-verify",
 )
 ```
@@ -227,9 +223,11 @@ To prepare this image, MLRun provides the following facilities:
 ```python
 # For remote Spark
 from mlrun.runtimes import RemoteSparkRuntime
+
 RemoteSparkRuntime.deploy_default_image()
 
 # For Spark operator
 from mlrun.runtimes import Spark3Runtime
+
 Spark3Runtime.deploy_default_image()
 ```

--- a/docs/runtimes/job-function.md
+++ b/docs/runtimes/job-function.md
@@ -15,15 +15,33 @@ Examples:
 
 ```python
 # register a (single) python file as a function
-project.set_function('src/data_prep.py', name='data-prep', image='mlrun/mlrun', handler='prep', kind="job")
+project.set_function(
+    "src/data_prep.py",
+    name="data-prep",
+    image="mlrun/mlrun",
+    handler="prep",
+    kind="job",
+)
 
-# register a notebook file as a function, specify custom image and extra requirements 
-project.set_function('src/mynb.ipynb', name='test-function', image="my-org/my-image",
-                      handler="run_test", requirements=["scikit-learn"], kind="job")
+# register a notebook file as a function, specify custom image and extra requirements
+project.set_function(
+    "src/mynb.ipynb",
+    name="test-function",
+    image="my-org/my-image",
+    handler="run_test",
+    requirements=["scikit-learn"],
+    kind="job",
+)
 
 # register a module.handler as a function (requires defining the default sources/work dir, if it's not root)
 project.spec.workdir = "src"
-project.set_function(name="train", handler="training.train",  image="mlrun/mlrun", kind="job", with_repo=True)
+project.set_function(
+    name="train",
+    handler="training.train",
+    image="mlrun/mlrun",
+    kind="job",
+    with_repo=True,
+)
 ```
 
 To run the job:

--- a/docs/runtimes/load-from-hub.md
+++ b/docs/runtimes/load-from-hub.md
@@ -75,14 +75,14 @@ import mlrun.common.schemas
 # Add a custom hub to the top of the list
 private_source = mlrun.common.schemas.IndexedHubSource(
     order=-1,
-	source=mlrun.common.schemas.HubSource(
-		metadata=mlrun.common.schemas.HubObjectMetadata(
-		name="private", description="a private hub"
-		),
-		spec=mlrun.common.schemas.HubSourceSpec(
-		path="https://mlrun.github.io/marketplace", channel="development"
-		),
-	)
+    source=mlrun.common.schemas.HubSource(
+        metadata=mlrun.common.schemas.HubObjectMetadata(
+            name="private", description="a private hub"
+        ),
+        spec=mlrun.common.schemas.HubSourceSpec(
+            path="https://mlrun.github.io/marketplace", channel="development"
+        ),
+    ),
 )
 
 db.create_hub_source(private_source)
@@ -97,11 +97,11 @@ The first step for each project is to set the project name and path:
 from os import path, getenv
 from mlrun import new_project
 
-project_name = 'load-func'
-project_path = path.abspath('conf')
+project_name = "load-func"
+project_path = path.abspath("conf")
 project = new_project(project_name, project_path, init_git=True)
 
-print(f'Project path: {project_path}\nProject name: {project_name}')
+print(f"Project path: {project_path}\nProject name: {project_name}")
 ```
 
 ### Set the artifacts path  <!-- omit in toc -->
@@ -112,11 +112,11 @@ The artifact path is the default path for saving all the artifacts that the func
 from mlrun import mlconf
 
 # Target location for storing pipeline artifacts
-artifact_path = path.abspath('jobs')
+artifact_path = path.abspath("jobs")
 # MLRun DB path or API service URL
-mlconf.dbpath = mlconf.dbpath or 'http://mlrun-api:8080'
+mlconf.dbpath = mlconf.dbpath or "http://mlrun-api:8080"
 
-print(f'Artifacts path: {artifact_path}\nMLRun DB path: {mlconf.dbpath}')
+print(f"Artifacts path: {artifact_path}\nMLRun DB path: {mlconf.dbpath}")
 ```
 
 ## Loading functions from the hub
@@ -141,12 +141,12 @@ The `describe` function analyzes a csv or parquet file for data analysis.
 To load the `describe` function from the MLRun function hub:
 
 ```python
-project.set_function('hub://describe', 'describe')
+project.set_function("hub://describe", "describe")
 ```
 
 To load the same function from your custom hub:
 ```python
-project.set_function('hub://<hub-name>/describe', 'describe')
+project.set_function("hub://<hub-name>/describe", "describe")
 ```
 ```{caution} 
 If you don't specify a hub name at all, the algorithm searches for the function in all the hubs, 
@@ -157,7 +157,7 @@ have multiple hubs, best practice is to explicitly mention the hub name.
 After loading the function, create a function object named, for example, `my_describe`:
 
 ```python
-my_describe = project.func('describe')
+my_describe = project.func("describe")
 ```
 
 ## View the function params
@@ -195,20 +195,22 @@ When working with functions, pay attention to the following:
 This example runs the describe function. This function analyzes a dataset (in this case it's a csv file) and generates HTML files (e.g. correlation, histogram) and saves them under the artifact path.
 
 ```python
-DATA_URL = 'https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv'
+DATA_URL = "https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv"
 
-my_describe.run(name='describe',
-                inputs={'table': DATA_URL},
-                artifact_path=artifact_path)
+my_describe.run(
+    name="describe", inputs={"table": DATA_URL}, artifact_path=artifact_path
+)
 ```
 
 ### Saving the artifacts in a unique folder for each run  <!-- omit in toc -->
 
 ```python
-out = mlconf.artifact_path or path.abspath('./data')
-my_describe.run(name='describe',
-                inputs={'table': DATA_URL},
-                artifact_path=path.join(out, '{{run.uid}}'))
+out = mlconf.artifact_path or path.abspath("./data")
+my_describe.run(
+    name="describe",
+    inputs={"table": DATA_URL},
+    artifact_path=path.join(out, "{{run.uid}}"),
+)
 ```
 
 ### Viewing the jobs & the artifacts  <!-- omit in toc -->

--- a/docs/runtimes/serving-function.md
+++ b/docs/runtimes/serving-function.md
@@ -13,35 +13,41 @@ import os
 import urllib.request
 import mlrun
 
-model_path = os.path.abspath('sklearn.pkl')
+model_path = os.path.abspath("sklearn.pkl")
 
 # Download the model file locally
-urllib.request.urlretrieve(mlrun.get_sample_path('models/serving/sklearn.pkl'), model_path)
+urllib.request.urlretrieve(
+    mlrun.get_sample_path("models/serving/sklearn.pkl"), model_path
+)
 
 # Set the base project name
-project_name_base = 'serving-project'
+project_name_base = "serving-project"
 
 # Initialize the MLRun project object
-project = mlrun.get_or_create_project(project_name_base, context="./", user_project=True)
+project = mlrun.get_or_create_project(
+    project_name_base, context="./", user_project=True
+)
 
 serving_function_image = "mlrun/mlrun"
 serving_model_class_name = "mlrun.frameworks.sklearn.SklearnModelServer"
 
 # Create a serving function
-serving_fn = mlrun.new_function("serving", project=project.name, kind="serving", image=serving_function_image)
+serving_fn = mlrun.new_function(
+    "serving", project=project.name, kind="serving", image=serving_function_image
+)
 
 # Add a model, the model key can be anything we choose. The class will be the built-in scikit-learn model server class
 model_key = "scikit-learn"
-serving_fn.add_model(key=model_key,
-                    model_path=model_path,
-                    class_name=serving_model_class_name)
+serving_fn.add_model(
+    key=model_key, model_path=model_path, class_name=serving_model_class_name
+)
 ```
 
 After the serving function is created, you can test it:
 
 ``` python
 # Test data to send
-my_data = {"inputs":[[5.1, 3.5, 1.4, 0.2],[7.7, 3.8, 6.7, 2.2]]}
+my_data = {"inputs": [[5.1, 3.5, 1.4, 0.2], [7.7, 3.8, 6.7, 2.2]]}
 
 # Create a mock server in order to test the model
 mock_server = serving_fn.to_mock_server()
@@ -57,7 +63,7 @@ Similarly, you can deploy the serving function and test it with some data:
 serving_fn.apply(mlrun.auto_mount()).deploy()
 
 # Check the result using the deployed serving function
-serving_fn.invoke(path=f'/v2/models/{model_key}/infer',body=my_data)
+serving_fn.invoke(path=f"/v2/models/{model_key}/infer", body=my_data)
 ```
 
 
@@ -67,9 +73,17 @@ This example illustrates how to use Git with serving function:
 
 ```python
 project = mlrun.get_or_create_project("serving-git", "./")
-project.set_source(source="git://github.com/<username>/<repo>.git#main", pull_at_runtime=True)
-function = project.set_function(name="serving", kind="serving", with_repo=True, func=<python-file>, image="mlrun/mlrun")
-function.add_model("serve", <model_path> ,class_name="MyClass")
+project.set_source(
+    source="git://github.com/<username>/<repo>.git#main", pull_at_runtime=True
+)
+function = project.set_function(
+    name="serving",
+    kind="serving",
+    with_repo=True,
+    func="<python-file>",
+    image="mlrun/mlrun",
+)
+function.add_model("serve", "<model_path>", class_name="MyClass")
 project.deploy_function(function="serving")
 ```
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -40,7 +40,7 @@ The following is an example of using project secrets:
 ```python
 # Create project secrets for the myproj project
 project = mlrun.get_or_create_project("myproj", "./")
-secrets = {'AWS_KEY': '111222333'}
+secrets = {"AWS_KEY": "111222333"}
 project.set_secrets(secrets=secrets, provider="kubernetes")
 
 # Create and run the MLRun job
@@ -49,7 +49,7 @@ function = mlrun.code_to_function(
     filename="my_code.py",
     handler="test_function",
     kind="job",
-    image="mlrun/mlrun"
+    image="mlrun/mlrun",
 )
 function.run()
 ```
@@ -133,7 +133,7 @@ a file containing a list of secrets. For example:
 ```python
 # Create project secrets for the myproj project.
 project = mlrun.get_or_create_project("myproj", "./")
-secrets = {'password': 'myPassw0rd', 'AWS_KEY': '111222333'}
+secrets = {"password": "myPassw0rd", "AWS_KEY": "111222333"}
 project.set_secrets(secrets=secrets, provider="kubernetes")
 ```
 
@@ -164,7 +164,7 @@ It is possible to limit access of an executing job to a
 subset of these secrets by calling the following function with a list of the secrets to be accessed:
 
 ```python
-task.with_secrets('kubernetes', ['password', 'AWS_KEY'])
+task.with_secrets("kubernetes", ["password", "AWS_KEY"])
 ```
 
 When the job is executed, the MLRun framework adds environment variables to the pod spec whose value is retrieved 
@@ -237,8 +237,8 @@ Once these steps are done, use `with_secrets` in the following manner:
 task.with_secrets(
     "azure_vault",
     {
-        "name": <azure_key_vault_name>,
-        "k8s_secret": <azure_key_vault_k8s_secret>,
+        "name": "<azure_key_vault_name>",
+        "k8s_secret": "<azure_key_vault_k8s_secret>",
         "secrets": [],
     },
 )

--- a/docs/serving/built-in-model-serving.md
+++ b/docs/serving/built-in-model-serving.md
@@ -26,35 +26,41 @@ import os
 import urllib.request
 import mlrun
 
-model_path = os.path.abspath('sklearn.pkl')
+model_path = os.path.abspath("sklearn.pkl")
 
 # Download the model file locally
-urllib.request.urlretrieve(mlrun.get_sample_path('models/serving/sklearn.pkl'), model_path)
+urllib.request.urlretrieve(
+    mlrun.get_sample_path("models/serving/sklearn.pkl"), model_path
+)
 
 # Set the base project name
-project_name_base = 'serving-test'
+project_name_base = "serving-test"
 
 # Initialize the MLRun project object
-project = mlrun.get_or_create_project(project_name_base, context="./", user_project=True)
+project = mlrun.get_or_create_project(
+    project_name_base, context="./", user_project=True
+)
 
 serving_function_image = "mlrun/mlrun"
 serving_model_class_name = "mlrun.frameworks.sklearn.SklearnModelServer"
 
 # Create a serving function
-serving_fn = mlrun.new_function("serving", project=project.name, kind="serving", image=serving_function_image)
+serving_fn = mlrun.new_function(
+    "serving", project=project.name, kind="serving", image=serving_function_image
+)
 
 # Add a model, the model key can be anything we choose. The class will be the built-in scikit-learn model server class
 model_key = "scikit-learn"
-serving_fn.add_model(key=model_key,
-                    model_path=model_path,
-                    class_name=serving_model_class_name)
+serving_fn.add_model(
+    key=model_key, model_path=model_path, class_name=serving_model_class_name
+)
 ```
 
 After the serving function is created, you can test it:
 
 ``` python
 # Test data to send
-my_data = {"inputs":[[5.1, 3.5, 1.4, 0.2],[7.7, 3.8, 6.7, 2.2]]}
+my_data = {"inputs": [[5.1, 3.5, 1.4, 0.2], [7.7, 3.8, 6.7, 2.2]]}
 
 # Create a mock server in order to test the model
 mock_server = serving_fn.to_mock_server()
@@ -66,11 +72,11 @@ mock_server.test(f"/v2/models/{model_key}/infer", body=my_data)
 Similarly, you can deploy the serving function and test it with some data:
 
 ``` python
-serving_fn.with_code(body=" ") # Workaround, required only for mlrun <= 1.0.2
+serving_fn.with_code(body=" ")  # Workaround, required only for mlrun <= 1.0.2
 
 # Deploy the serving function
 serving_fn.apply(mlrun.auto_mount()).deploy()
 
 # Check the result using the deployed serving function
-serving_fn.invoke(path=f'/v2/models/{model_key}/infer',body=my_data)
+serving_fn.invoke(path=f"/v2/models/{model_key}/infer", body=my_data)
 ```

--- a/docs/serving/custom-model-serving-class.md
+++ b/docs/serving/custom-model-serving-class.md
@@ -37,15 +37,16 @@ from cloudpickle import load
 import numpy as np
 import mlrun
 
+
 class ClassifierModel(mlrun.serving.V2ModelServer):
     def load(self):
         """load and initialize the model and/or other elements"""
-        model_file, extra_data = self.get_model('.pkl')
-        self.model = load(open(model_file, 'rb'))
+        model_file, extra_data = self.get_model(".pkl")
+        self.model = load(open(model_file, "rb"))
 
     def predict(self, body: dict) -> list:
         """Generate model predictions from sample"""
-        feats = np.asarray(body['inputs'])
+        feats = np.asarray(body["inputs"])
         result: np.ndarray = self.model.predict(feats)
         return result.tolist()
 ```
@@ -56,7 +57,7 @@ class ClassifierModel(mlrun.serving.V2ModelServer):
 import mlrun
 from sklearn.datasets import load_iris
 
-fn = mlrun.new_function('my_server', kind='serving')
+fn = mlrun.new_function("my_server", kind="serving")
 
 # set the topology/router and add models
 graph = fn.set_topology("router")
@@ -65,7 +66,7 @@ fn.add_model("model2", class_name="ClassifierModel", model_path="<path2>")
 
 # create and use the graph simulator
 server = fn.to_mock_server()
-x = load_iris()['data'].tolist()
+x = load_iris()["data"].tolist()
 result = server.test("/v2/models/model1/infer", {"inputs": x})
 ```
 
@@ -136,8 +137,9 @@ Example (run inside a notebook): this code converts a notebook to a serving func
 
 ```python
 from mlrun import code_to_function
-fn = code_to_function('my-function', kind='serving')
-fn.add_model('m1', model_path=<model-artifact/dir>, class_name='MyClass', x=100)
+
+fn = code_to_function("my-function", kind="serving")
+fn.add_model("m1", model_path="<model-artifact/dir>", class_name="MyClass", x=100)
 ``` 
 
 See [`.add_model()`](../api/mlrun.runtimes.html#mlrun.runtimes.ServingRuntime.add_model) docstring for help and parameters.

--- a/docs/serving/test-deploy-model-server.md
+++ b/docs/serving/test-deploy-model-server.md
@@ -10,15 +10,15 @@
 MLRun provides a mock server as part of the `serving` runtime. This gives you the ability to deploy your serving function in your local environment for testing purposes.
 
 ```python
-serving_fn = code_to_function(name='myService', kind='serving', image='mlrun/mlrun')
-serving_fn.add_model('my_model', model_path=model_file_path)
+serving_fn = code_to_function(name="myService", kind="serving", image="mlrun/mlrun")
+serving_fn.add_model("my_model", model_path=model_file_path)
 server = serving_fn.to_mock_server()
 ```
 
 You can use test data and programmatically invoke the `predict()` method of mock server. In this example, the model is expecting a python dictionary as input.
 
 ```python
-my_data = '''{"inputs":[[5.1, 3.5, 1.4, 0.2],[7.7, 3.8, 6.7, 2.2]]}'''
+my_data = """{"inputs":[[5.1, 3.5, 1.4, 0.2],[7.7, 3.8, 6.7, 2.2]]}"""
 server.test("/v2/models/my_model/infer", body=my_data)
 ```
 
@@ -43,8 +43,9 @@ This example converts a notebook to a serving function and adds a model to it:
 
 ```python
 from mlrun import code_to_function
-fn = code_to_function('my-function', kind='serving')
-fn.add_model('m1', model_path=<model-artifact/dir>, class_name='MyClass', x=100)
+
+fn = code_to_function("my-function", kind="serving")
+fn.add_model("m1", model_path="<model-artifact/dir>", class_name="MyClass", x=100)
 ``` 
 
 See [`.add_model()`](../api/mlrun.runtimes.html#mlrun.runtimes.ServingRuntime.add_model) docstring for help and parameters.

--- a/docs/store/artifacts.md
+++ b/docs/store/artifacts.md
@@ -90,7 +90,8 @@ to a `training_artifacts` variable:
 
 ```python
 from os import path
-training_artifacts = path.join(artifact_path, 'training')
+
+training_artifacts = path.join(artifact_path, "training")
 ```
 
 ```{admonition} Note

--- a/docs/store/data-items.md
+++ b/docs/store/data-items.md
@@ -13,23 +13,32 @@ Example function:
 # Save this code as a .py file:
 import mlrun
 
-def prep_data(context, source_url: mlrun.DataItem, label_column='label'):
+
+def prep_data(context, source_url: mlrun.DataItem, label_column="label"):
     # Convert the DataItem to a Pandas DataFrame
     df = source_url.as_df()
     df = df.drop(label_column, axis=1).dropna()
-    context.log_dataset('cleaned_data', df=df, index=False, format='csv')
+    context.log_dataset("cleaned_data", df=df, index=False, format="csv")
 ```
 
 Creating a project, setting the function into it, defining the URL with the data and running the function:
 
 ```python
-source_url = mlrun.get_sample_path('data/batch-predict/training_set.parquet')
+source_url = mlrun.get_sample_path("data/batch-predict/training_set.parquet")
 project = mlrun.get_or_create_project("data-items", "./", user_project=True)
-data_prep_func = project.set_function("data-prep.py", name="data-prep", kind="job", image="mlrun/mlrun", handler="prep_data")
-prep_data_run = data_prep_func.run(name='prep_data',
-                                   handler=prep_data,
-                                   inputs={'source_url': source_url},
-                                   params={'label_column': 'label'})
+data_prep_func = project.set_function(
+    "data-prep.py",
+    name="data-prep",
+    kind="job",
+    image="mlrun/mlrun",
+    handler="prep_data",
+)
+prep_data_run = data_prep_func.run(
+    name="prep_data",
+    handler=prep_data,
+    inputs={"source_url": source_url},
+    params={"label_column": "label"},
+)
 ```
 
 To call the function with an `input` you can use the `inputs` dictionary attribute. To pass
@@ -42,7 +51,7 @@ Reading the data results from the run, you can easily get a run output artifact 
 
 ```python
 # read the data locally as a Dataframe
-prep_data_run.artifact('cleaned_data').as_df()
+prep_data_run.artifact("cleaned_data").as_df()
 ```
 
 The {py:class}`~mlrun.datastore.DataItem` supports multiple convenience methods such as:

--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -51,7 +51,7 @@ Refer to [Working with secrets](../secrets.html) for details on secret handling 
 For example, running a function locally:
 
 ```python
-# Access object in AWS S3, in the "input-data" bucket 
+# Access object in AWS S3, in the "input-data" bucket
 source_url = "s3://input-data/input_data.csv"
 
 os.environ["AWS_ACCESS_KEY_ID"] = "<access key ID>"
@@ -59,22 +59,27 @@ os.environ["AWS_SECRET_ACCESS_KEY"] = "<access key>"
 
 # Execute a function that reads from the object pointed at by source_url.
 # When running locally, the function can use the local environment variables.
-local_run = func.run(name='aws_func', inputs={'source_url': source_url}, local=True)
+local_run = func.run(name="aws_func", inputs={"source_url": source_url}, local=True)
 ```
 
 Running the same function remotely:
 
 ```python
 # Executing the function remotely using env variables (not recommended!)
-func.set_env("AWS_ACCESS_KEY_ID", "<access key ID>").set_env("AWS_SECRET_ACCESS_KEY", "<access key>")
-remote_run = func.run(name='aws_func', inputs={'source_url': source_url})
+func.set_env("AWS_ACCESS_KEY_ID", "<access key ID>").set_env(
+    "AWS_SECRET_ACCESS_KEY", "<access key>"
+)
+remote_run = func.run(name="aws_func", inputs={"source_url": source_url})
 
 # Using project-secrets (recommended) - project secrets are automatically mounted to project functions
-secrets = {"AWS_ACCESS_KEY_ID": "<access key ID>", "AWS_SECRET_ACCESS_KEY": "<access key>"}
+secrets = {
+    "AWS_ACCESS_KEY_ID": "<access key ID>",
+    "AWS_SECRET_ACCESS_KEY": "<access key>",
+}
 db = mlrun.get_run_db()
 db.create_project_secrets(project=project_name, provider="kubernetes", secrets=secrets)
 
-remote_run = func.run(name='aws_func', inputs={'source_url': source_url})
+remote_run = func.run(name="aws_func", inputs={"source_url": source_url})
 ```
   
 ## Data store profiles
@@ -110,7 +115,12 @@ More options:
     For example, using Redis:
     ```python
     redis_profile = project.get_datastore_profile("my_profile")
-    local_redis_profile = DatastoreProfileRedis(redis_profile.name, redis_profile.endpoint_url, username="mylocaluser", password="mylocalpassword")
+    local_redis_profile = DatastoreProfileRedis(
+        redis_profile.name,
+        redis_profile.endpoint_url,
+        username="mylocaluser",
+        password="mylocalpassword",
+    )
     register_temporary_client_datastore_profile(local_redis_profile)
     ```
 
@@ -158,7 +168,9 @@ authentication methods that use the `fsspec` mechanism.
 
 ### Azure data store profile
 ```python
-profile = DatastoreProfileAzureBlob(name="profile-name",connection_string=connection_string)
+profile = DatastoreProfileAzureBlob(
+    name="profile-name", connection_string=connection_string
+)
 ParquetTarget(path="ds://profile-name/az_blob/path/to/parquet.pq")
 ```
 
@@ -212,7 +224,11 @@ Not supported by the spark and remote-spark runtimes.
 ### DBFS data store profile
 
 ```python
-profile = DatastoreProfileDBFS(name="profile-name", endpoint_url="abc-d1e2345f-a6b2.cloud.databricks.com", token=token)
+profile = DatastoreProfileDBFS(
+    name="profile-name",
+    endpoint_url="abc-d1e2345f-a6b2.cloud.databricks.com",
+    token=token,
+)
 ParquetTarget(path="ds://profile-name/path/to/parquet.pq")
 ```
 
@@ -237,7 +253,9 @@ contents directly to the query engine.
 ### GCS data store profile
 
 ```python
-profile = DatastoreProfileGCS(name="profile-name",credentials_path="/local_path/to/gcs_credentials.json")
+profile = DatastoreProfileGCS(
+    name="profile-name", credentials_path="/local_path/to/gcs_credentials.json"
+)
 ParquetTarget(path="ds://profile-name/gcs_bucket/path/to/parquet.pq")
 ```
 
@@ -277,6 +295,7 @@ ParquetTarget(path="ds://profile-name/path/to/parquet.pq")
 You can set `HADOOP_USER_NAME` locally as follows: 
 ```python
 import os
+
 os.environ["HADOOP_USER_NAME"] = "..."
 ```
 
@@ -298,15 +317,13 @@ function.spec.env.append({"name": "HADOOP_USER_NAME", "value": "galt"})
 In feature store, you can set it via `RunConfig`:
 ```python
 from mlrun.feature_store.common import RunConfig
+
 run_config = RunConfig(
     local=False,
     kind="remote-spark",
     extra_spec={"spec": {"env": [{"name": "HADOOP_USER_NAME", "value": "galt"}]}},
 )
-feature_set.ingest(
-    ...,
-    run_config=run_config
-)
+feature_set.ingest(..., run_config=run_config)
 ```
 
 ## S3
@@ -360,8 +377,12 @@ authenticate, it is used in several use-cases, such as resolving paths to the ho
 
 ### V3IO data store profile
 ```python
-profile = DatastoreProfileV3io(name="test_profile", v3io_access_key="12345678-1234-1234-1234-123456789012")
-register_temporary_client_datastore_profile(profile) or project.register_datastore_profile(profile)
+profile = DatastoreProfileV3io(
+    name="test_profile", v3io_access_key="12345678-1234-1234-1234-123456789012"
+)
+register_temporary_client_datastore_profile(
+    profile
+) or project.register_datastore_profile(profile)
 ParquetTarget(path="ds://test_profile/aws_bucket/path/to/parquet.pq")
 ```
 

--- a/docs/store/log-artifacts.md
+++ b/docs/store/log-artifacts.md
@@ -22,24 +22,24 @@ To log an artifacts file, specify the local file path to the file using the `loc
 
 **Log with local path**
 ```python
-    with open("file.txt","w") as f:
-        f.write("abc is 123")
-    
-    project.log_artifact(
-        "file-example",
-        local_path="file.txt",
-        labels={"Test": "label-test"},
-    )
+with open("file.txt", "w") as f:
+    f.write("abc is 123")
+
+project.log_artifact(
+    "file-example",
+    local_path="file.txt",
+    labels={"Test": "label-test"},
+)
 ```
 
 **Log with body**
 ```python
-    project.log_artifact(
-        "some-data",
-        body=b"abc is 123",
-        format="txt",
-        labels={"Test": "label-test"},
-    )
+project.log_artifact(
+    "some-data",
+    body=b"abc is 123",
+    format="txt",
+    labels={"Test": "label-test"},
+)
 ```
 
 ## Log a Plotly object as an html file
@@ -47,39 +47,40 @@ This example illustrates logging a Plotly figure using `log_artifact` as an `htm
 ```python
 import plotly.graph_objects as go
 import numpy as np
+
 # Create a Sin(x) Graph
 x = np.linspace(0, 10, 100)
 y = np.sin(x)
 # Create a Plotly figure
 fig = go.Figure()
 # Add a line trace to the figure
-fig.add_trace(go.Scatter(x=x, y=y, mode='lines', name='Sin(x)'))
+fig.add_trace(go.Scatter(x=x, y=y, mode="lines", name="Sin(x)"))
 # Update layout
 fig.update_layout(
-    title="Sin(x) Plot",
-    xaxis_title="x",
-    yaxis_title="sin(x)",
-    template="plotly_dark" 
+    title="Sin(x) Plot", xaxis_title="x", yaxis_title="sin(x)", template="plotly_dark"
 )
-project.log_artifact("plotly-artifact",
-                     body=fig.to_html(),# convert object for logging an html file
-                     format="html")
+project.log_artifact(
+    "plotly-artifact",
+    body=fig.to_html(),  # convert object for logging an html file
+    format="html",
+)
 ```
 ## Logging Plotly artifacts 
 This example illustrates using MLRun to convert and handle the object: 
 ```python
 # Use mlrun to convert the python object
-plotly_artifact = mlrun.artifacts.PlotlyArtifact(figure=fig, key="sin_x") 
+plotly_artifact = mlrun.artifacts.PlotlyArtifact(figure=fig, key="sin_x")
 # Log the artifact
-context.log_artifact(plotly_artifact) 
+context.log_artifact(plotly_artifact)
 ```
 ## Logging directory artifacts 
 When using `log_artifact` to log a directory, by default:
 - The artifact is logged as an `mlrun.artifacts.DirArtifact` object.
 - The files are not uploaded. If you want to upload the files, set `upload=True`.
 ```python
-    project.log_artifact(
+project.log_artifact(
     "artifact-directory-testing",
     local_path="./artifact_directory/",
-    labels={"Dir":"dir-example"})
+    labels={"Dir": "dir-example"},
+)
 ```

--- a/docs/store/models.md
+++ b/docs/store/models.md
@@ -7,8 +7,9 @@ The simplest way to store a model named `my_model` is with the following code:
 
 ``` python
 from pickle import dumps
+
 model_data = dumps(model)
-context.log_model(key='my_model', body=model_data, model_file='my_model.pkl')
+context.log_model(key="my_model", body=model_data, model_file="my_model.pkl")
 ```
 
 You can also store any related metrics by providing a dictionary in the `metrics` parameter, such as `metrics={'accuracy': 0.9}`. Furthermore, any additional data that you would like to store along with the model can be specified in the `extra_data` parameter. For example `extra_data={'confusion': confusion.target_path}`
@@ -26,26 +27,30 @@ from pickle import dumps
 from mlrun.execution import MLClientCtx
 from mlrun.mlutils import eval_model_v2
 
+
 def train_iris(context: MLClientCtx):
 
     # Basic scikit-learn iris SVM model
     X, y = datasets.load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42)
+        X, y, test_size=0.2, random_state=42
+    )
     model = linear_model.LogisticRegression(max_iter=10000)
     model.fit(X_train, y_train)
-    
+
     # Evaluate model results and get the evaluation metrics
     eval_metrics = eval_model_v2(context, X_test, y_test, model)
-    
+
     # Log model
-    context.log_model("model",
-                      body=dumps(model),
-                      artifact_path=context.artifact_subpath("models"),
-                      extra_data=eval_metrics, 
-                      model_file="model.pkl",
-                      metrics=context.results,
-                      labels={"class": "sklearn.linear_model.LogisticRegression"})
+    context.log_model(
+        "model",
+        body=dumps(model),
+        artifact_path=context.artifact_subpath("models"),
+        extra_data=eval_metrics,
+        model_file="model.pkl",
+        metrics=context.results,
+        labels={"class": "sklearn.linear_model.LogisticRegression"},
+    )
 ```
 
 Save the code above to `train_iris.py`. The following code loads the function and runs it as a job. See the [quick-start page](quick-start.html#mlrun-setup) to learn how to create the project and set the artifact path. 
@@ -53,17 +58,19 @@ Save the code above to `train_iris.py`. The following code loads the function an
 ``` python
 from mlrun import code_to_function
 
-gen_func = code_to_function(name='train_iris',
-                            filename='train_iris.py',
-                            handler='train_iris',
-                            kind='job',
-                            image='mlrun/mlrun')
+gen_func = code_to_function(
+    name="train_iris",
+    filename="train_iris.py",
+    handler="train_iris",
+    kind="job",
+    image="mlrun/mlrun",
+)
 
 train_iris_func = project.set_function(gen_func).apply(auto_mount())
 
-train_iris = train_iris_func.run(name='train_iris',
-                                 handler='train_iris',
-                                 artifact_path=artifact_path)
+train_iris = train_iris_func.run(
+    name="train_iris", handler="train_iris", artifact_path=artifact_path
+)
 ```
 
 You can now use `get_model` to read the model and run it. This function will get the model file, metadata, and extra data. The input can be either the path of the model, or the directory where the model resides. If you provide a directory, the function will search for the model file (by default it searches for .pkl files)
@@ -78,10 +85,10 @@ from mlrun.datastore import DataItem
 from mlrun.artifacts import get_model, update_model
 from mlrun.mlutils import eval_model_v2
 
-def test_model(context: MLClientCtx,
-               models_path: DataItem,
-               test_set: DataItem,
-               label_column: str):
+
+def test_model(
+    context: MLClientCtx, models_path: DataItem, test_set: DataItem, label_column: str
+):
 
     if models_path is None:
         models_path = context.artifact_subpath("models")
@@ -89,30 +96,41 @@ def test_model(context: MLClientCtx,
     ytest = xtest.pop(label_column)
 
     model_file, model_obj, _ = get_model(models_path)
-    model = load(open(model_file, 'rb'))
+    model = load(open(model_file, "rb"))
 
     extra_data = eval_model_v2(context, xtest, ytest.values, model)
-    update_model(model_artifact=model_obj, extra_data=extra_data, 
-                 metrics=context.results, key_prefix='validation-')
+    update_model(
+        model_artifact=model_obj,
+        extra_data=extra_data,
+        metrics=context.results,
+        key_prefix="validation-",
+    )
 ```
 
 To run the code, place the code above in `test_model.py` and use the following snippet. The model from the previous step is provided as the `models_path`:
 
 ``` python
 from mlrun.platforms import auto_mount
-gen_func = code_to_function(name='test_model',
-                            filename='test_model.py',
-                            handler='test_model',
-                            kind='job',
-                            image='mlrun/mlrun')
+
+gen_func = code_to_function(
+    name="test_model",
+    filename="test_model.py",
+    handler="test_model",
+    kind="job",
+    image="mlrun/mlrun",
+)
 
 func = project.set_function(gen_func).apply(auto_mount())
 
-run = func.run(name='test_model',
-                handler='test_model',
-                params={'label_column': 'label'},
-                inputs={'models_path': train_iris.outputs['model'],
-                        'test_set': 'https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv'}),
-                artifact_path=artifact_path)
+run = func.run(
+    name="test_model",
+    handler="test_model",
+    params={"label_column": "label"},
+    inputs={
+        "models_path": train_iris.outputs["model"],
+        "test_set": "https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv",
+    },
+    artifact_path=artifact_path,
+)
 ```
 

--- a/docs/training/working-with-data-and-model-artifacts.md
+++ b/docs/training/working-with-data-and-model-artifacts.md
@@ -13,13 +13,13 @@ Consider the following snippet from a pipeline in the [Build and run automated M
 train = mlrun.run_function(
     "hub://auto_trainer",
     inputs={"dataset": ingest.outputs["dataset"]},
-    params = {
+    params={
         "model_class": "sklearn.ensemble.RandomForestClassifier",
         "train_test_split_size": 0.2,
         "label_columns": "label",
-        "model_name": 'cancer',
-    }, 
-    handler='train',
+        "model_name": "cancer",
+    },
+    handler="train",
     outputs=["model"],
 )
 
@@ -37,7 +37,8 @@ For example, this Python training function is expecting a parameter called `data
 ```python
 import mlrun
 
-def train(context: mlrun.MLClientCtx, dataset: mlrun.DataItem, ...):
+
+def train(context: mlrun.MLClientCtx, dataset: mlrun.DataItem):
     df = dataset.as_df()
 ```
 Notice how this maps to the parameter `datasets` that you passed into your `inputs`.
@@ -53,21 +54,24 @@ from mlrun.frameworks.sklearn import apply_mlrun
 from sklearn import ensemble
 import cloudpickle
 
-def train(context: mlrun.MLClientCtx, dataset: mlrun.DataItem, ...):
+
+def train(context: mlrun.MLClientCtx, dataset: mlrun.DataItem):
     # Prep data using df
     df = dataset.as_df()
     X_train, X_test, y_train, y_test = ...
-    
+
     # Apply auto logging
     model = ensemble.GradientBoostingClassifier(...)
     apply_mlrun(model=model, model_name=model_name, x_test=X_test, y_test=y_test)
 
     # Train
     model.fit(X_train, y_train)
-    
+
     # Manual logging
     context.log_dataset(key="X_test_dataset", df=X_test)
-    context.log_model(key="my_model", body=cloudpickle.dumps(model), model_file="model.pkl")
+    context.log_model(
+        key="my_model", body=cloudpickle.dumps(model), model_file="model.pkl"
+    )
 ```
 
 Once your artifact is logged, it can be accessed throughout the rest of the pipeline. For example, for the pipeline snippet from the [Build and run automated ML pipelines and CI/CD](../tutorials/04-pipeline.html#build-and-run-automated-ml-pipelines-and-ci-cd) section of the docs, you can access your model like the following:
@@ -76,7 +80,6 @@ Once your artifact is logged, it can be accessed throughout the rest of the pipe
 train = mlrun.run_function(
     "hub://auto_trainer",
     inputs={"dataset": ingest.outputs["dataset"]},
-    ...
     outputs=["model"],
 )
 
@@ -97,8 +100,9 @@ The simplest way to store a model named `my_model` is with the following code:
 
 ``` python
 from pickle import dumps
+
 model_data = dumps(model)
-context.log_model(key='my_model', body=model_data, model_file='my_model.pkl')
+context.log_model(key="my_model", body=model_data, model_file="my_model.pkl")
 ```
 
 You can also store any related metrics by providing a dictionary in the `metrics` parameter, such as `metrics={'accuracy': 0.9}`. 
@@ -118,26 +122,30 @@ from pickle import dumps
 from mlrun.execution import MLClientCtx
 from mlrun.mlutils import eval_model_v2
 
+
 def train_iris(context: MLClientCtx):
 
     # Basic scikit-learn iris SVM model
     X, y = datasets.load_iris(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42)
+        X, y, test_size=0.2, random_state=42
+    )
     model = linear_model.LogisticRegression(max_iter=10000)
     model.fit(X_train, y_train)
-    
+
     # Evaluate model results and get the evaluation metrics
     eval_metrics = eval_model_v2(context, X_test, y_test, model)
-    
+
     # Log model
-    context.log_model("model",
-                      body=dumps(model),
-                      artifact_path=context.artifact_subpath("models"),
-                      extra_data=eval_metrics, 
-                      model_file="model.pkl",
-                      metrics=context.results,
-                      labels={"class": "sklearn.linear_model.LogisticRegression"})
+    context.log_model(
+        "model",
+        body=dumps(model),
+        artifact_path=context.artifact_subpath("models"),
+        extra_data=eval_metrics,
+        model_file="model.pkl",
+        metrics=context.results,
+        labels={"class": "sklearn.linear_model.LogisticRegression"},
+    )
 ```
 
 Save the code above to `train_iris.py`. The following code loads the function and runs it as a job. See the [Quick start tutorial](../tutorials/01-mlrun-basics.html) to learn how to create the project and set the artifact path. 
@@ -145,17 +153,19 @@ Save the code above to `train_iris.py`. The following code loads the function an
 ``` python
 from mlrun import code_to_function
 
-gen_func = code_to_function(name='train_iris',
-                            filename='train_iris.py',
-                            handler='train_iris',
-                            kind='job',
-                            image='mlrun/mlrun')
+gen_func = code_to_function(
+    name="train_iris",
+    filename="train_iris.py",
+    handler="train_iris",
+    kind="job",
+    image="mlrun/mlrun",
+)
 
 train_iris_func = project.set_function(gen_func).apply(auto_mount())
 
-train_iris = train_iris_func.run(name='train_iris',
-                                 handler='train_iris',
-                                 artifact_path=artifact_path)
+train_iris = train_iris_func.run(
+    name="train_iris", handler="train_iris", artifact_path=artifact_path
+)
 ```
 
 You can now use `get_model` to read the model and run it. This function gets the model file, metadata, and extra data. The input can be 
@@ -174,10 +184,10 @@ from mlrun.datastore import DataItem
 from mlrun.artifacts import get_model, update_model
 from mlrun.mlutils import eval_model_v2
 
-def test_model(context: MLClientCtx,
-               models_path: DataItem,
-               test_set: DataItem,
-               label_column: str):
+
+def test_model(
+    context: MLClientCtx, models_path: DataItem, test_set: DataItem, label_column: str
+):
 
     if models_path is None:
         models_path = context.artifact_subpath("models")
@@ -185,31 +195,42 @@ def test_model(context: MLClientCtx,
     ytest = xtest.pop(label_column)
 
     model_file, model_obj, _ = get_model(models_path)
-    model = load(open(model_file, 'rb'))
+    model = load(open(model_file, "rb"))
 
     extra_data = eval_model_v2(context, xtest, ytest.values, model)
-    update_model(model_artifact=model_obj, extra_data=extra_data, 
-                 metrics=context.results, key_prefix='validation-')
+    update_model(
+        model_artifact=model_obj,
+        extra_data=extra_data,
+        metrics=context.results,
+        key_prefix="validation-",
+    )
 ```
 
 To run the code, place the code above in `test_model.py` and use the following snippet. The model from the previous step is provided as the `models_path`:
 
 ``` python
 from mlrun.platforms import auto_mount
-gen_func = code_to_function(name='test_model',
-                            filename='test_model.py',
-                            handler='test_model',
-                            kind='job',
-                            image='mlrun/mlrun')
+
+gen_func = code_to_function(
+    name="test_model",
+    filename="test_model.py",
+    handler="test_model",
+    kind="job",
+    image="mlrun/mlrun",
+)
 
 func = project.set_function(gen_func).apply(auto_mount())
 
-run = func.run(name='test_model',
-                handler='test_model',
-                params={'label_column': 'label'},
-                inputs={'models_path': train_iris.outputs['model'],
-                        'test_set': 'https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv'}),
-                artifact_path=artifact_path)
+run = func.run(
+    name="test_model",
+    handler="test_model",
+    params={"label_column": "label"},
+    inputs={
+        "models_path": train_iris.outputs["model"],
+        "test_set": "https://s3.wasabisys.com/iguazio/data/iris/iris_dataset.csv",
+    },
+    artifact_path=artifact_path,
+)
 ```
 
 ### Plot artifacts
@@ -225,14 +246,13 @@ from mlrun.artifacts import PlotArtifact
 from mlrun.mlutils import gcf_clear
 
 gcf_clear(plt)
-confusion_matrix = metrics.plot_confusion_matrix(model,
-                                                 xtest,
-                                                 ytest,
-                                                 normalize='all',
-                                                 values_format = '.2g',
-                                                 cmap=plt.cm.Blues)
-confusion_matrix = context.log_artifact(PlotArtifact('confusion-matrix', body=confusion_matrix.figure_), 
-                                        local_path='plots/confusion_matrix.html')
+confusion_matrix = metrics.plot_confusion_matrix(
+    model, xtest, ytest, normalize="all", values_format=".2g", cmap=plt.cm.Blues
+)
+confusion_matrix = context.log_artifact(
+    PlotArtifact("confusion-matrix", body=confusion_matrix.figure_),
+    local_path="plots/confusion_matrix.html",
+)
 ```
 
 You can use the `update_dataset_meta` function to associate the plot with the dataset by assigning the value of the `extra_data` parameter:
@@ -240,6 +260,6 @@ You can use the `update_dataset_meta` function to associate the plot with the da
 ``` python
 from mlrun.artifacts import update_dataset_meta
 
-extra_data = {'confusion_matrix': confusion_matrix}
+extra_data = {"confusion_matrix": confusion_matrix}
 update_dataset_meta(dataset, extra_data=extra_data)
 ```


### PR DESCRIPTION
https://github.com/adamchainz/blacken-docs

This change introduces the following benefits:

1. Ensure code blocks in the docs are coherent syntax-wise.
2. Format them according to Black conventions.

Add a new phony target, `make fmt-docs`, and enforce it as part of `make lint`, which runs in the CI workflow.

Some examples of wrong syntax in the docs before this PR:
1. Missing closing parenthesis `)`: 
   https://github.com/mlrun/mlrun/blob/f72280de3594af30e85ea6d344fc5c4a34b11ec8/docs/monitoring/model-monitoring.md?plain=1#L38-L45
2. Missing trailing comma `,` in L61 and L62:
   https://github.com/mlrun/mlrun/blob/f72280de3594af30e85ea6d344fc5c4a34b11ec8/docs/data-prep/logging_datasets.md?plain=1#L60-L64
3. Not a Python code block: 
   https://github.com/mlrun/mlrun/blob/f72280de3594af30e85ea6d344fc5c4a34b11ec8/docs/install/kubernetes.md?plain=1#L378-L380
4. Function body (`...` placeholder) unindented:
   https://github.com/mlrun/mlrun/blob/f72280de3594af30e85ea6d344fc5c4a34b11ec8/docs/concepts/decorators-and-auto-logging.md?plain=1#L80-L88

There are many more wrong syntax examples, but they are all fixed here.

Note: I previously configured Ruff to check and format code blocks inside Python/Jupyter Notebooks, such as code blocks in docstrings.
However, it's not designed to run on markdown files.