### PR TITLE
[Model Monitoring] Exclude non-v3io stream from redeployment mechanism 

### DIFF
--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -527,7 +527,15 @@ def _deploy_nuclio_runtime(
                         "On deploy of serving-functions which is based on mlrun image "
                         "('mlrun/') and with set-tracking enabled, client version must be >= 1.6.3"
                     )
-                if not monitoring_deployment.is_monitoring_stream_has_the_new_stream_trigger():
+
+                # Update model monitoring stream trigger if using old V3IO stream path
+                stream_paths = server.api.crud.model_monitoring.get_stream_path(
+                    project=fn.metadata.project,
+                )
+                if (
+                    stream_paths[0].startswith("v3io")
+                    and not monitoring_deployment.is_monitoring_stream_has_the_new_stream_trigger()
+                ):
                     monitoring_deployment.deploy_model_monitoring_stream_processing(
                         overwrite=True
                     )

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -17,7 +17,6 @@ import traceback
 import typing
 from http import HTTPStatus
 
-import semver
 import sqlalchemy.orm
 from fastapi import APIRouter, Depends, Header, Request, Response
 from fastapi.concurrency import run_in_threadpool
@@ -513,26 +512,13 @@ def _deploy_nuclio_runtime(
             )
 
         if serving_to_monitor:
-            if not mlrun.mlconf.is_ce_mode():
-                if (
-                    fn.spec.image.startswith("mlrun/")
-                    and client_version
-                    and (
-                        semver.Version.parse(client_version)
-                        < semver.Version.parse("1.6.3")
-                        or "unstable" in client_version
-                    )
-                ):
-                    raise mlrun.errors.MLRunBadRequestError(
-                        "On deploy of serving-functions which is based on mlrun image "
-                        "('mlrun/') and with set-tracking enabled, client version must be >= 1.6.3"
-                    )
-
-                # Update model monitoring stream trigger if using old V3IO stream path
-                if not monitoring_deployment.is_monitoring_stream_has_the_new_stream_trigger():
-                    monitoring_deployment.deploy_model_monitoring_stream_processing(
-                        overwrite=True
-                    )
+            if monitoring_deployment.should_redeploy_monitoring_stream(
+                fn_image=fn.spec.image, client_version=client_version
+            ):
+                # Redeploy the monitoring stream processing function
+                monitoring_deployment.deploy_model_monitoring_stream_processing(
+                    overwrite=True
+                )
 
     server.api.crud.runtimes.nuclio.function.deploy_nuclio_function(
         fn,

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -529,13 +529,7 @@ def _deploy_nuclio_runtime(
                     )
 
                 # Update model monitoring stream trigger if using old V3IO stream path
-                stream_paths = server.api.crud.model_monitoring.get_stream_path(
-                    project=fn.metadata.project,
-                )
-                if (
-                    stream_paths[0].startswith("v3io")
-                    and not monitoring_deployment.is_monitoring_stream_has_the_new_stream_trigger()
-                ):
+                if not monitoring_deployment.is_monitoring_stream_has_the_new_stream_trigger():
                     monitoring_deployment.deploy_model_monitoring_stream_processing(
                         overwrite=True
                     )

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -594,9 +594,10 @@ class MonitoringDeployment:
 
     def is_monitoring_stream_has_the_new_stream_trigger(self) -> bool:
         """
-        Check if the monitoring stream function has the new stream trigger.
+        Check if the monitoring stream function has the new stream trigger. Note that this method is only relevant when
+        using V3IO stream path.
 
-        :return: True if the monitoring stream function has the new stream trigger, otherwise False.
+        :return: True if the monitoring stream function has valid stream trigger, otherwise False.
         """
 
         try:
@@ -611,6 +612,14 @@ class MonitoringDeployment:
                 "the stream function will be deployed with the new & the old stream triggers",
                 project=self.project,
             )
+            return True
+
+        stream_paths = server.api.crud.model_monitoring.get_stream_path(
+            project=self.project
+        )
+
+        if not stream_paths[0].startswith("v3io"):
+            # Stream path is not V3IO, no need to update the stream trigger
             return True
 
         if (

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -509,14 +509,10 @@ def test_tracking_on_serving(
     )
 
     functions_to_monkeypatch = {
-        server.api.api.utils: ["apply_enrichment_and_validation_on_function"],
         server.api.api.endpoints.nuclio: [
             "process_model_monitoring_secret",
-            "create_model_monitoring_stream",
         ],
-        server.api.crud: ["ModelEndpoints"],
         nuclio.deploy: ["deploy_config"],
-        server.api.crud.model_monitoring: ["get_stream_path"],
     }
 
     for package in functions_to_monkeypatch:


### PR DESCRIPTION
Following the security issue fix in #5393  , the mm stream pod is redeployed with the “new” V3IO stream trigger when the old version is based on the old V3IO stream location. 

However, this fix doesn’t take into account non-v3io streams such as Kafka and as a result each deployment of a serving function with non-v3io stream will lead to redeployment of the mm stream pod.


This PR excludes non-v3io streams from the mm stream pod redeployment process. 

A related JIRA: https://iguazio.atlassian.net/browse/ML-7002