### PR TITLE
[Alerts] Fix alert triggering for job events by adjusting the sliding window to account for monitoring interval

### DIFF
--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -169,10 +169,18 @@ class Alerts(
 
                 if alert.criteria.period is not None:
                     # adjust the sliding window of events
+                    # in case the EventEntityKind is JOB then we should consider the runs monitoring interval here
+                    # because the monitoring runs might miss events occurring just before the interval.
+                    offset = 0
+                    if (
+                        alert.entities.kind
+                        == mlrun.common.schemas.alert.EventEntityKind.JOB
+                    ):
+                        offset = int(mlconfig.monitoring.runs.interval)
                     self._normalize_events(
                         state_obj,
                         server.api.utils.helpers.string_to_timedelta(
-                            alert.criteria.period, raise_on_error=False
+                            alert.criteria.period, offset, raise_on_error=False
                         ),
                     )
 

--- a/server/api/utils/helpers.py
+++ b/server/api/utils/helpers.py
@@ -119,7 +119,9 @@ def is_request_from_leader(
     return False
 
 
-def string_to_timedelta(date_str, offset=0, raise_on_error=True):
+def string_to_timedelta(
+    date_str: str, offset: int = 0, raise_on_error: bool = True
+) -> Optional[datetime.timedelta]:
     date_str = date_str.strip().lower()
     try:
         seconds = parse_timespan(date_str) + offset

--- a/server/api/utils/helpers.py
+++ b/server/api/utils/helpers.py
@@ -119,10 +119,10 @@ def is_request_from_leader(
     return False
 
 
-def string_to_timedelta(date_str, raise_on_error=True):
+def string_to_timedelta(date_str, offset=0, raise_on_error=True):
     date_str = date_str.strip().lower()
     try:
-        seconds = parse_timespan(date_str)
+        seconds = parse_timespan(date_str) + offset
     except InvalidTimespan as exc:
         if raise_on_error:
             raise exc

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -265,15 +265,83 @@ class TestAlerts(TestMLRunSystem):
             nuclio_function_url, expected_notifications
         )
 
+    def test_job_failure_alert_sliding_window(self):
+        """
+
+        This test simulates a scenario where a job is expected to fail twice within a two-minute window,
+        which should trigger an alert. The monitoring interval is taken into account to ensure the sliding
+        window of events includes all relevant job failures, preventing the alert system from missing
+        events that occur just before the monitoring run.
+
+        The test first triggers a job failure, waits for slightly more than two minutes, and then triggers
+        another job failure to confirm that the alert does not trigger prematurely. Finally, a third failure
+        within the adjusted window is used to confirm that the alert triggers as expected.
+        """
+
+        self.project.set_function(
+            name="test-func",
+            func="assets/function.py",
+            handler="handler",
+            image="mlrun/mlrun" if self.image is None else self.image,
+            kind="job",
+        )
+
+        # nuclio function for storing notifications, to validate that alert notifications were sent on the failed job
+        nuclio_function_url = notification_helpers.deploy_notification_nuclio(
+            self.project, self.image
+        )
+
+        # create an alert with webhook notification that should trigger when the job fails twice in two minutes
+        alert_name = "failure_webhook"
+        alert_summary = "Job failed"
+        alert_criteria = alert_objects.AlertCriteria(period="2m", count=2)
+        run_id = "test-func-handler"
+        notifications = self._generate_failure_notifications(nuclio_function_url)
+
+        self._create_alert_config(
+            self.project_name,
+            alert_name,
+            alert_objects.EventEntityKind.JOB,
+            run_id,
+            alert_summary,
+            alert_objects.EventKind.FAILED,
+            notifications,
+            criteria=alert_criteria,
+        )
+
+        # this is the first failure
+        with pytest.raises(Exception):
+            self.project.run_function("test-func")
+
+        # Wait for more than two minutes to simulate a delay that is slightly longer than the alert period
+        time.sleep(125)
+
+        # this is the second failure
+        with pytest.raises(Exception):
+            self.project.run_function("test-func")
+
+        # validate that no notifications were sent yet, as the two failures did not occur within the same period
+        expected_notifications = []
+        self._validate_notifications_on_nuclio(
+            nuclio_function_url, expected_notifications
+        )
+
+        # this failure should fall within the adjusted sliding window when combined with the second failure
+        # should trigger the alert
+        with pytest.raises(Exception):
+            self.project.run_function("test-func")
+
+        # validate that the alert was triggered and the notification was sent
+        expected_notifications = ["notification failure"]
+        self._validate_notifications_on_nuclio(
+            nuclio_function_url, expected_notifications
+        )
+
     @staticmethod
     def _generate_failure_notifications(nuclio_function_url):
         notification = mlrun.common.schemas.Notification(
             kind="webhook",
             name="failure",
-            message="job failed !",
-            severity="warning",
-            when=["now"],
-            condition="failed",
             params={
                 "url": nuclio_function_url,
                 "override_body": {
@@ -289,10 +357,6 @@ class TestAlerts(TestMLRunSystem):
         first_notification = mlrun.common.schemas.Notification(
             kind="webhook",
             name="drift",
-            message="A drift was detected",
-            severity="warning",
-            when=["now"],
-            condition="failed",
             params={
                 "url": nuclio_function_url,
                 "override_body": {
@@ -304,10 +368,6 @@ class TestAlerts(TestMLRunSystem):
         second_notification = mlrun.common.schemas.Notification(
             kind="webhook",
             name="drift2",
-            message="A drift was detected",
-            severity="warning",
-            when=["now"],
-            condition="failed",
             params={
                 "url": nuclio_function_url,
                 "override_body": {


### PR DESCRIPTION
This PR addresses a bug in the alerts flow where alerts configured to trigger based on a specific number of events within a defined period might not trigger correctly when monitoring failed jobs. 
The issue occurred because the monitoring runs flow executes every 30 seconds, which could result in missing the last event in a sequence if it occurs just before the monitoring interval.
so when the monitoring interval is longer than the time gap between the last event and the end of the defined period, the monitoring might miss triggering the alert.

resolves:
https://iguazio.atlassian.net/browse/ML-7549