### PR TITLE
[DirArtifact] Add the `producer` field to the spec

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -632,6 +632,7 @@ class DirArtifactSpec(ArtifactSpec):
         "src_path",
         "target_path",
         "db_key",
+        "producer",
     ]
 
 


### PR DESCRIPTION
The 'producer' field was missing in the 'spec' parameter of the DirArtifact for the created artifact.

https://iguazio.atlassian.net/browse/ML-7326