### PR TITLE
[Model Monitoring] Define 1.7.0 as the minimum Client Version which supports MM & delete strem trigger duplication of the stream pod

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -532,7 +532,6 @@ default_config = {
         "store_prefixes": {
             "default": "v3io:///users/pipelines/{project}/model-endpoints/{kind}",
             "user_space": "v3io:///projects/{project}/model-endpoints/{kind}",
-            "stream": "",  # TODO: Delete in 1.9.0
             "monitoring_application": "v3io:///users/pipelines/{project}/monitoring-apps/",
         },
         # Offline storage path can be either relative or a full path. This path is used for general offline data
@@ -545,7 +544,6 @@ default_config = {
         "parquet_batching_max_events": 10_000,
         "parquet_batching_timeout_secs": timedelta(minutes=1).total_seconds(),
         # See mlrun.model_monitoring.db.stores.ObjectStoreFactory for available options
-        "store_type": "v3io-nosql",  # TODO: Delete in 1.9.0
         "endpoint_store_connection": "",
         # See mlrun.model_monitoring.db.tsdb.ObjectTSDBFactory for available options
         "tsdb_connection": "",
@@ -1126,7 +1124,7 @@ class Config:
         artifact_path: str = None,
         function_name: str = None,
         **kwargs,
-    ) -> typing.Union[str, list[str]]:
+    ) -> str:
         """Get the full path from the configuration based on the provided project and kind.
 
         :param project:         Project name.
@@ -1165,17 +1163,10 @@ class Config:
                     else f"{kind}-{function_name.lower()}",
                 )
             elif kind == "stream":  # return list for mlrun<1.6.3 BC
-                return [
-                    # TODO: remove the first stream in 1.9.0
-                    mlrun.mlconf.model_endpoint_monitoring.store_prefixes.default.format(
-                        project=project,
-                        kind=kind,
-                    ),  # old stream uri (pipelines) for BC ML-6043
-                    mlrun.mlconf.model_endpoint_monitoring.store_prefixes.user_space.format(
-                        project=project,
-                        kind=kind,
-                    ),  # new stream uri (projects)
-                ]
+                return mlrun.mlconf.model_endpoint_monitoring.store_prefixes.user_space.format(
+                    project=project,
+                    kind=kind,
+                )  # new stream uri (projects)
             else:
                 return mlrun.mlconf.model_endpoint_monitoring.store_prefixes.default.format(
                     project=project,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1121,8 +1121,8 @@ class Config:
         project: str = "",
         kind: str = "",
         target: str = "online",
-        artifact_path: str = None,
-        function_name: str = None,
+        artifact_path: typing.Optional[str] = None,
+        function_name: typing.Optional[str] = None,
         **kwargs,
     ) -> str:
         """Get the full path from the configuration based on the provided project and kind.
@@ -1140,8 +1140,7 @@ class Config:
                                 relative artifact path will be taken from the global MLRun artifact path.
         :param function_name:    Application name, None for model_monitoring_stream.
 
-        :return:                Full configured path for the provided kind. Can be either a single path
-                                or a list of paths in the case of the online model monitoring stream path.
+        :return:                Full configured path for the provided kind.
         """
 
         if target != "offline":

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1162,11 +1162,11 @@ class Config:
                     if function_name is None
                     else f"{kind}-{function_name.lower()}",
                 )
-            elif kind == "stream":  # return list for mlrun<1.6.3 BC
+            elif kind == "stream":
                 return mlrun.mlconf.model_endpoint_monitoring.store_prefixes.user_space.format(
                     project=project,
                     kind=kind,
-                )  # new stream uri (projects)
+                )
             else:
                 return mlrun.mlconf.model_endpoint_monitoring.store_prefixes.default.format(
                     project=project,

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -70,8 +70,6 @@ def get_stream_path(
             function_name=function_name,
         )
 
-    if isinstance(stream_uri, list):  # ML-6043 - user side gets only the new stream uri
-        stream_uri = stream_uri[1]  # get new stream path, under projects
     return mlrun.common.model_monitoring.helpers.parse_monitoring_stream_path(
         stream_uri=stream_uri, project=project, function_name=function_name
     )

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -63,7 +63,6 @@ def get_stream_path(
     )
 
     if not stream_uri or stream_uri == "v3io":
-        # TODO : remove the first part of this condition in 1.9.0
         stream_uri = mlrun.mlconf.get_model_monitoring_file_target_path(
             project=project,
             kind=mm_constants.FileTargetKind.STREAM,

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -12,3 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# Minimum client version that supports model monitoring,
+# Will be fixed when MM will be defined as BC supported feature
+MINIMUM_CLIENT_VERSION_FOR_MM = "1.7.0"

--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -22,8 +22,8 @@ from sqlalchemy.orm import Session
 import mlrun.common.schemas
 import server.api.api.utils
 import server.api.utils.auth.verifier
+from server.api import MINIMUM_CLIENT_VERSION_FOR_MM
 from server.api.api import deps
-from server.api.api.endpoints.model_monitoring import MINIMUM_CLIENT_VERSION_FOR_MM
 
 router = fastapi.APIRouter(prefix="/projects/{project}/jobs")
 

--- a/server/api/api/endpoints/jobs.py
+++ b/server/api/api/endpoints/jobs.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 #
 import typing
+from http import HTTPStatus
 
 import fastapi
 from fastapi import Header
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+import server.api.api.utils
 import server.api.utils.auth.verifier
 from server.api.api import deps
-from server.api.api.endpoints.nuclio import process_model_monitoring_secret
-from server.api.crud.model_monitoring.deployment import MonitoringDeployment
+from server.api.api.endpoints.model_monitoring import MINIMUM_CLIENT_VERSION_FOR_MM
 
 router = fastapi.APIRouter(prefix="/projects/{project}/jobs")
 
@@ -48,12 +49,7 @@ async def create_model_monitoring_controller(
     ),
 ):
     """
-    Deploy model monitoring application controller, writer and stream functions.
-    While the main goal of the controller function is to handle the monitoring processing and triggering
-    applications, the goal of the model monitoring writer function is to write all the monitoring
-    application results to the databases.
-    And the stream function goal is to monitor the log of the data stream. It is triggered when a new log entry
-    is detected. It processes the new events into statistics that are then written to statistics databases.
+    Deprecated.
 
     :param project:                  Project name.
     :param auth_info:                The auth info of the request.
@@ -65,34 +61,8 @@ async def create_model_monitoring_controller(
                                      is running. By default, the base period is 5 minutes.
     :param client_version:           The client version that sent the request.
     """
-    await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-        resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
-        project_name=project,
-        resource_name=mlrun.common.schemas.model_monitoring.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-        action=mlrun.common.schemas.AuthorizationAction.store,
-        auth_info=auth_info,
+    server.api.api.utils.log_and_raise(
+        HTTPStatus.BAD_REQUEST.value,
+        reason=f"Model monitoring is supported from client version {MINIMUM_CLIENT_VERSION_FOR_MM}. "
+        f"Please upgrade your client accordingly.",
     )
-    model_monitoring_access_key = None
-    if not mlrun.mlconf.is_ce_mode():
-        # Generate V3IO Access Key
-        model_monitoring_access_key = process_model_monitoring_secret(
-            db_session,
-            project,
-            mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
-        )
-
-    MonitoringDeployment(
-        project=project,
-        auth_info=auth_info,
-        db_session=db_session,
-        model_monitoring_access_key=model_monitoring_access_key,
-    ).deploy_monitoring_functions(
-        image=default_controller_image,
-        base_period=base_period,
-        deploy_histogram_data_drift_app=False,  # mlrun client < 1.7.0
-        client_version=client_version,
-    )
-
-    return {
-        "func": "Submitted the model-monitoring controller, writer and stream deployment"
-    }

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -17,15 +17,21 @@ from dataclasses import dataclass
 from typing import Annotated, Optional
 
 import fastapi
+import semver
 from fastapi import APIRouter, Depends, Header, Query
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+import server.api.api.utils
 import server.api.utils.auth.verifier
 import server.api.utils.clients.chief
 from server.api.api import deps
 from server.api.api.endpoints.nuclio import process_model_monitoring_secret
 from server.api.crud.model_monitoring.deployment import MonitoringDeployment
+
+# Minimum client version that supports model monitoring,
+# Will be fixed when MM will be defined as BC supported feature
+MINIMUM_CLIENT_VERSION_FOR_MM = "1.7.0"
 
 router = APIRouter(prefix="/projects/{project}/model-monitoring")
 
@@ -50,9 +56,19 @@ class _CommonParams:
 
 
 async def _verify_authorization(
-    project: str, auth_info: mlrun.common.schemas.AuthInfo
+    project: str, auth_info: mlrun.common.schemas.AuthInfo, client_version: str
 ) -> None:
     """Verify project authorization"""
+    if (
+        semver.Version.parse(client_version)
+        < semver.Version.parse(MINIMUM_CLIENT_VERSION_FOR_MM)
+        or "unstable" in client_version
+    ):
+        server.api.api.utils.log_and_raise(
+            http.HTTPStatus.BAD_REQUEST.value,
+            reason=f"Model monitoring is supported from client version {MINIMUM_CLIENT_VERSION_FOR_MM}. "
+            f"Please upgrade your client accordingly.",
+        )
     await server.api.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
         project_name=project,
@@ -68,16 +84,22 @@ async def _common_parameters(
         mlrun.common.schemas.AuthInfo, Depends(deps.authenticate_request)
     ],
     db_session: Annotated[Session, Depends(deps.get_db_session)],
+    client_version: Optional[str] = Header(
+        None, alias=mlrun.common.schemas.HeaderNames.client_version
+    ),
 ) -> _CommonParams:
     """
     Verify authorization and return common parameters.
 
-    :param project:    Project name.
-    :param auth_info:  The auth info of the request.
-    :param db_session: A session that manages the current dialog with the database.
+    :param project:         Project name.
+    :param auth_info:       The auth info of the request.
+    :param db_session:      A session that manages the current dialog with the database.
+    :param client_version:  The client version.
     :returns:          A `_CommonParameters` object that contains the input data.
     """
-    await _verify_authorization(project=project, auth_info=auth_info)
+    await _verify_authorization(
+        project=project, auth_info=auth_info, client_version=client_version
+    )
     return _CommonParams(
         project=project,
         auth_info=auth_info,
@@ -93,9 +115,6 @@ async def enable_model_monitoring(
     deploy_histogram_data_drift_app: bool = True,
     rebuild_images: bool = False,
     fetch_credentials_from_sys_config: bool = False,
-    client_version: Optional[str] = Header(
-        None, alias=mlrun.common.schemas.HeaderNames.client_version
-    ),
 ):
     """
     Deploy model monitoring application controller, writer and stream functions.
@@ -115,7 +134,6 @@ async def enable_model_monitoring(
     :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
                                               (controller, writer & stream).
     :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
-    :param client_version:                    The client version.
 
     """
     MonitoringDeployment(
@@ -129,7 +147,6 @@ async def enable_model_monitoring(
         deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
         rebuild_images=rebuild_images,
         fetch_credentials_from_sys_config=fetch_credentials_from_sys_config,
-        client_version=client_version,
     )
 
 
@@ -213,9 +230,6 @@ async def disable_model_monitoring(
     delete_histogram_data_drift_app: bool = True,
     delete_user_applications: bool = False,
     user_application_list: list[str] = None,
-    client_version: Optional[str] = Header(
-        None, alias=mlrun.common.schemas.HeaderNames.client_version
-    ),
 ):
     """
     Disable model monitoring application controller, writer, stream, histogram data drift application
@@ -239,7 +253,6 @@ async def disable_model_monitoring(
                                                 Default all the applications.
                                                 Note: you have to set delete_user_applications to True
                                                 in order to delete the desired application.
-    :param client_version:                      The client version.
 
     """
     tasks = await MonitoringDeployment(
@@ -254,7 +267,6 @@ async def disable_model_monitoring(
         delete_user_applications=delete_user_applications,
         user_application_list=user_application_list,
         background_tasks=background_tasks,
-        client_version=client_version,
     )
     response.status_code = http.HTTPStatus.ACCEPTED.value
     return tasks

--- a/server/api/api/endpoints/model_monitoring.py
+++ b/server/api/api/endpoints/model_monitoring.py
@@ -25,13 +25,10 @@ import mlrun.common.schemas
 import server.api.api.utils
 import server.api.utils.auth.verifier
 import server.api.utils.clients.chief
+from server.api import MINIMUM_CLIENT_VERSION_FOR_MM
 from server.api.api import deps
 from server.api.api.endpoints.nuclio import process_model_monitoring_secret
 from server.api.crud.model_monitoring.deployment import MonitoringDeployment
-
-# Minimum client version that supports model monitoring,
-# Will be fixed when MM will be defined as BC supported feature
-MINIMUM_CLIENT_VERSION_FOR_MM = "1.7.0"
 
 router = APIRouter(prefix="/projects/{project}/model-monitoring")
 

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -546,14 +546,17 @@ def _deploy_nuclio_runtime(
             )
 
         if serving_to_monitor:
-            if (
-                fn.spec.image.startswith("mlrun/")
-                and client_version
-                and (
-                    semver.Version.parse(client_version)
-                    < semver.Version.parse(MINIMUM_CLIENT_VERSION_FOR_MM)
-                    or "unstable" in client_version
+            if not client_version:
+                server.api.api.utils.log_and_raise(
+                    HTTPStatus.BAD_REQUEST.value,
+                    reason=f"On deployment of serving-functions that are based on mlrun image "
+                    f"('mlrun/') and set-tracking is enabled, "
+                    f"client version must be specified and  >= {MINIMUM_CLIENT_VERSION_FOR_MM}",
                 )
+            elif fn.spec.image.startswith("mlrun/") and (
+                semver.Version.parse(client_version)
+                < semver.Version.parse(MINIMUM_CLIENT_VERSION_FOR_MM)
+                or "unstable" in client_version
             ):
                 server.api.api.utils.log_and_raise(
                     HTTPStatus.BAD_REQUEST.value,

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -37,6 +37,7 @@ from mlrun.common.model_monitoring.helpers import parse_model_endpoint_store_pre
 from mlrun.utils import logger
 from mlrun.utils.helpers import generate_object_uri
 from server.api.api import deps
+from server.api.api.endpoints.model_monitoring import MINIMUM_CLIENT_VERSION_FOR_MM
 from server.api.crud.secrets import Secrets, SecretsClientType
 
 router = APIRouter()
@@ -549,14 +550,16 @@ def _deploy_nuclio_runtime(
                 fn.spec.image.startswith("mlrun/")
                 and client_version
                 and (
-                    semver.Version.parse(client_version) < semver.Version.parse("1.6.3")
+                    semver.Version.parse(client_version)
+                    < semver.Version.parse(MINIMUM_CLIENT_VERSION_FOR_MM)
                     or "unstable" in client_version
                 )
             ):
                 server.api.api.utils.log_and_raise(
                     HTTPStatus.BAD_REQUEST.value,
-                    reason="On deployment of serving-functions that are based on mlrun image "
-                    "('mlrun/') and set-tracking is enabled, client version must be >= 1.6.3",
+                    reason=f"On deployment of serving-functions that are based on mlrun image "
+                    f"('mlrun/') and set-tracking is enabled, "
+                    f"client version must be >= {MINIMUM_CLIENT_VERSION_FOR_MM}",
                 )
 
     server.api.crud.runtimes.nuclio.function.deploy_nuclio_function(

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -36,8 +36,8 @@ import server.api.utils.singletons.project_member
 from mlrun.common.model_monitoring.helpers import parse_model_endpoint_store_prefix
 from mlrun.utils import logger
 from mlrun.utils.helpers import generate_object_uri
+from server.api import MINIMUM_CLIENT_VERSION_FOR_MM
 from server.api.api import deps
-from server.api.api.endpoints.model_monitoring import MINIMUM_CLIENT_VERSION_FOR_MM
 from server.api.crud.secrets import Secrets, SecretsClientType
 
 router = APIRouter()

--- a/server/api/api/endpoints/nuclio.py
+++ b/server/api/api/endpoints/nuclio.py
@@ -17,6 +17,7 @@ import traceback
 import typing
 from http import HTTPStatus
 
+import semver
 import sqlalchemy.orm
 from fastapi import APIRouter, Depends, Header, Request, Response
 from fastapi.concurrency import run_in_threadpool
@@ -526,9 +527,7 @@ def _deploy_nuclio_runtime(
             )
         )
         try:
-            monitoring_deployment.check_if_credentials_are_set(
-                with_upgrade_case_check=True, client_version=client_version
-            )
+            monitoring_deployment.check_if_credentials_are_set()
         except mlrun.errors.MLRunBadRequestError as exc:
             if monitoring_application:
                 err_txt = f"Can not deploy model monitoring application due to: {exc}"
@@ -546,12 +545,18 @@ def _deploy_nuclio_runtime(
             )
 
         if serving_to_monitor:
-            if monitoring_deployment.should_redeploy_monitoring_stream(
-                fn_image=fn.spec.image, client_version=client_version
+            if (
+                fn.spec.image.startswith("mlrun/")
+                and client_version
+                and (
+                    semver.Version.parse(client_version) < semver.Version.parse("1.6.3")
+                    or "unstable" in client_version
+                )
             ):
-                # Redeploy the monitoring stream processing function
-                monitoring_deployment.deploy_model_monitoring_stream_processing(
-                    overwrite=True
+                server.api.api.utils.log_and_raise(
+                    HTTPStatus.BAD_REQUEST.value,
+                    reason="On deployment of serving-functions that are based on mlrun image "
+                    "('mlrun/') and set-tracking is enabled, client version must be >= 1.6.3",
                 )
 
     server.api.crud.runtimes.nuclio.function.deploy_nuclio_function(

--- a/server/api/crud/client_spec.py
+++ b/server/api/crud/client_spec.py
@@ -107,9 +107,6 @@ class ClientSpec(
             external_platform_tracking=self._get_config_value_if_not_default(
                 "external_platform_tracking"
             ),
-            model_endpoint_monitoring_store_type=self._get_config_value_if_not_default(
-                "model_endpoint_monitoring.store_type"
-            ),
             model_endpoint_monitoring_endpoint_store_connection=self._get_config_value_if_not_default(
                 "model_endpoint_monitoring.endpoint_store_connection"
             ),

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import fastapi
 import nuclio
 import nuclio.utils
-import semver
 import sqlalchemy.orm
 from fastapi import BackgroundTasks
 from fastapi.concurrency import run_in_threadpool
@@ -100,7 +99,6 @@ class MonitoringDeployment:
         deploy_histogram_data_drift_app: bool = True,
         rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
-        client_version: str = None,
     ) -> None:
         """
         Deploy model monitoring application controller, writer and stream functions.
@@ -114,14 +112,11 @@ class MonitoringDeployment:
         :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
                                                   (controller, writer & stream).
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
-        :param client_version:                    The client version.
         """
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
             self.set_credentials()
-        self.check_if_credentials_are_set(
-            with_upgrade_case_check=True, client_version=client_version
-        )
+        self.check_if_credentials_are_set()
 
         self.deploy_model_monitoring_controller(
             controller_image=image, base_period=base_period, overwrite=rebuild_images
@@ -288,54 +283,51 @@ class MonitoringDeployment:
         """
 
         # Get the stream path from the configuration
-        stream_paths = server.api.crud.model_monitoring.get_stream_path(
+        stream_path = server.api.crud.model_monitoring.get_stream_path(
             project=self.project, function_name=function_name
         )
         # set all MM app and infra to have only 1 replica
         function.spec.max_replicas = 1
-        for i, stream_path in enumerate(stream_paths):
-            if stream_path.startswith("kafka://"):
-                topic, brokers = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
-                # Generate Kafka stream source
-                stream_source = mlrun.datastore.sources.KafkaSource(
-                    brokers=brokers,
-                    topics=[topic],
-                )
-                stream_source.create_topics(num_partitions=1, replication_factor=1)
-                function = stream_source.add_nuclio_trigger(function)
+        if stream_path.startswith("kafka://"):
+            topic, brokers = mlrun.datastore.utils.parse_kafka_url(url=stream_path)
+            # Generate Kafka stream source
+            stream_source = mlrun.datastore.sources.KafkaSource(
+                brokers=brokers,
+                topics=[topic],
+            )
+            stream_source.create_topics(num_partitions=1, replication_factor=1)
+            function = stream_source.add_nuclio_trigger(function)
 
-            if not mlrun.mlconf.is_ce_mode():
-                if stream_path.startswith("v3io://"):
-                    if "projects" in stream_path:
-                        stream_args = (
-                            config.model_endpoint_monitoring.application_stream_args
-                        )
-                        access_key = self.model_monitoring_access_key
-                        kwargs = {"access_key": self.model_monitoring_access_key}
-                    else:
-                        stream_args = (
-                            config.model_endpoint_monitoring.serving_stream_args
-                        )
-                        access_key = os.getenv("V3IO_ACCESS_KEY")
-                        kwargs = {}
-                    if mlrun.mlconf.is_explicit_ack_enabled():
-                        kwargs["explicit_ack_mode"] = "explicitOnly"
-                        kwargs["worker_allocation_mode"] = "static"
-                    server.api.api.endpoints.nuclio.create_model_monitoring_stream(
-                        project=self.project,
-                        stream_path=stream_path,
-                        access_key=access_key,
-                        stream_args=stream_args,
+        if not mlrun.mlconf.is_ce_mode():
+            if stream_path.startswith("v3io://"):
+                if "projects" in stream_path:
+                    stream_args = (
+                        config.model_endpoint_monitoring.application_stream_args
                     )
-                    # Generate V3IO stream trigger
-                    function.add_v3io_stream_trigger(
-                        stream_path=stream_path,
-                        name=f"monitoring_{function_name}_trigger{f'_{i}' if i != 0 else ''}",
-                        **kwargs,
-                    )
-                function = self._apply_access_key_and_mount_function(
-                    function=function, function_name=function_name
+                    access_key = self.model_monitoring_access_key
+                    kwargs = {"access_key": self.model_monitoring_access_key}
+                else:
+                    stream_args = config.model_endpoint_monitoring.serving_stream_args
+                    access_key = os.getenv("V3IO_ACCESS_KEY")
+                    kwargs = {}
+                if mlrun.mlconf.is_explicit_ack_enabled():
+                    kwargs["explicit_ack_mode"] = "explicitOnly"
+                    kwargs["worker_allocation_mode"] = "static"
+                server.api.api.endpoints.nuclio.create_model_monitoring_stream(
+                    project=self.project,
+                    stream_path=stream_path,
+                    access_key=access_key,
+                    stream_args=stream_args,
                 )
+                # Generate V3IO stream trigger
+                function.add_v3io_stream_trigger(
+                    stream_path=stream_path,
+                    name=f"monitoring_{function_name}_trigger",
+                    **kwargs,
+                )
+            function = self._apply_access_key_and_mount_function(
+                function=function, function_name=function_name
+            )
 
         function.spec.disable_default_http_trigger = True
 
@@ -619,70 +611,6 @@ class MonitoringDeployment:
                 app_ready=ready,
             )
 
-    def should_redeploy_monitoring_stream(
-        self, fn_image: str, client_version: str
-    ) -> bool:
-        """
-        Check if the monitoring stream function should be redeployed. For example, if the stream is based on old V3IO
-        location.
-
-        :param fn_image:       The image of the serving function. Note that if the image starts with 'mlrun/' then the
-                               client version must be >= 1.6.3, otherwise an error will be raised.
-        :param client_version: The client version that is used to deploy the function.
-
-        :return: True if the monitoring stream function should be redeployed, otherwise False.
-        :raises MLRunBadRequestError: If the client version is not supported, right now only client version >= 1.6.3
-        is supported.
-        """
-
-        stream_paths = server.api.crud.model_monitoring.get_stream_path(
-            project=self.project
-        )
-
-        if not stream_paths[0].startswith("v3io"):
-            # Stream path is not V3IO, no need to redeploy the stream function
-            return False
-
-        if (
-            fn_image.startswith("mlrun/")
-            and client_version
-            and (
-                semver.Version.parse(client_version) < semver.Version.parse("1.6.3")
-                or "unstable" in client_version
-            )
-        ):
-            raise mlrun.errors.MLRunBadRequestError(
-                "On deployment of serving-functions that are based on mlrun image "
-                "('mlrun/') and set-tracking is enabled, client version must be >= 1.6.3"
-            )
-
-        try:
-            function = server.api.crud.Functions().get_function(
-                name=mm_constants.MonitoringFunctionNames.STREAM,
-                db_session=self.db_session,
-                project=self.project,
-            )
-        except mlrun.errors.MLRunNotFoundError:
-            logger.info(
-                "The stream function is not deployed yet when the user will run `enable_model_monitoring` "
-                "the stream function will be deployed with the new & the old stream triggers",
-                project=self.project,
-            )
-            return False
-
-        if (
-            function["spec"]["config"].get(
-                f"spec.triggers.monitoring_{mm_constants.MonitoringFunctionNames.STREAM}_trigger_1"
-            )
-            is None
-        ):
-            logger.info(
-                "The stream function needs to be updated with the new stream trigger",
-                project=self.project,
-            )
-            return True
-        return False
-
     def _create_tsdb_tables(self, connection_string: str):
         """Create the TSDB tables using the TSDB connector. At the moment we support 3 types of tables:
         - app_results: a detailed result that includes status, kind, extra data, etc.
@@ -729,7 +657,6 @@ class MonitoringDeployment:
         delete_user_applications: bool = False,
         user_application_list: list[str] = None,
         background_tasks: fastapi.BackgroundTasks = None,
-        client_version: str = None,
     ) -> mlrun.common.schemas.BackgroundTaskList:
         """
         Disable model monitoring application controller, writer, stream, histogram data drift application
@@ -751,9 +678,7 @@ class MonitoringDeployment:
                                                     Note: you have to set delete_user_applications to True
                                                     in order to delete the desired application.
         :param background_tasks:                    Fastapi Background tasks.
-        :param client_version:                      The client version.
         """
-        self._set_credentials_after_server_upgrade(client_version=client_version)
         function_to_delete = []
         if delete_resources:
             function_to_delete = mm_constants.MonitoringFunctionNames.list()
@@ -951,7 +876,7 @@ class MonitoringDeployment:
                     logger.debug(f"{function_name} pod found, retrying")
                     time.sleep(5)
 
-            stream_paths.extend(
+            stream_paths.append(
                 server.api.crud.model_monitoring.get_stream_path(
                     project=project, function_name=function_name
                 )
@@ -1045,7 +970,7 @@ class MonitoringDeployment:
         return credentials_dict
 
     def check_if_credentials_are_set(
-        self, with_upgrade_case_check: bool = False, client_version: str = None
+        self,
     ):
         """
         Check if the model monitoring credentials are set. If not, raise an error.
@@ -1057,101 +982,14 @@ class MonitoringDeployment:
         """
 
         credentials_dict = self._get_monitoring_mandatory_project_secrets()
-        # check if all the credentials are set (stream is not mandatory for now for BC, Todo: del in 1.9.0)
-        if all(
-            [
-                val is not None
-                if key
-                != mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
-                else True
-                for key, val in credentials_dict.items()
-            ]
-        ):
+        if all([val is not None for key, val in credentials_dict.items()]):
             return
-        if with_upgrade_case_check:
-            with_upgrade_case_check = self._set_credentials_after_server_upgrade(
-                client_version=client_version
-            )
 
-        if not with_upgrade_case_check:
-            raise mlrun.errors.MLRunBadRequestError(
-                "Model monitoring credentials are not set. "
-                "Please set them using the set_model_monitoring_credentials API/SDK "
-                "or pass fetch_credentials_from_sys_config=True when using enable_model_monitoring API/SDK."
-            )
-
-    def _set_credentials_after_server_upgrade(self, client_version: str = None) -> bool:
-        """
-        Check and set the model monitoring credentials for old project that included model monitoring before the server
-        upgrade. Will set the credentials only if at least one of the following conditions is met:
-            1. There is at least one model endpoint
-            2. Model monitoring stream pod is running
-            3. Part of the model monitoring credentials are already set
-        If True, set the cred in to the project secret (from exist cred/from sys config/v3io by default).
-
-        :param client_version: The client version.
-
-        :return: True if the credentials are set, otherwise False.
-        """
-        credentials_dict = self._get_monitoring_mandatory_project_secrets()
-        set_cred = False
-        store_connection_string = (
-            credentials_dict.get(
-                mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ENDPOINT_STORE_CONNECTION
-            )
-            or mm_constants.V3IO_MODEL_MONITORING_DB
-            if not mlrun.mlconf.is_ce_mode()
-            else None
-        )  # in case the user use the default v3io
-        if store_connection_string:
-            store_connector = mlrun.model_monitoring.get_store_object(
-                project=self.project, store_connection_string=store_connection_string
-            )
-        else:
-            store_connector = None
-
-        if store_connector and store_connector.list_model_endpoints():
-            # if there are model endpoints, the project has monitoring
-            set_cred = True
-        elif client_version and (
-            semver.Version.parse(client_version) < semver.Version.parse("1.7.0")
-            or "unstable" in client_version
-        ):
-            set_cred = True
-        else:
-            try:
-                server.api.crud.Functions().get_function(
-                    name=mm_constants.MonitoringFunctionNames.STREAM,
-                    db_session=self.db_session,
-                    project=self.project,
-                )
-                # if stream pod is on, the project has monitoring
-                set_cred = True
-            except mlrun.errors.MLRunNotFoundError:
-                # if one of the cred is already set, the project has monitoring
-                if any(
-                    [
-                        val is not None
-                        for key, val in credentials_dict.items()
-                        if key
-                        != mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
-                    ]
-                    # stream is not mandatory for now for BC, Todo: del in 1.9.0
-                ):
-                    set_cred = True
-
-        if set_cred and None in credentials_dict.values():
-            logger.info(
-                "Setting credentials for older client version(1.7.0)/ old projects, "
-                "using v3io as default (not in ce mode)"
-            )
-            self.set_credentials(
-                _default_secrets_v3io=mm_constants.V3IO_MODEL_MONITORING_DB
-                if not mlrun.mlconf.is_ce_mode()
-                else None,
-                replace_creds=True,
-            )
-        return set_cred
+        raise mlrun.errors.MLRunBadRequestError(
+            "Model monitoring credentials are not set. "
+            "Please set them using the set_model_monitoring_credentials API/SDK "
+            "or pass fetch_credentials_from_sys_config=True when using enable_model_monitoring API/SDK."
+        )
 
     def set_credentials(
         self,
@@ -1215,12 +1053,6 @@ class MonitoringDeployment:
                 # the credentials are not set
                 pass
 
-            if self._set_credentials_after_server_upgrade():
-                raise mlrun.errors.MLRunConflictError(
-                    f"For {self.project} the credentials are already set, if you want to set new credentials, "
-                    f"please set replace_creds=True"
-                )
-
         secrets_dict = {}
         old_secrets_dict = self._get_monitoring_mandatory_project_secrets()
         if access_key:
@@ -1271,13 +1103,9 @@ class MonitoringDeployment:
                     mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
                 )
                 or mlrun.mlconf.model_endpoint_monitoring.stream_connection
-                or mlrun.mlconf.model_endpoint_monitoring.store_prefixes.stream  # TODO: Delete in 1.9.0
                 or _default_secrets_v3io
-                or old_secrets_dict.get(
-                    mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
-                )  # TODO: Delete in 1.9.0
             )
-        if stream_path or stream_path == "":
+        if stream_path:
             if (
                 stream_path == mm_constants.V3IO_MODEL_MONITORING_DB
                 and mlrun.mlconf.is_ce_mode()
@@ -1285,9 +1113,6 @@ class MonitoringDeployment:
                 raise mlrun.errors.MLRunInvalidMMStoreTypeError(
                     "In CE mode, only kafka stream are supported for stream path"
                 )
-            elif stream_path == mm_constants.V3IO_MODEL_MONITORING_DB:
-                # TODO: Delete in 1.9.0 (for BC)
-                stream_path = ""
             elif stream_path:
                 if stream_path.startswith("kafka://") and "?topic" in stream_path:
                     raise mlrun.errors.MLRunInvalidMMStoreTypeError(
@@ -1295,7 +1120,6 @@ class MonitoringDeployment:
                     )
                 elif not stream_path.startswith("kafka://") and (
                     stream_path != mm_constants.V3IO_MODEL_MONITORING_DB
-                    or stream_path != ""
                 ):
                     raise mlrun.errors.MLRunInvalidMMStoreTypeError(
                         "Currently only Kafka connection is supported for non-v3io stream,"
@@ -1370,9 +1194,6 @@ class MonitoringDeployment:
             stream_path=secrets_dict.get(
                 mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
             )
-            or mm_constants.V3IO_MODEL_MONITORING_DB
-            if not mlrun.mlconf.is_ce_mode()
-            else None  # TODO: del in 1.9.0
         )
 
         server.api.crud.Secrets().store_project_secrets(
@@ -1407,11 +1228,6 @@ class MonitoringDeployment:
         old_stream = credentials_dict[
             mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
         ]
-        old_stream = (
-            old_stream or mm_constants.V3IO_MODEL_MONITORING_DB
-            if not mlrun.mlconf.is_ce_mode()
-            else None
-        )  # TODO: del in 1.9.0
         if stream_path and old_stream != stream_path:
             logger.debug(
                 "User provided different stream path",
@@ -1428,24 +1244,21 @@ class MonitoringDeployment:
         return True
 
     def _create_stream_output(self, stream_path: str = None, access_key: str = None):
-        stream_path_list = server.api.crud.model_monitoring.get_stream_path(
+        stream_path = server.api.crud.model_monitoring.get_stream_path(
             project=self.project, stream_uri=stream_path
         )
         if not mlrun.mlconf.is_ce_mode():
-            access_keys = [
-                os.getenv("V3IO_ACCESS_KEY"),
-                access_key or self.model_monitoring_access_key,
-            ]
+            access_key = access_key or self.model_monitoring_access_key
         else:
-            access_keys = [None] * 2
-        for i in range(len(stream_path_list)):
-            output_stream = mlrun.datastore.get_stream_pusher(
-                stream_path=stream_path_list[i],
-                endpoint=mlrun.mlconf.v3io_api,
-                access_key=access_keys[i],
-            )
-            if hasattr(output_stream, "_lazy_init"):
-                output_stream._lazy_init()
+            access_key = None
+
+        output_stream = mlrun.datastore.get_stream_pusher(
+            stream_path=stream_path,
+            endpoint=mlrun.mlconf.v3io_api,
+            access_key=access_key,
+        )
+        if hasattr(output_stream, "_lazy_init"):
+            output_stream._lazy_init()
 
 
 def get_endpoint_features(

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -975,9 +975,6 @@ class MonitoringDeployment:
         """
         Check if the model monitoring credentials are set. If not, raise an error.
 
-        :param with_upgrade_case_check:         If True, check if indeed the project is an old(<1.7.0) project
-                                                that had model monitoring, if indeed, set the credentials.
-        :param client_version:                  The client version.
         :raise mlrun.errors.MLRunBadRequestError:  if the credentials are not set.
         """
 
@@ -1029,7 +1026,6 @@ class MonitoringDeployment:
         :param replace_creds:             If True, the credentials will be set even if they are already set.
         :param _default_secrets_v3io:     Optional parameter for the upgrade process in which the v3io default secret
                                           key is set.
-        :param client_version:            The client version.
         :raise MLRunConflictError:        If the credentials are already set for the project and the user
                                           provided different creds.
         :raise MLRunInvalidMMStoreTypeError: If the user provided invalid credentials.
@@ -1113,18 +1109,17 @@ class MonitoringDeployment:
                 raise mlrun.errors.MLRunInvalidMMStoreTypeError(
                     "In CE mode, only kafka stream are supported for stream path"
                 )
-            elif stream_path:
-                if stream_path.startswith("kafka://") and "?topic" in stream_path:
-                    raise mlrun.errors.MLRunInvalidMMStoreTypeError(
-                        "Custom kafka topic is not allowed"
-                    )
-                elif not stream_path.startswith("kafka://") and (
-                    stream_path != mm_constants.V3IO_MODEL_MONITORING_DB
-                ):
-                    raise mlrun.errors.MLRunInvalidMMStoreTypeError(
-                        "Currently only Kafka connection is supported for non-v3io stream,"
-                        "please provide a full URL (e.g. kafka://<some_kafka_broker>:<port>)"
-                    )
+            elif stream_path.startswith("kafka://") and "?topic" in stream_path:
+                raise mlrun.errors.MLRunInvalidMMStoreTypeError(
+                    "Custom kafka topic is not allowed"
+                )
+            elif not stream_path.startswith("kafka://") and (
+                stream_path != mm_constants.V3IO_MODEL_MONITORING_DB
+            ):
+                raise mlrun.errors.MLRunInvalidMMStoreTypeError(
+                    "Currently only Kafka connection is supported for non-v3io stream,"
+                    "please provide a full URL (e.g. kafka://<some_kafka_broker>:<port>)"
+                )
             secrets_dict[
                 mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PATH
             ] = stream_path

--- a/server/api/crud/model_monitoring/helpers.py
+++ b/server/api/crud/model_monitoring/helpers.py
@@ -83,7 +83,7 @@ def get_stream_path(
     project: str,
     function_name: str = mm_constants.MonitoringFunctionNames.STREAM,
     stream_uri: typing.Optional[str] = None,
-) -> list[str]:
+) -> str:
     """
     Get stream path from the project secret. If wasn't set, take it from the system configurations.
 
@@ -102,7 +102,6 @@ def get_stream_path(
     )
 
     if not stream_uri or stream_uri == "v3io":
-        # TODO : remove the first part of this condition in 1.9.0
         stream_uri = mlrun.mlconf.get_model_monitoring_file_target_path(
             project=project,
             kind=mlrun.common.schemas.model_monitoring.FileTargetKind.STREAM,
@@ -110,20 +109,9 @@ def get_stream_path(
             function_name=function_name,
         )
 
-    if isinstance(
-        stream_uri, list
-    ):  # ML-6043 - server side gets the new  and the old stream uris.
-        return [
-            mlrun.common.model_monitoring.helpers.parse_monitoring_stream_path(
-                stream_uri=stream_uri_item, project=project, function_name=function_name
-            )
-            for stream_uri_item in stream_uri
-        ]
-    return [
-        mlrun.common.model_monitoring.helpers.parse_monitoring_stream_path(
-            stream_uri=stream_uri, project=project, function_name=function_name
-        )
-    ]
+    return mlrun.common.model_monitoring.helpers.parse_monitoring_stream_path(
+        stream_uri=stream_uri, project=project, function_name=function_name
+    )
 
 
 def get_store_object(project: str) -> mlrun.model_monitoring.db.stores.StoreBase:

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -525,13 +525,28 @@ class ModelEndpoints:
         # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,
         # we're using the igz version heuristic
         # TODO : adjust for ce scenario
-        stream_paths = server.api.crud.model_monitoring.get_stream_path(
+        stream_path = server.api.crud.model_monitoring.get_stream_path(
             project=project_name,
         )
-        if stream_paths[0].startswith("v3io") and (
+        if stream_path.startswith("v3io") and (
             not mlrun.mlconf.igz_version or not mlrun.mlconf.v3io_api
         ):
             return
+        elif stream_path.startswith("v3io") and not model_monitoring_access_key:
+            # Generate V3IO Access Key
+            try:
+                model_monitoring_access_key = server.api.api.endpoints.nuclio.process_model_monitoring_secret(
+                    db_session,
+                    project_name,
+                    mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
+                )
+
+            except mlrun.errors.MLRunNotFoundError:
+                logger.debug(
+                    "Project does not exist in Iguazio, skipping deletion of model monitoring stream resources",
+                    project_name=project_name,
+                )
+                return
 
         try:
             self.verify_project_has_no_model_endpoints(project_name=project_name)
@@ -568,9 +583,7 @@ class ModelEndpoints:
                 tsdb_connector.delete_tsdb_resources()
         self._delete_model_monitoring_stream_resources(
             project_name=project_name,
-            db_session=db_session,
             model_monitoring_applications=model_monitoring_applications,
-            stream_paths=stream_paths,
             model_monitoring_access_key=model_monitoring_access_key,
         )
         logger.debug(
@@ -581,9 +594,7 @@ class ModelEndpoints:
     @staticmethod
     def _delete_model_monitoring_stream_resources(
         project_name: str,
-        db_session: sqlalchemy.orm.Session,
         model_monitoring_applications: typing.Optional[list[str]],
-        stream_paths: typing.Optional[list[str]] = None,
         model_monitoring_access_key: typing.Optional[str] = None,
     ) -> None:
         """
@@ -593,8 +604,6 @@ class ModelEndpoints:
         :param db_session:                    A session that manages the current dialog with the database.
         :param model_monitoring_applications: A list of model monitoring applications that their resources should
                                               be deleted.
-        :param stream_paths:                  A list of stream paths to delete. If using Kafka, the stream path
-                                              represents the related topic.
         :param model_monitoring_access_key:   The access key for the model monitoring resources. Relevant only for
                                               V3IO resources.
         """
@@ -602,21 +611,6 @@ class ModelEndpoints:
             "Deleting model monitoring stream resources",
             project_name=project_name,
         )
-        if stream_paths[0].startswith("v3io") and not model_monitoring_access_key:
-            # Generate V3IO Access Key
-            try:
-                model_monitoring_access_key = server.api.api.endpoints.nuclio.process_model_monitoring_secret(
-                    db_session,
-                    project_name,
-                    mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
-                )
-
-            except mlrun.errors.MLRunNotFoundError:
-                logger.debug(
-                    "Project does not exist in Iguazio, skipping deletion of model monitoring stream resources",
-                    project_name=project_name,
-                )
-                return
 
         model_monitoring_applications = model_monitoring_applications or []
 

--- a/server/api/crud/model_monitoring/model_endpoints.py
+++ b/server/api/crud/model_monitoring/model_endpoints.py
@@ -601,7 +601,6 @@ class ModelEndpoints:
         Delete model monitoring stream resources.
 
         :param project_name:                  The name of the project.
-        :param db_session:                    A session that manages the current dialog with the database.
         :param model_monitoring_applications: A list of model monitoring applications that their resources should
                                               be deleted.
         :param model_monitoring_access_key:   The access key for the model monitoring resources. Relevant only for

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -536,7 +536,13 @@ def test_tracking_on_serving(
     # Adjust the required request endpoint and body
     endpoint = "build/function"
     json_body = _generate_build_function_request(function)
-    response = client.post(endpoint, data=json_body)
+    response = client.post(
+        endpoint,
+        data=json_body,
+        headers={
+            mlrun.common.schemas.HeaderNames.client_version: "1.7.0",
+        },
+    )
 
     assert response.status_code == 200
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -384,9 +384,9 @@ class _V3IORecordsChecker:
 @pytest.mark.enterprise
 @pytest.mark.model_monitoring
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-app-flow-v68"
+    project_name = "test-app-flow-v2"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "quay.io/davesh0812/mlrun:1.7.0"
+    image: typing.Optional[str] = None
     error_count = 10
 
     @classmethod

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -384,9 +384,9 @@ class _V3IORecordsChecker:
 @pytest.mark.enterprise
 @pytest.mark.model_monitoring
 class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
-    project_name = "test-app-flow-v2"
+    project_name = "test-app-flow-v68"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = None
+    image: typing.Optional[str] = "quay.io/davesh0812/mlrun:1.7.0"
     error_count = 10
 
     @classmethod


### PR DESCRIPTION
Currently, we maintain two different stream triggers for the mm-stream function to accommodate older clients. In this PR, we are removing the old stream trigger, so only clients with mlrun >= 1.7.0 will be able to use the model monitoring facilities.

More of the same for now user have to be align between server and client (==1.7.0) in order to use MM APIS.

related to [ML-7762](https://iguazio.atlassian.net/browse/ML-7762)

[ML-7762]: https://iguazio.atlassian.net/browse/ML-7762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ