### PR TITLE
[Application] Separate Application deploy and API gateway creation

### DIFF
--- a/docs/runtimes/application.ipynb
+++ b/docs/runtimes/application.ipynb
@@ -42,7 +42,10 @@
     "application.set_internal_application_port(port=8050)\n",
     "\n",
     "# Deploy\n",
-    "application.deploy()"
+    "application.deploy()\n",
+    "\n",
+    "# Create API gateway to make the application accessible\n",
+    "application.create_api_gateway()"
    ]
   },
   {
@@ -77,7 +80,9 @@
     "\n",
     "# Build the application image via MLRun and deploy the Nuclio function\n",
     "# Optionally add mlrun\n",
-    "application.deploy(with_mlrun=False)"
+    "application.deploy(with_mlrun=False)\n",
+    "# Create API gateway to make the application accessible\n",
+    "application.create_api_gateway()"
    ]
   },
   {
@@ -114,20 +119,20 @@
    "source": [
     "from mlrun.common.schemas.api_gateway import APIGatewayAuthenticationMode\n",
     "\n",
-    "# Deploy without authentication\n",
-    "application.deploy(\n",
+    "# Create API gateway without authentication\n",
+    "application.create_api_gateway(\n",
     "    authentication_mode=APIGatewayAuthenticationMode.none,\n",
     ")\n",
     "\n",
     "# Basic authentication mode.\n",
     "# This means that the application can be invoked only using the provided credentials\n",
-    "application.deploy(\n",
+    "application.create_api_gateway(\n",
     "    authentication_mode=APIGatewayAuthenticationMode.basic,\n",
     "    authentication_creds=(\"my-username\", \"my-password\"),\n",
     ")\n",
     "\n",
     "# Access-key authentication mode. the application can be invoked only with a valid session\n",
-    "application.deploy(\n",
+    "application.create_api_gateway(\n",
     "    authentication_mode=APIGatewayAuthenticationMode.access_key,\n",
     ")"
    ]
@@ -418,7 +423,8 @@
     "    \"--log-level\",\n",
     "    \"debug\",\n",
     "]\n",
-    "application.deploy(with_mlrun=True)"
+    "application.deploy(with_mlrun=True)\n",
+    "application.create_api_gateway()"
    ]
   },
   {

--- a/docs/runtimes/application.ipynb
+++ b/docs/runtimes/application.ipynb
@@ -42,10 +42,7 @@
     "application.set_internal_application_port(port=8050)\n",
     "\n",
     "# Deploy\n",
-    "application.deploy()\n",
-    "\n",
-    "# Create API gateway to make the application accessible\n",
-    "application.create_api_gateway()"
+    "application.deploy()"
    ]
   },
   {
@@ -80,9 +77,7 @@
     "\n",
     "# Build the application image via MLRun and deploy the Nuclio function\n",
     "# Optionally add mlrun\n",
-    "application.deploy(with_mlrun=False)\n",
-    "# Create API gateway to make the application accessible\n",
-    "application.create_api_gateway()"
+    "application.deploy(with_mlrun=False)"
    ]
   },
   {
@@ -118,6 +113,9 @@
    "outputs": [],
    "source": [
     "from mlrun.common.schemas.api_gateway import APIGatewayAuthenticationMode\n",
+    "\n",
+    "# Unless disabled, the default API gateway is created when the application is deployed\n",
+    "application.deploy(create_default_api_gateway=False)\n",
     "\n",
     "# Create API gateway without authentication\n",
     "application.create_api_gateway(\n",
@@ -423,8 +421,7 @@
     "    \"--log-level\",\n",
     "    \"debug\",\n",
     "]\n",
-    "application.deploy(with_mlrun=True)\n",
-    "application.create_api_gateway()"
+    "application.deploy(with_mlrun=True)"
    ]
   },
   {

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -428,7 +428,7 @@ class ApplicationRuntime(RemoteRuntime):
         path: str = None,
         direct_port_access: bool = False,
         authentication_mode: schemas.APIGatewayAuthenticationMode = None,
-        authentication_creds: tuple[str] = None,
+        authentication_creds: tuple[str, str] = None,
         ssl_redirect: bool = None,
         set_as_default: bool = False,
     ):
@@ -499,6 +499,8 @@ class ApplicationRuntime(RemoteRuntime):
             api_gateway = APIGateway.from_scheme(api_gateway_scheme)
             api_gateway.wait_for_readiness()
             url = api_gateway.invoke_url
+            # Update application status
+            self._get_state(raise_on_exception=False)
 
         logger.info("Successfully created API gateway", url=url)
         return url

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -354,7 +354,8 @@ class ApplicationRuntime(RemoteRuntime):
                 )
         else:
             logger.warning(
-                "Application online, proceed to API gateway creation to make it accessible."
+                "Application is online but is not accessible. "
+                "Use the `create_api_gateway` method to make it accessible."
             )
 
         return True

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -520,7 +520,10 @@ class ApplicationRuntime(RemoteRuntime):
         self._sync_api_gateway()
         # If the API Gateway is not ready or not set, try to invoke the function directly (without the API Gateway)
         if not self.status.api_gateway:
-            super().invoke(
+            logger.warning(
+                "Default API gateway is not configured, will use invocation URL."
+            )
+            return super().invoke(
                 path,
                 body,
                 method,

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -331,7 +331,7 @@ class ApplicationRuntime(RemoteRuntime):
             builder_env=builder_env,
         )
         logger.info(
-            "Successfully deployed function",
+            "Successfully deployed function.",
         )
 
         # Restore the source in case it was removed to make nuclio not consider it when building

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -299,7 +299,7 @@ class ApplicationRuntime(RemoteRuntime):
         :param is_kfp:                      Deploy as part of a kfp pipeline
         :param mlrun_version_specifier:     Which mlrun package version to include (if not current)
         :param show_on_failure:             Show logs only in case of build failure
-        :param create_default_api_gateway:  When deploy finishes will create the default API gateway for the
+        :param create_default_api_gateway:  When deploy finishes the default API gateway will be created for the
                                             application. Disabling this flag means that the application will not be
                                             accessible until an API gateway is created for it.
 
@@ -349,8 +349,9 @@ class ApplicationRuntime(RemoteRuntime):
                 return self.create_api_gateway(api_gateway_name, set_as_default=True)
             except Exception as exc:
                 logger.warning(
-                    "Failed to create default API gateway, application will not be accessible",
-                    mlrun.errors.err_to_str(exc),
+                    "Failed to create default API gateway, application will not be accessible. "
+                    "Use the `create_api_gateway` method to make it accessible",
+                    exc=mlrun.errors.err_to_str(exc),
                 )
         else:
             logger.warning(
@@ -439,7 +440,7 @@ class ApplicationRuntime(RemoteRuntime):
         :param path:                    Optional path of the API gateway, default value is "/"
         :param direct_port_access:      Set True to allow direct port access to the application sidecar
         :param authentication_mode:     API Gateway authentication mode
-        :param authentication_creds:    API Gateway authentication credentials as a tuple (username, password)
+        :param authentication_creds:    API Gateway basic authentication credentials as a tuple (username, password)
         :param ssl_redirect:            Set True to force SSL redirect, False to disable. Defaults to
                                         mlrun.mlconf.force_api_gateway_ssl_redirect()
         :param set_as_default:          Set the API gateway as the default for the application (`status.api_gateway`)
@@ -521,7 +522,7 @@ class ApplicationRuntime(RemoteRuntime):
         # If the API Gateway is not ready or not set, try to invoke the function directly (without the API Gateway)
         if not self.status.api_gateway:
             logger.warning(
-                "Default API gateway is not configured, will use invocation URL."
+                "Default API gateway is not configured, invoking function invocation URL."
             )
             return super().invoke(
                 path,

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -349,7 +349,7 @@ class ApplicationRuntime(RemoteRuntime):
                 return self.create_api_gateway(api_gateway_name, set_as_default=True)
             except Exception as exc:
                 logger.warning(
-                    "Failed to create default API gateway, application will not be accessible. "
+                    "Failed to create default API gateway, application may not be accessible. "
                     "Use the `create_api_gateway` method to make it accessible",
                     exc=mlrun.errors.err_to_str(exc),
                 )

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -410,13 +410,17 @@ class RunDBMock:
 
     def get_builder_status(
         self,
-        func: BaseRuntime,
+        func: mlrun.runtimes.RemoteRuntime,
         offset: int = 0,
         logs: bool = True,
         last_log_timestamp: float = 0,
         verbose: bool = False,
     ):
         func.status.state = mlrun.common.schemas.FunctionState.ready
+        func.status.external_invocation_urls = [
+            api_gateways.get_invoke_url()
+            for api_gateways in self._api_gateways.values()
+        ]
         return "ready", last_log_timestamp
 
     def deploy_nuclio_function(

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -194,10 +194,9 @@ def test_application_api_gateway(rundb_mock, igz_version_mock):
         image="mlrun/mlrun",
     )
     fn.deploy()
-    fn.create_api_gateway()
     api_gateway = fn.status.api_gateway
     assert api_gateway is not None
-    assert api_gateway.name == function_name
+    assert api_gateway.name == f"{function_name}-default"
     assert len(api_gateway.spec.functions) == 1
     assert function_name in api_gateway.spec.functions[0]
 
@@ -210,7 +209,6 @@ def test_application_api_gateway_ssl_redirect(rundb_mock, igz_version_mock):
     )
     # ssl redirect is enabled by default when running in iguazio
     function.deploy()
-    function.create_api_gateway()
 
     ssl_redirect_annotation = "nginx.ingress.kubernetes.io/force-ssl-redirect"
     api_gateway = function.status.api_gateway

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -196,7 +196,7 @@ def test_application_default_api_gateway(rundb_mock, igz_version_mock):
     fn.deploy()
     api_gateway = fn.status.api_gateway
     assert api_gateway is not None
-    assert api_gateway.name == f"{function_name}-default"
+    assert api_gateway.name == function_name
     assert len(api_gateway.spec.functions) == 1
     assert function_name in api_gateway.spec.functions[0]
 
@@ -213,9 +213,9 @@ def test_application_disable_default_api_gateway(rundb_mock, igz_version_mock):
 
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match=f"API gateway name='{fn.metadata.name}-default' conflicts with default while set_as_default=False.",
+        match=f"Non-default API gateway cannot use the default gateway name, name='{fn.metadata.name}'.",
     ):
-        fn.create_api_gateway(name=fn._resolve_default_api_gateway_name())
+        fn.create_api_gateway(name=fn.resolve_default_api_gateway_name())
 
     url = fn.create_api_gateway(
         "my-gateway",

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -186,7 +186,7 @@ def test_application_image_build(remote_builder_mock, igz_version_mock):
     )
 
 
-def test_application_api_gateway(rundb_mock, igz_version_mock):
+def test_application_default_api_gateway(rundb_mock, igz_version_mock):
     function_name = "application-test"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
         function_name,
@@ -199,6 +199,32 @@ def test_application_api_gateway(rundb_mock, igz_version_mock):
     assert api_gateway.name == f"{function_name}-default"
     assert len(api_gateway.spec.functions) == 1
     assert function_name in api_gateway.spec.functions[0]
+
+
+def test_application_disable_default_api_gateway(rundb_mock, igz_version_mock):
+    function_name = "application-test"
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        function_name,
+        kind="application",
+        image="mlrun/mlrun",
+    )
+    fn.deploy(create_default_api_gateway=False)
+    assert fn.status.api_gateway is None
+
+    # TODO: f string match
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="API gateway name='application-test-default' conflicts with default while set_as_default=False.",
+    ):
+        fn.create_api_gateway(name=fn._resolve_default_api_gateway_name())
+
+    fn.create_api_gateway(
+        "my-gateway",
+        authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.basic,
+        authentication_creds=("username", "password"),
+    )
+
+    # assert url == fn.status.external_invocation_urls[0]
 
 
 def test_application_api_gateway_ssl_redirect(rundb_mock, igz_version_mock):

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -211,20 +211,19 @@ def test_application_disable_default_api_gateway(rundb_mock, igz_version_mock):
     fn.deploy(create_default_api_gateway=False)
     assert fn.status.api_gateway is None
 
-    # TODO: f string match
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match="API gateway name='application-test-default' conflicts with default while set_as_default=False.",
+        match=f"API gateway name='{fn.metadata.name}-default' conflicts with default while set_as_default=False.",
     ):
         fn.create_api_gateway(name=fn._resolve_default_api_gateway_name())
 
-    fn.create_api_gateway(
+    url = fn.create_api_gateway(
         "my-gateway",
         authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.basic,
         authentication_creds=("username", "password"),
     )
 
-    # assert url == fn.status.external_invocation_urls[0]
+    assert url == f"https://{fn.status.external_invocation_urls[0]}"
 
 
 def test_application_api_gateway_ssl_redirect(rundb_mock, igz_version_mock):

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -194,6 +194,7 @@ def test_application_api_gateway(rundb_mock, igz_version_mock):
         image="mlrun/mlrun",
     )
     fn.deploy()
+    fn.create_api_gateway()
     api_gateway = fn.status.api_gateway
     assert api_gateway is not None
     assert api_gateway.name == function_name
@@ -209,6 +210,7 @@ def test_application_api_gateway_ssl_redirect(rundb_mock, igz_version_mock):
     )
     # ssl redirect is enabled by default when running in iguazio
     function.deploy()
+    function.create_api_gateway()
 
     ssl_redirect_annotation = "nginx.ingress.kubernetes.io/force-ssl-redirect"
     api_gateway = function.status.api_gateway

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -38,7 +38,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Deploying vizro application")
         function.deploy(with_mlrun=False)
-        function.create_api_gateway()
 
         assert function.invoke("/", verify=False)
 
@@ -71,7 +70,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Deploying first application")
         function.deploy(with_mlrun=False)
-        function.create_api_gateway()
 
         assert function.invoke("/", verify=False)
 
@@ -102,7 +100,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Deploying vizro application")
         function.deploy(with_mlrun=False)
-        function.create_api_gateway()
 
         assert function.invoke("/", verify=False)
 

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -38,6 +38,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Deploying vizro application")
         function.deploy(with_mlrun=False)
+        function.create_api_gateway()
 
         assert function.invoke("/", verify=False)
 
@@ -70,6 +71,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Deploying first application")
         function.deploy(with_mlrun=False)
+        function.create_api_gateway()
 
         assert function.invoke("/", verify=False)
 
@@ -100,6 +102,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
 
         self._logger.debug("Deploying vizro application")
         function.deploy(with_mlrun=False)
+        function.create_api_gateway()
 
         assert function.invoke("/", verify=False)
 

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -16,6 +16,10 @@ import io
 import os
 import sys
 
+import pytest
+from nuclio.auth import AuthInfo as NuclioAuthInfo
+
+import mlrun.common.schemas
 import mlrun.runtimes
 import tests.system.base
 
@@ -125,6 +129,49 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             function.metadata.annotations.get("kubectl.kubernetes.io/default-container")
             == function.status.sidecar_name
         )
+
+    @pytest.mark.enterprise
+    def test_deploy_application_with_custom_api_gateway(self):
+        self._upload_code_to_cluster()
+
+        self._logger.debug("Creating application")
+        function, source = self._create_vizro_application()
+
+        self._logger.debug("Deploying vizro application")
+        function.deploy(with_mlrun=False, create_default_api_gateway=False)
+
+        auth = NuclioAuthInfo(username="my-user", password="123").to_requests_auth()
+        function.create_api_gateway(
+            name="my-api-gateway",
+            authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.basic,
+            authentication_creds=(auth.username, auth.password),
+        )
+
+        assert function.invoke("/", verify=False, auth=auth)
+        with pytest.raises(RuntimeError, match="401 Authorization Required"):
+            function.invoke("/", verify=False)
+
+        # Change API gateway to access key mode
+        function.create_api_gateway(
+            name="my-api-gateway",
+            authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.access_key,
+        )
+
+        # Invoke with access key
+        auth = NuclioAuthInfo().from_envvar().to_requests_auth()
+        assert function.invoke("/", verify=False, auth=auth)
+        with pytest.raises(RuntimeError, match="401 Authorization Required"):
+            function.invoke("/", verify=False)
+
+        # Create API gateway with new name and set it as default
+        function.create_api_gateway(
+            name="my-other-api-gateway",
+            authentication_mode=mlrun.common.schemas.APIGatewayAuthenticationMode.access_key,
+            set_as_default=True,
+        )
+        # Invoke should infer access key is needed
+        assert function.invoke("/", verify=False)
+        assert len(function.status.external_invocation_urls) == 2
 
     def _create_vizro_application(
         self, name="vizro-app", app_image=None, with_repo: bool = False


### PR DESCRIPTION
Design fix for Application runtime - extracting the API gateway creation from the deploy process is needed for the following reasons:
- Clear separation between api gateway and application runtime entities for developers and for users
- Easier development process
- Shorter deploy process (less things can go wrong)
- Robustness to changes
- Option to redeploy without creating api gateway again

In mlrun they are separate entities but an application is not accessible until it has an API gateway so at 1st we wanted to make life easier for the user and give them everything they need with a single deploy call. However this makes life difficult for developers since it introduces cupeling and mixing responsibilities. More than that it will be useful for the users to know that they can change the API gateway without being dependent on the deploy process and vice versa.

Still to make life simple, we provide a default API gateway with opt-out option.

https://iguazio.atlassian.net/browse/ML-7698