### PR TITLE
[System-test] Add watch on remote workflow

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1595,6 +1595,7 @@ class TestProject(TestMLRunSystem):
             source="./",  # Relative to project.spec.build.source_code_target_dir
             artifact_path=artifact_path,
             dirty=True,
+            watch=True,
         )
         assert run.state == mlrun.run.RunStatuses.succeeded
 


### PR DESCRIPTION
The test is expecting for the workflow to be completed but it didn't watch it. That's because of a solved bug in remote runner that marked the job as succeeded while it was running.