### PR TITLE
[Background Task] Reverting the check for resource permissions on background tasks [1.7.x]

### DIFF
--- a/server/api/api/endpoints/background_tasks.py
+++ b/server/api/api/endpoints/background_tasks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import datetime
 import typing
 
@@ -199,14 +200,20 @@ async def _authorize_get_background_task_request(
     background_task: mlrun.common.schemas.BackgroundTask,
     auth_info: mlrun.common.schemas.AuthInfo,
 ):
+    return await asyncio.sleep(1)
+
+    # TODO: Check resource permissions for background tasks. We need to ensure that the user can read the project
+    # when attempting to access the background task. It appears that when a project is deleted, its associated
+    # policies are also removed, leading to "access denied" errors for users trying to access the background task.
+
     # Iguazio manifest doesn't support the global background task resource yet - therefore if the background task has a
     # project (e.g. delete project), we can authorize on the project
-    if background_task.metadata.project:
-        return await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
-            background_task.metadata.project,
-            mlrun.common.schemas.AuthorizationAction.read,
-            auth_info,
-        )
+    # if background_task.metadata.project:
+    #     return await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+    #         background_task.metadata.project,
+    #         mlrun.common.schemas.AuthorizationAction.read,
+    #         auth_info,
+    #     )
 
     # If there is no project we have to just omit authorization until iguazio supports it
     # igz_version = mlrun.mlconf.get_parsed_igz_version()

--- a/server/api/api/endpoints/background_tasks.py
+++ b/server/api/api/endpoints/background_tasks.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
 import datetime
 import typing
 
@@ -200,13 +199,13 @@ async def _authorize_get_background_task_request(
     background_task: mlrun.common.schemas.BackgroundTask,
     auth_info: mlrun.common.schemas.AuthInfo,
 ):
-    return await asyncio.sleep(1)
+    return
 
     # TODO: Check resource permissions for background tasks. We need to ensure that the user can read the project
     # when attempting to access the background task. It appears that when a project is deleted, its associated
     # policies are also removed, leading to "access denied" errors for users trying to access the background task.
     # Related to ML-7484
-    # Enable the test `test_get_internal_background_task_auth` once this is resolved.
+    # Change the test `test_get_internal_background_task_auth` once this is resolved.
 
     # Iguazio manifest doesn't support the global background task resource yet - therefore if the background task has a
     # project (e.g. delete project), we can authorize on the project

--- a/server/api/api/endpoints/background_tasks.py
+++ b/server/api/api/endpoints/background_tasks.py
@@ -205,6 +205,8 @@ async def _authorize_get_background_task_request(
     # TODO: Check resource permissions for background tasks. We need to ensure that the user can read the project
     # when attempting to access the background task. It appears that when a project is deleted, its associated
     # policies are also removed, leading to "access denied" errors for users trying to access the background task.
+    # Related to ML-7484
+    # Enable the test `test_get_internal_background_task_auth` once this is resolved.
 
     # Iguazio manifest doesn't support the global background task resource yet - therefore if the background task has a
     # project (e.g. delete project), we can authorize on the project

--- a/tests/api/api/test_background_tasks.py
+++ b/tests/api/api/test_background_tasks.py
@@ -296,34 +296,35 @@ def test_get_project_background_task_not_exists(
     assert response.status_code == http.HTTPStatus.NOT_FOUND.value
 
 
-def test_get_internal_background_task_auth(
-    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-):
-    server.api.utils.auth.verifier.AuthVerifier().query_project_permissions = (
-        unittest.mock.AsyncMock()
-    )
-    response = client.post("/test/internal-background-tasks?project=my-proj")
-    assert response.status_code == http.HTTPStatus.OK.value
-    background_task = mlrun.common.schemas.BackgroundTask(**response.json())
-    response = client.get(
-        f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks/{background_task.metadata.name}"
-    )
-    assert response.status_code == http.HTTPStatus.OK.value
-    assert (
-        server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
-        == 1
-    )
-
-    # Create another task without a project should skip authz
-    response = client.post("/test/internal-background-tasks")
-    assert response.status_code == http.HTTPStatus.OK.value
-
-    response = client.get(f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks")
-    assert response.status_code == http.HTTPStatus.OK.value
-    assert (
-        server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
-        == 1
-    )
+# TODO: Enable this test after checking resource permissions for background tasks.
+# def test_get_internal_background_task_auth(
+#     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+# ):
+#     server.api.utils.auth.verifier.AuthVerifier().query_project_permissions = (
+#         unittest.mock.AsyncMock()
+#     )
+#     response = client.post("/test/internal-background-tasks?project=my-proj")
+#     assert response.status_code == http.HTTPStatus.OK.value
+#     background_task = mlrun.common.schemas.BackgroundTask(**response.json())
+#     response = client.get(
+#         f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks/{background_task.metadata.name}"
+#     )
+#     assert response.status_code == http.HTTPStatus.OK.value
+#     assert (
+#         server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
+#         == 1
+#     )
+#
+#     # Create another task without a project should skip authz
+#     response = client.post("/test/internal-background-tasks")
+#     assert response.status_code == http.HTTPStatus.OK.value
+#
+#     response = client.get(f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks")
+#     assert response.status_code == http.HTTPStatus.OK.value
+#     assert (
+#         server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
+#         == 1
+#     )
 
 
 def test_get_internal_background_task_redirect_from_worker_to_chief_exists(

--- a/tests/api/api/test_background_tasks.py
+++ b/tests/api/api/test_background_tasks.py
@@ -296,35 +296,34 @@ def test_get_project_background_task_not_exists(
     assert response.status_code == http.HTTPStatus.NOT_FOUND.value
 
 
-# TODO: Enable this test after checking resource permissions for background tasks.
-# def test_get_internal_background_task_auth(
-#     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
-# ):
-#     server.api.utils.auth.verifier.AuthVerifier().query_project_permissions = (
-#         unittest.mock.AsyncMock()
-#     )
-#     response = client.post("/test/internal-background-tasks?project=my-proj")
-#     assert response.status_code == http.HTTPStatus.OK.value
-#     background_task = mlrun.common.schemas.BackgroundTask(**response.json())
-#     response = client.get(
-#         f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks/{background_task.metadata.name}"
-#     )
-#     assert response.status_code == http.HTTPStatus.OK.value
-#     assert (
-#         server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
-#         == 1
-#     )
-#
-#     # Create another task without a project should skip authz
-#     response = client.post("/test/internal-background-tasks")
-#     assert response.status_code == http.HTTPStatus.OK.value
-#
-#     response = client.get(f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks")
-#     assert response.status_code == http.HTTPStatus.OK.value
-#     assert (
-#         server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
-#         == 1
-#     )
+def test_get_internal_background_task_auth(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+):
+    server.api.utils.auth.verifier.AuthVerifier().query_project_permissions = (
+        unittest.mock.AsyncMock()
+    )
+    response = client.post("/test/internal-background-tasks?project=my-proj")
+    assert response.status_code == http.HTTPStatus.OK.value
+    background_task = mlrun.common.schemas.BackgroundTask(**response.json())
+    response = client.get(
+        f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks/{background_task.metadata.name}"
+    )
+    assert response.status_code == http.HTTPStatus.OK.value
+    assert (
+        server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
+        == 0
+    )
+
+    # Create another task without a project should skip authz
+    response = client.post("/test/internal-background-tasks")
+    assert response.status_code == http.HTTPStatus.OK.value
+
+    response = client.get(f"{ORIGINAL_VERSIONED_API_PREFIX}/background-tasks")
+    assert response.status_code == http.HTTPStatus.OK.value
+    assert (
+        server.api.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
+        == 0
+    )
 
 
 def test_get_internal_background_task_redirect_from_worker_to_chief_exists(


### PR DESCRIPTION
When a project is deleted, its associated policies are also removed, leading to "access denied" errors for users trying to access the background task. 
https://iguazio.atlassian.net/browse/ML-7951

related issue 
https://iguazio.atlassian.net/browse/ML-7484
