### PR TITLE
[Dependencies] Upgrade Ruff

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ twine~=5.1
 build~=1.0
 
 # formatting & linting
-ruff==0.6.2
+ruff==0.6.3
 import-linter~=2.0
 blacken-docs~=1.18
 black~=24.4  # only used by by blacken-docs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ twine~=5.1
 build~=1.0
 
 # formatting & linting
-ruff==0.5.0
+ruff==0.6.2
 import-linter~=2.0
 blacken-docs~=1.18
 black~=24.4  # only used by by blacken-docs

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -863,7 +863,7 @@ class Config:
                     f"Unable to decode {attribute_path}"
                 )
             parsed_attribute_value = json.loads(decoded_attribute_value)
-            if isinstance(parsed_attribute_value, expected_type):
+            if not isinstance(parsed_attribute_value, expected_type):
                 raise mlrun.errors.MLRunInvalidArgumentTypeError(
                     f"Expected type {expected_type}, got {type(parsed_attribute_value)}"
                 )

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -863,7 +863,7 @@ class Config:
                     f"Unable to decode {attribute_path}"
                 )
             parsed_attribute_value = json.loads(decoded_attribute_value)
-            if type(parsed_attribute_value) != expected_type:
+            if isinstance(parsed_attribute_value, expected_type):
                 raise mlrun.errors.MLRunInvalidArgumentTypeError(
                     f"Expected type {expected_type}, got {type(parsed_attribute_value)}"
                 )

--- a/mlrun/data_types/to_pandas.py
+++ b/mlrun/data_types/to_pandas.py
@@ -21,7 +21,7 @@ import semver
 
 def _toPandas(spark_df):
     """
-    Modified version of spark DataFrame.toPandas() –
+    Modified version of spark DataFrame.toPandas() -
     https://github.com/apache/spark/blob/v3.2.3/python/pyspark/sql/pandas/conversion.py#L35
 
     The original code (which is only replaced in pyspark 3.5.0) fails with Pandas 2 installed, with the following error:
@@ -223,21 +223,21 @@ def _to_corrected_pandas_type(dt):
         TimestampType,
     )
 
-    if type(dt) == ByteType:
+    if isinstance(dt, ByteType):
         return np.int8
-    elif type(dt) == ShortType:
+    elif isinstance(dt, ShortType):
         return np.int16
-    elif type(dt) == IntegerType:
+    elif isinstance(dt, IntegerType):
         return np.int32
-    elif type(dt) == LongType:
+    elif isinstance(dt, LongType):
         return np.int64
-    elif type(dt) == FloatType:
+    elif isinstance(dt, FloatType):
         return np.float32
-    elif type(dt) == DoubleType:
+    elif isinstance(dt, DoubleType):
         return np.float64
-    elif type(dt) == BooleanType:
+    elif isinstance(dt, BooleanType):
         return bool
-    elif type(dt) == TimestampType:
+    elif isinstance(dt, TimestampType):
         return "datetime64[ns]"
     else:
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ extend-select = [
     "N999", # snake_case for module names
     "B006", # mutable default arguments
 ]
-exclude = ["*.ipynb"]
 explicit-preview-rules = true
 
 [tool.ruff.lint.pycodestyle]
@@ -26,6 +25,7 @@ max-line-length = 120
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
 "docs/**.py" = ["CPY001"]
+"*.ipynb" = ["ALL"]  # TODO: enable linting rules on Jupyter notebooks
 
 [tool.ruff.lint.flake8-copyright]
 author = "Iguazio"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.ruff]
-extend-include = ["*.ipynb"]
 target-version = "py39"
 required-version = ">=0.6.2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 target-version = "py39"
-required-version = ">=0.6.2"
+required-version = ">=0.6.3"
 
 [tool.ruff.lint]
 extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 extend-include = ["*.ipynb"]
 target-version = "py39"
-required-version = ">=0.5.0"
+required-version = ">=0.6.2"
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
Upgrade to the latest Ruff version [0.6.3](https://github.com/astral-sh/ruff/releases/tag/0.6.3) following the [migration guide](https://astral.sh/blog/ruff-v0.6.0#migrating-to-v06).