### PR TITLE
[Runs] Remove for update lock on store run

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -212,7 +212,8 @@ class SQLDB(DBInterface):
             iter=iter,
             run_name=run_data["metadata"]["name"],
         )
-        run = self._get_run(session, uid, project, iter, with_for_update=True)
+        # Do not lock run as it may cause deadlocks
+        run = self._get_run(session, uid, project, iter)
         now = datetime.now(timezone.utc)
         if not run:
             run = Run(


### PR DESCRIPTION
## Root cause:

When transaction A wants to create `runA` it tries to acquire a record lock on non-existing row which results with a next-key lock:

> A next-key lock is a combination of a record lock on the index record and a gap lock on the gap before the index record.
> A next-key lock on an index record also affects the “gap” before that index record.

This locks an area of the index where `runA` should be created.

Then transaction B wants to create `runB` and blocks the same index gap so both sessions share the same record lock.

But wait.. I bet you are thinking what I was. How can they share an exclusive lock ?! well..

> Gap locks in InnoDB are “purely inhibitive”, which means that their only purpose is to prevent other transactions from inserting to the gap. Gap locks can co-exist. A gap lock taken by one transaction does not prevent another transaction from taking a gap lock on the same gap. There is no difference between shared and exclusive gap locks. They do not conflict with each other, and they perform the same function.

Next, transaction A tries to acquire an insert lock on the same gap which is essentially an elevation of the same lock it already has but transaction B is blocking it with the previously acquired gap lock.

Then, transaction B tries to do the same thing - 💥  ***DEADLOCK*** 💥 

## Possible solutions:

1. If the run does not exist, there is no need to hold the gap lock. Therefore we can rollback the transaction.
2. Don’t lock on storing run.

## Considering the previous reason to lock:

The reason we lock when storing run is obviously to avoid race conditions where some flow may override another flow's changes. However, this is anyway the behavior when storing (unlike update or patch) and the original issue was solved by using patch instead of store. This led me to choose solution (2).

## References:

https://dev.mysql.com/doc/refman/8.4/en/innodb-locking.html

https://dev.to/eyo000000/a-straightforward-guide-for-mysql-locks-56i1

https://blog.tekenlight.com/2019/02/21/database-deadlock-mysql.html

## Jira

Current issue - https://iguazio.atlassian.net/browse/ML-7247
Previous issue - https://iguazio.atlassian.net/browse/ML-4991