### PR TITLE
[Projects] Fix Project Event Types to be System Events

### DIFF
--- a/server/api/utils/events/iguazio.py
+++ b/server/api/utils/events/iguazio.py
@@ -114,7 +114,7 @@ class Client(base_events.BaseEventClient):
             ],
             severity=igz_mgmt.constants.EventSeverity.info,
             classification=igz_mgmt.constants.EventClassification.security,
-            system_event=False,
+            system_event=True,
             visibility=igz_mgmt.constants.EventVisibility.external,
         )
 
@@ -139,7 +139,7 @@ class Client(base_events.BaseEventClient):
             description=f"Project {project} secret created",
             severity=igz_mgmt.constants.EventSeverity.info,
             classification=igz_mgmt.constants.EventClassification.security,
-            system_event=False,
+            system_event=True,
             visibility=igz_mgmt.constants.EventVisibility.external,
         )
 
@@ -167,7 +167,7 @@ class Client(base_events.BaseEventClient):
             ],
             severity=igz_mgmt.constants.EventSeverity.info,
             classification=igz_mgmt.constants.EventClassification.security,
-            system_event=False,
+            system_event=True,
             visibility=igz_mgmt.constants.EventVisibility.external,
         )
 
@@ -188,7 +188,7 @@ class Client(base_events.BaseEventClient):
             ],
             severity=igz_mgmt.constants.EventSeverity.info,
             classification=igz_mgmt.constants.EventClassification.security,
-            system_event=False,
+            system_event=True,
             visibility=igz_mgmt.constants.EventVisibility.external,
         )
 


### PR DESCRIPTION
Non-system events are called communication events in Iguazio and are not journaled in the same DB table as the audit events displayed in the UI. There exists another bug somewhere in the flow where these events are anyway saved in the audit events table, however this should be changed and fixed here to make sure the behaviour is as expected.