### PR TITLE
[Tutorials] Revert Serving Tutorial to `new_function`

### DIFF
--- a/docs/tutorials/03-model-serving.ipynb
+++ b/docs/tutorials/03-model-serving.ipynb
@@ -187,7 +187,7 @@
     "> If you want to add specific packages to the base image, specify the `requirements` attribute, example:\n",
     "> \n",
     "> ```python\n",
-    "> serving_fn = project.set_function(name=\"serving\", image=image, kind=\"serving\", requirements=[\"tensorflow==2.8.1\"])\n",
+    "> serving_fn = mlrun.new_function(name=\"serving\", image=image, kind=\"serving\", requirements=[\"tensorflow==2.8.1\"])\n",
     "> ```\n",
     "\n",
     "The following example uses a basic topology of a model `router` and adds a single model behind it. (You can add multiple models to the same function.)"
@@ -256,7 +256,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "serving_fn = project.set_function(\n",
+    "serving_fn = mlrun.new_function(\n",
     "    name=\"serving\", image=image, kind=\"serving\", requirements=requirements\n",
     ")\n",
     "serving_fn.add_model(\n",


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-7928

Reverts change from https://github.com/mlrun/mlrun/pull/6235

When using `set_function` without supplying code or a handler, the method will attempt to load the entire notebook as the function code. This means that once the `mock_to_server` tries to run the function locally, it runs the notebook, which runs `mock_to_server` - until infinite recursion.

Using `new_function` with the following `add_model` doesn't try to load the notebook as code.

The real solution is to facilitate the model serving within `set_function`, but reverting for now until we fix it, so the tutorial works.