### PR TITLE
[RuntimeResources] Enhance resources deletion upon project deletion

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1374,20 +1374,14 @@ class HTTPRunDB(RunDBInterface):
         :returns: :py:class:`~mlrun.common.schemas.GroupedByProjectRuntimeResourcesOutput` listing the runtime resources
             that were removed.
         """
-        if grace_period is None:
-            grace_period = config.runtime_resources_deletion_grace_period
-            logger.info(
-                "Using default grace period for runtime resources deletion",
-                grace_period=grace_period,
-            )
-
         params = {
             "label-selector": label_selector,
             "kind": kind,
             "object-id": object_id,
             "force": force,
-            "grace-period": grace_period,
         }
+        if grace_period is not None:
+            params["grace-period"] = grace_period
         error = "Failed deleting runtime resources"
         project_path = project if project else "*"
         response = self.api_call(

--- a/server/api/api/endpoints/runtime_resources.py
+++ b/server/api/api/endpoints/runtime_resources.py
@@ -94,7 +94,7 @@ async def _delete_runtime_resources(
     kind: typing.Optional[str] = None,
     object_id: typing.Optional[str] = None,
     force: bool = False,
-    grace_period: int = mlrun.mlconf.runtime_resources_deletion_grace_period,
+    grace_period: typing.Optional[int] = None,
     return_body: bool = True,
 ) -> typing.Union[
     mlrun.common.schemas.GroupedByProjectRuntimeResourcesOutput, fastapi.Response

--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -177,6 +177,8 @@ class Projects(
             session,
             label_selector=f"{mlrun_constants.MLRunInternalLabels.project}={name}",
             force=True,
+            # immediate deletion of resources
+            grace_period=0,
         )
         if mlrun.mlconf.kfp_url:
             logger.debug("Removing KFP pipelines project resources", project_name=name)

--- a/server/api/crud/runtime_resources.py
+++ b/server/api/crud/runtime_resources.py
@@ -114,7 +114,7 @@ class RuntimeResources(
         object_id: typing.Optional[str] = None,
         label_selector: typing.Optional[str] = None,
         force: bool = False,
-        grace_period: int = mlrun.mlconf.runtime_resources_deletion_grace_period,
+        grace_period: typing.Optional[int] = None,
     ):
         kinds = mlrun.runtimes.RuntimeKinds.runtime_with_handlers()
         if kind is not None:

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -125,7 +125,7 @@ class BaseRuntimeHandler(ABC):
         # 'force' is used to skip waiting X seconds *after* pod terminated.
         # 'grace_period' is used to set the time to wait *after* the pod terminated and before it's deleted.
         # if force is True and grace period is 0, simply delete the pod without waiting.
-        resource_deletion_grace_period = 0 if True and grace_period == 0 else None
+        resource_deletion_grace_period = 0 if force and grace_period == 0 else None
         # We currently don't support removing runtime resources in non k8s env
         if not server.api.utils.singletons.k8s.get_k8s_helper().is_running_inside_kubernetes_cluster():
             return

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import traceback
+import typing
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
@@ -115,16 +116,30 @@ class BaseRuntimeHandler(ABC):
         db_session: Session,
         label_selector: str = None,
         force: bool = False,
-        grace_period: int = None,
+        grace_period: typing.Optional[int] = None,
     ):
         if grace_period is None:
             grace_period = config.runtime_resources_deletion_grace_period
+
+        # set resource deletion grace period to 0 when explicitly requested by force and grace period.
+        # 'force' is used to skip waiting X seconds *after* pod terminated.
+        # 'grace_period' is used to set the time to wait *after* the pod terminated and before it's deleted.
+        # if force is True and grace period is 0, simply delete the pod without waiting.
+        resource_deletion_grace_period = 0 if True and grace_period == 0 else None
         # We currently don't support removing runtime resources in non k8s env
         if not server.api.utils.singletons.k8s.get_k8s_helper().is_running_inside_kubernetes_cluster():
             return
         namespace = server.api.utils.singletons.k8s.get_k8s_helper().resolve_namespace()
         label_selector = self.resolve_label_selector("*", label_selector=label_selector)
         crd_group, crd_version, crd_plural = self._get_crd_info()
+        logger.debug(
+            "Deleting runtime resources",
+            resource_deletion_grace_period=resource_deletion_grace_period,
+            label_selector=label_selector,
+            force=force,
+            grace_period=grace_period,
+            crd_plural=crd_plural,
+        )
         if crd_group and crd_version and crd_plural:
             deleted_resources = self._delete_crd_resources(
                 db,
@@ -133,6 +148,7 @@ class BaseRuntimeHandler(ABC):
                 label_selector,
                 force,
                 grace_period,
+                resource_deletion_grace_period,
             )
         else:
             deleted_resources = self._delete_pod_resources(
@@ -142,6 +158,7 @@ class BaseRuntimeHandler(ABC):
                 label_selector,
                 force,
                 grace_period,
+                resource_deletion_grace_period,
             )
         self._delete_extra_resources(
             db,
@@ -151,6 +168,7 @@ class BaseRuntimeHandler(ABC):
             label_selector,
             force,
             grace_period,
+            resource_deletion_grace_period,
         )
 
     def delete_runtime_object_resources(
@@ -160,10 +178,8 @@ class BaseRuntimeHandler(ABC):
         object_id: str,
         label_selector: str = None,
         force: bool = False,
-        grace_period: int = None,
+        grace_period: typing.Optional[int] = None,
     ):
-        if grace_period is None:
-            grace_period = config.runtime_resources_deletion_grace_period
         label_selector = self._add_object_label_selector_if_needed(
             object_id, label_selector
         )
@@ -672,7 +688,7 @@ class BaseRuntimeHandler(ABC):
         mlrun.common.schemas.GroupedByProjectRuntimeResourcesOutput,
     ]:
         """
-        Override this to list resources other then pods or CRDs (which are handled by the base class)
+        Override this to list resources other than pods or CRDs (which are handled by the base class)
         """
         return response
 
@@ -703,13 +719,11 @@ class BaseRuntimeHandler(ABC):
         label_selector: str = None,
         force: bool = False,
         grace_period: int = None,
+        resource_deletion_grace_period: typing.Optional[int] = None,
     ):
         """
         Override this to handle deletion of resources other than pods or CRDs (which are handled by the base class)
         Note that this is happening after the deletion of the CRDs or the pods
-        Note to add this at the beginning:
-        if grace_period is None:
-            grace_period = config.runtime_resources_deletion_grace_period
         """
         pass
 
@@ -1015,9 +1029,8 @@ class BaseRuntimeHandler(ABC):
         label_selector: str = None,
         force: bool = False,
         grace_period: int = None,
+        resource_deletion_grace_period: typing.Optional[int] = None,
     ) -> list[dict]:
-        if grace_period is None:
-            grace_period = config.runtime_resources_deletion_grace_period
         deleted_pods = []
         for pod in server.api.utils.singletons.k8s.get_k8s_helper().list_pods_paginated(
             namespace, selector=label_selector
@@ -1059,7 +1072,9 @@ class BaseRuntimeHandler(ABC):
                         )
 
                 server.api.utils.singletons.k8s.get_k8s_helper().delete_pod(
-                    pod.metadata.name, namespace
+                    pod.metadata.name,
+                    namespace,
+                    grace_period_seconds=resource_deletion_grace_period,
                 )
                 deleted_pods.append(pod_dict)
             except Exception as exc:
@@ -1078,9 +1093,8 @@ class BaseRuntimeHandler(ABC):
         label_selector: str = None,
         force: bool = False,
         grace_period: int = None,
+        resource_deletion_grace_period: typing.Optional[int] = None,
     ) -> list[dict]:
-        if grace_period is None:
-            grace_period = config.runtime_resources_deletion_grace_period
         crd_group, crd_version, crd_plural = self._get_crd_info()
         deleted_crds = []
         try:
@@ -1149,6 +1163,7 @@ class BaseRuntimeHandler(ABC):
                         crd_version,
                         crd_plural,
                         namespace,
+                        resource_deletion_grace_period,
                     )
                     deleted_crds.append(crd_object)
                 except Exception as exc:

--- a/server/api/runtime_handlers/daskjob.py
+++ b/server/api/runtime_handlers/daskjob.py
@@ -198,12 +198,11 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         label_selector: str = None,
         force: bool = False,
         grace_period: int = None,
+        resource_deletion_grace_period: typing.Optional[int] = None,
     ):
         """
         Handling services deletion
         """
-        if grace_period is None:
-            grace_period = config.runtime_resources_deletion_grace_period
         service_names = []
         for pod_dict in deleted_resources:
             dask_component = (
@@ -226,7 +225,9 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
             try:
                 if force or service.metadata.name in service_names:
                     server.api.utils.singletons.k8s.get_k8s_helper().v1api.delete_namespaced_service(
-                        service.metadata.name, namespace
+                        service.metadata.name,
+                        namespace,
+                        grace_period_seconds=resource_deletion_grace_period,
                     )
                     logger.info(f"Deleted service: {service.metadata.name}")
             except ApiException as exc:

--- a/server/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/api/runtime_handlers/sparkjob/spark3job.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import abc
 import os
+import typing
 from copy import deepcopy
 from datetime import datetime
 from typing import Optional
@@ -562,6 +563,7 @@ with ctx:
         label_selector: str = None,
         force: bool = False,
         grace_period: int = None,
+        resource_deletion_grace_period: typing.Optional[int] = None,
     ):
         """
         Handling config maps deletion
@@ -585,7 +587,9 @@ with ctx:
                 )
                 if force or uid in uids:
                     server.api.utils.singletons.k8s.get_k8s_helper().v1api.delete_namespaced_config_map(
-                        config_map.metadata.name, namespace
+                        config_map.metadata.name,
+                        namespace,
+                        grace_period_seconds=resource_deletion_grace_period,
                     )
                     logger.info(f"Deleted config map: {config_map.metadata.name}")
             except ApiException as exc:

--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -154,7 +154,9 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             )
 
         if page_size is None and token is None:
-            self._logger.debug("No token or page size provided, returning all records")
+            self._logger.debug(
+                "No token or page size provided, returning all records", method=method
+            )
             return await server.api.utils.asyncio.await_or_call_in_threadpool(
                 method, session, **method_kwargs
             ), None

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -422,7 +422,11 @@ class TestRuntimeHandlerBase:
         expected_service_names: list[str], expected_service_namespace: str = None
     ):
         calls = [
-            unittest.mock.call(expected_service_name, expected_service_namespace)
+            unittest.mock.call(
+                expected_service_name,
+                expected_service_namespace,
+                grace_period_seconds=None,
+            )
             for expected_service_name in expected_service_names
         ]
         if not expected_service_names:


### PR DESCRIPTION
In a nutshell, upon project deletion - do not wait the entire runtime grace period but perform force removal of each runtime resources (specifically k8s one), that way, project deletion would occur faster

https://iguazio.atlassian.net/browse/ML-7803

In addition, removed repeated code of grace period initialization to a single place where needed