### PR TITLE
[Model Monitoring] Remove `current_stats` from tsdb

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -233,7 +233,6 @@ class AppResultTable(TDEngineSchema):
             mm_schemas.WriterEvent.START_INFER_TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.ResultData.RESULT_VALUE: _TDEngineColumn.FLOAT,
             mm_schemas.ResultData.RESULT_STATUS: _TDEngineColumn.INT,
-            mm_schemas.ResultData.CURRENT_STATS: _TDEngineColumn.BINARY_10000,
         }
         tags = {
             mm_schemas.EventFieldType.PROJECT: _TDEngineColumn.BINARY_64,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -108,6 +108,7 @@ class TDEngineConnector(TSDBConnector):
             table_name = (
                 f"{table_name}_" f"{event[mm_schemas.ResultData.RESULT_NAME]}"
             ).replace("-", "_")
+            del event[mm_schemas.ResultData.CURRENT_STATS]
 
         else:
             # Write a new metric

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -117,6 +117,16 @@ class TDEngineConnector(TSDBConnector):
                 f"{table_name}_" f"{event[mm_schemas.MetricData.METRIC_NAME]}"
             ).replace("-", "_")
 
+        # Convert the datetime strings to datetime objects
+        event[mm_schemas.WriterEvent.END_INFER_TIME] = self._convert_string_to_datetime(
+            event[mm_schemas.WriterEvent.END_INFER_TIME]
+        )
+        event[mm_schemas.WriterEvent.START_INFER_TIME] = (
+            self._convert_string_to_datetime(
+                event[mm_schemas.WriterEvent.START_INFER_TIME]
+            )
+        )
+
         create_table_query = table._create_subtable_query(
             subtable=table_name, values=event
         )
@@ -129,6 +139,10 @@ class TDEngineConnector(TSDBConnector):
         )
         insert_statement.add_batch()
         insert_statement.execute()
+
+    @staticmethod
+    def _convert_string_to_datetime(string):
+        return datetime.fromisoformat(string)
 
     def apply_monitoring_stream_steps(self, graph):
         """

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -108,7 +108,7 @@ class TDEngineConnector(TSDBConnector):
             table_name = (
                 f"{table_name}_" f"{event[mm_schemas.ResultData.RESULT_NAME]}"
             ).replace("-", "_")
-            del event[mm_schemas.ResultData.CURRENT_STATS]
+            event.pop(mm_schemas.ResultData.CURRENT_STATS, None)
 
         else:
             # Write a new metric
@@ -118,13 +118,11 @@ class TDEngineConnector(TSDBConnector):
             ).replace("-", "_")
 
         # Convert the datetime strings to datetime objects
-        event[mm_schemas.WriterEvent.END_INFER_TIME] = self._convert_string_to_datetime(
-            event[mm_schemas.WriterEvent.END_INFER_TIME]
+        event[mm_schemas.WriterEvent.END_INFER_TIME] = self._convert_to_datetime(
+            key=event[mm_schemas.WriterEvent.END_INFER_TIME]
         )
-        event[mm_schemas.WriterEvent.START_INFER_TIME] = (
-            self._convert_string_to_datetime(
-                event[mm_schemas.WriterEvent.START_INFER_TIME]
-            )
+        event[mm_schemas.WriterEvent.START_INFER_TIME] = self._convert_to_datetime(
+            key=event[mm_schemas.WriterEvent.START_INFER_TIME]
         )
 
         create_table_query = table._create_subtable_query(
@@ -141,8 +139,8 @@ class TDEngineConnector(TSDBConnector):
         insert_statement.execute()
 
     @staticmethod
-    def _convert_string_to_datetime(string):
-        return datetime.fromisoformat(string)
+    def _convert_to_datetime(key):
+        return datetime.fromisoformat(key) if isinstance(key, str) else key
 
     def apply_monitoring_stream_steps(self, graph):
         """

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -119,10 +119,10 @@ class TDEngineConnector(TSDBConnector):
 
         # Convert the datetime strings to datetime objects
         event[mm_schemas.WriterEvent.END_INFER_TIME] = self._convert_to_datetime(
-            key=event[mm_schemas.WriterEvent.END_INFER_TIME]
+            val=event[mm_schemas.WriterEvent.END_INFER_TIME]
         )
         event[mm_schemas.WriterEvent.START_INFER_TIME] = self._convert_to_datetime(
-            key=event[mm_schemas.WriterEvent.START_INFER_TIME]
+            val=event[mm_schemas.WriterEvent.START_INFER_TIME]
         )
 
         create_table_query = table._create_subtable_query(
@@ -139,8 +139,8 @@ class TDEngineConnector(TSDBConnector):
         insert_statement.execute()
 
     @staticmethod
-    def _convert_to_datetime(key):
-        return datetime.fromisoformat(key) if isinstance(key, str) else key
+    def _convert_to_datetime(val: typing.Union[str, datetime]) -> datetime:
+        return datetime.fromisoformat(val) if isinstance(val, str) else val
 
     def apply_monitoring_stream_steps(self, graph):
         """

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -326,10 +326,9 @@ class V3IOTSDBConnector(TSDBConnector):
         elif kind == mm_schemas.WriterEventKind.RESULT:
             table = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]
             index_cols = index_cols_base + [mm_schemas.ResultData.RESULT_NAME]
-            del (
-                event[mm_schemas.ResultData.RESULT_EXTRA_DATA],
-                event[mm_schemas.ResultData.CURRENT_STATS],
-            )
+            event.pop(mm_schemas.ResultData.CURRENT_STATS, None)
+            # TODO: remove this when extra data is supported (ML-7460)
+            event.pop(mm_schemas.ResultData.RESULT_EXTRA_DATA, None)
         else:
             raise ValueError(f"Invalid {kind = }")
 

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -326,7 +326,10 @@ class V3IOTSDBConnector(TSDBConnector):
         elif kind == mm_schemas.WriterEventKind.RESULT:
             table = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]
             index_cols = index_cols_base + [mm_schemas.ResultData.RESULT_NAME]
-            del event[mm_schemas.ResultData.RESULT_EXTRA_DATA]
+            del (
+                event[mm_schemas.ResultData.RESULT_EXTRA_DATA],
+                event[mm_schemas.ResultData.CURRENT_STATS],
+            )
         else:
             raise ValueError(f"Invalid {kind = }")
 

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -71,6 +71,7 @@ def test_write_application_event(connector):
         "end_infer_time": end_infer_time,
         "result_status": result_status,
         # make sure we can write apostrophes (ML-7535)
+        "current_stats": """{"question": "Who wrote 'To Kill a Mockingbird'?"}""",
         # TODO: add this back when extra data is supported (ML-7460)
         # "result_extra_data": """{"question": "Who wrote 'To Kill a Mockingbird'?"}""",
         "result_value": result_value,

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -71,7 +71,8 @@ def test_write_application_event(connector):
         "end_infer_time": end_infer_time,
         "result_status": result_status,
         # make sure we can write apostrophes (ML-7535)
-        "current_stats": """{"question": "Who wrote 'To Kill a Mockingbird'?"}""",
+        # TODO: add this back when extra data is supported (ML-7460)
+        # "result_extra_data": """{"question": "Who wrote 'To Kill a Mockingbird'?"}""",
         "result_value": result_value,
     }
     connector.create_tables()

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -265,6 +265,12 @@ class TestTSDB:
         )
 
         actual_columns = list(record_from_tsdb.columns)
+
+        assert (
+            ResultData.CURRENT_STATS not in actual_columns
+        ), "Current stats should not be written to the TSDB"
+
+        # TODO: Remove this assertion after the extra data is supported in TSDB (ML-7460)
         assert (
             ResultData.RESULT_EXTRA_DATA not in actual_columns
         ), "The extra data should not be written to the TSDB"


### PR DESCRIPTION
Right now there are no consumers for the `current_stats` value within the TSDB. In addition, this values is not limited and therefore can cause storage issues within the TSDB when using a large model with many features.
In the near future, the user will be able to store the `current_stats` as part of the `result_extra_data` or generate a `current_stats` artifact for each run (if the value is too large). 

A fix for https://iguazio.atlassian.net/browse/ML-7519