### PR TITLE
[API] Fix schedulers not being initialized correctly

### DIFF
--- a/server/api/utils/projects/follower.py
+++ b/server/api/utils/projects/follower.py
@@ -87,6 +87,9 @@ class Member(
                     exc=err_to_str(exc),
                     traceback=traceback.format_exc(),
                 )
+
+    def start(self):
+        if self._should_sync:
             self._start_periodic_sync()
 
     def shutdown(self):

--- a/server/api/utils/projects/leader.py
+++ b/server/api/utils/projects/leader.py
@@ -52,6 +52,8 @@ class Member(
         self._projects_in_deletion = set()
         # run one sync to start off on the right foot
         self._sync_projects()
+
+    def start(self):
         self._start_periodic_sync()
 
     def shutdown(self):

--- a/server/api/utils/projects/member.py
+++ b/server/api/utils/projects/member.py
@@ -30,6 +30,10 @@ class Member(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def start(self):
+        pass
+
+    @abc.abstractmethod
     def shutdown(self):
         pass
 

--- a/server/api/utils/scheduler.py
+++ b/server/api/utils/scheduler.py
@@ -75,11 +75,9 @@ class Scheduler:
 
         # don't fail the start on re-scheduling failure
         try:
-            if (
-                mlrun.mlconf.httpdb.clusterization.role
-                == mlrun.common.schemas.ClusterizationRole.chief
-            ):
-                self._reload_schedules(db_session)
+            await fastapi.concurrency.run_in_threadpool(
+                self._reload_schedules, db_session
+            )
         except Exception as exc:
             logger.warning("Failed reloading schedules", exc=err_to_str(exc))
 

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -150,11 +150,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             if not _continue:
                 break
 
-            logger.debug(
-                "Getting next pods",
-                remaining_item_count=pods_list.metadata.remaining_item_count,
-            )
-
     @raise_for_status_code
     def list_crds_paginated(
         self,

--- a/server/api/utils/singletons/scheduler.py
+++ b/server/api/utils/singletons/scheduler.py
@@ -19,13 +19,16 @@ from server.api.utils.scheduler import Scheduler
 scheduler: Scheduler = None
 
 
-async def initialize_scheduler():
+def ensure_scheduler():
     global scheduler
     scheduler = Scheduler()
+
+
+async def start_scheduler():
     db_session = None
     try:
         db_session = create_session()
-        await scheduler.start(
+        await get_scheduler().start(
             db_session,
         )
     finally:

--- a/tests/api/api/test_schedules.py
+++ b/tests/api/api/test_schedules.py
@@ -256,7 +256,7 @@ async def test_redirection_from_worker_to_chief_delete_schedules(
     expected_body: dict,
 ):
     # so get_scheduler().list_schedules, which is called in the delete_schedules endpoint, will return something
-    await server.api.utils.singletons.scheduler.initialize_scheduler()
+    server.api.utils.singletons.scheduler.ensure_scheduler()
     endpoint, chief_mocked_url = _prepare_test_redirection_from_worker_to_chief(
         project="test-project",
     )


### PR DESCRIPTION
Seems that https://github.com/mlrun/mlrun/pull/5985 created a regression where workers scheduler object was not initialized causing GET/LIST requests to fail as scheduler object was not ensured properly.

This PR ensures scheduler object is created on both chief and worker, *and* in addition, fixes some blocking calls upon startup.
1. start_scheduler reload schedules using DB - moved to run in a thread
2. project membership initialized performs initial sync (requests) thus - moved to run in a thread


