### PR TITLE
[Pipelines] Fix test_remote_pipeline_with_kfp_engine_from_github

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -653,8 +653,8 @@ class TestProject(TestMLRunSystem):
             notification_steps={
                 # gen data function build step
                 "build": 1,
-                # workflow runner, gen data, summary, train, test and model testing steps
-                "run": 6,
+                # gen data, summary, train and test steps
+                "run": 4,
                 # serving step
                 "deploy": 1,
             },
@@ -1640,6 +1640,9 @@ class TestProject(TestMLRunSystem):
         )[0]
         notification_data_steps = {}
         for step in notification_data:
+            if not step.get("step_kind"):
+                # If there is not step_kind in the step, it means that it is the workflow runner, so we skip it
+                continue
             notification_data_steps.setdefault(step.get("step_kind"), 0)
             notification_data_steps[step.get("step_kind")] += 1
 


### PR DESCRIPTION
The `test_remote_pipeline_with_kfp_engine_from_github` is testing the flow of **remote pipeline** with **kfp engine** **from github**.
We also test that the notification steps that we got during the pipeline are as expected.
There are several things to fix:
1. Changing the `run` count from 6 to 4 because we don't count anymore the workflow-runner itself and also [this pr](https://github.com/mlrun/project-demo/pull/18) removed  model testing step.
2. The `workflow-runner` step doesn't contain `step_kind` so we skip it during counting the `notification_data_steps`.
