### PR TITLE
[Feature Store] Fix parsing of feature string when feature set name contains a dot

### DIFF
--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -37,17 +37,12 @@ def parse_feature_string(feature):
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"feature {feature} must be {expected_message}"
         )
-    splitted = feature.split(feature_separator)
-    if len(splitted) > 2:
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            f"feature {feature} must be {expected_message}, cannot have more than one '.'"
-        )
-    feature_set = splitted[0]
-    feature_name = splitted[1]
-    splitted = feature_name.split(" as ")
-    if len(splitted) > 1:
-        return feature_set.strip(), splitted[0].strip(), splitted[1].strip()
-    return feature_set.strip(), feature_name.strip(), None
+    feature_set, feature_name = feature.rsplit(feature_separator, 1)
+    feature_set = feature_set.strip()
+    split_result = feature_name.split(" as ", 1)
+    feature_name = split_result[0].strip()
+    alias = split_result[1].strip() if len(split_result) > 1 else None
+    return feature_set, feature_name, alias
 
 
 def parse_project_name_from_feature_string(feature):

--- a/tests/feature-store/test_common.py
+++ b/tests/feature-store/test_common.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from mlrun.feature_store.common import parse_feature_string
 
 

--- a/tests/feature-store/test_common.py
+++ b/tests/feature-store/test_common.py
@@ -1,0 +1,18 @@
+from mlrun.feature_store.common import parse_feature_string
+
+
+# ML-7453
+def test_parse_feature_string_with_dot_in_feature_set_name():
+    feature_set, feature, alias = parse_feature_string(
+        "monitoring-llm-server-Qwen-Qwen2-0.5B-latest.*"
+    )
+    assert feature_set == "monitoring-llm-server-Qwen-Qwen2-0.5B-latest"
+    assert feature == "*"
+    assert alias is None
+
+
+def test_parse_feature_string_with_alias():
+    feature_set, feature, alias = parse_feature_string("fset.feature as alias")
+    assert feature_set == "fset"
+    assert feature == "feature"
+    assert alias == "alias"


### PR DESCRIPTION
[ML-7453](https://iguazio.atlassian.net/browse/ML-7453)

[ML-7453]: https://iguazio.atlassian.net/browse/ML-7453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ