### PR TITLE
[Model Monitoring] Skipping deletion of stream resources when the project does not exist in Iguazio

### DIFF
--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -364,9 +364,16 @@ def process_model_monitoring_secret(
             allow_internal_secrets=True,
         )
         if not secret_value:
-            project_owner = server.api.utils.singletons.project_member.get_project_member().get_project_owner(
-                db_session, project_name
-            )
+            try:
+                project_owner = server.api.utils.singletons.project_member.get_project_member().get_project_owner(
+                    db_session, project_name
+                )
+            except mlrun.errors.MLRunNotFoundError:
+                logger.debug(
+                    "Failed to retrieve project owner, the project does not exist in Iguazio.",
+                    project_name=project_name,
+                )
+                raise
 
             secret_value = project_owner.access_key
             if not secret_value:

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -557,19 +557,13 @@ class ModelEndpoints:
             if tsdb_connector:
                 tsdb_connector.delete_tsdb_resources()
 
-        try:
-            self._delete_model_monitoring_stream_resources(
-                project_name=project_name,
-                db_session=db_session,
-                model_monitoring_applications=model_monitoring_applications,
-                stream_paths=stream_paths,
-                model_monitoring_access_key=model_monitoring_access_key,
-            )
-        except mlrun.errors.MLRunNotFoundError:
-            logger.debug(
-                "Project does not exist in Iguazio, skipping deletion of model monitoring stream resources",
-                project_name=project_name,
-            )
+        self._delete_model_monitoring_stream_resources(
+            project_name=project_name,
+            db_session=db_session,
+            model_monitoring_applications=model_monitoring_applications,
+            stream_paths=stream_paths,
+            model_monitoring_access_key=model_monitoring_access_key,
+        )
 
     @staticmethod
     def _delete_model_monitoring_stream_resources(
@@ -594,13 +588,19 @@ class ModelEndpoints:
 
         if stream_paths[0].startswith("v3io") and not model_monitoring_access_key:
             # Generate V3IO Access Key
-            model_monitoring_access_key = (
-                server.api.api.endpoints.nuclio.process_model_monitoring_secret(
+            try:
+                model_monitoring_access_key = server.api.api.endpoints.nuclio.process_model_monitoring_secret(
                     db_session,
                     project_name,
                     mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
                 )
-            )
+
+            except mlrun.errors.MLRunNotFoundError:
+                logger.debug(
+                    "Project does not exist in Iguazio, skipping deletion of model monitoring stream resources",
+                    project_name=project_name,
+                )
+                return
 
         model_monitoring_applications = model_monitoring_applications or []
 

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -558,7 +558,6 @@ class ModelEndpoints:
                 tsdb_connector.delete_tsdb_resources()
 
         try:
-            # Delete model monitoring stream resources
             self._delete_model_monitoring_stream_resources(
                 project_name=project_name,
                 db_session=db_session,

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -556,14 +556,21 @@ class ModelEndpoints:
                     tsdb_connector = None
             if tsdb_connector:
                 tsdb_connector.delete_tsdb_resources()
-        # Delete model monitoring stream resources
-        self._delete_model_monitoring_stream_resources(
-            project_name=project_name,
-            db_session=db_session,
-            model_monitoring_applications=model_monitoring_applications,
-            stream_paths=stream_paths,
-            model_monitoring_access_key=model_monitoring_access_key,
-        )
+
+        try:
+            # Delete model monitoring stream resources
+            self._delete_model_monitoring_stream_resources(
+                project_name=project_name,
+                db_session=db_session,
+                model_monitoring_applications=model_monitoring_applications,
+                stream_paths=stream_paths,
+                model_monitoring_access_key=model_monitoring_access_key,
+            )
+        except mlrun.errors.MLRunNotFoundError:
+            logger.debug(
+                "Project does not exist in Iguazio, skipping deletion of model monitoring stream resources",
+                project_name=project_name,
+            )
 
     @staticmethod
     def _delete_model_monitoring_stream_resources(


### PR DESCRIPTION
A new bug occurs when a project is deleted from Nuclio (while MLRun is disabled). In this case, the project is removed from Nuclio and Iguazio, but it still exists in MLRun. When MLRun is re-enabled, the sync process runs and moves the project to the archive. The trying to delete the project from MLRun and all its associated resources, including model monitoring resources.During this process, model monitoring tries to retrieve the project secret. If no secret value is found, it attempts to get the project owner to retrieve the access key. To find the project owner, a request is sent to Iguazio to get the project details. However, the project does not exist in Iguazio, leading to an error.

To fix this, I added a try-except block to handle the `mlrun.errors.MLRunNotFoundError` exception.
In this case, we will not continue with the deletion of the model monitoring stream resources

https://iguazio.atlassian.net/browse/ML-7365