### PR TITLE
[Model Monitoring] Fix duplicated KPIs in overview dashboard

### DIFF
--- a/docs/monitoring/dashboards/model-monitoring-overview.json
+++ b/docs/monitoring/dashboards/model-monitoring-overview.json
@@ -180,6 +180,10 @@
       "title": "Predictions/s (5 Minute Average)",
       "transformations": [
         {
+          "id": "merge",
+          "options": {}
+        },
+        {
           "id": "extractFields",
           "options": {
             "source": "metrics"
@@ -264,6 +268,10 @@
       ],
       "title": "Average Latency (Last Hour)",
       "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
         {
           "id": "extractFields",
           "options": {
@@ -353,6 +361,12 @@
         }
       ],
       "title": "Errors",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
       "transparent": true,
       "type": "stat"
     },
@@ -624,6 +638,10 @@
       ],
       "title": "Models",
       "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
         {
           "id": "organize",
           "options": {


### PR DESCRIPTION
When using large amount of models under the same project (e.g. 200+), Grafana splits the data into different groups, which can lead to duplications in the results. In this PR we fix that issue by margining all of the results into a single frame. 

JIRA: https://iguazio.atlassian.net/browse/ML-6588