### PR TITLE
[Model Monitoring] Handle exception when using kafka without applying model monitoring 

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -969,7 +969,7 @@ class MonitoringDeployment:
                     error=mlrun.errors.err_to_str(e),
                 )
             except kafka.errors.UnknownTopicOrPartitionError as e:
-                logger.warning(
+                logger.info(
                     "Kafka model monitoring topics not found, probably not created",
                     topics=topics,
                     error=mlrun.errors.err_to_str(e),

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -954,11 +954,12 @@ class MonitoringDeployment:
             for stream_path in stream_paths[1:]:
                 topic, _ = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
                 topics.append(topic)
+
             try:
                 kafka_client = kafka.KafkaAdminClient(
                     bootstrap_servers=brokers,
                     client_id=project,
-                )  # check python library that parse the requirements for open source
+                )
                 kafka_client.delete_topics(topics)
                 logger.debug("Deleted kafka topics", topics=topics)
             except kafka.errors.TopicAuthorizationFailedError as e:

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -954,12 +954,11 @@ class MonitoringDeployment:
             for stream_path in stream_paths[1:]:
                 topic, _ = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
                 topics.append(topic)
-            print('[EYAL]: kafka topics are: ', topics)
             try:
                 kafka_client = kafka.KafkaAdminClient(
                     bootstrap_servers=brokers,
                     client_id=project,
-                ) # check python library that parse the requirements for open source
+                )  # check python library that parse the requirements for open source
                 kafka_client.delete_topics(topics)
                 logger.debug("Deleted kafka topics", topics=topics)
             except kafka.errors.TopicAuthorizationFailedError as e:
@@ -972,7 +971,8 @@ class MonitoringDeployment:
                 logger.warning(
                     "Kafka model monitoring topics not found, probably not created",
                     topics=topics,
-                    error=mlrun.errors.err_to_str(e),)
+                    error=mlrun.errors.err_to_str(e),
+                )
         else:
             logger.warning(
                 "Stream path is not supported and therefore can't be deleted, expected v3io or kafka",

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -954,12 +954,12 @@ class MonitoringDeployment:
             for stream_path in stream_paths[1:]:
                 topic, _ = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
                 topics.append(topic)
-
+            print('[EYAL]: kafka topics are: ', topics)
             try:
                 kafka_client = kafka.KafkaAdminClient(
                     bootstrap_servers=brokers,
                     client_id=project,
-                )
+                ) # check python library that parse the requirements for open source
                 kafka_client.delete_topics(topics)
                 logger.debug("Deleted kafka topics", topics=topics)
             except kafka.errors.TopicAuthorizationFailedError as e:
@@ -968,6 +968,11 @@ class MonitoringDeployment:
                     topics=topics,
                     error=mlrun.errors.err_to_str(e),
                 )
+            except kafka.errors.UnknownTopicOrPartitionError as e:
+                logger.warning(
+                    "Kafka model monitoring topics not found, probably not created",
+                    topics=topics,
+                    error=mlrun.errors.err_to_str(e),)
         else:
             logger.warning(
                 "Stream path is not supported and therefore can't be deleted, expected v3io or kafka",


### PR DESCRIPTION
This PR fix a bug in the delete project flow when the user decides to delete his project after he defined model monitoring credentials with `kafka` stream but didn't deployed the model monitoring infrastructure afterwards (meaning he didn't applied `project.enable_model_monitoring()`). In this case, no kafka topic has been generated and therefore no need to try and search for the model monitoring topics. 

A fix to https://iguazio.atlassian.net/browse/ML-7154