### PR TITLE
[Datastore] Timestamp as a timezone-aware pandas datetime.

### DIFF
--- a/mlrun/data_types/data_types.py
+++ b/mlrun/data_types/data_types.py
@@ -144,7 +144,7 @@ def gbq_to_pandas_dtype(gbq_type):
         "BOOL": "bool",
         "FLOAT": "float64",
         "INTEGER": pd.Int64Dtype(),
-        "TIMESTAMP": "datetime64[ns]",
+        "TIMESTAMP": "datetime64[ns, UTC]",
     }
     return type_map.get(gbq_type, "object")
 


### PR DESCRIPTION
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type

The TIMESTAMP data type in BigQuery represents an absolute point in time. When querying it, we should use timezone-aware datetime objects, preferably in UTC.

[ML-7630](https://iguazio.atlassian.net/browse/ML-7630)

[ML-7630]: https://iguazio.atlassian.net/browse/ML-7630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ