### PR TITLE
[Model Monitoring] Fix storage size limit for both V3IO KV and MySQL 

### DIFF
--- a/mlrun/model_monitoring/db/stores/sqldb/models/base.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/base.py
@@ -23,6 +23,8 @@ from sqlalchemy import (
     Text,
 )
 
+from sqlalchemy.dialects.mysql import MEDIUMTEXT
+
 from mlrun.common.schemas.model_monitoring import (
     EventFieldType,
     FileTargetKind,
@@ -65,8 +67,8 @@ class ModelEndpointsBaseTable(BaseModel):
         EventFieldType.MONITORING_MODE,
         String(10),
     )
-    feature_stats = Column(EventFieldType.FEATURE_STATS, Text)
-    current_stats = Column(EventFieldType.CURRENT_STATS, Text)
+    feature_stats = Column(EventFieldType.FEATURE_STATS, MEDIUMTEXT)
+    current_stats = Column(EventFieldType.CURRENT_STATS, MEDIUMTEXT)
     feature_names = Column(EventFieldType.FEATURE_NAMES, Text)
     children = Column(EventFieldType.CHILDREN, Text)
     label_names = Column(EventFieldType.LABEL_NAMES, Text)
@@ -89,7 +91,7 @@ class ModelEndpointsBaseTable(BaseModel):
         String(255),
     )
     error_count = Column(EventFieldType.ERROR_COUNT, Integer)
-    metrics = Column(EventFieldType.METRICS, Text)
+    metrics = Column(EventFieldType.METRICS, MEDIUMTEXT)
     first_request = Column(
         EventFieldType.FIRST_REQUEST,
         TIMESTAMP(timezone=True),  # TODO: migrate to DATETIME, see ML-6921
@@ -134,8 +136,8 @@ class ApplicationResultBaseTable(BaseModel):
     result_status = Column(ResultData.RESULT_STATUS, String(10))
     result_kind = Column(ResultData.RESULT_KIND, String(40))
     result_value = Column(ResultData.RESULT_VALUE, Float)
-    result_extra_data = Column(ResultData.RESULT_EXTRA_DATA, Text)
-    current_stats = Column(ResultData.CURRENT_STATS, Text)
+    result_extra_data = Column(ResultData.RESULT_EXTRA_DATA, MEDIUMTEXT)
+    current_stats = Column(ResultData.CURRENT_STATS, MEDIUMTEXT)
 
 
 class ApplicationMetricsBaseTable(BaseModel):

--- a/mlrun/model_monitoring/db/stores/sqldb/models/base.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/base.py
@@ -22,7 +22,6 @@ from sqlalchemy import (
     String,
     Text,
 )
-
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 
 from mlrun.common.schemas.model_monitoring import (

--- a/mlrun/model_monitoring/db/stores/sqldb/models/base.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/base.py
@@ -22,7 +22,6 @@ from sqlalchemy import (
     String,
     Text,
 )
-from sqlalchemy.dialects.mysql import MEDIUMTEXT
 
 from mlrun.common.schemas.model_monitoring import (
     EventFieldType,
@@ -66,8 +65,8 @@ class ModelEndpointsBaseTable(BaseModel):
         EventFieldType.MONITORING_MODE,
         String(10),
     )
-    feature_stats = Column(EventFieldType.FEATURE_STATS, MEDIUMTEXT)
-    current_stats = Column(EventFieldType.CURRENT_STATS, MEDIUMTEXT)
+    feature_stats = Column(EventFieldType.FEATURE_STATS, Text)
+    current_stats = Column(EventFieldType.CURRENT_STATS, Text)
     feature_names = Column(EventFieldType.FEATURE_NAMES, Text)
     children = Column(EventFieldType.CHILDREN, Text)
     label_names = Column(EventFieldType.LABEL_NAMES, Text)
@@ -90,7 +89,7 @@ class ModelEndpointsBaseTable(BaseModel):
         String(255),
     )
     error_count = Column(EventFieldType.ERROR_COUNT, Integer)
-    metrics = Column(EventFieldType.METRICS, MEDIUMTEXT)
+    metrics = Column(EventFieldType.METRICS, Text)
     first_request = Column(
         EventFieldType.FIRST_REQUEST,
         TIMESTAMP(timezone=True),  # TODO: migrate to DATETIME, see ML-6921
@@ -135,8 +134,8 @@ class ApplicationResultBaseTable(BaseModel):
     result_status = Column(ResultData.RESULT_STATUS, String(10))
     result_kind = Column(ResultData.RESULT_KIND, String(40))
     result_value = Column(ResultData.RESULT_VALUE, Float)
-    result_extra_data = Column(ResultData.RESULT_EXTRA_DATA, MEDIUMTEXT)
-    current_stats = Column(ResultData.CURRENT_STATS, MEDIUMTEXT)
+    result_extra_data = Column(ResultData.RESULT_EXTRA_DATA, Text)
+    current_stats = Column(ResultData.CURRENT_STATS, Text)
 
 
 class ApplicationMetricsBaseTable(BaseModel):

--- a/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
+++ b/mlrun/model_monitoring/db/stores/sqldb/models/mysql.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.declarative import declarative_base, declared_attr
 
 from mlrun.common.schemas.model_monitoring import (
     EventFieldType,
+    ResultData,
     WriterEvent,
 )
 
@@ -32,6 +33,13 @@ Base = declarative_base()
 
 
 class ModelEndpointsTable(Base, ModelEndpointsBaseTable):
+    feature_stats = Column(
+        EventFieldType.FEATURE_STATS, sqlalchemy.dialects.mysql.MEDIUMTEXT
+    )
+    current_stats = Column(
+        EventFieldType.CURRENT_STATS, sqlalchemy.dialects.mysql.MEDIUMTEXT
+    )
+    metrics = Column(EventFieldType.METRICS, sqlalchemy.dialects.mysql.MEDIUMTEXT)
     first_request = Column(
         EventFieldType.FIRST_REQUEST,
         # TODO: migrate to DATETIME, see ML-6921
@@ -72,7 +80,12 @@ class _ApplicationResultOrMetric:
 class ApplicationResultTable(
     Base, _ApplicationResultOrMetric, ApplicationResultBaseTable
 ):
-    pass
+    result_extra_data = Column(
+        ResultData.RESULT_EXTRA_DATA, sqlalchemy.dialects.mysql.MEDIUMTEXT
+    )
+    current_stats = Column(
+        ResultData.CURRENT_STATS, sqlalchemy.dialects.mysql.MEDIUMTEXT
+    )
 
 
 class ApplicationMetricsTable(

--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -350,7 +350,7 @@ class KVStoreBase(StoreBase):
             table_path = self._get_results_table_path(endpoint_id)
             key = event.pop(mm_schemas.WriterEvent.APPLICATION_NAME)
             metric_name = event.pop(mm_schemas.ResultData.RESULT_NAME)
-            attributes = {metric_name: json.dumps(event)}
+            attributes = {metric_name: self._encode_field(json.dumps(event))}
         else:
             raise ValueError(f"Invalid {kind = }")
 

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1285,15 +1285,15 @@ class TestModelEndpointWithManyFeatures(TestMLRunSystem):
         )
 
         # Generate a model with 500 features
-        X, y = make_classification(n_samples=1000, n_features=500, random_state=42)
-        X_train, X_test, y_train, y_test = train_test_split(
-            X, y, train_size=0.8, test_size=0.2, random_state=42
+        x, y = make_classification(n_samples=1000, n_features=500, random_state=42)
+        x_train, x_test, y_train, y_test = train_test_split(
+            x, y, train_size=0.8, test_size=0.2, random_state=42
         )
         model = LinearRegression()
-        model.fit(X_train, y_train)
-        X_test = pd.DataFrame(X_test, columns=[f"column_{i}" for i in range(500)])
+        model.fit(x_train, y_train)
+        x_test = pd.DataFrame(x_test, columns=[f"column_{i}" for i in range(500)])
         y_test = pd.DataFrame(y_test, columns=["label"])
-        training_set = pd.concat([X_test, y_test], axis=1)
+        training_set = pd.concat([x_test, y_test], axis=1)
 
         model_obj = project.log_model(
             key="model",

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -26,7 +26,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import v3iofs
-from sklearn.datasets import load_diabetes, load_iris
+from sklearn.datasets import load_diabetes, load_iris, make_classification
+from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
 
@@ -1255,3 +1256,59 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
         sleep(130)
 
         self._test_v3io_tsdb_record()
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+@pytest.mark.model_monitoring
+class TestModelEndpointWithManyFeatures(TestMLRunSystem):
+    """Log a model with 500 features and validate the model endpoint feature stats."""
+
+    project_name = "pr-many-features-model-monitoring"
+
+    @pytest.mark.parametrize(
+        "with_sql_target",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_model_endpoint_with_many_features(self, with_sql_target: bool) -> None:
+        project = self.project
+
+        project.set_model_monitoring_credentials(
+            endpoint_store_connection=_MLRUN_MODEL_MONITORING_DB
+            if with_sql_target
+            else mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection,
+            stream_path=mlrun.mlconf.model_endpoint_monitoring.stream_connection,
+            tsdb_connection=mlrun.mlconf.model_endpoint_monitoring.tsdb_connection,
+        )
+
+        # Generate a model with 500 features
+        X, y = make_classification(n_samples=1000, n_features=500, random_state=42)
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, train_size=0.8, test_size=0.2, random_state=42
+        )
+        model = LinearRegression()
+        model.fit(X_train, y_train)
+        X_test = pd.DataFrame(X_test, columns=[f"column_{i}" for i in range(500)])
+        y_test = pd.DataFrame(y_test, columns=["label"])
+        training_set = pd.concat([X_test, y_test], axis=1)
+
+        model_obj = project.log_model(
+            key="model",
+            body=pickle.dumps(model),
+            model_file="model.pkl",
+            training_set=training_set,
+            label_column="label",
+        )
+
+        # Generate a model endpoint
+        model_endpoint = mlrun.model_monitoring.api.get_or_create_model_endpoint(
+            project=project.name,
+            model_path=model_obj.uri,
+            function_name="dummy_func",
+            model_endpoint_name="dummy_ep",
+        )
+
+        assert len(model_endpoint.status.feature_stats) == 501


### PR DESCRIPTION
This PR fix data storage limitations within both V3IO KV and MySQL databases. These issues were exposed when testing a model with 200 features. 

The main changes are: 

- **V3IO KV**:  encode application result into binary string (~64KB -> ~1MB).
- **MySQL**: convert metrics and statistics columns `feature_stats`, `current_stats`, `metrics`, and `result_extra_data` from `TEXT` to `MEDIUMTEXT` (~64KB -> ~16MB).

In addition, we add a new test that validates that a model endpoint can be generated from a model with 500 features. 

Related JIRA: https://iguazio.atlassian.net/browse/ML-6963