### PR TITLE
[Model Monitoring] Fix credentials limitation to old clients

### DIFF
--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import typing
 
 import fastapi
+from fastapi import Header
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
@@ -41,6 +43,9 @@ async def create_model_monitoring_controller(
     db_session: Session = fastapi.Depends(deps.get_db_session),
     default_controller_image: str = "mlrun/mlrun",
     base_period: int = 10,
+    client_version: typing.Optional[str] = Header(
+        None, alias=mlrun.common.schemas.HeaderNames.client_version
+    ),
 ):
     """
     Deploy model monitoring application controller, writer and stream functions.
@@ -58,6 +63,7 @@ async def create_model_monitoring_controller(
                                      image. By default, the image is mlrun/mlrun.
     :param base_period:              Minutes to determine the frequency in which the model monitoring controller job
                                      is running. By default, the base period is 5 minutes.
+    :param client_version:           The client version that sent the request.
     """
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
@@ -84,6 +90,7 @@ async def create_model_monitoring_controller(
         image=default_controller_image,
         base_period=base_period,
         deploy_histogram_data_drift_app=False,  # mlrun client < 1.7.0
+        client_version=client_version,
     )
 
     return {

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Annotated, Optional
 
 import fastapi
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Header, Query
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
@@ -93,6 +93,9 @@ async def enable_model_monitoring(
     deploy_histogram_data_drift_app: bool = True,
     rebuild_images: bool = False,
     fetch_credentials_from_sys_config: bool = False,
+    client_version: Optional[str] = Header(
+        None, alias=mlrun.common.schemas.HeaderNames.client_version
+    ),
 ):
     """
     Deploy model monitoring application controller, writer and stream functions.
@@ -112,6 +115,7 @@ async def enable_model_monitoring(
     :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
                                               (controller, writer & stream).
     :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
+    :param client_version:                    The client version.
 
     """
     MonitoringDeployment(
@@ -125,6 +129,7 @@ async def enable_model_monitoring(
         deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
         rebuild_images=rebuild_images,
         fetch_credentials_from_sys_config=fetch_credentials_from_sys_config,
+        client_version=client_version,
     )
 
 
@@ -208,6 +213,9 @@ async def disable_model_monitoring(
     delete_histogram_data_drift_app: bool = True,
     delete_user_applications: bool = False,
     user_application_list: list[str] = None,
+    client_version: Optional[str] = Header(
+        None, alias=mlrun.common.schemas.HeaderNames.client_version
+    ),
 ):
     """
     Disable model monitoring application controller, writer, stream, histogram data drift application
@@ -231,6 +239,7 @@ async def disable_model_monitoring(
                                                 Default all the applications.
                                                 Note: you have to set delete_user_applications to True
                                                 in order to delete the desired application.
+    :param client_version:                      The client version.
 
     """
     tasks = await MonitoringDeployment(
@@ -245,6 +254,7 @@ async def disable_model_monitoring(
         delete_user_applications=delete_user_applications,
         user_application_list=user_application_list,
         background_tasks=background_tasks,
+        client_version=client_version,
     )
     response.status_code = http.HTTPStatus.ACCEPTED.value
     return tasks

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -517,8 +517,7 @@ def _deploy_nuclio_runtime(
         except mlrun.errors.MLRunBadRequestError as exc:
             raise_error = True
             if (
-                fn.spec.image.startswith("mlrun/")
-                and client_version
+                client_version
                 and (
                     semver.Version.parse(client_version) < semver.Version.parse("1.7.0")
                     or "unstable" in client_version

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -17,6 +17,7 @@ import traceback
 import typing
 from http import HTTPStatus
 
+import semver
 import sqlalchemy.orm
 from fastapi import APIRouter, Depends, Header, Request, Response
 from fastapi.concurrency import run_in_threadpool
@@ -514,16 +515,40 @@ def _deploy_nuclio_runtime(
                 with_upgrade_case_check=True
             )
         except mlrun.errors.MLRunBadRequestError as exc:
-            if monitoring_application:
-                err_txt = f"Can not deploy model monitoring application due to: {exc}"
-            else:
-                err_txt = (
-                    f"Can not deploy serving function with track models due to: {exc}"
+            raise_error = True
+            if (
+                fn.spec.image.startswith("mlrun/")
+                and client_version
+                and (
+                    semver.Version.parse(client_version) < semver.Version.parse("1.7.0")
+                    or "unstable" in client_version
                 )
-            server.api.api.utils.log_and_raise(
-                HTTPStatus.BAD_REQUEST.value,
-                reason=err_txt,
-            )
+            ):
+                logger.info(
+                    "Setting credentials for older client version(1.7.0), using v3io as default (not in ce mode)"
+                )
+                try:
+                    monitoring_deployment.set_credentials(
+                        _default_secrets_v3io=mm_constants.V3IO_MODEL_MONITORING_DB
+                        if not mlrun.mlconf.is_ce_mode()
+                        else None,
+                        replace_creds=True,
+                    )
+                    raise_error = False
+                except mlrun.errors.MLRunInvalidMMStoreType:
+                    raise_error = True
+
+            if raise_error:
+                if monitoring_application:
+                    err_txt = (
+                        f"Can not deploy model monitoring application due to: {exc}"
+                    )
+                else:
+                    err_txt = f"Can not deploy serving function with track models due to: {exc}"
+                server.api.api.utils.log_and_raise(
+                    HTTPStatus.BAD_REQUEST.value,
+                    reason=err_txt,
+                )
         if monitoring_application:
             fn = monitoring_deployment.apply_and_create_stream_trigger(
                 function=fn,

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -101,6 +101,7 @@ class MonitoringDeployment:
         deploy_histogram_data_drift_app: bool = True,
         rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
+        client_version: str = None,
     ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
@@ -114,11 +115,14 @@ class MonitoringDeployment:
         :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
                                                   (controller, writer & stream).
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
+        :param client_version:                    The client version that is used to deploy the function.
         """
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
             self.set_credentials()
-        self.check_if_credentials_are_set(with_upgrade_case_check=True)
+        self.check_if_credentials_are_set(
+            with_upgrade_case_check=True, client_version=client_version
+        )
 
         self.deploy_model_monitoring_controller(
             controller_image=image, base_period=base_period, overwrite=rebuild_images
@@ -703,6 +707,7 @@ class MonitoringDeployment:
         delete_user_applications: bool = False,
         user_application_list: list[str] = None,
         background_tasks: fastapi.BackgroundTasks = None,
+        client_version: str = None,
     ) -> mlrun.common.schemas.BackgroundTaskList:
         """
         Disable model monitoring application controller, writer, stream, histogram data drift application
@@ -724,8 +729,9 @@ class MonitoringDeployment:
                                                     Note: you have to set delete_user_applications to True
                                                     in order to delete the desired application.
         :param background_tasks:                    Fastapi Background tasks.
+        :param client_version:                      The client version that is used to deploy the function.
         """
-        self._set_credentials_after_server_upgrade()
+        self._set_credentials_after_server_upgrade(client_version=client_version)
         function_to_delete = []
         if delete_resources:
             function_to_delete = mm_constants.MonitoringFunctionNames.list()
@@ -998,12 +1004,15 @@ class MonitoringDeployment:
 
         return credentials_dict
 
-    def check_if_credentials_are_set(self, with_upgrade_case_check: bool = False):
+    def check_if_credentials_are_set(
+        self, with_upgrade_case_check: bool = False, client_version: str = None
+    ):
         """
         Check if the model monitoring credentials are set. If not, raise an error.
 
         :param with_upgrade_case_check:         If True, check if indeed the project is an old(<1.7.0) project
                                                 that had model monitoring, if indeed, set the credentials.
+        :param client_version:                  The client version that is used to deploy the function.
         :raise mlrun.errors.MLRunBadRequestError:  if the credentials are not set.
         """
 
@@ -1020,7 +1029,9 @@ class MonitoringDeployment:
         ):
             return
         if with_upgrade_case_check:
-            with_upgrade_case_check = self._set_credentials_after_server_upgrade()
+            with_upgrade_case_check = self._set_credentials_after_server_upgrade(
+                client_version=client_version
+            )
 
         if not with_upgrade_case_check:
             raise mlrun.errors.MLRunBadRequestError(
@@ -1029,7 +1040,7 @@ class MonitoringDeployment:
                 "or pass fetch_credentials_from_sys_config=True when using enable_model_monitoring API/SDK."
             )
 
-    def _set_credentials_after_server_upgrade(self) -> bool:
+    def _set_credentials_after_server_upgrade(self, client_version: str = None) -> bool:
         """
         Check and set the model monitoring credentials for old project that included model monitoring before the server
         upgrade. Will set the credentials only if at least one of the following conditions is met:
@@ -1038,10 +1049,12 @@ class MonitoringDeployment:
             3. Part of the model monitoring credentials are already set
         If True, set the cred in to the project secret (from exist cred/from sys config/v3io by default).
 
+        :param client_version: The client version.
+
         :return: True if the credentials are set, otherwise False.
         """
         credentials_dict = self._get_monitoring_mandatory_project_secrets()
-        mm_enabled = False
+        set_cred = False
         store_connection_string = (
             credentials_dict.get(
                 mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION
@@ -1059,7 +1072,12 @@ class MonitoringDeployment:
 
         if store_connector and store_connector.list_model_endpoints():
             # if there are model endpoints, the project has monitoring
-            mm_enabled = True
+            set_cred = True
+        elif client_version and (
+            semver.Version.parse(client_version) < semver.Version.parse("1.7.0")
+            or "unstable" in client_version
+        ):
+            set_cred = True
         else:
             try:
                 server.api.crud.Functions().get_function(
@@ -1068,7 +1086,7 @@ class MonitoringDeployment:
                     project=self.project,
                 )
                 # if stream pod is on, the project has monitoring
-                mm_enabled = True
+                set_cred = True
             except mlrun.errors.MLRunNotFoundError:
                 # if one of the cred is already set, the project has monitoring
                 if any(
@@ -1080,16 +1098,20 @@ class MonitoringDeployment:
                     ]
                     # stream is not mandatory for now for BC, Todo: del in 1.9.0
                 ):
-                    mm_enabled = True
+                    set_cred = True
 
-        if mm_enabled and None in credentials_dict.values():
+        if set_cred and None in credentials_dict.values():
+            logger.info(
+                "Setting credentials for older client version(1.7.0)/ old projects, "
+                "using v3io as default (not in ce mode)"
+            )
             self.set_credentials(
                 _default_secrets_v3io=mm_constants.V3IO_MODEL_MONITORING_DB
                 if not mlrun.mlconf.is_ce_mode()
                 else None,
                 replace_creds=True,
             )
-        return mm_enabled
+        return set_cred
 
     def set_credentials(
         self,
@@ -1099,6 +1121,7 @@ class MonitoringDeployment:
         tsdb_connection: typing.Optional[str] = None,
         replace_creds: bool = False,
         _default_secrets_v3io: typing.Optional[str] = None,
+        client_version: str = None,
     ) -> None:
         """
         Set the model monitoring credentials for the project. The credentials are stored in the project secrets.
@@ -1129,6 +1152,7 @@ class MonitoringDeployment:
         :param replace_creds:             If True, the credentials will be set even if they are already set.
         :param _default_secrets_v3io:     Optional parameter for the upgrade process in which the v3io default secret
                                           key is set.
+        :param client_version:            The client version that is used to deploy the function.
         :raise MLRunConflictError:        If the credentials are already set for the project and the user
                                           provided different creds.
         :raise MLRunInvalidMMStoreType:   If the user provided invalid credentials.
@@ -1152,7 +1176,9 @@ class MonitoringDeployment:
                 # the credentials are not set
                 pass
 
-            if self._set_credentials_after_server_upgrade():
+            if self._set_credentials_after_server_upgrade(
+                client_version=client_version
+            ):
                 raise mlrun.errors.MLRunConflictError(
                     f"For {self.project} the credentials are already set, if you want to set new credentials, "
                     f"please set replace_creds=True"

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -1121,7 +1121,6 @@ class MonitoringDeployment:
         tsdb_connection: typing.Optional[str] = None,
         replace_creds: bool = False,
         _default_secrets_v3io: typing.Optional[str] = None,
-        client_version: str = None,
     ) -> None:
         """
         Set the model monitoring credentials for the project. The credentials are stored in the project secrets.
@@ -1176,9 +1175,7 @@ class MonitoringDeployment:
                 # the credentials are not set
                 pass
 
-            if self._set_credentials_after_server_upgrade(
-                client_version=client_version
-            ):
+            if self._set_credentials_after_server_upgrade():
                 raise mlrun.errors.MLRunConflictError(
                     f"For {self.project} the credentials are already set, if you want to set new credentials, "
                     f"please set replace_creds=True"

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -115,7 +115,7 @@ class MonitoringDeployment:
         :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
                                                   (controller, writer & stream).
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
-        :param client_version:                    The client version that is used to deploy the function.
+        :param client_version:                    The client version.
         """
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
@@ -729,7 +729,7 @@ class MonitoringDeployment:
                                                     Note: you have to set delete_user_applications to True
                                                     in order to delete the desired application.
         :param background_tasks:                    Fastapi Background tasks.
-        :param client_version:                      The client version that is used to deploy the function.
+        :param client_version:                      The client version.
         """
         self._set_credentials_after_server_upgrade(client_version=client_version)
         function_to_delete = []
@@ -1012,7 +1012,7 @@ class MonitoringDeployment:
 
         :param with_upgrade_case_check:         If True, check if indeed the project is an old(<1.7.0) project
                                                 that had model monitoring, if indeed, set the credentials.
-        :param client_version:                  The client version that is used to deploy the function.
+        :param client_version:                  The client version.
         :raise mlrun.errors.MLRunBadRequestError:  if the credentials are not set.
         """
 
@@ -1152,7 +1152,7 @@ class MonitoringDeployment:
         :param replace_creds:             If True, the credentials will be set even if they are already set.
         :param _default_secrets_v3io:     Optional parameter for the upgrade process in which the v3io default secret
                                           key is set.
-        :param client_version:            The client version that is used to deploy the function.
+        :param client_version:            The client version.
         :raise MLRunConflictError:        If the credentials are already set for the project and the user
                                           provided different creds.
         :raise MLRunInvalidMMStoreType:   If the user provided invalid credentials.


### PR DESCRIPTION
Fix this issue for running `enabale_model_monitoring` and for  deploying of tracked model server / monitoring application.

related jira  - https://iguazio.atlassian.net/browse/ML-7321