### PR TITLE
[Schedule] Synchronize labels on upgrade

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2278,6 +2278,7 @@ class SQLDB(DBInterface):
         name: str = None,
         labels: list[str] = None,
         kind: mlrun.common.schemas.ScheduleKinds = None,
+        as_records: bool = False,
     ) -> list[mlrun.common.schemas.ScheduleRecord]:
         logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
         query = self._query(session, Schedule, kind=kind)
@@ -2287,6 +2288,9 @@ class SQLDB(DBInterface):
             query = query.filter(generate_query_predicate_for_name(Schedule.name, name))
         labels = label_set(labels)
         query = self._add_labels_filter(session, query, Schedule, labels)
+
+        if as_records:
+            return query
 
         schedules = [
             self._transform_schedule_record_to_scheme(db_schedule)
@@ -2336,6 +2340,27 @@ class SQLDB(DBInterface):
             main_table_identifier=Schedule.name,
             main_table_identifier_values=names,
         )
+
+    def align_schedule_labels(self, session: Session):
+        schedules_update = []
+        for db_schedule in self.list_schedules(session=session, as_records=True):
+            schedule_record = self._transform_schedule_record_to_scheme(db_schedule)
+            db_schedule_labels = {
+                label.name: label.value for label in db_schedule.labels
+            }
+            merged_labels = (
+                server.api.utils.helpers.merge_schedule_and_schedule_object_labels(
+                    labels=db_schedule_labels,
+                    scheduled_object=schedule_record.scheduled_object,
+                )
+            )
+            self._update_schedule_body(
+                schedule=db_schedule,
+                scheduled_object=schedule_record.scheduled_object,
+                labels=merged_labels,
+            )
+            schedules_update.append(db_schedule)
+        self._upsert(session, schedules_update)
 
     @staticmethod
     def _delete_multi_objects(

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -240,11 +240,6 @@ def test_create_project_summaries():
 def test_align_schedule_labels():
     db, db_session = _initialize_db_without_migrations()
 
-    # Create a project
-    project = mlrun.common.schemas.Project(
-        metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
-    )
-
     # Create a schedule
     db.create_schedule(
         session=db_session,
@@ -257,13 +252,13 @@ def test_align_schedule_labels():
         labels={"label2": "value2"},
     )
 
-    with unittest.mock.patch.object(db, "_append_project_summary"):
-        db.create_project(db_session, project)
-
+    # Align schedule.labels and schedule.scheduled_object.task.metadata.labels
     server.api.initial_data._align_schedule_labels(db, db_session)
 
+    # Get updated schedules
     migrated_schedules = db.list_schedules(db_session)
 
+    # Convert list[LabelRecord] to dict
     migrated_schedules_dict = {
         label.name: label.value for label in migrated_schedules[0].labels
     }

--- a/tests/api/utils/test_scheduler.py
+++ b/tests/api/utils/test_scheduler.py
@@ -33,6 +33,7 @@ import mlrun.launcher.factory
 import server.api.crud
 import server.api.utils.auth
 import server.api.utils.auth.verifier
+import server.api.utils.helpers
 import server.api.utils.singletons.project_member
 import tests.api.conftest
 from mlrun.common.runtimes.constants import RunStates
@@ -1528,7 +1529,7 @@ def test_store_schedule(db: Session, scheduler: Scheduler):
 def test_merge_schedule_and_schedule_object_labels(
     scheduler, labels, scheduled_object, expected
 ):
-    result = scheduler._merge_schedule_and_schedule_object_labels(
+    result = server.api.utils.helpers.merge_schedule_and_schedule_object_labels(
         labels,
         scheduled_object,
     )
@@ -1676,7 +1677,7 @@ def test_merge_schedule_and_db_schedule_labels(
     db_schedule.scheduled_object = db_scheduled_object
 
     result_labels, result_scheduled_object = (
-        scheduler._merge_schedule_and_db_schedule_labels(
+        server.api.utils.helpers.merge_schedule_and_db_schedule_labels(
             labels,
             scheduled_object,
             db_schedule,


### PR DESCRIPTION
After implementing [ML-7349](https://iguazio.atlassian.net/browse/ML-7349), which aligns the labels in schedules and schedule objects, we need to account for objects created prior to this change. To address this, a new data migration (version 8) has been added. This migration retrieves all schedules from the database and aligns their labels accordingly.

Jira - https://iguazio.atlassian.net/browse/ML-7914

[ML-7349]: https://iguazio.atlassian.net/browse/ML-7349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ