### PR TITLE
[Context] Fix some `MLClientCtx` related stuff

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -78,7 +78,6 @@ class MLClientCtx:
         self._tmpfile = tmp
         self._logger = log_stream or logger
         self._log_level = "info"
-        self._matrics_db = None
         self._autocommit = autocommit
         self._notifications = []
         self._state_thresholds = {}
@@ -103,8 +102,7 @@ class MLClientCtx:
         self._error = None
         self._commit = ""
         self._host = None
-        self._start_time = now_date()
-        self._last_update = now_date()
+        self._start_time = self._last_update = now_date()
         self._iteration_results = None
         self._children = []
         self._parent = None

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -56,7 +56,7 @@ class MonitoringApplicationContext(MLClientCtx):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def __post_init__(self):
+    def _enrich_data(self):
         self.application_name: typing.Optional[str] = None
         self.start_infer_time: typing.Optional[pd.Timestamp] = None
         self.end_infer_time: typing.Optional[pd.Timestamp] = None
@@ -87,39 +87,37 @@ class MonitoringApplicationContext(MLClientCtx):
         """
 
         if not context:
-            self = (
+            ctx = (
                 super().from_dict(
                     attrs=attrs.get(mm_constants.ApplicationEvent.MLRUN_CONTEXT, {}),
                     **kwargs,
                 ),
             )
         else:
-            self = context
-            self.__post_init__()
+            ctx = context
+            cls._enrich_data(ctx)
 
-        self.start_infer_time = pd.Timestamp(
+        ctx.start_infer_time = pd.Timestamp(
             attrs.get(mm_constants.ApplicationEvent.START_INFER_TIME)
         )
-        self.end_infer_time = pd.Timestamp(
+        ctx.end_infer_time = pd.Timestamp(
             attrs.get(mm_constants.ApplicationEvent.END_INFER_TIME)
         )
-        self.latest_request = pd.Timestamp(
+        ctx.latest_request = pd.Timestamp(
             attrs.get(mm_constants.ApplicationEvent.LAST_REQUEST)
         )
-        self.application_name = attrs.get(
-            mm_constants.ApplicationEvent.APPLICATION_NAME
-        )
-        self._feature_stats = json.loads(
+        ctx.application_name = attrs.get(mm_constants.ApplicationEvent.APPLICATION_NAME)
+        ctx._feature_stats = json.loads(
             attrs.get(mm_constants.ApplicationEvent.FEATURE_STATS, "{}")
         )
-        self._sample_df_stats = json.loads(
+        ctx._sample_df_stats = json.loads(
             attrs.get(mm_constants.ApplicationEvent.CURRENT_STATS, "{}")
         )
 
-        self.endpoint_id = attrs.get(mm_constants.ApplicationEvent.ENDPOINT_ID)
-        self._model_endpoint = model_endpoint_dict.get(self.endpoint_id)
+        ctx.endpoint_id = attrs.get(mm_constants.ApplicationEvent.ENDPOINT_ID)
+        ctx._model_endpoint = model_endpoint_dict.get(ctx.endpoint_id)
 
-        return self
+        return ctx
 
     @property
     def sample_df(self) -> pd.DataFrame:

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -21,6 +21,7 @@ import tempfile
 import time
 import typing
 import uuid
+import warnings
 from base64 import b64decode
 from copy import deepcopy
 from os import environ, makedirs, path
@@ -196,11 +197,12 @@ def load_func_code(command="", workdir=None, secrets=None, name="name"):
 def get_or_create_ctx(
     name: str,
     event=None,
-    spec=None,
+    spec: Optional[dict] = None,
     with_env: bool = True,
     rundb: str = "",
     project: str = "",
-    upload_artifacts=False,
+    upload_artifacts: bool = False,
+    labels: Optional[dict] = None,
 ) -> MLClientCtx:
     """
     Called from within the user program to obtain a run context.
@@ -220,6 +222,7 @@ def get_or_create_ctx(
     :param project:  project to initiate the context in (by default `mlrun.mlconf.default_project`)
     :param upload_artifacts:  when using local context (not as part of a job/run), upload artifacts to the
                               system default artifact path location
+    :param labels: (deprecated - use spec instead) dict of the context labels.
     :return: execution context
 
     Examples::
@@ -252,6 +255,20 @@ def get_or_create_ctx(
         context.log_artifact("results.html", body=b"<b> Some HTML <b>", viewer="web-app")
 
     """
+    if labels:
+        warnings.warn(
+            "The `labels` argument is deprecated and will be removed in 1.9.0. "
+            "Please use `spec` instead, e.g.:\n"
+            "spec={'metadata': {'labels': {'key': 'value'}}}",
+            FutureWarning,
+        )
+        if spec is None:
+            spec = {}
+        if "metadata" not in spec:
+            spec["metadata"] = {}
+        if "labels" not in spec["metadata"]:
+            spec["metadata"]["labels"] = {}
+        spec["metadata"]["labels"].update(labels)
 
     if global_context.get() and not spec and not event:
         return global_context.get()

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -201,13 +201,13 @@ def get_or_create_ctx(
     rundb: str = "",
     project: str = "",
     upload_artifacts=False,
-    labels: Optional[dict] = None,
 ) -> MLClientCtx:
-    """called from within the user program to obtain a run context
+    """
+    Called from within the user program to obtain a run context.
 
-    the run context is an interface for receiving parameters, data and logging
+    The run context is an interface for receiving parameters, data and logging
     run results, the run context is read from the event, spec, or environment
-    (in that order), user can also work without a context (local defaults mode)
+    (in that order), user can also work without a context (local defaults mode).
 
     all results are automatically stored in the "rundb" or artifact store,
     the path to the rundb can be specified in the call or obtained from env.
@@ -220,7 +220,6 @@ def get_or_create_ctx(
     :param project:  project to initiate the context in (by default `mlrun.mlconf.default_project`)
     :param upload_artifacts:  when using local context (not as part of a job/run), upload artifacts to the
                               system default artifact path location
-    :param labels:   dict of the context labels
     :return: execution context
 
     Examples::
@@ -306,9 +305,6 @@ def get_or_create_ctx(
     ctx = MLClientCtx.from_dict(
         newspec, rundb=out, autocommit=autocommit, tmp=tmp, host=socket.gethostname()
     )
-    labels = labels or {}
-    for key, val in labels.items():
-        ctx.set_label(key=key, value=val)
     global_context.set(ctx)
     return ctx
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -321,9 +321,9 @@ def v2_serving_init(context, namespace=None):
         server.http_trigger = getattr(context.trigger, "kind", "http") == "http"
     context.logger.info_with(
         "Setting current function",
-        current_functiton=os.environ.get("SERVING_CURRENT_FUNCTION", ""),
+        current_function=os.getenv("SERVING_CURRENT_FUNCTION", ""),
     )
-    server.set_current_function(os.environ.get("SERVING_CURRENT_FUNCTION", ""))
+    server.set_current_function(os.getenv("SERVING_CURRENT_FUNCTION", ""))
     context.logger.info_with(
         "Initializing states", namespace=namespace or get_caller_globals()
     )
@@ -422,7 +422,7 @@ def create_graph_server(
     parameters = parameters or {}
     server = GraphServer(graph, parameters, load_mode, verbose=verbose, **kwargs)
     server.set_current_function(
-        current_function or os.environ.get("SERVING_CURRENT_FUNCTION", "")
+        current_function or os.getenv("SERVING_CURRENT_FUNCTION", "")
     )
     return server
 


### PR DESCRIPTION
This PR makes some small improvements and fixes related to `MLClientCtx` and `MonitoringApplicationContext`.

* Remove an unused private attribute from `MLClientCtx` and initialize the start and end times to be the same.
* In `MonitoringApplicationContext`, don't use `__post_init__` or `self` in a class method.
* In `get_or_create_ctx` - remove the `labels` argument. It was not used anywhere and was set only after the context was created, resulting in off-sync with the DB saved context.

(Partly related to [ML-6836](https://iguazio.atlassian.net/browse/ML-6836).)

[ML-6836]: https://iguazio.atlassian.net/browse/ML-6836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ