### PR TITLE
[Alerts] Avoid caching session argument

### DIFF
--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -233,7 +233,9 @@ class Alerts(
     def _get_alert_by_id_cached(cls):
         if not cls._alert_cache:
             cls._alert_cache = server.api.utils.lru_cache.LRUCache(
-                server.api.utils.singletons.db.get_db().get_alert_by_id, maxsize=1000
+                server.api.utils.singletons.db.get_db().get_alert_by_id,
+                maxsize=1000,
+                ignore_args_for_hash=[0],
             )
 
         return cls._alert_cache
@@ -244,6 +246,7 @@ class Alerts(
             cls._alert_state_cache = server.api.utils.lru_cache.LRUCache(
                 server.api.utils.singletons.db.get_db().get_alert_state_dict,
                 maxsize=1000,
+                ignore_args_for_hash=[0],
             )
         return cls._alert_state_cache
 

--- a/tests/utils/test_lru.py
+++ b/tests/utils/test_lru.py
@@ -73,8 +73,23 @@ class LRUTest(unittest.TestCase):
         self.assertTrue(info.misses == 0)
         self.assertTrue(info.currsize == 0)
 
+        lru = server.api.utils.lru_cache.LRUCache(
+            self._func_getter2, maxsize=3, ignore_args_for_hash=[0]
+        )
+        lru("not_important", 1)
+        self.assertTrue(lru.cached("not_important", 1))
+        self.assertTrue(lru.cached("not_at_all_important", 1))
+        self.assertFalse(lru.cached("not_important", 2))
+
     def _func_getter(self, arg, increment=False, decrement=False):
         result = int(arg)
+        if increment:
+            result += 1
+        if decrement:
+            result -= 1
+
+    def _func_getter2(self, arg1, arg2, increment=False, decrement=False):
+        result = int(arg2)
         if increment:
             result += 1
         if decrement:


### PR DESCRIPTION
We are using LRU cache for caching objects. The hash is calculated based on the arguments to the function. The session argument will change between different requests, so we must not count it towards the hash, as what we care about are the actual alert/state parameters