### PR TITLE
[Model Monitoring] Fix app context output path

### DIFF
--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -20,6 +20,7 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring.constants as mm_constant
 import mlrun.datastore
 import mlrun.serving
+import mlrun.utils.helpers
 import mlrun.utils.v3io_clients
 from mlrun.model_monitoring.helpers import get_stream_path
 from mlrun.serving.utils import StepToDict
@@ -150,12 +151,15 @@ class _PrepareMonitoringEvent(StepToDict):
 
     @staticmethod
     def _create_mlrun_context(app_name: str):
+        artifact_path = mlrun.utils.helpers.template_artifact_path(
+            mlrun.mlconf.artifact_path, mlrun.mlconf.default_project
+        )
         context = mlrun.get_or_create_ctx(
             f"{app_name}-logger",
             spec={
-                "metadata": {"labels": {"kind": mlrun.runtimes.RuntimeKinds.serving}}
+                "metadata": {"labels": {"kind": mlrun.runtimes.RuntimeKinds.serving}},
+                "spec": {mlrun.utils.helpers.RunKeys.output_path: artifact_path},
             },
-            upload_artifacts=True,
         )
         context.__class__ = MonitoringApplicationContext
         return context

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -396,12 +396,10 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
 
         cls.run_db = mlrun.get_run_db()
 
-    @classmethod
-    def custom_setup(cls) -> None:
-        _V3IORecordsChecker.custom_setup(project_name=cls.project_name)
+    def custom_setup(self) -> None:
+        _V3IORecordsChecker.custom_setup(project_name=self.project_name)
 
-    @classmethod
-    def custom_teardown(self):
+    def custom_teardown(self) -> None:
         # validate that stream resources were deleted as expected
         stream_path = self._test_env[
             "MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"


### PR DESCRIPTION
Fixes [ML-7403](https://iguazio.atlassian.net/browse/ML-7403).

Add coverage in the system tests.

I ran both "app flow" system tests - v1 and v2, each with `True`/`False` in the `with_training_set` parameter. All the four permutations passed.

[ML-7403]: https://iguazio.atlassian.net/browse/ML-7403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ