### PR TITLE
[Docs] Fix demo notebook

### DIFF
--- a/docs/feature-store/basic-demo.ipynb
+++ b/docs/feature-store/basic-demo.ipynb
@@ -545,7 +545,9 @@
    "outputs": [],
    "source": [
     "# create a new feature set\n",
-    "quotes_set = fstore.FeatureSet(\"stock-quotes\", entities=[fstore.Entity(\"ticker\")])"
+    "quotes_set = fstore.FeatureSet(\n",
+    "    \"stock-quotes\", entities=[fstore.Entity(\"ticker\")], timestamp_key=\"time\"\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
Following removal of `timestamp_key` parameter from `preview()` in 1.5.0 (#4312).

[ML-6887](https://iguazio.atlassian.net/browse/ML-6887)

[ML-6887]: https://iguazio.atlassian.net/browse/ML-6887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ