### PR TITLE
[Model Monitoring] Enhance exception handling when deleting stream resources

### DIFF
--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -874,8 +874,10 @@ class MonitoringDeployment:
                 # waiting for the function pod to be deleted
                 # max 10 retries (5 sec sleep between each retry)
                 try:
-                    function_pod = server.api.utils.singletons.k8s.get_k8s_helper().list_pods(
-                        selector=f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={project}-{function_name}"
+                    function_pod = (
+                        server.api.utils.singletons.k8s.get_k8s_helper().list_pods(
+                            selector=label_selector
+                        )
                     )
                 except Exception as exc:
                     raise mlrun.errors.MLRunStreamConnectionFailureError(

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -861,13 +861,26 @@ class MonitoringDeployment:
         )
         stream_paths = []
         for function_name in function_names:
+            label_selector = f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={project}-{function_name}"
+            if len(label_selector) > 63:
+                logger.warning(
+                    "k8s label character limit exceeded, skipping deletion of stream resources",
+                    project_name=project,
+                    function=function_name,
+                    label_selector=label_selector,
+                )
+                continue
             for i in range(10):
                 # waiting for the function pod to be deleted
                 # max 10 retries (5 sec sleep between each retry)
-
-                function_pod = server.api.utils.singletons.k8s.get_k8s_helper().list_pods(
-                    selector=f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={project}-{function_name}"
-                )
+                try:
+                    function_pod = server.api.utils.singletons.k8s.get_k8s_helper().list_pods(
+                        selector=f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={project}-{function_name}"
+                    )
+                except Exception as exc:
+                    raise mlrun.errors.MLRunStreamConnectionFailureError(
+                        f"Failed to list pods for function {function_name}"
+                    ) from exc
                 if not function_pod:
                     logger.debug(
                         "No function pod found for project, deleting stream",

--- a/server/api/crud/model_monitoring/deployment.py
+++ b/server/api/crud/model_monitoring/deployment.py
@@ -863,12 +863,7 @@ class MonitoringDeployment:
         for function_name in function_names:
             label_selector = f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={project}-{function_name}"
             if len(label_selector) > 63:
-                logger.warning(
-                    "k8s label character limit exceeded, skipping deletion of stream resources",
-                    project_name=project,
-                    function=function_name,
-                    label_selector=label_selector,
-                )
+                # k8s label character limit exceeded, skipping deletion of stream resources"
                 continue
             for i in range(10):
                 # waiting for the function pod to be deleted


### PR DESCRIPTION
Fix an issue where an error during the `list_pods` API call in the process of deleting model monitoring stream resources could cause the entire delete project API to fail. 
To address this, we should catch the error and ensure the project deletion proceeds regardless. Additionally, if the error is due to exceeding the k8s function name length limit, skip the deletion of the corresponding resource.

JIRA - https://iguazio.atlassian.net/browse/ML-7970