### PR TITLE
[Project delete] on failure to delete `kafka` stream or `tdengine` TSDB, do not fail the project deletion 

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -209,6 +209,14 @@ class MLRunInvalidMMStoreType(MLRunHTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 
+class MLRunStreamConnectionFailure(MLRunHTTPStatusError, ValueError):
+    error_status_code = HTTPStatus.BAD_REQUEST.value
+
+
+class MLRunTSDBConnectionFailure(MLRunHTTPStatusError, ValueError):
+    error_status_code = HTTPStatus.BAD_REQUEST.value
+
+
 class MLRunRetryExhaustedError(Exception):
     pass
 

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -58,7 +58,12 @@ class TDEngineConnector(TSDBConnector):
         except taosws.QueryError:
             # Database already exists
             pass
-        conn.execute(f"USE {self.database}")
+        try:
+            conn.execute(f"USE {self.database}")
+        except taosws.QueryError as e:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Failed to use TDEngine database {self.database}, {mlrun.errors.err_to_str(e)}"
+            )
         return conn
 
     def _init_super_tables(self):

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -61,7 +61,7 @@ class TDEngineConnector(TSDBConnector):
         try:
             conn.execute(f"USE {self.database}")
         except taosws.QueryError as e:
-            raise mlrun.errors.MLRunInvalidArgumentError(
+            raise mlrun.errors.MLRunTSDBConnectionFailure(
                 f"Failed to use TDEngine database {self.database}, {mlrun.errors.err_to_str(e)}"
             )
         return conn

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -895,11 +895,12 @@ class MonitoringDeployment:
                     function_names=[function_name],
                     access_key=access_key,
                 )
-            except mlrun.errors.MLRunInvalidArgumentError:
+            except mlrun.errors.MLRunInvalidArgumentError as e:
                 logger.warning(
                     "Can't delete stream resources, you may need to delete them manually",
                     project_name=project,
                     function=function_name,
+                    error=mlrun.errors.err_to_str(e),
                 )
 
     @staticmethod

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -895,9 +895,9 @@ class MonitoringDeployment:
                     function_names=[function_name],
                     access_key=access_key,
                 )
-            except mlrun.errors.MLRunInvalidArgumentError as e:
+            except mlrun.errors.MLRunStreamConnectionFailure as e:
                 logger.warning(
-                    "Can't delete stream resources, you may need to delete them manually",
+                    "Failed to delete stream resources, you may need to delete them manually",
                     project_name=project,
                     function=function_name,
                     error=mlrun.errors.err_to_str(e),
@@ -971,7 +971,7 @@ class MonitoringDeployment:
                     logger.debug("Deleted v3io stream", stream_path=stream_path)
                 except v3io.dataplane.response.HttpResponseError as e:
                     logger.warning(
-                        "Can't delete v3io stream",
+                        "Failed to delete v3io stream",
                         stream_path=stream_path,
                         error=mlrun.errors.err_to_str(e),
                     )
@@ -998,7 +998,7 @@ class MonitoringDeployment:
                 logger.debug("Deleted kafka topics", topics=topics)
             except kafka.errors.TopicAuthorizationFailedError as e:
                 logger.warning(
-                    "Can't delete kafka topics",
+                    "Failed to delete kafka topics",
                     topics=topics,
                     error=mlrun.errors.err_to_str(e),
                 )
@@ -1009,9 +1009,9 @@ class MonitoringDeployment:
                     error=mlrun.errors.err_to_str(e),
                 )
             except kafka.errors.NoBrokersAvailable as e:
-                # Raise an error that will be caught by the called and skip the deletion of the stream
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Can't delete kafka topics {topics}, no brokers available, {mlrun.errors.err_to_str(e)}"
+                # Raise an error that will be caught by the caller and skip the deletion of the stream
+                raise mlrun.errors.MLRunStreamConnectionFailure(
+                    f"Failed to delete kafka topics {topics}, no brokers available, {mlrun.errors.err_to_str(e)}"
                 )
         else:
             logger.warning(

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -544,10 +544,11 @@ class ModelEndpoints:
                         project=project_name
                     ),
                 )
-            except mlrun.errors.MLRunInvalidArgumentError:
+            except mlrun.errors.MLRunInvalidArgumentError as e:
                 logger.warning(
                     "Failed to delete TSDB resources, you may need to delete them manually",
                     project=project_name,
+                    error=mlrun.errors.err_to_str(e),
                 )
                 tsdb_connector = None
             except mlrun.errors.MLRunInvalidMMStoreType:
@@ -616,11 +617,19 @@ class ModelEndpoints:
             mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.STREAM
         )
 
-        server.api.crud.model_monitoring.deployment.MonitoringDeployment._delete_model_monitoring_stream_resources(
-            project=project_name,
-            function_names=model_monitoring_applications,
-            access_key=model_monitoring_access_key,
-        )
+        try:
+            server.api.crud.model_monitoring.deployment.MonitoringDeployment._delete_model_monitoring_stream_resources(
+                project=project_name,
+                function_names=model_monitoring_applications,
+                access_key=model_monitoring_access_key,
+            )
+        except mlrun.errors.MLRunInvalidArgumentError as e:
+            logger.warning(
+                "Can't delete stream resources, you may need to delete them manually",
+                project_name=project_name,
+                function=model_monitoring_applications,
+                error=mlrun.errors.err_to_str(e),
+            )
 
     @staticmethod
     def _validate_length_features_and_labels(

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -544,7 +544,7 @@ class ModelEndpoints:
                         project=project_name
                     ),
                 )
-            except mlrun.errors.MLRunInvalidArgumentError as e:
+            except mlrun.errors.MLRunTSDBConnectionFailure as e:
                 logger.warning(
                     "Failed to delete TSDB resources, you may need to delete them manually",
                     project=project_name,
@@ -623,9 +623,9 @@ class ModelEndpoints:
                 function_names=model_monitoring_applications,
                 access_key=model_monitoring_access_key,
             )
-        except mlrun.errors.MLRunInvalidArgumentError as e:
+        except mlrun.errors.MLRunStreamConnectionFailure as e:
             logger.warning(
-                "Can't delete stream resources, you may need to delete them manually",
+                "Failed to delete stream resources, you may need to delete them manually",
                 project_name=project_name,
                 function=model_monitoring_applications,
                 error=mlrun.errors.err_to_str(e),

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -544,7 +544,12 @@ class ModelEndpoints:
                         project=project_name
                     ),
                 )
-
+            except mlrun.errors.MLRunInvalidArgumentError:
+                logger.warning(
+                    "Failed to delete TSDB resources, you may need to delete them manually",
+                    project=project_name,
+                )
+                tsdb_connector = None
             except mlrun.errors.MLRunInvalidMMStoreType:
                 # TODO: delete in 1.9.0 - for BC trying to delete from v3io store
                 if not mlrun.mlconf.is_ce_mode():
@@ -556,7 +561,6 @@ class ModelEndpoints:
                     tsdb_connector = None
             if tsdb_connector:
                 tsdb_connector.delete_tsdb_resources()
-
         self._delete_model_monitoring_stream_resources(
             project_name=project_name,
             db_session=db_session,


### PR DESCRIPTION
This PR fix an issue in which the user has decided to delete his project but for some reason there is a communication issue with one of the external model monitoring resources that he defined (`kafka`/`tdengine`). In this case we will skip the error and delete other project resources. However, we do log the original error for the user and in addition suggesting him to delete there resources manually. 

Related JIRA: https://iguazio.atlassian.net/browse/ML-7545