### PR TITLE
[Runs] Abort run from run object

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1789,6 +1789,11 @@ class RunObject(RunTemplate):
 
         return state
 
+    def abort(self):
+        """abort the run"""
+        db = mlrun.get_run_db()
+        db.abort_run(self.metadata.uid, self.metadata.project)
+
     @staticmethod
     def create_uri(project: str, uid: str, iteration: Union[int, str], tag: str = ""):
         if tag:


### PR DESCRIPTION
just a syntactic sugar to make run abort-able from the sdk itself