### PR TITLE
[Model Monitoring] Fix appication context and runs

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1166,6 +1166,7 @@ class Config:
                 )
             elif kind == "stream":  # return list for mlrun<1.6.3 BC
                 return [
+                    # TODO: remove the first stream in 1.9.0
                     mlrun.mlconf.model_endpoint_monitoring.store_prefixes.default.format(
                         project=project,
                         kind=kind,

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -19,6 +19,7 @@ import mlrun.common.helpers
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring.constants as mm_constant
 import mlrun.datastore
+import mlrun.serving
 import mlrun.utils.v3io_clients
 from mlrun.model_monitoring.helpers import get_stream_path
 from mlrun.serving.utils import StepToDict
@@ -151,6 +152,9 @@ class _PrepareMonitoringEvent(StepToDict):
     def _create_mlrun_context(app_name: str):
         context = mlrun.get_or_create_ctx(
             f"{app_name}-logger",
+            spec={
+                "metadata": {"labels": {"kind": mlrun.runtimes.RuntimeKinds.serving}}
+            },
             upload_artifacts=True,
         )
         context.__class__ = MonitoringApplicationContext

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -526,8 +526,7 @@ def _deploy_nuclio_runtime(
             )
         if monitoring_application:
             fn = monitoring_deployment.apply_and_create_stream_trigger(
-                function=fn,
-                function_name=fn.metadata.name,
+                function=fn, function_name=fn.metadata.name
             )
 
         if serving_to_monitor:

--- a/server/api/crud/model_monitoring/__init__.py
+++ b/server/api/crud/model_monitoring/__init__.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# flake8: noqa: F401 - this is until we take care of the F401 violations with respect to __all__ & sphinx
 
 from .helpers import get_stream_path
 from .model_endpoints import ModelEndpoints

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -260,15 +260,14 @@ class MonitoringDeployment:
         self, function: mlrun.runtimes.ServingRuntime, function_name: str
     ) -> mlrun.runtimes.ServingRuntime:
         """
-        Add stream source for the nuclio serving function. By default, the function has HTTP stream trigger along
-        with another supported stream source that can be either Kafka or V3IO, depends on the stream path schema
-        that is defined by `project.set_model_monitoring_credentials(..., stream_path="...")`.
-        Note that if no valid stream path has been provided then the function will have a single HTTP stream source.
+        Add stream source for the nuclio serving function. The function's stream trigger can be either Kafka or V3IO,
+        depends on the stream path schema that is defined by
+        `project.set_model_monitoring_credentials(..., stream_path="...")`.
 
-        :param function:                    The serving function object that will be applied with the stream trigger.
-        :param function_name:               The name of the function that be applied with the stream trigger.
+        :param function:      The serving function object that will be applied with the stream trigger.
+        :param function_name: The name of the function that be applied with the stream trigger.
 
-        :return: ServingRuntime object with stream trigger.
+        :return: `ServingRuntime` object with stream trigger.
         """
 
         # Get the stream path from the configuration
@@ -317,9 +316,8 @@ class MonitoringDeployment:
                 function = self._apply_access_key_and_mount_function(
                     function=function, function_name=function_name
                 )
-        # Add the default HTTP source
-        http_source = mlrun.datastore.sources.HttpSource()
-        function = http_source.add_nuclio_trigger(function)
+
+        function.spec.disable_default_http_trigger = True
 
         return function
 

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -108,7 +108,7 @@ class MonitoringDeployment:
         :param base_period:                       The time period in minutes in which the model monitoring controller
                                                   function triggers. By default, the base period is 10 minutes.
         :param image:                             The image of the model monitoring controller, writer & monitoring
-                                                  stream functions, which are real time nuclio functino.
+                                                  stream functions, which are real time nuclio function.
                                                   By default, the image is mlrun/mlrun.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
         :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
@@ -257,16 +257,16 @@ class MonitoringDeployment:
             )
 
     def apply_and_create_stream_trigger(
-        self, function: mlrun.runtimes.ServingRuntime, function_name: str = None
+        self, function: mlrun.runtimes.ServingRuntime, function_name: str
     ) -> mlrun.runtimes.ServingRuntime:
-        """Adding stream source for the nuclio serving function. By default, the function has HTTP stream trigger along
-        with another supported stream source that can be either Kafka or V3IO, depends on the stream path schema that is
-        defined under mlrun.mlconf.model_endpoint_monitoring.store_prefixes. Note that if no valid stream path has been
-        provided then the function will have a single HTTP stream source.
+        """
+        Add stream source for the nuclio serving function. By default, the function has HTTP stream trigger along
+        with another supported stream source that can be either Kafka or V3IO, depends on the stream path schema
+        that is defined by `project.set_model_monitoring_credentials(..., stream_path="...")`.
+        Note that if no valid stream path has been provided then the function will have a single HTTP stream source.
 
         :param function:                    The serving function object that will be applied with the stream trigger.
-        :param function_name:               The name of the function that be applied with the stream trigger,
-                                            None for model_monitoring_stream
+        :param function_name:               The name of the function that be applied with the stream trigger.
 
         :return: ServingRuntime object with stream trigger.
         """

--- a/server/api/crud/model_monitoring/helpers.py
+++ b/server/api/crud/model_monitoring/helpers.py
@@ -17,37 +17,13 @@ import typing
 
 import sqlalchemy.orm
 
-import mlrun.common
 import mlrun.common.model_monitoring.helpers
+import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
-import mlrun.common.schemas.schedule
 import mlrun.errors
 import mlrun.model_monitoring
 import mlrun.model_monitoring.db.stores
 import server.api.crud.secrets
-
-
-def get_batching_interval_param(intervals_list: list):
-    """Convert each value in the intervals list into a float number. None
-    Values will be converted into 0.0.
-
-    param intervals_list: A list of values based on the ScheduleCronTrigger expression. Note that at the moment
-                          it supports minutes, hours, and days. e.g. [0, '*/1', None] represents on the hour
-                          every hour.
-
-    :return: A tuple of:
-             [0] = minutes interval as a float
-             [1] = hours interval as a float
-             [2] = days interval as a float
-    """
-    return tuple(
-        [
-            0.0
-            if isinstance(interval, (float, int)) or interval is None
-            else float(f"0{interval.partition('/')[-1]}")
-            for interval in intervals_list
-        ]
-    )
 
 
 def json_loads_if_not_none(field: typing.Any) -> typing.Any:
@@ -104,18 +80,18 @@ def get_monitoring_parquet_path(
 
 
 def get_stream_path(
-    project: str = None,
+    project: str,
     function_name: str = mm_constants.MonitoringFunctionNames.STREAM,
     stream_uri: typing.Optional[str] = None,
-) -> typing.Union[list[str]]:
+) -> list[str]:
     """
-     Get stream path from the project secret. If wasn't set, take it from the system configurations
+    Get stream path from the project secret. If wasn't set, take it from the system configurations.
 
-     :param project:             Project name.
-     :param function_name:       Application name. Default is model_monitoring_stream.
-    :param stream_uri:           Stream URI. If not provided, it will be taken from the project secret.
+    :param project:       Project name.
+    :param function_name: Application name. Default is model_monitoring_stream.
+    :param stream_uri:    Stream URI. If not provided, it will be taken from the project secret.
 
-     :return:                    Monitoring stream path to the relevant application.
+    :return:              Monitoring stream path to the relevant application.
     """
 
     stream_uri = stream_uri or server.api.crud.secrets.Secrets().get_project_secret(


### PR DESCRIPTION
Resolves [ML-6836](https://iguazio.atlassian.net/browse/ML-6836).

* Remove the HTTP trigger from the model monitoring Nuclio functions except for the controller. This includes the stream and writer infrastructure functions and all user applications.
  From 1.7 the user must provide a valid stream for model monitoring - either Kafka or V3IO, so there's no need for an HTTP trigger.
  This removal reduces the number of runs per app to a single run.
* Set the run kind to "serving" instead of the default "local".

![image](https://github.com/user-attachments/assets/ade81637-0f3b-4c49-8ffc-36c6589fed57)

Note:
* The status stays "running" since there's a single run per app.
* The log collection warns about these application runs. This leftover needs to be addressed later.

[ML-6836]: https://iguazio.atlassian.net/browse/ML-6836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ