### PR TITLE
[Server] Filter permissions correctly when getting project summaries

### DIFF
--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -63,6 +63,7 @@ class AuthorizationResourceTypes(mlrun.common.types.StrEnum):
     event = "event"
     datastore_profile = "datastore-profile"
     api_gateway = "api-gateway"
+    project_summaries = "project-summaries"
 
     def to_resource_string(
         self,
@@ -72,6 +73,7 @@ class AuthorizationResourceTypes(mlrun.common.types.StrEnum):
         return {
             # project is the resource itself, so no need for both resource_name and project_name
             AuthorizationResourceTypes.project: "/projects/{project_name}",
+            AuthorizationResourceTypes.project_summaries: "/projects/{project_name}/project-summaries/{resource_name}",
             AuthorizationResourceTypes.function: "/projects/{project_name}/functions/{resource_name}",
             AuthorizationResourceTypes.artifact: "/projects/{project_name}/artifacts/{resource_name}",
             AuthorizationResourceTypes.project_background_task: (

--- a/server/api/api/endpoints/projects.py
+++ b/server/api/api/endpoints/projects.py
@@ -383,6 +383,18 @@ async def list_project_summaries(
             projects_output.projects,
             auth_info,
         )
+    allowed_project_names = [
+        project
+        for project in allowed_project_names
+        if server.api.utils.auth.verifier.AuthVerifier().query_project_resoue_permissions(
+            resource_type=mlrun.common.schemas.AuthorizationResourceTypes.project_summaries,
+            project_name=project,
+            resource_name="",
+            action=mlrun.common.schemas.AuthorizationAction.read,
+            auth_info=auth_info,
+            raise_on_forbidden=False,
+        )
+    ]
     return await get_project_member().list_project_summaries(
         db_session,
         owner,

--- a/server/api/api/endpoints/projects.py
+++ b/server/api/api/endpoints/projects.py
@@ -379,22 +379,17 @@ async def list_project_summaries(
     allowed_project_names = projects_output.projects
     # skip permission check if it's the leader
     if not server.api.utils.helpers.is_request_from_leader(auth_info.projects_role):
-        allowed_project_names = await server.api.utils.auth.verifier.AuthVerifier().filter_projects_by_permissions(
-            projects_output.projects,
-            auth_info,
-        )
-    allowed_project_names = [
-        project
-        for project in allowed_project_names
-        if server.api.utils.auth.verifier.AuthVerifier().query_project_resoue_permissions(
+        auth_verifier = server.api.utils.auth.verifier.AuthVerifier()
+        allowed_project_names = await auth_verifier.filter_project_resources_by_permissions(
             resource_type=mlrun.common.schemas.AuthorizationResourceTypes.project_summaries,
-            project_name=project,
-            resource_name="",
-            action=mlrun.common.schemas.AuthorizationAction.read,
+            resources=allowed_project_names,
+            project_and_resource_name_extractor=lambda project: (
+                project,
+                "",
+            ),
             auth_info=auth_info,
-            raise_on_forbidden=False,
+            action=mlrun.common.schemas.AuthorizationAction.read,
         )
-    ]
     return await get_project_member().list_project_summaries(
         db_session,
         owner,

--- a/server/api/utils/auth/providers/opa.py
+++ b/server/api/utils/auth/providers/opa.py
@@ -89,20 +89,16 @@ class Provider(
         if server.api.utils.helpers.is_request_from_leader(
             auth_info.projects_role, leader_name=self._leader_name
         ):
-            print("ADAM: REQUEST FROM LEADER, IGNORE AUTH")
             return True
         if self._check_allowed_project_owners_cache(resource, auth_info):
-            print("ADAM: CHECK CACHE RESULTED TRUE, IGNORE AUTH")
             return True
         body = self._generate_permission_request_body(resource, action, auth_info)
-        print(f"ADAM: OPA CHECK BODY {body}")
         if self._log_level > 5:
             logger.debug("Sending request to OPA", body=body)
         async with self._send_request_to_api(
             "POST", self._permission_query_path, json=body
         ) as response:
             response_body = await response.json()
-            print(f"ADAM: OPA CHECK BODY RESPONSE {response_body}")
         if self._log_level > 5:
             logger.debug("Received response from OPA", body=response_body)
         allowed = response_body["result"]

--- a/server/api/utils/auth/providers/opa.py
+++ b/server/api/utils/auth/providers/opa.py
@@ -89,16 +89,20 @@ class Provider(
         if server.api.utils.helpers.is_request_from_leader(
             auth_info.projects_role, leader_name=self._leader_name
         ):
+            print("ADAM: REQUEST FROM LEADER, IGNORE AUTH")
             return True
         if self._check_allowed_project_owners_cache(resource, auth_info):
+            print("ADAM: CHECK CACHE RESULTED TRUE, IGNORE AUTH")
             return True
         body = self._generate_permission_request_body(resource, action, auth_info)
+        print(f"ADAM: OPA CHECK BODY {body}")
         if self._log_level > 5:
             logger.debug("Sending request to OPA", body=body)
         async with self._send_request_to_api(
             "POST", self._permission_query_path, json=body
         ) as response:
             response_body = await response.json()
+            print(f"ADAM: OPA CHECK BODY RESPONSE {response_body}")
         if self._log_level > 5:
             logger.debug("Received response from OPA", body=response_body)
         allowed = response_body["result"]


### PR DESCRIPTION
Filter permissions correctly when getting project summaries [ML-7393]  
Query OPA using a new resource type "project-summaries"

https://iguazio.atlassian.net/browse/ML-7665

[ML-7393]: https://iguazio.atlassian.net/browse/ML-7393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ