### PR TITLE
[Monitoring] Refine list runs filter

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -112,7 +112,7 @@ default_config = {
             "missing_runtime_resources_debouncing_interval": None,
             # max number of parallel abort run jobs in runs monitoring
             "concurrent_abort_stale_runs_workers": 10,
-            "list_runs_time_period_in_hours": 24 * 1,
+            "list_runs_time_period_in_hours": 24 * 3,  # 3 days
         },
         "projects": {
             "summaries": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -112,7 +112,7 @@ default_config = {
             "missing_runtime_resources_debouncing_interval": None,
             # max number of parallel abort run jobs in runs monitoring
             "concurrent_abort_stale_runs_workers": 10,
-            "list_runs_time_period_in_days": 7,  # days
+            "list_runs_time_period_in_hours": 24 * 1,
         },
         "projects": {
             "summaries": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -112,7 +112,7 @@ default_config = {
             "missing_runtime_resources_debouncing_interval": None,
             # max number of parallel abort run jobs in runs monitoring
             "concurrent_abort_stale_runs_workers": 10,
-            "list_runs_time_period_in_days": 7,  # 7 days
+            "list_runs_time_period_in_days": 7,  # days
         },
         "projects": {
             "summaries": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -112,7 +112,7 @@ default_config = {
             "missing_runtime_resources_debouncing_interval": None,
             # max number of parallel abort run jobs in runs monitoring
             "concurrent_abort_stale_runs_workers": 10,
-            "list_runs_time_period_in_hours": 24 * 3,  # 3 days
+            "list_runs_time_period_in_days": 7,  # 7 days
         },
         "projects": {
             "summaries": {

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -901,7 +901,6 @@ def _generate_event_on_failed_runs(
         event_data = mlrun.common.schemas.Event(
             kind=alert_objects.EventKind.FAILED, entity=entity, value_dict=event_value
         )
-        mlrun.get_run_db().generate_event(alert_objects.EventKind.FAILED, event_data)
 
         server.api.crud.Events().process_event(
             session=db_session,

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1219,11 +1219,11 @@ class BaseRuntimeHandler(ABC):
         self, db: DBInterface, db_session: Session, states: list = None
     ):
         last_update_time_from = None
-        if config.monitoring.runs.list_runs_time_period_in_hours:
+        if config.monitoring.runs.list_runs_time_period_in_days:
             last_update_time_from = (
                 datetime.now()
                 - timedelta(
-                    hours=int(config.monitoring.runs.list_runs_time_period_in_hours)
+                    days=int(config.monitoring.runs.list_runs_time_period_in_days)
                 )
             ).isoformat()
 

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1211,11 +1211,11 @@ class BaseRuntimeHandler(ABC):
         self, db: DBInterface, db_session: Session, states: list = None
     ):
         last_update_time_from = None
-        if config.monitoring.runs.list_runs_time_period_in_days:
+        if config.monitoring.runs.list_runs_time_period_in_hours:
             last_update_time_from = (
                 datetime.now()
                 - timedelta(
-                    days=int(config.monitoring.runs.list_runs_time_period_in_days)
+                    hours=int(config.monitoring.runs.list_runs_time_period_in_hours)
                 )
             ).isoformat()
 
@@ -1223,6 +1223,7 @@ class BaseRuntimeHandler(ABC):
             db_session,
             project="*",
             states=states,
+            labels=f"{mlrun_constants.MLRunInternalLabels.kind}={self.kind}",
             last_update_time_from=last_update_time_from,
         )
         project_run_uid_map = {}

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -181,7 +181,11 @@ class BaseRuntimeHandler(ABC):
         label_selector = self._get_default_label_selector()
         crd_group, crd_version, crd_plural = self._get_crd_info()
         runtime_resource_is_crd = bool(crd_group and crd_version and crd_plural)
-        project_run_uid_map = self._list_runs_for_monitoring(db, db_session)
+        project_run_uid_map = self._list_runs_for_monitoring(
+            db,
+            db_session,
+            states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
+        )
         # project -> uid -> {"name": <runtime-resource-name>}
         run_runtime_resources_map = {}
         stale_runs = []
@@ -720,6 +724,10 @@ class BaseRuntimeHandler(ABC):
         3. the desired run state matching the crd object state
         """
         return False, None, None
+
+    def _is_terminal_state(self, runtime_resource: dict) -> bool:
+        phase = runtime_resource.get("status", {}).get("phase")
+        return phase in PodPhases.terminal_phases()
 
     def _update_ui_url(
         self,
@@ -1293,6 +1301,12 @@ class BaseRuntimeHandler(ABC):
             return
 
         run = project_run_uid_map.get(project, {}).get(uid)
+        if not run:
+            # We filter runs in terminal states so if the runtime resource is also in terminal state,
+            # there is nothing to do
+            if self._is_terminal_state(runtime_resource):
+                return
+
         run = self._ensure_run(
             db, db_session, name, project, run, search_run=True, uid=uid
         )

--- a/server/api/runtime_handlers/mpijob/v1.py
+++ b/server/api/runtime_handlers/mpijob/v1.py
@@ -254,9 +254,7 @@ class MpiV1RuntimeHandler(AbstractMPIJobRuntimeHandler):
         # the launcher status also has running property, but it's empty for
         # short period after the creation, so we're
         # checking terminal state by the completion time existence
-        in_terminal_state = (
-            crd_object.get("status", {}).get("completionTime", None) is not None
-        )
+        in_terminal_state = self._is_terminal_state(crd_object)
         desired_run_state = RunStates.running
         completion_time = None
         if in_terminal_state:
@@ -271,6 +269,11 @@ class MpiV1RuntimeHandler(AbstractMPIJobRuntimeHandler):
                 else RunStates.completed
             )
         return in_terminal_state, completion_time, desired_run_state
+
+    def _is_terminal_state(self, runtime_resource: dict) -> bool:
+        return (
+            runtime_resource.get("status", {}).get("completionTime", None) is not None
+        )
 
     @staticmethod
     def are_resources_coupled_to_run_object() -> bool:

--- a/server/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/api/runtime_handlers/sparkjob/spark3job.py
@@ -477,6 +477,12 @@ with ctx:
                     )
         return in_terminal_state, completion_time, desired_run_state
 
+    def _is_terminal_state(self, runtime_resource: dict) -> bool:
+        state = (
+            runtime_resource.get("status", {}).get("applicationState", {}).get("state")
+        )
+        return state in SparkApplicationStates.terminal_states()
+
     def _update_ui_url(
         self,
         db: DBInterface,

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -649,7 +649,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     @pytest.mark.asyncio
     async def test_monitor_stale_run(self, db: Session, client: TestClient):
         # set list run time period to be negative so that list runs will not find the run
-        config.monitoring.runs.list_runs_time_period_in_days = -1
+        config.monitoring.runs.list_runs_time_period_in_hours = -1
         list_namespaced_pods_calls = [
             [self.completed_job_pod],
             # additional time for the get_logger_pods

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -626,7 +626,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     @pytest.mark.asyncio
     async def test_monitor_stale_run(self, db: Session, client: TestClient):
         # set list run time period to be negative so that list runs will not find the run
-        config.monitoring.runs.list_runs_time_period_in_hours = -1
+        config.monitoring.runs.list_runs_time_period_in_days = -1
         list_namespaced_pods_calls = [
             [self.running_job_pod],
         ]

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -381,29 +381,6 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
 
     @pytest.mark.asyncio
-    async def test_monitor_run_overriding_terminal_state(
-        self, db: Session, client: TestClient
-    ):
-        list_namespaced_pods_calls = [
-            [self.failed_job_pod],
-        ]
-        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
-        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
-        self.run["status"]["state"] = RunStates.completed
-        server.api.crud.Runs().store_run(
-            db, self.run, self.run_uid, project=self.project
-        )
-        expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls
-        )
-        for _ in range(expected_monitor_cycles_to_reach_expected_state):
-            self.runtime_handler.monitor_runs(get_db(), db)
-        self._assert_list_namespaced_pods_calls(
-            self.runtime_handler, expected_number_of_list_pods_calls
-        )
-        self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
-
-    @pytest.mark.asyncio
     async def test_monitor_run_debouncing_non_terminal_state(
         self, db: Session, client: TestClient
     ):
@@ -481,7 +458,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     ):
         get_db().del_run(db, self.run_uid, self.project)
         list_namespaced_pods_calls = [
-            [self.completed_job_pod],
+            [self.running_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
@@ -494,7 +471,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler, expected_number_of_list_pods_calls
         )
         self._assert_run_reached_state(
-            db, self.project, self.run_uid, RunStates.completed
+            db, self.project, self.run_uid, RunStates.running
         )
 
     @pytest.mark.asyncio
@@ -651,15 +628,13 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         # set list run time period to be negative so that list runs will not find the run
         config.monitoring.runs.list_runs_time_period_in_hours = -1
         list_namespaced_pods_calls = [
-            [self.completed_job_pod],
-            # additional time for the get_logger_pods
-            [self.completed_job_pod],
+            [self.running_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_read_namespaced_pod_log()
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls - 1
+            expected_number_of_list_pods_calls
         )
 
         run = get_db().read_run(db, self.run_uid, self.project)
@@ -672,7 +647,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
 
             mock_read_run.assert_called_once()
         self._assert_run_reached_state(
-            db, self.project, self.run_uid, RunStates.completed
+            db, self.project, self.run_uid, RunStates.running
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This shall help reduce the memory footprint of the runs monitoring job.
The changes are:
1. List runs filtered by kind label
2. List runs with non terminal states. It a run is in terminal state there is no need to update it. If the run does not exist and the pod is in terminal state, then the run was deleted and it will not be recreated (because the run is created when the job is launched).

https://iguazio.atlassian.net/browse/ML-7354