### PR TITLE
[Projects] Enforce project_setup.py returns a project object

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -18,6 +18,7 @@ import glob
 import http
 import importlib.util as imputil
 import json
+import os.path
 import pathlib
 import shutil
 import tempfile
@@ -600,6 +601,10 @@ def _run_project_setup(
     if hasattr(mod, "setup"):
         try:
             project = getattr(mod, "setup")(project)
+            if not project or not isinstance(project, mlrun.projects.MlrunProject):
+                raise ValueError(
+                    "MLRun project_setup:setup() must return a project object"
+                )
         except Exception as exc:
             logger.error(
                 "Failed to run project_setup script",
@@ -610,7 +615,9 @@ def _run_project_setup(
         if save:
             project.save()
     else:
-        logger.warn("skipping setup, setup() handler was not found in project_setup.py")
+        logger.warn(
+            f"skipping setup, setup() handler was not found in {os.path.basename(setup_file_path)}"
+        )
     return project
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -18,7 +18,6 @@ import glob
 import http
 import importlib.util as imputil
 import json
-import os.path
 import pathlib
 import shutil
 import tempfile
@@ -616,7 +615,7 @@ def _run_project_setup(
             project.save()
     else:
         logger.warn(
-            f"skipping setup, setup() handler was not found in {os.path.basename(setup_file_path)}"
+            f"skipping setup, setup() handler was not found in {path.basename(setup_file_path)}"
         )
     return project
 


### PR DESCRIPTION
Otherwise, the flow fails unexpectedly as the returned project is being used later on for the creation / load

https://iguazio.atlassian.net/browse/ML-7531