### PR TITLE
[Pagination] Page Token Improvements

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -332,19 +332,18 @@ class HTTPRunDB(RunDBInterface):
         first_page_params["page"] = 1
         first_page_params["page-size"] = config.httpdb.pagination.default_page_size
         response = _api_call(first_page_params)
-        page_token = response.json().get("pagination", {}).get("page-token")
-        if not page_token:
-            yield response
-            return
+
+        yield response
+        page_token = response.json().get("pagination", {}).get("page-token", None)
 
         while page_token:
-            yield response
             try:
                 response = _api_call({"page-token": page_token})
             except mlrun.errors.MLRunNotFoundError:
                 # pagination token expired
                 break
 
+            yield response
             page_token = response.json().get("pagination", {}).get("page-token", None)
 
     @staticmethod

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -337,12 +337,10 @@ class HTTPRunDB(RunDBInterface):
             yield response
             return
 
-        params_with_page_token = deepcopy(params) or {}
-        params_with_page_token["page-token"] = page_token
         while page_token:
             yield response
             try:
-                response = _api_call(params_with_page_token)
+                response = _api_call({"page-token": page_token})
             except mlrun.errors.MLRunNotFoundError:
                 # pagination token expired
                 break

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -338,6 +338,9 @@ class HTTPRunDB(RunDBInterface):
 
         while page_token:
             try:
+                # Use the page token to get the next page.
+                # No need to supply any other parameters as the token informs the pagination cache
+                # which parameters to use.
                 response = _api_call({"page-token": page_token})
             except mlrun.errors.MLRunNotFoundError:
                 # pagination token expired

--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -138,9 +138,6 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             # on the last page, we don't return the token, but we keep it live in the cache
             # so the client can access previous pages.
             # the token will be revoked after some time of none-usage.
-            self._logger.debug(
-                "Last page, not returning token", token=token, method=method.__name__
-            )
             last_pagination_info.page_token = None
 
         return result, last_pagination_info.dict(by_alias=True)
@@ -204,9 +201,6 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             if isinstance(exc, StopIteration) or "StopIteration" in str(exc):
                 # don't revoke the token here as we might still want to go to previous pages.
                 # the token will be revoked after some time of none-usage.
-                self._logger.debug(
-                    "End of pagination", token=token, method=method.__name__
-                )
                 return [], None
             raise
 

--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -162,11 +162,6 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
                 f"Pagination is not supported for method {method}"
             )
 
-        if token and len(method_kwargs) > 0:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "Pagination token and query filter cannot be provided together"
-            )
-
         if page_size is None and token is None:
             self._logger.debug(
                 "No token or page size provided, returning all records", method=method

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -155,7 +155,8 @@ async def test_list_functions_with_pagination(
             "page-token": page_token,
         },
     )
-    assert response.status_code == HTTPStatus.NOT_FOUND.value
+    assert response.status_code == HTTPStatus.OK.value
+    assert response.json()["pagination"]["page-token"] is None
 
 
 def _assert_pagination_info(

--- a/tests/api/api/test_runs.py
+++ b/tests/api/api/test_runs.py
@@ -587,14 +587,15 @@ def test_list_runs_with_pagination(db: Session, client: TestClient):
     assert pagination["page-size"] == 10
     assert runs[0]["metadata"]["name"] == "run_4"
 
-    response = client.get(
-        RUNS_API_ENDPOINT.format(project=project),
-        params={
+    runs = _list_and_assert_objects(
+        client,
+        {
             "page-token": token,
         },
+        0,
+        project=project,
     )
-    # token is expired
-    assert response.status_code == HTTPStatus.NOT_FOUND.value
+    assert not runs
 
     runs = _list_and_assert_objects(
         client,

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -170,12 +170,6 @@ async def test_paginate_request(
     assert len(response) == 0
     assert not pagination_info
 
-    logger.info("Checking db cache record was removed")
-    cache_record = server.api.crud.PaginationCache().get_pagination_cache_record(
-        db, token
-    )
-    assert cache_record is None
-
 
 @pytest.mark.asyncio
 async def test_paginate_other_users_token(

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -158,9 +158,6 @@ async def test_paginate_request(
         cache_record, auth_info.user_id, paginated_method, 2, page_size
     )
 
-    logger.info("Saving token for next assert")
-    token = pagination_info.page_token
-
     logger.info(
         "Requesting third page, which is the end of the items and should return empty response"
     )

--- a/tests/api/utils/test_pagination.py
+++ b/tests/api/utils/test_pagination.py
@@ -384,7 +384,6 @@ async def test_pagination_cache_cleanup(
             token,
             1,
             page_size,
-            **method_kwargs,
         )
 
 
@@ -463,7 +462,9 @@ async def test_paginate_permission_filtered_request(
 
     auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
     page_size = 4
-    method_kwargs = {"total_amount": 20}
+    total = 20
+    last_page = total // page_size
+    method_kwargs = {"total_amount": total}
 
     paginator = server.api.utils.pagination.Paginator()
 
@@ -482,7 +483,11 @@ async def test_paginate_permission_filtered_request(
     assert len(response) == len(permitted_items)
     for i, item in enumerate(permitted_items):
         assert response[i]["name"] == item
-    assert pagination_info.page_token is not None
+
+    if target_page < last_page:
+        assert pagination_info.page_token is not None
+    else:
+        assert pagination_info.page_token is None
     assert pagination_info.page == target_page
     assert pagination_info.page_size == page_size
 
@@ -592,16 +597,26 @@ async def test_paginate_permission_filtered_with_token(
         db, paginated_method, filter_, auth_info, token
     )
     pagination_info = mlrun.common.schemas.PaginationInfo(**pagination_info)
-    _assert_paginated_response(response, pagination_info, 5, page_size, ["item12"])
+    _assert_paginated_response(
+        response, pagination_info, 5, page_size, ["item12"], last_page=True
+    )
 
 
 def _assert_paginated_response(
-    response, pagination_info, page, page_size, expected_items
+    response,
+    pagination_info,
+    page,
+    page_size,
+    expected_items,
+    last_page=False,
 ):
     assert len(response) == len(expected_items)
     for i, item in enumerate(expected_items):
         assert response[i]["name"] == item
-    assert pagination_info.page_token is not None
+    if not last_page:
+        assert pagination_info.page_token is not None
+    else:
+        assert pagination_info.page_token is None
     assert pagination_info.page == page
     assert pagination_info.page_size == page_size
 


### PR DESCRIPTION
On the last page, don't return the page token, but don't revoke it, so you can use it to go to previous pages (tokens are cleaned up after a configured amount of time of non-usage and when the table reaches a max-size).
