### PR TITLE
[Model Monitoring] Remove unnecessary fields from `ModelEndpoint`'s current stats

### DIFF
--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -265,13 +265,6 @@ def calculate_inputs_statistics(
                 counts.tolist(),
                 bins.tolist(),
             ]
-        elif "hist" in inputs_statistics[feature]:
-            # Comply with the other common features' histogram length
-            mlrun.common.model_monitoring.helpers.pad_hist(
-                mlrun.common.model_monitoring.helpers.Histogram(
-                    inputs_statistics[feature]["hist"]
-                )
-            )
         else:
             # If the feature is not in the sample set and doesn't have a histogram, remove it from the statistics:
             inputs_statistics.pop(feature)

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -138,22 +138,13 @@ def test_plot_produce(tmp_path: Path) -> None:
 class TestCalculateInputsStatistics:
     _HIST = "hist"
     _DEFAULT_NUM_BINS = default_num_bins
-
-    @staticmethod
-    @pytest.fixture
-    def shared_feat() -> str:
-        return "orig_feat0"
-
-    @staticmethod
-    @pytest.fixture
-    def new_feat() -> str:
-        return "new_feat0"
+    _SHARED_FEATURE = "shared_feature"
 
     @classmethod
     @pytest.fixture
-    def sample_set_statistics(cls, shared_feat: str) -> dict:
+    def sample_set_statistics(cls) -> dict:
         return {
-            shared_feat: {
+            cls._SHARED_FEATURE: {
                 cls._HIST: [
                     [0, *list(np.random.randint(10, size=cls._DEFAULT_NUM_BINS)), 0],
                     [
@@ -165,25 +156,21 @@ class TestCalculateInputsStatistics:
             }
         }
 
-    @staticmethod
+    @classmethod
     @pytest.fixture
-    def inputs_df(shared_feat: str, new_feat: str) -> pd.DataFrame:
+    def inputs_df(cls) -> pd.DataFrame:
         return pd.DataFrame(
-            columns=[shared_feat, new_feat],
+            columns=[cls._SHARED_FEATURE, "feature_1"],
             data=np.random.randint(-15, 20, size=(9, 2)),
         )
 
-    @staticmethod
-    @pytest.fixture
-    def input_statistics(sample_set_statistics: dict, inputs_df: pd.DataFrame) -> dict:
-        return calculate_inputs_statistics(
+    @classmethod
+    def test_histograms_features(
+        cls, sample_set_statistics: dict, inputs_df: pd.DataFrame
+    ) -> None:
+        current_stats = calculate_inputs_statistics(
             sample_set_statistics=sample_set_statistics, inputs=inputs_df
         )
-
-    @classmethod
-    def test_histograms_length(
-        cls, shared_feat: str, new_feat: str, input_statistics: dict
-    ) -> None:
-        assert len(input_statistics[shared_feat][cls._HIST][0]) == len(
-            input_statistics[new_feat][cls._HIST][0]
-        ), "The lengths of the histograms do not match"
+        assert (
+            current_stats.keys() == sample_set_statistics.keys()
+        ), "Inputs statistics and the current statistics should have the same features"

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -384,9 +384,9 @@ class _V3IORecordsChecker:
 @pytest.mark.enterprise
 @pytest.mark.model_monitoring
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-app-flow-v2"
+    project_name = "test-app-flow-v88"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = None
+    image: typing.Optional[str] = "quay.io/davesh0812/mlrun:1.7.0"
     error_count = 10
 
     @classmethod
@@ -673,13 +673,7 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
         ), "The endpoint's feature stats keys are not the same as the feature names"
         assert set(ep.status.current_stats.keys()) == set(
             ep.status.feature_stats.keys()
-        ) | {
-            "timestamp",
-            "latency",
-            "error_count",
-            "metrics",
-            "p0",
-        }, "The endpoint's current stats is different than expected"
+        ), "The endpoint's current stats is different than expected"
         assert ep.status.drift_status, "The general drift status is empty"
         assert ep.status.drift_measures, "The drift measures are empty"
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -384,9 +384,9 @@ class _V3IORecordsChecker:
 @pytest.mark.enterprise
 @pytest.mark.model_monitoring
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-app-flow-v88"
+    project_name = "test-app-flow-v2"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "quay.io/davesh0812/mlrun:1.7.0"
+    image: typing.Optional[str] = None
     error_count = 10
 
     @classmethod


### PR DESCRIPTION
`"timestamp", "latency", "error_count", "metrics",` fields were saved to the current stats without any reason.
After this pr `current_stats` features are equal to `feature_stats` features.
test_app is working after this pr.