### PR TITLE
[Model Monitoring] Change the update controller to a PATCH endpoint

### DIFF
--- a/mlrun/common/types.py
+++ b/mlrun/common/types.py
@@ -30,6 +30,7 @@ class HTTPMethod(StrEnum):
     GET = "GET"
     POST = "POST"
     DELETE = "DELETE"
+    PATCH = "PATCH"
 
 
 class Operation(StrEnum):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3380,7 +3380,7 @@ class HTTPRunDB(RunDBInterface):
                                          By default, the image is mlrun/mlrun.
         """
         self.api_call(
-            method=mlrun.common.types.HTTPMethod.POST,
+            method=mlrun.common.types.HTTPMethod.PATCH,
             path=f"projects/{project}/model-monitoring/model-monitoring-controller",
             params={
                 "base_period": base_period,

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -128,7 +128,7 @@ async def enable_model_monitoring(
     )
 
 
-@router.post("/model-monitoring-controller")
+@router.patch("/model-monitoring-controller")
 async def update_model_monitoring_controller(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     base_period: int = 10,


### PR DESCRIPTION
This is the correct verb and not POST, as we do not create it in this API from scratch, but simply update it.
We even raise an error if the controller did not exist before.

Note: this API endpoint is new in 1.7 - no BC issues.

* Deprecated endpoint:
https://github.com/mlrun/mlrun/blob/bc4b9ccf94134978eaee4099fa6fac644cb077ba/server/api/api/endpoints/jobs.py#L25
https://github.com/mlrun/mlrun/blob/bc4b9ccf94134978eaee4099fa6fac644cb077ba/server/api/api/endpoints/jobs.py#L28-L36

* New endpoint - changed in this PR: https://github.com/mlrun/mlrun/blob/bc4b9ccf94134978eaee4099fa6fac644cb077ba/server/api/api/endpoints/model_monitoring.py#L30
https://github.com/mlrun/mlrun/blob/bc4b9ccf94134978eaee4099fa6fac644cb077ba/server/api/api/endpoints/model_monitoring.py#L131-L132