### PR TITLE
[Project] Fail sync functions silently on workflow runs

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -4638,7 +4638,7 @@ class SQLDB(DBInterface):
             session.delete(obj)
         session.commit()
 
-    def _find_lables(self, session, cls, label_cls, labels):
+    def _find_labels(self, session, cls, label_cls, labels):
         return session.query(cls).join(label_cls).filter(label_cls.name.in_(labels))
 
     def _add_labels_filter(self, session, query, cls, labels):

--- a/tests/api/api/feature_store/test_feature_vectors.py
+++ b/tests/api/api/feature_store/test_feature_vectors.py
@@ -117,7 +117,7 @@ def test_list_feature_vectors(db: Session, client: TestClient) -> None:
 
     count = 10
     dead_count = 0
-    blue_lables_count = 0
+    blue_labels_count = 0
     ooga_name_count = 0
     not_latest_count = 0
     for i in range(count):
@@ -129,7 +129,7 @@ def test_list_feature_vectors(db: Session, client: TestClient) -> None:
             dead_count = dead_count + 1
         if i % 3 == 0:
             feature_set["metadata"]["labels"] = {"owner": "somebody", "color": "blue"}
-            blue_lables_count = blue_lables_count + 1
+            blue_labels_count = blue_labels_count + 1
         if i % 4 == 0:
             feature_set["metadata"]["name"] = f"ooga_booga_{i}"
             ooga_name_count = ooga_name_count + 1
@@ -147,7 +147,7 @@ def test_list_feature_vectors(db: Session, client: TestClient) -> None:
         "feature_vectors",
         project_name,
         "label=color=blue&label=owner",
-        blue_lables_count,
+        blue_labels_count,
     )
     _list_and_assert_objects(
         client, "feature_vectors", project_name, "label=owner", count

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -338,7 +338,7 @@ class RunDBMock:
 
     def get_function(self, function, project, tag, hash_key=None):
         if function not in self._functions:
-            raise mlrun.errors.MLRunNotFoundError("Function not found")
+            raise mlrun.errors.MLRunNotFoundError(f"Function {function} not found")
         return self._functions[function]
 
     def delete_function(self, name: str, project: str = ""):

--- a/tests/projects/assets/artifact.yaml
+++ b/tests/projects/assets/artifact.yaml
@@ -1,31 +1,17 @@
-# Copyright 2023 Iguazio
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-kind: artifact
+status:
+  state: created
 metadata:
-  key: x
-  project: inline
   iter: 0
-  tree: latest
+  project: inline
+  key: x
+  tree: b2cb8a03-76db-4144-8ef5-2c300b073e49
+kind: artifact
 spec:
   inline: '123'
   db_key: x
+  license: ''
   producer:
     kind: project
     name: inline
-    tag: latest
-  sources: []
-  license: ''
-status:
-  state: created
+    tag: b2cb8a03-76db-4144-8ef5-2c300b073e49
+    owner: require_Normalization

--- a/tests/projects/assets/artifact.yaml
+++ b/tests/projects/assets/artifact.yaml
@@ -1,17 +1,31 @@
-status:
-  state: created
-metadata:
-  iter: 0
-  project: inline
-  key: x
-  tree: b2cb8a03-76db-4144-8ef5-2c300b073e49
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 kind: artifact
+metadata:
+  key: x
+  project: inline
+  iter: 0
+  tree: latest
 spec:
   inline: '123'
   db_key: x
-  license: ''
   producer:
     kind: project
     name: inline
-    tag: b2cb8a03-76db-4144-8ef5-2c300b073e49
-    owner: require_Normalization
+    tag: latest
+  sources: []
+  license: ''
+status:
+  state: created

--- a/tests/projects/test_local_pipeline.py
+++ b/tests/projects/test_local_pipeline.py
@@ -31,7 +31,6 @@ class TestLocalPipeline(tests.projects.base_pipeline.TestPipeline):
             str(f"{self.assets_path / self.pipeline_path}"),
             "tstfunc",
             image="mlrun/mlrun",
-            # kind="job"
         )
 
     def test_set_artifact(self, rundb_mock):


### PR DESCRIPTION
Sync functions reloads functions that are not necessarily related to the workflow, therefore it may fail on issues like file not found for functions that are not needed. This changes sync functions to fail silently when there is a failure to reload a function when trying to run a workflow. If a function fails to load and is later needed in the workflow, it shall be fetched from the DB or fail if it doesn't exist.

https://iguazio.atlassian.net/browse/ML-7706