### PR TITLE
[Tests] Skip only the failed item in model monitoring system test

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -239,7 +239,6 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         )
 
 
-@pytest.mark.skip(reason="Chronically fails, see ML-5820")
 @TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise
 class TestBasicModelMonitoring(TestMLRunSystem):
@@ -250,7 +249,15 @@ class TestBasicModelMonitoring(TestMLRunSystem):
     image: Optional[str] = None
 
     @pytest.mark.timeout(540)
-    @pytest.mark.parametrize("with_sql_target", [True, False])
+    @pytest.mark.parametrize(
+        "with_sql_target",
+        [
+            pytest.param(
+                True, marks=pytest.mark.skip(reason="Chronically fails, see ML-5820")
+            ),
+            False,
+        ],
+    )
     def test_basic_model_monitoring(self, with_sql_target: bool) -> None:
         # Main validations:
         # 1 - a single model endpoint is created


### PR DESCRIPTION
```
FAILED tests/system/model_monitoring/test_model_monitoring.py::TestBasicModelMonitoring::test_basic_model_monitoring[True] - Failed: Timeout >540.0s
```
https://github.com/mlrun/mlrun/actions/runs/9578535260/job/26415725363#step:9:2611 https://github.com/mlrun/mlrun/actions/runs/9629559040/job/26561917759#step:9:2264
See https://github.com/mlrun/mlrun/pull/5832.
The `False` case passed.