### PR TITLE
[Logs] Fix list runs for log collection from all projects

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -411,6 +411,7 @@ async def _start_log_and_update_runs(
         get_db().list_runs,
         db_session,
         uid=runs_uids,
+        project="*",
     )
 
     # the max number of consecutive start log requests for a run before we mark it as requested logs collection


### PR DESCRIPTION
When starting log collection for runs, we first list the run UIDs only, then later list the run objects from the DB.
If the `project` argument is not passed to `list_runs`, the default project is taken instead of all projects.

To list the runs from all projects, we need to pass `project="*"`.

Resolves:
- https://iguazio.atlassian.net/browse/ML-7138
- https://iguazio.atlassian.net/browse/ML-7145