### PR TITLE
[Dask] Tune cluster teardown

### DIFF
--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -145,7 +145,10 @@ class ParallelRunner:
         if function_name and generator.options.teardown_dask:
             logger.info("Tearing down the dask cluster..")
             mlrun.get_run_db().delete_runtime_resources(
-                kind="dask", object_id=function_name, force=True
+                project=self.metadata.project,
+                kind=mlrun.runtimes.RuntimeKinds.dask,
+                object_id=function_name,
+                force=True,
             )
 
         return results


### PR DESCRIPTION
Delete dask cluster is done by function name but users may have the same function name across multiple projects which means we need to teardown clusters from a single project.

https://iguazio.atlassian.net/browse/ML-4200