### PR TITLE
Revert "[PipelineAdapters] Deprecate unused rundb function argument"

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -674,7 +674,7 @@ class BaseRuntime(ModelObj):
         selector="",
         hyper_param_options: HyperParamOptions = None,
         inputs: dict = None,
-        outputs: dict = None,
+        outputs: list = None,
         workdir: str = "",
         artifact_path: str = "",
         image: str = "",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -674,7 +674,7 @@ class BaseRuntime(ModelObj):
         selector="",
         hyper_param_options: HyperParamOptions = None,
         inputs: dict = None,
-        outputs: list = None,
+        outputs: dict = None,
         workdir: str = "",
         artifact_path: str = "",
         image: str = "",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.1.3",
+    version="0.1.5",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.1.4",
+    version="0.1.3",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
@@ -15,7 +15,6 @@
 
 import json
 import os
-import warnings
 from copy import deepcopy
 from typing import Union
 
@@ -110,7 +109,7 @@ def mlrun_op(
                      omitted the path will be the out_path/key.
     :param in_path:  default input path/url (prefix) for inputs
     :param out_path: default output path/url (prefix) for artifacts
-    :param rundb:    Deprecated. use 'MLRUN_DBPATH' env instead.
+    :param rundb:    path for rundb (or use 'MLRUN_DBPATH' env instead)
     :param mode:     run mode, e.g. 'pass' for using the command without mlrun wrapper
     :param handler   code entry-point/handler name
     :param job_image name of the image user for the job
@@ -141,14 +140,16 @@ def mlrun_op(
                     command = '/User/kubeflow/training.py',
                     params = {'p1':p1, 'p2':p2},
                     outputs = {'model.txt':'', 'dataset.csv':''},
-                    out_path ='v3io:///projects/my-proj/mlrun/{{workflow.uid}}/')
+                    out_path ='v3io:///projects/my-proj/mlrun/{{workflow.uid}}/',
+                    rundb = '/User/kubeflow')
 
     # use data from the first step
     def mlrun_validate(modelfile):
         return mlrun_op('validation',
                     command = '/User/kubeflow/validation.py',
                     inputs = {'model.txt':modelfile},
-                    out_path ='v3io:///projects/my-proj/{{workflow.uid}}/')
+                    out_path ='v3io:///projects/my-proj/{{workflow.uid}}/',
+                    rundb = '/User/kubeflow')
 
     @dsl.pipeline(
         name='My MLRUN pipeline', description='Shows how to use mlrun.'
@@ -166,13 +167,6 @@ def mlrun_op(
     """
     from mlrun_pipelines.ops import generate_pipeline_node
 
-    if rundb:
-        warnings.warn(
-            "rundb parameter is deprecated and will be removed in 1.9.0. "
-            "use 'MLRUN_DBPATH' env instead.",
-            DeprecationWarning,
-        )
-
     secrets = [] if secrets is None else secrets
     params = {} if params is None else params
     hyperparams = {} if hyperparams is None else hyperparams
@@ -183,6 +177,7 @@ def mlrun_op(
     outputs = [] if outputs is None else outputs
     labels = {} if labels is None else labels
 
+    rundb = rundb or mlrun.db.get_or_set_dburl()
     cmd = [
         "python",
         "-m",
@@ -205,6 +200,7 @@ def mlrun_op(
                 command = command or function.spec.command
                 more_args = more_args or function.spec.args
                 mode = mode or function.spec.mode
+                rundb = rundb or function.spec.rundb
                 code_env = str(function.spec.build.functionSourceCode)
             else:
                 runtime = str(function.to_dict())
@@ -445,7 +441,9 @@ def get_default_reg():
     return ""
 
 
-def format_summary_from_kfp_run(kfp_run, project=None):
+def format_summary_from_kfp_run(
+    kfp_run, project=None, run_db: "mlrun.db.RunDBInterface" = None
+):
     from mlrun_pipelines.ops import generate_kfp_dag_and_resolve_project
 
     override_project = project if project and project != "*" else None
@@ -455,8 +453,13 @@ def format_summary_from_kfp_run(kfp_run, project=None):
     run_id = kfp_run.id
     logger.debug("Formatting summary from KFP run", run_id=run_id, project=project)
 
+    # run db parameter allows us to use the same db session for the whole flow and avoid session isolation issues
+    if not run_db:
+        run_db = mlrun.db.get_run_db()
+
     # enrich DAG with mlrun run info
-    runs = mlrun.db.get_run_db().list_runs(project=project, labels=f"workflow={run_id}")
+    runs = run_db.list_runs(project=project, labels=f"workflow={run_id}")
+
     for run in runs:
         step = get_in(
             run,


### PR DESCRIPTION
Reverts mlrun/mlrun#5956

mistakenly removed on https://github.com/mlrun/mlrun/pull/5661/files#diff-e8344a65bd3093b98d6cce47bf2ccc79653b1afc64141e7b4ea9076a7b399d62L328-L330 leading me to think it was not needed