### PR TITLE
[Config] reload config in set_environment

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -136,15 +136,16 @@ def set_environment(
     if not mlconf.dbpath:
         raise ValueError("DB/API path was not detected, please specify its address")
 
-    if mock_functions is not None:
-        mock_functions = "1" if mock_functions is True else mock_functions
-        mlconf.force_run_local = mock_functions
-        mlconf.mock_nuclio_deployment = mock_functions
-
     # check connectivity and load remote defaults
     get_run_db()
     if api_path:
         environ["MLRUN_DBPATH"] = mlconf.dbpath
+    mlconf.reload()
+
+    if mock_functions is not None:
+        mock_functions = "1" if mock_functions is True else mock_functions
+        mlconf.force_run_local = mock_functions
+        mlconf.mock_nuclio_deployment = mock_functions
 
     if not mlconf.artifact_path and not artifact_path:
         raise ValueError(
@@ -159,7 +160,7 @@ def set_environment(
                 "artifact_path must refer to an absolute path" " or a valid url"
             )
         mlconf.artifact_path = artifact_path
-    mlconf.reload()
+
     return mlconf.default_project, mlconf.artifact_path
 
 

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -159,6 +159,7 @@ def set_environment(
                 "artifact_path must refer to an absolute path" " or a valid url"
             )
         mlconf.artifact_path = artifact_path
+    mlconf.reload()
     return mlconf.default_project, mlconf.artifact_path
 
 


### PR DESCRIPTION
In order to populate environment variables, such as `V3IO_API` and `V3IO_FRAMESD` ,
we need to use `read_env` method.

In this method we create environment variables from the MLRun dbpath, if not exists.
In general, we should use our configuration logic instead of relying solely on manual environment variable settings.


[ML-7491](https://iguazio.atlassian.net/browse/ML-7491)

[ML-7491]: https://iguazio.atlassian.net/browse/ML-7491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ