### PR TITLE
[KFP] Support no-op adapter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
         # 3.9 is the current >= 1.3.0 python version
         python-version: [3.9]
         default-pipeline-adapter: ["kfp-v1-8"]
-        pipeline-adapter: ["kfp-v1-8", "kfp-v2"]
+        pipeline-adapter: ["kfp-v1-8", "kfp-v2", "kfp-nop"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up python ${{ matrix.python-version }}

--- a/.github/workflows/release-pipeline-adapters.yaml
+++ b/.github/workflows/release-pipeline-adapters.yaml
@@ -23,6 +23,7 @@ on:
         options:
           - '*'
           - 'mlrun-pipelines-kfp-common'
+          - 'mlrun-pipelines-kfp-nop'
           - 'mlrun-pipelines-kfp-v1-8'
           - 'mlrun-pipelines-kfp-v2'
 
@@ -40,7 +41,7 @@ jobs:
         shell: bash
         run: |
           if [[ "$PACKAGES" = "*" ]]; then \
-            export packages=("mlrun-pipelines-kfp-common" "mlrun-pipelines-kfp-v1-8" "mlrun-pipelines-kfp-v2") ;\
+            export packages=("mlrun-pipelines-kfp-common" "mlrun-pipelines-kfp-v1-8" "mlrun-pipelines-kfp-v2" "mlrun-pipelines-kfp-nop") ;\
           else \
             export packages=("${PACKAGES}") ;\
           fi

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -222,7 +222,6 @@ class _PipelineContext:
             if not mlrun.mlconf.kfp_url:
                 logger.debug("Kubeflow pipeline URL is not set, running locally")
                 force_run_local = True
-
         if self.workflow:
             force_run_local = force_run_local or self.workflow.run_local
 

--- a/pipeline-adapters/Makefile
+++ b/pipeline-adapters/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PACKAGES ?= mlrun-pipelines-kfp-common mlrun-pipelines-kfp-v1-8 mlrun-pipelines-kfp-v2
+PACKAGES ?= mlrun-pipelines-kfp-common mlrun-pipelines-kfp-v1-8 mlrun-pipelines-kfp-v2 mlrun-pipelines-kfp-nop
 
 TWINE_USERNAME ?= __token__
 TWINE_PASSWORD ?= "replace with your token"

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/setup.py
@@ -21,8 +21,8 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-nop",
-    version="0.1.2",
-    description="MLRun Pipelines package for removing any KFP functionality",
+    version="0.1.4",
+    description="MLRun Pipelines package to no-op any KFP functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",
     license="Apache License 2.0",
@@ -39,6 +39,6 @@ setup(
         "kfp",
     ],
     python_requires=">=3.9, <3.12",
-    long_description="MLRun Pipelines package for removing any KFP functionality",
+    long_description="MLRun Pipelines package to no-op any KFP functionality",
     long_description_content_type="text/markdown",
 )

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/setup.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from setuptools import find_namespace_packages, setup
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mlrun-kfp-setup")
+
+setup(
+    name="mlrun-pipelines-kfp-nop",
+    version="0.1.2",
+    description="MLRun Pipelines package for removing any KFP functionality",
+    author="Yaron Haviv",
+    author_email="yaronh@iguazio.com",
+    license="Apache License 2.0",
+    url="https://github.com/mlrun/mlrun",
+    packages=find_namespace_packages(
+        where="src/",
+        include=[
+            "mlrun_pipelines",
+        ],
+    ),
+    package_dir={"": "src"},
+    keywords=[
+        "mlrun",
+        "kfp",
+    ],
+    python_requires=">=3.9, <3.12",
+    long_description="MLRun Pipelines package for removing any KFP functionality",
+    long_description_content_type="text/markdown",
+)

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/helpers.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/helpers.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def new_pipe_metadata(*args, **kwargs):
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/helpers.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/helpers.py
@@ -15,4 +15,4 @@
 
 
 def new_pipe_metadata(*args, **kwargs):
-    raise NotImplementedError
+    pass

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mixins.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mixins.py
@@ -16,9 +16,9 @@
 
 class KfpAdapterMixin:
     def apply(self, *args, **kwargs):
-        raise NotImplementedError
+        pass
 
 
 class PipelineProviderMixin:
     def resolve_project_from_workflow_manifest(self, *args, **kwargs):
-        raise NotImplementedError
+        pass

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mixins.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mixins.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class KfpAdapterMixin:
+    def apply(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class PipelineProviderMixin:
+    def resolve_project_from_workflow_manifest(self, *args, **kwargs):
+        raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/models.py
@@ -16,9 +16,9 @@
 
 import unittest.mock
 
-PipelineNodeWrapper = unittest.mock.MagicMock
-
 from mlrun_pipelines.common.helpers import FlexibleMapper
+
+PipelineNodeWrapper = unittest.mock.MagicMock
 
 
 class PipelineStep(FlexibleMapper):

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/models.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import unittest.mock
+
+PipelineNodeWrapper = unittest.mock.MagicMock
+
+from mlrun_pipelines.common.helpers import FlexibleMapper
+
+
+class PipelineStep(FlexibleMapper):
+    pass
+
+
+class PipelineManifest(FlexibleMapper):
+    pass
+
+
+class PipelineRun(FlexibleMapper):
+    pass
+
+
+class PipelineExperiment(FlexibleMapper):
+    pass

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mounts.py
@@ -15,44 +15,44 @@
 
 
 def v3io_cred(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_v3io(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_v3iod(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_pvc(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def set_env_variables(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_s3(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_spark_conf():
-    raise NotImplementedError
+    pass
 
 
 def mount_secret(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_configmap(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def mount_hostpath(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def auto_mount(*args, **kwargs):
-    raise NotImplementedError
+    pass

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/mounts.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def v3io_cred(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_v3io(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_v3iod(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_pvc(*args, **kwargs):
+    raise NotImplementedError
+
+
+def set_env_variables(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_s3(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_spark_conf():
+    raise NotImplementedError
+
+
+def mount_secret(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_configmap(*args, **kwargs):
+    raise NotImplementedError
+
+
+def mount_hostpath(*args, **kwargs):
+    raise NotImplementedError
+
+
+def auto_mount(*args, **kwargs):
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/ops.py
@@ -15,44 +15,44 @@
 
 
 def generate_kfp_dag_and_resolve_project(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def add_default_function_resources(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def add_function_node_selection_attributes(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def add_annotations(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def add_labels(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def add_default_env(task):
-    raise NotImplementedError
+    pass
 
 
 def sync_environment_variables(function, task):
-    raise NotImplementedError
+    pass
 
 
 def sync_mounts(function, task):
-    raise NotImplementedError
+    pass
 
 
 def generate_pipeline_node(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def generate_image_builder_pipeline_node(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def generate_deployer_pipeline_node(*args, **kwargs):
-    raise NotImplementedError
+    pass

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/ops.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def generate_kfp_dag_and_resolve_project(*args, **kwargs):
+    raise NotImplementedError
+
+
+def add_default_function_resources(*args, **kwargs):
+    raise NotImplementedError
+
+
+def add_function_node_selection_attributes(*args, **kwargs):
+    raise NotImplementedError
+
+
+def add_annotations(*args, **kwargs):
+    raise NotImplementedError
+
+
+def add_labels(*args, **kwargs):
+    raise NotImplementedError
+
+
+def add_default_env(task):
+    raise NotImplementedError
+
+
+def sync_environment_variables(function, task):
+    raise NotImplementedError
+
+
+def sync_mounts(function, task):
+    raise NotImplementedError
+
+
+def generate_pipeline_node(*args, **kwargs):
+    raise NotImplementedError
+
+
+def generate_image_builder_pipeline_node(*args, **kwargs):
+    raise NotImplementedError
+
+
+def generate_deployer_pipeline_node(*args, **kwargs):
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/patcher.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/patcher.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/utils.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/utils.py
@@ -1,0 +1,22 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def compile_pipeline(*args, **kwargs):
+    raise NotImplementedError
+
+
+def get_client(*args, **kwargs):
+    raise NotImplementedError

--- a/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/utils.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-nop/src/mlrun_pipelines/utils.py
@@ -15,8 +15,8 @@
 
 
 def compile_pipeline(*args, **kwargs):
-    raise NotImplementedError
+    pass
 
 
 def get_client(*args, **kwargs):
-    raise NotImplementedError
+    pass


### PR DESCRIPTION
This adapter, gives the client the ability to
1. Remove the default adapter (Currently 1.8) from mlrun's requirement
2. Install the nop adapter to ensure mlrun wont break when default adapter is missing

The idea is to relax mlrun requirements without breaking compatibility of removing the default kfp requirement.

