### PR TITLE
[Tests] Mark `test_drift_detection_alert` as model_monitoring test

### DIFF
--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -209,11 +209,17 @@ class TestAlerts(TestMLRunSystem):
             )
         return expected_notifications
 
+    @pytest.mark.model_monitoring
     def test_drift_detection_alert(self):
         """
         validate that an alert is sent with different result kind and different detection result
         """
         # enable model monitoring - deploy writer function
+        self.project.set_model_monitoring_credentials(
+            endpoint_store_connection=mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection,
+            stream_path=mlrun.mlconf.model_endpoint_monitoring.stream_connection,
+            tsdb_connection=mlrun.mlconf.model_endpoint_monitoring.tsdb_connection,
+        )
         self.project.enable_model_monitoring(image=self.image or "mlrun/mlrun")
         # deploy nuclio func for storing notifications, to validate an alert notifications were sent on drift detection
         nuclio_function_url = notification_helpers.deploy_notification_nuclio(


### PR DESCRIPTION
After merging #5827 all the users have to set model monitoring credentials in order to use MM facilities.

After this change in order to run   `test_drift_detection_alert` you will have to define the following env vars : 
```
MLRUN_MODEL_ENDPOINT_MONITORING__ENDPOINT_STORE_CONNECTION: "v3io"
MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION: "v3io"
MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION: "v3io"
```

Note in the system of the system tests we define those env vars in the the client side. 