### PR TITLE
Revert "[Model Monitoring] Fix model endpoint labels and tag enrichment [1.6.x] (#5719)"

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -1078,9 +1078,6 @@ class UpdateEndpoint(mlrun.feature_store.steps.MapClass):
         self.model_endpoint_store_target = model_endpoint_store_target
 
     def do(self, event: dict):
-        # Remove labels from the event
-        event.pop(EventFieldType.LABELS)
-
         update_endpoint_record(
             project=self.project,
             endpoint_id=event.pop(EventFieldType.ENDPOINT_ID),

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -485,11 +485,7 @@ def _init_endpoint_record(
         return None
 
     # Generating version model value based on the model name and model version
-    if model.model_path and model.model_path.startswith("store://"):
-        # Enrich the model server with the model artifact metadata
-        model.get_model()
-        model.version = model.model_spec.tag
-        model.labels = model.model_spec.labels
+    if model.version:
         versioned_model_name = f"{model.name}:{model.version}"
     else:
         versioned_model_name = f"{model.name}:latest"


### PR DESCRIPTION
This reverts commit 4ff467d48503cd9f237f235ff1be908bea702957.