### PR TITLE
[API Gateway] Add API gateway path to function's external_invocation_urls

### DIFF
--- a/mlrun/common/schemas/api_gateway.py
+++ b/mlrun/common/schemas/api_gateway.py
@@ -103,7 +103,11 @@ class APIGateway(_APIGatewayBaseModel):
         ]
 
     def get_invoke_url(self):
-        return self.spec.host + self.spec.path if self.spec.path and self.spec.host else self.spec.host
+        return (
+            self.spec.host + self.spec.path
+            if self.spec.path and self.spec.host
+            else self.spec.host
+        )
 
     def enrich_mlrun_names(self):
         self._enrich_api_gateway_mlrun_name()

--- a/mlrun/common/schemas/api_gateway.py
+++ b/mlrun/common/schemas/api_gateway.py
@@ -102,6 +102,9 @@ class APIGateway(_APIGatewayBaseModel):
             if upstream.nucliofunction.get("name")
         ]
 
+    def get_invoke_url(self):
+        return self.spec.host + self.spec.path if self.spec.path and self.spec.host else self.spec.host
+
     def enrich_mlrun_names(self):
         self._enrich_api_gateway_mlrun_name()
         self._enrich_mlrun_function_names()

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -141,7 +141,7 @@ async def store_api_gateway(
                 # delete api gateway url from those functions which are not used in api gateway anymore
                 await _delete_functions_external_invocation_url(
                     project=project,
-                    url=existing_api_gateway.spec.host,
+                    url=existing_api_gateway.get_invoke_url(),
                     function_names=unused_functions,
                 )
 
@@ -158,7 +158,7 @@ async def store_api_gateway(
     if api_gateway:
         await _add_functions_external_invocation_url(
             project=project,
-            url=api_gateway.spec.host,
+            url=api_gateway.get_invoke_url(),
             function_names=api_gateway.get_function_names(),
         )
     return api_gateway
@@ -190,7 +190,7 @@ async def delete_api_gateway(
         if api_gateway:
             await _delete_functions_external_invocation_url(
                 project=project,
-                url=api_gateway.spec.host,
+                url=api_gateway.get_invoke_url(),
                 function_names=api_gateway.get_function_names(),
             )
             return await client.delete_api_gateway(project_name=project, name=name)

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -605,7 +605,7 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
         assert res.status_code == 200
         # check that api gateway url is in function's external_invocation_urls
         self._check_functions_external_invocation_urls(
-            function_name=self.f1.metadata.name, expected_url=api_gateway.spec.host
+            function_name=self.f1.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
         )
         self._cleanup_gateway()
 
@@ -617,7 +617,7 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
 
         # check that api gateway url is in function's external_invocation_urls
         self._check_functions_external_invocation_urls(
-            function_name=self.f1.metadata.name, expected_url=api_gateway.spec.host
+            function_name=self.f1.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
         )
         self._cleanup_gateway()
 
@@ -629,10 +629,10 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
 
         # check that api gateway url is in function's external_invocation_urls
         self._check_functions_external_invocation_urls(
-            function_name=self.f1.metadata.name, expected_url=api_gateway.spec.host
+            function_name=self.f1.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
         )
         self._check_functions_external_invocation_urls(
-            function_name=self.f2.metadata.name, expected_url=api_gateway.spec.host
+            function_name=self.f2.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
         )
 
     def _get_basic_gateway(self):

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -605,7 +605,8 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
         assert res.status_code == 200
         # check that api gateway url is in function's external_invocation_urls
         self._check_functions_external_invocation_urls(
-            function_name=self.f1.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
+            function_name=self.f1.metadata.name,
+            expected_url=api_gateway.invoke_url.replace("https://", ""),
         )
         self._cleanup_gateway()
 
@@ -617,7 +618,8 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
 
         # check that api gateway url is in function's external_invocation_urls
         self._check_functions_external_invocation_urls(
-            function_name=self.f1.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
+            function_name=self.f1.metadata.name,
+            expected_url=api_gateway.invoke_url.replace("https://", ""),
         )
         self._cleanup_gateway()
 
@@ -629,10 +631,12 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
 
         # check that api gateway url is in function's external_invocation_urls
         self._check_functions_external_invocation_urls(
-            function_name=self.f1.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
+            function_name=self.f1.metadata.name,
+            expected_url=api_gateway.invoke_url.replace("https://", ""),
         )
         self._check_functions_external_invocation_urls(
-            function_name=self.f2.metadata.name, expected_url=api_gateway.invoke_url.replace("https://", "")
+            function_name=self.f2.metadata.name,
+            expected_url=api_gateway.invoke_url.replace("https://", ""),
         )
 
     def _get_basic_gateway(self):


### PR DESCRIPTION
This PR adds API gateway's `host+path` instead of just `host` to function's `external_invocation_urls`
Jira - https://iguazio.atlassian.net/browse/ML-6970

System test `test_basic_api_gateway_flow` :white_check_mark: