### PR TITLE
[Formatters] Add the algorithm field to the artifacts response when the format is minimal

### DIFF
--- a/mlrun/common/formatters/artifact.py
+++ b/mlrun/common/formatters/artifact.py
@@ -37,6 +37,7 @@ class ArtifactFormat(ObjectFormat, mlrun.common.types.StrEnum):
                     "spec.db_key",
                     "spec.size",
                     "spec.framework",
+                    "spec.algorithm",
                     "spec.metrics",
                     "spec.target_path",
                 ]


### PR DESCRIPTION
When calling get artifact or list artifact with `format=minimal`, we also want to display the `algorithm` field on the artifact object.
https://iguazio.atlassian.net/browse/ML-7121