### PR TITLE
[CI] Change the enterprise system tests schedule to once a day

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 name: System Tests Enterprise
 
 on:
@@ -23,7 +23,7 @@ on:
 
     # * is a special character in YAML so you have to quote this string
     # Run the system tests every 8 hours (cron hours should divide 24 equally, otherwise there will be an overlap at the end of the day)
-    - cron: '0 */8 * * *'
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
     inputs:
@@ -173,7 +173,7 @@ jobs:
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info
       run: |
-        
+
         # Get the latest commit of mlrun/mlrun (that is older than 1 hour)
         echo "mlrun_hash=$( \
           cd /tmp && \
@@ -182,7 +182,7 @@ jobs:
           git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit HEAD && \
           cd .. && \
           rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
-        
+
         # Get the latest commit of mlrun/ui (that is older than 1 hour)
         echo "ui_hash=$( \
           cd /tmp && \
@@ -191,7 +191,7 @@ jobs:
           git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit HEAD && \
           cd .. && \
           rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
-        
+
         # Get the tested mlrun version
         echo "unstable_version_prefix=$( \
           curl https://raw.githubusercontent.com/mlrun/mlrun/${{ steps.current-branch.outputs.name }}/automation/version/unstable_version_prefix \
@@ -265,7 +265,7 @@ jobs:
           --passphrase "${{ env.GPG_PASSPHRASE }}" \
           --output "$GITHUB_WORKSPACE/env.yml.gpg" \
           --symmetric "$GITHUB_WORKSPACE/env.yml"
-        
+
         echo "env_file_path=$(echo $GITHUB_WORKSPACE/env.yml.gpg)" >> $GITHUB_OUTPUT
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
@@ -355,7 +355,7 @@ jobs:
 
     - name: Pre Tests Requirements
       run: |
-        
+
         # due to
         # https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
         # ensure mlrun git is safe to use


### PR DESCRIPTION
The previous schedule was once every 8 hours, but since this workflow takes longer to complete - about 18 hrs on dev:
https://github.com/mlrun/mlrun/actions/runs/9629559040

Since this workflow has a single runner and explicitly forbids concurrency, it caused most of the runs to fail as there's no available runner.
Some recent examples:
https://github.com/mlrun/mlrun/actions/runs/9688898397
https://github.com/mlrun/mlrun/actions/runs/9658883699

Changing it to once a day will prevent such situations and reduce the noise in the workflow's runs page:
https://github.com/mlrun/mlrun/actions/workflows/system-tests-enterprise.yml