### PR TITLE
[Requirements] Avoid `v3io-py` 0.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyyaml>=5.4.1, <7
 requests~=2.31
 # >=0.8.6 from kfp 1.6.0 (and still up until 1.8.10)
 tabulate~=0.8.6
-v3io~=0.6.6
+v3io~=0.6.6, !=0.6.7
 # pydantic 1.10.8 fixes a bug with literal and typing-extension 4.6.0
 # https://docs.pydantic.dev/latest/changelog/#v1108-2023-05-23
 # TODO: loosen upperbound and remove the below comment once fixed upstream

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -144,6 +144,7 @@ def test_requirement_specifiers_convention():
         # used in tests
         "aioresponses": {"~=0.7"},
         "scikit-learn": {"~=1.4.0"},
+        "v3io": {"~=0.6.6, !=0.6.7"},  # A workaround for IG-22956
     }
 
     for (


### PR DESCRIPTION
A workaround until [IG-22956](https://iguazio.atlassian.net/browse/IG-22956) is fixed.
[`v3io-py` 0.6.7](https://github.com/v3io/v3io-py/releases/tag/v0.6.7) broke the model endpoint `monitoring_mode` value.

[IG-22956]: https://iguazio.atlassian.net/browse/IG-22956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ