### PR TITLE
[Datastore] Fix redis tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,7 @@ mlrun.egg-info
 **/test-aws-s3.yml
 **/test-google-cloud-storage.yml
 **/test-dbfs-store.yml
+**/test-redis.yml
 
 **/google-big-query-credentials.json
 

--- a/tests/integration/redis/__init__.py
+++ b/tests/integration/redis/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/integration/redis/test-redis.yml
+++ b/tests/integration/redis/test-redis.yml
@@ -1,0 +1,16 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+env:
+  redis_endpoint:

--- a/tests/integration/redis/test_redis.py
+++ b/tests/integration/redis/test_redis.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import tempfile
 import uuid
 
@@ -24,13 +24,25 @@ from mlrun.datastore.datastore_profile import (
     DatastoreProfileRedis,
     register_temporary_client_datastore_profile,
 )
+import yaml
 
-redis_endpoint = ("redis://", "redis://localhost:6379")
+here = os.path.dirname(__file__)
+config_file_path = os.path.join(here, "test-redis.yml")
+
+config = {}
+if os.path.exists(config_file_path):
+    with open(config_file_path) as yaml_file:
+        config = yaml.safe_load(yaml_file)
+
+#redis_endpoint = ("redis://", "redis://localhost:6379")
 
 
 @pytest.mark.parametrize("use_datastore_profile", [True, False])
 class TestRedisDataStore:
     profile_name = "redis_profile"
+    @classmethod
+    def setup_class(cls):
+        cls.redis_endpoint = os.environ["REDIS_ENDPOINT"]
 
     def setup_before_test(self, use_datastore_profile, redis_endpoint):
         file = f"file_{uuid.uuid4()}.txt"


### PR DESCRIPTION
Fix redis tests by adding skip method if redis url is not exists.


\+ move redis tests to integration as the rest of the datastores tests.