### PR TITLE
[Notifications] Add params & secret_params validations for slack, git and webhook

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -732,6 +732,25 @@ class Notification(ModelObj):
                 "Notification params size exceeds max size of 1 MB"
             )
 
+    def validate_notification_params(self):
+        notification_class = mlrun.utils.notifications.NotificationTypes(
+            self.kind
+        ).get_notification()
+
+        secret_params = self.secret_params
+        params = self.params
+
+        if not secret_params and not params:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Both 'secret_params' and 'params' are empty, at least one must be defined."
+            )
+        if secret_params and params and secret_params != params:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Both 'secret_params' and 'params' are defined but they contain different values"
+            )
+
+        notification_class.validate_params(secret_params or params)
+
     @staticmethod
     def validate_notification_uniqueness(notifications: list["Notification"]):
         """Validate that all notifications in the list are unique by name"""

--- a/mlrun/utils/notifications/notification/base.py
+++ b/mlrun/utils/notifications/notification/base.py
@@ -28,6 +28,10 @@ class NotificationBase:
         self.name = name
         self.params = params or {}
 
+    @classmethod
+    def validate_params(cls, params):
+        pass
+
     @property
     def active(self) -> bool:
         return True

--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -30,6 +30,27 @@ class GitNotification(NotificationBase):
     API/Client notification for setting a rich run statuses git issue comment (github/gitlab)
     """
 
+    @classmethod
+    def validate_params(cls, params):
+        git_repo = params.get("repo", None)
+        git_issue = params.get("issue", None)
+        git_merge_request = params.get("merge_request", None)
+        token = (
+            params.get("token", None)
+            or params.get("GIT_TOKEN", None)
+            or params.get("GITHUB_TOKEN", None)
+        )
+        if not git_repo:
+            raise ValueError("Parameter 'repo' is required for GitNotification")
+
+        if not token:
+            raise ValueError("Parameter 'token' is required for GitNotification")
+
+        if not git_issue and not git_merge_request:
+            raise ValueError(
+                "At least one of 'issue' or 'merge_request' is required for GitNotification"
+            )
+
     async def push(
         self,
         message: str,

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -35,6 +35,14 @@ class SlackNotification(NotificationBase):
         "skipped": ":zzz:",
     }
 
+    @classmethod
+    def validate_params(cls, params):
+        webhook = params.get("webhook", None) or mlrun.get_secret_or_env(
+            "SLACK_WEBHOOK"
+        )
+        if not webhook:
+            raise ValueError("Parameter 'webhook' is required for SlackNotification")
+
     async def push(
         self,
         message: str,

--- a/mlrun/utils/notifications/notification/webhook.py
+++ b/mlrun/utils/notifications/notification/webhook.py
@@ -28,6 +28,12 @@ class WebhookNotification(NotificationBase):
     API/Client notification for sending run statuses in a http request
     """
 
+    @classmethod
+    def validate_params(cls, params):
+        url = params.get("url", None)
+        if not url:
+            raise ValueError("Parameter 'url' is required for WebhookNotification")
+
     async def push(
         self,
         message: str,

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -427,6 +427,8 @@ def validate_and_mask_notification_list(
         # validate notification schema
         mlrun.common.schemas.Notification(**notification_object.to_dict())
 
+        notification_object.validate_notification_params()
+
         notification_objects.append(notification_object)
 
     mlrun.model.Notification.validate_notification_uniqueness(notification_objects)

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -209,7 +209,7 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         )
         alert_from_template.with_entities(entities=entities)
 
-        notification = mlrun.common.schemas.Notification(
+        notification = mlrun.model.Notification(
             kind="slack",
             name="slack_drift",
             message="Ay caramba!",
@@ -220,7 +220,9 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             },
             condition="oops",
         )
-        notifications = [alert_objects.AlertNotification(notification=notification)]
+        notifications = [
+            alert_objects.AlertNotification(notification=notification.to_dict())
+        ]
 
         alert_from_template.with_notifications(notifications=notifications)
 
@@ -413,8 +415,10 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                     "severity": "warning",
                     "when": ["now"],
                     "condition": "failed",
-                    "secret_params": {
-                        "webhook": "https://hooks.slack.com/services/",
+                    "params": {
+                        "repo": "some-repo",
+                        "issue": "some-issue",
+                        "token": "some-token",
                     },
                 }
             },


### PR DESCRIPTION
This enhancement ensures robustness and reliability in handling notification params & secret_params, reducing potential errors due to missing or invalid parameters.

resolves:
https://iguazio.atlassian.net/browse/ML-6979