### PR TITLE
[API] Fix warning raised from pydantic for private arguments

### DIFF
--- a/mlrun/common/formatters/base.py
+++ b/mlrun/common/formatters/base.py
@@ -28,42 +28,42 @@ class ObjectFormat:
     full = "full"
 
     @staticmethod
-    def format_method(_format: str) -> typing.Optional[typing.Callable]:
+    def format_method(format_: str) -> typing.Optional[typing.Callable]:
         """
         Get the formatting method for the provided format.
         A `None` value signifies a pass-through formatting method (no formatting).
-        :param _format: The format as a string representation.
+        :param format_: The format as a string representation.
         :return: The formatting method.
         """
         return {
             ObjectFormat.full: None,
-        }[_format]
+        }[format_]
 
     @classmethod
     def format_obj(
         cls,
         obj: typing.Any,
-        _format: str,
+        format_: str,
         exclude_formats: typing.Optional[list[str]] = None,
     ) -> typing.Any:
         """
         Format the provided object based on the provided format.
         :param obj: The object to format.
-        :param _format: The format as a string representation.
+        :param format_: The format as a string representation.
         :param exclude_formats: A list of formats to exclude from the formatting process. If the provided format is in
                                 this list, an invalid format exception will be raised.
         """
         exclude_formats = exclude_formats or []
-        _format = _format or cls.full
+        format_ = format_ or cls.full
         invalid_format_exc = mlrun.errors.MLRunBadRequestError(
-            f"Provided format is not supported. format={_format}"
+            f"Provided format is not supported. format={format_}"
         )
 
-        if _format in exclude_formats:
+        if format_ in exclude_formats:
             raise invalid_format_exc
 
         try:
-            format_method = cls.format_method(_format)
+            format_method = cls.format_method(format_)
         except KeyError:
             raise invalid_format_exc
 

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -115,7 +115,7 @@ async def get_function(
     name: str,
     tag: str = "",
     hash_key="",
-    _format: str = Query(mlrun.common.formatters.FunctionFormat.full, alias="format"),
+    format_: str = Query(mlrun.common.formatters.FunctionFormat.full, alias="format"),
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -126,7 +126,7 @@ async def get_function(
         project,
         tag,
         hash_key,
-        _format,
+        format_,
     )
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.function,
@@ -210,7 +210,7 @@ async def list_functions(
     page: int = Query(None, gt=0),
     page_size: int = Query(None, alias="page-size", gt=0),
     page_token: str = Query(None, alias="page-token"),
-    _format: str = Query(mlrun.common.formatters.FunctionFormat.full, alias="format"),
+    format_: str = Query(mlrun.common.formatters.FunctionFormat.full, alias="format"),
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -250,7 +250,7 @@ async def list_functions(
         tag=tag,
         labels=labels,
         hash_key=hash_key,
-        _format=_format,
+        format_=format_,
     )
 
     return {

--- a/server/api/crud/functions.py
+++ b/server/api/crud/functions.py
@@ -68,11 +68,11 @@ class Functions(
         project: str = mlrun.mlconf.default_project,
         tag: str = "",
         hash_key: str = "",
-        _format: str = None,
+        format_: str = None,
     ) -> dict:
         project = project or mlrun.mlconf.default_project
         return server.api.utils.singletons.db.get_db().get_function(
-            db_session, name, project, tag, hash_key, _format
+            db_session, name, project, tag, hash_key, format_
         )
 
     def delete_function(
@@ -95,7 +95,7 @@ class Functions(
         hash_key: str = None,
         page: int = None,
         page_size: int = None,
-        _format: str = None,
+        format_: str = None,
     ) -> list:
         project = project or mlrun.mlconf.default_project
         if labels is None:
@@ -107,7 +107,7 @@ class Functions(
             tag=tag,
             labels=labels,
             hash_key=hash_key,
-            _format=_format,
+            format_=format_,
             page=page,
             page_size=page_size,
         )

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -313,7 +313,7 @@ class DBInterface(ABC):
         project: str = None,
         tag: str = None,
         hash_key: str = None,
-        _format: str = None,
+        format_: str = None,
     ):
         pass
 
@@ -336,7 +336,7 @@ class DBInterface(ABC):
         tag: str = None,
         labels: list[str] = None,
         hash_key: str = None,
-        _format: str = None,
+        format_: str = None,
         page: int = None,
         page_size: int = None,
     ):

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1734,7 +1734,7 @@ class SQLDB(DBInterface):
         tag: typing.Optional[str] = None,
         labels: list[str] = None,
         hash_key: typing.Optional[str] = None,
-        _format: str = mlrun.common.formatters.FunctionFormat.full,
+        format_: str = mlrun.common.formatters.FunctionFormat.full,
         page: typing.Optional[int] = None,
         page_size: typing.Optional[int] = None,
     ) -> list[dict]:
@@ -1765,7 +1765,7 @@ class SQLDB(DBInterface):
 
             functions.append(
                 mlrun.common.formatters.FunctionFormat.format_obj(
-                    function_dict, _format
+                    function_dict, format_
                 )
             )
         return functions
@@ -1777,7 +1777,7 @@ class SQLDB(DBInterface):
         project: str = None,
         tag: str = None,
         hash_key: str = None,
-        _format: str = None,
+        format_: str = None,
     ) -> dict:
         """
         In version 1.4.0 we added a normalization to the function name before storing.
@@ -1799,7 +1799,7 @@ class SQLDB(DBInterface):
                     function_name=name,
                 )
                 return self._get_function(
-                    session, name, project, tag, hash_key, _format
+                    session, name, project, tag, hash_key, format_
                 )
             else:
                 raise exc
@@ -1916,7 +1916,7 @@ class SQLDB(DBInterface):
         project: str = None,
         tag: str = None,
         hash_key: str = None,
-        _format: str = mlrun.common.formatters.FunctionFormat.full,
+        format_: str = mlrun.common.formatters.FunctionFormat.full,
     ):
         project = project or config.default_project
         computed_tag = tag or "latest"
@@ -1937,7 +1937,7 @@ class SQLDB(DBInterface):
             # If connected to a tag add it to metadata
             if tag_function_uid:
                 function["metadata"]["tag"] = computed_tag
-            return mlrun.common.formatters.FunctionFormat.format_obj(function, _format)
+            return mlrun.common.formatters.FunctionFormat.format_obj(function, format_)
         else:
             function_uri = generate_object_uri(project, name, tag, hash_key)
             raise mlrun.errors.MLRunNotFoundError(f"Function not found {function_uri}")

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1790,7 +1790,7 @@ class SQLDB(DBInterface):
         normalized_function_name = mlrun.utils.normalize_name(name)
         try:
             return self._get_function(
-                session, normalized_function_name, project, tag, hash_key, _format
+                session, normalized_function_name, project, tag, hash_key, format_
             )
         except mlrun.errors.MLRunNotFoundError as exc:
             if "_" in name:

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -276,12 +276,12 @@ def test_list_functions_with_format(db: DBInterface, db_session: Session):
         },
     }
     db.store_function(db_session, function_body, name, tag=tag, versioned=True)
-    functions = db.list_functions(db_session, tag=tag, _format="full")
+    functions = db.list_functions(db_session, tag=tag, format_="full")
     assert len(functions) == 1
     function = functions[0]
     assert function["spec"] == function_body["spec"]
 
-    functions = db.list_functions(db_session, tag=tag, _format="minimal")
+    functions = db.list_functions(db_session, tag=tag, format_="minimal")
     assert len(functions) == 1
     function = functions[0]
     del function_body["spec"]["extra_field"]


### PR DESCRIPTION
Rename _format -> format_ to avoid warning logs of
`2024-06-27T02:26:52.150713007Z stderr F fields may not start with an underscore, ignoring "_format"`

the reason we had `_` before is not to mark it as private but rather avoid overriding python builtins.
instead, the convention should be to put the `_` after the argument name.