### PR TITLE
[DB] Exit early when there are no artifacts to tag

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -991,6 +991,15 @@ class SQLDB(DBInterface):
         project: str,
     ):
         artifacts_keys = [artifact.key for artifact in artifacts]
+        if not artifacts_keys:
+            logger.debug(
+                "No artifacts to tag",
+                project=project,
+                tag=tag_name,
+                artifacts=artifacts,
+            )
+            return
+
         logger.debug(
             "Locking artifacts in db before tagging artifacts",
             project=project,


### PR DESCRIPTION
In case the DB's `tag_artifacts` gets an empty list of artifacts to tag, we can exit early and not lock the artifact records in the DB.

This can possibly happen if you call the `tag_artifacts` SDK with some wrong parameters.