### PR TITLE
[K8S] Fix deleting project secret flow

### DIFF
--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -595,9 +595,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 )
                 raise exc
 
-        if k8s_secret.data is None:
+        if not k8s_secret.data:
             logger.debug(
-                "Kubernetes secret data not found",
+                "No data found in the Kubernetes secret",
                 secret_name=secret_name,
             )
             return None

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -605,7 +605,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 "No data found in the Kubernetes secret",
                 secret_name=secret_name,
             )
-            return None
+            self.v1api.delete_namespaced_secret(secret_name, namespace)
+            return mlrun.common.schemas.SecretEventActions.deleted
 
         # Create a copy of the k8s secret data, filtering out specified secrets if any
         if secrets:

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -595,6 +595,13 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 )
                 raise exc
 
+        if k8s_secret.data is None:
+            logger.debug(
+                "Kubernetes secret data not found",
+                secret_name=secret_name,
+            )
+            return None
+
         # Create a copy of the k8s secret data, filtering out specified secrets if any
         if secrets:
             secret_data = {

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -80,6 +80,7 @@ def test_get_logger_pods_label_selector(
     "k8s_secret_data,secrets_data",
     [
         ({"key1": "value1", "key2": "value2"}, []),
+        ({"key1": "value1", "key2": "value2"}, None),
         (None, ["key1"]),
     ],
 )

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -82,6 +82,7 @@ def test_get_logger_pods_label_selector(
         ({"key1": "value1", "key2": "value2"}, []),
         ({"key1": "value1", "key2": "value2"}, None),
         (None, ["key1"]),
+        ({}, ["key1"]),
     ],
 )
 def test_delete_secrets_no_changes(k8s_helper, k8s_secret_data, secrets_data):

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -124,14 +124,14 @@ def test_store_secret(k8s_helper, secret_data, secrets, expected_data, expected_
             None,
             {"key1": "value1", "key2": "value2"},
         ),
-        (None, ["key1"], None, {}),
-        ({}, ["key1"], None, {}),
         (
             {"key1": "value1", "key2": "value2"},
             ["key3"],
             None,
             {"key1": "value1", "key2": "value2"},
         ),
+        (None, ["key1"], mlrun.common.schemas.SecretEventActions.deleted, {}),
+        ({}, ["key1"], mlrun.common.schemas.SecretEventActions.deleted, {}),
         (
             {"key1": "value1"},
             ["key1"],

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -83,6 +83,7 @@ def test_get_logger_pods_label_selector(
         ({"key1": "value1", "key2": "value2"}, None),
         (None, ["key1"]),
         ({}, ["key1"]),
+        ({"key1": "value1", "key2": "value2"}, ["key3"]),
     ],
 )
 def test_delete_secrets_no_changes(k8s_helper, k8s_secret_data, secrets_data):

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -77,50 +77,6 @@ def test_get_logger_pods_label_selector(
 
 
 @pytest.mark.parametrize(
-    "k8s_secret_data,secrets_data",
-    [
-        ({"key1": "value1", "key2": "value2"}, []),
-        ({"key1": "value1", "key2": "value2"}, None),
-        (None, ["key1"]),
-        ({}, ["key1"]),
-        ({"key1": "value1", "key2": "value2"}, ["key3"]),
-    ],
-)
-def test_delete_secrets_no_changes_with_no_key_overlap(
-    k8s_helper, k8s_secret_data, secrets_data
-):
-    k8s_helper.v1api.read_namespaced_secret.return_value = unittest.mock.MagicMock(
-        data=k8s_secret_data
-    )
-
-    result = k8s_helper.delete_secrets("my-secret", secrets_data)
-    assert result is None
-
-
-def test_delete_secrets_confirms_deletion_for_matching_keys(k8s_helper):
-    secret_data = {"key1": "value1"}
-    k8s_secret_mock = unittest.mock.MagicMock(data=secret_data)
-    k8s_helper.v1api.read_namespaced_secret.return_value = k8s_secret_mock
-
-    result = k8s_helper.delete_secrets("my-secret", ["key1"])
-    assert result == mlrun.common.schemas.SecretEventActions.deleted
-
-
-def test_delete_secrets_secret_found_with_changes(k8s_helper):
-    secret_data = {"key1": "value1", "key2": "value2"}
-    k8s_secret_mock = unittest.mock.MagicMock(data=secret_data)
-    k8s_helper.v1api.read_namespaced_secret.return_value = k8s_secret_mock
-
-    result = k8s_helper.delete_secrets("my-secret", ["key1"])
-    assert result == mlrun.common.schemas.SecretEventActions.updated
-
-    k8s_secret_mock.data = {"key2": "value2"}
-    k8s_helper.v1api.replace_namespaced_secret.assert_called_once_with(
-        "my-secret", k8s_helper.namespace, k8s_secret_mock
-    )
-
-
-@pytest.mark.parametrize(
     "k8s_secret_data, secrets_data, expected_action, expected_secret_data",
     [
         (

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -86,7 +86,9 @@ def test_get_logger_pods_label_selector(
         ({"key1": "value1", "key2": "value2"}, ["key3"]),
     ],
 )
-def test_delete_secrets_no_changes(k8s_helper, k8s_secret_data, secrets_data):
+def test_delete_secrets_no_changes_with_no_key_overlap(
+    k8s_helper, k8s_secret_data, secrets_data
+):
     k8s_helper.v1api.read_namespaced_secret.return_value = unittest.mock.MagicMock(
         data=k8s_secret_data
     )
@@ -119,7 +121,7 @@ def test_delete_secrets_secret_found_with_changes(k8s_helper):
     k8s_helper.v1api.delete_namespaced_secret.assert_not_called()
 
 
-def test_delete_secrets_delete_secret(k8s_helper):
+def test_delete_secrets_confirms_deletion_for_matching_keys(k8s_helper):
     secret_data = {"key1": "value1"}
     k8s_secret_mock = unittest.mock.MagicMock(data=secret_data)
     k8s_helper.v1api.read_namespaced_secret.return_value = k8s_secret_mock


### PR DESCRIPTION
Fixed a bug that occurred when trying to delete project secrets with `secret_data` being None. 
When checking the length of `secret_data` using `if len(secret_data) == len(k8s_secret.data):`, an error was raised `object of type 'NoneType' has no len()`

The fix involves copying only the secrets from the `k8s_secret` that do not exist in the `secrets` dictionary, instead of creating a copy of the entire `k8s_secret` dictionary and deleting the `secrets` from it. 
We then update the `k8s_secret` accordingly.

https://iguazio.atlassian.net/browse/ML-7373