### PR TITLE
[Requirements] Bump nuclio-jupyter

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -3,6 +3,6 @@ paramiko~=3.4
 semver~=3.0
 requests~=2.31
 boto3>=1.28.0,<1.29.0
-pyyaml~=5.1
+pyyaml>=5.4.1, <7
 packaging~=23.1
 coloredlogs~=15.0

--- a/conda-arm64-requirements.txt
+++ b/conda-arm64-requirements.txt
@@ -2,4 +2,4 @@
 protobuf>=3.20.3, <4
 
 # see requirements.txt for the constraint
-pyyaml>=5.4.1, <6
+pyyaml>=5.4.1, <7

--- a/dockerfiles/jupyter/requirements.txt
+++ b/dockerfiles/jupyter/requirements.txt
@@ -6,7 +6,7 @@ scikit-plot~=0.3.7
 xgboost~=1.1
 graphviz~=0.20.0
 python-dotenv~=0.17.0
-nuclio-jupyter[jupyter-server]~=0.9.17
+nuclio-jupyter[jupyter-server]~=0.10.0
 nbclassic>=0.2.8
 # added to tackle security vulnerabilities
 notebook~=6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pandas>=1.2, <2.2
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)
 # <15 to prevent bugs due to major upgrading
 pyarrow>=10.0, <15
-pyyaml>=5.1, <7
+pyyaml>=5.4.1, <7
 requests~=2.31
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ aiohttp-retry~=2.8
 click~=8.1
 nest-asyncio~=1.0
 ipython~=8.10
-nuclio-jupyter~=0.9.17
+nuclio-jupyter~=0.10.0
 numpy>=1.16.5, <1.27.0
 # pandas 2.2 requires sqlalchemy 2
 pandas>=1.2, <2.2
@@ -14,7 +14,7 @@ pandas>=1.2, <2.2
 # >=10 to resolve https://issues.apache.org/jira/browse/ARROW-16838 bug that is triggered by ingest (ML-3299)
 # <15 to prevent bugs due to major upgrading
 pyarrow>=10.0, <15
-pyyaml~=5.1
+pyyaml>=5.1, <7
 requests~=2.31
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6

--- a/tests/runtimes/test_funcdoc.py
+++ b/tests/runtimes/test_funcdoc.py
@@ -24,7 +24,7 @@ from tests.conftest import tests_root_directory
 
 def load_rst_cases(name):
     with open(tests_root_directory / "runtimes" / name) as fp:
-        data = yaml.load(fp)
+        data = yaml.safe_load(fp)
 
     for i, case in enumerate(data):
         name = case.get("name", "")
@@ -52,7 +52,7 @@ def ast_func(code):
 
 def load_info_cases():
     with open(tests_root_directory / "runtimes" / "info_cases.yml") as fp:
-        cases = yaml.load(fp)
+        cases = yaml.safe_load(fp)
 
     for case in cases:
         obj = ast_func(case["code"])

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -181,7 +181,7 @@ def test_requirement_specifiers_inconsistencies():
         # conda requirements since conda does not support ~= operator and
         # since platform condition is not required for docker
         "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
-        "pyyaml": {"~=5.1", ">=5.4.1, <6"},
+        "pyyaml": {">=5.4.1, <7"},
     }
 
     for (


### PR DESCRIPTION
Bump to version 0.10.0 to include
- Remove limitation of PyYaml <6
- Fix introduced on https://github.com/nuclio/nuclio-jupyter/pull/182