### PR TITLE
[Artifacts] Fix the docstring for uploading an artifact when logging a directory artifact

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -200,8 +200,9 @@ class ArtifactManager:
         :param artifact_path: The path to store the artifact.
          If not provided, the artifact will be stored in the default artifact path.
         :param format: The format of the artifact. (e.g. csv, json, html, etc.)
-        :param upload: Whether to upload the artifact to the datastore. If logging a directory, it will not be
-                       uploaded unless this flag is set to `True`.
+        :param upload: Whether to upload the artifact to the datastore. If not provided, and the
+        `local_path` is not a directory, upload occurs by default. Directories are uploaded only when this
+        flag is explicitly set to `True`.
         :param labels: Labels to add to the artifact.
         :param db_key: The key to use when logging the artifact to the DB.
         If not provided, will generate a key based on the producer name and the artifact key.

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -200,7 +200,8 @@ class ArtifactManager:
         :param artifact_path: The path to store the artifact.
          If not provided, the artifact will be stored in the default artifact path.
         :param format: The format of the artifact. (e.g. csv, json, html, etc.)
-        :param upload: Whether to upload the artifact or not.
+        :param upload: Whether to upload the artifact to the datastore. If logging a directory, it will not be
+                       uploaded unless this flag is set to `True`.
         :param labels: Labels to add to the artifact.
         :param db_key: The key to use when logging the artifact to the DB.
         If not provided, will generate a key based on the producer name and the artifact key.

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -634,8 +634,9 @@ class MLClientCtx:
         :param viewer:        Kubeflow viewer type
         :param target_path:   Absolute target path (instead of using artifact_path + local_path)
         :param src_path:      Deprecated, use local_path
-        :param upload:        Upload to datastore (default is True). If logging a directory, it will not be
-                              uploaded unless this flag is set to `True`.
+        :param upload:        Whether to upload the artifact to the datastore. If not provided, and the `local_path`
+                              is not a directory, upload occurs by default. Directories are uploaded only when this
+                              flag is explicitly set to `True`.
         :param labels:        A set of key/value labels to tag the artifact with
         :param format:        Optional, format to use (e.g. csv, parquet, ..)
         :param db_key:        The key to use in the artifact DB table, by default its run name + '_' + key

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -634,7 +634,8 @@ class MLClientCtx:
         :param viewer:        Kubeflow viewer type
         :param target_path:   Absolute target path (instead of using artifact_path + local_path)
         :param src_path:      Deprecated, use local_path
-        :param upload:        Upload to datastore (default is True)
+        :param upload:        Upload to datastore (default is True). If logging a directory, it will not be
+                              uploaded unless this flag is set to `True`.
         :param labels:        A set of key/value labels to tag the artifact with
         :param format:        Optional, format to use (e.g. csv, parquet, ..)
         :param db_key:        The key to use in the artifact DB table, by default its run name + '_' + key

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1599,8 +1599,9 @@ class MlrunProject(ModelObj):
         :param format:        artifact file format: csv, png, ..
         :param tag:           version tag
         :param target_path:   absolute target path (instead of using artifact_path + local_path)
-        :param upload:        Whether to upload the artifact to the datastore (default is True). If logging a directory,
-                              it will not be uploaded unless this flag is set to `True`.
+        :param upload:        Whether to upload the artifact to the datastore. If not provided, and the `local_path`
+                              is not a directory, upload occurs by default. Directories are uploaded only when this
+                              flag is explicitly set to `True`.
         :param labels:        a set of key/value labels to tag the artifact with
 
         :returns: artifact object

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1599,7 +1599,8 @@ class MlrunProject(ModelObj):
         :param format:        artifact file format: csv, png, ..
         :param tag:           version tag
         :param target_path:   absolute target path (instead of using artifact_path + local_path)
-        :param upload:        upload to datastore (default is True)
+        :param upload:        Whether to upload the artifact to the datastore (default is True). If logging a directory,
+                              it will not be uploaded unless this flag is set to `True`.
         :param labels:        a set of key/value labels to tag the artifact with
 
         :returns: artifact object


### PR DESCRIPTION
When logging a directory artifact, the directory is not uploaded by default unless the `upload` flag is set to true
https://iguazio.atlassian.net/browse/ML-6064