### PR TITLE
[Serving] Fix model serving stream path

### DIFF
--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -34,8 +34,8 @@ class _PushToMonitoringWriter(StepToDict):
 
     def __init__(
         self,
-        project: Optional[str] = None,
-        writer_application_name: Optional[str] = None,
+        project: str,
+        writer_application_name: str,
         stream_uri: Optional[str] = None,
         name: Optional[str] = None,
     ):

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -45,8 +45,7 @@ class _BatchDict(typing.TypedDict):
 
 
 def get_stream_path(
-    project: str = None,
-    function_name: str = mm_constants.MonitoringFunctionNames.STREAM,
+    project: str, function_name: str = mm_constants.MonitoringFunctionNames.STREAM
 ) -> str:
     """
     Get stream path from the project secret. If wasn't set, take it from the system configurations

--- a/mlrun/serving/routers.py
+++ b/mlrun/serving/routers.py
@@ -32,7 +32,6 @@ from mlrun.errors import err_to_str
 from mlrun.utils import logger, now_date
 
 from ..common.helpers import parse_versioned_object_uri
-from ..config import config
 from .server import GraphServer
 from .utils import RouterToDict, _extract_input_data, _update_result_body
 from .v2_serving import _ModelLogPusher
@@ -1057,9 +1056,7 @@ def _init_endpoint_record(
                 function_uri=graph_server.function_uri,
                 model=versioned_model_name,
                 model_class=voting_ensemble.__class__.__name__,
-                stream_path=config.model_endpoint_monitoring.store_prefixes.default.format(
-                    project=project, kind="stream"
-                ),
+                stream_path=voting_ensemble.context.stream.stream_uri,
                 active=True,
                 monitoring_mode=mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled,
             ),

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -38,10 +38,7 @@ from ..errors import MLRunInvalidArgumentError
 from ..model import ModelObj
 from ..utils import get_caller_globals
 from .states import RootFlowStep, RouterStep, get_function, graph_root_setter
-from .utils import (
-    event_id_key,
-    event_path_key,
-)
+from .utils import event_id_key, event_path_key
 
 
 class _StreamContext:
@@ -71,15 +68,15 @@ class _StreamContext:
                 function_uri, config.default_project
             )
 
-            stream_uri = mlrun.model_monitoring.get_stream_path(project=project)
+            self.stream_uri = mlrun.model_monitoring.get_stream_path(project=project)
 
             if log_stream:
                 # Update the stream path to the log stream value
-                stream_uri = log_stream.format(project=project)
+                self.stream_uri = log_stream.format(project=project)
 
             stream_args = parameters.get("stream_args", {})
 
-            self.output_stream = get_stream_pusher(stream_uri, **stream_args)
+            self.output_stream = get_stream_pusher(self.stream_uri, **stream_args)
 
 
 class GraphServer(ModelObj):

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -15,11 +15,11 @@
 import threading
 import time
 import traceback
-from typing import Union
+from typing import Optional, Union
 
+import mlrun.artifacts
 import mlrun.common.model_monitoring
 import mlrun.common.schemas.model_monitoring
-from mlrun.artifacts import ModelArtifact  # noqa: F401
 from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.utils import logger, now_date
@@ -102,7 +102,7 @@ class V2ModelServer(StepToDict):
         self.error = ""
         self.protocol = protocol or "v2"
         self.model_path = model_path
-        self.model_spec: mlrun.artifacts.ModelArtifact = None
+        self.model_spec: Optional[mlrun.artifacts.ModelArtifact] = None
         self._input_path = input_path
         self._result_path = result_path
         self._kwargs = kwargs  # for to_dict()

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -20,7 +20,6 @@ from typing import Optional, Union
 import mlrun.artifacts
 import mlrun.common.model_monitoring
 import mlrun.common.schemas.model_monitoring
-from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.utils import logger, now_date
 
@@ -570,9 +569,7 @@ def _init_endpoint_record(
                 model=versioned_model_name,
                 model_class=model.__class__.__name__,
                 model_uri=model.model_path,
-                stream_path=config.model_endpoint_monitoring.store_prefixes.default.format(
-                    project=project, kind="stream"
-                ),
+                stream_path=model.context.stream.stream_uri,
                 active=True,
                 monitoring_mode=mlrun.common.schemas.model_monitoring.ModelMonitoringMode.enabled,
             ),

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -35,6 +35,7 @@ import mlrun.common.types
 import mlrun.db.httpdb
 import mlrun.feature_store
 import mlrun.feature_store as fstore
+import mlrun.model_monitoring
 import mlrun.model_monitoring.api
 from mlrun.datastore.targets import ParquetTarget
 from mlrun.model_monitoring.applications import (
@@ -541,8 +542,12 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
     @classmethod
     def _get_model_endpoint_id(cls) -> str:
         endpoints = cls.run_db.list_model_endpoints(project=cls.project_name)
-        assert endpoints and len(endpoints) == 1
-        return endpoints[0].metadata.uid
+        assert endpoints and len(endpoints) == 1, "Expects a single model endpoint"
+        endpoint = typing.cast(mlrun.model_monitoring.ModelEndpoint, endpoints[0])
+        assert endpoint.spec.stream_path == mlrun.model_monitoring.get_stream_path(
+            project=cls.project_name
+        ), "The model endpoint stream path is different than expected"
+        return endpoint.metadata.uid
 
     @classmethod
     def _test_model_endpoint_stats(cls, ep_id: str) -> None:


### PR DESCRIPTION
Fixes [ML-7424](https://iguazio.atlassian.net/browse/ML-7424).

The model serving stream path of the serving function is the input stream to the "model monitoring stream" function.
The model endpoint record was not synced with the actual output stream path, and this PR fixes it both for v2 serving and voting ensemble `_init_endpoint_record` functions.

Add coverage in the "app flow" system test.

Before - always `v3io:///users/piplines/`, including in CE systems :
![image](https://github.com/user-attachments/assets/b55023f6-f422-4a0b-8172-909e54ba93d3)
![image](https://github.com/user-attachments/assets/ca8d97d2-529e-4c90-ab53-980d946e29d3)

After - updated stream path:
![image](https://github.com/user-attachments/assets/cbd64ba9-c6a9-43e6-93cc-67a6e06b1310)
`v3io:///projects/` in Iguazio or `kafka://` in CE.

[ML-7424]: https://iguazio.atlassian.net/browse/ML-7424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ