### PR TITLE
[MLCtx] Fix `MLClientCtx.log_level` setter not changing the object's logger's level

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import uuid
 from copy import deepcopy
@@ -168,6 +169,8 @@ class MLClientCtx:
     @log_level.setter
     def log_level(self, value: str):
         """Set the logging level, e.g. 'debug', 'info', 'error'"""
+        level = logging.getLevelName(value.upper())
+        self._logger.set_logger_level(level)
         self._log_level = value
 
     @property


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-7674

The `MLClientCtx.log_level` was only setting some member for later specific uses. The setter now also changes the ctx's logger's log level.