### PR TITLE
[API Gateway] Fix invocation URL deletion

### DIFF
--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -137,15 +137,14 @@ async def store_api_gateway(
                 if func not in api_gateway.get_function_names()
             ]
             # if invocation URL has changed, delete URL from all the functions
-            # if only function list has changed, then delete URL only from those functions
-            # which are not used in api gateway anymore
             if existing_api_gateway.get_invoke_url != api_gateway.get_invoke_url:
-                # delete api gateway url from all the functions from old api gateway
                 await _delete_functions_external_invocation_url(
                     project=project,
                     url=existing_api_gateway.get_invoke_url(),
                     function_names=existing_api_gateway.get_function_names(),
                 )
+            # if only functions list has changed, then delete URL only from those functions
+            # which are not used in api gateway anymore
             elif unused_functions:
                 # delete api gateway url from those functions which are not used in api gateway anymore
                 await _delete_functions_external_invocation_url(

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -136,7 +136,17 @@ async def store_api_gateway(
                 for func in existing_api_gateway.get_function_names()
                 if func not in api_gateway.get_function_names()
             ]
-            if unused_functions:
+            # if invocation URL has changed, delete URL from all the functions
+            # if only function list has changed, then delete URL only from those functions
+            # which are not used in api gateway anymore
+            if existing_api_gateway.get_invoke_url != api_gateway.get_invoke_url:
+                # delete api gateway url from all the functions from old api gateway
+                await _delete_functions_external_invocation_url(
+                    project=project,
+                    url=existing_api_gateway.get_invoke_url(),
+                    function_names=existing_api_gateway.get_function_names(),
+                )
+            elif unused_functions:
                 # delete api gateway url from those functions which are not used in api gateway anymore
                 await _delete_functions_external_invocation_url(
                     project=project,


### PR DESCRIPTION
This PR addresses the bug of not deleting old invocation URL when changing API Gateway's path. 

Jira - https://iguazio.atlassian.net/browse/ML-6970