### PR TITLE
[MySQL] Avoid year 2038 problem in new MySQL tables

### DIFF
--- a/mlrun/model_monitoring/db/stores/sqldb/models/base.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/base.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from sqlalchemy import (
     DATETIME,
-    TIMESTAMP,
+    TIMESTAMP,  # TODO: migrate to DATETIME, see ML-6921
     Boolean,
     Column,
     Float,
@@ -91,11 +92,11 @@ class ModelEndpointsBaseTable(BaseModel):
     metrics = Column(EventFieldType.METRICS, Text)
     first_request = Column(
         EventFieldType.FIRST_REQUEST,
-        TIMESTAMP(timezone=True),
+        TIMESTAMP(timezone=True),  # TODO: migrate to DATETIME, see ML-6921
     )
     last_request = Column(
         EventFieldType.LAST_REQUEST,
-        TIMESTAMP(timezone=True),
+        TIMESTAMP(timezone=True),  # TODO: migrate to DATETIME, see ML-6921
     )
 
 

--- a/mlrun/model_monitoring/db/stores/sqldb/models/base.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from sqlalchemy import (
+    DATETIME,
     TIMESTAMP,
     Boolean,
     Column,
@@ -122,11 +123,11 @@ class ApplicationResultBaseTable(BaseModel):
 
     start_infer_time = Column(
         WriterEvent.START_INFER_TIME,
-        TIMESTAMP(timezone=True),
+        DATETIME(timezone=True),
     )
     end_infer_time = Column(
         WriterEvent.END_INFER_TIME,
-        TIMESTAMP(timezone=True),
+        DATETIME(timezone=True),
     )
 
     result_status = Column(ResultData.RESULT_STATUS, String(10))
@@ -152,11 +153,11 @@ class ApplicationMetricsBaseTable(BaseModel):
     )
     start_infer_time = Column(
         WriterEvent.START_INFER_TIME,
-        TIMESTAMP(timezone=True),
+        DATETIME(timezone=True),
     )
     end_infer_time = Column(
         WriterEvent.END_INFER_TIME,
-        TIMESTAMP(timezone=True),
+        DATETIME(timezone=True),
     )
     metric_name = Column(
         MetricData.METRIC_NAME,

--- a/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
@@ -52,11 +52,11 @@ class _ApplicationResultOrMetric:
 
     start_infer_time = Column(
         WriterEvent.START_INFER_TIME,
-        sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3, timezone=True),
+        sqlalchemy.dialects.mysql.DATETIME(fsp=3, timezone=True),
     )
     end_infer_time = Column(
         WriterEvent.END_INFER_TIME,
-        sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3, timezone=True),
+        sqlalchemy.dialects.mysql.DATETIME(fsp=3, timezone=True),
     )
 
     @declared_attr

--- a/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
@@ -34,10 +34,12 @@ Base = declarative_base()
 class ModelEndpointsTable(Base, ModelEndpointsBaseTable):
     first_request = Column(
         EventFieldType.FIRST_REQUEST,
+        # TODO: migrate to DATETIME, see ML-6921
         sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3, timezone=True),
     )
     last_request = Column(
         EventFieldType.LAST_REQUEST,
+        # TODO: migrate to DATETIME, see ML-6921
         sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3, timezone=True),
     )
 

--- a/server/api/db/sqldb/models.py
+++ b/server/api/db/sqldb/models.py
@@ -644,7 +644,7 @@ with warnings.catch_warnings():
         page_size = Column(Integer)
         kwargs = Column(JSON)
         last_accessed = Column(
-            SQLTypesUtil.timestamp(),
+            SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
             default=datetime.now(timezone.utc),
         )
 
@@ -655,11 +655,11 @@ with warnings.catch_warnings():
         id = Column(Integer, primary_key=True)
         count = Column(Integer)
         created = Column(
-            SQLTypesUtil.timestamp(),
+            SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
             default=datetime.now(timezone.utc),
         )
         last_updated = Column(
-            SQLTypesUtil.timestamp(),
+            SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
             default=None,
         )
         active = Column(BOOLEAN, default=False)

--- a/server/api/utils/db/sql_types.py
+++ b/server/api/utils/db/sql_types.py
@@ -28,6 +28,10 @@ class SQLTypesUtil:
         sqlite = sqlalchemy.TIMESTAMP
         mysql = sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3)
 
+    class _Datetime:
+        sqlite = sqlalchemy.DATETIME(timezone=True)
+        mysql = sqlalchemy.dialects.mysql.DATETIME(timezone=True, fsp=3)
+
     class _Blob:
         sqlite = sqlalchemy.BLOB
         mysql = sqlalchemy.dialects.mysql.MEDIUMBLOB
@@ -38,7 +42,15 @@ class SQLTypesUtil:
 
     @classmethod
     def timestamp(cls):
+        """
+        Use `SQLTypesUtil.datetime()` in new columns.
+        See ML-6921.
+        """
         return cls._return_type(cls._Timestamp)
+
+    @classmethod
+    def datetime(cls):
+        return cls._return_type(cls._Datetime)
 
     @classmethod
     def blob(cls):

--- a/server/api/utils/db/sql_types.py
+++ b/server/api/utils/db/sql_types.py
@@ -19,30 +19,30 @@ from .mysql import MySQLUtil
 
 
 class SQLTypesUtil:
-    class Collations:
+    class _Collations:
         # with sqlite we use the default collation
         sqlite = None
         mysql = "utf8mb3_bin"
 
-    class Timestamp:
+    class _Timestamp:
         sqlite = sqlalchemy.TIMESTAMP
         mysql = sqlalchemy.dialects.mysql.TIMESTAMP(fsp=3)
 
-    class Blob:
+    class _Blob:
         sqlite = sqlalchemy.BLOB
         mysql = sqlalchemy.dialects.mysql.MEDIUMBLOB
 
     @classmethod
     def collation(cls):
-        return cls._return_type(cls.Collations)
+        return cls._return_type(cls._Collations)
 
     @classmethod
     def timestamp(cls):
-        return cls._return_type(cls.Timestamp)
+        return cls._return_type(cls._Timestamp)
 
     @classmethod
     def blob(cls):
-        return cls._return_type(cls.Blob)
+        return cls._return_type(cls._Blob)
 
     @staticmethod
     def _return_type(type_cls: type):

--- a/server/api/utils/db/sql_types.py
+++ b/server/api/utils/db/sql_types.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import sqlalchemy
 import sqlalchemy.dialects.mysql
 
@@ -32,20 +32,20 @@ class SQLTypesUtil:
         sqlite = sqlalchemy.BLOB
         mysql = sqlalchemy.dialects.mysql.MEDIUMBLOB
 
-    @staticmethod
-    def collation():
-        return SQLTypesUtil._return_type(SQLTypesUtil.Collations)
+    @classmethod
+    def collation(cls):
+        return cls._return_type(cls.Collations)
+
+    @classmethod
+    def timestamp(cls):
+        return cls._return_type(cls.Timestamp)
+
+    @classmethod
+    def blob(cls):
+        return cls._return_type(cls.Blob)
 
     @staticmethod
-    def timestamp():
-        return SQLTypesUtil._return_type(SQLTypesUtil.Timestamp)
-
-    @staticmethod
-    def blob():
-        return SQLTypesUtil._return_type(SQLTypesUtil.Blob)
-
-    @staticmethod
-    def _return_type(type_cls):
+    def _return_type(type_cls: type):
         mysql_dsn_data = MySQLUtil.get_mysql_dsn_data()
         if mysql_dsn_data:
             return type_cls.mysql


### PR DESCRIPTION
Fixes [ML-7040](https://iguazio.atlassian.net/browse/ML-7040) for new model monitoring tables.
I verified the main MM app flow test with MySQL passed.

Added a new `datetime` method to the `SQLTypesUtil` class - not used yet.

## Background

(Copied from the description of [ML-6921](https://iguazio.atlassian.net/browse/ML-6921).)

https://en.wikipedia.org/wiki/Year_2038_problem

We use `TIMESTAMP` fields in almost all of our tables in the MySQL DBs:

* `mlrun` DB: https://github.com/mlrun/mlrun/blob/acf958f31f6a0e2658d6732680fc971fea2d28f7/server/api/utils/db/sql_types.py#L29
* `mlrun_model_monitoring` DB: https://github.com/mlrun/mlrun/blob/acf958f31f6a0e2658d6732680fc971fea2d28f7/mlrun/model_monitoring/db/stores/sqldb/models/base.py#L93

However, this type is designed to hold int32 values from the Unix epoch (1970-2038). For reference, see:

https://dev.mysql.com/doc/refman/8.0/en/datetime.html 

> `TIMESTAMP` has a range of `'1970-01-01 00:00:01'` UTC to `'2038-01-19 03:14:07'` UTC.

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html 

> The behavior of the `TIMESTAMP` type is also unaffected by this change; its maximum allowed value remains `'2038-01-19 03:14:07.999999'` UTC, regardless of platform. **For dates futureward of this, use the MySQL `DATETIME` type instead.** (WL #14630)

https://bugs.mysql.com/bug.php?id=12654 

From now on, it’s better to use `DATETIME` instead of `TIMESTAMP`:

> The `DATETIME` type is used for values that contain both date and time parts. MySQL retrieves and displays `DATETIME` values in `'YYYY-MM-DD hh:mm:ss'` format. The supported range is `'1000-01-01 00:00:00'` to `'9999-12-31 23:59:59'`.

[ML-7040]: https://iguazio.atlassian.net/browse/ML-7040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-6921]: https://iguazio.atlassian.net/browse/ML-6921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Backwards Compatibility

The changed tables in this PR did not exist in 1.6, so there is no BC issue for users.
However, for developers working on 1.7 model monitoring with MySQL - the new tables need to be removed.

This can be done easily with:

```py
from sqlalchemy import create_engine

# Change according to the relevant database
connection_uri = "mysql+pymysql://root@<host>:<node-port>/mlrun_model_monitoring"

engine = create_engine(connection_uri)

with engine.connect() as connection:
    connection.execute("DROP TABLE IF EXISTS app_results,app_metrics;")
```