### PR TITLE
[Alerts] Optimize access to DB

### DIFF
--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -21,6 +21,7 @@ import mlrun.common.schemas
 import mlrun.utils.singleton
 import server.api.api.utils
 import server.api.utils.helpers
+import server.api.utils.lru_cache
 import server.api.utils.singletons.db
 from mlrun.config import config as mlconfig
 from mlrun.utils import logger
@@ -31,6 +32,8 @@ class Alerts(
     metaclass=mlrun.utils.singleton.Singleton,
 ):
     _states = dict()
+    _alert_cache = None
+    _alert_state_cache = None
 
     def store_alert(
         self,
@@ -52,6 +55,7 @@ class Alerts(
 
         if alert is not None:
             self._delete_notifications(alert)
+            self._get_alert_by_id_cached().cache_remove(session, alert.id)
         else:
             num_alerts = (
                 server.api.utils.singletons.db.get_db().get_num_configured_alerts(
@@ -67,7 +71,9 @@ class Alerts(
 
         if alert is not None:
             for kind in alert.trigger.events:
-                server.api.crud.Events().remove_event_configuration(project, kind, name)
+                server.api.crud.Events().remove_event_configuration(
+                    project, kind, alert.id
+                )
             alert_data.created = alert.created
             alert_data.id = alert.id
 
@@ -77,12 +83,14 @@ class Alerts(
 
         for kind in new_alert.trigger.events:
             server.api.crud.Events().add_event_configuration(
-                project, kind, new_alert.name
+                project, kind, new_alert.id
             )
 
         self.reset_alert(session, project, new_alert.name)
 
         server.api.utils.singletons.db.get_db().enrich_alert(session, new_alert)
+
+        logger.debug("Stored alert", alert=new_alert)
 
         return new_alert
 
@@ -133,7 +141,7 @@ class Alerts(
             return
 
         for kind in alert.trigger.events:
-            server.api.crud.Events().remove_event_configuration(project, kind, name)
+            server.api.crud.Events().remove_event_configuration(project, kind, alert.id)
 
         server.api.utils.singletons.db.get_db().delete_alert(session, project, name)
         if alert.id in self._states:
@@ -143,19 +151,14 @@ class Alerts(
         self,
         session: sqlalchemy.orm.Session,
         project: str,
-        name: str,
+        alert_id: int,
         event_data: mlrun.common.schemas.Event,
     ):
-        alert = server.api.utils.singletons.db.get_db().get_alert(
-            session, project, name
-        )
-
-        state = server.api.utils.singletons.db.get_db().get_alert_state(
-            session, alert.id
-        )
+        state = self._get_alert_state_cached()(session, alert_id)
         if state.active:
-            logger.debug("Alert already active, so ignoring event", name=alert.name)
             return
+
+        alert = self._get_alert_by_id_cached()(session, alert_id)
 
         state_obj = None
         # check if the entity of the alert matches the one in event
@@ -193,6 +196,9 @@ class Alerts(
                     self.reset_alert(session, alert.project, alert.name)
                 else:
                     active = True
+                    self._get_alert_state_cached().cache_replace(
+                        state, session, alert.id
+                    )
 
                 # we store the state along with the events that triggered the alert
                 server.api.utils.singletons.db.get_db().store_alert_state(
@@ -228,12 +234,29 @@ class Alerts(
         server.api.crud.Events().cache_initialized = True
         logger.debug("Finished populating event cache for alerts")
 
+    @classmethod
+    def _get_alert_by_id_cached(cls):
+        if not cls._alert_cache:
+            cls._alert_cache = server.api.utils.lru_cache.LRUCache(
+                server.api.utils.singletons.db.get_db().get_alert_by_id, maxsize=1000
+            )
+
+        return cls._alert_cache
+
+    @classmethod
+    def _get_alert_state_cached(cls):
+        if not cls._alert_state_cache:
+            cls._alert_state_cache = server.api.utils.lru_cache.LRUCache(
+                server.api.utils.singletons.db.get_db().get_alert_state, maxsize=1000
+            )
+        return cls._alert_state_cache
+
     @staticmethod
     def _try_populate_event_cache(session: sqlalchemy.orm.Session):
         for alert in server.api.utils.singletons.db.get_db().get_all_alerts(session):
             for event_name in alert.trigger.events:
                 server.api.crud.Events().add_event_configuration(
-                    alert.project, event_name, alert.name
+                    alert.project, event_name, alert.id
                 )
 
     def process_event_no_cache(
@@ -338,6 +361,7 @@ class Alerts(
         server.api.utils.singletons.db.get_db().store_alert_state(
             session, project, name, last_updated=None
         )
+        self._get_alert_state_cached().cache_remove(session, alert.id)
 
     def _delete_notifications(self, alert: mlrun.common.schemas.AlertConfig):
         for notification in alert.notifications:

--- a/server/api/crud/events.py
+++ b/server/api/crud/events.py
@@ -39,12 +39,12 @@ class Events(
 
         return bool(event_data.is_valid())
 
-    def add_event_configuration(self, project, name, alert_name):
-        self._cache.setdefault((project, name), []).append(alert_name)
+    def add_event_configuration(self, project, name, alert_id):
+        self._cache.setdefault((project, name), []).append(alert_id)
 
-    def remove_event_configuration(self, project, name, alert_name):
+    def remove_event_configuration(self, project, name, alert_id):
         alerts = self._cache[(project, name)]
-        alerts.remove(alert_name)
+        alerts.remove(alert_id)
         if len(alerts) == 0:
             self._cache.pop((project, name))
 
@@ -77,9 +77,9 @@ class Events(
             return
 
         try:
-            for name in self._cache[(project, event_name)]:
+            for alert_id in self._cache[(project, event_name)]:
                 server.api.crud.Alerts().process_event(
-                    session, project, name, event_data
+                    session, project, alert_id, event_data
                 )
         except KeyError:
             logger.debug(

--- a/server/api/utils/lru_cache.py
+++ b/server/api/utils/lru_cache.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import collections
+import hashlib
+from copy import deepcopy
+
+
+class LRUCache:
+    """LRU cache which solves some of lru_cache from functools deficiencies.
+    Most importantly, the ability to remove/modify a cache value on top
+    of the ability to clear entire cache.
+    We strive to provide similar API to lru_cache.
+    Note this class is used as is instead of using a decorator for performance reasons.
+    If performance is not as important, a decorator can be added.
+    Note this can be used as a decorator, but only with default parameters i.e. maxsize
+    This code is based on https://pastebin.com/LDwMwtp8
+    """
+
+    class CacheInfo:
+        def __init__(self, maxsize: int):
+            self.maxsize = maxsize
+            self.reset()
+
+        def reset(self):
+            self.hits = 0
+            self.misses = 0
+            self.currsize = 0
+
+    def __init__(self, func, maxsize: int = 128):
+        self.cache = collections.OrderedDict()
+        self.func = func
+        self.maxsize = maxsize
+        self._cache_info = self.CacheInfo(maxsize)
+
+    def __call__(self, *args, **kwargs):
+        cache = self.cache
+        key = self._gen_key(args, kwargs)
+        if key in cache:
+            self._cache_info.hits += 1
+            cache.move_to_end(key)
+            return cache[key]
+        result = self.func(*args, **kwargs)
+        cache[key] = result
+        self._cache_info.misses += 1
+        if len(cache) > self.maxsize:
+            cache.popitem(last=False)
+        return result
+
+    def cache_info(self) -> CacheInfo:
+        """Get cache statistics. We emulate lru_cache API.
+        We return a deep copy of our internal CacheInfo object to make sure user
+        does not accidentally modify our internal structures"""
+        self._cache_info.currsize = len(self.cache)
+        return deepcopy(self._cache_info)
+
+    def cache_clear(self) -> None:
+        """Remove all values from cache and reset statistics"""
+        self.cache.clear()
+        self._cache_info.reset()
+
+    def cache_remove(self, *args, **kwargs) -> None:
+        """Remove an item from the cache by passing the same args used in the call"""
+        key = self._gen_key(args, kwargs)
+        if key in self.cache:
+            self.cache.pop(key)
+
+    def cache_replace(self, value, *args, **kwargs) -> None:
+        """Replace value only if in cache. Use cache_set() if you want to make sure the value is set in the cache"""
+        cache = self.cache
+        key = self._gen_key(args, kwargs)
+        if key in cache:
+            cache[key] = value
+            cache.move_to_end(key)
+
+    def cache_set(self, value, *args, **kwargs) -> None:
+        """Set a single value in cache"""
+        cache = self.cache
+        key = self._gen_key(args, kwargs)
+        is_cached = self.cached(key)
+        cache[key] = value
+        cache.move_to_end(key)
+        if not is_cached and len(cache) > self.maxsize:
+            cache.popitem(last=False)
+
+    def cached(self, *args, **kwargs) -> bool:
+        """Return if argument in cache"""
+        key = self._gen_key(args, kwargs)
+        return key in self.cache
+
+    @staticmethod
+    def _gen_key(args, kwargs) -> str:
+        return hashlib.sha256(f"{args}/{sorted(kwargs.items())}".encode()).hexdigest()

--- a/tests/utils/test_lru.py
+++ b/tests/utils/test_lru.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import server.api.utils.lru_cache
+
+
+class LRUTest(unittest.TestCase):
+    def test_lru(self):
+        lru = server.api.utils.lru_cache.LRUCache(self._func_getter, maxsize=3)
+        lru("1")
+        lru("2")
+        lru("3")
+        lru("4")
+        lru("5")
+
+        # test eviction
+        self.assertFalse(lru.cached("1"))
+        self.assertFalse(lru.cached("2"))
+        self.assertTrue(lru.cached("3"))
+        self.assertTrue(lru.cached("4"))
+        self.assertTrue(lru.cached("5"))
+
+        lru.cache_remove("5")
+        self.assertFalse(lru.cached("5"))
+
+        lru.cache_set(5, "5")
+        self.assertTrue(lru.cached("5"))
+
+        info = lru.cache_info()
+        self.assertTrue(info.currsize == 3)
+        self.assertTrue(info.misses == 5)
+        self.assertTrue(info.maxsize == 3)
+        self.assertTrue(info.hits == 0)
+
+        lru("5")
+        info2 = lru.cache_info()
+        self.assertTrue(info2.currsize == 3)
+        self.assertTrue(info2.misses == 5)
+        self.assertTrue(info2.hits == 1)
+        # check that returned cache_info is not the internal object
+        self.assertFalse(info.hits == info2.hits)
+
+        # make sure we don't care about kwargs order
+        lru("6", increment=True, decrement=False)
+        self.assertTrue(lru.cached("6", decrement=False, increment=True))
+        self.assertFalse(lru.cached("6"))
+
+        # verify replace semantics
+        lru.cache_replace(123, "123")
+        self.assertFalse(lru.cached("123"))
+
+        # verify set semantics
+        lru.cache_set(123, "123")
+        self.assertTrue(lru.cached("123"))
+
+        lru.cache_clear()
+        info = lru.cache_info()
+        self.assertTrue(info.hits == 0)
+        self.assertTrue(info.misses == 0)
+        self.assertTrue(info.currsize == 0)
+
+    def _func_getter(self, arg, increment=False, decrement=False):
+        result = int(arg)
+        if increment:
+            result += 1
+        if decrement:
+            result -= 1


### PR DESCRIPTION
We lower access to DB by re-arranging calls
to avoid getting AlertConfig from db when
not necessary. Also, cache AlertState
and AlertConfig structs

https://iguazio.atlassian.net/browse/ML-6977
https://iguazio.atlassian.net/browse/ML-6993
