### PR TITLE
[Model Monitoring] Fix missing means of metrics in the model endpoint

### DIFF
--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -195,7 +195,10 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBaseV2):
                 EventFieldType.CURRENT_STATS: json.dumps(
                     monitoring_context.sample_df_stats
                 ),
-                EventFieldType.DRIFT_MEASURES: metrics_per_feature.T.to_json(),
+                EventFieldType.DRIFT_MEASURES: json.dumps(
+                    metrics_per_feature.T.to_dict()
+                    | {metric.name: metric.value for metric in metrics}
+                ),
                 EventFieldType.DRIFT_STATUS: status.value,
             },
         )

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -552,6 +552,11 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
         assert ep.status.drift_status, "The general drift status is empty"
         assert ep.status.drift_measures, "The drift measures are empty"
 
+        for measure in ["hellinger_mean", "kld_mean", "tvd_mean"]:
+            assert isinstance(
+                ep.status.drift_measures.pop(measure, None), float
+            ), f"Expected '{measure}' in drift measures"
+
         drift_table = pd.DataFrame.from_dict(ep.status.drift_measures, orient="index")
         assert set(drift_table.columns) == {
             "hellinger",


### PR DESCRIPTION
Fixes [ML-6938](https://iguazio.atlassian.net/browse/ML-6938).
Pass the following "drift measures" in the extra data of the histogram data drift app:

* `hellinger_mean`
* `kld_mean`
* `tvd_mean`

And save them in the model endpoint's `status.drift_measures`.

I verified the system test passed and the data is present in the UI:
![image](https://github.com/mlrun/mlrun/assets/36337649/18c3857e-5e5e-46ff-be76-a4a3655d27c5)
(The thresholds should be completed by the UI.)

[ML-6938]: https://iguazio.atlassian.net/browse/ML-6938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ