### PR TITLE
[Model Monitoring] Fix monitoring parquet partitioning 

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -353,6 +353,7 @@ class EventStreamProcessor:
                 index_cols=[EventFieldType.ENDPOINT_ID],
                 key_bucketing_number=0,
                 time_partitioning_granularity="hour",
+                time_field=EventFieldType.TIMESTAMP,
                 partition_cols=["$key", "$year", "$month", "$day", "$hour"],
             )
 


### PR DESCRIPTION
Adjust the partitioning of the Parquet target in the model monitoring stream graph by setting `time_field=timestamp`. This change ensures partitioning is based on the data timestamp rather than the stream pod's runtime.

Related JIRA: https://iguazio.atlassian.net/browse/ML-7691