### PR TITLE
[Model Monitoring] Override artifacts in custom evidently app and add V1 deprecation 

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -113,6 +113,7 @@ class ModelMonitoringApplicationBaseV2(MonitoringApplicationToDict, ABC):
         raise NotImplementedError
 
 
+# TODO: Remove in 1.9.0
 @deprecated(
     version="1.7.0",
     reason="The `ModelMonitoringApplicationBase` class is deprecated from "

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -17,6 +17,7 @@ from typing import Any, Union, cast
 
 import numpy as np
 import pandas as pd
+from deprecated import deprecated
 
 import mlrun
 import mlrun.model_monitoring.applications.context as mm_context
@@ -112,6 +113,12 @@ class ModelMonitoringApplicationBaseV2(MonitoringApplicationToDict, ABC):
         raise NotImplementedError
 
 
+@deprecated(
+    version="1.7.0",
+    reason="The `ModelMonitoringApplicationBase` class is deprecated from "
+    "version 1.7.0 and will be removed in version 1.9.0. "
+    "Use `ModelMonitoringApplicationBaseV2` as your application's base class.",
+)
 class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
     """
     A base class for a model monitoring application.

--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -14,7 +14,6 @@
 
 import uuid
 import warnings
-from typing import Union
 
 import pandas as pd
 import semver
@@ -57,8 +56,7 @@ except ModuleNotFoundError:
 
 
 if _HAS_EVIDENTLY:
-    from evidently.report.report import Report
-    from evidently.suite.base_suite import Suite
+    from evidently.suite.base_suite import Display
     from evidently.ui.type_aliases import STR_UUID
     from evidently.ui.workspace import Workspace
     from evidently.utils.dashboard import TemplateParams, file_html_template
@@ -86,12 +84,12 @@ class EvidentlyModelMonitoringApplicationBase(mm_base.ModelMonitoringApplication
         )
 
     def log_evidently_object(
-        self, evidently_object: Union["Report", "Suite"], artifact_name: str
-    ):
+        self, evidently_object: "Display", artifact_name: str
+    ) -> None:
         """
          Logs an Evidently report or suite as an artifact.
 
-        :param evidently_object:    (Union[Report, Suite]) The Evidently report or suite object.
+        :param evidently_object:    (Display) The Evidently display to log, e.g. a report or a test suite object.
         :param artifact_name:       (str) The name for the logged artifact.
         """
         evidently_object_html = evidently_object.get_html()
@@ -156,14 +154,14 @@ class EvidentlyModelMonitoringApplicationBaseV2(
     @staticmethod
     def log_evidently_object(
         monitoring_context: mm_context.MonitoringApplicationContext,
-        evidently_object: Union["Report", "Suite"],
+        evidently_object: "Display",
         artifact_name: str,
-    ):
+    ) -> None:
         """
          Logs an Evidently report or suite as an artifact.
 
         :param monitoring_context:  (MonitoringApplicationContext) The monitoring context to process.
-        :param evidently_object:    (Union[Report, Suite]) The Evidently report or suite object.
+        :param evidently_object:    (Display) The Evidently display to log, e.g. a report or a test suite object.
         :param artifact_name:       (str) The name for the logged artifact.
         """
         evidently_object_html = evidently_object.get_html()
@@ -177,7 +175,7 @@ class EvidentlyModelMonitoringApplicationBaseV2(
         timestamp_start: pd.Timestamp,
         timestamp_end: pd.Timestamp,
         artifact_name: str = "dashboard",
-    ):
+    ) -> None:
         """
         Logs an Evidently project dashboard.
 

--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -122,14 +122,10 @@ class EvidentlyModelMonitoringApplicationBase(mm_base.ModelMonitoringApplication
             additional_graphs={},
         )
 
-        dashboard_html = self._render(file_html_template, template_params)
+        dashboard_html = file_html_template(params=template_params)
         self.context.log_artifact(
             artifact_name, body=dashboard_html.encode("utf-8"), format="html"
         )
-
-    @staticmethod
-    def _render(temple_func, template_params: "TemplateParams"):
-        return temple_func(params=template_params)
 
 
 class EvidentlyModelMonitoringApplicationBaseV2(
@@ -200,11 +196,7 @@ class EvidentlyModelMonitoringApplicationBaseV2(
             additional_graphs={},
         )
 
-        dashboard_html = self._render(file_html_template, template_params)
+        dashboard_html = file_html_template(params=template_params)
         monitoring_context.log_artifact(
             artifact_name, body=dashboard_html.encode("utf-8"), format="html"
         )
-
-    @staticmethod
-    def _render(temple_func, template_params: "TemplateParams"):
-        return temple_func(params=template_params)

--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -14,6 +14,7 @@
 
 import uuid
 import warnings
+from abc import ABC
 
 import pandas as pd
 import semver
@@ -70,7 +71,9 @@ if _HAS_EVIDENTLY:
     "version 1.7.0 and will be removed in version 1.9.0. "
     "Use `EvidentlyModelMonitoringApplicationBaseV2` as your application's base class.",
 )
-class EvidentlyModelMonitoringApplicationBase(mm_base.ModelMonitoringApplicationBase):
+class EvidentlyModelMonitoringApplicationBase(
+    mm_base.ModelMonitoringApplicationBase, ABC
+):
     def __init__(
         self, evidently_workspace_path: str, evidently_project_id: "STR_UUID"
     ) -> None:
@@ -135,7 +138,7 @@ class EvidentlyModelMonitoringApplicationBase(mm_base.ModelMonitoringApplication
 
 
 class EvidentlyModelMonitoringApplicationBaseV2(
-    mm_base.ModelMonitoringApplicationBaseV2
+    mm_base.ModelMonitoringApplicationBaseV2, ABC
 ):
     def __init__(
         self, evidently_workspace_path: str, evidently_project_id: "STR_UUID"

--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -63,6 +63,7 @@ if _HAS_EVIDENTLY:
     from evidently.utils.dashboard import TemplateParams, file_html_template
 
 
+# TODO: Remove in 1.9.0
 @deprecated(
     version="1.7.0",
     reason="The `EvidentlyModelMonitoringApplicationBase` class is deprecated from "

--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -17,6 +17,7 @@ import warnings
 
 import pandas as pd
 import semver
+from deprecated import deprecated
 
 import mlrun.model_monitoring.applications.base as mm_base
 import mlrun.model_monitoring.applications.context as mm_context
@@ -62,6 +63,12 @@ if _HAS_EVIDENTLY:
     from evidently.utils.dashboard import TemplateParams, file_html_template
 
 
+@deprecated(
+    version="1.7.0",
+    reason="The `EvidentlyModelMonitoringApplicationBase` class is deprecated from "
+    "version 1.7.0 and will be removed in version 1.9.0. "
+    "Use `EvidentlyModelMonitoringApplicationBaseV2` as your application's base class.",
+)
 class EvidentlyModelMonitoringApplicationBase(mm_base.ModelMonitoringApplicationBase):
     def __init__(
         self, evidently_workspace_path: str, evidently_project_id: "STR_UUID"

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -22,7 +22,7 @@ from mlrun.model_monitoring.applications import (
 
 def test_deprecation_v1_instantiation() -> None:
     class DeprecatedApp(ModelMonitoringApplicationBase):
-        def do_tracking(self):
+        def do_tracking(self, **kwargs):
             pass
 
     with pytest.warns(DeprecationWarning):
@@ -32,7 +32,7 @@ def test_deprecation_v1_instantiation() -> None:
 @pytest.mark.filterwarnings("error")
 def test_no_deprecation_v2_instantiation() -> None:
     class AppV2(ModelMonitoringApplicationBaseV2):
-        def do_tracking(self):
+        def do_tracking(self, **kwargs):
             pass
 
     AppV2()

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from mlrun.model_monitoring.applications import (
+    ModelMonitoringApplicationBase,
+    ModelMonitoringApplicationBaseV2,
+)
+
+
+def test_deprecation_v1_instantiation() -> None:
+    class DeprecatedApp(ModelMonitoringApplicationBase):
+        def do_tracking(self):
+            pass
+
+    with pytest.warns(DeprecationWarning):
+        DeprecatedApp()
+
+
+@pytest.mark.filterwarnings("error")
+def test_no_deprecation_v2_instantiation() -> None:
+    class AppV2(ModelMonitoringApplicationBaseV2):
+        def do_tracking(self):
+            pass
+
+    AppV2()

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -291,10 +291,18 @@ class CustomEvidentlyMonitoringAppV2(EvidentlyModelMonitoringApplicationBaseV2):
         self.log_evidently_object(
             monitoring_context, data_drift_test_suite, "evidently_suite"
         )
+
+        window_start = monitoring_context.start_infer_time
+        window_end = monitoring_context.end_infer_time
+
+        # Note: the times for evidently are those of the next monitoring window.
+        evidently_start = window_end
+        evidently_end = window_end + (window_end - window_start)
+
         self.log_project_dashboard(
             monitoring_context,
-            monitoring_context.start_infer_time,
-            monitoring_context.end_infer_time,
+            timestamp_start=evidently_start,
+            timestamp_end=evidently_end,
         )
 
         monitoring_context.logger.info("Logged evidently objects")

--- a/tests/system/model_monitoring/assets/custom_evidently_app.py
+++ b/tests/system/model_monitoring/assets/custom_evidently_app.py
@@ -188,8 +188,8 @@ class CustomEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
             self.evidently_project_id, data_drift_test_suite
         )
 
-        self.log_evidently_object(data_drift_report, f"report_{str(end_infer_time)}")
-        self.log_evidently_object(data_drift_test_suite, f"suite_{str(end_infer_time)}")
+        self.log_evidently_object(data_drift_report, "evidently_report")
+        self.log_evidently_object(data_drift_test_suite, "evidently_suite")
         self.log_project_dashboard(None, end_infer_time + datetime.timedelta(minutes=1))
 
         self.context.logger.info("Logged evidently objects")
@@ -286,19 +286,15 @@ class CustomEvidentlyMonitoringAppV2(EvidentlyModelMonitoringApplicationBaseV2):
         )
 
         self.log_evidently_object(
-            monitoring_context,
-            data_drift_report,
-            f"report_{str(monitoring_context.end_infer_time)}",
+            monitoring_context, data_drift_report, "evidently_report"
         )
         self.log_evidently_object(
-            monitoring_context,
-            data_drift_test_suite,
-            f"suite_{str(monitoring_context.end_infer_time)}",
+            monitoring_context, data_drift_test_suite, "evidently_suite"
         )
         self.log_project_dashboard(
             monitoring_context,
-            None,
-            monitoring_context.end_infer_time + datetime.timedelta(minutes=1),
+            monitoring_context.start_infer_time,
+            monitoring_context.end_infer_time,
         )
 
         monitoring_context.logger.info("Logged evidently objects")


### PR DESCRIPTION
Related to the discussion in [ML-7159](https://iguazio.atlassian.net/browse/ML-7159).

- Override evidently artifacts - use a constant name. Using different artifact names doesn't scale in memory for long runs, see [ML-7347](https://iguazio.atlassian.net/browse/ML-7347).
- Add a deprecation warning to the V1 base classes: `ModelMonitoringApplicationBase` and `EvidentlyModelMonitoringApplicationBase`.

I tested it and the artifacts look the same as before.

[ML-7159]: https://iguazio.atlassian.net/browse/ML-7159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-7347]: https://iguazio.atlassian.net/browse/ML-7347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ