### PR TITLE
[Alerts] Show the alert severity when pushing alert notifications

### DIFF
--- a/server/api/utils/notification_pusher.py
+++ b/server/api/utils/notification_pusher.py
@@ -160,10 +160,7 @@ class AlertNotificationPusher(_NotificationPusherBase):
             f": {notification_object.message}" if notification_object.message else ""
         )
 
-        severity = (
-            notification_object.severity
-            or mlrun.common.schemas.NotificationSeverity.INFO
-        )
+        severity = alert.severity
         return message, severity
 
     @staticmethod


### PR DESCRIPTION
when sending notification of an alert we should show the alert's severity and not the notification's.

https://iguazio.atlassian.net/browse/ML-7313