### PR TITLE
[Artifacts] Limit the artifact body size when logging artifacts

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -159,7 +159,7 @@ class ArtifactSpec(ModelObj):
             self._is_inline = True
 
     def get_body(self):
-        """get the artifact body when inline"""
+        """Get the artifact body"""
         return self._body
 
 

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -23,7 +23,7 @@ import mlrun.utils.regex
 from mlrun.utils.helpers import (
     get_local_file_schema,
     template_artifact_path,
-    validate_inline_artifact_body_size,
+    validate_artifact_body_size,
 )
 
 from ..utils import (
@@ -188,7 +188,7 @@ class ArtifactManager:
         Log an artifact to the DB and upload it to the artifact store.
         :param producer: The producer of the artifact, the producer depends on where the artifact is being logged.
         :param item: The artifact to log.
-        :param body: The body of the artifact.
+        :param body: The body of the artifact. the maximim size
         :param target_path: The target path of the artifact. (cannot be a relative path)
                             If not provided, the artifact will be stored in the default artifact path.
                             If provided and is a remote path (e.g. s3://bucket/path), no artifact will be uploaded
@@ -223,7 +223,7 @@ class ArtifactManager:
             target_path = target_path or item.target_path
 
         validate_artifact_key_name(key, "artifact.key")
-        validate_inline_artifact_body_size(item.spec.inline)
+        validate_artifact_body_size(item.spec.get_body())
         src_path = local_path or item.src_path  # TODO: remove src_path
         self.ensure_artifact_source_file_exists(item=item, path=src_path, body=body)
         if format == "html" or (src_path and pathlib.Path(src_path).suffix == "html"):

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -225,7 +225,9 @@ class ArtifactManager:
         validate_artifact_key_name(key, "artifact.key")
 
         # TODO: Create a tmp file, write the body to it, and use it as `local_path` instead of validating the body size.
-        validate_artifact_body_size(item.spec.get_body())
+        validate_artifact_body_size(
+            body=item.spec.get_body(), is_inline=item.is_inline()
+        )
         src_path = local_path or item.src_path  # TODO: remove src_path
         self.ensure_artifact_source_file_exists(item=item, path=src_path, body=body)
         if format == "html" or (src_path and pathlib.Path(src_path).suffix == "html"):

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -188,7 +188,7 @@ class ArtifactManager:
         Log an artifact to the DB and upload it to the artifact store.
         :param producer: The producer of the artifact, the producer depends on where the artifact is being logged.
         :param item: The artifact to log.
-        :param body: The body of the artifact. the maximim size
+        :param body: The body of the artifact.
         :param target_path: The target path of the artifact. (cannot be a relative path)
                             If not provided, the artifact will be stored in the default artifact path.
                             If provided and is a remote path (e.g. s3://bucket/path), no artifact will be uploaded

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -223,6 +223,8 @@ class ArtifactManager:
             target_path = target_path or item.target_path
 
         validate_artifact_key_name(key, "artifact.key")
+
+        # TODO: Create a tmp file, write the body to it, and use it as `local_path` instead of validating the body size.
         validate_artifact_body_size(item.spec.get_body())
         src_path = local_path or item.src_path  # TODO: remove src_path
         self.ensure_artifact_source_file_exists(item=item, path=src_path, body=body)

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -280,9 +280,7 @@ def validate_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
             "The body of the artifact exceeds the maximum allowed size. "
             "Avoid embedding the artifact body. "
             "This increases the size of the project yaml file and could affect the project during loading and saving. "
-            "More information is available at "
-            "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts."
-            " For larger objects, please use the `src_path` parameter to log artifacts through files instead."
+            "For larger artifacts, consider logging them through files instead."
         )
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -282,9 +282,9 @@ def validate_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
             "The body of the artifact exceeds the maximum allowed size. "
             "Avoid embedding the artifact body. "
             "This increases the size of the project yaml file and could affect the project during loading and saving. "
-            "More information is available at"
-            "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts"
-            "Please use `src_path` instead."
+            "More information is available at "
+            "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts. "
+            "For larger objects, please use the `src_path` parameter to log artifacts through files instead."
         )
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -271,11 +271,9 @@ def validate_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
     """
     Validates the size of the artifact body.
 
-    Args:
-        body: The artifact body, which can be a string, bytes, or None.
+    :param body: The artifact body, which can be a string, bytes, or None.
 
-    Raises:
-        mlrun.errors.MLRunBadRequestError: If the body exceeds the maximum allowed size.
+    :raises mlrun.errors.MLRunBadRequestError: If the body exceeds the maximum allowed size.
     """
     if body and len(body) > MYSQL_MEDIUMBLOB_SIZE_BYTES:
         raise mlrun.errors.MLRunBadRequestError(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -283,8 +283,8 @@ def validate_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
             "Avoid embedding the artifact body. "
             "This increases the size of the project yaml file and could affect the project during loading and saving. "
             "More information is available at "
-            "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts. "
-            "For larger objects, please use the `src_path` parameter to log artifacts through files instead."
+            "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts."
+            " For larger objects, please use the `src_path` parameter to log artifacts through files instead."
         )
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -274,21 +274,29 @@ def validate_artifact_key_name(
     )
 
 
-def validate_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
+def validate_artifact_body_size(
+    body: typing.Union[str, bytes, None], is_inline: bool
+) -> None:
     """
     Validates the size of the artifact body.
 
     :param body: The artifact body, which can be a string, bytes, or None.
+    :param is_inline: A flag indicating whether the artifact body is inline.
 
     :raises mlrun.errors.MLRunBadRequestError: If the body exceeds the maximum allowed size.
     """
     if body and len(body) > MYSQL_MEDIUMBLOB_SIZE_BYTES:
-        raise mlrun.errors.MLRunBadRequestError(
-            "The body of the artifact exceeds the maximum allowed size. "
-            "Avoid embedding the artifact body. "
-            "This increases the size of the project yaml file and could affect the project during loading and saving. "
-            "For larger artifacts, consider logging them through files instead."
-        )
+        error_message = "The body of the artifact exceeds the maximum allowed size. "
+        if is_inline:
+            error_message += (
+                "Avoid embedding the artifact body. This increases the size of the project yaml file and could "
+                "affect the project during loading and saving. "
+            )
+        else:
+            error_message += (
+                "For larger artifacts, consider logging them through files instead."
+            )
+        raise mlrun.errors.MLRunBadRequestError(error_message)
 
 
 def validate_v3io_stream_consumer_group(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -267,7 +267,16 @@ def validate_artifact_key_name(
     )
 
 
-def validate_inline_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
+def validate_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
+    """
+    Validates the size of the artifact body.
+
+    Args:
+        body: The artifact body, which can be a string, bytes, or None.
+
+    Raises:
+        mlrun.errors.MLRunBadRequestError: If the body exceeds the maximum allowed size.
+    """
     if body and len(body) > MYSQL_MEDIUMBLOB_SIZE_BYTES:
         raise mlrun.errors.MLRunBadRequestError(
             "The body of the artifact exceeds the maximum allowed size. "
@@ -275,6 +284,7 @@ def validate_inline_artifact_body_size(body: typing.Union[str, bytes, None]) -> 
             "This increases the size of the project yaml file and could affect the project during loading and saving. "
             "More information is available at"
             "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts"
+            "Please use `src_path` instead."
         )
 
 

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -282,9 +282,7 @@ class Artifacts(
                         err=err_to_str(err),
                     )
         if "spec" in artifact and "inline" in artifact["spec"]:
-            mlrun.utils.helpers.validate_inline_artifact_body_size(
-                artifact["spec"]["inline"]
-            )
+            mlrun.utils.helpers.validate_artifact_body_size(artifact["spec"]["inline"])
 
     def _delete_artifact_data(
         self,

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -282,7 +282,9 @@ class Artifacts(
                         err=err_to_str(err),
                     )
         if "spec" in artifact and "inline" in artifact["spec"]:
-            mlrun.utils.helpers.validate_artifact_body_size(artifact["spec"]["inline"])
+            mlrun.utils.helpers.validate_artifact_body_size(
+                artifact["spec"]["inline"], is_inline=True
+            )
 
     def _delete_artifact_data(
         self,

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -402,7 +402,6 @@ def test_ensure_artifact_source_file_exists(local_path, fail):
 def test_ensure_fail_on_oversized_artifact(body_size, expectation):
     artifact = mlrun.artifacts.Artifact(
         "artifact-name",
-        is_inline=True,
         body="a" * body_size,
     )
     context = mlrun.get_or_create_ctx("test")

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -403,6 +403,7 @@ def test_ensure_artifact_source_file_exists(local_path, fail):
             pytest.raises(mlrun.errors.MLRunBadRequestError),
         ),
         (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, True, does_not_raise()),
+        (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, False, does_not_raise()),
     ],
 )
 def test_ensure_fail_on_oversized_artifact(body_size, is_inline, expectation):

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -390,18 +390,25 @@ def test_ensure_artifact_source_file_exists(local_path, fail):
 
 
 @pytest.mark.parametrize(
-    "body_size,expectation",
+    "body_size,is_inline,expectation",
     [
         (
             MYSQL_MEDIUMBLOB_SIZE_BYTES + 1,
+            True,
             pytest.raises(mlrun.errors.MLRunBadRequestError),
         ),
-        (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, does_not_raise()),
+        (
+            MYSQL_MEDIUMBLOB_SIZE_BYTES + 1,
+            False,
+            pytest.raises(mlrun.errors.MLRunBadRequestError),
+        ),
+        (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, True, does_not_raise()),
     ],
 )
-def test_ensure_fail_on_oversized_artifact(body_size, expectation):
+def test_ensure_fail_on_oversized_artifact(body_size, is_inline, expectation):
     artifact = mlrun.artifacts.Artifact(
         "artifact-name",
+        is_inline=is_inline,
         body="a" * body_size,
     )
     context = mlrun.get_or_create_ctx("test")


### PR DESCRIPTION
To avoid handling large amounts of data in memory, we limit the body size to 16MB. 
If the body exceeds this limit, an error will be raised, directing users to log larger artifacts through files using the `src_path` parameter.
https://iguazio.atlassian.net/browse/ML-7240