### PR TITLE
[Artifacts] Change the artifact target to include the artifact tag

### DIFF
--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -86,7 +86,7 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
             hash_key = db.store_function(
                 struct, runtime.metadata.name, runtime.metadata.project, tag=tag, versioned=True
             )
-            run.spec.function = runtime._function_uri(tag=tag, hash_key=hash_key)
+            run.spec.function = runtime._function_uri(hash_key=hash_key)
 
     @staticmethod
     def _refresh_function_metadata(runtime: "mlrun.runtimes.BaseRuntime"):

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -82,10 +82,11 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
         db = runtime._get_db()
         if db and runtime.kind != "handler":
             struct = runtime.to_dict()
+            tag = run.spec.parameters.get("tag", None)
             hash_key = db.store_function(
-                struct, runtime.metadata.name, runtime.metadata.project, versioned=True
+                struct, runtime.metadata.name, runtime.metadata.project, tag=tag, versioned=True
             )
-            run.spec.function = runtime._function_uri(hash_key=hash_key)
+            run.spec.function = runtime._function_uri(tag=tag, hash_key=hash_key)
 
     @staticmethod
     def _refresh_function_metadata(runtime: "mlrun.runtimes.BaseRuntime"):

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -82,9 +82,8 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
         db = runtime._get_db()
         if db and runtime.kind != "handler":
             struct = runtime.to_dict()
-            tag = run.spec.parameters.get("tag", None)
             hash_key = db.store_function(
-                struct, runtime.metadata.name, runtime.metadata.project, tag=tag, versioned=True
+                struct, runtime.metadata.name, runtime.metadata.project, versioned=True
             )
             run.spec.function = runtime._function_uri(hash_key=hash_key)
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -688,10 +688,11 @@ def parse_artifact_uri(uri, default_project=""):
 def generate_object_uri(project, name, tag=None, hash_key=None):
     uri = f"{project}/{name}"
 
-    if tag:
-        uri += f":{tag}"
+    # prioritize hash key over tag
     if hash_key:
         uri += f"@{hash_key}"
+    elif tag:
+        uri += f":{tag}"
     return uri
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -109,10 +109,13 @@ def get_artifact_target(item: dict, project=None):
     db_key = item["spec"].get("db_key")
     project_str = project or item["metadata"].get("project")
     tree = item["metadata"].get("tree")
+    tag = item["metadata"].get("tag")
 
     kind = item.get("kind")
     if kind in ["dataset", "model", "artifact"] and db_key:
         target = f"{DB_SCHEMA}://{StorePrefix.Artifact}/{project_str}/{db_key}"
+        if tag:
+            target = f"{target}:{tag}"
         if tree:
             target = f"{target}@{tree}"
         return target

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -688,11 +688,10 @@ def parse_artifact_uri(uri, default_project=""):
 def generate_object_uri(project, name, tag=None, hash_key=None):
     uri = f"{project}/{name}"
 
-    # prioritize hash key over tag
+    if tag:
+        uri += f":{tag}"
     if hash_key:
         uri += f"@{hash_key}"
-    elif tag:
-        uri += f":{tag}"
     return uri
 
 

--- a/tests/run/assets/handler.py
+++ b/tests/run/assets/handler.py
@@ -17,12 +17,11 @@ import os
 import mlrun
 
 
-def myhandler(context: mlrun.MLClientCtx, p1, p2=3, p3=4):
+def myhandler(context: mlrun.MLClientCtx, tag):
     print(f"Run: {context.name} (uid={context.uid})")
-    context.logger.info(f"iter={context.iteration} p2={p2}")
-    context.log_result("accuracy", p2 * 2)
-    context.log_result("loss", p3 * 3)
-    context.log_artifact("file_result", body=b"abc123", local_path="result.txt")
+    context.log_artifact(
+        "file_result", body=b"abc123", local_path="result.txt", tag=tag
+    )
 
 
 def handler2(context: mlrun.MLClientCtx):

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -331,3 +331,15 @@ def test_get_or_create_ctx_run_kind_exists_in_mlrun_exec_config(
     )
     context = mlrun.get_or_create_ctx("ctx")
     assert context.labels.get("kind") == "spark"
+
+
+def test_varify_tag_exists_in_output_uri_on_run():
+    project = mlrun.get_or_create_project("dummy-project")
+    project.set_function(
+        func=function_path, handler="myhandler", name="test", image="mlrun/mlrun"
+    )
+    run = project.run_function("test", params={"tag": "v1"}, local=True)
+    uri = run.output("file_result")
+
+    # Verify that the tag exists in the URI
+    assert ":v1" in uri

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -333,7 +333,7 @@ def test_get_or_create_ctx_run_kind_exists_in_mlrun_exec_config(
     assert context.labels.get("kind") == "spark"
 
 
-def test_varify_tag_exists_in_output_uri_on_run():
+def test_verify_tag_exists_in_run_output_uri():
     project = mlrun.get_or_create_project("dummy-project")
     project.set_function(
         func=function_path, handler="myhandler", name="test", image="mlrun/mlrun"

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -998,3 +998,15 @@ def test_normalize_username(username, expected_normalized_username):
 def test_is_safe_path(basedir, path, is_symlink, is_valid):
     safe = mlrun.utils.is_safe_path(basedir, path, is_symlink)
     assert safe == is_valid
+
+
+def test_get_artifact_target():
+    item = {
+        "kind": "artifact",
+        "spec": {
+            "db_key": "dummy-db-key",
+        },
+        "metadata": {"tree": "dummy-tree", "tag": "dummy-tag"},
+    }
+    target = mlrun.utils.get_artifact_target(item, project="dummy-project")
+    assert target == "store://artifacts/dummy-project/dummy-db-key:dummy-tag@dummy-tree"


### PR DESCRIPTION
This PR tries to resolve the issue that occurs when an artifact is logged with the v1 tag and then logged with the v2 tag.
Then get the dataitem v1 tag, which fails.
When running log artifact inside a function, the output function returns the artifact uri without the artifact tag, causing the get artifact to fail because if the uri does not have a tag, we will search for the latest tag (instead of v1 tag).

https://iguazio.atlassian.net/browse/ML-6602