### PR TITLE
[Grafana] Fix `Feature Analysis` API 

### DIFF
--- a/server/api/crud/model_monitoring/grafana.py
+++ b/server/api/crud/model_monitoring/grafana.py
@@ -287,7 +287,6 @@ async def grafana_overall_feature_analysis(
     )
     endpoint = await run_in_threadpool(
         server.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
         project=project,
         endpoint_id=endpoint_id,
         feature_analysis=True,
@@ -349,7 +348,6 @@ async def grafana_incoming_features(
 
     endpoint = await run_in_threadpool(
         server.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
         project=project,
         endpoint_id=endpoint_id,
     )

--- a/server/api/crud/model_monitoring/grafana.py
+++ b/server/api/crud/model_monitoring/grafana.py
@@ -206,7 +206,6 @@ async def grafana_individual_feature_analysis(
 
     endpoint = await run_in_threadpool(
         server.api.crud.ModelEndpoints().get_model_endpoint,
-        auth_info=auth_info,
         project=project,
         endpoint_id=endpoint_id,
         feature_analysis=True,


### PR DESCRIPTION
`Feature Analysis` chart is based on MLRun API (https://github.com/mlrun/mlrun/pull/5065) that calls the `get_model_endpoint` API to get data from the KV table. However, Grafana passed an old parameter called `auth_info` which is no longer needed in this case.

In this PR we fix that issue by avoiding passing that param to the `get_model_endpoint` API. 

Related JIRA: https://iguazio.atlassian.net/browse/ML-7341