### PR TITLE
[Application] Support pre-building reverse proxy image

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -930,5 +930,5 @@ class BaseRuntime(ModelObj):
                             line += f", default={p['default']}"
                         print("    " + line)
 
-    def skip_base_image_enrichment(self):
+    def skip_image_enrichment(self):
         return False

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -930,5 +930,5 @@ class BaseRuntime(ModelObj):
                             line += f", default={p['default']}"
                         print("    " + line)
 
-    def skip_image_enrichment(self):
+    def skip_base_image_enrichment(self):
         return False

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -929,3 +929,6 @@ class BaseRuntime(ModelObj):
                         if "default" in p:
                             line += f", default={p['default']}"
                         print("    " + line)
+
+    def skip_image_enrichment(self):
+        return False

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -508,7 +508,7 @@ class ApplicationRuntime(RemoteRuntime):
         # default max replicas is 4, we only need one replica for the reverse proxy
         reverse_proxy_func.spec.max_replicas = 1
 
-        # clear out the base image, so it won't be mlrun/mlrun
+        # the reverse proxy image should not be based on another image
         reverse_proxy_func.set_config("spec.build.baseImage", None)
         reverse_proxy_func.spec.image = ""
         reverse_proxy_func.spec.build.base_image = ""

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -308,10 +308,11 @@ class ApplicationRuntime(RemoteRuntime):
                 show_on_failure=show_on_failure,
             )
 
+        # This is a class method that accepts a function instance, so we pass self as the function instance
         self._ensure_reverse_proxy_configurations(self)
         self._configure_application_sidecar()
 
-        # we only allow accessing the application via the API Gateway
+        # We only allow accessing the application via the API Gateway
         name_tag = tag or self.metadata.tag
         self.status.api_gateway_name = (
             f"{self.metadata.name}-{name_tag}" if name_tag else self.metadata.name
@@ -563,7 +564,7 @@ class ApplicationRuntime(RemoteRuntime):
         )
 
     @staticmethod
-    def _ensure_reverse_proxy_configurations(function):
+    def _ensure_reverse_proxy_configurations(function: RemoteRuntime):
         if function.spec.build.functionSourceCode or function.status.container_image:
             return
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -707,6 +707,11 @@ class RemoteRuntime(KubeResource):
         """
         self.spec.disable_default_http_trigger = False
 
+    def skip_image_enrichment(self):
+        return (
+            self.spec.nuclio_runtime is None or "python" not in self.spec.nuclio_runtime
+        )
+
     def _get_state(
         self,
         dashboard="",

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -707,8 +707,8 @@ class RemoteRuntime(KubeResource):
         """
         self.spec.disable_default_http_trigger = False
 
-    def skip_base_image_enrichment(self):
-        # make sure the API does not enrich the base image with mlrun/mlrun if the function is not a python function
+    def skip_image_enrichment(self):
+        # make sure the API does not enrich the base image if the function is not a python function
         return (
             self.spec.nuclio_runtime is None or "python" not in self.spec.nuclio_runtime
         )

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -709,9 +709,7 @@ class RemoteRuntime(KubeResource):
 
     def skip_image_enrichment(self):
         # make sure the API does not enrich the base image if the function is not a python function
-        return (
-            self.spec.nuclio_runtime is None or "python" not in self.spec.nuclio_runtime
-        )
+        return self.spec.nuclio_runtime and "python" not in self.spec.nuclio_runtime
 
     def _get_state(
         self,

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -707,7 +707,8 @@ class RemoteRuntime(KubeResource):
         """
         self.spec.disable_default_http_trigger = False
 
-    def skip_image_enrichment(self):
+    def skip_base_image_enrichment(self):
+        # make sure the API does not enrich the base image with mlrun/mlrun if the function is not a python function
         return (
             self.spec.nuclio_runtime is None or "python" not in self.spec.nuclio_runtime
         )

--- a/server/api/launcher.py
+++ b/server/api/launcher.py
@@ -280,7 +280,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
             not runtime.spec.image
             and not runtime.requires_build()
             and runtime.kind in mlrun.mlconf.function_defaults.image_by_kind.to_dict()
-            and not runtime.skip_base_image_enrichment()
+            and not runtime.skip_image_enrichment()
         ):
             runtime.spec.image = mlrun.mlconf.function_defaults.image_by_kind.to_dict()[
                 runtime.kind

--- a/server/api/launcher.py
+++ b/server/api/launcher.py
@@ -292,7 +292,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
             not runtime.spec.image
             and not runtime.requires_build()
             and runtime.kind in mlrun.mlconf.function_defaults.image_by_kind.to_dict()
-            and not runtime.skip_image_enrichment()
+            and not runtime.skip_base_image_enrichment()
         ):
             runtime.spec.image = mlrun.mlconf.function_defaults.image_by_kind.to_dict()[
                 runtime.kind

--- a/server/api/launcher.py
+++ b/server/api/launcher.py
@@ -292,6 +292,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
             not runtime.spec.image
             and not runtime.requires_build()
             and runtime.kind in mlrun.mlconf.function_defaults.image_by_kind.to_dict()
+            and not runtime.skip_image_enrichment()
         ):
             runtime.spec.image = mlrun.mlconf.function_defaults.image_by_kind.to_dict()[
                 runtime.kind

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -339,6 +339,9 @@ class RunDBMock:
             raise mlrun.errors.MLRunNotFoundError("Function not found")
         return self._functions[function]
 
+    def delete_function(self, name: str, project: str = ""):
+        self._functions.pop(name, None)
+
     def submit_job(self, runspec, schedule=None):
         return {"status": {"status_text": "just a status"}}
 
@@ -395,6 +398,7 @@ class RunDBMock:
         function.setdefault("status", {})
         function["status"]["state"] = "ready"
         function["status"]["nuclio_name"] = "test-nuclio-name"
+        function["status"]["container_image"] = function["metadata"]["name"]
         self._functions[function["metadata"]["name"]] = function
         return {
             "data": {

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -19,6 +19,7 @@ import pytest
 
 import mlrun
 import mlrun.common.schemas
+import mlrun.runtimes
 import mlrun.utils
 
 
@@ -245,6 +246,11 @@ def test_application_runtime_resources(rundb_mock, igz_version_mock):
             },
         }
     ]
+
+
+def test_deploy_reverse_proxy_image(rundb_mock, igz_version_mock):
+    mlrun.runtimes.ApplicationRuntime.deploy_reverse_proxy_image()
+    assert mlrun.runtimes.ApplicationRuntime.reverse_proxy_image
 
 
 def _assert_function_code(fn, file_path=None):

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -16,6 +16,7 @@ import io
 import os
 import sys
 
+import mlrun.runtimes
 import tests.system.base
 
 
@@ -110,6 +111,24 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
                 pull_at_runtime=False,
             )
         return function, source
+
+    def test_deploy_reverse_proxy_base_image(self):
+        tests.system.base.TestMLRunSystem._logger.debug(
+            "Deploying reverse proxy base image"
+        )
+        mlrun.runtimes.ApplicationRuntime.deploy_reverse_proxy_image()
+        assert mlrun.runtimes.ApplicationRuntime.reverse_proxy_image
+
+        # deploy an application and expect it to use the reverse proxy image
+        function, source = self._create_vizro_application()
+
+        self._logger.debug("Deploying vizro application")
+        function.deploy(with_mlrun=False)
+
+        assert (
+            function.status.container_image
+            == mlrun.runtimes.ApplicationRuntime.reverse_proxy_image
+        )
 
     @staticmethod
     def _deploy_application_with_stdout_capture(function):


### PR DESCRIPTION
Add an option to pre-deploy the reverse proxy image for using it in application runtime.

The 2 main reasons for this are:
1. Speed up deployment - if specifying an existing application image, the build time is only for the reverse proxy. If it is pre-built the function can be deploying much quicker.
2. Using application runtime in air-gapped environments - There is a known issue where golang images cannot be built in an air-gapped environment. To overcome this, users can build the reverse proxy image (golang image) in an exposed environment, and save it in the air-gapped docker registry. This can later be used when creation application functions.

### Usage:
```python
import mlrun

# build the reverse proxy image
mlrun.runtimes.nuclio.application.ApplicationRuntime.deploy_reverse_proxy_image()

# the image is saved on the class:
mlrun.runtimes.nuclio.application.ApplicationRuntime.reverse_proxy_image
```

When the image is set on the class, it will automatically be used by following deployments of instances.

For air-gapped systems, we can also use:
```python
application.from_image(reverse_proxy_image)
```

https://iguazio.atlassian.net/browse/ML-7236