### PR TITLE
[Model Monitoring] Fix model monitoring system tests

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -268,7 +268,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
             else mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection,
             stream_path=mlrun.mlconf.model_endpoint_monitoring.stream_connection,
             tsdb_connection=mlrun.mlconf.model_endpoint_monitoring.tsdb_connection,
-            replace_creds=True,
+            replace_creds=True,  # remove once ML-7501 is resolved
         )
 
         iris = load_iris()
@@ -1180,7 +1180,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
     project_name = "infer-model-tsdb"
     name_prefix = "infer-model-only"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: Optional[str] = None
+    image = "docker.io/eyaligu/mlrun:unstablev8"
 
     @classmethod
     def custom_setup_class(cls) -> None:

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1180,7 +1180,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
     project_name = "infer-model-tsdb"
     name_prefix = "infer-model-only"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image = "docker.io/eyaligu/mlrun:unstablev8"
+    image: Optional[str] = None
 
     @classmethod
     def custom_setup_class(cls) -> None:

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -268,6 +268,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
             else mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection,
             stream_path=mlrun.mlconf.model_endpoint_monitoring.stream_connection,
             tsdb_connection=mlrun.mlconf.model_endpoint_monitoring.tsdb_connection,
+            replace_creds=True,
         )
 
         iris = load_iris()
@@ -1094,6 +1095,12 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
 
     def custom_setup(self) -> None:
         mlrun.runtimes.utils.global_context.set(None)
+        # Set the model monitoring credentials
+        self.project.set_model_monitoring_credentials(
+            endpoint_store_connection=mlrun.mlconf.model_endpoint_monitoring.endpoint_store_connection,
+            stream_path=mlrun.mlconf.model_endpoint_monitoring.stream_connection,
+            tsdb_connection=mlrun.mlconf.model_endpoint_monitoring.tsdb_connection,
+        )
 
     @classmethod
     def _generate_data(cls) -> list[Union[pd.DataFrame, pd.Series]]:


### PR DESCRIPTION
This PR includes 2 fixes:
- `TestBasicModelMonitoring`: pass `replace_creds=True` to override old model monitoring secrets if exist. This fix is just a workaround at the moment because the old secrets should be deleted during the test teardown. (https://iguazio.atlassian.net/browse/ML-7501).
- `TestInferenceWithSpecialChars`: apply `set_model_monitoring_credentials` which was missing from that test.