### PR TITLE
[Workflows] Fix resolving source code target dir

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -175,6 +175,7 @@ from .project import (
     ProjectOwner,
     ProjectsOutput,
     ProjectSpec,
+    ProjectSpecOut,
     ProjectState,
     ProjectStatus,
     ProjectSummariesOutput,

--- a/server/api/api/endpoints/workflows.py
+++ b/server/api/api/endpoints/workflows.py
@@ -87,7 +87,7 @@ async def submit_workflow(
     :returns: response that contains the project name, workflow name, name of the workflow,
              status, run id (in case of a single run) and schedule (in case of scheduling)
     """
-    project = await run_in_threadpool(
+    project: mlrun.common.schemas.ProjectOut = await run_in_threadpool(
         server.api.utils.singletons.project_member.get_project_member().get_project,
         db_session=db_session,
         name=project,
@@ -244,7 +244,7 @@ async def submit_workflow(
 def _is_requested_schedule(
     name: str,
     workflow_spec: mlrun.common.schemas.WorkflowSpec,
-    project: mlrun.common.schemas.Project,
+    project: mlrun.common.schemas.ProjectOut,
 ) -> bool:
     """
     Checks if the workflow needs to be scheduled, which can be decided either the request itself
@@ -264,7 +264,7 @@ def _is_requested_schedule(
 
 
 def _get_workflow_by_name(
-    project: mlrun.common.schemas.Project, name: str
+    project: mlrun.common.schemas.ProjectOut, name: str
 ) -> typing.Optional[dict]:
     """
     Getting workflow from project by name.
@@ -281,7 +281,7 @@ def _get_workflow_by_name(
 
 
 def _fill_workflow_missing_fields_from_project(
-    project: mlrun.common.schemas.Project,
+    project: mlrun.common.schemas.ProjectOut,
     workflow_name: str,
     spec: mlrun.common.schemas.WorkflowSpec,
     arguments: dict,

--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -73,7 +73,7 @@ class WorkflowRunners(
     def schedule(
         self,
         runner: mlrun.run.KubejobRuntime,
-        project: mlrun.common.schemas.Project,
+        project: mlrun.common.schemas.ProjectOut,
         workflow_request: mlrun.common.schemas.WorkflowRequest,
         db_session: Session = None,
         auth_info: mlrun.common.schemas.AuthInfo = None,
@@ -127,7 +127,7 @@ class WorkflowRunners(
 
     def _prepare_run_object_for_scheduling(
         self,
-        project: mlrun.common.schemas.Project,
+        project: mlrun.common.schemas.ProjectOut,
         workflow_request: mlrun.common.schemas.WorkflowRequest,
         labels: dict[str, str],
     ) -> mlrun.run.RunObject:
@@ -200,7 +200,7 @@ class WorkflowRunners(
     def run(
         self,
         runner: mlrun.run.KubejobRuntime,
-        project: mlrun.common.schemas.Project,
+        project: mlrun.common.schemas.ProjectOut,
         workflow_request: mlrun.common.schemas.WorkflowRequest = None,
         load_only: bool = False,
         auth_info: mlrun.common.schemas.AuthInfo = None,
@@ -306,7 +306,7 @@ class WorkflowRunners(
 
     def _prepare_run_object_for_single_run(
         self,
-        project: mlrun.common.schemas.Project,
+        project: mlrun.common.schemas.ProjectOut,
         labels: dict[str, str],
         workflow_request: mlrun.common.schemas.WorkflowRequest = None,
         run_name: str = None,
@@ -380,7 +380,7 @@ class WorkflowRunners(
 
     @staticmethod
     def _validate_source(
-        project: mlrun.common.schemas.Project, source: str, load_only: bool = False
+        project: mlrun.common.schemas.ProjectOut, source: str, load_only: bool = False
     ) -> tuple[str, bool, bool]:
         """
         In case the user provided a source we want to load the project from the source
@@ -411,11 +411,16 @@ class WorkflowRunners(
                 return source, save, True
 
             if source.startswith("./") or source == ".":
+                build = project.spec.build
+                source_code_target_dir = (
+                    build.get("source_code_target_dir") if build else ""
+                )
+
                 # When the source is relative, it is relative to the project's source_code_target_dir
                 # If the project's source_code_target_dir is not set, the source is relative to the cwd
-                if project.spec.build and project.spec.build.source_code_target_dir:
+                if source_code_target_dir:
                     source = os.path.normpath(
-                        os.path.join(project.spec.build.source_code_target_dir, source)
+                        os.path.join(source_code_target_dir, source)
                     )
                 return source, save, True
 

--- a/server/api/utils/projects/follower.py
+++ b/server/api/utils/projects/follower.py
@@ -233,7 +233,7 @@ class Member(
         leader_session: typing.Optional[str] = None,
         from_leader: bool = False,
         format_: mlrun.common.formatters.ProjectFormat = mlrun.common.formatters.ProjectFormat.full,
-    ) -> mlrun.common.schemas.Project:
+    ) -> mlrun.common.schemas.ProjectOutput:
         # by default, get project will use mlrun db to get/list the project.
         # from leader is relevant for cases where we want to get the project from the leader
         if from_leader:

--- a/server/api/utils/projects/member.py
+++ b/server/api/utils/projects/member.py
@@ -119,7 +119,7 @@ class Member(abc.ABC):
         leader_session: typing.Optional[str] = None,
         from_leader: bool = False,
         format_: mlrun.common.formatters.ProjectFormat = mlrun.common.formatters.ProjectFormat.full,
-    ) -> mlrun.common.schemas.Project:
+    ) -> mlrun.common.schemas.ProjectOutput:
         pass
 
     @abc.abstractmethod

--- a/tests/api/crud/test_workflows.py
+++ b/tests/api/crud/test_workflows.py
@@ -45,14 +45,12 @@ class TestWorkflows(tests.api.conftest.MockedK8sHelper):
         source_code_target_dir: str,
         source: str,
     ):
-        project = mlrun.common.schemas.Project(
+        project = mlrun.common.schemas.ProjectOut(
             metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
-            spec=mlrun.common.schemas.ProjectSpec(),
+            spec=mlrun.common.schemas.ProjectSpecOut(),
         )
         if source_code_target_dir:
-            project.spec.build = mlrun.common.schemas.common.ImageBuilder(
-                source_code_target_dir=source_code_target_dir
-            )
+            project.spec.build = {"source_code_target_dir": source_code_target_dir}
 
         server.api.crud.Projects().create_project(db, project)
 

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1609,7 +1609,7 @@ class TestProject(TestMLRunSystem):
             db.get_project(name)
 
     def test_remote_workflow_source_on_image(self):
-        name = "source-project"
+        name = "pipe"
         self.custom_project_names_to_delete.append(name)
 
         project_dir = f"{projects_dir}/{name}"


### PR DESCRIPTION
`project.spec.build` is not a dictionary because we created a different schema for project output to disable validation and not explode on projects that are already in the DB

https://iguazio.atlassian.net/browse/ML-7920