### PR TITLE
[KFP] Raise exception if trying to schedule function

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -190,7 +190,6 @@ def run_function(
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Scheduling is not supported in KFP run function."
-                "Use either project.set_workflow() or project.run() to schedule runs."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -189,7 +189,7 @@ def run_function(
     if engine == "kfp":
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Scheduling is not supported in KFP run function."
+                "Scheduling job is not supported when running a workflow with kfp engine."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -190,7 +190,7 @@ def run_function(
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Scheduling is not supported in KFP run function."
-                "Use project.run() to schedule runs."
+                "Use either project.set_workflow() or project.run() to schedule runs."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -189,7 +189,8 @@ def run_function(
     if engine == "kfp":
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Schedule is not supported in KFP runs"
+                "Schedule is not supported in KFP run function."
+                "Use project.set_schedule() or project.run() instead for scheduled runs."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -189,7 +189,7 @@ def run_function(
     if engine == "kfp":
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "schedule is not supported in KFP runs"
+                "Schedule is not supported in KFP runs"
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -189,8 +189,8 @@ def run_function(
     if engine == "kfp":
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Schedule is not supported in KFP run function."
-                "Use project.set_schedule() or project.run() instead for scheduled runs."
+                "Scheduling is not supported in KFP run function."
+                "Use either project.set_schedule() or project.run() to schedule runs."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -190,7 +190,7 @@ def run_function(
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Scheduling is not supported in KFP run function."
-                "Use either project.set_schedule() or project.run() to schedule runs."
+                "Use either project.set_workflow() or project.run() to schedule runs."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -187,6 +187,10 @@ def run_function(
     task.spec.verbose = task.spec.verbose or verbose
 
     if engine == "kfp":
+        if schedule:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "schedule is not supported in KFP runs"
+            )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels
         )

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -190,7 +190,7 @@ def run_function(
         if schedule:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Scheduling is not supported in KFP run function."
-                "Use either project.set_workflow() or project.run() to schedule runs."
+                "Use project.run() to schedule runs."
             )
         return function.as_step(
             name=name, runspec=task, workdir=workdir, outputs=outputs, labels=labels


### PR DESCRIPTION
Kubeflow doesn't support submitting  schedule job, so if the user use `kfp` engine and also pass `schedule` arg we want to raise exception about it.
(There was also option to only warn and just not run the function, but we use the approach  of raising exception because there shouldn't be much cases where users used `schedule` on `kfp` engine).

https://iguazio.atlassian.net/browse/ML-7226