### PR TITLE
[Model Monitoring] Revert to using `storeytargets`

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -167,9 +167,10 @@ class TDEngineConnector(TSDBConnector):
 
         def apply_tdengine_target(name, after):
             graph.add_step(
-                "mlrun.datastore.storeytargets.TDEngineStoreyTarget",
+                "storey.TDEngineTarget",
                 name=name,
                 after=after,
+                url=self._tdengine_connection_string,
                 supertable=mm_schemas.TDEngineSuperTables.PREDICTIONS,
                 table_col=mm_schemas.EventFieldType.TABLE_COLUMN,
                 time_col=mm_schemas.EventFieldType.TIME,

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -181,7 +181,7 @@ class V3IOTSDBConnector(TSDBConnector):
 
         # Write latency per prediction, labeled by endpoint ID only
         graph.add_step(
-            "mlrun.datastore.storeytargets.TSDBStoreyTarget",
+            "storey.TSDBTarget",
             name="tsdb_predictions",
             after="MapFeatureNames",
             path=f"{self.container}/{self.tables[mm_schemas.FileTargetKind.PREDICTIONS]}",
@@ -232,7 +232,7 @@ class V3IOTSDBConnector(TSDBConnector):
 
         def apply_tsdb_target(name, after):
             graph.add_step(
-                "mlrun.datastore.storeytargets.TSDBStoreyTarget",
+                "storey.TSDBTarget",
                 name=name,
                 after=after,
                 path=f"{self.container}/{self.tables[mm_schemas.V3IOTSDBTables.EVENTS]}",

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -322,11 +322,12 @@ class EventStreamProcessor:
         # Write the Parquet target file, partitioned by key (endpoint_id) and time.
         def apply_parquet_target():
             graph.add_step(
-                "mlrun.datastore.storeytargets.ParquetStoreyTarget",
+                "storey.ParquetTarget",
                 name="ParquetTarget",
                 after="ProcessBeforeParquet",
                 graph_shape="cylinder",
                 path=self.parquet_path,
+                storage_options=self.storage_options,
                 max_events=self.parquet_batching_max_events,
                 flush_after_seconds=self.parquet_batching_timeout_secs,
                 attributes={"infer_columns_from_data": True},


### PR DESCRIPTION
[ML-7766](https://iguazio.atlassian.net/browse/ML-7766)
[ML-7769](https://iguazio.atlassian.net/browse/ML-7769)

Partially reverts #6184.

[ML-7766]: https://iguazio.atlassian.net/browse/ML-7766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-7769]: https://iguazio.atlassian.net/browse/ML-7769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ