### PR TITLE
[Tests] Skip "basic model monitoring" failing system test

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -239,6 +239,7 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         )
 
 
+@pytest.mark.skip(reason="Chronically fails, see ML-5820")
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestBasicModelMonitoring(TestMLRunSystem):


### PR DESCRIPTION
It's the only one still failing. See:
https://github.com/mlrun/mlrun/actions/runs/9629559040/job/26561917759#step:9:2264
It should be fixed as a part of [ML-5820](https://iguazio.atlassian.net/browse/ML-5820).

[ML-5820]: https://iguazio.atlassian.net/browse/ML-5820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ