### PR TITLE
[Alerts] Fix cached AlertState usage

### DIFF
--- a/mlrun/utils/db.py
+++ b/mlrun/utils/db.py
@@ -28,6 +28,9 @@ class BaseModel:
         columns = [column.key for column in mapper.columns if column.key not in exclude]
 
         def get_key_value(c):
+            # all (never say never) DB classes have "object" defined as "full_object"
+            if c == "object":
+                c = "full_object"
             if isinstance(getattr(self, c), datetime):
                 return c, getattr(self, c).isoformat()
             return c, getattr(self, c)

--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -153,7 +153,7 @@ class Alerts(
         event_data: mlrun.common.schemas.Event,
     ):
         state = self._get_alert_state_cached()(session, alert_id)
-        if state.active:
+        if state["active"]:
             return
 
         alert = self._get_alert_by_id_cached()(session, alert_id)
@@ -183,7 +183,7 @@ class Alerts(
 
             active = False
             if send_notification:
-                state.count += 1
+                state["count"] += 1
                 logger.debug("Sending notifications for alert", name=alert.name)
                 AlertNotificationPusher().push(alert, event_data)
 
@@ -200,7 +200,7 @@ class Alerts(
                     session,
                     alert.project,
                     alert.name,
-                    count=state.count,
+                    count=state["count"],
                     last_updated=event_data.timestamp,
                     obj=state_obj,
                     active=active,
@@ -242,7 +242,8 @@ class Alerts(
     def _get_alert_state_cached(cls):
         if not cls._alert_state_cache:
             cls._alert_state_cache = server.api.utils.lru_cache.LRUCache(
-                server.api.utils.singletons.db.get_db().get_alert_state, maxsize=1000
+                server.api.utils.singletons.db.get_db().get_alert_state_dict,
+                maxsize=1000,
             )
         return cls._alert_state_cache
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -5203,6 +5203,11 @@ class SQLDB(DBInterface):
     def get_alert_state(self, session, alert_id: int) -> AlertState:
         return self._query(session, AlertState, parent_id=alert_id).one()
 
+    def get_alert_state_dict(self, session, alert_id: int) -> dict:
+        state = self.get_alert_state(session, alert_id)
+        if state is not None:
+            return state.to_dict()
+
     def delete_alert_notifications(
         self,
         session,


### PR DESCRIPTION
We can't cache a DB object as alembic holds reference to session that is no longer valid once we cache the object