### PR TITLE
[Serving] Default `QueueStep` to `full_event=True` also when engine is sync

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -873,7 +873,7 @@ class QueueStep(BaseStep):
 
         if self._stream:
             full_event = self.options.get("full_event")
-            if full_event or full_event is None and self.next is not None:
+            if full_event or full_event is None and self.next:
                 data = storey.utils.wrap_event_for_serialization(event, data)
             self._stream.push(data)
             event.terminated = True

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1632,10 +1632,9 @@ def _init_async_objects(context, steps):
                     stream_path = step.path
                     endpoint = None
                     # in case of a queue, we default to a full_event=True
+                    full_event = step.options.get("full_event")
                     options = {
-                        "full_event": step.full_event
-                        or step.full_event is None
-                        and step.next is not None
+                        "full_event": full_event or full_event is None and step.next
                     }
                     options.update(step.options)
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -872,7 +872,8 @@ class QueueStep(BaseStep):
             return event
 
         if self._stream:
-            if self.options.get("full_event", True):
+            full_event = self.options.get("full_event")
+            if full_event or full_event is None and self.next is not None:
                 data = storey.utils.wrap_event_for_serialization(event, data)
             self._stream.push(data)
             event.terminated = True
@@ -1631,7 +1632,11 @@ def _init_async_objects(context, steps):
                     stream_path = step.path
                     endpoint = None
                     # in case of a queue, we default to a full_event=True
-                    options = {"full_event": step.full_event is not False}
+                    options = {
+                        "full_event": step.full_event
+                        or step.full_event is None
+                        and step.next is not None
+                    }
                     options.update(step.options)
 
                     kafka_brokers = get_kafka_brokers_from_dict(options, pop=True)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1630,7 +1630,8 @@ def _init_async_objects(context, steps):
                 if step.path and not skip_stream:
                     stream_path = step.path
                     endpoint = None
-                    options = {}
+                    # in case of a queue, we default to a full_event=True
+                    options = {"full_event": step.full_event is not False}
                     options.update(step.options)
 
                     kafka_brokers = get_kafka_brokers_from_dict(options, pop=True)


### PR DESCRIPTION
To match the behaviour when engine is async.

[ML-7198](https://iguazio.atlassian.net/browse/ML-7198)

[ML-7198]: https://iguazio.atlassian.net/browse/ML-7198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ