### PR TITLE
Revert "[Artifacts] Limit the artifact body size when logging artifacts"

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -159,7 +159,7 @@ class ArtifactSpec(ModelObj):
             self._is_inline = True
 
     def get_body(self):
-        """Get the artifact body"""
+        """get the artifact body when inline"""
         return self._body
 
 

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -23,7 +23,7 @@ import mlrun.utils.regex
 from mlrun.utils.helpers import (
     get_local_file_schema,
     template_artifact_path,
-    validate_artifact_body_size,
+    validate_inline_artifact_body_size,
 )
 
 from ..utils import (
@@ -223,11 +223,7 @@ class ArtifactManager:
             target_path = target_path or item.target_path
 
         validate_artifact_key_name(key, "artifact.key")
-
-        # TODO: Create a tmp file, write the body to it, and use it as `local_path` instead of validating the body size.
-        validate_artifact_body_size(
-            body=item.spec.get_body(), is_inline=item.is_inline()
-        )
+        validate_inline_artifact_body_size(item.spec.inline)
         src_path = local_path or item.src_path  # TODO: remove src_path
         self.ensure_artifact_source_file_exists(item=item, path=src_path, body=body)
         if format == "html" or (src_path and pathlib.Path(src_path).suffix == "html"):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -274,29 +274,15 @@ def validate_artifact_key_name(
     )
 
 
-def validate_artifact_body_size(
-    body: typing.Union[str, bytes, None], is_inline: bool
-) -> None:
-    """
-    Validates the size of the artifact body.
-
-    :param body: The artifact body, which can be a string, bytes, or None.
-    :param is_inline: A flag indicating whether the artifact body is inline.
-
-    :raises mlrun.errors.MLRunBadRequestError: If the body exceeds the maximum allowed size.
-    """
+def validate_inline_artifact_body_size(body: typing.Union[str, bytes, None]) -> None:
     if body and len(body) > MYSQL_MEDIUMBLOB_SIZE_BYTES:
-        error_message = "The body of the artifact exceeds the maximum allowed size. "
-        if is_inline:
-            error_message += (
-                "Avoid embedding the artifact body. This increases the size of the project yaml file and could "
-                "affect the project during loading and saving. "
-            )
-        else:
-            error_message += (
-                "For larger artifacts, consider logging them through files instead."
-            )
-        raise mlrun.errors.MLRunBadRequestError(error_message)
+        raise mlrun.errors.MLRunBadRequestError(
+            "The body of the artifact exceeds the maximum allowed size. "
+            "Avoid embedding the artifact body. "
+            "This increases the size of the project yaml file and could affect the project during loading and saving. "
+            "More information is available at"
+            "https://docs.mlrun.org/en/latest/projects/automate-project-git-source.html#setting-and-registering-the-project-artifacts"
+        )
 
 
 def validate_v3io_stream_consumer_group(

--- a/server/api/crud/artifacts.py
+++ b/server/api/crud/artifacts.py
@@ -282,8 +282,8 @@ class Artifacts(
                         err=err_to_str(err),
                     )
         if "spec" in artifact and "inline" in artifact["spec"]:
-            mlrun.utils.helpers.validate_artifact_body_size(
-                artifact["spec"]["inline"], is_inline=True
+            mlrun.utils.helpers.validate_inline_artifact_body_size(
+                artifact["spec"]["inline"]
             )
 
     def _delete_artifact_data(

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -390,26 +390,19 @@ def test_ensure_artifact_source_file_exists(local_path, fail):
 
 
 @pytest.mark.parametrize(
-    "body_size,is_inline,expectation",
+    "body_size,expectation",
     [
         (
             MYSQL_MEDIUMBLOB_SIZE_BYTES + 1,
-            True,
             pytest.raises(mlrun.errors.MLRunBadRequestError),
         ),
-        (
-            MYSQL_MEDIUMBLOB_SIZE_BYTES + 1,
-            False,
-            pytest.raises(mlrun.errors.MLRunBadRequestError),
-        ),
-        (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, True, does_not_raise()),
-        (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, False, does_not_raise()),
+        (MYSQL_MEDIUMBLOB_SIZE_BYTES - 1, does_not_raise()),
     ],
 )
-def test_ensure_fail_on_oversized_artifact(body_size, is_inline, expectation):
+def test_ensure_fail_on_oversized_artifact(body_size, expectation):
     artifact = mlrun.artifacts.Artifact(
         "artifact-name",
-        is_inline=is_inline,
+        is_inline=True,
         body="a" * body_size,
     )
     context = mlrun.get_or_create_ctx("test")


### PR DESCRIPTION
Reverts mlrun/mlrun#6349


```
[info] Job is running in the background, pod: summary-6ljkg
> 2024-09-19 05:25:51,768 [error] Execution error, Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/mlrun/runtimes/local.py", line 506, in exec_from_params
    val = mlrun.handler(
  File "/opt/conda/lib/python3.9/site-packages/mlrun/package/__init__.py", line 140, in wrapper
    func_outputs = func(*args, **kwargs)
  File "main.py", line 142, in analyze
    extra_data["describe csv"] = context.log_artifact(
  File "/opt/conda/lib/python3.9/site-packages/mlrun/execution.py", line 648, in log_artifact
    item = self._artifacts_manager.log_artifact(
  File "/opt/conda/lib/python3.9/site-packages/mlrun/artifacts/manager.py", line 228, in log_artifact
    validate_artifact_body_size(
  File "/opt/conda/lib/python3.9/site-packages/mlrun/utils/helpers.py", line 288, in validate_artifact_body_size
    if body and len(body) > MYSQL_MEDIUMBLOB_SIZE_BYTES:
  File "/opt/conda/lib/python3.9/site-packages/pandas/core/generic.py", line 1519, in __nonzero__
    raise ValueError(
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```