### PR TITLE
[Tests] Fix transient failures in alerts system test

### DIFF
--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -322,4 +322,9 @@ class TestAlerts(TestMLRunSystem):
                 nuclio_function_url
             )
         )
-        assert deepdiff.DeepDiff(sent_notifications, expected_notifications) == {}
+        assert (
+            deepdiff.DeepDiff(
+                sent_notifications, expected_notifications, ignore_order=True
+            )
+            == {}
+        )


### PR DESCRIPTION
We do not care about order of events that may change due to scheduling. Only of their correctness