### PR TITLE
[API] Fix spammy log on run uids

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -385,7 +385,7 @@ async def _initiate_logs_collection(start_logs_limit: asyncio.Semaphore):
         if runs_uids:
             logger.debug(
                 "Found runs which require logs collection",
-                runs_uids=runs_uids,
+                runs_uids=len(runs_uids),
             )
             await _start_log_and_update_runs(
                 start_logs_limit=start_logs_limit,


### PR DESCRIPTION
This is very spammy:
![image](https://github.com/user-attachments/assets/d215391c-ae7a-4158-91b2-93ad23df0bc8)
