### PR TITLE
[Dask] Do not embed file-named module in system modules

### DIFF
--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -548,7 +548,13 @@ class DaskCluster(KubejobRuntime):
                     "specified handler (string) without command "
                     "(py file path), specify command or use handler pointer"
                 )
-            handler = load_module(self.spec.command, handler, context=context)
+            # Do not embed the module in system as it is not persistent with the dask cluster
+            handler = load_module(
+                self.spec.command,
+                handler,
+                context=context,
+                embed_in_sys=False,
+            )
         client = self.client
         setattr(context, "dask_client", client)
         sout, serr = exec_from_params(handler, runobj, context)

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -372,8 +372,20 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
             return run_obj_dict
 
 
-def load_module(file_name, handler, context):
-    """Load module from file name"""
+def load_module(
+    file_name: str,
+    handler: str,
+    context: MLClientCtx,
+    embed_in_sys: bool = True,
+):
+    """
+    Load module from filename
+    :param file_name:       The module path to load
+    :param handler:         The callable to load
+    :param context:         Execution context
+    :param embed_in_sys:    Embed the file-named module in sys.modules. This is not persistent with remote
+                            environments and therefore can effect pickling.
+    """
     module = None
     if file_name:
         path = Path(file_name)
@@ -384,7 +396,8 @@ def load_module(file_name, handler, context):
         if spec is None:
             raise RunError(f"Cannot import from {file_name!r}")
         module = imputil.module_from_spec(spec)
-        sys.modules[mod_name] = module
+        if embed_in_sys:
+            sys.modules[mod_name] = module
         spec.loader.exec_module(module)
 
     class_args = {}


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6757

This is a regression from https://github.com/mlrun/mlrun/pull/5636
Changing the module name is not persistent with the dask scheduler, therefore it can't find the module and we get ModuleNotFoundError
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/distributed/scheduler.py", line 4606, in update_graph
    graph = deserialize(graph_header, graph_frames).data
  File "/opt/conda/lib/python3.9/site-packages/distributed/protocol/serialize.py", line 434, in deserialize
    return loads(header, frames)
  File "/opt/conda/lib/python3.9/site-packages/distributed/protocol/serialize.py", line 100, in pickle_loads
    return pickle.loads(x, buffers=buffers)
  File "/opt/conda/lib/python3.9/site-packages/distributed/protocol/pickle.py", line 96, in loads
    return pickle.loads(x)
ModuleNotFoundError: No module named 'dask_jobs_func'
```