### PR TITLE
[Project] Do not pass url as command when initializing nuclio function

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4422,7 +4422,6 @@ def _init_function_from_dict(
     elif kind in mlrun.runtimes.RuntimeKinds.nuclio_runtimes():
         func = new_function(
             name,
-            command=relative_url,
             image=image,
             kind=kind,
             handler=handler,


### PR DESCRIPTION
When initializing a function from a dict (as part of `project.set_function`), if it is a function of kind "Remote" / "Serving", the `command` argument is ignored. However when the kind is "Application" the `command` is used as the command to run the sidecar application container.

The `func` argument of `set_function` was passed to the `command` argument of `new_function`, causing issues when in application runtime trying to invoke the application image with this argument.
Instead, it should be ignored completely for Nuclio runtimes.

If a user wants to set the `command` property, they should do it after calling `set_function` in a separate call.