### PR TITLE
[Functions] Support time filters when listing functions

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1253,13 +1253,17 @@ class HTTPRunDB(RunDBInterface):
                     function_name=name,
                 )
 
-    def list_functions(self, name=None, project=None, tag=None, labels=None):
+    def list_functions(
+        self, name=None, project=None, tag=None, labels=None, since=None, until=None
+    ):
         """Retrieve a list of functions, filtered by specific criteria.
 
         :param name: Return only functions with a specific name.
         :param project: Return functions belonging to this project. If not specified, the default project is used.
         :param tag: Return function versions with specific tags.
         :param labels: Return functions that have specific labels assigned to them.
+        :param since: Return functions updated after this date.
+        :param until: Return functions updated before this date.
         :returns: List of function objects (as dictionary).
         """
         project = project or config.default_project
@@ -1267,6 +1271,8 @@ class HTTPRunDB(RunDBInterface):
             "name": name,
             "tag": tag,
             "label": labels or [],
+            "since": since,
+            "until": until,
         }
         error = "list functions"
         path = f"projects/{project}/functions"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1262,8 +1262,8 @@ class HTTPRunDB(RunDBInterface):
         :param project: Return functions belonging to this project. If not specified, the default project is used.
         :param tag: Return function versions with specific tags.
         :param labels: Return functions that have specific labels assigned to them.
-        :param since: Return functions updated after this date.
-        :param until: Return functions updated before this date.
+        :param since: Return functions updated after this date (as datetime object).
+        :param until: Return functions updated before this date (as datetime object).
         :returns: List of function objects (as dictionary).
         """
         project = project or config.default_project
@@ -1271,8 +1271,8 @@ class HTTPRunDB(RunDBInterface):
             "name": name,
             "tag": tag,
             "label": labels or [],
-            "since": since,
-            "until": until,
+            "since": datetime_to_iso(since),
+            "until": datetime_to_iso(until),
         }
         error = "list functions"
         path = f"projects/{project}/functions"

--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -207,6 +207,8 @@ async def list_functions(
     tag: str = None,
     labels: list[str] = Query([], alias="label"),
     hash_key: str = None,
+    since: str = None,
+    until: str = None,
     page: int = Query(None, gt=0),
     page_size: int = Query(None, alias="page-size", gt=0),
     page_token: str = Query(None, alias="page-token"),
@@ -251,6 +253,8 @@ async def list_functions(
         labels=labels,
         hash_key=hash_key,
         format_=format_,
+        since=mlrun.utils.datetime_from_iso(since),
+        until=mlrun.utils.datetime_from_iso(until),
     )
 
     return {

--- a/server/api/crud/functions.py
+++ b/server/api/crud/functions.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+import datetime
+
 import sqlalchemy.orm
 
 import mlrun.common.schemas
@@ -96,6 +98,8 @@ class Functions(
         page: int = None,
         page_size: int = None,
         format_: str = None,
+        since: datetime = None,
+        until: datetime = None,
     ) -> list:
         project = project or mlrun.mlconf.default_project
         if labels is None:
@@ -108,6 +112,8 @@ class Functions(
             labels=labels,
             hash_key=hash_key,
             format_=format_,
+            since=since,
+            until=until,
             page=page,
             page_size=page_size,
         )

--- a/server/api/crud/functions.py
+++ b/server/api/crud/functions.py
@@ -98,8 +98,8 @@ class Functions(
         page: int = None,
         page_size: int = None,
         format_: str = None,
-        since: datetime = None,
-        until: datetime = None,
+        since: datetime.datetime = None,
+        until: datetime.datetime = None,
     ) -> list:
         project = project or mlrun.mlconf.default_project
         if labels is None:

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -339,8 +339,8 @@ class DBInterface(ABC):
         format_: str = None,
         page: int = None,
         page_size: int = None,
-        since: datetime = None,
-        until: datetime = None,
+        since: datetime.datetime = None,
+        until: datetime.datetime = None,
     ):
         pass
 

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -339,6 +339,8 @@ class DBInterface(ABC):
         format_: str = None,
         page: int = None,
         page_size: int = None,
+        since: datetime = None,
+        until: datetime = None,
     ):
         pass
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1755,6 +1755,8 @@ class SQLDB(DBInterface):
         format_: str = mlrun.common.formatters.FunctionFormat.full,
         page: typing.Optional[int] = None,
         page_size: typing.Optional[int] = None,
+        since: datetime = None,
+        until: datetime = None,
     ) -> list[dict]:
         project = project or mlrun.mlconf.default_project
         functions = []
@@ -4504,9 +4506,25 @@ class SQLDB(DBInterface):
         labels: typing.Union[str, list[str], None] = None,
         tag: typing.Optional[str] = None,
         hash_key: typing.Optional[str] = None,
+        since: datetime = None,
+        until: datetime = None,
         page: typing.Optional[int] = None,
         page_size: typing.Optional[int] = None,
     ) -> list[tuple[Function, str]]:
+        """
+        Query functions from the DB by the given filters.
+
+        :param session: The DB session.
+        :param name: The name of the function to query.
+        :param project: The project of the function to query.
+        :param labels: The labels of the function to query.
+        :param tag: The tag of the function to query.
+        :param hash_key: The hash key of the function to query.
+        :param since: Filter functions that were updated after this time
+        :param until: Filter functions that were updated before this time
+        :param page: The page number to query.
+        :param page_size: The page size to query.
+        """
         query = session.query(Function, Function.Tag.name)
         query = query.filter(Function.project == project)
 
@@ -4515,6 +4533,13 @@ class SQLDB(DBInterface):
 
         if hash_key is not None:
             query = query.filter(Function.uid == hash_key)
+
+        if since or until:
+            since = since or datetime.min
+            until = until or datetime.max
+            query = query.filter(
+                and_(Function.updated >= since, Function.updated <= until)
+            )
 
         if not tag:
             # If no tag is given, we need to outer join to get all functions, even if they don't have tags.

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1761,12 +1761,14 @@ class SQLDB(DBInterface):
         project = project or mlrun.mlconf.default_project
         functions = []
         for function, function_tag in self._find_functions(
-            session,
-            name,
-            project,
-            labels,
-            tag,
-            hash_key,
+            session=session,
+            name=name,
+            project=project,
+            labels=labels,
+            tag=tag,
+            hash_key=hash_key,
+            since=since,
+            until=until,
             page=page,
             page_size=page_size,
         ):

--- a/tests/api/db/test_functions.py
+++ b/tests/api/db/test_functions.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
+import time
+
 import pytest
 from sqlalchemy.orm import Session
 
@@ -401,6 +404,51 @@ def test_list_function_with_tag_and_uid(db: DBInterface, db_session: Session):
     assert (
         len(functions) == 1 and functions[0]["metadata"]["hash"] == function_1_hash_key
     )
+
+
+def test_list_artifacts_with_time_filters(db: DBInterface, db_session: Session):
+    function_1 = _generate_function("function-name-1")
+    function_2 = _generate_function("function-name-2")
+    function_3 = _generate_function("function-name-3")
+
+    for function in [function_1, function_2, function_3]:
+        db.store_function(
+            db_session, function.to_dict(), function.metadata.name, versioned=True
+        )
+        time.sleep(1)
+
+    # Verifying that the time filters are working:
+    # No Filters
+    all_functions = db.list_functions(db_session)
+    assert len(all_functions) == 3
+
+    # extract the updated time of the functions
+    function_times = [
+        function["metadata"]["updated"]
+        for function in sorted(all_functions, key=lambda x: x["metadata"]["updated"])
+    ]
+
+    # Since only
+    functions = db.list_functions(db_session, since=function_times[1])
+    assert len(functions) == 2
+
+    # Until only
+    functions = db.list_functions(db_session, until=function_times[1])
+    assert len(functions) == 2
+
+    # Since and Until
+    functions = db.list_functions(
+        db_session, since=function_times[0], until=function_times[0]
+    )
+    assert len(functions) == 1
+
+    # Since and Until with no results
+    now = datetime.datetime.now()
+    yesterday = now - datetime.timedelta(days=1)
+    functions = db.list_functions(db_session, until=yesterday)
+    assert len(functions) == 0
+    functions = db.list_functions(db_session, since=now)
+    assert len(functions) == 0
 
 
 def test_delete_functions(db: DBInterface, db_session: Session):


### PR DESCRIPTION
Add the following parameters to the API:

`GET api/v1/projects/{project}/functions?since=<timestamp>&until=<timestamp>`

By default both the since and until parameters will be None leading to no time filtering. 
Using this filter will filter based on the updated field of the function, i.e. it will return functions updated in this time period.
Both filters accept ISO format, but the SDK accepts `datetime` objects.

https://iguazio.atlassian.net/browse/ML-7130