### PR TITLE
[Serving] Fix event path when trigger is RabbitMQ

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -401,6 +401,8 @@ def v2_serving_handler(context, event, get_body=False):
         "kafka-cluster",
         "v3ioStream",
         "v3io-stream",
+        "rabbit-mq",
+        "rabbitMq",
     ):
         event.path = "/"
 


### PR DESCRIPTION
[ML-7907](https://iguazio.atlassian.net/browse/ML-7907)

This adds RabbitMQ to the list of Nuclio triggers where we need to work around [NUC-178](https://iguazio.atlassian.net/browse/NUC-178).

[ML-7907]: https://iguazio.atlassian.net/browse/ML-7907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NUC-178]: https://iguazio.atlassian.net/browse/NUC-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ