### PR TITLE
[API] Fix storing monitoring access key during delete project API  

### DIFF
--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -322,7 +322,9 @@ async def deploy_status(
     )
 
 
-def process_model_monitoring_secret(db_session, project_name: str, secret_key: str):
+def process_model_monitoring_secret(
+    db_session, project_name: str, secret_key: str, store: bool = True
+):
     # The expected result of this method is an access-key placed in an internal project-secret.
     # If the user provided an access-key as the "regular" secret_key, then we delete this secret and move contents
     # to the internal secret instead. Else, if the internal secret already contained a value, keep it. Last option
@@ -368,16 +370,18 @@ def process_model_monitoring_secret(db_session, project_name: str, secret_key: s
                 project_name=project_name,
                 project_owner=project_owner.username,
             )
-
-    secrets = mlrun.common.schemas.SecretsData(
-        provider=provider, secrets={internal_key_name: secret_value}
-    )
-    Secrets().store_project_secrets(project_name, secrets, allow_internal_secrets=True)
-    if user_provided_key:
-        logger.info(
-            "Deleting user-provided access-key - replaced with an internal secret"
+    if store:
+        secrets = mlrun.common.schemas.SecretsData(
+            provider=provider, secrets={internal_key_name: secret_value}
         )
-        Secrets().delete_project_secret(project_name, provider, secret_key)
+        Secrets().store_project_secrets(
+            project_name, secrets, allow_internal_secrets=True
+        )
+        if user_provided_key:
+            logger.info(
+                "Deleting user-provided access-key - replaced with an internal secret"
+            )
+            Secrets().delete_project_secret(project_name, provider, secret_key)
 
     return secret_value
 

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -1121,12 +1121,11 @@ def get_or_create_project_deletion_background_task(
             # Due to backwards compatibility reasons, the model monitoring access key should be retrieved before the
             # project deletion. his key will be used to delete the model monitoring resources associated with the
             # project.
-            model_monitoring_access_key = (
-                server.api.api.endpoints.nuclio.process_model_monitoring_secret(
-                    db_session,
-                    project.metadata.name,
-                    mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
-                )
+            model_monitoring_access_key = server.api.api.endpoints.nuclio.process_model_monitoring_secret(
+                db_session=db_session,
+                project_name=project.metadata.name,
+                secret_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+                store=False,
             )
         background_task_kind_format = (
             server.api.utils.background_tasks.BackgroundTaskKinds.project_deletion


### PR DESCRIPTION
**Background**
As part of the delete project API, we delete some of the model monitoring resources that are associated with the related project. As part of the delete flow we are trying to get the model monitoring access key secret. If not exist, we generate and store that access key based on the project owner access key. However, this behaviour has exposed a bug in which a user **without** model monitoring resources tries to delete his project and gets an error during the store process. 

**Solution**
In this PR, we fix that issue by skipping the store process when trying to get the access key during the delete process. If the secret has already been stored, then the API will get the secret anyway. If it hasn't been store, there is no need to store it because it mens that there are no model monitoring resources in this case. In addition, in this case it doesn't make sense to store a secret that will be deleted immediately and anyway won't be used. 


Related JIRA: https://iguazio.atlassian.net/browse/ML-7301