### PR TITLE
[Secretes] If secrets is None delete all secrets data

### DIFF
--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -615,6 +615,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 for key, value in k8s_secret.data.items()
                 if key not in secrets
             }
+        elif secrets is None:
+            # Delete all secrets
+            secret_data = {}
         else:
             secret_data = k8s_secret.data.copy()
 

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -577,7 +577,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         """
         Delete secrets from a kubernetes secret object
         :param secret_name: the project secret name
-        :param secrets:     the secrets to delete
+        :param secrets:     the secrets to delete. If None, all secrets will be deleted
         :param namespace:   k8s namespace
         :return: returns the action if the secret was deleted or updated, None if nothing changed
         """
@@ -622,7 +622,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             secret_data = k8s_secret.data.copy()
 
         # Check if there were any changes to the secret data
-        if k8s_secret.data and len(secret_data) == len(k8s_secret.data):
+        if len(secret_data) == len(k8s_secret.data):
             # No secrets were deleted
             return None
 

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -622,7 +622,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             secret_data = k8s_secret.data.copy()
 
         # Check if there were any changes to the secret data
-        if len(secret_data) == len(k8s_secret.data):
+        if k8s_secret.data and len(secret_data) == len(k8s_secret.data):
             # No secrets were deleted
             return None
 

--- a/tests/api/utils/singletons/test_k8s_utils.py
+++ b/tests/api/utils/singletons/test_k8s_utils.py
@@ -120,9 +120,9 @@ def test_store_secret(k8s_helper, secret_data, secrets, expected_data, expected_
         ),
         (
             {"key1": "value1", "key2": "value2"},
-            None,
-            None,
-            {"key1": "value1", "key2": "value2"},
+            None,  # delete all secrets
+            mlrun.common.schemas.SecretEventActions.deleted,
+            {},
         ),
         (
             {"key1": "value1", "key2": "value2"},


### PR DESCRIPTION
[Here](https://github.com/mlrun/mlrun/blob/30aadb6f3d83b27db15c5704d6c0be0d7503032d/server/api/crud/projects.py#L477) we expect that when passing None as the `secrets` that we want to delete, we should delete **all** secrets.
Fixing it by checking if `secrets` is None and in that case set the `secret_data` to empty dict.

https://iguazio.atlassian.net/browse/ML-7440