### PR TITLE
[Docs] Note OAuth2 API gateway mode is not supported

### DIFF
--- a/docs/concepts/nuclio-real-time-functions.ipynb
+++ b/docs/concepts/nuclio-real-time-functions.ipynb
@@ -225,7 +225,7 @@
     "   - None (default)\n",
     "   - Basic\n",
     "   - Access key\n",
-    "   - OAuth2 (Not supported yet in MLRun)\n",
+    "   - OAuth2 (Not supported yet in MLRun SDK)\n",
     "   \n",
     "   and fill in any required values.\n",
     "2. Type in the API Gateway parameters:\n",

--- a/docs/concepts/nuclio-real-time-functions.ipynb
+++ b/docs/concepts/nuclio-real-time-functions.ipynb
@@ -225,7 +225,7 @@
     "   - None (default)\n",
     "   - Basic\n",
     "   - Access key\n",
-    "   - OAuth2\n",
+    "   - OAuth2 (Not supported yet in MLRun)\n",
     "   \n",
     "   and fill in any required values.\n",
     "2. Type in the API Gateway parameters:\n",


### PR DESCRIPTION
mlrun doesn't have oauth2 kind so if a user changes the api gateway kind from nuclio UI, mlrun will not be able to load it