### PR TITLE
[Datastore] fix spark_url in azure

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -208,6 +208,7 @@ class AzureBlobStore(DataStore):
             for key in spark_options:
                 if key.startswith(prefix):
                     account_key = key[len(prefix) :]
-                    url += f"@{account_key}"
+                    if not url.endswith(account_key):
+                        url += f"@{account_key}"
                     break
         return url


### PR DESCRIPTION
[ML-6951](https://iguazio.atlassian.net/browse/ML-6951)


[ML-6951]: https://iguazio.atlassian.net/browse/ML-6951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Note: There is a problem of testing this issue because we can not control spark config in `TestFeatureStoreAzureSparkEngine` without making custom session.