### PR TITLE
[Datastore] Fix error on missing URL

### DIFF
--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -27,6 +27,8 @@ from .targets import get_online_target
 
 def is_store_uri(url):
     """detect if the uri starts with the store schema prefix"""
+    if not url:
+        return False
     return url.startswith(DB_SCHEMA + "://")
 
 


### PR DESCRIPTION
[ML-6997](https://iguazio.atlassian.net/browse/ML-6997)

Fixes
```
AttributeError: 'NoneType' object has no attribute 'startswith'
```

[ML-6997]: https://iguazio.atlassian.net/browse/ML-6997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ