### PR TITLE
[Serving] Fix removal of event path for V3IO stream

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -390,6 +390,7 @@ def v2_serving_handler(context, event, get_body=False):
         "kafka",
         "kafka-cluster",
         "v3ioStream",
+        "v3io-stream",
     ):
         event.path = "/"
 


### PR DESCRIPTION
[ML-6863](https://iguazio.atlassian.net/browse/ML-6863)

Trigger kind can be "v3io-stream" or "v3ioStream", but only the latter was accounted for. #5798 was missing this.

[ML-6863]: https://iguazio.atlassian.net/browse/ML-6863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ