### PR TITLE
[Alerts] Add abstract methods and fix imports and type hints

### DIFF
--- a/server/api/api/endpoints/alerts.py
+++ b/server/api/api/endpoints/alerts.py
@@ -20,7 +20,9 @@ from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+import server.api.crud
 import server.api.utils.auth.verifier
+import server.api.utils.clients.chief
 import server.api.utils.singletons.project_member
 from mlrun.utils import logger
 from server.api.api import deps

--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -358,7 +358,8 @@ class Alerts(
         self._get_alert_state_cached().cache_remove(session, alert.id)
         self._clear_alert_states(alert)
 
-    def _delete_notifications(self, alert: mlrun.common.schemas.AlertConfig):
+    @staticmethod
+    def _delete_notifications(alert: mlrun.common.schemas.AlertConfig):
         for notification in alert.notifications:
             server.api.api.utils.delete_notification_params_secret(
                 alert.project, notification.notification

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -835,11 +835,56 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def store_alert(self, session, alert: mlrun.common.schemas.AlertConfig):
+    def store_alert(
+        self, session, alert: mlrun.common.schemas.AlertConfig
+    ) -> mlrun.common.schemas.AlertConfig:
         pass
 
     @abstractmethod
     def get_all_alerts(self, session) -> list[mlrun.common.schemas.AlertConfig]:
+        pass
+
+    @abstractmethod
+    def list_alerts(
+        self, session, project: str = None
+    ) -> list[mlrun.common.schemas.AlertConfig]:
+        pass
+
+    @abstractmethod
+    def get_alert(
+        self, session, project: str, name: str
+    ) -> mlrun.common.schemas.AlertConfig:
+        pass
+
+    @abstractmethod
+    def get_alert_by_id(
+        self, session, alert_id: int
+    ) -> mlrun.common.schemas.AlertConfig:
+        pass
+
+    @abstractmethod
+    def enrich_alert(self, session, alert: mlrun.common.schemas.AlertConfig):
+        pass
+
+    @abstractmethod
+    def delete_alert(self, session, project: str, name: str):
+        pass
+
+    @abstractmethod
+    def store_alert_state(
+        self,
+        session,
+        project: str,
+        name: str,
+        last_updated: datetime,
+        count: typing.Union[int, None] = None,
+        active: bool = False,
+        obj: dict = None,
+    ):
+        pass
+
+    @abstractmethod
+    def get_alert_state_dict(self, session, alert_id: int) -> dict:
         pass
 
     @abstractmethod

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -877,9 +877,9 @@ class DBInterface(ABC):
         project: str,
         name: str,
         last_updated: datetime,
-        count: typing.Union[int, None] = None,
+        count: typing.Optional[int] = None,
         active: bool = False,
-        obj: dict = None,
+        obj: typing.Optional[dict] = None,
     ):
         pass
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -5107,7 +5107,7 @@ class SQLDB(DBInterface):
             self._get_alert_record_by_id(session, alert_id)
         )
 
-    def enrich_alert(self, session, alert: AlertConfig):
+    def enrich_alert(self, session, alert: mlrun.common.schemas.AlertConfig):
         state = self.get_alert_state(session, alert.id)
         alert.state = (
             mlrun.common.schemas.AlertActiveState.ACTIVE

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -5207,9 +5207,9 @@ class SQLDB(DBInterface):
         project: str,
         name: str,
         last_updated: datetime,
-        count: typing.Union[int, None] = None,
+        count: typing.Optional[int] = None,
         active: bool = False,
-        obj: dict = None,
+        obj: typing.Optional[dict] = None,
     ):
         alert = self.get_alert(session, project, name)
         state = self.get_alert_state(session, alert.id)

--- a/server/api/utils/clients/chief.py
+++ b/server/api/utils/clients/chief.py
@@ -221,7 +221,7 @@ class Client(
 
     async def store_alert(
         self, project: str, name: str, request: fastapi.Request, json: dict
-    ) -> fastapi.Response:
+    ) -> typing.Union[fastapi.Response, mlrun.common.schemas.AlertConfig]:
         """
         Alerts are running only on chief
         """
@@ -240,7 +240,7 @@ class Client(
         )
 
     async def reset_alert(
-        self, project: str, name: int, request: fastapi.Request
+        self, project: str, name: str, request: fastapi.Request
     ) -> fastapi.Response:
         """
         Alerts are running only on chief


### PR DESCRIPTION
Some improvements to the alert related db methods that align alerts with the rest of the resources (and improves QOL for developers).