### PR TITLE
[ProjectSummaries] Fix wrong schedule jobs count

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -27,7 +27,7 @@ from typing import Any
 import fastapi.concurrency
 import mergedeep
 import pytz
-from sqlalchemy import MetaData, and_, delete, distinct, func, or_, select, text
+from sqlalchemy import MetaData, and_, case, delete, distinct, func, or_, select, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Session, aliased
@@ -2846,7 +2846,42 @@ class SQLDB(DBInterface):
         next_day = datetime.now(timezone.utc) + timedelta(hours=24)
 
         schedules_pending_count_per_project = (
-            session.query(Schedule.project, Schedule.name, Schedule.Label)
+            session.query(
+                Schedule.project,
+                Schedule.name,
+                # The logic here is the following:
+                # If the schedule has a label with the name "workflow" then we take the value of that label
+                # name. Otherwise, we take the value of the label with the name "kind".
+                # The reason for that is that for schedule workflow we have both workflow label and kind label
+                # with job, and on schedule job we have only kind label with job and because of that we first
+                # want to check for workflow label and if it doesn't exist then we take the kind label.
+                func.coalesce(
+                    func.max(
+                        case(
+                            [
+                                (
+                                    Schedule.Label.name
+                                    == mlrun_constants.MLRunInternalLabels.workflow,
+                                    Schedule.Label.name,
+                                )
+                            ],
+                            else_=None,
+                        )
+                    ),
+                    func.max(
+                        case(
+                            [
+                                (
+                                    Schedule.Label.name
+                                    == mlrun_constants.MLRunInternalLabels.kind,
+                                    Schedule.Label.value,
+                                )
+                            ],
+                            else_=None,
+                        )
+                    ),
+                ).label("preferred_label_value"),
+            )
             .join(Schedule.Label, Schedule.Label.parent == Schedule.id)
             .filter(Schedule.next_run_time < next_day)
             .filter(Schedule.next_run_time >= datetime.now(timezone.utc))
@@ -2858,48 +2893,24 @@ class SQLDB(DBInterface):
                     ]
                 )
             )
+            .group_by(Schedule.project, Schedule.name)
             .all()
         )
 
-        project_to_schedule_pending_jobs_count = collections.defaultdict(list)
-        project_to_schedule_pending_workflows_count = collections.defaultdict(list)
+        project_to_schedule_pending_jobs_count = collections.defaultdict(int)
+        project_to_schedule_pending_workflows_count = collections.defaultdict(int)
 
-        # First Iterating over schedules for counting the workflows
         for result in schedules_pending_count_per_project:
-            project_name, schedule_name, labels = result
-            if labels.to_dict()["name"] == mlrun_constants.MLRunInternalLabels.workflow:
-                project_to_schedule_pending_workflows_count[project_name].append(
-                    schedule_name
-                )
-
-        # Then, iterating over schedules for counting the jobs and filtering out the workflows
-        for result in schedules_pending_count_per_project:
-            project_name, schedule_name, labels = result
-            if (
-                labels.to_dict()["value"] == "job"
-                and schedule_name
-                not in project_to_schedule_pending_workflows_count[project_name]
-            ):
-                project_to_schedule_pending_jobs_count[project_name].append(
-                    schedule_name
-                )
+            project_name, schedule_name, kind = result
+            if kind == mlrun_constants.MLRunInternalLabels.workflow:
+                project_to_schedule_pending_workflows_count[project_name] += 1
+            elif kind == mlrun.common.schemas.ScheduleKinds.job.value:
+                project_to_schedule_pending_jobs_count[project_name] += 1
 
         return (
             project_to_schedule_count,
-            collections.defaultdict(
-                int,
-                {
-                    key: len(value)
-                    for key, value in project_to_schedule_pending_jobs_count.items()
-                },
-            ),
-            collections.defaultdict(
-                int,
-                {
-                    key: len(value)
-                    for key, value in project_to_schedule_pending_workflows_count.items()
-                },
-            ),
+            project_to_schedule_pending_jobs_count,
+            project_to_schedule_pending_workflows_count,
         )
 
     @staticmethod

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2904,7 +2904,7 @@ class SQLDB(DBInterface):
             project_name, schedule_name, kind = result
             if kind == mlrun_constants.MLRunInternalLabels.workflow:
                 project_to_schedule_pending_workflows_count[project_name] += 1
-            elif kind == mlrun.common.schemas.ScheduleKinds.job.value:
+            elif kind == mlrun.common.schemas.ScheduleKinds.job:
                 project_to_schedule_pending_jobs_count[project_name] += 1
 
         return (

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2886,14 +2886,20 @@ class SQLDB(DBInterface):
 
         return (
             project_to_schedule_count,
-            {
-                key: len(value)
-                for key, value in project_to_schedule_pending_jobs_count.items()
-            },
-            {
-                key: len(value)
-                for key, value in project_to_schedule_pending_workflows_count.items()
-            },
+            collections.defaultdict(
+                int,
+                {
+                    key: len(value)
+                    for key, value in project_to_schedule_pending_jobs_count.items()
+                },
+            ),
+            collections.defaultdict(
+                int,
+                {
+                    key: len(value)
+                    for key, value in project_to_schedule_pending_workflows_count.items()
+                },
+            ),
         )
 
     @staticmethod

--- a/tests/api/db/test_schedule.py
+++ b/tests/api/db/test_schedule.py
@@ -110,5 +110,5 @@ def test_calculate_schedules_counters(db: DBInterface, db_session: Session):
     assert counters == (
         {"project1": 1, "project2": 3},  # total schedule count per project
         {"project1": 1},  # pending jobs count per project
-        {"project2": 3, "project1": 0},
+        {"project2": 3},
     )  # pending pipelines count per project

--- a/tests/api/db/test_schedule.py
+++ b/tests/api/db/test_schedule.py
@@ -84,7 +84,9 @@ def test_calculate_schedules_counters(db: DBInterface, db_session: Session):
         db_session,
         project="project1",
         name="job1",
-        labels={mlrun_constants.MLRunInternalLabels.kind: "job"},
+        labels={
+            mlrun_constants.MLRunInternalLabels.kind: mlrun.runtimes.RuntimeKinds.job
+        },
         kind=mlrun.common.schemas.ScheduleKinds.job,
         cron_trigger=mlrun.common.schemas.ScheduleCronTrigger(minute=10),
         next_run_time=next_minute,
@@ -98,7 +100,7 @@ def test_calculate_schedules_counters(db: DBInterface, db_session: Session):
             project="project2",
             name=name,
             labels={
-                mlrun_constants.MLRunInternalLabels.kind: "job",
+                mlrun_constants.MLRunInternalLabels.kind: mlrun.runtimes.RuntimeKinds.job,
                 mlrun_constants.MLRunInternalLabels.workflow: name,
             },
             kind=mlrun.common.schemas.ScheduleKinds.job,

--- a/tests/api/db/test_schedule.py
+++ b/tests/api/db/test_schedule.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from datetime import datetime, timedelta, timezone
+
 from sqlalchemy.orm import Session
 
+import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 from server.api.db.base import DBInterface
+from server.api.db.sqldb.db import SQLDB
 from server.api.db.sqldb.models import Schedule
 
 
@@ -68,6 +72,43 @@ def test_delete_schedules(db: DBInterface, db_session: Session):
         cron_trigger=mlrun.common.schemas.ScheduleCronTrigger(minute=10),
     )
     db.delete_schedules(db_session, "*", names=names[:2])
-
     assert db_session.query(Schedule.Label).count() == 3
     assert db_session.query(Schedule).count() == 3
+
+
+def test_calculate_schedules_counters(db: DBInterface, db_session: Session):
+    next_minute = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    # Store schedule job
+    db.store_schedule(
+        db_session,
+        project="project1",
+        name="job1",
+        labels={mlrun_constants.MLRunInternalLabels.kind: "job"},
+        kind=mlrun.common.schemas.ScheduleKinds.job,
+        cron_trigger=mlrun.common.schemas.ScheduleCronTrigger(minute=10),
+        next_run_time=next_minute,
+    )
+
+    pipelines_name = ["some_name", "some_name2", "some_name3"]
+    for name in pipelines_name:
+        # Store schedule pipeline
+        db.store_schedule(
+            db_session,
+            project="project2",
+            name=name,
+            labels={
+                mlrun_constants.MLRunInternalLabels.kind: "job",
+                mlrun_constants.MLRunInternalLabels.workflow: name,
+            },
+            kind=mlrun.common.schemas.ScheduleKinds.job,
+            cron_trigger=mlrun.common.schemas.ScheduleCronTrigger(minute=10),
+            next_run_time=next_minute,
+        )
+
+    counters = SQLDB._calculate_schedules_counters(db_session)
+    assert counters == (
+        {"project1": 1, "project2": 3},  # total schedule count per project
+        {"project1": 1},  # pending jobs count per project
+        {"project2": 3, "project1": 0},
+    )  # pending pipelines count per project


### PR DESCRIPTION
Fixing bug on project summaries schedule jobs count.
To determine if schedule object is jobs/workflow we check its labels:

1. Schedule workflow will have label with name `workflow` and value of the name of the workflow, but also will have label with name `kind` and value `job`.
2. Schedule job will have  label with name `kind` and value `job`.

On the first implementation we count twice schedule workflow, one as workflow (because the name of the label is workflow), and another time as a schedule job - which is wrong.

Fixing it by first creating list of scheduled pipelines per project and only then iterate over schedules and add the schedule only if it not workflow.

for more details see my [comment](https://iguazio.atlassian.net/browse/ML-7875?focusedCommentId=158377).

https://iguazio.atlassian.net/browse/ML-7875