### PR TITLE
[Project] Add owner when logging artifacts

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -72,7 +72,12 @@ class ArtifactProducer:
         self.inputs = {}
 
     def get_meta(self) -> dict:
-        return {"kind": self.kind, "name": self.name, "tag": self.tag}
+        return {
+            "kind": self.kind,
+            "name": self.name,
+            "tag": self.tag,
+            "owner": self.owner,
+        }
 
     @property
     def uid(self):

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -335,7 +335,7 @@ class MLClientCtx:
             "name": self.name,
             "kind": "run",
             "uri": uri,
-            "owner": get_in(self._labels, "owner"),
+            "owner": get_in(self._labels, mlrun_constants.MLRunInternalLabels.owner),
         }
         if mlrun_constants.MLRunInternalLabels.workflow in self._labels:
             resp[mlrun_constants.MLRunInternalLabels.workflow] = self._labels[

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4341,9 +4341,7 @@ class MlrunProject(ModelObj):
         return self._get_hexsha() or str(uuid.uuid4())
 
     def _resolve_artifact_owner(self):
-        if username := os.getenv("V3IO_USERNAME"):
-            return username
-        return self.spec.owner
+        return os.getenv("V3IO_USERNAME") or self.spec.owner
 
 
 def _set_as_current_default_project(project: MlrunProject):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -18,6 +18,7 @@ import glob
 import http
 import importlib.util as imputil
 import json
+import os
 import pathlib
 import shutil
 import tempfile
@@ -4289,6 +4290,7 @@ class MlrunProject(ModelObj):
                     kind=producer_dict.get("kind", ""),
                     project=producer_project,
                     tag=producer_tag,
+                    owner=producer_dict.get("owner", ""),
                 ), True
 
         # do not retain the artifact's producer, replace it with the project as the producer
@@ -4298,6 +4300,7 @@ class MlrunProject(ModelObj):
             name=self.metadata.name,
             project=self.metadata.name,
             tag=project_producer_tag,
+            owner=self._resolve_artifact_owner(),
         ), False
 
     def _resolve_existing_artifact(
@@ -4336,6 +4339,11 @@ class MlrunProject(ModelObj):
 
     def _get_project_tag(self):
         return self._get_hexsha() or str(uuid.uuid4())
+
+    def _resolve_artifact_owner(self):
+        if username := os.getenv("V3IO_USERNAME"):
+            return username
+        return self.spec.owner
 
 
 def _set_as_current_default_project(project: MlrunProject):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1120,24 +1120,22 @@ def test_replace_exported_artifact_producer(rundb_mock):
         ("project-owner", None),
         (None, "username"),
         ("project-owner", "username"),
+        (None, None),
     ],
 )
-def test_artifact_owner(rundb_mock, project_owner, username):
+def test_artifact_owner(
+    rundb_mock, project_owner, username, monkeypatch: pytest.MonkeyPatch
+):
     if username:
-        # set the V3IO_USERNAME env var
-        os.environ["V3IO_USERNAME"] = username
+        monkeypatch.setenv("V3IO_USERNAME", username)
 
-    try:
-        project = mlrun.new_project("artifact-owner", save=False)
-        project.spec.owner = project_owner
-        artifact = project.log_artifact("x", body="123", format="txt")
-        if username:
-            assert artifact.spec.producer.get("owner") == username
-        else:
-            assert artifact.spec.producer.get("owner") == project_owner
-    finally:
-        # remove the env var when done
-        os.environ.pop("V3IO_USERNAME", None)
+    project = mlrun.new_project("artifact-owner", save=False)
+    project.spec.owner = project_owner
+    artifact = project.log_artifact("x", body="123", format="txt")
+    if username:
+        assert artifact.producer.get("owner") == username
+    else:
+        assert artifact.producer.get("owner") == project_owner
 
 
 @pytest.mark.parametrize(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1017,6 +1017,9 @@ def test_import_artifact_retain_producer(rundb_mock):
         name="project-2", context=f"{base_path}/project_2", save=False
     )
 
+    # set project owners
+    project_1.spec.owner = "owner-1"
+
     # create an artifact with a 'run' producer
     artifact = mlrun.artifacts.Artifact(key="x", body="123", is_inline=True)
     run_name = "my-run"
@@ -1027,6 +1030,7 @@ def test_import_artifact_retain_producer(rundb_mock):
         kind="run",
         project=project_1.name,
         name=run_name,
+        owner=project_1.spec.owner,
     ).get_meta()
 
     # imitate the artifact being produced by a run with uri and without a tag
@@ -1039,6 +1043,7 @@ def test_import_artifact_retain_producer(rundb_mock):
         "kind": "run",
         "name": run_name,
         "tag": run_tag,
+        "owner": project_1.spec.owner,
     }
 
     # export the artifact
@@ -1107,6 +1112,32 @@ def test_replace_exported_artifact_producer(rundb_mock):
     loaded_artifact = project_3.get_artifact(key)
     assert loaded_artifact.producer != artifact.producer
     assert loaded_artifact.producer["name"] == project_3.name
+
+
+@pytest.mark.parametrize(
+    "project_owner,username",
+    [
+        ("project-owner", None),
+        (None, "username"),
+        ("project-owner", "username"),
+    ],
+)
+def test_artifact_owner(rundb_mock, project_owner, username):
+    if username:
+        # set the V3IO_USERNAME env var
+        os.environ["V3IO_USERNAME"] = username
+
+    try:
+        project = mlrun.new_project("artifact-owner", save=False)
+        project.spec.owner = project_owner
+        artifact = project.log_artifact("x", body="123", format="txt")
+        if username:
+            assert artifact.spec.producer.get("owner") == username
+        else:
+            assert artifact.spec.producer.get("owner") == project_owner
+    finally:
+        # remove the env var when done
+        os.environ.pop("V3IO_USERNAME", None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -233,6 +233,27 @@ def test_is_logging_worker(host: str, is_logging_worker: bool):
     assert context.is_logging_worker() is is_logging_worker
 
 
+@pytest.mark.parametrize(
+    "owner",
+    [
+        "some-owner",
+        None,
+    ],
+)
+def test_artifact_owner(rundb_mock, owner):
+    run_dict = _generate_run_dict()
+    if owner:
+        run_dict["metadata"]["labels"][mlrun_constants.MLRunInternalLabels.owner] = (
+            owner
+        )
+
+    run = mlrun.run.RunObject.from_dict(run_dict)
+    context = mlrun.MLClientCtx.from_dict(run.to_dict())
+
+    artifact = context.log_artifact("artifact", body="123")
+    assert artifact.producer.get("owner") == owner
+
+
 def _generate_run_dict():
     return {
         "metadata": {


### PR DESCRIPTION
When artifact are logged via a context, the artifact producer has an `owner` field which is the run owner.
When logging via a project, the owner field was left empty.

In this PR we populate the owner field when logging artifacts via a project according to the following logic:
- If we have the current username at hand (in the `V3IO_USERNAME` env var) - use it as the artifact owner.
- If not - use the project owner as the artifact owner.

Resolves https://iguazio.atlassian.net/browse/ML-7730