### PR TITLE
[Model Monitoring] Some improvements in tests debugging

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -183,7 +183,7 @@ class TestMLRunSystem:
         return pytest.mark.skipif(
             not configured,
             reason=f"This is a system test, add the needed environment variables {*mandatory_env_vars,} "
-            "in tests/system/env.yml to run it",
+            f"in tests/system/env.yml to run it. Currently at least {env_var} is missing",
         )(test)
 
     @classmethod

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -170,20 +170,21 @@ class TestMLRunSystem:
         )
         if cls._has_marker(test, cls.model_monitoring_marker_name):
             mandatory_env_vars += cls.model_monitoring_mandatory_env_vars
-        configured = True
+
+        missing_env_vars = []
         try:
             env = cls._get_env_from_file()
         except FileNotFoundError:
-            configured = False
+            missing_env_vars = mandatory_env_vars
         else:
             for env_var in mandatory_env_vars:
                 if env_var not in env or env[env_var] is None:
-                    configured = False
+                    missing_env_vars.append(env_var)
 
         return pytest.mark.skipif(
-            not configured,
+            len(missing_env_vars) > 0,
             reason=f"This is a system test, add the needed environment variables {*mandatory_env_vars,} "
-            f"in tests/system/env.yml to run it. Currently at least {env_var} is missing",
+            f"in tests/system/env.yml. You are missing: {missing_env_vars}",
         )(test)
 
     @classmethod

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -431,7 +431,8 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
         cls.run_db = mlrun.get_run_db()
 
     def custom_setup(self) -> None:
-        _V3IORecordsChecker.custom_setup(project_name=self.project_name)
+        # skips TestMLRunSystem, calls custom_setup() of _V3IORecordsChecker
+        super(TestMLRunSystem, self).custom_setup(project_name=self.project_name)
 
     def custom_teardown(self) -> None:
         # validate that stream resources were deleted as expected


### PR DESCRIPTION
1. In case env-vars are missing for a test, print one of them.
2. fix mm test infra to allow logging from _V3IORecordsChecker custom_setup()