### PR TITLE
[Dependabot] Add a prefix Dependabot PRs' title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,6 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[Dependabot-automated] "
+    open-pull-requests-limit: 6


### PR DESCRIPTION
I chose "[Dependabot-automated]" and not just "[Dependabot]" to distinguish from non-automated PRs related to Depedabot, such as this one.
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message

We will see the effect after merging this one - the default limit is 5 PRs a day, I increase it here to 6.
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit