### PR TITLE
[ProjectSummary] Create new data migration for creating project summaries

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2531,6 +2531,7 @@ class SQLDB(DBInterface):
             updated=datetime.now(timezone.utc),
         )
         objects_to_store.append(project_summary)
+        return project_summary
 
     @retry_on_conflict
     def store_project(

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2516,12 +2516,12 @@ class SQLDB(DBInterface):
 
         objects_to_store = [project_record]
 
-        self._generate_project_summary(project, objects_to_store)
+        self._append_project_summary(project, objects_to_store)
 
         self._upsert(session, objects_to_store)
 
     @staticmethod
-    def _generate_project_summary(project, objects_to_store):
+    def _append_project_summary(project, objects_to_store):
         summary = mlrun.common.schemas.ProjectSummary(
             name=project.metadata.name,
         )
@@ -2531,7 +2531,6 @@ class SQLDB(DBInterface):
             updated=datetime.now(timezone.utc),
         )
         objects_to_store.append(project_summary)
-        return project_summary
 
     @retry_on_conflict
     def store_project(

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2515,9 +2515,7 @@ class SQLDB(DBInterface):
         update_labels(project_record, labels)
 
         objects_to_store = [project_record]
-
         self._append_project_summary(project, objects_to_store)
-
         self._upsert(session, objects_to_store)
 
     @staticmethod

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2514,16 +2514,14 @@ class SQLDB(DBInterface):
         labels = project.metadata.labels or {}
         update_labels(project_record, labels)
 
-        object_to_store = [project_record]
+        objects_to_store = [project_record]
 
-        project_summary = self._generate_project_summary(project)
-        if project_summary:
-            object_to_store.append(project_summary)
+        self._generate_project_summary(project, objects_to_store)
 
-        self._upsert(session, object_to_store)
+        self._upsert(session, objects_to_store)
 
     @staticmethod
-    def _generate_project_summary(project):
+    def _generate_project_summary(project, objects_to_store):
         summary = mlrun.common.schemas.ProjectSummary(
             name=project.metadata.name,
         )
@@ -2532,7 +2530,7 @@ class SQLDB(DBInterface):
             summary=summary.dict(),
             updated=datetime.now(timezone.utc),
         )
-        return project_summary
+        objects_to_store.append(project_summary)
 
     @retry_on_conflict
     def store_project(

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -884,15 +884,14 @@ def _migrate_project_summaries(db, db_session):
     projects = db.list_projects(
         db_session, format_=mlrun.common.formatters.ProjectFormat.name_only
     )
-    for project_name in projects.projects:
-        summary = mlrun.common.schemas.ProjectSummary(
-            name=project_name,
-        )
-        project_summary = ProjectSummary(
+    project_summaries = [
+        ProjectSummary(
             project=project_name,
-            summary=summary.dict(),
+            summary=mlrun.common.schemas.ProjectSummary(name=project_name).dict(),
         )
-        db._upsert(db_session, [project_summary], ignore=True)
+        for project_name in projects.projects
+    ]
+    db._upsert(db_session, project_summaries, ignore=True)
 
 
 def main() -> None:

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -36,7 +36,6 @@ import server.api.utils.db.alembic
 import server.api.utils.db.backup
 import server.api.utils.db.mysql
 from mlrun.artifacts.base import fill_artifact_object_hash
-from server.api.db.sqldb.models import ProjectSummary
 from mlrun.config import config
 from mlrun.errors import MLRunPreconditionFailedError, err_to_str
 from mlrun.utils import (
@@ -46,6 +45,7 @@ from mlrun.utils import (
 )
 from server.api.db.init_db import init_db
 from server.api.db.session import close_session, create_session
+from server.api.db.sqldb.models import ProjectSummary
 
 
 def init_data(
@@ -893,7 +893,6 @@ def _migrate_project_summaries(db, db_session):
             summary=summary.dict(),
         )
         db._upsert(db_session, [project_summary], ignore=True)
-
 
 
 def main() -> None:

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -874,13 +874,13 @@ def _migrate_model_monitoring_jobs(db, db_session):
 def _perform_version_7_data_migrations(
     db: server.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
 ):
-    _migrate_project_summaries(db, db_session)
+    _create_project_summaries(db, db_session)
 
 
-def _migrate_project_summaries(db, db_session):
-    # Here we want to iterate other all projects and create the related project summary.
-    # We do this because we create ProjectSummary record only when creating project.
-    # Because we upgrade from a version that doesn't have ProjectSummary, we need to create them manually now.
+def _create_project_summaries(db, db_session):
+    # Create a project summary record for all projects.
+    # We need to create them manually because a summary record is created only when a new
+    # project is created, so project that existing prior to the upgrade don't have summaries.
     projects = db.list_projects(
         db_session, format_=mlrun.common.formatters.ProjectFormat.name_only
     )

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -215,7 +215,7 @@ def test_migrate_project_summaries():
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
     )
-    db.create_project(db_session, project)
+    db.create_project(db_session, project, with_summary=False)
 
     # Migrate the project summaries
     server.api.initial_data._migrate_project_summaries(db, db_session)

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -208,17 +208,19 @@ def test_add_default_hub_source_if_needed():
         assert update_default_hub_source.call_count == 0
 
 
-def test_migrate_project_summaries():
+def test_create_project_summaries():
     db, db_session = _initialize_db_without_migrations()
 
     # Create a project
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
     )
-    db.create_project(db_session, project, with_summary=False)
+
+    with unittest.mock.patch.object(db, "_generate_project_summary", return_value=None):
+        db.create_project(db_session, project)
 
     # Migrate the project summaries
-    server.api.initial_data._migrate_project_summaries(db, db_session)
+    server.api.initial_data._create_project_summaries(db, db_session)
 
     # Check that the project summary was migrated
     migrated_project_summary = db.get_project_summary(db_session, project.metadata.name)

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -90,6 +90,10 @@ def test_perform_data_migrations_from_first_version():
         server.api.initial_data._perform_version_6_data_migrations
     )
     server.api.initial_data._perform_version_6_data_migrations = unittest.mock.Mock()
+    original_perform_version_7_data_migrations = (
+        server.api.initial_data._perform_version_7_data_migrations
+    )
+    server.api.initial_data._perform_version_7_data_migrations = unittest.mock.Mock()
 
     # perform migrations
     server.api.initial_data._perform_data_migrations(db_session)
@@ -102,6 +106,7 @@ def test_perform_data_migrations_from_first_version():
     server.api.initial_data._perform_version_4_data_migrations.assert_called_once()
     server.api.initial_data._perform_version_5_data_migrations.assert_called_once()
     server.api.initial_data._perform_version_6_data_migrations.assert_called_once()
+    server.api.initial_data._perform_version_7_data_migrations.assert_called_once()
 
     assert db.get_current_data_version(db_session, raise_on_not_found=True) == str(
         server.api.initial_data.latest_data_version
@@ -122,6 +127,9 @@ def test_perform_data_migrations_from_first_version():
     )
     server.api.initial_data._perform_version_6_data_migrations = (
         original_perform_version_6_data_migrations
+    )
+    server.api.initial_data._perform_version_7_data_migrations = (
+        original_perform_version_7_data_migrations
     )
 
 
@@ -199,6 +207,25 @@ def test_add_default_hub_source_if_needed():
         server.api.initial_data._add_default_hub_source_if_needed(db, db_session)
         assert update_default_hub_source.call_count == 0
 
+
+def test_migrate_project_summaries():
+    db, db_session = _initialize_db_without_migrations()
+
+    # Create a project
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+    )
+    db.create_project(db_session, project)
+
+    # Migrate the project summaries
+    server.api.initial_data._migrate_project_summaries(db, db_session)
+
+    # Check that the project summary was migrated
+    migrated_project_summary = db.get_project_summary(
+        db_session, project.metadata.name
+    )
+
+    assert migrated_project_summary.name == project.metadata.name
 
 def _initialize_db_without_migrations() -> (
     tuple[server.api.db.sqldb.db.SQLDB, sqlalchemy.orm.Session]

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -216,7 +216,7 @@ def test_create_project_summaries():
         metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
     )
 
-    with unittest.mock.patch.object(db, "_generate_project_summary", return_value=None):
+    with unittest.mock.patch.object(db, "_append_project_summary"):
         db.create_project(db_session, project)
 
     # Migrate the project summaries

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -221,11 +221,10 @@ def test_migrate_project_summaries():
     server.api.initial_data._migrate_project_summaries(db, db_session)
 
     # Check that the project summary was migrated
-    migrated_project_summary = db.get_project_summary(
-        db_session, project.metadata.name
-    )
+    migrated_project_summary = db.get_project_summary(db_session, project.metadata.name)
 
     assert migrated_project_summary.name == project.metadata.name
+
 
 def _initialize_db_without_migrations() -> (
     tuple[server.api.db.sqldb.db.SQLDB, sqlalchemy.orm.Session]


### PR DESCRIPTION
When upgrading MLRun from a version that did not have project summaries DB table, to a version that has them, summaries for the existing projects are not created, causing the UI to fail on: `project summary not found for project X`.

This means that we cannot rely on the project creation flow to create the relevant summary.
Here we added new data migration step where we create project summary record for each existing project.
This summaries can be empty as they will be recalculated during the refresh.

https://iguazio.atlassian.net/browse/ML-7303