### PR TITLE
[Contributing] Updated script installing protobuf

### DIFF
--- a/automation/scripts/compile_protobuf320_for_mac_arm64.sh
+++ b/automation/scripts/compile_protobuf320_for_mac_arm64.sh
@@ -16,23 +16,18 @@
 
 set -e
 
-MLRUN_PYTHON_PACKAGE_INSTALLER=${1:-${MLRUN_PYTHON_PACKAGE_INSTALLER:-pip}}
 TARGET_PROTOBUF_VERSION=3.20.3
 
-install_command=""
-if [[ "${MLRUN_PYTHON_PACKAGE_INSTALLER}" == "pip" ]]; then
-  install_command=$(echo pip install protobuf=="${TARGET_PROTOBUF_VERSION}" --force-reinstall --force --no-cache --no-binary :all: --global-option=\"--cpp_implementation\")
-elif [[ "${MLRUN_PYTHON_PACKAGE_INSTALLER}" == "uv" ]]; then
-  install_command=$(echo uv pip install --force-reinstall --no-cache --no-binary :all:  protobuf=="${TARGET_PROTOBUF_VERSION}")
-else
-    echo "Unknown package installer ${MLRUN_PYTHON_PACKAGE_INSTALLER}"
-    exit 1
-fi
+# uncomment above and delete this line once `uv` would be able to accept
+# cpp_implementation as a global option.
+install_command=$(echo pip install protobuf=="${TARGET_PROTOBUF_VERSION}" --force-reinstall --force --no-cache --no-binary :all: --global-option=\"--cpp_implementation\")
 
 
 # Install and use protobuf 3.20
-brew install protobuf@3.20
-brew link --overwrite protobuf@3.20
+brew install --force protobuf@3.20
+
+# Ensure that the correct version of protobuf is linked
+brew unlink protobuf@3 && brew link --force protobuf@3
 
 # Compile protobuf on mac
 #   used https://github.com/protocolbuffers/protobuf/issues/8820#issuecomment-961552604
@@ -58,4 +53,4 @@ export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"
 INSTALL_PREFIX_PATH="/usr/local" && \
    CFLAGS="-I${INSTALL_PREFIX_PATH}/include" && \
    LDFLAGS="-L${INSTALL_PREFIX_PATH}/lib" && \
-   echo $install_command && $install_command
+   $install_command


### PR DESCRIPTION
uv cannot install protobuf 3.20 as needed for mac os arm64 based as it lacks some of `pip`'s options
so while mlrun with `uv` is still an option, we would still need native `pip` to install protobuf 3.20 for us