### PR TITLE
[Alerts] Validate only the alert name in the `store_alert_config` function

### DIFF
--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -136,10 +136,6 @@ class AlertConfig(ModelObj):
         if template:
             self._apply_template(template)
 
-    def validate_required_fields(self):
-        if not self.name:
-            raise mlrun.errors.MLRunBadRequestError("Alert name must be provided")
-
     def _serialize_field(
         self, struct: dict, field_name: str = None, strip: bool = False
     ):

--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -136,6 +136,10 @@ class AlertConfig(ModelObj):
         if template:
             self._apply_template(template)
 
+    def validate_required_fields(self):
+        if not self.name:
+            raise mlrun.errors.MLRunInvalidArgumentError("Alert name must be provided")
+
     def _serialize_field(
         self, struct: dict, field_name: str = None, strip: bool = False
     ):

--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -137,8 +137,8 @@ class AlertConfig(ModelObj):
             self._apply_template(template)
 
     def validate_required_fields(self):
-        if not self.project or not self.name:
-            raise mlrun.errors.MLRunBadRequestError("Project and name must be provided")
+        if not self.name:
+            raise mlrun.errors.MLRunBadRequestError("Alert name must be provided")
 
     def _serialize_field(
         self, struct: dict, field_name: str = None, strip: bool = False

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4224,7 +4224,6 @@ class HTTPRunDB(RunDBInterface):
             if isinstance(alert_data, AlertConfig)
             else AlertConfig.from_dict(alert_data)
         )
-        alert_instance.validate_required_fields()
 
         alert_data = alert_instance.to_dict()
         body = _as_json(alert_data)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4227,8 +4227,8 @@ class HTTPRunDB(RunDBInterface):
             if isinstance(alert_data, AlertConfig)
             else AlertConfig.from_dict(alert_data)
         )
-        # The validation must be here because the user can call this function directly
-        # via `mlrun.get_run_db().store_alert_config()`
+        # Validation is necessary here because users can directly invoke this function
+        # through `mlrun.get_run_db().store_alert_config()`.
         alert_instance.validate_required_fields()
 
         alert_data = alert_instance.to_dict()

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4216,6 +4216,9 @@ class HTTPRunDB(RunDBInterface):
         :param project:    The project that the alert belongs to.
         :returns:          The created/modified alert.
         """
+        if not alert_data:
+            raise mlrun.errors.MLRunInvalidArgumentError("Alert data must be provided")
+
         project = project or config.default_project
         endpoint_path = f"projects/{project}/alerts/{alert_name}"
         error_message = f"put alert {project}/alerts/{alert_name}"
@@ -4224,6 +4227,9 @@ class HTTPRunDB(RunDBInterface):
             if isinstance(alert_data, AlertConfig)
             else AlertConfig.from_dict(alert_data)
         )
+        # The validation must be here because the user can call this function directly
+        # via `mlrun.get_run_db().store_alert_config()`
+        alert_instance.validate_required_fields()
 
         alert_data = alert_instance.to_dict()
         body = _as_json(alert_data)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4070,11 +4070,11 @@ class MlrunProject(ModelObj):
         :param alert_name: The name of the alert.
         :return: the created/modified alert.
         """
+        if not alert_data:
+            raise mlrun.errors.MLRunInvalidArgumentError("Alert data must be provided")
+
         db = mlrun.db.get_run_db(secrets=self._secrets)
         alert_name = alert_name or alert_data.name
-        if not alert_name:
-            raise mlrun.errors.MLRunInvalidArgumentError("Alert name must be provided")
-
         if alert_data.project is not None and alert_data.project != self.metadata.name:
             logger.warn(
                 "Project in alert does not match project in operation",

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4061,7 +4061,7 @@ class MlrunProject(ModelObj):
         mlrun.db.get_run_db().delete_api_gateway(name=name, project=self.name)
 
     def store_alert_config(
-        self, alert_data: AlertConfig, alert_name=None
+        self, alert_data: AlertConfig, alert_name: str = None
     ) -> AlertConfig:
         """
         Create/modify an alert.
@@ -4071,8 +4071,10 @@ class MlrunProject(ModelObj):
         :return: the created/modified alert.
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        if alert_name is None:
-            alert_name = alert_data.name
+        alert_name = alert_name or alert_data.name
+        if not alert_name:
+            raise mlrun.errors.MLRunInvalidArgumentError("Alert name must be provided")
+
         if alert_data.project is not None and alert_data.project != self.metadata.name:
             logger.warn(
                 "Project in alert does not match project in operation",

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4061,7 +4061,7 @@ class MlrunProject(ModelObj):
         mlrun.db.get_run_db().delete_api_gateway(name=name, project=self.name)
 
     def store_alert_config(
-        self, alert_data: AlertConfig, alert_name: str = None
+        self, alert_data: AlertConfig, alert_name: typing.Optional[str] = None
     ) -> AlertConfig:
         """
         Create/modify an alert.

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -283,28 +283,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             alerts[0], project_name=project_name, alert_name=alert_name
         )
 
-    @pytest.mark.parametrize(
-        "alert_name_in_config, alert_name_as_func_param",
-        [
-            (None, None),
-            (None, ""),
-            ("", None),
-            ("", ""),
-        ],
-    )
-    def test_store_alert_config_missing_alert_name(
-        self, alert_name_in_config, alert_name_as_func_param
-    ):
-        project_name = "my-project"
-        project = mlrun.new_project(project_name)
-        alert_data = mlrun.alerts.alert.AlertConfig(
-            name=alert_name_in_config, project=None
-        )
-        with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError, match="Alert name must be provided"
-        ):
-            project.store_alert_config(alert_data, alert_name=alert_name_as_func_param)
-
     def _create_alerts_test(self, project_name, alert1, alert2):
         invalid_notification = [
             {

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -352,15 +352,9 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         expectations = [
             {
-                "param_name": "project_name",
-                "param_value": "",
-                "exception": mlrun.errors.MLRunBadRequestError,
-                "case": "testing create alert without passing project",
-            },
-            {
                 "param_name": "alert_name",
                 "param_value": "",
-                "exception": mlrun.errors.MLRunBadRequestError,
+                "exception": mlrun.errors.MLRunInvalidArgumentError,
                 "case": "testing create alert without passing alert name",
             },
             {

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -283,6 +283,28 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             alerts[0], project_name=project_name, alert_name=alert_name
         )
 
+    @pytest.mark.parametrize(
+        "alert_name_in_config, alert_name_as_func_param",
+        [
+            (None, None),
+            (None, ""),
+            ("", None),
+            ("", ""),
+        ],
+    )
+    def test_store_alert_config_missing_alert_name(
+        self, alert_name_in_config, alert_name_as_func_param
+    ):
+        project_name = "my-project"
+        project = mlrun.new_project(project_name)
+        alert_data = mlrun.alerts.alert.AlertConfig(
+            name=alert_name_in_config, project=None
+        )
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError, match="Alert name must be provided"
+        ):
+            project.store_alert_config(alert_data, alert_name=alert_name_as_func_param)
+
     def _create_alerts_test(self, project_name, alert1, alert2):
         invalid_notification = [
             {

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2316,24 +2316,16 @@ def test_workflow_path_with_project_workdir():
 
 
 @pytest.mark.parametrize(
-    "alert_name_in_config, alert_name_as_func_param",
-    [
-        (None, None),
-        (None, ""),
-        ("", None),
-        ("", ""),
-    ],
+    "alert_data",
+    [None, ""],
 )
-def test_store_alert_config_missing_alert_name(
-    alert_name_in_config, alert_name_as_func_param
-):
+def test_store_alert_config_missing_alert_data(alert_data):
     project_name = "dummy-project"
     project = mlrun.new_project(project_name, save=False)
-    alert_data = mlrun.alerts.alert.AlertConfig(name=alert_name_in_config, project=None)
     with pytest.raises(
-        mlrun.errors.MLRunInvalidArgumentError, match="Alert name must be provided"
+        mlrun.errors.MLRunInvalidArgumentError, match="Alert data must be provided"
     ):
-        project.store_alert_config(alert_data, alert_name=alert_name_as_func_param)
+        project.store_alert_config(alert_data=alert_data)
 
 
 class TestModelMonitoring:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2324,7 +2324,7 @@ def test_workflow_path_with_project_workdir():
         ("", ""),
     ],
 )
-def test_store_alert_config_missing_alert_name_in_config(
+def test_store_alert_config_missing_alert_name(
     alert_name_in_config, alert_name_as_func_param
 ):
     project_name = "dummy-project"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -27,6 +27,7 @@ import inflection
 import pytest
 
 import mlrun
+import mlrun.alerts.alert
 import mlrun.artifacts
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
@@ -2312,6 +2313,27 @@ def test_workflow_path_with_project_workdir():
     project.spec.workdir = "./workdir"
     path = workflow_spec.get_source_file(project.spec.get_code_path())
     assert path == "./context/./workdir/workflow.py"
+
+
+@pytest.mark.parametrize(
+    "alert_name_in_config, alert_name_as_func_param",
+    [
+        (None, None),
+        (None, ""),
+        ("", None),
+        ("", ""),
+    ],
+)
+def test_store_alert_config_missing_alert_name_in_config(
+    alert_name_in_config, alert_name_as_func_param
+):
+    project_name = "dummy-project"
+    project = mlrun.new_project(project_name, save=False)
+    alert_data = mlrun.alerts.alert.AlertConfig(name=alert_name_in_config, project=None)
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="Alert name must be provided"
+    ):
+        project.store_alert_config(alert_data, alert_name=alert_name_as_func_param)
 
 
 class TestModelMonitoring:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -30,6 +30,7 @@ import deepdiff
 import pytest
 import requests_mock as requests_mock_package
 
+import mlrun.alerts
 import mlrun.artifacts.base
 import mlrun.common.formatters
 import mlrun.common.schemas
@@ -963,3 +964,27 @@ def _assert_projects(expected_project, project):
     )
     assert expected_project.spec.desired_state == project.spec.desired_state
     assert expected_project.spec.desired_state == project.status.state
+
+
+@pytest.mark.parametrize(
+    "alert_name_in_config, alert_name_as_func_param",
+    [
+        (None, None),
+        (None, ""),
+        ("", None),
+        ("", ""),
+    ],
+)
+def test_store_alert_config_missing_alert_name(
+    alert_name_in_config, alert_name_as_func_param, create_server
+):
+    server: Server = create_server()
+    db: HTTPRunDB = server.conn
+    alert_data = mlrun.alerts.alert.AlertConfig(name=alert_name_in_config, project=None)
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="Alert name must be provided"
+    ):
+        db.store_alert_config(
+            alert_name=alert_name_as_func_param,
+            alert_data=alert_data,
+        )


### PR DESCRIPTION
When no name is provided in the alert config, the error message the user receives is `MLRunBadRequestError: Project and name must be provided`, although only the alert name should be required 

I also made some changes:
1. Added validation for the `alert_data` argument.
2. Changed the error raised for a missing alert name from `MLRunBadRequestError` to `MLRunInvalidArgumentError` to clarify the error, even though both raise a `BadRequest` (400) error code."

https://iguazio.atlassian.net/browse/ML-7489
