### PR TITLE
[Functions] Do not enrich project image if function base_image is set

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -320,7 +320,7 @@ def enrich_function_object(
     setattr(f, "_enriched", True)
 
     # set project default image if defined and function does not have an image specified
-    if project.spec.default_image and not f.spec.image:
+    if project.spec.default_image and not f.spec.image and not f.spec.build.base_image:
         f._enriched_image = True
         f.spec.image = project.spec.default_image
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -319,7 +319,7 @@ def enrich_function_object(
     f.metadata.project = project.metadata.name
     setattr(f, "_enriched", True)
 
-    # set project default image if defined and function does not have an image specified
+    # set project default image if defined and function does not have an image/base image specified
     if project.spec.default_image and not f.spec.image and not f.spec.build.base_image:
         f._enriched_image = True
         f.spec.image = project.spec.default_image


### PR DESCRIPTION
We want to avoid the enrichment of project's `default_image` if `base_image` was set for a function.
 
jira - http://iguazio.atlassian.net/browse/ML-6258

