### PR TITLE
[Automation] Support push images to multi data nodes

### DIFF
--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -46,3 +46,7 @@ REGISTRY_PASSWORD:
 
 # Optional - only required if asking to reset DB
 DB_USER:
+
+# Optional - relevant when working with multiple DATA_NODES and iguazio datanode registry
+# set to "true" if you want the image to be pushed only to a single registry specified in DOCKER_REGISTRY
+SKIP_MULTI_NODE_PUSH:

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -49,12 +49,13 @@ class MLRunPatcher:
         self._patch_log_collector = bool(log_collector)
         self._validate_config()
 
-    def patch_mlrun_api(self):
-        vers = self._get_current_version()
-
         nodes = self._config["DATA_NODES"]
         if not isinstance(nodes, list):
             nodes = [nodes]
+        self._nodes = nodes
+
+    def patch_mlrun_api(self):
+        vers = self._get_current_version()
 
         image_tag = self._get_image_tag(vers)
         built_api_image = self._make_mlrun("api", image_tag, "mlrun-api")
@@ -69,9 +70,10 @@ class MLRunPatcher:
 
         self._docker_login_if_configured()
 
+        built_images = self._tag_images_for_multi_node_registries(built_images)
         self._push_docker_images(built_images)
 
-        node = nodes[0]
+        node = self._nodes[0]
         self._connect_to_node(node)
         try:
             self._replace_deploy_policy()
@@ -181,6 +183,34 @@ class MLRunPatcher:
 
     def _disconnect_from_node(self):
         self._ssh_client.close()
+
+    def _tag_images_for_multi_node_registries(self, built_images):
+        if self._config.get("SKIP_MULTI_NODE_PUSH") == "true":
+            return
+
+        resolve_built_images = []
+        for built_image in built_images:
+            for node in self._nodes:
+                if node in built_image:
+                    resolve_built_images.append(built_image)
+                    for replacement_node in self._nodes:
+                        if replacement_node != node:
+                            replaced_built_image = built_image.replace(
+                                node, replacement_node
+                            )
+                            self._exec_local(
+                                [
+                                    "docker",
+                                    "tag",
+                                    built_image,
+                                    replaced_built_image,
+                                ],
+                                live=True,
+                            )
+                            resolve_built_images.append(replaced_built_image)
+                    break
+
+        return resolve_built_images or built_images
 
     def _push_docker_images(self, built_images):
         logger.info(f"Pushing mlrun docker images: {built_images}")

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -208,6 +208,9 @@ class MLRunPatcher:
                                 live=True,
                             )
                             resolve_built_images.append(replaced_built_image)
+
+                    # Once we found the node configured in the built_image we can stop because it is only possible
+                    # to specify one node when building the image
                     break
 
         return resolve_built_images or built_images


### PR DESCRIPTION
Relevant to multi data nodes system where the api image must be pushed to all data nodes for the pods to be able to pull the updated image.