### PR TITLE
[Scheduler] Elaborate cron trigger validation error message

### DIFF
--- a/server/api/utils/scheduler.py
+++ b/server/api/utils/scheduler.py
@@ -704,8 +704,9 @@ class Scheduler:
                     delta=second_next_run_time - next_run_time,
                 )
                 raise ValueError(
-                    f"Cron trigger too frequent. no more than one job "
-                    f"per {self._min_allowed_interval} is allowed"
+                    f"Cron trigger too frequent. No more than one job "
+                    f"per {self._min_allowed_interval} is allowed. Runs at {next_run_time.replace(tzinfo=None)} and "
+                    f"{second_next_run_time.replace(tzinfo=None)} are too close."
                 )
 
     def _create_schedule_in_scheduler(

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -564,9 +564,9 @@ async def test_validate_cron_trigger_determinism(
 ):
     """
     minute=*/X notation means on every Xth minute.
-    For example, minute=*/13 means every 13th minute and therefore will run on: 0, 13, 26, 39, 52.
-    The difference between the run at the 52nd minute and the run at the 0th minute is 8 minutes, which is less
-    than the 10 minutes limit, so it should fail validation.
+    For example, minute=*/13 means every 13th minute and therefore will run on: 0, 13, 26, 39, 52, 0, 13 and so on..
+    The difference between the run at the 52nd minute and the run at the 0th minute after that is 8 minutes,
+    which is less than the 10 minutes limit, so it should fail validation.
     """
     scheduler._min_allowed_interval = "10 minutes"
     cron_trigger = mlrun.common.schemas.ScheduleCronTrigger(minute=minute)


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6839

minute=*/13 means every 13th minute and therefore will run on: 0, 13, 26, 39, 52, 0, 13 and so on..
The difference between the run at the 52nd minute and the run at the 0th minute after that is 8 minutes, which is less
than the 10 minutes limit, so it should fail validation.