### PR TITLE
[Coding Conventions] Enforce CamelCase for class names

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -50,12 +50,12 @@ from .run import (
 from .runtimes import RemoteRuntime, RunError, RuntimeKinds, ServingRuntime
 from .secrets import SecretsStore
 from .utils import (
+    RunKeys,
     dict_to_yaml,
     get_in,
     is_relative_path,
     list2dict,
     logger,
-    run_keys,
     update_in,
 )
 from .utils.version import Version
@@ -380,15 +380,15 @@ def run(
     set_item(runobj.spec.hyper_param_options, hyper_param_strategy, "strategy")
     set_item(runobj.spec.hyper_param_options, selector, "selector")
 
-    set_item(runobj.spec, inputs, run_keys.inputs, list2dict(inputs))
+    set_item(runobj.spec, inputs, RunKeys.inputs, list2dict(inputs))
     set_item(
-        runobj.spec, returns, run_keys.returns, [py_eval(value) for value in returns]
+        runobj.spec, returns, RunKeys.returns, [py_eval(value) for value in returns]
     )
-    set_item(runobj.spec, in_path, run_keys.input_path)
-    set_item(runobj.spec, out_path, run_keys.output_path)
-    set_item(runobj.spec, outputs, run_keys.outputs, list(outputs))
+    set_item(runobj.spec, in_path, RunKeys.input_path)
+    set_item(runobj.spec, out_path, RunKeys.output_path)
+    set_item(runobj.spec, outputs, RunKeys.outputs, list(outputs))
     set_item(
-        runobj.spec, secrets, run_keys.secrets, line2keylist(secrets, "kind", "source")
+        runobj.spec, secrets, RunKeys.secrets, line2keylist(secrets, "kind", "source")
     )
     set_item(runobj.spec, verbose, "verbose")
     set_item(runobj.spec, scrape_metrics, "scrape_metrics")

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -21,7 +21,7 @@ from mlrun.datastore.datastore_profile import datastore_profile_read
 from mlrun.errors import err_to_str
 from mlrun.utils.helpers import get_local_file_schema
 
-from ..utils import DB_SCHEMA, run_keys
+from ..utils import DB_SCHEMA, RunKeys
 from .base import DataItem, DataStore, HttpStore
 from .filestore import FileStore
 from .inmem import InMemoryStore
@@ -133,7 +133,7 @@ class StoreManager:
         return self._db
 
     def from_dict(self, struct: dict):
-        stor_list = struct.get(run_keys.data_stores)
+        stor_list = struct.get(RunKeys.data_stores)
         if stor_list and isinstance(stor_list, list):
             for stor in stor_list:
                 schema, endpoint, parsed_url = parse_url(stor.get("url"))
@@ -145,7 +145,7 @@ class StoreManager:
                 self._stores[stor["name"]] = new_stor
 
     def to_dict(self, struct):
-        struct[run_keys.data_stores] = [
+        struct[RunKeys.data_stores] = [
             stor.to_dict() for stor in self._stores.values() if stor.from_spec
         ]
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -34,13 +34,13 @@ from .features import Feature
 from .model import HyperParamOptions
 from .secrets import SecretsStore
 from .utils import (
+    RunKeys,
     dict_to_json,
     dict_to_yaml,
     get_in,
     is_relative_path,
     logger,
     now_date,
-    run_keys,
     to_date_str,
     update_in,
 )
@@ -365,7 +365,7 @@ class MLClientCtx:
             self._labels = meta.get("labels", self._labels)
         spec = attrs.get("spec")
         if spec:
-            self._secrets_manager = SecretsStore.from_list(spec.get(run_keys.secrets))
+            self._secrets_manager = SecretsStore.from_list(spec.get(RunKeys.secrets))
             self._log_level = spec.get("log_level", self._log_level)
             self._function = spec.get("function", self._function)
             self._parameters = spec.get("parameters", self._parameters)
@@ -383,9 +383,9 @@ class MLClientCtx:
             self._allow_empty_resources = spec.get(
                 "allow_empty_resources", self._allow_empty_resources
             )
-            self.artifact_path = spec.get(run_keys.output_path, self.artifact_path)
-            self._in_path = spec.get(run_keys.input_path, self._in_path)
-            inputs = spec.get(run_keys.inputs)
+            self.artifact_path = spec.get(RunKeys.output_path, self.artifact_path)
+            self._in_path = spec.get(RunKeys.input_path, self._in_path)
+            inputs = spec.get(RunKeys.inputs)
             self._notifications = spec.get("notifications", self._notifications)
             self._state_thresholds = spec.get(
                 "state_thresholds", self._state_thresholds
@@ -567,7 +567,7 @@ class MLClientCtx:
             self._results["best_iteration"] = best
             for k, v in get_in(task, ["status", "results"], {}).items():
                 self._results[k] = v
-            for artifact in get_in(task, ["status", run_keys.artifacts], []):
+            for artifact in get_in(task, ["status", RunKeys.artifacts], []):
                 self._artifacts_manager.artifacts[artifact["metadata"]["key"]] = (
                     artifact
                 )
@@ -939,8 +939,8 @@ class MLClientCtx:
                 "parameters": self._parameters,
                 "handler": self._handler,
                 "outputs": self._outputs,
-                run_keys.output_path: self.artifact_path,
-                run_keys.inputs: self._inputs,
+                RunKeys.output_path: self.artifact_path,
+                RunKeys.inputs: self._inputs,
                 "notifications": self._notifications,
                 "state_thresholds": self._state_thresholds,
             },
@@ -964,7 +964,7 @@ class MLClientCtx:
         set_if_not_none(struct["status"], "commit", self._commit)
         set_if_not_none(struct["status"], "iterations", self._iteration_results)
 
-        struct["status"][run_keys.artifacts] = self._artifacts_manager.artifact_list()
+        struct["status"][RunKeys.artifacts] = self._artifacts_manager.artifact_list()
         self._data_stores.to_dict(struct["spec"])
         return struct
 
@@ -1058,7 +1058,7 @@ class MLClientCtx:
         set_if_not_none(struct, "status.commit", self._commit)
         set_if_not_none(struct, "status.iterations", self._iteration_results)
 
-        struct[f"status.{run_keys.artifacts}"] = self._artifacts_manager.artifact_list()
+        struct[f"status.{RunKeys.artifacts}"] = self._artifacts_manager.artifact_list()
         return struct
 
     def _init_dbs(self, rundb):

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -63,11 +63,11 @@ from .runtimes.funcdoc import update_function_entry_points
 from .runtimes.nuclio.application import ApplicationRuntime
 from .runtimes.utils import add_code_metadata, global_context
 from .utils import (
+    RunKeys,
     extend_hub_uri_if_needed,
     get_in,
     logger,
     retry_until_successful,
-    run_keys,
     update_in,
 )
 
@@ -280,7 +280,7 @@ def get_or_create_ctx(
             artifact_path = mlrun.utils.helpers.template_artifact_path(
                 mlconf.artifact_path, project or mlconf.default_project
             )
-            update_in(newspec, ["spec", run_keys.output_path], artifact_path)
+            update_in(newspec, ["spec", RunKeys.output_path], artifact_path)
 
     newspec.setdefault("metadata", {})
     update_in(newspec, "metadata.name", name, replace=False)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -149,7 +149,7 @@ if is_ipython and config.nest_asyncio_enabled in ["1", "True"]:
     nest_asyncio.apply()
 
 
-class run_keys:
+class RunKeys:
     input_path = "input_path"
     output_path = "output_path"
     inputs = "inputs"
@@ -158,6 +158,10 @@ class run_keys:
     outputs = "outputs"
     data_stores = "data_stores"
     secrets = "secret_sources"
+
+
+# for Backward compatibility
+run_keys = RunKeys
 
 
 def verify_field_regex(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ extend-select = [
     "I",   # isort
     "UP",  # pyupgrade
     "CPY", # flake8-copyright
+    "N801", # CamelCase for class names
     "N805", # first argument of instance method should be 'self'
     "N806", # lowercase variable names
     "N816", # snake_case for global variable names

--- a/tests/integration/sdk_api/run/test_main.py
+++ b/tests/integration/sdk_api/run/test_main.py
@@ -391,7 +391,7 @@ class TestMain(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         out = self._exec_run(
             function_path,
-            self._compose_param_list(dict(x=8)) + ["--handler", "mycls::mtd"],
+            self._compose_param_list(dict(x=8)) + ["--handler", "MyCls::mtd"],
             "test_main_run_class",
         )
         assert out.find("state: completed") != -1, out

--- a/tests/run/assets/handler.py
+++ b/tests/run/assets/handler.py
@@ -34,7 +34,7 @@ def env_file_test(context: mlrun.MLClientCtx):
     context.log_result("kfp_ttl", mlrun.mlconf.kfp_ttl)
 
 
-class mycls:
+class MyCls:
     def __init__(self, context=None, a1=1):
         self.context = context
         self.a1 = a1

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -259,7 +259,7 @@ def test_run_class_code():
     ]
     fn = mlrun.code_to_function("mytst", filename=function_path, kind="local")
     for params, results in cases:
-        run = mlrun.run_function(fn, handler="mycls::mtd", params=params)
+        run = mlrun.run_function(fn, handler="MyCls::mtd", params=params)
         assert run.status.results == results
 
 
@@ -270,7 +270,7 @@ def test_run_class_file():
     ]
     fn = mlrun.new_function("mytst", command=function_path, kind="job")
     for params, results in cases:
-        run = fn.run(handler="mycls::mtd", params=params, local=True)
+        run = fn.run(handler="MyCls::mtd", params=params, local=True)
         assert run.status.results == results
 
 

--- a/tests/serving/assets/myfunc.py
+++ b/tests/serving/assets/myfunc.py
@@ -22,7 +22,7 @@ def myhand(x, context=None):
     return x * 2
 
 
-class Mycls(storey.MapClass):
+class MyCls(storey.MapClass):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -333,7 +333,7 @@ def test_module_load():
 
     def check_function(name, fn):
         graph = fn.set_topology("flow", engine="sync")
-        graph.to(name="s1", class_name="Mycls").to(name="s2", handler="myhand")
+        graph.to(name="s1", class_name="MyCls").to(name="s2", handler="myhand")
 
         server = fn.to_mock_server()
         resp = server.test(body=5)

--- a/tests/system/runtimes/assets/kubejob_function.py
+++ b/tests/system/runtimes/assets/kubejob_function.py
@@ -16,7 +16,7 @@ def hello_world(context):
     context.logger.info("hello world")
 
 
-class mycls:
+class MyCls:
     def __init__(self, context=None, a1=1):
         self.context = context
         self.a1 = a1

--- a/tests/system/runtimes/assets/kubejob_function_custom_requirements.py
+++ b/tests/system/runtimes/assets/kubejob_function_custom_requirements.py
@@ -27,7 +27,7 @@ def hello_world(context):
     )
 
 
-class mycls:
+class MyCls:
     def __init__(self, context=None):
         self.context = context
 

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -67,7 +67,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             requirements_file=requirements_path,
         )
         function.deploy()
-        run = function.run(handler="mycls::do")
+        run = function.run(handler="MyCls::do")
         outputs = run.outputs
         assert "requests" in outputs, "requests not in outputs"
         assert "chardet" in outputs, "chardet not in outputs"
@@ -341,7 +341,7 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             image="mlrun/mlrun",
         )
         for params, results in cases:
-            run = function.run(handler="mycls::mtd", params=params)
+            run = function.run(handler="MyCls::mtd", params=params)
             print(run.to_yaml())
             assert run.status.results == results
 


### PR DESCRIPTION
resolves:
https://iguazio.atlassian.net/browse/ML-6934

This PR addresses the second python coding convention rule of the conventions that we defined:
"Use CamelCase for Class names."
