### PR TITLE
[Requirements] Pin the `black` version for `blacken-docs`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ build~=1.0
 ruff==0.4.2
 import-linter~=2.0
 blacken-docs~=1.16
+black~=24.4  # only used by by blacken-docs
 
 # testing
 pytest~=8.2


### PR DESCRIPTION
`blacken-docs` depends on `black` but doesn't pin its version.
Pin the version to avoid incompatible versions on dev machines.
`blacken-docs` was added in https://github.com/mlrun/mlrun/pull/5803.