### PR TITLE
[CI] Always upload tests reports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,7 @@ jobs:
     - name: Run Dockerized tests
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
     - name: Upload test report
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: unit-test-report
@@ -125,6 +126,7 @@ jobs:
       run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-integration-dockerized
       timeout-minutes: 90
     - name: Upload test report
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: integration-tests-report
@@ -150,6 +152,7 @@ jobs:
       - name: Run Dockerized DB Migration tests
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: migrations-tests-report
@@ -238,6 +241,7 @@ jobs:
           cd head/mlrun
           MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-backward-compatibility-dockerized
       - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: backward-compatibility-tests-report

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -373,6 +373,7 @@ jobs:
           make test-system
 
     - name: Upload test report
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: system-tests-enterprise-report

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -200,6 +200,7 @@ jobs:
           make test-system-open-source
     
     - name: Upload test report
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: system-tests-opensource-report

--- a/.run/Patch remote.run.xml
+++ b/.run/Patch remote.run.xml
@@ -6,6 +6,7 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="PATH" value="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
@@ -23,8 +24,13 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </EXTENSION>
+    <EXTENSION ID="software.aws.toolkits.jetbrains.core.execution.PythonAwsConnectionExtension">
+      <option name="credential" />
+      <option name="region" />
+      <option name="useCurrentConnection" value="false" />
+    </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/automation/patch_igz/patch_remote.py" />
-    <option name="PARAMETERS" value="-v" />
+    <option name="PARAMETERS" value="-v -t 1.7.0-rc27" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.run/Patch remote.run.xml
+++ b/.run/Patch remote.run.xml
@@ -6,7 +6,6 @@
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
-      <env name="PATH" value="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
@@ -24,13 +23,8 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </EXTENSION>
-    <EXTENSION ID="software.aws.toolkits.jetbrains.core.execution.PythonAwsConnectionExtension">
-      <option name="credential" />
-      <option name="region" />
-      <option name="useCurrentConnection" value="false" />
-    </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/automation/patch_igz/patch_remote.py" />
-    <option name="PARAMETERS" value="-v -t 1.7.0-rc27" />
+    <option name="PARAMETERS" value="-v" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />


### PR DESCRIPTION
Make the upload tests reports run always, so even if the previous step failed we can also download the report.