### PR TITLE
[Model Monitoring] Avoid suppressing errors in `KVStoreBase.get_last_analyzed`

### DIFF
--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import http
 import json
 import typing
 from dataclasses import dataclass
@@ -417,11 +417,14 @@ class KVStoreBase(StoreBase):
             )
             return response.output.item[mm_schemas.SchedulingKeys.LAST_ANALYZED]
         except v3io.dataplane.response.HttpResponseError as err:
-            logger.debug("Error while getting last analyzed time", err=err)
-            raise mlrun.errors.MLRunNotFoundError(
-                f"No last analyzed value has been found for {application_name} "
-                f"that processes model endpoint {endpoint_id}",
-            )
+            if err.status_code == http.HTTPStatus.NOT_FOUND:
+                logger.debug("Last analyzed time not found", err=err)
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"No last analyzed value has been found for {application_name} "
+                    f"that processes model endpoint {endpoint_id}",
+                )
+            logger.error("Error while getting last analyzed time", err=err)
+            raise err
 
     def update_last_analyzed(
         self, endpoint_id: str, application_name: str, last_analyzed: int

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import http
 from collections.abc import Iterator
 from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
@@ -177,7 +178,9 @@ class TestBatchInterval:
     @pytest.fixture(autouse=True)
     def mock_kv() -> Iterator[None]:
         mock = Mock(spec=["kv"])
-        mock.kv.get = Mock(side_effect=HttpResponseError)
+        mock.kv.get = Mock(
+            side_effect=HttpResponseError(status_code=http.HTTPStatus.NOT_FOUND)
+        )
         with patch(
             "mlrun.utils.v3io_clients.get_v3io_client",
             return_value=mock,


### PR DESCRIPTION
Noticed while investigating an otherwise unrelated issue – https://iguazio.atlassian.net/browse/ML-7160?focusedCommentId=154985