### PR TITLE
[Pipelines] Override PVC mount params only if not given

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-v1-8",
-    version="0.1.3",
+    version="0.1.4",
     description="MLRun Pipelines package for providing KFP 1.8 compatibility",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mounts.py
@@ -305,17 +305,20 @@ def mount_pvc(pvc_name=None, volume_name="pipeline", volume_mount_path="/mnt/pip
         train = train_op(...)
         train.apply(mount_pvc("claim-name", "pipeline", "/mnt/pipeline"))
     """
-    if "MLRUN_PVC_MOUNT" in os.environ:
-        mount = os.environ.get("MLRUN_PVC_MOUNT")
-        items = mount.split(":")
-        if len(items) != 2:
-            raise MLRunInvalidArgumentError(
-                "MLRUN_PVC_MOUNT should include <pvc-name>:<mount-path>"
-            )
-        pvc_name = items[0]
-        volume_mount_path = items[1]
+    if not pvc_name:
+        # Try to get the PVC mount configuration from the environment variable
+        if "MLRUN_PVC_MOUNT" in os.environ:
+            mount = os.environ.get("MLRUN_PVC_MOUNT")
+            items = mount.split(":")
+            if len(items) != 2:
+                raise MLRunInvalidArgumentError(
+                    "MLRUN_PVC_MOUNT should include <pvc-name>:<mount-path>"
+                )
+            pvc_name = items[0]
+            volume_mount_path = items[1]
 
     if not pvc_name:
+        # The PVC name is still not set, raise an error
         raise MLRunInvalidArgumentError(
             "No PVC name: use the pvc_name parameter or configure the MLRUN_PVC_MOUNT environment variable"
         )

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-v2",
-    version="0.1.3",
+    version="0.1.4",
     description="MLRun Pipelines package for providing KFP 2.* compatibility",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/mounts.py
@@ -66,17 +66,20 @@ def mount_pvc(pvc_name=None, volume_name="pipeline", volume_mount_path="/mnt/pip
         train = train_op(...)
         train.apply(mount_pvc("claim-name", "pipeline", "/mnt/pipeline"))
     """
-    if "MLRUN_PVC_MOUNT" in os.environ:
-        mount = os.environ.get("MLRUN_PVC_MOUNT")
-        items = mount.split(":")
-        if len(items) != 2:
-            raise MLRunInvalidArgumentError(
-                "MLRUN_PVC_MOUNT should include <pvc-name>:<mount-path>"
-            )
-        pvc_name = items[0]
-        volume_mount_path = items[1]
+    if not pvc_name:
+        # Try to get the PVC mount configuration from the environment variable
+        if "MLRUN_PVC_MOUNT" in os.environ:
+            mount = os.environ.get("MLRUN_PVC_MOUNT")
+            items = mount.split(":")
+            if len(items) != 2:
+                raise MLRunInvalidArgumentError(
+                    "MLRUN_PVC_MOUNT should include <pvc-name>:<mount-path>"
+                )
+            pvc_name = items[0]
+            volume_mount_path = items[1]
 
     if not pvc_name:
+        # The PVC name is still not set, raise an error
         raise MLRunInvalidArgumentError(
             "No PVC name: use the pvc_name parameter or configure the MLRUN_PVC_MOUNT environment variable"
         )


### PR DESCRIPTION
In case custom auto mount params are set, but there is an env var `MLRUN_PVC_MOUNT` configured, the custom params will always be overridden by the values in the env var.

Instead, override them only if not set. 

https://iguazio.atlassian.net/browse/CEML-181