### PR TITLE
[Requirements] Raise v3io-py version to 0.6.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyyaml>=5.4.1, <7
 requests~=2.31
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6
-v3io~=0.6.4
+v3io~=0.6.6
 # pydantic 1.10.8 fixes a bug with literal and typing-extension 4.6.0
 # https://docs.pydantic.dev/latest/changelog/#v1108-2023-05-23
 # TODO: loosen upperbound and remove the below comment once fixed upstream


### PR DESCRIPTION
[ML-5598](https://iguazio.atlassian.net/browse/ML-5598)

To include fix in https://github.com/v3io/v3io-py/pull/121.

[ML-5598]: https://iguazio.atlassian.net/browse/ML-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ