### PR TITLE
[Projects] Change the background task timeout for project deletion

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -5473,7 +5473,7 @@ class SQLDB(DBInterface):
         return self._query(session, BackgroundTask, project=project)
 
     def _delete_background_tasks(self, session: Session, project: str):
-        logger.debug("Removing background tasks from db", project=project)
+        logger.debug("Removing project background tasks from db", project=project)
         for background_task_name in self._list_project_background_task_names(
             session, project
         ):

--- a/server/api/utils/clients/iguazio.py
+++ b/server/api/utils/clients/iguazio.py
@@ -618,7 +618,7 @@ class Client(
 
         job_state, job_result = mlrun.utils.helpers.retry_until_successful(
             self._wait_for_job_completion_retry_interval,
-            timeout,
+            int(timeout),
             self._logger,
             False,
             _verify_job_in_terminal_state,

--- a/server/api/utils/clients/iguazio.py
+++ b/server/api/utils/clients/iguazio.py
@@ -293,7 +293,7 @@ class Client(
             self._wait_for_job_completion(
                 session,
                 job_id,
-                mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
+                timeout=mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
             )
             self._logger.debug(
                 "Successfully deleted project in Iguazio",

--- a/server/api/utils/clients/iguazio.py
+++ b/server/api/utils/clients/iguazio.py
@@ -290,7 +290,11 @@ class Client(
                 name=name,
                 job_id=job_id,
             )
-            self._wait_for_job_completion(session, job_id)
+            self._wait_for_job_completion(
+                session,
+                job_id,
+                mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
+            )
             self._logger.debug(
                 "Successfully deleted project in Iguazio",
                 name=name,
@@ -599,7 +603,11 @@ class Client(
         return self._transform_iguazio_project_to_mlrun_project(response.json()["data"])
 
     def _wait_for_job_completion(
-        self, session: str, job_id: str, error_message: str = ""
+        self,
+        session: str,
+        job_id: str,
+        error_message: str = "",
+        timeout: typing.Optional[int] = 360,  # in seconds
     ):
         def _verify_job_in_terminal_state():
             job_response_body = self._get_job_from_iguazio(session, job_id)
@@ -610,7 +618,7 @@ class Client(
 
         job_state, job_result = mlrun.utils.helpers.retry_until_successful(
             self._wait_for_job_completion_retry_interval,
-            360,
+            timeout,
             self._logger,
             False,
             _verify_job_in_terminal_state,


### PR DESCRIPTION
When creating the background task for project deletion, the timeout should be configured using the default value `mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project` from `config.py`, which is set to 15 minutes. However, the background task was hardcoded to wait only 6 minutes. 

The fix is to use the default value from the config to ensure consistency
https://iguazio.atlassian.net/browse/ML-7686
https://iguazio.atlassian.net/browse/ML-6595