### PR TITLE
[Notifications] Check if secret key is internal before deleting it

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -737,8 +737,17 @@ class Notification(ModelObj):
             self.kind
         ).get_notification()
 
-        secret_params = self.secret_params
-        params = self.params
+        secret_params = self.secret_params or {}
+        params = self.params or {}
+
+        # if the secret_params are already masked - no need to validate
+        params_secret = secret_params.get("secret", "")
+        if params_secret:
+            if len(secret_params) > 1:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "When the 'secret' key is present, 'secret_params' should not contain any other keys."
+                )
+            return
 
         if not secret_params and not params:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -430,11 +430,7 @@ def validate_and_mask_notification_list(
         # validate notification schema
         mlrun.common.schemas.Notification(**notification_object.to_dict())
 
-        # skip the params validation if the key is "secret"
-        secret_params = notification_object.secret_params or {}
-        params_secret = secret_params.get("secret", "")
-        if not params_secret:
-            notification_object.validate_notification_params()
+        notification_object.validate_notification_params()
 
         notification_objects.append(notification_object)
 

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -430,14 +430,11 @@ def validate_and_mask_notification_list(
         # validate notification schema
         mlrun.common.schemas.Notification(**notification_object.to_dict())
 
-        # store the original secret_params and temporarily unmask for validation
-        original_secret_params = notification_object.secret_params
-        unmask_notification_params_secret(project, notification_object)
-
-        notification_object.validate_notification_params()
-
-        # restore the original secret_params to maintain the object state
-        notification_object.secret_params = original_secret_params
+        # skip the params validation if the key is "secret"
+        secret_params = notification_object.secret_params or {}
+        params_secret = secret_params.get("secret", "")
+        if not params_secret:
+            notification_object.validate_notification_params()
 
         notification_objects.append(notification_object)
 

--- a/server/api/crud/secrets.py
+++ b/server/api/crud/secrets.py
@@ -90,7 +90,7 @@ class Secrets(
     def validate_internal_project_secret_key_allowed(
         self, key: str, allow_internal_secrets: bool = False
     ):
-        if self._is_internal_project_secret_key(key) and not allow_internal_secrets:
+        if self.is_internal_project_secret_key(key) and not allow_internal_secrets:
             raise mlrun.errors.MLRunAccessDeniedError(
                 f"Not allowed to create/update internal secrets (key starts with "
                 f"{self.internal_secrets_key_prefix})"
@@ -216,7 +216,7 @@ class Secrets(
         if not allow_internal_secrets:
             if secrets:
                 for secret_key in secrets:
-                    if self._is_internal_project_secret_key(secret_key):
+                    if self.is_internal_project_secret_key(secret_key):
                         raise mlrun.errors.MLRunAccessDeniedError(
                             f"Not allowed to delete internal secrets (key starts with "
                             f"{self.internal_secrets_key_prefix})"
@@ -298,7 +298,7 @@ class Secrets(
         if not allow_internal_secrets:
             secret_keys = list(
                 filter(
-                    lambda key: not self._is_internal_project_secret_key(key),
+                    lambda key: not self.is_internal_project_secret_key(key),
                     secret_keys,
                 )
             )
@@ -341,7 +341,7 @@ class Secrets(
             secrets_data = {
                 key: value
                 for key, value in secrets_data.items()
-                if not self._is_internal_project_secret_key(key)
+                if not self.is_internal_project_secret_key(key)
             }
         return mlrun.common.schemas.SecretsData(provider=provider, secrets=secrets_data)
 
@@ -414,6 +414,9 @@ class Secrets(
             allow_internal_secrets,
         )
         return secrets_data.secrets.get(secret_key)
+
+    def is_internal_project_secret_key(self, key: str) -> bool:
+        return key.startswith(self.internal_secrets_key_prefix)
 
     def _resolve_project_secret_key(
         self,
@@ -535,9 +538,6 @@ class Secrets(
     def _is_project_secret_stored_in_key_map(self, key: str) -> bool:
         # Key map are only used for invalid keys
         return not self.validate_project_secret_key_regex(key, raise_on_failure=False)
-
-    def _is_internal_project_secret_key(self, key: str) -> bool:
-        return key.startswith(self.internal_secrets_key_prefix)
 
     def _is_key_map_project_secret_key(self, key: str) -> bool:
         return key.startswith(self.key_map_secrets_key_prefix)


### PR DESCRIPTION
resolves:
https://iguazio.atlassian.net/browse/ML-6936

when deleting notifications, only internal project secrets should be deleted.

also, this PR introduces a change to skip the validation of notification parameters when the "secret" key is present in the secret parameters.