### PR TITLE
[Model Monitoring] Select only the relevant columns in V3IO TSDB query

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -246,11 +246,9 @@ class TDEngineConnector(TSDBConnector):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Failed to query table {table} in database {self.database}, {str(e)}"
             )
-        columns = []
-        for column in query_result.fields:
-            columns.append(column.name())
 
-        return pd.DataFrame(query_result, columns=columns)
+        df_columns = [field.name() for field in query_result.fields]
+        return pd.DataFrame(query_result, columns=df_columns)
 
     def read_metrics_data(
         self,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -272,13 +272,22 @@ class TDEngineConnector(TSDBConnector):
             ],
         ],
     ]:
+        timestamp_column = mm_schemas.WriterEvent.END_INFER_TIME
+        columns = [timestamp_column, mm_schemas.WriterEvent.APPLICATION_NAME]
         if type == "metrics":
             table = mm_schemas.TDEngineSuperTables.METRICS
             name = mm_schemas.MetricData.METRIC_NAME
+            columns += [name, mm_schemas.MetricData.METRIC_VALUE]
             df_handler = self.df_to_metrics_values
         elif type == "results":
             table = mm_schemas.TDEngineSuperTables.APP_RESULTS
             name = mm_schemas.ResultData.RESULT_NAME
+            columns += [
+                name,
+                mm_schemas.ResultData.RESULT_VALUE,
+                mm_schemas.ResultData.RESULT_STATUS,
+                mm_schemas.ResultData.RESULT_KIND,
+            ]
             df_handler = self.df_to_results_values
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
@@ -298,7 +307,8 @@ class TDEngineConnector(TSDBConnector):
             start=start,
             end=end,
             filter_query=filter_query,
-            timestamp_column=mm_schemas.WriterEvent.END_INFER_TIME,
+            timestamp_column=timestamp_column,
+            columns=columns,
         )
 
         df[mm_schemas.WriterEvent.END_INFER_TIME] = pd.to_datetime(

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -504,19 +504,29 @@ class V3IOTSDBConnector(TSDBConnector):
         if type == "metrics":
             table_path = self.tables[mm_schemas.V3IOTSDBTables.METRICS]
             name = mm_schemas.MetricData.METRIC_NAME
+            columns = [mm_schemas.MetricData.METRIC_VALUE]
             df_handler = self.df_to_metrics_values
         elif type == "results":
             table_path = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]
             name = mm_schemas.ResultData.RESULT_NAME
+            columns = [
+                mm_schemas.ResultData.RESULT_VALUE,
+                mm_schemas.ResultData.RESULT_STATUS,
+                mm_schemas.ResultData.RESULT_KIND,
+            ]
             df_handler = self.df_to_results_values
         else:
             raise ValueError(f"Invalid {type = }")
+
+        groupby = [name, mm_schemas.WriterEvent.APPLICATION_NAME]
 
         query = self._get_sql_query(
             endpoint_id=endpoint_id,
             metric_and_app_names=[(metric.app, metric.name) for metric in metrics],
             table_path=table_path,
             name=name,
+            columns=columns,
+            groupby=groupby,
         )
 
         logger.debug("Querying V3IO TSDB", query=query)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -518,15 +518,12 @@ class V3IOTSDBConnector(TSDBConnector):
         else:
             raise ValueError(f"Invalid {type = }")
 
-        groupby = [name, mm_schemas.WriterEvent.APPLICATION_NAME]
-
         query = self._get_sql_query(
             endpoint_id=endpoint_id,
             metric_and_app_names=[(metric.app, metric.name) for metric in metrics],
             table_path=table_path,
             name=name,
             columns=columns,
-            groupby=groupby,
         )
 
         logger.debug("Querying V3IO TSDB", query=query)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -546,6 +546,7 @@ class V3IOTSDBConnector(TSDBConnector):
         name: str = mm_schemas.ResultData.RESULT_NAME,
         metric_and_app_names: Optional[list[tuple[str, str]]] = None,
         columns: Optional[list[str]] = None,
+        groupby: Optional[list[str]] = None,
     ) -> str:
         """Get the SQL query for the results/metrics table"""
         if columns:
@@ -571,6 +572,9 @@ class V3IOTSDBConnector(TSDBConnector):
                     query.write(sub_cond)
 
                 query.write(")")
+
+            if groupby:
+                query.write(f" GROUP BY {','.join(groupby)}")
 
             query.write(";")
             return query.getvalue()

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -556,7 +556,6 @@ class V3IOTSDBConnector(TSDBConnector):
         name: str = mm_schemas.ResultData.RESULT_NAME,
         metric_and_app_names: Optional[list[tuple[str, str]]] = None,
         columns: Optional[list[str]] = None,
-        groupby: Optional[list[str]] = None,
     ) -> str:
         """Get the SQL query for the results/metrics table"""
         if columns:
@@ -582,9 +581,6 @@ class V3IOTSDBConnector(TSDBConnector):
                     query.write(sub_cond)
 
                 query.write(")")
-
-            if groupby:
-                query.write(f" GROUP BY {','.join(groupby)}")
 
             query.write(";")
             return query.getvalue()

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -372,15 +372,21 @@ class TestGetModelEndpointMetrics:
             "ddw2lke",
             [],
             "app-results",
-            "SELECT * FROM 'app-results' WHERE endpoint_id='ddw2lke';",
+            (
+                "SELECT result_value,result_status,result_kind "
+                "FROM 'app-results' WHERE endpoint_id='ddw2lke' "
+                "GROUP BY application_name,result_name;"
+            ),
         ),
         (
             "ep123",
             [("app1", "res1")],
             "path/to/app-results",
             (
-                "SELECT * FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
-                "AND ((application_name='app1' AND result_name='res1'));"
+                "SELECT result_value,result_status,result_kind "
+                "FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
+                "AND ((application_name='app1' AND result_name='res1')) "
+                "GROUP BY application_name,result_name;"
             ),
         ),
         (
@@ -388,20 +394,26 @@ class TestGetModelEndpointMetrics:
             [("app1", "res1"), ("app1", "res2"), ("app2", "res1")],
             "app-results",
             (
-                "SELECT * FROM 'app-results' WHERE endpoint_id='ep123' AND "
+                "SELECT result_value,result_status,result_kind "
+                "FROM 'app-results' WHERE endpoint_id='ep123' AND "
                 "((application_name='app1' AND result_name='res1') OR "
                 "(application_name='app1' AND result_name='res2') OR "
-                "(application_name='app2' AND result_name='res1'));"
+                "(application_name='app2' AND result_name='res1')) "
+                "GROUP BY application_name,result_name;"
             ),
         ),
     ],
 )
-def test_tsdb_query(
+def test_tsdb_results_query(
     endpoint_id: str, names: list[tuple[str, str]], table_path: str, expected_query: str
 ) -> None:
     assert (
         V3IOTSDBConnector._get_sql_query(
-            endpoint_id=endpoint_id, metric_and_app_names=names, table_path=table_path
+            endpoint_id=endpoint_id,
+            metric_and_app_names=names,
+            table_path=table_path,
+            columns=["result_value", "result_status", "result_kind"],
+            groupby=["application_name", "result_name"],
         )
         == expected_query
     )

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -372,21 +372,15 @@ class TestGetModelEndpointMetrics:
             "ddw2lke",
             [],
             "app-results",
-            (
-                "SELECT result_value,result_status,result_kind "
-                "FROM 'app-results' WHERE endpoint_id='ddw2lke' "
-                "GROUP BY application_name,result_name;"
-            ),
+            "SELECT * FROM 'app-results' WHERE endpoint_id='ddw2lke';",
         ),
         (
             "ep123",
             [("app1", "res1")],
             "path/to/app-results",
             (
-                "SELECT result_value,result_status,result_kind "
-                "FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
-                "AND ((application_name='app1' AND result_name='res1')) "
-                "GROUP BY application_name,result_name;"
+                "SELECT * FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
+                "AND ((application_name='app1' AND result_name='res1'));"
             ),
         ),
         (
@@ -394,26 +388,20 @@ class TestGetModelEndpointMetrics:
             [("app1", "res1"), ("app1", "res2"), ("app2", "res1")],
             "app-results",
             (
-                "SELECT result_value,result_status,result_kind "
-                "FROM 'app-results' WHERE endpoint_id='ep123' AND "
+                "SELECT * FROM 'app-results' WHERE endpoint_id='ep123' AND "
                 "((application_name='app1' AND result_name='res1') OR "
                 "(application_name='app1' AND result_name='res2') OR "
-                "(application_name='app2' AND result_name='res1')) "
-                "GROUP BY application_name,result_name;"
+                "(application_name='app2' AND result_name='res1'));"
             ),
         ),
     ],
 )
-def test_tsdb_results_query(
+def test_tsdb_query(
     endpoint_id: str, names: list[tuple[str, str]], table_path: str, expected_query: str
 ) -> None:
     assert (
         V3IOTSDBConnector._get_sql_query(
-            endpoint_id=endpoint_id,
-            metric_and_app_names=names,
-            table_path=table_path,
-            columns=["result_value", "result_status", "result_kind"],
-            groupby=["application_name", "result_name"],
+            endpoint_id=endpoint_id, metric_and_app_names=names, table_path=table_path
         )
         == expected_query
     )

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -366,20 +366,23 @@ class TestGetModelEndpointMetrics:
 
 
 @pytest.mark.parametrize(
-    ("endpoint_id", "names", "table_path", "expected_query"),
+    ("endpoint_id", "names", "table_path", "columns", "expected_query"),
     [
         (
             "ddw2lke",
             [],
             "app-results",
+            None,
             "SELECT * FROM 'app-results' WHERE endpoint_id='ddw2lke';",
         ),
         (
             "ep123",
             [("app1", "res1")],
             "path/to/app-results",
+            ["result_value", "result_status", "result_kind"],
             (
-                "SELECT * FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
+                "SELECT result_value,result_status,result_kind "
+                "FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
                 "AND ((application_name='app1' AND result_name='res1'));"
             ),
         ),
@@ -387,8 +390,10 @@ class TestGetModelEndpointMetrics:
             "ep123",
             [("app1", "res1"), ("app1", "res2"), ("app2", "res1")],
             "app-results",
+            ["result_value", "result_status", "result_kind"],
             (
-                "SELECT * FROM 'app-results' WHERE endpoint_id='ep123' AND "
+                "SELECT result_value,result_status,result_kind "
+                "FROM 'app-results' WHERE endpoint_id='ep123' AND "
                 "((application_name='app1' AND result_name='res1') OR "
                 "(application_name='app1' AND result_name='res2') OR "
                 "(application_name='app2' AND result_name='res1'));"
@@ -397,11 +402,18 @@ class TestGetModelEndpointMetrics:
     ],
 )
 def test_tsdb_query(
-    endpoint_id: str, names: list[tuple[str, str]], table_path: str, expected_query: str
+    endpoint_id: str,
+    names: list[tuple[str, str]],
+    table_path: str,
+    expected_query: str,
+    columns: Optional[list[str]],
 ) -> None:
     assert (
         V3IOTSDBConnector._get_sql_query(
-            endpoint_id=endpoint_id, metric_and_app_names=names, table_path=table_path
+            endpoint_id=endpoint_id,
+            metric_and_app_names=names,
+            table_path=table_path,
+            columns=columns,
         )
         == expected_query
     )


### PR DESCRIPTION
Fixes [ML-7318](https://iguazio.atlassian.net/browse/ML-7318).

Select only the columns required for the data to be returned in the `/metrics-values` API endpoint. This does not include `current_stats`, resulting in a significantly reduced response size from V3IO web-API.
I tested it and it works.

[ML-7318]: https://iguazio.atlassian.net/browse/ML-7318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ