### PR TITLE
[Makefile] Support dual Python package installer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Using [UV](https://github.com/astral-sh/uv) is also an option,
 you may need to override current MLRun default packager-installer env var `MLRUN_PYTHON_PACKAGE_INSTALLER` to `uv`
 
 ```shell script
-uv venv venv
+uv venv venv --seed
 source venv/bin/activate
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,14 @@ python -m venv venv
 source venv/bin/activate
 ```
 
+Using [UV](https://github.com/astral-sh/uv) is also an option, 
+you may need to override current MLRun default packager-installer env var `MLRUN_PYTHON_PACKAGE_INSTALLER` to `uv`
+
+```shell script
+uv venv venv
+source venv/bin/activate
+```
+
 Install MLRun, dependencies and dev dependencies
 ```shell script
 make install-requirements
@@ -44,8 +52,8 @@ pip install -e '.[complete]'
 
 ## Developing with ARM64 machines
 
-Some mlrun dependencies are not yet available for ARM64 machines via pypi, so we need to work with conda to get the packages compiled for ARM64 platform.   
-Install Anaconda from [here](https://docs.anaconda.com/free/anaconda/install/index.html) and then follow the steps below:
+Some MLRun dependencies are not yet available for ARM64 machines via pypi, 
+so we need to work with conda to get the packages compiled for ARM64 platform.   
 
 Fork, clone and cd into the MLRun repository directory
 ```shell script
@@ -53,15 +61,26 @@ git clone git@github.com:<your username>/mlrun.git
 cd mlrun
 ```
 
-Create a conda environment and activate it
+Create a [Conda](https://docs.anaconda.com/free/anaconda/install/index.html) environment and activate it
 ```shell script
 conda create -n mlrun python=3.9
 conda activate mlrun
-``` 
+```
 
 Then, install the dependencies
 ```shell script
 make install-conda-requirements
+```
+
+*Or*, alternatively, you may use native Python atop the ARM64 machine, but you will need to compile some dependencies.
+Execute below script to overcome MLRun current protobuf~3.20 incompatibility.
+
+NOTE: This script will compile and install protobuf 3.20.0 for macOS arm64. At the end of the installation, it will
+ask you to type your password to finish installing the compiled protobuf.
+
+```shell script
+./automation/scripts/compile_protobuf320_for_mac_arm64.sh
+make install-requirements
 ```
 
 Run some unit tests to make sure everything works:
@@ -312,7 +331,7 @@ def function_name(parameter1, parameter2):
 try to avoid logging large objects which are hard to decipher.
 17. Use f-strings for string formatting instead of the old `.format(...)` except when dealing with template strings.
 
-### MLRun Code Conventions:
+### MLRun Coding Conventions:
 
 1. When converting an error object to a string representation, instead of using: `str(error)` use: `mlrun.errors.err_to_str(error)`
 2. Use `mlrun.mlconf` Instead of `mlrun.config.config`.

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,15 @@ else
 	MLRUN_SYSTEM_TESTS_COMMAND_SUFFIX = "--ignore=tests/system/$(MLRUN_SYSTEM_TESTS_COMPONENT) tests/system"
 endif
 
+MLRUN_PYTHON_PACKAGE_INSTALLER ?= pip
+ifeq ($(MLRUN_PYTHON_PACKAGE_INSTALLER),pip)
+	MLRUN_PYTHON_VENV_PIP_INSTALL ?= python -m pip install
+else ifeq ($(MLRUN_PYTHON_PACKAGE_INSTALLER),uv)
+	MLRUN_PYTHON_VENV_PIP_INSTALL ?= uv pip install
+else
+	$(error MLRUN_PYTHON_PACKAGE_INSTALLER must be either "pip" or "uv")
+endif
+
 .PHONY: help
 help: ## Display available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -90,8 +99,12 @@ all:
 
 .PHONY: install-requirements
 install-requirements: ## Install all requirements needed for development
-	python -m pip install --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
-	python -m pip install \
+	# relevant for pip package installer only
+	@if [ "$(MLRUN_PYTHON_PACKAGE_INSTALLER)" = "pip" ]; then \
+		$(MLRUN_PYTHON_VENV_PIP_INSTALL) --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION); \
+	fi
+
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) \
 		$(MLRUN_PIP_NO_CACHE_FLAG) \
 		-r requirements.txt \
 		-r extras-requirements.txt \
@@ -106,13 +119,13 @@ install-conda-requirements: ## Install all requirements needed for development w
 
 .PHONY: install-complete-requirements
 install-complete-requirements: ## Install all requirements needed for development and testing
-	python -m pip install --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
-	python -m pip install .[complete]
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) .[complete]
 
 .PHONY: install-all-requirements
 install-all-requirements: ## Install all requirements needed for development and testing
-	python -m pip install --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
-	python -m pip install .[all]
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) .[all]
 
 .PHONY: create-migration-mysql
 create-migration-mysql: ## Create a DB migration (MLRUN_MIGRATION_MESSAGE must be set)

--- a/automation/scripts/compile_protobuf320_for_mac_arm64.sh
+++ b/automation/scripts/compile_protobuf320_for_mac_arm64.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+MLRUN_PYTHON_PACKAGE_INSTALLER=${1:-${MLRUN_PYTHON_PACKAGE_INSTALLER:-pip}}
+TARGET_PROTOBUF_VERSION=3.20.3
+
+install_command=""
+if [[ "${MLRUN_PYTHON_PACKAGE_INSTALLER}" == "pip" ]]; then
+  install_command=$(echo pip install protobuf=="${TARGET_PROTOBUF_VERSION}" --force-reinstall --force --no-cache --no-binary :all: --global-option=\"--cpp_implementation\")
+elif [[ "${MLRUN_PYTHON_PACKAGE_INSTALLER}" == "uv" ]]; then
+  install_command=$(echo uv pip install --force-reinstall --no-cache --no-binary :all:  protobuf=="${TARGET_PROTOBUF_VERSION}")
+else
+    echo "Unknown package installer ${MLRUN_PYTHON_PACKAGE_INSTALLER}"
+    exit 1
+fi
+
+
+# Install and use protobuf 3.20
+brew install protobuf@3.20
+brew link --overwrite protobuf@3.20
+
+# Compile protobuf on mac
+#   used https://github.com/protocolbuffers/protobuf/issues/8820#issuecomment-961552604
+# Download and unpack protobuf compiler source code
+PROTOC_SRC_ARCHIVE="protobuf-cpp-${TARGET_PROTOBUF_VERSION}.tar.gz" && \
+    curl -sSL "https://github.com/protocolbuffers/protobuf/releases/download/v${TARGET_PROTOBUF_VERSION}/${PROTOC_SRC_ARCHIVE}" | tar -C /tmp -xzf -
+
+# Build protobuf compiler from source (this will take a while)
+#   see: https://github.com/protocolbuffers/protobuf/blob/master/src/README.md for more info
+PROTOC_SRC_PATH="/tmp/protobuf-${TARGET_PROTOBUF_VERSION}" && \
+   pushd "${PROTOC_SRC_PATH}" && \
+   ./configure && \
+   make -j8 && \
+   make check && \
+   sudo make install && \
+   popd && \
+   rm -rf "${PROTOC_SRC_PATH}"
+
+# Export protobuf to install package correctly
+export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"
+
+# Install protobuf package
+INSTALL_PREFIX_PATH="/usr/local" && \
+   CFLAGS="-I${INSTALL_PREFIX_PATH}/include" && \
+   LDFLAGS="-L${INSTALL_PREFIX_PATH}/lib" && \
+   echo $install_command && $install_command


### PR DESCRIPTION
This PR brings the support of dual python package installer withe the support of both `pip` and `uv`.
To enable `uv` as the default package installer, set `MLRUN_PYTHON_PACKAGE_INSTALLER` to be `uv`. The package installer is for the internal `venv` (and not Dockerfiles and etc).

In addition to that, Ive updated the documentation to enable installing MLRun over MacOS arm64-based. While Conda env is still recommended, using native Python atop uv is now fully supported for development over MLRun.

