### PR TITLE
[GithubActions] Fix conflict during upload test report artifacts of system tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,7 +167,7 @@ jobs:
         with:
           name: ${{ env.UUID }}-tests-report
           path:
-            /tmp/${{ env.UUID }}_report.html
+            /tmp/${{ env.UUID }}_test_report.html
 
   package-tests:
     name: Run package tests (Python ${{ matrix.python-version }}; Pipeline ${{ matrix.pipeline-adapter }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,7 +285,7 @@ jobs:
         with:
           name: ${{ env.UUID }}-tests-report
           path:
-            /tmp/$BC*{{ env.UUID }}_test_report.html
+            /tmp/BC*${{ env.UUID }}_test_report.html
 
   verify-compatible-requirements-one-after-one:
     name: Verify compatible requirements (one after one)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,15 +149,25 @@ jobs:
           export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
           echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
+      - name: Generate UUID for test report
+        id: generate-uuid
+        run: |
+          UUID=$(uuidgen)
+          echo "UUID=$UUID" >> $GITHUB_ENV
+          echo "Generated UUID: $UUID"
       - name: Run Dockerized DB Migration tests
-        run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
+        run: |
+          MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+          MLRUN_TESTS_REPORT_UUID=${{ env.UUID }} \
+          make test-migrations-dockerized
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: migrations-tests-report
+          name: ${{ env.UUID }}-tests-report
           path:
-            /tmp/*_report.html
+            /tmp/${{ env.UUID }}_report.html
 
   package-tests:
     name: Run package tests (Python ${{ matrix.python-version }}; Pipeline ${{ matrix.pipeline-adapter }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,15 +96,25 @@ jobs:
         export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
         echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
+    - name: Generate UUID for test report
+      id: generate-uuid
+      run: |
+        UUID=$(uuidgen)
+        echo "UUID=$UUID" >> $GITHUB_ENV
+        echo "Generated UUID: $UUID"
     - name: Run Dockerized tests
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-dockerized
+      run: |
+        MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+        MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+        MLRUN_TESTS_REPORT_UUID=${{ env.UUID }} \
+        make test-dockerized
     - name: Upload test report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: unit-test-report
+        name: ${{ env.UUID }}-tests-report
         path:
-          /tmp/*_report.html
+          /tmp/${{ env.UUID }}_test_report.html
 
   integration-tests:
     name: Run Dockerized Integration Tests
@@ -122,16 +132,26 @@ jobs:
         export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
         export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
         echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
+    - name: Generate UUID for test report
+      id: generate-uuid
+      run: |
+        UUID=$(uuidgen)
+        echo "UUID=$UUID" >> $GITHUB_ENV
+        echo "Generated UUID: $UUID"
     - name: Run Dockerized tests
-      run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-integration-dockerized
+      run: |
+        MLRUN_DOCKER_REGISTRY=ghcr.io/
+        MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+        MLRUN_TESTS_REPORT_UUID=${{ env.UUID }} \
+        make test-integration-dockerized
       timeout-minutes: 90
     - name: Upload test report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: integration-tests-report
+        name: ${{ env.UUID }}-tests-report
         path:
-          /tmp/*_report.html
+          /tmp/${{ env.UUID }}_test_report.html
 
   migrations-tests:
     name: Run Dockerized Migrations Tests
@@ -246,17 +266,26 @@ jobs:
           export version_suffix=$(echo "${{ steps.git_info.outputs.branch }}" | grep -E "^[0-9]+\.[0-9]+\.x$" | tr -d '.')
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
           echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
+      - name: Generate UUID for test report
+        id: generate-uuid
+        run: |
+          UUID=$(uuidgen)
+          echo "UUID=$UUID" >> $GITHUB_ENV
+          echo "Generated UUID: $UUID"
       - name: Run Backward Compatibility Tests
         run: |
           cd head/mlrun
-          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-backward-compatibility-dockerized
+          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+          MLRUN_TESTS_REPORT_UUID=${{ env.UUID }} \
+          make test-backward-compatibility-dockerized
+
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: backward-compatibility-tests-report
+          name: ${{ env.UUID }}-tests-report
           path:
-            /tmp/*_report.html
+            /tmp/$BC*{{ env.UUID }}_test_report.html
 
   verify-compatible-requirements-one-after-one:
     name: Verify compatible requirements (one after one)

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -376,6 +376,6 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: system-tests-enterprise-report-${{ github.run_number }}-${{ github.run_id }}-${{ github.sha }}-${{ steps.timestamp.outputs.date }}
+        name: system-tests-enterprise-report-${{ matrix.test_component }}-${{ github.run_number }}-${{ github.run_id }}-${{ github.sha }}-${{ steps.timestamp.outputs.date }}
         path:
           /tmp/*_report.html

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -363,6 +363,12 @@ jobs:
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
           make install-requirements install-complete-requirements update-version-file
 
+    - name: Generate UUID for test report
+      id: generate-uuid
+      run: |
+        UUID=$(uuidgen)
+        echo "UUID=$UUID" >> $GITHUB_ENV
+        echo "Generated UUID: $UUID"
     - name: Run System Tests
       run: |
         MLRUN_SYSTEM_TESTS_GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
@@ -370,12 +376,13 @@ jobs:
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
         MLRUN_SYSTEM_TESTS_COMPONENT="${{ matrix.test_component }}" \
         MLRUN_SYSTEM_TESTS_BRANCH="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}" \
+        MLRUN_TESTS_REPORT_UUID=${{ env.UUID }} \
           make test-system
 
     - name: Upload test report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: system-tests-enterprise-report-${{ matrix.test_component }}-${{ github.run_number }}-${{ github.run_id }}-${{ github.sha }}-${{ steps.timestamp.outputs.date }}
+        name: ${{ env.UUID }}-tests-report
         path:
-          /tmp/*_report.html
+          /tmp/${{ env.UUID }}_test_report.html

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -192,20 +192,28 @@ jobs:
         # it will wait until the user disconnects before finishing up the job.
         detached: true
 
+    - name: Generate UUID for test report
+      id: generate-uuid
+      run: |
+        UUID=$(uuidgen)
+        echo "UUID=$UUID" >> $GITHUB_ENV
+        echo "Generated UUID: $UUID"
+
     - name: Run system tests
       timeout-minutes: 180
       run: |
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ steps.computed_params.outputs.mlrun_system_tests_clean_resources }}" \
         MLRUN_VERSION="${{ steps.computed_params.outputs.mlrun_version }}" \
+        MLRUN_TESTS_REPORT_UUID=${{ env.UUID }} \
           make test-system-open-source
-    
+
     - name: Upload test report
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: system-tests-opensource-report-${{ github.run_number }}-${{ github.run_id }}-${{ github.sha }}-${{ steps.timestamp.outputs.date }}
+        name: ${{ env.UUID }}-tests-report
         path:
-          /tmp/*_report.html
+          /tmp/${{ env.UUID }}_test_report.html
 
     - name: Output some logs in case of failure
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ test-system: ## Run mlrun system tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=/tmp/$${timestamp}_system_tests_report.html \
+		--html=/tmp/$(MLRUN_SYSTEM_TESTS_COMPONENT)_$${timestamp}_system_tests_report.html \
 		--self-contained-html \
 		-rf \
 		$(MLRUN_SYSTEM_TESTS_COMMAND_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ test-dockerized: build-test ## Run mlrun tests in docker container
 		--network='host' \
 		-v /tmp:/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID)
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID) \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test
 
 .PHONY: test
@@ -476,7 +476,7 @@ test-integration-dockerized: build-test ## Run mlrun integration tests in docker
 		--network='host' \
 		-v /tmp:/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID)
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID) \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-integration
 
 .PHONY: test-integration
@@ -513,7 +513,7 @@ test-system-dockerized: build-test-system ## Run mlrun system tests in docker co
 		--env MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=$(MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES) \
 		--env MLRUN_SYSTEM_TESTS_COMPONENT=$(MLRUN_SYSTEM_TESTS_COMPONENT) \
 		--env MLRUN_VERSION=$(MLRUN_VERSION) \
-		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID)
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID) \
 		-t \
 		--rm \
 		$(MLRUN_SYSTEM_TEST_IMAGE_NAME)

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ test-integration: clean ## Run mlrun integration tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=/tmp/integration_test_report.html \
+		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		-rf \
 		tests/integration \

--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,7 @@ test-dockerized: build-test ## Run mlrun tests in docker container
 		--network='host' \
 		-v /tmp:/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID)
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test
 
 .PHONY: test
@@ -475,6 +476,7 @@ test-integration-dockerized: build-test ## Run mlrun integration tests in docker
 		--network='host' \
 		-v /tmp:/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID)
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-integration
 
 .PHONY: test-integration
@@ -511,6 +513,7 @@ test-system-dockerized: build-test-system ## Run mlrun system tests in docker co
 		--env MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=$(MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES) \
 		--env MLRUN_SYSTEM_TESTS_COMPONENT=$(MLRUN_SYSTEM_TESTS_COMPONENT) \
 		--env MLRUN_VERSION=$(MLRUN_VERSION) \
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID)
 		-t \
 		--rm \
 		$(MLRUN_SYSTEM_TEST_IMAGE_NAME)
@@ -524,7 +527,7 @@ test-system: ## Run mlrun system tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=/tmp/$(MLRUN_SYSTEM_TESTS_COMPONENT)_$${timestamp}_system_tests_report.html \
+		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		-rf \
 		$(MLRUN_SYSTEM_TESTS_COMMAND_SUFFIX)
@@ -536,7 +539,7 @@ test-system-open-source: update-version-file ## Run mlrun system tests with open
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=/tmp/$${timestamp}_system_tests_opensource_report.html \
+		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		-rf \
 		-m "not enterprise" \
@@ -698,6 +701,7 @@ endif
 	    -v /var/run/docker.sock:/var/run/docker.sock \
 	    --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
 	    --env MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH=$(shell pwd) \
+	    --env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID) \
 	    --workdir=$(shell pwd) \
 	    $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
 

--- a/Makefile
+++ b/Makefile
@@ -457,7 +457,7 @@ test: clean ## Run mlrun tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=/tmp/unit_test_report.html \
+		--html=${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		--ignore=tests/integration \
 		--ignore=tests/system \
@@ -483,7 +483,7 @@ test-integration: clean ## Run mlrun integration tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
+		--html=${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		-rf \
 		tests/integration \
@@ -711,9 +711,9 @@ ifndef MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH
 endif
 	export MLRUN_HTTPDB__DSN='sqlite:////mlrun/db/mlrun.db?check_same_thread=false' && \
 	export MLRUN_OPENAPI_JSON_NAME=mlrun_bc_base_oai.json && \
-	python -m pytest -v --capture=no --disable-warnings --durations=100 --html=/tmp/backword_compatibility_report.html --self-contained-html $(MLRUN_BC_TESTS_BASE_CODE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
+	python -m pytest -v --capture=no --disable-warnings --durations=100 --html=/tmp/BC_1_${MLRUN_TESTS_REPORT_UUID}_test_report.html --self-contained-html $(MLRUN_BC_TESTS_BASE_CODE_PATH)/tests/api/api/test_docs.py::test_save_openapi_json && \
 	export MLRUN_OPENAPI_JSON_NAME=mlrun_bc_head_oai.json && \
-	python -m pytest -v --capture=no --disable-warnings --durations=100 --html=/tmp/backword_compatibility_report.html --self-contained-html tests/api/api/test_docs.py::test_save_openapi_json && \
+	python -m pytest -v --capture=no --disable-warnings --durations=100 --html=/tmp/BC_2_${MLRUN_TESTS_REPORT_UUID}_test_report.html --self-contained-html tests/api/api/test_docs.py::test_save_openapi_json && \
 	docker run --rm -t -v $(MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH):/specs:ro openapitools/openapi-diff:latest /specs/mlrun_bc_base_oai.json /specs/mlrun_bc_head_oai.json --fail-on-incompatible
 
 

--- a/Makefile
+++ b/Makefile
@@ -498,6 +498,7 @@ test-migrations-dockerized: build-test ## Run mlrun db migrations tests in docke
 		-v $(shell pwd):/mlrun \
 		-v /tmp:/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
+		--env MLRUN_TESTS_REPORT_UUID=$(MLRUN_TESTS_REPORT_UUID) \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-migrations
 
 .PHONY: test-migrations

--- a/Makefile
+++ b/Makefile
@@ -458,7 +458,7 @@ test: clean ## Run mlrun tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=${MLRUN_TESTS_REPORT_UUID}_test_report.html \
+		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		--ignore=tests/integration \
 		--ignore=tests/system \
@@ -485,7 +485,7 @@ test-integration: clean ## Run mlrun integration tests
 		--capture=no \
 		--disable-warnings \
 		--durations=100 \
-		--html=${MLRUN_TESTS_REPORT_UUID}_test_report.html \
+		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--self-contained-html \
 		-rf \
 		tests/integration \

--- a/automation/scripts/test_migration_mysql.sh
+++ b/automation/scripts/test_migration_mysql.sh
@@ -55,6 +55,7 @@ python -m pytest -v \
 		--capture=no \
 		--disable-warnings \
 		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
+		--self-contained-html \
 		--durations=100 \
 		-rf \
 		${ROOT_DIR}/server/api/migrations/tests/*

--- a/automation/scripts/test_migration_mysql.sh
+++ b/automation/scripts/test_migration_mysql.sh
@@ -54,6 +54,7 @@ export PYTHONPATH=$ROOT_DIR
 python -m pytest -v \
 		--capture=no \
 		--disable-warnings \
+		--html=/tmp/${MLRUN_TESTS_REPORT_UUID}_test_report.html \
 		--durations=100 \
 		-rf \
 		${ROOT_DIR}/server/api/migrations/tests/*


### PR DESCRIPTION
The flow for generating tests report is:

1. Run pytest command with `html` flag for generating html report
2. We generate the reports to `/tmp/` folder because if the tests are running in container, this folder is shared between the container and the host machine, and we need to upload the reports from the host machine.
3. `Upload test report` step in the job should upload any report under `/tmp/*_report.html`

Because of that, we added step for generating `UUID` before run the tests, and we will use this `UUID` as the artifact name& file name for resolving conflicts / overrides.