### PR TITLE
[Application] Don't allow disabling default http trigger

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -552,6 +552,20 @@ class ApplicationRuntime(RemoteRuntime):
             reverse_proxy_func.metadata.name, reverse_proxy_func.metadata.project
         )
 
+    @min_nuclio_versions("1.13.1")
+    def disable_default_http_trigger(
+        self,
+    ):
+        raise mlrun.runtimes.RunError(
+            "Application runtime does not support disabling the default HTTP trigger"
+        )
+
+    @min_nuclio_versions("1.13.1")
+    def enable_default_http_trigger(
+        self,
+    ):
+        pass
+
     def _run(self, runobj: "mlrun.RunObject", execution):
         raise mlrun.runtimes.RunError(
             "Application runtime .run() is not yet supported. Use .invoke() instead."

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -698,7 +698,7 @@ class RemoteRuntime(KubeResource):
         """
         self.spec.disable_default_http_trigger = True
 
-    @min_nuclio_versions("1.12.8")
+    @min_nuclio_versions("1.13.1")
     def enable_default_http_trigger(
         self,
     ):

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1730,7 +1730,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         self, db: Session, client: TestClient
     ):
         # TODO: delete version mocking as soon as we release it in nuclio
-        mlconf.nuclio_version = "1.12.8"
+        mlconf.nuclio_version = "1.13.1"
         function = self._generate_runtime(self.runtime_kind)
         function.enable_default_http_trigger()
 


### PR DESCRIPTION
Since application runtime is only accessible via API gateway, the function must have an http trigger to handle the API gateway's requests.

Thus, we wan't to forbid disabling http trigger for application runtime.