### PR TITLE
[Application] Fix deploying from image

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -367,12 +367,20 @@ class ApplicationRuntime(RemoteRuntime):
         )
 
     def from_image(self, image):
+        """
+        Deploy the function from an existing image
+
+        :param image: image name
+        """
         super().from_image(image)
         # nuclio implementation detail - when providing the image and emptying out the source code and build source,
         # nuclio skips rebuilding the image and simply takes the prebuilt image
         self.spec.build.functionSourceCode = ""
         self.status.application_source = self.spec.build.source
         self.spec.build.source = ""
+
+        # save the image in the status, so we won't repopulate the function source code
+        self.status.container_image = image
 
     @classmethod
     def get_filename_and_handler(cls) -> (str, str):

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -368,7 +368,8 @@ class ApplicationRuntime(RemoteRuntime):
 
     def from_image(self, image):
         """
-        Deploy the function from an existing image
+        Deploy the function with an existing nuclio processor image.
+        This applies only for the reverse proxy and not the application image.
 
         :param image: image name
         """

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -446,6 +446,11 @@ class RemoteRuntime(KubeResource):
         return self
 
     def from_image(self, image):
+        """
+        Deploy the function from an existing image
+
+        :param image: image name
+        """
         config = nuclio.config.new_config()
         update_in(
             config,

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -447,7 +447,7 @@ class RemoteRuntime(KubeResource):
 
     def from_image(self, image):
         """
-        Deploy the function from an existing image
+        Deploy the function with an existing nuclio processor image.
 
         :param image: image name
         """

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -347,15 +347,12 @@ def _compile_function_config(
     _set_function_replicas(function, nuclio_spec)
     _set_misc_specs(function, nuclio_spec)
 
-    is_nuclio_image_set = function.spec.config.get("spec.image") is not None
-
     # if the user code is given explicitly or from a source, we need to set the handler and relevant attributes
     if (
         function.spec.base_spec
         or function.spec.build.functionSourceCode
         or function.spec.build.source
         or function.kind == mlrun.runtimes.RuntimeKinds.serving  # serving can be empty
-        or is_nuclio_image_set
     ):
         config = function.spec.base_spec
         if not config:
@@ -371,7 +368,6 @@ def _compile_function_config(
         if (
             function.kind == mlrun.runtimes.RuntimeKinds.serving
             and not mlrun.utils.get_in(config, "spec.build.functionSourceCode")
-            and not is_nuclio_image_set
         ):
             _set_source_code_and_handler(function, config)
     else:

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -347,13 +347,15 @@ def _compile_function_config(
     _set_function_replicas(function, nuclio_spec)
     _set_misc_specs(function, nuclio_spec)
 
+    is_nuclio_image_set = function.spec.config.get("spec.image") is not None
+
     # if the user code is given explicitly or from a source, we need to set the handler and relevant attributes
     if (
         function.spec.base_spec
         or function.spec.build.functionSourceCode
         or function.spec.build.source
         or function.kind == mlrun.runtimes.RuntimeKinds.serving  # serving can be empty
-    ):
+    ) and not is_nuclio_image_set:
         config = function.spec.base_spec
         if not config:
             # if base_spec was not set (when not using code_to_function) and we have base64 code

--- a/server/api/crud/runtimes/nuclio/function.py
+++ b/server/api/crud/runtimes/nuclio/function.py
@@ -355,7 +355,8 @@ def _compile_function_config(
         or function.spec.build.functionSourceCode
         or function.spec.build.source
         or function.kind == mlrun.runtimes.RuntimeKinds.serving  # serving can be empty
-    ) and not is_nuclio_image_set:
+        or is_nuclio_image_set
+    ):
         config = function.spec.base_spec
         if not config:
             # if base_spec was not set (when not using code_to_function) and we have base64 code
@@ -370,6 +371,7 @@ def _compile_function_config(
         if (
             function.kind == mlrun.runtimes.RuntimeKinds.serving
             and not mlrun.utils.get_in(config, "spec.build.functionSourceCode")
+            and not is_nuclio_image_set
         ):
             _set_source_code_and_handler(function, config)
     else:

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -32,6 +32,58 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         self._upload_code_to_cluster()
 
         self._logger.debug("Creating application")
+        function, source = self._deploy_vizro_application()
+
+        assert function.invoke("/", verify=False)
+
+        # Application runtime function is created without external url
+        # check that empty string is not added to func.status.external_invocation_urls
+        assert "" not in function.status.external_invocation_urls
+
+        assert function.spec.build.source == source
+        assert (
+            function.status.application_image
+            == f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest"
+        )
+
+        self._logger.debug("Redeploying the same application with capturing stdout")
+        output = self._deploy_application_with_stdout_capture(function)
+
+        # Assert nuclio image build was skipped
+        assert "(info) Skipping build" in output
+
+        assert function.invoke("/", verify=False)
+        assert function.spec.build.source == source
+        assert (
+            function.status.application_image
+            == f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest"
+        )
+
+    def test_deploy_application_from_image(self):
+        self._logger.debug("Creating application")
+        function, source = self._deploy_vizro_application()
+
+        assert function.invoke("/", verify=False)
+
+        # take the application image and container image, and use them to deploy a new function
+        application_image = function.status.application_image
+        container_image = function.status.container_image
+
+        function = self.project.set_function(
+            name="new-app",
+            kind="application",
+            image=application_image,
+        )
+        function.set_internal_application_port(8050)
+        function.from_image(container_image)
+
+        self._logger.debug("Deploying a new vizro application")
+        output = self._deploy_application_with_stdout_capture(function)
+
+        # make sure the build was skipped
+        assert "(info) Skipping build" in output
+
+    def _deploy_vizro_application(self):
         function = self.project.set_function(
             name="vizro-app",
             kind="application",
@@ -46,30 +98,17 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             "--log-level",
             "debug",
         ]
-
         source = os.path.join(self.remote_code_dir, self._vizro_app_code_filename)
         function.with_source_archive(
             source=source,
             pull_at_runtime=False,
         )
-
         self._logger.debug("Deploying vizro application")
         function.deploy(with_mlrun=False)
+        return function, source
 
-        assert function.invoke("/", verify=False)
-
-        # Application runtime function is created without external url
-        # check that empty string is not added to func.status.external_invocation_urls
-        assert "" not in function.status.external_invocation_urls
-
-        assert function.spec.build.source == source
-        assert (
-            function.status.application_image
-            == f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest"
-        )
-
-        self._logger.debug("Redeploying vizro application with capturing stdout")
-
+    @staticmethod
+    def _deploy_application_with_stdout_capture(function):
         # Create a StringIO object to capture stdout
         old_stdout = sys.stdout
         new_stdout = io.StringIO()
@@ -80,13 +119,4 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             sys.stdout = old_stdout
         output = new_stdout.getvalue()
         new_stdout.close()
-
-        # Assert nuclio image build was skipped
-        assert "(info) Skipping build" in output
-
-        assert function.invoke("/", verify=False)
-        assert function.spec.build.source == source
-        assert (
-            function.status.application_image
-            == f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest"
-        )
+        return output


### PR DESCRIPTION
Deploying an application runtime from image was impossible because the reverse-proxy source code was always populated at first deployment.

Fix is to set the image on the status before the deployment, so the reverse proxy source code won't be set on the function spec.

Furthermore, make sure that if `spec.image` is set, we do not enrich the source code in the backend.