### PR TITLE
[Linting] Upgrade blacken-docs - use the `--check` flag in `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -618,9 +618,8 @@ fmt: ## Format the code using Ruff and blacken-docs
 
 .PHONY: lint-docs
 lint-docs: ## Format the code blocks in markdown files
-# TODO: use the `--check` flag when blacken-docs 1.17 is released
 	@echo "Checking the code blocks with blacken-docs"
-	git ls-files -z -- '*.md' | xargs -0 blacken-docs -t=py39
+	git ls-files -z -- '*.md' | xargs -0 blacken-docs -t=py39 --check
 
 .PHONY: lint-imports
 lint-imports: ## Validates import dependencies

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ build~=1.0
 # formatting & linting
 ruff==0.4.2
 import-linter~=2.0
-blacken-docs~=1.16
+blacken-docs~=1.18
 black~=24.4  # only used by by blacken-docs
 
 # testing


### PR DESCRIPTION
Blacken-docs 1.18.0 has been released:
https://pypi.org/project/blacken-docs/1.18.0/

It includes the `--check` flag:
https://github.com/adamchainz/blacken-docs/blob/main/CHANGELOG.rst#1170-2024-06-29

Resolves https://github.com/mlrun/mlrun/pull/5803#discussion_r1647269748.