### PR TITLE
[Alerts] Fix passing a notification without the condition field

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -5567,7 +5567,7 @@ class SQLDB(DBInterface):
                 or mlrun.common.schemas.NotificationSeverity.INFO
             )
             notification.when = ",".join(notification_model.when or [])
-            notification.condition = notification_model.condition
+            notification.condition = notification_model.condition or ""
             notification.secret_params = notification_model.secret_params
             notification.params = notification_model.params
             notification.status = (

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -442,7 +442,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                 "notification": {
                     "kind": "slack",
                     "name": "slack_jobs",
-                    "condition": "failed",
                     "secret_params": {
                         "webhook": "https://hooks.slack.com/services/",
                     },
@@ -452,7 +451,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                 "notification": {
                     "kind": "git",
                     "name": "git_jobs",
-                    "condition": "failed",
                     "params": {
                         "repo": "some-repo",
                         "issue": "some-issue",
@@ -676,7 +674,6 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
                         "secret_params": {
                             "webhook": "https://hooks.slack.com/services/",
                         },
-                        "condition": "oops",
                     }
                 }
             ]


### PR DESCRIPTION
when creating a notification without the condition field, the sqldb side translates that as a null, which causes a failure.. so in this case need to give it a default value which is an empty string.

resolves:
https://iguazio.atlassian.net/browse/ML-7389