### PR TITLE
[Run] Function name 'handler' is not allowed when the function kind is 'nuclio:mlrun'

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -248,8 +248,9 @@ class BaseLauncher(abc.ABC):
         # for other runtimes we need to convert the handler to a string
         if run.spec.handler and runtime.kind not in ["handler", "dask"]:
             run.spec.handler = run.spec.handler_name
+            function_kind = getattr(runtime.spec, "function_kind", None)
             mlrun.utils.helpers.validate_handler_name(
-                runtime.spec.function_kind, run.spec.handler
+                function_kind=function_kind, handler=run.spec.handler
             )
 
         def_name = runtime.metadata.name

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -248,6 +248,12 @@ class BaseLauncher(abc.ABC):
         # for other runtimes we need to convert the handler to a string
         if run.spec.handler and runtime.kind not in ["handler", "dask"]:
             run.spec.handler = run.spec.handler_name
+            # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
+            # it would override MLRun's wrapper
+            if runtime.spec.function_kind == "mlrun" and run.spec.handler == "handler":
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "Handler function name cannot be 'handler'"
+                )
 
         def_name = runtime.metadata.name
         if run.spec.handler_name:

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -248,10 +248,6 @@ class BaseLauncher(abc.ABC):
         # for other runtimes we need to convert the handler to a string
         if run.spec.handler and runtime.kind not in ["handler", "dask"]:
             run.spec.handler = run.spec.handler_name
-            function_kind = getattr(runtime.spec, "function_kind", None)
-            mlrun.utils.helpers.validate_handler_name(
-                function_kind=function_kind, handler=run.spec.handler
-            )
 
         def_name = runtime.metadata.name
         if run.spec.handler_name:

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -248,12 +248,9 @@ class BaseLauncher(abc.ABC):
         # for other runtimes we need to convert the handler to a string
         if run.spec.handler and runtime.kind not in ["handler", "dask"]:
             run.spec.handler = run.spec.handler_name
-            # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
-            # it would override MLRun's wrapper
-            if runtime.spec.function_kind == "mlrun" and run.spec.handler == "handler":
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Handler function name cannot be 'handler'"
-                )
+            mlrun.utils.helpers.validate_handler_name(
+                runtime.spec.function_kind, run.spec.handler
+            )
 
         def_name = runtime.metadata.name
         if run.spec.handler_name:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -738,12 +738,8 @@ def code_to_function(
         filename, handler = ApplicationRuntime.get_filename_and_handler()
 
     is_nuclio, sub_kind = RuntimeKinds.resolve_nuclio_sub_kind(kind)
-    # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
-    # it would override MLRun's wrapper
-    if sub_kind == "mlrun" and handler == "handler":
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            "Handler function name cannot be 'handler'"
-        )
+
+    mlrun.utils.helpers.validate_handler_name(function_kind=sub_kind, handler=handler)
 
     code_origin = add_name(add_code_metadata(filename), name)
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -751,7 +751,6 @@ def code_to_function(
         filename, handler = ApplicationRuntime.get_filename_and_handler()
 
     is_nuclio, sub_kind = RuntimeKinds.resolve_nuclio_sub_kind(kind)
-
     code_origin = add_name(add_code_metadata(filename), name)
 
     name, spec, code = nuclio.build_file(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -794,13 +794,10 @@ def code_to_function(
             raise ValueError("code_output option is only used with notebooks")
 
     if is_nuclio:
-        # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
-        # it would override MLRun's wrapper
-        if sub_kind == "mlrun" and code.count("def handler(") > 1:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "The code file contains a function named “handler“, which is reserved. "
-                + "Use a different name for your function."
-            )
+        mlrun.utils.helpers.validate_single_def_handler(
+            function_kind=sub_kind, code=code
+        )
+
         runtime = RuntimeKinds.resolve_nuclio_runtime(kind, sub_kind)
         # default_handler is only used in :mlrun sub kind, determine the handler to invoke in function.run()
         runtime.spec.default_handler = handler if sub_kind == "mlrun" else ""

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -738,6 +738,13 @@ def code_to_function(
         filename, handler = ApplicationRuntime.get_filename_and_handler()
 
     is_nuclio, sub_kind = RuntimeKinds.resolve_nuclio_sub_kind(kind)
+    # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
+    # it would override MLRun's wrapper
+    if sub_kind == "mlrun" and handler == "handler":
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Handler function name cannot be 'handler'"
+        )
+
     code_origin = add_name(add_code_metadata(filename), name)
 
     name, spec, code = nuclio.build_file(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -781,6 +781,13 @@ def code_to_function(
             raise ValueError("code_output option is only used with notebooks")
 
     if is_nuclio:
+        # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
+        # it would override MLRun's wrapper
+        if sub_kind == "mlrun" and code.count("def handler(") > 1:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "The code file contains a function named “handler“, which is reserved. "
+                + "Use a different name for your function."
+            )
         runtime = RuntimeKinds.resolve_nuclio_runtime(kind, sub_kind)
         # default_handler is only used in :mlrun sub kind, determine the handler to invoke in function.run()
         runtime.spec.default_handler = handler if sub_kind == "mlrun" else ""

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -752,8 +752,6 @@ def code_to_function(
 
     is_nuclio, sub_kind = RuntimeKinds.resolve_nuclio_sub_kind(kind)
 
-    mlrun.utils.helpers.validate_handler_name(function_kind=sub_kind, handler=handler)
-
     code_origin = add_name(add_code_metadata(filename), name)
 
     name, spec, code = nuclio.build_file(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1705,6 +1705,15 @@ def is_parquet_file(file_path, format_=None):
     )
 
 
+def validate_handler_name(function_kind: str, handler: str):
+    # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
+    # it would override MLRun's wrapper
+    if function_kind == "mlrun" and handler == "handler":
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Handler function name 'handler' is reserved. Use different name instead."
+        )
+
+
 def _reload(module, max_recursion_depth):
     """Recursively reload modules."""
     if max_recursion_depth <= 0:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1710,7 +1710,7 @@ def validate_handler_name(function_kind: str, handler: str):
     # it would override MLRun's wrapper
     if function_kind == "mlrun" and handler == "handler":
         raise mlrun.errors.MLRunInvalidArgumentError(
-            "Handler function name 'handler' is reserved. Use different name instead."
+            "The name “handler“ is reserved. Use a different name for your function."
         )
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1714,6 +1714,21 @@ def validate_handler_name(function_kind: str, handler: str):
         )
 
 
+def validate_single_def_handler(function_kind: str, code: str):
+    # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
+    # it would override MLRun's wrapper
+    if function_kind == "mlrun":
+        # Find all lines that start with "def handler("
+        pattern = re.compile(r"^def handler\(", re.MULTILINE)
+        matches = pattern.findall(code)
+
+        if len(matches) > 1:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "The code file contains a function named “handler“, which is reserved. "
+                + "Use a different name for your function."
+            )
+
+
 def _reload(module, max_recursion_depth):
     """Recursively reload modules."""
     if max_recursion_depth <= 0:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1722,6 +1722,7 @@ def validate_single_def_handler(function_kind: str, code: str):
         pattern = re.compile(r"^def handler\(", re.MULTILINE)
         matches = pattern.findall(code)
 
+        # Only MLRun's wrapper handler (footer) can be in the code
         if len(matches) > 1:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "The code file contains a function named “handler“, which is reserved. "

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1705,15 +1705,6 @@ def is_parquet_file(file_path, format_=None):
     )
 
 
-def validate_handler_name(function_kind: str, handler: str):
-    # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
-    # it would override MLRun's wrapper
-    if function_kind == "mlrun" and handler == "handler":
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            "The name “handler“ is reserved. Use a different name for your function."
-        )
-
-
 def validate_single_def_handler(function_kind: str, code: str):
     # The name of MLRun's wrapper is 'handler', which is why the handler function name cannot be 'handler'
     # it would override MLRun's wrapper

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -48,6 +48,10 @@ assets_path = str(pathlib.Path(__file__).parent / "assets")
 ERROR_MSG_INVALID_HANDLER_NAME = (
     "The name “handler“ is reserved. Use a different name for your function."
 )
+ERROR_MSG_INVALID_HANDLER_NAME_IN_FILE = (
+    "The code file contains a function named “handler“, which is reserved. "
+    + "Use a different name for your function."
+)
 
 
 @contextlib.contextmanager
@@ -398,34 +402,14 @@ def test_code_to_function_invalid_handler_name_for_nuclio_mlrun_run_kind():
         )
 
 
-def test_nuclio_mlrun_invalid_handler_name():
-    function = mlrun.code_to_function(
-        filename=f"{assets_path}/fail.py",
-        name="nuclio-mlrun",
-        image="mlrun/mlrun",
-        kind="nuclio:mlrun",
-    )
-
+def test_code_to_function_file_include_invalid_handler_name_for_nuclio_mlrun_run_kind():
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match=ERROR_MSG_INVALID_HANDLER_NAME,
+        match=ERROR_MSG_INVALID_HANDLER_NAME_IN_FILE,
     ):
-        function.run(handler="handler")
-
-
-def test_nuclio_mlrun_invalid_handler_signature():
-    def handler(context):
-        context.log_result("accuracy", 16)
-
-    function = mlrun.code_to_function(
-        filename=f"{assets_path}/fail.py",
-        name="nuclio-mlrun",
-        image="mlrun/mlrun",
-        kind="nuclio:mlrun",
-    )
-
-    with pytest.raises(
-        mlrun.errors.MLRunInvalidArgumentError,
-        match=ERROR_MSG_INVALID_HANDLER_NAME,
-    ):
-        function.run(handler=handler)
+        mlrun.code_to_function(
+            filename=f"{assets_path}/fail.py",
+            name="nuclio-mlrun",
+            image="mlrun/mlrun",
+            kind="nuclio:mlrun",
+        )

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -378,3 +378,50 @@ def test_verify_tag_in_output_for_relogged_artifact(setup_project):
 
     assert "v3" in output_uri, "Expected 'v3' tag in output_uri"
     assert "v3" in outputs_uri, "Expected 'v3' tag in outputs_uri"
+
+
+def test_code_to_function_invalid_handler_name_for_nuclio_mlrun_run_kind():
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="Handler function name cannot be 'handler'",
+    ):
+        mlrun.code_to_function(
+            filename=f"{assets_path}/fail.py",
+            name="nuclio-mlrun",
+            image="mlrun/mlrun",
+            kind="nuclio:mlrun",
+            handler="handler",
+        )
+
+
+def test_nuclio_mlrun_invalid_handler_name():
+    function = mlrun.code_to_function(
+        filename=f"{assets_path}/fail.py",
+        name="nuclio-mlrun",
+        image="mlrun/mlrun",
+        kind="nuclio:mlrun",
+    )
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="Handler function name cannot be 'handler'",
+    ):
+        function.run(handler="handler")
+
+
+def test_nuclio_mlrun_invalid_handler_signature():
+    def handler(context):
+        context.log_result("accuracy", 16)
+
+    function = mlrun.code_to_function(
+        filename=f"{assets_path}/fail.py",
+        name="nuclio-mlrun",
+        image="mlrun/mlrun",
+        kind="nuclio:mlrun",
+    )
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="Handler function name cannot be 'handler'",
+    ):
+        function.run(handler=handler)

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -45,6 +45,10 @@ s3_spec = base_spec.copy().with_secrets("file", "secrets.txt")
 s3_spec.spec.inputs = {"infile.txt": "s3://yarons-tests/infile.txt"}
 assets_path = str(pathlib.Path(__file__).parent / "assets")
 
+ERROR_MSG_INVALID_HANDLER_NAME = (
+    "Handler function name 'handler' is reserved. Use different name instead."
+)
+
 
 @contextlib.contextmanager
 def captured_output():
@@ -383,7 +387,7 @@ def test_verify_tag_in_output_for_relogged_artifact(setup_project):
 def test_code_to_function_invalid_handler_name_for_nuclio_mlrun_run_kind():
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match="Handler function name cannot be 'handler'",
+        match=ERROR_MSG_INVALID_HANDLER_NAME,
     ):
         mlrun.code_to_function(
             filename=f"{assets_path}/fail.py",
@@ -404,7 +408,7 @@ def test_nuclio_mlrun_invalid_handler_name():
 
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match="Handler function name cannot be 'handler'",
+        match=ERROR_MSG_INVALID_HANDLER_NAME,
     ):
         function.run(handler="handler")
 
@@ -422,6 +426,6 @@ def test_nuclio_mlrun_invalid_handler_signature():
 
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match="Handler function name cannot be 'handler'",
+        match=ERROR_MSG_INVALID_HANDLER_NAME,
     ):
         function.run(handler=handler)

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -46,7 +46,7 @@ s3_spec.spec.inputs = {"infile.txt": "s3://yarons-tests/infile.txt"}
 assets_path = str(pathlib.Path(__file__).parent / "assets")
 
 ERROR_MSG_INVALID_HANDLER_NAME = (
-    "Handler function name 'handler' is reserved. Use different name instead."
+    "The name “handler“ is reserved. Use a different name for your function."
 )
 
 

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -45,9 +45,6 @@ s3_spec = base_spec.copy().with_secrets("file", "secrets.txt")
 s3_spec.spec.inputs = {"infile.txt": "s3://yarons-tests/infile.txt"}
 assets_path = str(pathlib.Path(__file__).parent / "assets")
 
-ERROR_MSG_INVALID_HANDLER_NAME = (
-    "The name “handler“ is reserved. Use a different name for your function."
-)
 ERROR_MSG_INVALID_HANDLER_NAME_IN_FILE = (
     "The code file contains a function named “handler“, which is reserved. "
     + "Use a different name for your function."
@@ -386,20 +383,6 @@ def test_verify_tag_in_output_for_relogged_artifact(setup_project):
 
     assert "v3" in output_uri, "Expected 'v3' tag in output_uri"
     assert "v3" in outputs_uri, "Expected 'v3' tag in outputs_uri"
-
-
-def test_code_to_function_invalid_handler_name_for_nuclio_mlrun_run_kind():
-    with pytest.raises(
-        mlrun.errors.MLRunInvalidArgumentError,
-        match=ERROR_MSG_INVALID_HANDLER_NAME,
-    ):
-        mlrun.code_to_function(
-            filename=f"{assets_path}/fail.py",
-            name="nuclio-mlrun",
-            image="mlrun/mlrun",
-            kind="nuclio:mlrun",
-            handler="handler",
-        )
 
 
 def test_code_to_function_file_include_invalid_handler_name_for_nuclio_mlrun_run_kind():

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1078,6 +1078,12 @@ def dummy_handler():
         pass
     handler()
 """,
+        """
+# def handler():
+#     pass
+def handler():
+    pass
+""",
     ],
 )
 def test_validate_single_def_handler_valid_handler(code):


### PR DESCRIPTION
When creating a `nuclio:mlrun` function, an MLRun wrapper called 'handler' is generated. Therefore, if the user creates a function with the name 'handler', it overrides the MLRun wrapper's handler function
To fix this, we check that the code does not include a `def handler` function. The only `def handler` in the code should be the MLRun wrapper's handler (the footer).

https://iguazio.atlassian.net/browse/ML-113