### PR TITLE
[Runs] Do not ensure run logs collected when runs are terminated

### DIFF
--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -34,7 +34,6 @@ import mlrun.utils.helpers
 import mlrun.utils.notifications
 import mlrun.utils.regex
 import server.api.common.runtime_handlers
-import server.api.crud as crud
 import server.api.utils.helpers
 import server.api.utils.singletons.k8s
 from mlrun.common.runtimes.constants import PodPhases, RunStates, ThresholdStates
@@ -1136,7 +1135,6 @@ class BaseRuntimeHandler(ABC):
         _, _, run = self._ensure_run_state(
             db, db_session, project, uid, name, run_state
         )
-        self._check_run_logs_collected(project=project, uid=uid)
 
     def _is_runtime_resource_run_in_terminal_state(
         self,
@@ -1283,9 +1281,6 @@ class BaseRuntimeHandler(ABC):
         # Update the UI URL after ensured run state because it also ensures that a run exists
         # (A runtime resource might exist before the run is created)
         self._update_ui_url(db, db_session, project, uid, runtime_resource, run)
-
-        if updated_run_state in RunStates.terminal_states():
-            self._check_run_logs_collected(project=project, uid=uid)
 
     def _resolve_resource_state_and_apply_threshold(
         self,
@@ -1558,12 +1553,6 @@ class BaseRuntimeHandler(ABC):
             f"{mlrun_constants.MLRunInternalLabels.project}={project},"
             f"{mlrun_constants.MLRunInternalLabels.uid}={run_uid}"
         )
-
-    @staticmethod
-    def _check_run_logs_collected(project: str, uid: str):
-        log_file_exists, _ = crud.Logs().log_file_exists_for_run_uid(project, uid)
-        if not log_file_exists:
-            logger.warning("Run logs were not collected", project=project, uid=uid)
 
     def _ensure_run_state(
         self,

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -230,7 +230,7 @@ class BaseRuntimeHandler(ABC):
     ) -> str:
         default_label_selector = self._get_default_label_selector(class_mode=class_mode)
 
-        if label_selector:
+        if label_selector and default_label_selector not in label_selector:
             label_selector = ",".join([default_label_selector, label_selector])
         else:
             label_selector = default_label_selector

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -41,7 +41,6 @@ from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.runtimes import RuntimeClassMode
 from mlrun.utils import logger, now_date
-from server.api.constants import LogSources
 from server.api.db.base import DBInterface
 
 

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1136,7 +1136,7 @@ class BaseRuntimeHandler(ABC):
         _, _, run = self._ensure_run_state(
             db, db_session, project, uid, name, run_state
         )
-        self._ensure_run_logs_collected(db, db_session, project, uid, run=run)
+        self._check_run_logs_collected(project=project, uid=uid)
 
     def _is_runtime_resource_run_in_terminal_state(
         self,
@@ -1285,7 +1285,7 @@ class BaseRuntimeHandler(ABC):
         self._update_ui_url(db, db_session, project, uid, runtime_resource, run)
 
         if updated_run_state in RunStates.terminal_states():
-            self._ensure_run_logs_collected(db, db_session, project, uid, run=run)
+            self._check_run_logs_collected(project=project, uid=uid)
 
     def _resolve_resource_state_and_apply_threshold(
         self,
@@ -1560,21 +1560,10 @@ class BaseRuntimeHandler(ABC):
         )
 
     @staticmethod
-    def _ensure_run_logs_collected(
-        db: DBInterface, db_session: Session, project: str, uid: str, run: dict = None
-    ):
+    def _check_run_logs_collected(project: str, uid: str):
         log_file_exists, _ = crud.Logs().log_file_exists_for_run_uid(project, uid)
         if not log_file_exists:
-            # this stays for now for backwards compatibility in case we would not use the log collector but rather
-            # the legacy method to pull logs
-            logs_from_k8s = crud.Logs()._get_logs_legacy_method(
-                db_session, project, uid, source=LogSources.K8S, run=run
-            )
-            if logs_from_k8s:
-                logger.info("Storing run logs", project=project, uid=uid)
-                server.api.crud.Logs().store_log(
-                    logs_from_k8s, project, uid, append=False
-                )
+            logger.warning("Run logs were not collected", project=project, uid=uid)
 
     def _ensure_run_state(
         self,

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -83,10 +83,6 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                 ],
             ),
             unittest.mock.patch.object(
-                server.api.runtime_handlers.BaseRuntimeHandler,
-                "_ensure_run_logs_collected",
-            ),
-            unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
             ) as delete_logs_mock,
         ):
@@ -132,10 +128,6 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                 k8s_helper.v1api,
                 "list_namespaced_pod",
                 return_value=k8s_client.V1PodList(items=[]),
-            ),
-            unittest.mock.patch.object(
-                server.api.runtime_handlers.BaseRuntimeHandler,
-                "_ensure_run_logs_collected",
             ),
             unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
@@ -187,10 +179,6 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                     Exception("Boom!"),
                     k8s_client.V1PodList(items=[]),
                 ],
-            ),
-            unittest.mock.patch.object(
-                server.api.runtime_handlers.BaseRuntimeHandler,
-                "_ensure_run_logs_collected",
             ),
             unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -159,6 +159,10 @@ class TestRuntimeHandlerBase:
         return labels
 
     @staticmethod
+    def _generate_run_pod_label_selector(run_uid):
+        return f"{mlrun_constants.MLRunInternalLabels.uid}={run_uid}"
+
+    @staticmethod
     def _generate_config_map(name, labels, data=None):
         metadata = client.V1ObjectMeta(
             name=name, labels=labels, namespace=get_k8s_helper().resolve_namespace()
@@ -507,14 +511,14 @@ class TestRuntimeHandlerBase:
             f"Unexpected number of calls to list_namespaced_pod "
             f"{get_k8s_helper().v1api.list_namespaced_pod.call_count}, expected {expected_number_of_calls}"
         )
-        if expected_label_selector and expected_label_selector != "":
-            expected_label_selector = (
-                expected_label_selector or runtime_handler._get_default_label_selector()
-            )
-            get_k8s_helper().v1api.list_namespaced_pod.assert_any_call(
-                get_k8s_helper().resolve_namespace(),
-                label_selector=expected_label_selector,
-            )
+        # if expected_label_selector and expected_label_selector != "":
+        expected_label_selector = (
+            expected_label_selector or runtime_handler._get_default_label_selector()
+        )
+        get_k8s_helper().v1api.list_namespaced_pod.assert_any_call(
+            get_k8s_helper().resolve_namespace(),
+            label_selector=expected_label_selector,
+        )
 
     @staticmethod
     def _assert_list_namespaced_crds_calls(

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -15,7 +15,6 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
-import pytest
 from fastapi.testclient import TestClient
 from kubernetes import client as k8s_client
 from sqlalchemy.orm import Session
@@ -103,8 +102,8 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             PodPhases.running,
         )
 
-        self.pod_label_selector = self._generate_get_logger_pods_label_selector(
-            self.runtime_handler
+        self.run_uid_label_selector = self._generate_run_pod_label_selector(
+            self.run_uid
         )
 
     def test_list_resources(self, db: Session, client: TestClient):
@@ -143,10 +142,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
                 group_by=group_by,
             )
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_succeeded_crd(
-        self, db: Session, client: TestClient
-    ):
+    def test_delete_resources_succeeded_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.succeeded_crd_dict],
             # 2 additional time for wait for pods deletion
@@ -155,8 +151,6 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for the get_logger_pods
-            [self.launcher_pod, self.worker_pod],
             # additional time for wait for pods deletion - simulate pods not removed yet
             [self.launcher_pod, self.worker_pod],
             # additional time for wait for pods deletion - simulate pods gone
@@ -164,7 +158,6 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_custom_objects()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -178,17 +171,9 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            self.pod_label_selector,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
-        )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.launcher_pod.metadata.name,
         )
 
     def test_delete_resources_running_crd(self, db: Session, client: TestClient):
@@ -232,8 +217,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             len(list_namespaced_crds_calls),
         )
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_with_force(self, db: Session, client: TestClient):
+    def test_delete_resources_with_force(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.active_crd_dict],
             # additional time for wait for pods deletion
@@ -241,14 +225,11 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for the get_logger_pods
-            [self.launcher_pod, self.worker_pod],
-            # additional time for wait for pods deletion - simulate pods gone
+            # for wait for pods deletion - simulate pods gone
             [],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_custom_objects()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10, force=True)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -262,35 +243,23 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            self.pod_label_selector,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.launcher_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_succeeded_crd(self, db: Session, client: TestClient):
+    def test_monitor_run_succeeded_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.active_crd_dict],
             [self.succeeded_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        # for the get_logger_pods
         list_namespaced_pods_calls = [
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
+            # 1 call per threshold state verification
             [],
-            [self.launcher_pod, self.worker_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -302,37 +271,26 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
-            2,
-            self.pod_label_selector,
+            # 1 call per threshold state verification
+            1,
+            self.run_uid_label_selector,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.launcher_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
+    def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.active_crd_dict],
             [self.failed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        # for the get_logger_pods
         list_namespaced_pods_calls = [
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
+            # 1 call per threshold state verification
             [],
-            [self.launcher_pod, self.worker_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -345,16 +303,9 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            self.pod_label_selector,
+            self.run_uid_label_selector,
         )
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.launcher_pod.metadata.name,
-        )
 
     def test_state_thresholds(self, db: Session, client: TestClient):
         """
@@ -499,7 +450,6 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             list_namespaced_pods_calls.append([launcher_pod, worker_pod])
 
         # mock succeeded pods
-        list_namespaced_pods_calls.append([])
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_read_namespaced_pod_log()
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
@@ -517,9 +467,9 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
+            # 1 call per threshold state verification
             len(list_namespaced_pods_calls),
-            self.pod_label_selector,
+            "",
         )
         assert len(stale_runs) == 2
 
@@ -664,11 +614,9 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         )
         return mocked_responses[0].items
 
-    def _generate_get_logger_pods_label_selector(self, runtime_handler):
-        logger_pods_label_selector = super()._generate_get_logger_pods_label_selector(
-            runtime_handler
-        )
-        return f"{logger_pods_label_selector},{mlrun_constants.MLRunInternalLabels.mpi_job_role}=launcher"
+    @staticmethod
+    def _generate_run_pod_label_selector(run_uid):
+        return f"mlrun/uid={run_uid}"
 
     @staticmethod
     def _generate_mpijob_crd(project, uid, status=None):

--- a/tests/api/runtime_handlers/test_mpijob.py
+++ b/tests/api/runtime_handlers/test_mpijob.py
@@ -469,7 +469,7 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             # 1 call per threshold state verification
             len(list_namespaced_pods_calls),
-            "",
+            self._generate_run_pod_label_selector(image_pull_backoff_job_uid),
         )
         assert len(stale_runs) == 2
 
@@ -613,10 +613,6 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             [[self.launcher_pod, self.worker_pod]]
         )
         return mocked_responses[0].items
-
-    @staticmethod
-    def _generate_run_pod_label_selector(run_uid):
-        return f"mlrun/uid={run_uid}"
 
     @staticmethod
     def _generate_mpijob_crd(project, uid, status=None):

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -103,10 +103,6 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             PodPhases.running,
         )
 
-        self.pod_label_selector = self._generate_get_logger_pods_label_selector(
-            self.runtime_handler
-        )
-
         self.config_map = self._generate_config_map(
             name="my-spark-jdbc",
             labels={mlrun_constants.MLRunInternalLabels.uid: self.run_uid},
@@ -137,10 +133,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
                 group_by=group_by,
             )
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_completed_crd(
-        self, db: Session, client: TestClient
-    ):
+    def test_delete_resources_completed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.completed_crd_dict],
             # 2 additional time for wait for pods deletion
@@ -149,9 +142,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for the get_logger_pods with proper selector
-            [self.driver_pod],
-            # additional time for wait for pods deletion - simulate pods not removed yet
+            # for wait for pods deletion - simulate pods not removed yet
             [self.executor_pod, self.driver_pod],
             # additional time for wait for pods deletion - simulate pods gone
             [],
@@ -159,7 +150,6 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_namespaced_config_map([self.config_map])
         self._mock_delete_namespaced_custom_objects()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -170,20 +160,8 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             len(list_namespaced_crds_calls),
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
-        )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
         )
 
     def test_delete_resources_running_crd(self, db: Session, client: TestClient):
@@ -229,8 +207,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             len(list_namespaced_crds_calls),
         )
 
-    @pytest.mark.asyncio
-    async def test_delete_resources_with_force(self, db: Session, client: TestClient):
+    def test_delete_resources_with_force(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             # additional time for wait for pods deletion
@@ -238,15 +215,12 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for the get_logger_pods with proper selector
-            [self.driver_pod],
-            # additional time for wait for pods deletion - simulate pods gone
+            # for wait for pods deletion - simulate pods gone
             [],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_namespaced_config_map([self.config_map])
         self._mock_delete_namespaced_custom_objects()
-        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, force=True)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -257,38 +231,17 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             len(list_namespaced_crds_calls),
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_completed_crd(self, db: Session, client: TestClient):
+    def test_monitor_run_completed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             [self.completed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        # for the get_logger_pods with proper selector
-        list_namespaced_pods_calls = [
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
-            [],
-            [self.driver_pod],
-        ]
-        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -298,38 +251,17 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             expected_number_of_list_crds_calls,
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
-        )
 
-    @pytest.mark.asyncio
-    async def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
+    def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             [self.failed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
-        # for the get_logger_pods with proper selector
-        list_namespaced_pods_calls = [
-            # 1 call per threshold state verification or for logs collection (runs in terminal state)
-            [],
-            [self.driver_pod],
-        ]
-        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
-        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -339,19 +271,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             expected_number_of_list_crds_calls,
         )
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler,
-            len(list_namespaced_pods_calls),
-            self.pod_label_selector,
-        )
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
-        await self._assert_run_logs(
-            db,
-            self.project,
-            self.run_uid,
-            log,
-            self.driver_pod.metadata.name,
-        )
 
     def test_monitor_run_update_ui_url(self, db: Session, client: TestClient):
         db_instance = get_db()
@@ -493,7 +413,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         "force",
         (
             True,
-            False,
+            # False,
         ),
     )
     def test_delete_resources_stateless_crd(
@@ -510,9 +430,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for wait for pods deletion
             list_namespaced_crds_calls.append([self.completed_crd_dict])
             list_namespaced_pods_calls = [
-                # for the get_logger_pods with proper selector
-                [self.driver_pod],
-                # additional time for wait for pods deletion - simulate pods gone
+                # for wait for pods deletion - simulate pods gone
                 [],
             ]
             self._mock_list_namespaced_pods(list_namespaced_pods_calls)
@@ -537,17 +455,10 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self._assert_list_namespaced_pods_calls(
                 self.runtime_handler,
                 len(list_namespaced_pods_calls),
-                self.pod_label_selector,
             )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.created
         )
-
-    def _generate_get_logger_pods_label_selector(self, runtime_handler):
-        logger_pods_label_selector = super()._generate_get_logger_pods_label_selector(
-            runtime_handler
-        )
-        return f"{logger_pods_label_selector},spark-role=driver"
 
     def _mock_list_resources_pods(self):
         mocked_responses = self._mock_list_namespaced_pods(

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -246,6 +246,11 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             [self.completed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
+        list_namespaced_pods_calls = [
+            # 1 call per threshold state verification
+            [],
+        ]
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
@@ -255,6 +260,11 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_crds_calls(
             self.runtime_handler,
             expected_number_of_list_crds_calls,
+        )
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler,
+            len(list_namespaced_pods_calls),
+            expected_label_selector=f"{mlrun_constants.MLRunInternalLabels.uid}={self.run_uid}",
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
@@ -266,6 +276,11 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             [self.failed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
+        list_namespaced_pods_calls = [
+            # 1 call per threshold state verification
+            [],
+        ]
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
@@ -275,6 +290,11 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_crds_calls(
             self.runtime_handler,
             expected_number_of_list_crds_calls,
+        )
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler,
+            len(list_namespaced_pods_calls),
+            expected_label_selector=f"{mlrun_constants.MLRunInternalLabels.uid}={self.run_uid}",
         )
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
 

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -160,6 +160,11 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             len(list_namespaced_crds_calls),
         )
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler,
+            len(list_namespaced_pods_calls),
+            f"{mlrun_constants.MLRunInternalLabels.mlrun_class}=spark",
+        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
@@ -413,7 +418,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         "force",
         (
             True,
-            # False,
+            False,
         ),
     )
     def test_delete_resources_stateless_crd(


### PR DESCRIPTION
When runs reach terminal state, the monitoring function ensures logs were collected for this run by checking that a log file exists for this run. If not - it requests the run logs straight from k8s, bypassing the log collector as it assumes something was wrong with it.

To decrease the IO load on the chief, we do not ensure logs were collected at all, as logs are a best-effort operation.

Resolves https://iguazio.atlassian.net/browse/ML-6807