### PR TITLE
[Model Monitoring] Fix application metric KV saving with `orjson`

### DIFF
--- a/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
+++ b/mlrun/model_monitoring/db/stores/v3io_kv/kv_store.py
@@ -34,11 +34,11 @@ fields_to_encode_decode = [
 ]
 
 _METRIC_FIELDS: list[str] = [
-    mm_schemas.WriterEvent.APPLICATION_NAME,
-    mm_schemas.MetricData.METRIC_NAME,
-    mm_schemas.MetricData.METRIC_VALUE,
-    mm_schemas.WriterEvent.START_INFER_TIME,
-    mm_schemas.WriterEvent.END_INFER_TIME,
+    mm_schemas.WriterEvent.APPLICATION_NAME.value,
+    mm_schemas.MetricData.METRIC_NAME.value,
+    mm_schemas.MetricData.METRIC_VALUE.value,
+    mm_schemas.WriterEvent.START_INFER_TIME.value,
+    mm_schemas.WriterEvent.END_INFER_TIME.value,
 ]
 
 


### PR DESCRIPTION
Fixes [ML-7682](https://iguazio.atlassian.net/browse/ML-7682) following:
* https://github.com/mlrun/mlrun/pull/6200
* https://github.com/v3io/v3io-py/pull/126

`orjson` does not accept `StrEnum` as a dictionary key by default.

`tests/system/model_monitoring/test_app.py::TestMonitoringAppFlow::test_app_flow[True]` passes after this change.

[ML-7682]: https://iguazio.atlassian.net/browse/ML-7682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ