### PR TITLE
[Artifact] Verify that secrets passed by users are not internal when deleting artifact data

### DIFF
--- a/server/api/crud/files.py
+++ b/server/api/crud/files.py
@@ -48,6 +48,13 @@ class Files(
         secrets: dict = None,
     ):
         secrets = secrets or {}
+
+        # Verify that, similar project secrets, secrets passed by users are not internal.
+        for secret_key in secrets.keys():
+            server.api.crud.Secrets().validate_internal_project_secret_key_allowed(
+                secret_key
+            )
+
         project_secrets = self._verify_and_get_project_secrets(project)
         project_secrets.update(secrets)
 

--- a/server/api/crud/files.py
+++ b/server/api/crud/files.py
@@ -50,6 +50,9 @@ class Files(
         secrets = secrets or {}
 
         # Verify that, similar project secrets, secrets passed by users are not internal.
+        # Internal secrets are internal for the use of MLRun only. If the user may pass in any arbitrary secret
+        # to override its value, we allow the user to interfere with how MLRun manages its secrets internally,
+        # which can lead to unexpected results.
         for secret_key in secrets.keys():
             server.api.crud.Secrets().validate_internal_project_secret_key_allowed(
                 secret_key

--- a/tests/api/crud/test_files.py
+++ b/tests/api/crud/test_files.py
@@ -15,6 +15,7 @@
 import unittest.mock
 
 import fastapi.testclient
+import pytest
 import sqlalchemy.orm
 
 import mlrun.common.schemas
@@ -55,3 +56,22 @@ def test_delete_artifact_data(
         store_manager_object_mock.assert_called_once_with(
             url=path, secrets=override_secrets, project=project
         )
+
+
+def test_delete_artifact_data_internal_secret(
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    k8s_secrets_mock,
+) -> None:
+    path = "s3://somebucket/some/path/file"
+    project = "proj1"
+    user_secrets = {"mlrun.secret1": "user-secret"}
+
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError) as exc:
+        server.api.crud.Files().delete_artifact_data(
+            mlrun.common.schemas.AuthInfo(), project, path, secrets=user_secrets
+        )
+    assert (
+        str(exc.value)
+        == "Not allowed to create/update internal secrets (key starts with mlrun.)"
+    )


### PR DESCRIPTION
Verify that, similar project secrets, secrets passed by users are not internal.
Not allowed to create/update internal secrets (key starts with `mlrun.`)

Internal secrets are internal for the use of MLRun only. If the user may pass in any arbitrary secret to override its value, we allow the user to interfere with how MLRun manages its secrets internally, which can lead to unexpected results.

https://iguazio.atlassian.net/browse/ML-6957
