### PR TITLE
[Notification] Fix `send_start_notification` param not propagating to scheduled workflows

### DIFF
--- a/mlrun/common/schemas/workflow.py
+++ b/mlrun/common/schemas/workflow.py
@@ -42,6 +42,7 @@ class WorkflowRequest(pydantic.BaseModel):
     run_name: typing.Optional[str] = None
     namespace: typing.Optional[str] = None
     notifications: typing.Optional[list[Notification]] = None
+    send_start_notification: typing.Optional[bool] = None
 
 
 class WorkflowResponse(pydantic.BaseModel):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -876,6 +876,7 @@ class RunDBInterface(ABC):
         run_name: Optional[str] = None,
         namespace: Optional[str] = None,
         notifications: list["mlrun.model.Notification"] = None,
+        send_start_notification: bool = True,
     ) -> "mlrun.common.schemas.WorkflowResponse":
         pass
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3989,19 +3989,21 @@ class HTTPRunDB(RunDBInterface):
         run_name: Optional[str] = None,
         namespace: Optional[str] = None,
         notifications: list[mlrun.model.Notification] = None,
+        send_start_notification: bool = True,
     ) -> mlrun.common.schemas.WorkflowResponse:
         """
         Submitting workflow for a remote execution.
 
-        :param project:         project name
-        :param name:            workflow name
-        :param workflow_spec:   the workflow spec to execute
-        :param arguments:       arguments for the workflow
-        :param artifact_path:   artifact target path of the workflow
-        :param source:          source url of the project
-        :param run_name:        run name to override the default: 'workflow-runner-<workflow name>'
-        :param namespace:       kubernetes namespace if other than default
-        :param notifications:   list of notifications to send when workflow execution is completed
+        :param project:                  project name
+        :param name:                     workflow name
+        :param workflow_spec:            the workflow spec to execute
+        :param arguments:                arguments for the workflow
+        :param artifact_path:            artifact target path of the workflow
+        :param source:                   source url of the project
+        :param run_name:                 run name to override the default: 'workflow-runner-<workflow name>'
+        :param namespace:                kubernetes namespace if other than default
+        :param notifications:            list of notifications to send when workflow execution is completed
+        :param send_start_notification:  whether to send a notification when the workflow execution starts
 
         :returns:    :py:class:`~mlrun.common.schemas.WorkflowResponse`.
         """
@@ -4021,6 +4023,7 @@ class HTTPRunDB(RunDBInterface):
             "source": source,
             "run_name": run_name,
             "namespace": namespace,
+            "send_start_notification": send_start_notification,
         }
         if isinstance(
             workflow_spec,

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -693,6 +693,7 @@ class NopDB(RunDBInterface):
         run_name: Optional[str] = None,
         namespace: Optional[str] = None,
         notifications: list["mlrun.model.Notification"] = None,
+        send_start_notification: bool = True,
     ) -> "mlrun.common.schemas.WorkflowResponse":
         pass
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -810,6 +810,7 @@ class _RemoteRunner(_PipelineRunner):
                 ),
                 namespace=namespace,
                 notifications=notifications,
+                send_start_notification=send_start_notification,
             )
             if workflow_spec.schedule:
                 logger.info(
@@ -1007,6 +1008,7 @@ def load_and_run(
     load_only: bool = False,
     wait_for_completion: bool = False,
     project_context: str = None,
+    send_start_notification: bool = True,
 ):
     """
     Auxiliary function that the RemoteRunner run once or run every schedule.
@@ -1093,6 +1095,7 @@ def load_and_run(
         cleanup_ttl=cleanup_ttl,
         engine=engine,
         local=local,
+        send_start_notification=send_start_notification,
     )
     context.log_result(key="workflow_id", value=run.run_id)
     context.log_result(key="engine", value=run._engine.engine, commit=True)

--- a/server/api/api/endpoints/workflows.py
+++ b/server/api/api/endpoints/workflows.py
@@ -203,6 +203,9 @@ async def submit_workflow(
         ] = sanitize_label_value(client_python_version)
     try:
         if workflow_spec.schedule:
+            send_start_notification = getattr(
+                workflow_request, "send_start_notification", True
+            )
             await run_in_threadpool(
                 server.api.crud.WorkflowRunners().schedule,
                 runner=workflow_runner,
@@ -210,6 +213,7 @@ async def submit_workflow(
                 workflow_request=updated_request,
                 db_session=db_session,
                 auth_info=auth_info,
+                send_start_notification=send_start_notification,
             )
             status = "scheduled"
 

--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -77,15 +77,17 @@ class WorkflowRunners(
         workflow_request: mlrun.common.schemas.WorkflowRequest,
         db_session: Session = None,
         auth_info: mlrun.common.schemas.AuthInfo = None,
+        send_start_notification: bool = True,
     ):
         """
         Schedule workflow runner.
 
-        :param runner:              workflow runner function object
-        :param project:             MLRun project
-        :param workflow_request:    contains the workflow spec, that will be scheduled
-        :param db_session:          session that manages the current dialog with the database
-        :param auth_info:           auth info of the request
+        :param runner:                   workflow runner function object
+        :param project:                  MLRun project
+        :param workflow_request:         contains the workflow spec, that will be scheduled
+        :param db_session:               session that manages the current dialog with the database
+        :param auth_info:                auth info of the request
+        :param send_start_notification:  if True, will send a notification when the workflow starts
         """
         labels = {
             mlrun_constants.MLRunInternalLabels.job_type: "workflow-runner",
@@ -96,6 +98,7 @@ class WorkflowRunners(
             project=project,
             workflow_request=workflow_request,
             labels=labels,
+            send_start_notification=send_start_notification,
         )
         # this includes filling the spec.function which is required for submit run
         runner._store_function(
@@ -131,6 +134,7 @@ class WorkflowRunners(
         project: mlrun.common.schemas.Project,
         workflow_request: mlrun.common.schemas.WorkflowRequest,
         labels: dict[str, str],
+        send_start_notification: bool = True,
     ) -> mlrun.run.RunObject:
         """
         Preparing all the necessary metadata and specifications for scheduling workflow from server-side.
@@ -169,6 +173,7 @@ class WorkflowRunners(
                     # once the pipeline is done, the pod finishes (either successfully or not) and notifications
                     # can be sent.
                     wait_for_completion=True,
+                    send_start_notification=send_start_notification,
                 ),
                 handler="mlrun.projects.load_and_run",
                 scrape_metrics=config.scrape_metrics,

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -1073,6 +1073,7 @@ class SQLRunDB(RunDBInterface):
         run_name: Optional[str] = None,
         namespace: Optional[str] = None,
         notifications: list[mlrun.model.Notification] = None,
+        send_start_notification: bool = True,
     ) -> "mlrun.common.schemas.WorkflowResponse":
         raise NotImplementedError()
 


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-6644

Passing the `send_start_notification` from SDK all the way to the `load_and_run` function so it affects scheduled pipelines as well.