### PR TITLE
[Application] Set sidecar container as default container

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -558,6 +558,12 @@ class ApplicationRuntime(RemoteRuntime):
         self.set_env("SIDECAR_PORT", self.spec.internal_application_port)
         self.set_env("SIDECAR_HOST", "http://localhost")
 
+        # configure the sidecar container as the default container for logging purposes
+        self.set_config(
+            "metadata.annotations",
+            {"kubectl.kubernetes.io/default-container": self.status.sidecar_name},
+        )
+
     def _sync_api_gateway(self):
         if not self.status.api_gateway_name:
             return


### PR DESCRIPTION
Together with https://github.com/nuclio/nuclio/pull/3306 , set the sidecar container as the default container so logs will be retrieved from the application instead of the reverse proxy.

Related to https://iguazio.atlassian.net/browse/ML-7345