### PR TITLE
[Notifications] Fix notification schema condition `Optional` type hint

### DIFF
--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -75,9 +75,9 @@ class Notification(pydantic.BaseModel):
     severity: NotificationSeverity
     when: list[str]
     condition: typing.Optional[str] = None
-    params: dict[str, typing.Any] = None
-    status: NotificationStatus = None
-    sent_time: typing.Union[str, datetime.datetime] = None
+    params: typing.Optional[dict[str, typing.Any]] = None
+    status: typing.Optional[NotificationStatus] = None
+    sent_time: typing.Optional[typing.Union[str, datetime.datetime]] = None
     secret_params: typing.Optional[dict[str, typing.Any]] = None
     reason: typing.Optional[str] = None
 

--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -50,12 +50,31 @@ class NotificationLimits(enum.Enum):
 
 
 class Notification(pydantic.BaseModel):
+    """
+    Notification object schema
+    :param kind: notification implementation kind - slack, webhook, etc.
+    :param name: for logging and identification
+    :param message: message content in the notification
+    :param severity: severity to display in the notification
+    :param when: list of statuses to trigger the notification: 'running', 'completed', 'error'
+    :param condition: optional condition to trigger the notification, a jinja2 expression that can use run data
+                      to evaluate if the notification should be sent in addition to the 'when' statuses.
+                      e.g.: '{{ run["status"]["results"]["accuracy"] < 0.9}}'
+    :param params: Implementation specific parameters for the notification implementation (e.g. slack webhook url,
+                   git repository details, etc.)
+    :param secret_params: secret parameters for the notification implementation, same as params but will be stored
+                          in a k8s secret and passed as a secret reference to the implementation.
+    :param status: notification status - pending, sent, error
+    :param sent_time: time the notification was sent
+    :param reason: failure reason if the notification failed to send
+    """
+
     kind: NotificationKind
     name: str
     message: str
     severity: NotificationSeverity
     when: list[str]
-    condition: str = None
+    condition: typing.Optional[str] = None
     params: dict[str, typing.Any] = None
     status: NotificationStatus = None
     sent_time: typing.Union[str, datetime.datetime] = None


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-7253
https://iguazio.atlassian.net/browse/ML-7389

It's not enough to supply pydantic with a `None` default, we need to have the type hint as `Optional` as well.
Added thorough schema description as well.