### PR TITLE
[Model Monitoring] Fix skip stream deletion if failed

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -980,11 +980,10 @@ class MonitoringDeployment:
                     logger.debug(
                         "Deleted v3io stream", project=project, stream_path=stream_path
                     )
-                except v3io.dataplane.response.HttpResponseError as e:
-                    logger.warning(
-                        "Failed to delete v3io stream",
-                        stream_path=stream_path,
-                        error=mlrun.errors.err_to_str(e),
+                except Exception as exc:
+                    # Raise an error that will be caught by the caller and skip the deletion of the stream
+                    raise mlrun.errors.MLRunStreamConnectionFailure(
+                        f"Failed to delete v3io stream {stream_path}, {mlrun.errors.err_to_str(exc)}"
                     )
         elif stream_paths[0].startswith("kafka://"):
             # Delete Kafka topics
@@ -1007,22 +1006,10 @@ class MonitoringDeployment:
                 )
                 kafka_client.delete_topics(topics)
                 logger.debug("Deleted kafka topics", topics=topics)
-            except kafka.errors.TopicAuthorizationFailedError as e:
-                logger.warning(
-                    "Failed to delete kafka topics",
-                    topics=topics,
-                    error=mlrun.errors.err_to_str(e),
-                )
-            except kafka.errors.UnknownTopicOrPartitionError as e:
-                logger.info(
-                    "Kafka model monitoring topics not found, probably not created",
-                    topics=topics,
-                    error=mlrun.errors.err_to_str(e),
-                )
-            except kafka.errors.NoBrokersAvailable as e:
+            except Exception as exc:
                 # Raise an error that will be caught by the caller and skip the deletion of the stream
                 raise mlrun.errors.MLRunStreamConnectionFailure(
-                    f"Failed to delete kafka topics {topics}, no brokers available, {mlrun.errors.err_to_str(e)}"
+                    f"Failed to delete kafka topics {topics}, {mlrun.errors.err_to_str(exc)}"
                 )
         else:
             logger.warning(

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -983,7 +983,7 @@ class MonitoringDeployment:
                 except Exception as exc:
                     # Raise an error that will be caught by the caller and skip the deletion of the stream
                     raise mlrun.errors.MLRunStreamConnectionFailure(
-                        f"Failed to delete v3io stream {stream_path}, {mlrun.errors.err_to_str(exc)}"
+                        f"Failed to delete v3io stream {stream_path}"
                     ) from exc
         elif stream_paths[0].startswith("kafka://"):
             # Delete Kafka topics
@@ -1009,7 +1009,7 @@ class MonitoringDeployment:
             except Exception as exc:
                 # Raise an error that will be caught by the caller and skip the deletion of the stream
                 raise mlrun.errors.MLRunStreamConnectionFailure(
-                    f"Failed to delete kafka topics {topics}, {mlrun.errors.err_to_str(exc)}"
+                    "Failed to delete kafka topics"
                 ) from exc
         else:
             logger.warning(

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -984,7 +984,7 @@ class MonitoringDeployment:
                     # Raise an error that will be caught by the caller and skip the deletion of the stream
                     raise mlrun.errors.MLRunStreamConnectionFailure(
                         f"Failed to delete v3io stream {stream_path}, {mlrun.errors.err_to_str(exc)}"
-                    )
+                    ) from exc
         elif stream_paths[0].startswith("kafka://"):
             # Delete Kafka topics
             import kafka
@@ -1010,7 +1010,7 @@ class MonitoringDeployment:
                 # Raise an error that will be caught by the caller and skip the deletion of the stream
                 raise mlrun.errors.MLRunStreamConnectionFailure(
                     f"Failed to delete kafka topics {topics}, {mlrun.errors.err_to_str(exc)}"
-                )
+                ) from exc
         else:
             logger.warning(
                 "Stream path is not supported and therefore can't be deleted, expected v3io or kafka",


### PR DESCRIPTION
Currently, the delete project API fails if the model monitoring stream resources (either `v3io` or `kafka`) cannot be deleted, except for specific errors that are already handled. In this PR, we catch all possible errors, log them as a warning in the API, and ensure the delete project API does not fail.

Related JIRA: https://iguazio.atlassian.net/browse/ML-7719