### PR TITLE
[Model Monitoring] Fix delete pipeline model monitoring stream resources

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -940,15 +940,15 @@ class MonitoringDeployment:
                         stream_path
                     )
                 )
-                if container.startswith("users"):
-                    # The stream is in the pipelines directory
-                    access_key_to_delete = mlrun.mlconf.get_v3io_access_key()
-                else:
-                    # The stream is in the projects directory
-                    access_key_to_delete = access_key
+
                 try:
+                    # if the stream path is in the users directory, we need to use pipelines access key to delete it
                     v3io_client.stream.delete(
-                        container, stream_path, access_key=access_key_to_delete
+                        container,
+                        stream_path,
+                        access_key=mlrun.mlconf.get_v3io_access_key()
+                        if container.startswith("users")
+                        else access_key,
                     )
                     logger.debug("Deleted v3io stream", stream_path=stream_path)
                 except v3io.dataplane.response.HttpResponseError as e:

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -940,10 +940,15 @@ class MonitoringDeployment:
                         stream_path
                     )
                 )
-
+                if container.startswith("users"):
+                    # The stream is in the pipelines directory
+                    access_key_to_delete = mlrun.mlconf.get_v3io_access_key()
+                else:
+                    # The stream is in the projects directory
+                    access_key_to_delete = access_key
                 try:
                     v3io_client.stream.delete(
-                        container, stream_path, access_key=access_key
+                        container, stream_path, access_key=access_key_to_delete
                     )
                     logger.debug("Deleted v3io stream", stream_path=stream_path)
                 except v3io.dataplane.response.HttpResponseError as e:


### PR DESCRIPTION
Fix an issue in which the "old" model monitoring stream resources that were stored under the `users` container were not deleted as expected due to invalid v3io access key. In case that the stream is stored under the `users` container, the API will use the `pipeline v3io access key` instead of the `model monitoring access key` which is related to the project resources and doesn't have permission to the `users` container. 