### PR TITLE
[SQLDB] Change log logic in `_delete_multi_objects`

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2432,7 +2432,7 @@ class SQLDB(DBInterface):
             "main_table_identifier_values_count": len(main_table_identifier_values),
         }
         if deletions_count != len(main_table_identifier_values):
-            logger.warning("Removed less rows than expected from table", **log_kwargs)
+            logger.debug("Removed less rows than expected from table", **log_kwargs)
         else:
             logger.debug("Removed rows from table", **log_kwargs)
         session.commit()

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2429,12 +2429,9 @@ class SQLDB(DBInterface):
             "main_table": main_table,
             "project": project,
             "main_table_identifier": main_table_identifier,
-            "main_table_identifier_values_count": len(main_table_identifier_values),
+            "main_table_identifier_values": main_table_identifier_values,
         }
-        if deletions_count != len(main_table_identifier_values):
-            logger.debug("Removed less rows than expected from table", **log_kwargs)
-        else:
-            logger.debug("Removed rows from table", **log_kwargs)
+        logger.debug("Removed rows from table", **log_kwargs)
         session.commit()
         return deletions_count
 


### PR DESCRIPTION
The log logic doesn't account for a few scenarios, such as:

- The `project = "*"` condition, where the deleted object exists in more than one project.
- The case where the deleted object doesn't exist at all or only in some of the projects.

For now, we'll keep this debug log to understand how many objects were deleted.



