### PR TITLE
[Tutorials] Fix `scikit-learn` version in installation commands [1.7.x]

### DIFF
--- a/docs/tutorials/01-mlrun-basics.ipynb
+++ b/docs/tutorials/01-mlrun-basics.ipynb
@@ -1362,7 +1362,7 @@
     "    name=\"serving\",\n",
     "    image=\"mlrun/mlrun\",\n",
     "    kind=\"serving\",\n",
-    "    requirements=[\"scikit-learn~=1.4.0\"],\n",
+    "    requirements=[\"scikit-learn~=1.5.1\"],\n",
     ")"
    ]
   },

--- a/docs/tutorials/01-mlrun-basics.ipynb
+++ b/docs/tutorials/01-mlrun-basics.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "**Before you start, make sure the MLRun client package is installed and configured properly:**\n",
     "\n",
-    "This notebook uses sklearn and numpy. If it is not installed in your environment run `!pip install scikit-learn~=1.4.0 numpy~=1.26`."
+    "This notebook uses `sklearn`. If it is not installed in your environment, run `!pip install scikit-learn~=1.5.1`."
    ]
   },
   {
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "# Install MLRun and sklearn, run this only once (restart the notebook after the install !!!)\n",
-    "%pip install mlrun scikit-learn~=1.4.0 numpy~=1.26"
+    "%pip install mlrun scikit-learn~=1.5.1"
    ]
   },
   {

--- a/docs/tutorials/mlflow.ipynb
+++ b/docs/tutorials/mlflow.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "# Install MLRun and scikit-learn if not already installed. Run this only once. Restart the notebook after the install!\n",
-    "%pip install mlrun scikit-learn~=1.4.0 xgboost~=2.0.3"
+    "%pip install mlrun scikit-learn~=1.5.1 xgboost~=2.0.3"
    ]
   },
   {

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -21,6 +21,7 @@ import subprocess
 import unittest.mock
 
 import deepdiff
+import pytest
 import setuptools
 
 import tests.conftest
@@ -324,6 +325,13 @@ def _is_ignored_requirement_line(line):
     return (not line) or (line[0] == "#")
 
 
+@pytest.mark.skipif(
+    subprocess.run(["git", "rev-parse", "--is-inside-work-tree"], capture_output=True)
+    .stdout.decode()
+    .strip()
+    != "true",
+    reason="Not inside a Git repository",  # e.g. in a Docker image, as happens in the CI
+)
 def test_scikit_learn_requirements_are_aligned() -> None:
     """
     We mention `pip install scikit-learn~=x.y.z` many times in the tutorials and

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import builtins
 import collections
 import json
 import pathlib
 import re
+import subprocess
 import unittest.mock
 
 import deepdiff
@@ -321,3 +322,36 @@ def _load_requirements(path):
 def _is_ignored_requirement_line(line):
     line = line.strip()
     return (not line) or (line[0] == "#")
+
+
+def test_scikit_learn_requirements_are_aligned() -> None:
+    """
+    We mention `pip install scikit-learn~=x.y.z` many times in the tutorials and
+    in the Docker `requirements.txt` files, check it by running:
+    git grep -n "scikit-learn.="
+
+    This test makes sure all these versions are aligned by catching deviating version specifications.
+    """
+    scikit_learn_version = "1.5.1"
+
+    escaped_version = re.escape(scikit_learn_version)
+    pattern = (
+        f"scikit-learn.=(?!{escaped_version})[0-9\\.]*"  # match only other versions
+    )
+
+    ignored_files = [
+        "tests/test_requirements.py",  # this test file
+        "docs/change-log/index.md",  # a historic document
+        "docs/genai/development/working-with-rag.ipynb",  # includes a generated requirement
+    ]
+    pathspec = [f":!{file}" for file in ignored_files]
+
+    output = subprocess.run(
+        ["git", "grep", "--line-number", "--perl-regexp", pattern, "--", *pathspec],
+        capture_output=True,
+    )
+    no_matches = output.returncode == 1
+    assert no_matches, (
+        "The following files include a scikit-learn requirement which is not aligned "
+        f"to version {scikit_learn_version}:\n{output.stdout.decode()}"
+    )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -353,5 +353,7 @@ def test_scikit_learn_requirements_are_aligned() -> None:
     no_matches = output.returncode == 1
     assert no_matches, (
         "The following files include a scikit-learn requirement which is not aligned "
-        f"to version {scikit_learn_version}:\n{output.stdout.decode()}"
+        f"to version {scikit_learn_version}:\n{output.stdout.decode()}\n"
+        f"returncode: {output.returncode}\n"
+        f"stderr:\n{output.stderr.decode()}"
     )


### PR DESCRIPTION
Fixes [ML-7716](https://iguazio.atlassian.net/browse/ML-7716).
In `docs/tutorials/01-mlrun-basics.ipynb`:

* Align the `scikit-learn` version
* Remove the `numpy` installation, as it's included with `mlrun`: https://github.com/mlrun/mlrun/blob/efce6df76e301a94049bc8cd8eb236302c3193ec/requirements.txt#L10 And not even used in this tutorial.

Add a test with [`git grep`](https://git-scm.com/docs/git-grep) to catch all occurrences and ensure alignment.

[ML-7716]: https://iguazio.atlassian.net/browse/ML-7716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ