### PR TITLE
[Dependencies] Update `plotly` version

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -49,9 +49,7 @@ def extra_requirements() -> dict[str, list[str]]:
             # >=2.4.2 to force having a security fix done in 2.4.2
             "bokeh~=2.4, >=2.4.2",
         ],
-        # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
-        # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
-        "plotly": ["plotly~=5.4, <5.12.0"],
+        "plotly": ["plotly~=5.23"],
         # used to generate visualization nuclio/serving graph steps
         "graphviz": ["graphviz~=0.20.0"],
         "google-cloud": [

--- a/dockerfiles/base/requirements.txt
+++ b/dockerfiles/base/requirements.txt
@@ -7,7 +7,7 @@ yellowbrick~=1.1
 lifelines~=0.25.0
 # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
 # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
-plotly~=5.4, <5.12.0
+plotly~=5.23
 pyod~=0.8.1
 scikit-multiflow~=0.5.3
 scikit-optimize~=0.8.1

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -28,9 +28,7 @@ azure-keyvault-secrets~=4.2
 # AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms' (ML-3471)
 pyopenssl>=23
 bokeh~=2.4, >=2.4.2
-# plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
-# so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
-plotly~=5.4, <5.12.0
+plotly~=5.23
 # To support python 11, google-cloud-bigquery requires grpcio>=1.49.1, which is incompatible with the grpcio version
 # required by frames (because it upgrades protobuf from 3.x to 4.x, breaking binary compatibility)
 google-cloud-bigquery[pandas, bqstorage]==3.14.1

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -136,9 +136,6 @@ def test_requirement_specifiers_convention():
         "pyopenssl": {">=23"},
         "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
         "google-cloud-bigquery": {"[pandas, bqstorage]==3.14.1"},
-        # plotly artifact body in 5.12.0 may contain chars that are not encodable in 'latin-1' encoding
-        # so, it cannot be logged as artifact (raised UnicodeEncode error - ML-3255)
-        "plotly": {"~=5.4, <5.12.0"},
         # due to a bug in apscheduler with python 3.9 https://github.com/agronholm/apscheduler/issues/770
         "apscheduler": {"~=3.6, !=3.10.2"},
         # used in tests


### PR DESCRIPTION
Fixes [ML-5789](https://iguazio.atlassian.net/browse/ML-5789).
Upgrade `plotly` from 5.11.0 to 5.23.0.
I tested it with various Plotly artifacts, including the MM histogram data drift application, and it works and shows fine in the UI.

[ML-5789]: https://iguazio.atlassian.net/browse/ML-5789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ