### PR TITLE
[Project] Terminate pipelines before deleting pods on delete job [1.7.x]

### DIFF
--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -168,6 +168,13 @@ class Projects(
             skip_notification_secrets=True,
         )
 
+        # Same for pipelines - delete the runs so that the pipelines will stop creating pods
+        if mlrun.mlconf.kfp_url:
+            logger.debug("Removing KFP pipelines project resources", project_name=name)
+            server.api.crud.pipelines.Pipelines().delete_pipelines_runs(
+                db_session=session, project_name=name
+            )
+
         logger.debug(
             "Deleting project runtime resources",
             project_name=name,
@@ -180,11 +187,6 @@ class Projects(
             # immediate deletion of resources
             grace_period=0,
         )
-        if mlrun.mlconf.kfp_url:
-            logger.debug("Removing KFP pipelines project resources", project_name=name)
-            server.api.crud.pipelines.Pipelines().delete_pipelines_runs(
-                db_session=session, project_name=name
-            )
 
         # log collector service will delete the logs, so we don't need to do it here
         if (


### PR DESCRIPTION
We see pods being created during the delete job which interferes with the project delete job.
This will terminate the pipelines before starting to delete pods.

https://iguazio.atlassian.net/browse/ML-7786