### PR TITLE
[Model Monitoring] Fix error class name

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -992,7 +992,7 @@ class MonitoringDeployment:
                     )
                 except Exception as exc:
                     # Raise an error that will be caught by the caller and skip the deletion of the stream
-                    raise mlrun.errors.MLRunStreamConnectionFailure(
+                    raise mlrun.errors.MLRunStreamConnectionFailureError(
                         f"Failed to delete v3io stream {stream_path}"
                     ) from exc
         elif stream_paths[0].startswith("kafka://"):


### PR DESCRIPTION
It occurred due to a conflict between #6244 and #6274.