### PR TITLE
[workflow] Skip `v2-model-tester` in system tests

### DIFF
--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -79,7 +79,7 @@ def newpipe():
     )
 
     # deploy our model as a serverless function, we can pass a list of models to serve
-    deploy = deploy_function(
+    deploy_function(
         "serving",
         models=[{"key": f"{DATASET}:v1", "model_path": train.outputs["model"]}],
     )

--- a/tests/system/projects/assets/newflow.py
+++ b/tests/system/projects/assets/newflow.py
@@ -83,11 +83,11 @@ def newpipe():
         "serving",
         models=[{"key": f"{DATASET}:v1", "model_path": train.outputs["model"]}],
     )
-
-    # test out new model server (via REST API calls), use imported function
-    run_function(
-        "hub://v2-model-tester",
-        name="model-tester",
-        params={"addr": deploy.outputs["endpoint"], "model": f"{DATASET}:v1"},
-        inputs={"table": train.outputs["test_set"]},
-    )
+    # TODO: Add the following function once v2-model-tester is fixed
+    # # test out new model server (via REST API calls), use imported function
+    # run_function(
+    #     "hub://v2-model-tester",
+    #     name="model-tester",
+    #     params={"addr": deploy.outputs["endpoint"], "model": f"{DATASET}:v1"},
+    #     inputs={"table": train.outputs["test_set"]},
+    # )


### PR DESCRIPTION
Following the deprecation of the ChartArtifact (https://github.com/mlrun/mlrun/pull/5510), the v2-model-tester func is not supported.
Until we decide either to fix or to remove this func, in this PR we skip that func in the workflow tests to avoid unnecessary failures.