### PR TITLE
[Model Monitoring] Organize mm-related labels and add to internal labels

### DIFF
--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 IMAGE_NAME_ENRICH_REGISTRY_PREFIX = "."  # prefix for image name to enrich with registry
 MLRUN_SERVING_CONF = "serving-conf"
@@ -70,6 +69,7 @@ class MLRunInternalLabels:
     job_type = "job-type"
     kind = "kind"
     component = "component"
+    mlrun_type = "mlrun__type"
 
     owner = "owner"
     v3io_user = "v3io_user"

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum
 from typing import Optional
 
+import mlrun.common.constants
 import mlrun.common.helpers
 from mlrun.common.types import StrEnum
 
@@ -354,7 +355,7 @@ class ResultStatusApp(IntEnum):
 
 
 class ModelMonitoringAppLabel:
-    KEY = "mlrun__type"
+    KEY = mlrun.common.constants.MLRunInternalLabels.mlrun_type
     VAL = "mlrun__model-monitoring-application"
 
     def __str__(self) -> str:

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -378,3 +378,6 @@ class PredictionsQueryConstants:
 
 class SpecialApps:
     MLRUN_INFRA = "mlrun-infra"
+
+
+_RESERVED_FUNCTION_NAMES = MonitoringFunctionNames.list() + [SpecialApps.MLRUN_INFRA]

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -569,10 +569,10 @@ def _create_model_monitoring_function_base(
             "please use `ModelMonitoringApplicationBaseV2`. It will be removed in 1.9.0.",
             FutureWarning,
         )
-    if name in mm_constants.MonitoringFunctionNames.list():
+    if name in mm_constants._RESERVED_FUNCTION_NAMES:
         raise mlrun.errors.MLRunInvalidArgumentError(
-            f"An application cannot have the following names: "
-            f"{mm_constants.MonitoringFunctionNames.list()}"
+            "An application cannot have the following names: "
+            f"{mm_constants._RESERVED_FUNCTION_NAMES}"
         )
     if func is None:
         func = ""

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -639,7 +639,7 @@ def code_to_function(
     :param requirements: a list of python packages
     :param requirements_file: path to a python requirements file
     :param categories:   list of categories for mlrun Function Hub, defaults to None
-    :param labels:       immutable name/value pairs to tag the function with useful metadata, defaults to None
+    :param labels:       name/value pairs dict to tag the function with useful metadata, defaults to None
     :param with_doc:     indicates whether to document the function parameters, defaults to True
     :param ignored_tags: notebook cells to ignore when converting notebooks to py code (separated by ';')
 

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -254,14 +254,9 @@ class MonitoringDeployment:
             fn = self._initial_model_monitoring_writer_function(
                 writer_image=writer_image
             )
-
-            # Adding label to the function - will be used to identify the writer pod
-            fn.metadata.labels = {"type": mm_constants.MonitoringFunctionNames.WRITER}
-
             fn, ready = server.api.utils.functions.build_function(
                 db_session=self.db_session, auth_info=self.auth_info, function=fn
             )
-
             logger.debug(
                 "Submitted the writer deployment",
                 writer_data=fn.to_dict(),
@@ -348,7 +343,6 @@ class MonitoringDeployment:
                                monitoring stream nuclio function.
 
         :return:               A function object from a mlrun runtime class
-
         """
 
         # Initialize Stream Processor object

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -160,18 +160,12 @@ class MonitoringDeployment:
                     db_session=self.db_session, project=self.project
                 )
             )
-
             fn = self._initial_model_monitoring_stream_processing_function(
                 stream_image=stream_image, parquet_target=parquet_target
             )
-
-            # Adding label to the function - will be used to identify the stream pod
-            fn.metadata.labels = {"type": mm_constants.MonitoringFunctionNames.STREAM}
-
             fn, ready = server.api.utils.functions.build_function(
                 db_session=self.db_session, auth_info=self.auth_info, function=fn
             )
-
             logger.debug(
                 "Submitted the stream deployment",
                 stream_data=fn.to_dict(),
@@ -365,6 +359,8 @@ class MonitoringDeployment:
                 filename=_STREAM_PROCESSING_FUNCTION_PATH,
                 kind=mlrun.run.RuntimeKinds.serving,
                 image=stream_image,
+                # The label is used to identify the stream function in Prometheus
+                labels={"type": mm_constants.MonitoringFunctionNames.STREAM},
             ),
         )
         function.set_db_connection(


### PR DESCRIPTION
* Add model monitoring function label `mlrun__type` to `MLRunInternalLabels`
* Remove the "type" label from the writer function - not used
* Check that application name is also not "mlrun-infra"