### PR TITLE
[Model Monitoring] Fix avoiding non-numeric features in `current_stats`

### DIFF
--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -254,7 +254,7 @@ def calculate_inputs_statistics(
     )
 
     # Recalculate the histograms over the bins that are set in the sample-set of the end point:
-    for feature in inputs_statistics.keys():
+    for feature in list(inputs_statistics):
         if feature in sample_set_statistics:
             counts, bins = np.histogram(
                 inputs[feature].to_numpy(),

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -271,6 +271,9 @@ def calculate_inputs_statistics(
                     inputs_statistics[feature]["hist"]
                 )
             )
+        else:
+            # If the feature is not in the sample set and doesn't have a histogram, remove it from the statistics:
+            inputs_statistics.pop(feature)
 
     return inputs_statistics
 

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -157,22 +157,22 @@ def test_calculate_input_statistics(
     statistics. In addition, we will add a string feature to the sample data and check that it was removed from the
     input statistics."""
 
-    current_stats = generate_sample_data(feature_stats)
+    input_data = generate_sample_data(feature_stats)
 
-    # add string feature to current_stats
-    current_stats["str_feat"] = "blabla"
-    inputs_stats = mlrun.model_monitoring.helpers.calculate_inputs_statistics(
+    # add string feature to input data
+    input_data["str_feat"] = "blabla"
+    current_stats = mlrun.model_monitoring.helpers.calculate_inputs_statistics(
         sample_set_statistics=feature_stats,
-        inputs=current_stats,
+        inputs=input_data,
     )
     # check that the string feature was removed
-    assert "str_feat" not in inputs_stats.keys()
+    assert "str_feat" not in current_stats.keys()
 
-    # check that the input_stats have the same keys as the feature_stats
-    assert inputs_stats.keys() == feature_stats.keys()
+    # check that the current_stats have the same keys as the feature_stats
+    assert current_stats.keys() == feature_stats.keys()
 
     # validate the expected keys in a certain feature statistics
-    feature_statistics = inputs_stats[next(iter(feature_stats))]
+    feature_statistics = current_stats[next(iter(feature_stats))]
     assert list(feature_statistics.keys()) == [
         "count",
         "mean",

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -153,8 +153,9 @@ def generate_sample_data(
 def test_calculate_input_statistics(
     feature_stats: FeatureStats,
 ) -> None:
-    """In the following test we will generate a sample data and calculate the input statistics based on the feature statistics.
-    In addition, we will add a string feature to the sample data and check that it was removed from the input statistics."""
+    """In the following test we will generate a sample data and calculate the input statistics based on the feature
+    statistics. In addition, we will add a string feature to the sample data and check that it was removed from the
+    input statistics."""
 
     current_stats = generate_sample_data(feature_stats)
 

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -19,6 +19,8 @@ from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
 
 import nuclio
+import numpy as np
+import pandas as pd
 import pytest
 from v3io.dataplane.response import HttpResponseError
 
@@ -129,6 +131,58 @@ def test_pad_features_hist(
     pad_features_hist(feature_stats)
     for feat_name, feat in feature_stats.items():
         _check_padded_hist_spec(feat["hist"], orig_feature_stats_hist_data[feat_name])
+
+
+def generate_sample_data(
+    feature_stats: FeatureStats,
+    num_samples: int = 50,
+) -> pd.DataFrame:
+    data = {}
+    for feature in feature_stats.keys():
+        data[feature] = []
+        for sample in range(num_samples):
+            loc = np.random.uniform(
+                low=feature_stats[feature]["hist"][1][0],
+                high=feature_stats[feature]["hist"][1][-1],
+            )
+            feature_data = np.random.normal(loc=loc, scale=1.5, size=1)
+            data[feature].append(float(feature_data))
+    return pd.DataFrame(data)
+
+
+def test_calculate_input_statistics(
+    feature_stats: FeatureStats,
+) -> None:
+    """In the following test we will generate a sample data and calculate the input statistics based on the feature statistics.
+    In addition, we will add a string feature to the sample data and check that it was removed from the input statistics."""
+
+    current_stats = generate_sample_data(feature_stats)
+
+    # add string feature to current_stats
+    current_stats["str_feat"] = "blabla"
+    inputs_stats = mlrun.model_monitoring.helpers.calculate_inputs_statistics(
+        sample_set_statistics=feature_stats,
+        inputs=current_stats,
+    )
+    # check that the string feature was removed
+    assert "str_feat" not in inputs_stats.keys()
+
+    # check that the input_stats have the same keys as the feature_stats
+    assert inputs_stats.keys() == feature_stats.keys()
+
+    # validate the expected keys in a certain feature statistics
+    feature_statistics = inputs_stats[next(iter(feature_stats))]
+    assert list(feature_statistics.keys()) == [
+        "count",
+        "mean",
+        "std",
+        "min",
+        "25%",
+        "50%",
+        "75%",
+        "max",
+        "hist",
+    ]
 
 
 class TestBatchInterval:


### PR DESCRIPTION
When calculating inputs data statistics for drift monitoring purpose (aka `current_stats`) we only support numerical features. In this PR we are excluding the non-numeric features to avoid possible conflicts that cause issues in the UI. 

Related JIRA: https://iguazio.atlassian.net/browse/ML-7709