### PR TITLE
[Model Monitoring] Fix error on empty TSDB table

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -38,7 +38,8 @@ def _is_no_schema_error(exc: v3io_frames.ReadError) -> bool:
     In case of a nonexistent TSDB table - a `v3io_frames.ReadError` error is raised.
     Check if the error message contains the relevant string to verify the cause.
     """
-    return "No TSDB schema file found" in str(exc)
+    msg = str(exc)
+    return "No TSDB schema file found" in msg or "Failed to read schema at path" in msg
 
 
 class V3IOTSDBConnector(TSDBConnector):

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -39,6 +39,8 @@ def _is_no_schema_error(exc: v3io_frames.ReadError) -> bool:
     Check if the error message contains the relevant string to verify the cause.
     """
     msg = str(exc)
+    # https://github.com/v3io/v3io-tsdb/blob/v0.14.1/pkg/tsdb/v3iotsdb.go#L205
+    # https://github.com/v3io/v3io-tsdb/blob/v0.14.1/pkg/partmgr/partmgr.go#L238
     return "No TSDB schema file found" in msg or "Failed to read schema at path" in msg
 
 


### PR DESCRIPTION
This was fixed in #5706, but not for the case where framesd already accessed the table, the table was deleted (e.g. if whole project was deleted), and then we try to read the table again. In this case, the error is different.