### PR TITLE
[Alerts] Don't overrun state with reset policy AUTO

### DIFF
--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -28,6 +28,7 @@ class AlertConfig(ModelObj):
         "severity",
         "reset_policy",
         "state",
+        "count",
     ]
     _fields_to_serialize = ModelObj._fields_to_serialize + [
         "entities",

--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -182,6 +182,7 @@ class Alerts(
                 send_notification = True
 
             active = False
+            update_state = True
             if send_notification:
                 state["count"] += 1
                 logger.debug("Sending notifications for alert", name=alert.name)
@@ -189,6 +190,7 @@ class Alerts(
 
                 if alert.reset_policy == "auto":
                     self.reset_alert(session, alert.project, alert.name)
+                    update_state = False
                 else:
                     active = True
                     self._get_alert_state_cached().cache_replace(
@@ -206,7 +208,9 @@ class Alerts(
                     active=active,
                 )
 
-            self._states[alert.id] = state_obj
+            if update_state:
+                # we don't want to update the state if reset_alert() was called, as we will override the reset
+                self._states[alert.id] = state_obj
 
     def populate_event_cache(self, session: sqlalchemy.orm.Session):
         try:

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -98,13 +98,17 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # since the reset_policy of the alert is "manual", the state now should be active
         alert = self._get_alerts(project_name, created_alert2.name)
-        self._validate_alert(alert, alert_state=alert_objects.AlertActiveState.ACTIVE)
+        self._validate_alert(
+            alert, alert_state=alert_objects.AlertActiveState.ACTIVE, alert_count=1
+        )
 
         # reset the alert and trigger the event again and validate that the state is inactive
         self._reset_alert(project_name, created_alert2.name)
         self._post_event(project_name, alert2["event_name"], alert2["entity"]["kind"])
         alert = self._get_alerts(project_name, created_alert2.name)
-        self._validate_alert(alert, alert_state=alert_objects.AlertActiveState.INACTIVE)
+        self._validate_alert(
+            alert, alert_state=alert_objects.AlertActiveState.INACTIVE, alert_count=1
+        )
 
         # create an alert with reset_policy = "auto"
         self._create_alert(
@@ -114,6 +118,7 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             alert2["entity"]["project"],
             alert2["summary"],
             alert2["event_name"],
+            criteria=alert2["criteria"],
             reset_policy=alert_objects.ResetPolicy.AUTO,
         )
 
@@ -124,7 +129,9 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # since the reset_policy of the alert now is "auto", after sending 3 events the state should be inactive
         alert = self._get_alerts(project_name, created_alert2.name)
-        self._validate_alert(alert, alert_state=alert_objects.AlertActiveState.INACTIVE)
+        self._validate_alert(
+            alert, alert_state=alert_objects.AlertActiveState.INACTIVE, alert_count=2
+        )
 
         new_event_name = alert_objects.EventKind.DATA_DRIFT_SUSPECTED
         modified_alert = self._modify_alert_test(
@@ -608,6 +615,7 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         alert_reset_policy=None,
         alert_entity=None,
         alert_notifications=None,
+        alert_count=None,
     ):
         if project_name:
             assert alert.project == project_name
@@ -634,6 +642,8 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             assert alert.entities == alert_entity
         if alert_notifications:
             assert alert.notifications == alert_notifications
+        if alert_count:
+            assert alert.count == alert_count
 
     @staticmethod
     def _generate_event_request(project, event_kind, entity_kind):


### PR DESCRIPTION
When reset policy is auto we were effectively
overriding the reset operation thus counting
previous events towards the alert state.

https://iguazio.atlassian.net/browse/ML-7293