### PR TITLE
[Projects] Fix Load Project Failing on `None` Workflow Request

### DIFF
--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -312,10 +312,12 @@ class WorkflowRunners(
 
         :returns: RunObject ready for execution.
         """
-        notifications = [
-            mlrun.model.Notification.from_dict(notification.dict())
-            for notification in workflow_request.notifications or []
-        ]
+        notifications = None
+        if workflow_request:
+            notifications = [
+                mlrun.model.Notification.from_dict(notification.dict())
+                for notification in workflow_request.notifications or []
+            ]
 
         source = workflow_request.source if workflow_request else ""
         source, save, is_context = self._validate_source(project, source, load_only)


### PR DESCRIPTION
We use the Workflow runners (in addition to running workflows), to load projects when users aren't using the SDK (via UI).
So in that case the workflow runner doesn't receive a `workflow_request`. Added a check to skip extracting notifications when this is the case.