### PR TITLE
[Datastore] Fix gcs exists bug

### DIFF
--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -72,10 +72,10 @@ class GoogleCloudStorageStore(DataStore):
             return self._sanitize_storage_options(None)
 
     def get_storage_options(self):
-        credentials = self._get_credentials()
-        # due to caching problem from gcsfs==2024.3.1, ML-7636.
-        credentials["use_listings_cache"] = False
-        return credentials
+        storage_options = self._get_credentials()
+        # due to caching problem introduced in gcsfs 2024.3.1 (ML-7636)
+        storage_options["use_listings_cache"] = False
+        return storage_options
 
     def _make_path(self, key):
         key = key.strip("/")

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -139,8 +139,9 @@ class GoogleCloudStorageStore(DataStore):
 
     def rm(self, path, recursive=False, maxdepth=None):
         path = self._make_path(path)
-        if self.filesystem.exists(path):
-            self.filesystem.rm(path=path, recursive=recursive, maxdepth=maxdepth)
+        #  In order to raise an error if there is connection error, ML-7056.
+        self.filesystem.exists(path)
+        super().rm(path, recursive=recursive, maxdepth=maxdepth)
 
     def get_spark_options(self):
         res = {}

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -45,6 +45,7 @@ class GoogleCloudStorageStore(DataStore):
         self._filesystem = makeDatastoreSchemaSanitizer(
             filesystem_class,
             using_bucket=self.using_bucket,
+            use_listings_cache=False,
             **self.get_storage_options(),
         )
         return self._filesystem

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -49,7 +49,7 @@ class GoogleCloudStorageStore(DataStore):
         )
         return self._filesystem
 
-    def get_credentials(self):
+    def _get_credentials(self):
         credentials = self._get_secret_or_env(
             "GCP_CREDENTIALS"
         ) or self._get_secret_or_env("GOOGLE_APPLICATION_CREDENTIALS")
@@ -72,7 +72,7 @@ class GoogleCloudStorageStore(DataStore):
             return self._sanitize_storage_options(None)
 
     def get_storage_options(self):
-        credentials = self.get_credentials()
+        credentials = self._get_credentials()
         # due to caching problem from gcsfs==2024.3.1, ML-7636.
         credentials["use_listings_cache"] = False
         return credentials
@@ -144,7 +144,7 @@ class GoogleCloudStorageStore(DataStore):
 
     def get_spark_options(self):
         res = {}
-        st = self.get_credentials()
+        st = self._get_credentials()
         if "token" in st:
             res = {"spark.hadoop.google.cloud.auth.service.account.enable": "true"}
             if isinstance(st["token"], str):

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -139,7 +139,7 @@ class GoogleCloudStorageStore(DataStore):
 
     def rm(self, path, recursive=False, maxdepth=None):
         path = self._make_path(path)
-        #  In order to raise an error if there is connection error, ML-7056.
+        # in order to raise an error in case of a connection error (ML-7056)
         self.filesystem.exists(path)
         super().rm(path, recursive=recursive, maxdepth=maxdepth)
 

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -133,8 +133,9 @@ class GoogleCloudStorageStore(DataStore):
 
     def rm(self, path, recursive=False, maxdepth=None):
         path = self._make_path(path)
-        self.filesystem.exists(path)
-        self.filesystem.rm(path=path, recursive=recursive, maxdepth=maxdepth)
+        is_exist = self.filesystem.exists(path)
+        if is_exist:
+            self.filesystem.rm(path=path, recursive=recursive, maxdepth=maxdepth)
 
     def get_spark_options(self):
         res = {}

--- a/tests/datastore/test_google_cloud_storage.py
+++ b/tests/datastore/test_google_cloud_storage.py
@@ -22,19 +22,27 @@ def test_get_storage_options():
     st = GoogleCloudStorageStore(parent="parent", schema="schema", name="name")
 
     st._get_secret_or_env = MagicMock(return_value=None)
-    assert st.get_storage_options() == {}
+    use_listings_cache_dict = {"use_listings_cache": False}
+    assert st.get_storage_options() == {**use_listings_cache_dict}
 
     st._get_secret_or_env = MagicMock(
         return_value='{"key1": "value1", "key2": "value2"}'
     )
-    assert st.get_storage_options() == {"token": {"key1": "value1", "key2": "value2"}}
+    assert st.get_storage_options() == {
+        "token": {"key1": "value1", "key2": "value2"},
+        **use_listings_cache_dict,
+    }
 
     st._get_secret_or_env = MagicMock(return_value="/path/to/gcs_credentials_file")
-    assert st.get_storage_options() == {"token": "/path/to/gcs_credentials_file"}
+    assert st.get_storage_options() == {
+        "token": "/path/to/gcs_credentials_file",
+        **use_listings_cache_dict,
+    }
 
     st._get_secret_or_env = MagicMock(
         return_value={"token": {"key1": "value1", "key2": "value2"}}
     )
     assert st.get_storage_options() == {
-        "token": {"token": {"key1": "value1", "key2": "value2"}}
+        "token": {"token": {"key1": "value1", "key2": "value2"}},
+        **use_listings_cache_dict,
     }

--- a/tests/system/datastore/test_google_cloud_storage.py
+++ b/tests/system/datastore/test_google_cloud_storage.py
@@ -66,6 +66,7 @@ class TestGoogleCloudStorage(TestMLRunSystem):
             token = credentials
         except json.JSONDecodeError:
             token = cls.credentials_path
+        # use_listings_cache added due to caching problem from gcsfs==2024.3.1, ML-7636
         cls._gcs_fs = fsspec.filesystem("gcs", token=token, use_listings_cache=False)
         cls.clean_test_directory()
 

--- a/tests/system/datastore/test_google_cloud_storage.py
+++ b/tests/system/datastore/test_google_cloud_storage.py
@@ -66,7 +66,7 @@ class TestGoogleCloudStorage(TestMLRunSystem):
             token = credentials
         except json.JSONDecodeError:
             token = cls.credentials_path
-        # use_listings_cache added due to caching problem from gcsfs==2024.3.1, ML-7636
+        # due to caching problem introduced in gcsfs 2024.3.1 (ML-7636)
         cls._gcs_fs = fsspec.filesystem("gcs", token=token, use_listings_cache=False)
         cls.clean_test_directory()
 

--- a/tests/system/datastore/test_google_cloud_storage.py
+++ b/tests/system/datastore/test_google_cloud_storage.py
@@ -66,7 +66,7 @@ class TestGoogleCloudStorage(TestMLRunSystem):
             token = credentials
         except json.JSONDecodeError:
             token = cls.credentials_path
-        cls._gcs_fs = fsspec.filesystem("gcs", token=token)
+        cls._gcs_fs = fsspec.filesystem("gcs", token=token, use_listings_cache=False)
         cls.clean_test_directory()
 
     @classmethod


### PR DESCRIPTION
`gcsfs` have a bug in 2024.3.1 in exists function - probably due to a bug in caching.
Caching has been disabled in this PR.

[ML-7636](https://iguazio.atlassian.net/browse/ML-7636)

[ML-7636]: https://iguazio.atlassian.net/browse/ML-7636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ