### PR TITLE
[Operations] Pass requirements file when building function

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -330,6 +330,7 @@ def build_function(
                 commands=commands,
                 secret=secret_name,
                 requirements=requirements,
+                requirements_file=requirements_file,
                 overwrite=overwrite_build_params,
                 extra_args=extra_args,
             )


### PR DESCRIPTION
`Requirements_file` should be passed to the `build_config` as well as `requirements` parameter.

Jira - https://iguazio.atlassian.net/browse/ML-6253