### PR TITLE
[Alerts] Handle the duplicated attributes between alert and notification

### DIFF
--- a/mlrun/common/schemas/notification.py
+++ b/mlrun/common/schemas/notification.py
@@ -71,9 +71,9 @@ class Notification(pydantic.BaseModel):
 
     kind: NotificationKind
     name: str
-    message: str
-    severity: NotificationSeverity
-    when: list[str]
+    message: typing.Optional[str] = None
+    severity: typing.Optional[NotificationSeverity] = None
+    when: typing.Optional[list[str]] = None
     condition: typing.Optional[str] = None
     params: typing.Optional[dict[str, typing.Any]] = None
     status: typing.Optional[NotificationStatus] = None

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -5561,9 +5561,12 @@ class SQLDB(DBInterface):
                 )
 
             notification.kind = notification_model.kind
-            notification.message = notification_model.message
-            notification.severity = notification_model.severity
-            notification.when = ",".join(notification_model.when)
+            notification.message = notification_model.message or ""
+            notification.severity = (
+                notification_model.severity
+                or mlrun.common.schemas.NotificationSeverity.INFO
+            )
+            notification.when = ",".join(notification_model.when or [])
             notification.condition = notification_model.condition
             notification.secret_params = notification_model.secret_params
             notification.params = notification_model.params

--- a/server/api/utils/notification_pusher.py
+++ b/server/api/utils/notification_pusher.py
@@ -157,7 +157,9 @@ class AlertNotificationPusher(_NotificationPusherBase):
         notification_object: mlrun.common.schemas.Notification,
     ):
         message = (
-            f": {notification_object.message}" if notification_object.message else ""
+            f": {notification_object.message}"
+            if notification_object.message
+            else alert.summary
         )
 
         severity = alert.severity

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -254,9 +254,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         notification = mlrun.model.Notification(
             kind="slack",
             name="slack_drift",
-            message="Ay caramba!",
-            severity="warning",
-            when=["now"],
             secret_params={
                 "webhook": "https://hooks.slack.com/services/",
             },
@@ -445,9 +442,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                 "notification": {
                     "kind": "slack",
                     "name": "slack_jobs",
-                    "message": "Ay ay ay!",
-                    "severity": "warning",
-                    "when": ["now"],
                     "condition": "failed",
                     "secret_params": {
                         "webhook": "https://hooks.slack.com/services/",
@@ -458,9 +452,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                 "notification": {
                     "kind": "git",
                     "name": "git_jobs",
-                    "message": "Ay ay ay!",
-                    "severity": "warning",
-                    "when": ["now"],
                     "condition": "failed",
                     "params": {
                         "repo": "some-repo",
@@ -682,9 +673,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                     "notification": {
                         "kind": "slack",
                         "name": "slack_drift",
-                        "message": "Ay caramba!",
-                        "severity": "warning",
-                        "when": ["now"],
                         "secret_params": {
                             "webhook": "https://hooks.slack.com/services/",
                         },

--- a/tests/utils/test_alerts.py
+++ b/tests/utils/test_alerts.py
@@ -51,9 +51,6 @@ def test_summary_formatter(summary, project, alert_name, entity_id, expected_str
     notification = mlrun.common.schemas.Notification(
         kind="slack",
         name="slack_drift",
-        message="Ay caramba!",
-        severity="warning",
-        when=["now"],
         secret_params={
             "webhook": "https://hooks.slack.com/services/",
         },


### PR DESCRIPTION
This PR is intended to handle 3 duplicated attributes between the alert and the notification objects.
the duplicated attributes are :
alert.severity & notification.severity
alert.trigger & notification.when
alert.summary & notification.message

in the current flow the user needed to supply all of the above fields in order to create the alert config, even though we don't use some the attributes that were given in the notification..
so now the user can set these attributes only in the alert config, and will not have to supply them in the notification.
this shortens the process of creating the alert.

resolves:
https://iguazio.atlassian.net/browse/ML-7248