### PR TITLE
[Config] Raising more coherent message when config reload is failing

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -801,10 +801,10 @@ class Config:
                     # input error that can lead to unexpected behavior.
                     # raise the exception to ensure configuration is loaded correctly and do not
                     # ignore any errors.
+                    config_value = getattr(self, key)
                     try:
-                        getattr(self, key).update(value)
+                        config_value.update(value)
                     except AttributeError as exc:
-                        config_value = getattr(self, key)
                         if not isinstance(config_value, (dict, Config)):
                             raise ValueError(
                                 f"Can not update `{key}` config. "

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -796,7 +796,14 @@ class Config:
         for key, value in cfg.items():
             if hasattr(self, key):
                 if isinstance(value, dict):
-                    getattr(self, key).update(value)
+                    try:
+                        getattr(self, key).update(value)
+                    except AttributeError as exc:
+                        config_value = getattr(self, key)
+                        if not isinstance(config_value, (dict, Config)):
+                            raise ValueError(
+                                f"Can not update `{key}` config. Expected a configuration but received {type(config_value)}"
+                            ) from exc
                 else:
                     try:
                         setattr(self, key, value)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -796,6 +796,11 @@ class Config:
         for key, value in cfg.items():
             if hasattr(self, key):
                 if isinstance(value, dict):
+                    # ignore the `skip_errors` flag here
+                    # if the key does not align with what mlrun config expects it is a user
+                    # input error that can lead to unexpected behavior.
+                    # raise the exception to ensure configuration is loaded correctly and do not
+                    # ignore any errors.
                     try:
                         getattr(self, key).update(value)
                     except AttributeError as exc:
@@ -803,8 +808,9 @@ class Config:
                         if not isinstance(config_value, (dict, Config)):
                             raise ValueError(
                                 f"Can not update `{key}` config. "
-                                f"Expected a configuration but received {type(config_value)}"
+                                f"Expected a configuration but received {type(value)}"
                             ) from exc
+                        raise exc
                 else:
                     try:
                         setattr(self, key, value)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -802,7 +802,8 @@ class Config:
                         config_value = getattr(self, key)
                         if not isinstance(config_value, (dict, Config)):
                             raise ValueError(
-                                f"Can not update `{key}` config. Expected a configuration but received {type(config_value)}"
+                                f"Can not update `{key}` config. "
+                                f"Expected a configuration but received {type(config_value)}"
                             ) from exc
                 else:
                     try:


### PR DESCRIPTION
when providing wrong envvar for mlrun to load, the error is not user-friendly in terms of the root cause.

https://iguazio.atlassian.net/browse/CEML-32