### PR TITLE
[API Gateway] Fix joining URL when getting invoke_url on server side

### DIFF
--- a/mlrun/common/schemas/api_gateway.py
+++ b/mlrun/common/schemas/api_gateway.py
@@ -103,11 +103,11 @@ class APIGateway(_APIGatewayBaseModel):
         ]
 
     def get_invoke_url(self):
-        return (
-            self.spec.host + self.spec.path
-            if self.spec.path and self.spec.host
-            else self.spec.host
-        ).rstrip("/")
+        if self.spec.host and self.spec.path:
+            if not self.spec.path.startswith("/"):
+                return f"{self.spec.host.rstrip('/')}/{self.spec.path}"
+            return f"{self.spec.host.rstrip('/')}{self.spec.path}"
+        return self.spec.host
 
     def enrich_mlrun_names(self):
         self._enrich_api_gateway_mlrun_name()

--- a/mlrun/common/schemas/api_gateway.py
+++ b/mlrun/common/schemas/api_gateway.py
@@ -104,10 +104,10 @@ class APIGateway(_APIGatewayBaseModel):
 
     def get_invoke_url(self):
         if self.spec.host and self.spec.path:
-            if not self.spec.path.startswith("/"):
-                return f"{self.spec.host.rstrip('/')}/{self.spec.path}"
-            return f"{self.spec.host.rstrip('/')}{self.spec.path}"
-        return self.spec.host
+            return f"{self.spec.host.rstrip('/')}/{self.spec.path.lstrip('/')}".rstrip(
+                "/"
+            )
+        return self.spec.host.rstrip("/")
 
     def enrich_mlrun_names(self):
         self._enrich_api_gateway_mlrun_name()

--- a/tests/runtimes/test_api_gateway.py
+++ b/tests/runtimes/test_api_gateway.py
@@ -1,0 +1,39 @@
+import pytest
+
+import mlrun.common.schemas
+import mlrun.runtimes.nuclio
+
+
+@pytest.mark.parametrize(
+    "host, path, expected_url",
+    [
+        ("example.com", "/api", "example.com/api"),
+        ("example.com/", "/api", "example.com/api"),
+        ("example.com", "api", "example.com/api"),
+        ("example.com/", "api", "example.com/api"),
+        ("example.com/", "/api/", "example.com/api"),
+        ("example.com/", "/api/long/path/", "example.com/api/long/path"),
+        ("example.com", "/", "example.com"),
+        ("example.com/", "/", "example.com"),
+        ("example.com", None, "example.com"),
+        ("example.com/", None, "example.com"),
+    ],
+)
+def test_get_invoke_url(host, path, expected_url):
+    # testing server side api gateway
+    api_gateway = mlrun.common.schemas.APIGateway(
+        metadata=mlrun.common.schemas.APIGatewayMetadata(name="test"),
+        spec=mlrun.common.schemas.APIGatewaySpec(
+            name="test", host=host, path=path, upstreams=[]
+        ),
+    )
+    assert api_gateway.get_invoke_url() == expected_url
+
+    # testing client side api gateway
+    api_gateway = mlrun.runtimes.nuclio.api_gateway.APIGateway(
+        metadata=mlrun.runtimes.nuclio.api_gateway.APIGatewayMetadata(name="test"),
+        spec=mlrun.runtimes.nuclio.api_gateway.APIGatewaySpec(
+            project="test", host=host, path=path, functions=["test"]
+        ),
+    )
+    assert api_gateway.invoke_url == "https://" + expected_url

--- a/tests/runtimes/test_api_gateway.py
+++ b/tests/runtimes/test_api_gateway.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import pytest
 
 import mlrun.common.schemas


### PR DESCRIPTION
Fixes the issue where `/` wasn't added between host and path when generating `invoke_url` on server side. 
Now it will be always added and we also ensure that `/` isn't duplicated. 

Jira - https://iguazio.atlassian.net/browse/NUC-252