### PR TITLE
[Alerts] Update cached state once alert becomes active

### DIFF
--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -193,6 +193,7 @@ class Alerts(
                     update_state = False
                 else:
                     active = True
+                    state["active"] = True
                     self._get_alert_state_cached().cache_replace(
                         state, session, alert.id
                     )

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -102,6 +102,16 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             alert, alert_state=alert_objects.AlertActiveState.ACTIVE, alert_count=1
         )
 
+        # send events again to make sure alert does not trigger, since it is active already
+        for _ in range(alert2["criteria"].count):
+            self._post_event(
+                project_name, alert2["event_name"], alert2["entity"]["kind"]
+            )
+        alert = self._get_alerts(project_name, created_alert2.name)
+        self._validate_alert(
+            alert, alert_state=alert_objects.AlertActiveState.ACTIVE, alert_count=1
+        )
+
         # reset the alert and trigger the event again and validate that the state is inactive
         self._reset_alert(project_name, created_alert2.name)
         self._post_event(project_name, alert2["event_name"], alert2["entity"]["kind"])


### PR DESCRIPTION
When alert becomes active, we update state cache,
but we (I) forgot to update the active field inside state object, so we will always get inactive state from cache. Just need to update the state object before replacing the cache

Resolve https://iguazio.atlassian.net/browse/ML-7388