### PR TITLE
[Helpers] Fix min component version validation

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1701,11 +1701,21 @@ def validate_component_version_compatibility(
             )
         return True
 
+    # Feature might have been back-ported e.g. nuclio node selection is supported from
+    # 1.5.20 and 1.6.10 but not in 1.6.9 - therefore we reverse sort to validate against 1.6.x 1st and
+    # then against 1.5.x
     parsed_min_versions.sort(reverse=True)
     for parsed_min_version in parsed_min_versions:
-        if parsed_current_version < parsed_min_version:
+        if (
+            parsed_current_version.major == parsed_min_version.major
+            and parsed_current_version.minor == parsed_min_version.minor
+            and parsed_current_version.patch < parsed_min_version.patch
+        ):
             return False
-    return True
+
+        if parsed_current_version >= parsed_min_version:
+            return True
+    return False
 
 
 def format_alert_summary(

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -844,10 +844,13 @@ class TestNuclioRuntime(TestRuntimeBase):
         self._assert_nuclio_v3io_mount(local_path, remote_path)
 
     def test_deploy_with_node_selection(self, db: Session, client: TestClient):
-        mlconf.nuclio_version = "1.6.10"
         function = self._generate_runtime(self.runtime_kind)
-
         node_name = "some-node-name"
+        mlconf.nuclio_version = "1.6.3"
+        with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
+            function.with_node_selection(node_name=node_name)
+
+        mlconf.nuclio_version = "1.5.21"
         function.with_node_selection(node_name=node_name)
 
         self.execute_function(function)
@@ -856,6 +859,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         function = self._generate_runtime(self.runtime_kind)
 
+        mlconf.nuclio_version = "1.6.10"
         config_node_selector = {
             "label-1": "val1",
             "label-2": "val2",

--- a/tests/api/runtimes/test_nuclio.py
+++ b/tests/api/runtimes/test_nuclio.py
@@ -1211,6 +1211,9 @@ class TestNuclioRuntime(TestRuntimeBase):
         assert not mlrun.runtimes.nuclio.function.validate_nuclio_version_compatibility(
             "1.6.11", "1.5.9"
         )
+        assert mlrun.runtimes.nuclio.function.validate_nuclio_version_compatibility(
+            "1.6.9", "1.7.0"
+        )
         assert not mlrun.runtimes.nuclio.function.validate_nuclio_version_compatibility(
             "2.0.0"
         )

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -250,7 +250,7 @@ def test_is_iguazio_session_cookie():
         ["3.5.5-b25.20231224135202"],
         ["3.6.0"],
         ["4.0.0"],
-        ["3.2.0", "3.6.0"],
+        ["3.5.5", "3.6.0"],
     ],
 )
 def test_min_iguazio_version_fail(min_versions):

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -108,9 +108,6 @@ def test_requirement_specifiers_convention():
                 continue
 
     ignored_invalid_map = {
-        # 0.1.0 is not compatible with mlrun >=1.7.0rc19
-        "mlrun-pipelines-kfp-common": {"~=0.1.2"},
-        "mlrun-pipelines-kfp-v1-8": {"~=0.1.2"},
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "aiobotocore": {">=2.5.0,<2.8"},
         "storey": {"~=1.7.23"},


### PR DESCRIPTION
As described in the code comment:

> Feature might have been back-ported e.g. nuclio node selection is supported from 1.5.20 and 1.6.10 but not in 1.6.9 - therefore we reverse sort to validate against 1.6.x 1st and then against 1.5.x