### PR TITLE
[Model Monitoring] Delete stream resources during the delete project API  

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -917,7 +917,7 @@ class MonitoringDeployment:
 
         if not stream_paths:
             # No stream paths to delete
-            pass
+            return
 
         elif stream_paths[0].startswith("v3io"):
             # Delete V3IO stream

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -705,9 +705,9 @@ class MonitoringDeployment:
         Disable model monitoring application controller, writer, stream, histogram data drift application
         and the user's applications functions, according to the given params.
 
-        :param delete_resources:                    If True, it would delete the model monitoring controller & writer
-                                                    functions. Default True
-        :param delete_stream_function:              If True, it would delete model monitoring stream function,
+        :param delete_resources:                    If True, delete the model monitoring controller & writer functions.
+                                                    Default True.
+        :param delete_stream_function:              If True, delete model monitoring stream function,
                                                     need to use wisely because if you're deleting this function
                                                     this can cause data loss in case you will want to
                                                     enable the model monitoring capability to the project.
@@ -745,8 +745,7 @@ class MonitoringDeployment:
                     self.project,
                     function_name,
                     self.auth_info,
-                    delete_v3io_stream=not mlrun.mlconf.is_ce_mode()
-                    and function_name
+                    delete_app_stream_resources=True
                     not in [
                         mm_constants.MonitoringFunctionNames.STREAM,
                         mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
@@ -819,7 +818,7 @@ class MonitoringDeployment:
         project_name: str,
         function_name: str,
         auth_info: mlrun.common.schemas.AuthInfo,
-        delete_v3io_stream: bool,
+        delete_app_stream_resources: bool,
         access_key: str,
     ):
         background_task_name = str(uuid.uuid4())
@@ -837,7 +836,7 @@ class MonitoringDeployment:
             function_name,
             auth_info,
             background_task_name,
-            delete_v3io_stream,
+            delete_app_stream_resources,
             access_key,
         )
 
@@ -848,19 +847,19 @@ class MonitoringDeployment:
         function_name: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         background_task_name: str,
-        delete_v3io_stream: bool,
+        delete_app_stream_resources: bool,
         access_key: str,
-    ):
+    ) -> None:
         """
         Delete the model monitoring function and its resources.
 
-        :param db_session:              A session that manages the current dialog with the database.
-        :param project:                 The name of the project.
-        :param function_name:           The name of the function to delete.
-        :param auth_info:               The auth info of the request.
-        :param background_task_name:    The name of the background task.
-        :param delete_v3io_stream:      If True, delete the V3IO stream.
-        :param access_key:              Model monitoring access key.
+        :param db_session:                  A session that manages the current dialog with the database.
+        :param project:                     The name of the project.
+        :param function_name:               The name of the function to delete.
+        :param auth_info:                   The auth info of the request.
+        :param background_task_name:        The name of the background task.
+        :param delete_app_stream_resources: If True, delete the stream resources (e.g., v3io stream or kafka  topics).
+        :param access_key:                  Model monitoring access key, relevant only for V3IO stream.
         """
         await server.api.api.utils._delete_function(
             db_session=db_session,
@@ -869,10 +868,27 @@ class MonitoringDeployment:
             auth_info=auth_info,
             background_task_name=background_task_name,
         )
-        if delete_v3io_stream:
-            import v3io.dataplane
-            import v3io.dataplane.response
+        if delete_app_stream_resources:
+            MonitoringDeployment._delete_model_monitoring_stream_resources(
+                project=project,
+                function_names=[function_name],
+                access_key=access_key,
+            )
 
+    @staticmethod
+    def _delete_model_monitoring_stream_resources(
+        project: str,
+        function_names: list[str],
+        access_key: typing.Optional[str] = None,
+    ) -> None:
+        """
+        :param project:        The name of the project.
+        :param function_names: A list of functions that their resources should be deleted.
+        :param access_key:     If the stream is V3IO, the access key is required.
+
+        """
+        stream_paths = []
+        for function_name in function_names:
             for i in range(10):
                 # waiting for the function pod to be deleted
                 # max 10 retries (5 sec sleep between each retry)
@@ -891,10 +907,19 @@ class MonitoringDeployment:
                     logger.debug(f"{function_name} pod found, retrying")
                     time.sleep(5)
 
-            v3io_client = v3io.dataplane.Client(endpoint=mlrun.mlconf.v3io_api)
-            stream_paths = server.api.crud.model_monitoring.get_stream_path(
-                project=project, function_name=function_name
+            stream_paths.extend(
+                server.api.crud.model_monitoring.get_stream_path(
+                    project=project, function_name=function_name
+                )
             )
+
+        if stream_paths[0].startswith("v3io"):
+            # Delete V3IO stream
+            import v3io.dataplane
+            import v3io.dataplane.response
+
+            v3io_client = v3io.dataplane.Client(endpoint=mlrun.mlconf.v3io_api)
+
             for stream_path in stream_paths:
                 _, container, stream_path = (
                     mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
@@ -906,12 +931,40 @@ class MonitoringDeployment:
                     v3io_client.stream.delete(
                         container, stream_path, access_key=access_key
                     )
+                    logger.debug("Deleted v3io stream", stream_path=stream_path)
                 except v3io.dataplane.response.HttpResponseError as e:
                     logger.warning(
-                        f"Can't delete {function_name}'s stream",
+                        "Can't delete v3io stream",
                         stream_path=stream_path,
                         error=e,
                     )
+        elif stream_paths[0].startswith("kafka://"):
+            # Delete Kafka topics
+            import kafka
+            import kafka.errors
+
+            topics = []
+
+            topic, brokers = mlrun.datastore.utils.parse_kafka_url(url=stream_paths[0])
+            topics.append(topic)
+
+            for stream_path in stream_paths[1:]:
+                topic, _ = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
+                topics.append(topic)
+
+            try:
+                kafka_client = kafka.KafkaAdminClient(
+                    bootstrap_servers=brokers,
+                    client_id=f"{project}",
+                )
+                kafka_client.delete_topics(topics)
+                logger.debug("Deleted kafka topics", topics=topics)
+            except kafka.errors.TopicAuthorizationFailedError as e:
+                logger.warning(
+                    "Can't delete kafka topics",
+                    topics=topics,
+                    error=e,
+                )
 
     def check_if_credentials_are_set(self, only_project_secrets: bool = False):
         """

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -745,13 +745,11 @@ class MonitoringDeployment:
                     self.project,
                     function_name,
                     self.auth_info,
-                    delete_app_stream_resources=True
-                    if function_name
+                    delete_app_stream_resources=function_name
                     not in [
                         mm_constants.MonitoringFunctionNames.STREAM,
                         mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-                    ]
-                    else False,
+                    ],
                     access_key=self.model_monitoring_access_key,
                 )
                 tasks.append(task)

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -23,7 +23,6 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring
 import mlrun.feature_store
 import mlrun.model_monitoring
-import server.api.api.endpoints.nuclio
 import server.api.api.utils
 import server.api.crud.model_monitoring.deployment
 import server.api.crud.model_monitoring.helpers

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -592,6 +592,8 @@ class ModelEndpoints:
                 )
             )
 
+        model_monitoring_applications = model_monitoring_applications or []
+
         # Add the writer and monitoring stream to the application streams list
         model_monitoring_applications.append(
             mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.WRITER

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -566,7 +566,7 @@ class ModelEndpoints:
     def _delete_model_monitoring_stream_resources(
         project_name: str,
         db_session: sqlalchemy.orm.Session,
-        model_monitoring_applications: typing.Optional[list[str]] = None,
+        model_monitoring_applications: typing.Optional[list[str]],
         stream_paths: typing.Optional[list[str]] = None,
     ) -> None:
         """

--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -27,6 +27,7 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.singleton
 import server.api.crud
+import server.api.crud.model_monitoring.deployment
 import server.api.crud.runtimes.nuclio
 import server.api.db.session
 import server.api.utils.background_tasks
@@ -174,6 +175,22 @@ class Projects(
 
         server.api.crud.Events().delete_project_alert_events(name)
 
+        # get model monitoring application names, important for deleting model monitoring resources
+        model_monitoring_deployment = (
+            server.api.crud.model_monitoring.deployment.MonitoringDeployment(
+                project=name,
+                db_session=session,
+                auth_info=auth_info,
+                model_monitoring_access_key=None,
+            )
+        )
+
+        model_monitoring_applications = (
+            model_monitoring_deployment._get_monitoring_application_to_delete(
+                delete_user_applications=True
+            )
+        )
+
         # delete db resources
         server.api.utils.singletons.db.get_db().delete_project_related_resources(
             session, name
@@ -183,7 +200,11 @@ class Projects(
         self._wait_for_nuclio_project_deletion(name, session, auth_info)
 
         # delete model monitoring resources
-        server.api.crud.ModelEndpoints().delete_model_endpoints_resources(name)
+        server.api.crud.ModelEndpoints().delete_model_endpoints_resources(
+            project_name=name,
+            db_session=session,
+            model_monitoring_applications=model_monitoring_applications,
+        )
 
         if mlrun.mlconf.is_api_running_on_k8s():
             self._delete_project_secrets(name)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -766,19 +766,21 @@ class TestRecordResults(TestMLRunSystem, _V3IORecordsChecker):
 @pytest.mark.enterprise
 @pytest.mark.model_monitoring
 class TestModelMonitoringInitialize(TestMLRunSystem):
+    """Test model monitoring infrastructure initialization and cleanup, including the usage of
+    disable the model monitoring and delete a specific model monitoring application."""
+
     project_name = "test-mm-initialize"
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
 
     def test_model_monitoring_crud(self) -> None:
-        stream_path = self._test_env[
-            "MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"
-        ]
-        if not stream_path.startswith("v3io:///"):
-            # TODO : add support for testing Kafka
-            return
-
-        import v3io.dataplane
+        # Main validations:
+        # 1 - Deploy model monitoring infrastructure and validate controller cron trigger
+        # 2 - Validate that all the model monitoring functions are deployed
+        # 3 - Update the controller cron trigger and validate the change
+        # 4 - Disable model monitoring and validate the related resources are deleted
+        # 5 - Disable the monitoring stream pod and validate the stream resource is not deleted
+        # 6 - Delete the histogram data drift application and validate the related resources are deleted
 
         all_functions = mm_constants.MonitoringFunctionNames.list() + [
             mm_constants.HistogramDataDriftApplicationConstants.NAME
@@ -853,66 +855,43 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
         )
 
         self.project.disable_model_monitoring(delete_histogram_data_drift_app=False)
-        v3io_client = v3io.dataplane.Client(endpoint=mlrun.mlconf.v3io_api)
 
-        # controller and writer(with hus stream) should be deleted
-        for name in mm_constants.MonitoringFunctionNames.list():
-            stream_path = mlrun.model_monitoring.helpers.get_stream_path(
-                project=self.project.name, function_name=name
-            )
-            _, container, stream_path = (
-                mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
-                    stream_path
+        stream_path = self._test_env[
+            "MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"
+        ]
+        if stream_path.startswith("v3io:///"):
+            import v3io.dataplane
+
+            v3io_client = v3io.dataplane.Client(endpoint=mlrun.mlconf.v3io_api)
+
+            # controller and writer(with has stream) should be deleted
+            for name in mm_constants.MonitoringFunctionNames.list():
+                stream_path = mlrun.model_monitoring.helpers.get_stream_path(
+                    project=self.project.name, function_name=name
                 )
-            )
-            if name != mm_constants.MonitoringFunctionNames.STREAM:
-                with pytest.raises(mlrun.errors.MLRunNotFoundError):
+                _, container, stream_path = (
+                    mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
+                        stream_path
+                    )
+                )
+                if name != mm_constants.MonitoringFunctionNames.STREAM:
+                    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+                        self.project.get_function(
+                            key=name,
+                            ignore_cache=True,
+                        )
+                    with pytest.raises(v3io.dataplane.response.HttpResponseError):
+                        v3io_client.stream.describe(container, stream_path)
+                else:
                     self.project.get_function(
                         key=name,
                         ignore_cache=True,
                     )
-                with pytest.raises(v3io.dataplane.response.HttpResponseError):
                     v3io_client.stream.describe(container, stream_path)
-            else:
-                self.project.get_function(
-                    key=name,
-                    ignore_cache=True,
-                )
-                v3io_client.stream.describe(container, stream_path)
 
-        self.project.disable_model_monitoring(
-            delete_histogram_data_drift_app=False, delete_stream_function=True
-        )
+            self._disable_stream_function()
 
-        with pytest.raises(mlrun.errors.MLRunNotFoundError):
-            self.project.get_function(
-                key=mm_constants.MonitoringFunctionNames.STREAM,
-                ignore_cache=True,
-            )
-
-        # check that the stream of the stream pod is not deleted
-        stream_path = mlrun.model_monitoring.helpers.get_stream_path(
-            project=self.project.name,
-            function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME,
-        )
-        _, container, stream_path = (
-            mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
-                stream_path
-            )
-        )
-        v3io_client.stream.describe(container, stream_path)
-
-        self.project.delete_model_monitoring_function(
-            mm_constants.HistogramDataDriftApplicationConstants.NAME
-        )
-        # check that the histogram data drift app and it's stream is deleted
-        with pytest.raises(mlrun.errors.MLRunNotFoundError):
-            self.project.get_function(
-                key=mm_constants.HistogramDataDriftApplicationConstants.NAME,
-                ignore_cache=True,
-            )
-
-        with pytest.raises(v3io.dataplane.response.HttpResponseError):
+            # check that the stream of the stream resource is not deleted
             stream_path = mlrun.model_monitoring.helpers.get_stream_path(
                 project=self.project.name,
                 function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME,
@@ -923,6 +902,90 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
                 )
             )
             v3io_client.stream.describe(container, stream_path)
+
+            # check that the stream of the histogram data drift app is deleted
+            self._delete_histogram_app()
+
+            with pytest.raises(v3io.dataplane.response.HttpResponseError):
+                stream_path = mlrun.model_monitoring.helpers.get_stream_path(
+                    project=self.project.name,
+                    function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME,
+                )
+                _, container, stream_path = (
+                    mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
+                        stream_path
+                    )
+                )
+                v3io_client.stream.describe(container, stream_path)
+
+        elif stream_path.startswith("kafka://"):
+            import kafka
+
+            _, brokers = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
+            consumer = kafka.KafkaConsumer(
+                bootstrap_servers=brokers,
+            )
+            topics = consumer.topics()
+
+            with pytest.raises(mlrun.errors.MLRunNotFoundError):
+                self.project.get_function(
+                    key=mm_constants.MonitoringFunctionNames.WRITER,
+                    ignore_cache=True,
+                )
+            assert (
+                f"monitoring_stream_{self.project_name}_{mm_constants.MonitoringFunctionNames.WRITER}"
+                not in topics
+            )
+
+            self.project.get_function(
+                key=mm_constants.MonitoringFunctionNames.STREAM,
+                ignore_cache=True,
+            )
+
+            assert f"monitoring_stream_{self.project_name}" in topics
+
+            self._disable_stream_function()
+
+            # check that the topic of the stream resource is not deleted
+            consumer = kafka.KafkaConsumer(
+                bootstrap_servers=brokers,
+            )
+            topics = consumer.topics()
+            assert f"monitoring_stream_{self.project_name}" in topics
+
+            self._delete_histogram_app()
+
+            # check that the topic of the histogram data drift app is deleted
+            consumer = kafka.KafkaConsumer(
+                bootstrap_servers=brokers,
+            )
+            topics = consumer.topics()
+            assert (
+                f"monitoring_stream_{self.project_name}_{mm_constants.HistogramDataDriftApplicationConstants.NAME}"
+                not in topics
+            )
+
+    def _disable_stream_function(self):
+        self.project.disable_model_monitoring(
+            delete_histogram_data_drift_app=False, delete_stream_function=True
+        )
+
+        with pytest.raises(mlrun.errors.MLRunNotFoundError):
+            self.project.get_function(
+                key=mm_constants.MonitoringFunctionNames.STREAM,
+                ignore_cache=True,
+            )
+
+    def _delete_histogram_app(self):
+        self.project.delete_model_monitoring_function(
+            mm_constants.HistogramDataDriftApplicationConstants.NAME
+        )
+        # check that the histogram data drift app and it's stream is deleted
+        with pytest.raises(mlrun.errors.MLRunNotFoundError):
+            self.project.get_function(
+                key=mm_constants.HistogramDataDriftApplicationConstants.NAME,
+                ignore_cache=True,
+            )
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -776,7 +776,7 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
         ]
         if not stream_path.startswith("v3io:///"):
             # TODO : add support for testing Kafka
-            pass
+            return
 
         import v3io.dataplane
 


### PR DESCRIPTION
Delete model monitoring stream resources as part of the delete project API. It includes the stream resources of both mm-stream pod and mm-writer pod along with the existing applications stream resources. 

Note that if the stream resources are based on Kafka, the relevant topics will be removed. 

JIRA: https://iguazio.atlassian.net/browse/ML-6837