### PR TITLE
[Tests] Add config NS to system tests

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1174,6 +1174,7 @@ class TestProject(TestMLRunSystem):
 
         # Verify that the node selector is correctly enriched on job object
         assert job.spec.node_selector == {
+            **mlrun.mlconf.get_default_function_node_selector(),
             **project.spec.default_function_node_selector,
             function_override_label: function_override_val,
             function_label_name: function_label_val,
@@ -1216,6 +1217,7 @@ class TestProject(TestMLRunSystem):
 
         # Verify that the node selector is correctly enriched on job object
         assert mpijob_run.spec.node_selector == {
+            **mlrun.mlconf.get_default_function_node_selector(),
             **project.spec.default_function_node_selector,
             function_override_label: function_override_val,
             function_label_name: function_label_val,


### PR DESCRIPTION
This PR addresses system test failures caused by changes introduced in [this PR](https://github.com/mlrun/mlrun/pull/6000). 
The recent update incorporated the config node selector set on our system tests env: `{'[app.iguazio.com/scale-group': 'added-eu4yk4rc09j'}` into the run enrichment logic.
To resolve this, we are adding the default_function_node_selector to the expected run node selector results in the tests. This ensures that the expected results align with the updated configuration and fixes the test mismatches.