### PR TITLE
[Functions] Remove trailing slash when updating external invocation urls

### DIFF
--- a/mlrun/common/schemas/api_gateway.py
+++ b/mlrun/common/schemas/api_gateway.py
@@ -107,7 +107,7 @@ class APIGateway(_APIGatewayBaseModel):
             self.spec.host + self.spec.path
             if self.spec.path and self.spec.host
             else self.spec.host
-        )
+        ).rstrip("/")
 
     def enrich_mlrun_names(self):
         self._enrich_api_gateway_mlrun_name()

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -657,7 +657,7 @@ class APIGateway(ModelObj):
         host = self.spec.host
         if not self.spec.host.startswith("http"):
             host = f"https://{self.spec.host}"
-        return urljoin(host, self.spec.path)
+        return urljoin(host, self.spec.path).rstrip("/")
 
     @staticmethod
     def _generate_basic_auth(username: str, password: str):

--- a/tests/api/crud/test_functions.py
+++ b/tests/api/crud/test_functions.py
@@ -72,9 +72,9 @@ def test_update_functions_with_api_gateway_url(db: sqlalchemy.orm.Session):
     # check that URL is there
     assert updated_function["status"]["external_invocation_urls"][0] == gw_host
 
-    # try to add existed external invocation URL
+    # try to add existing external invocation URL, with a slash at the end
     server.api.crud.Functions().add_function_external_invocation_url(
-        db, uri, project, gw_host
+        db, uri, project, gw_host + "/"
     )
     updated_function = server.api.crud.Functions().get_function(
         db, project=project, name=function_name, tag=function_tag

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1893,7 +1893,7 @@ def test_create_api_gateway_valid(
     assert "metadata" in gateway_dict
     assert "spec" in gateway_dict
 
-    assert gateway.invoke_url == "https://gateway-f1-f2-project-name.some-domain.com/"
+    assert gateway.invoke_url == "https://gateway-f1-f2-project-name.some-domain.com"
     if authentication_mode == mlrun.common.schemas.APIGatewayAuthenticationMode.basic:
         assert gateway.authentication.authentication_mode == "basicAuth"
     elif (

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1999,7 +1999,7 @@ def test_list_api_gateways(patched_list_api_gateways, context):
     assert gateways[0].host == "http://gateway-f1-f2-project-name.some-domain.com"
     assert gateways[0].spec.functions == ["project-name/my-func1"]
 
-    assert gateways[1].invoke_url == "http://test-basic-default.domain.com/"
+    assert gateways[1].invoke_url == "http://test-basic-default.domain.com"
 
 
 def test_project_create_remote():


### PR DESCRIPTION
Sometimes URLs return with a trailing slash and this causes duplicates in the function external invocations url.
Remove them to not cause duplicated.

Also, when updating the external invocation urls and there isn't anything to updated, no need to commit anything to the DB (skip an un-needed DB call).