### PR TITLE
[Model Monitoring] Remove drift thresholds config and usage

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -78,8 +78,6 @@ class EventFieldType:
     FEATURE_SET_URI = "monitoring_feature_set_uri"
     ALGORITHM = "algorithm"
     VALUE = "value"
-    DRIFT_DETECTED_THRESHOLD = "drift_detected_threshold"
-    POSSIBLE_DRIFT_THRESHOLD = "possible_drift_threshold"
     SAMPLE_PARQUET_PATH = "sample_parquet_path"
     TIME = "time"
     TABLE_COLUMN = "table_column"

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -103,18 +103,6 @@ class ModelEndpointSpec(ObjectSpec):
             json_parse_values=json_parse_values,
         )
 
-    @validator("monitor_configuration")
-    @classmethod
-    def set_name(cls, monitor_configuration):
-        return monitor_configuration or {
-            EventFieldType.DRIFT_DETECTED_THRESHOLD: (
-                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.drift_detected
-            ),
-            EventFieldType.POSSIBLE_DRIFT_THRESHOLD: (
-                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.possible_drift
-            ),
-        }
-
     @validator("model_uri")
     @classmethod
     def validate_model_uri(cls, model_uri):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -504,7 +504,6 @@ default_config = {
     "model_endpoint_monitoring": {
         "serving_stream_args": {"shard_count": 1, "retention_period_hours": 24},
         "application_stream_args": {"shard_count": 1, "retention_period_hours": 24},
-        "drift_thresholds": {"default": {"possible_drift": 0.5, "drift_detected": 0.7}},
         # Store prefixes are used to handle model monitoring storing policies based on project and kind, such as events,
         # stream, and endpoints.
         "store_prefixes": {

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -47,8 +47,8 @@ def get_or_create_model_endpoint(
     function_name: str = "",
     context: mlrun.MLClientCtx = None,
     sample_set_statistics: dict[str, typing.Any] = None,
-    drift_threshold: float = None,
-    possible_drift_threshold: float = None,
+    drift_threshold: typing.Optional[float] = None,
+    possible_drift_threshold: typing.Optional[float] = None,
     monitoring_mode: mm_constants.ModelMonitoringMode = mm_constants.ModelMonitoringMode.disabled,
     db_session=None,
 ) -> ModelEndpoint:
@@ -69,13 +69,13 @@ def get_or_create_model_endpoint(
                                      full function hash.
     :param sample_set_statistics:    Dictionary of sample set statistics that will be used as a reference data for
                                      the new model endpoint (applicable only to new endpoint_id).
-    :param drift_threshold:          The threshold of which to mark drifts (applicable only to new endpoint_id).
-    :param possible_drift_threshold: The threshold of which to mark possible drifts (applicable only to new
+    :param drift_threshold:          (deprecated) The threshold of which to mark drifts (applicable only to new
+                                     endpoint_id).
+    :param possible_drift_threshold: (deprecated) The threshold of which to mark possible drifts (applicable only to new
                                      endpoint_id).
     :param monitoring_mode:          If enabled, apply model monitoring features on the provided endpoint id
                                      (applicable only to new endpoint_id).
     :param db_session:               A runtime session that manages the current dialog with the database.
-
 
     :return: A ModelEndpoint object
     """

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -98,8 +98,6 @@ def get_or_create_model_endpoint(
             model_endpoint=model_endpoint,
             model_path=model_path,
             sample_set_statistics=sample_set_statistics,
-            drift_threshold=drift_threshold,
-            possible_drift_threshold=possible_drift_threshold,
         )
 
     except mlrun.errors.MLRunNotFoundError:
@@ -113,8 +111,6 @@ def get_or_create_model_endpoint(
             function_name=function_name,
             context=context,
             sample_set_statistics=sample_set_statistics,
-            drift_threshold=drift_threshold,
-            possible_drift_threshold=possible_drift_threshold,
             monitoring_mode=monitoring_mode,
         )
     return model_endpoint
@@ -241,9 +237,7 @@ def _model_endpoint_validations(
     model_endpoint: ModelEndpoint,
     model_path: str = "",
     sample_set_statistics: dict[str, typing.Any] = None,
-    drift_threshold: float = None,
-    possible_drift_threshold: float = None,
-):
+) -> None:
     """
     Validate that provided model endpoint configurations match the stored fields of the provided `ModelEndpoint`
     object. Usually, this method is called by `get_or_create_model_endpoint()` in cases that the model endpoint
@@ -257,11 +251,6 @@ def _model_endpoint_validations(
                                      is forbidden to provide a different reference data to that model endpoint.
                                      In case of discrepancy between the provided `sample_set_statistics` and the
                                      `model_endpoints.spec.feature_stats`, a warning will be presented to the user.
-    :param drift_threshold:          The threshold of which to mark drifts. Should be similar to the drift threshold
-                                     that has already assigned to the current model endpoint.
-    :param possible_drift_threshold: The threshold of which to mark possible drifts. Should be similar to the possible
-                                     drift threshold  that has already assigned to the current model endpoint.
-
     """
     # Model path
     if model_path and model_endpoint.spec.model_uri != model_path:
@@ -280,28 +269,6 @@ def _model_endpoint_validations(
             "Provided sample set statistics is different from the registered statistics. "
             "If new sample set statistics is to be used, new model endpoint should be created"
         )
-    # drift and possible drift thresholds
-    if drift_threshold:
-        current_drift_threshold = model_endpoint.spec.monitor_configuration.get(
-            mm_constants.EventFieldType.DRIFT_DETECTED_THRESHOLD,
-            mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.drift_detected,
-        )
-        if current_drift_threshold != drift_threshold:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Cannot change existing drift threshold. Expected {current_drift_threshold}, got {drift_threshold} "
-                f"Please update drift threshold or generate a new model endpoint record"
-            )
-
-    if possible_drift_threshold:
-        current_possible_drift_threshold = model_endpoint.spec.monitor_configuration.get(
-            mm_constants.EventFieldType.POSSIBLE_DRIFT_THRESHOLD,
-            mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.possible_drift,
-        )
-        if current_possible_drift_threshold != possible_drift_threshold:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Cannot change existing possible drift threshold. Expected {current_possible_drift_threshold}, "
-                f"got {possible_drift_threshold}. Please update drift threshold or generate a new model endpoint record"
-            )
 
 
 def write_monitoring_df(
@@ -354,8 +321,6 @@ def _generate_model_endpoint(
     function_name: str,
     context: mlrun.MLClientCtx,
     sample_set_statistics: dict[str, typing.Any],
-    drift_threshold: float,
-    possible_drift_threshold: float,
     monitoring_mode: mm_constants.ModelMonitoringMode = mm_constants.ModelMonitoringMode.disabled,
 ) -> ModelEndpoint:
     """
@@ -374,8 +339,6 @@ def _generate_model_endpoint(
     :param sample_set_statistics:    Dictionary of sample set statistics that will be used as a reference data for
                                      the current model endpoint. Will be stored under
                                      `model_endpoint.status.feature_stats`.
-    :param drift_threshold:          The threshold of which to mark drifts.
-    :param possible_drift_threshold: The threshold of which to mark possible drifts.
 
     :return `mlrun.model_monitoring.model_endpoint.ModelEndpoint` object.
     """
@@ -393,15 +356,6 @@ def _generate_model_endpoint(
     model_endpoint.spec.model_uri = model_path
     model_endpoint.spec.model = model_endpoint_name
     model_endpoint.spec.model_class = "drift-analysis"
-    if drift_threshold:
-        model_endpoint.spec.monitor_configuration[
-            mm_constants.EventFieldType.DRIFT_DETECTED_THRESHOLD
-        ] = drift_threshold
-    if possible_drift_threshold:
-        model_endpoint.spec.monitor_configuration[
-            mm_constants.EventFieldType.POSSIBLE_DRIFT_THRESHOLD
-        ] = possible_drift_threshold
-
     model_endpoint.spec.monitoring_mode = monitoring_mode
     model_endpoint.status.first_request = model_endpoint.status.last_request = (
         datetime_now().isoformat()

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -106,25 +106,9 @@ class TestModelEndpointsOperations(TestMLRunSystem):
 
         assert endpoint_before_update.status.state == "null"
 
-        # Check default drift thresholds
-        assert endpoint_before_update.spec.monitor_configuration == {
-            mlrun.common.schemas.EventFieldType.DRIFT_DETECTED_THRESHOLD: (
-                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.drift_detected
-            ),
-            mlrun.common.schemas.EventFieldType.POSSIBLE_DRIFT_THRESHOLD: (
-                mlrun.mlconf.model_endpoint_monitoring.drift_thresholds.default.possible_drift
-            ),
-        }
-
         updated_state = "testing...testing...1 2 1 2"
         drift_status = "DRIFT_DETECTED"
         current_stats = {
-            "tvd_sum": 2.2,
-            "tvd_mean": 0.5,
-            "hellinger_sum": 3.6,
-            "hellinger_mean": 0.9,
-            "kld_sum": 24.2,
-            "kld_mean": 6.0,
             "f1": {"tvd": 0.5, "hellinger": 1.0, "kld": 6.4},
             "f2": {"tvd": 0.5, "hellinger": 1.0, "kld": 6.5},
         }


### PR DESCRIPTION
Resolves [ML-7028](https://iguazio.atlassian.net/browse/ML-7028).

Starting from 1.7.0, the thresholds are not used anymore, as the model monitoring batch job is removed.
The thresholds are currently defined inside each application.

Keep the `monitor_configuration` column in the model endpoint table to avoid model monitoring DB migration issues.

I verified that:
* the client spec object did not consume this configuration, 
* and provazio did not modify it.

[ML-7022]: https://iguazio.atlassian.net/browse/ML-7022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-7028]: https://iguazio.atlassian.net/browse/ML-7028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ