### PR TITLE
[Notifications] Resolve notification params from the db

### DIFF
--- a/mlrun/common/formatters/run.py
+++ b/mlrun/common/formatters/run.py
@@ -22,5 +22,8 @@ class RunFormat(ObjectFormat, mlrun.common.types.StrEnum):
     # No enrichment, data is pulled as-is from the database.
     standard = "standard"
 
+    # Performs run enrichment, including the run's artifacts..
+    notifications = "notifications"
+
     # Performs run enrichment, including the run's artifacts. Only available for the `get` run API.
     full = "full"

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -25,6 +25,7 @@ import mlrun_pipelines.patcher
 import mlrun_pipelines.utils
 
 import mlrun
+import mlrun.common.formatters
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.utils.notifications
@@ -1062,10 +1063,18 @@ def load_and_run(
         return
 
     # extract "start" notification if exists
+    run_db = mlrun.get_run_db()
+
+    # Here we want to get the run object with the notifications because we want to also get the notifications params
+    # (the context.get_notifications() doesn't include notifications params,
+    # see https://github.com/mlrun/mlrun/pull/4334/files)
+    run = run_db.read_run(
+        context.uid, format_=mlrun.common.formatters.RunFormat.notifications
+    )
     start_notifications = [
-        notification
-        for notification in context.get_notifications()
-        if "running" in notification.when
+        mlrun.model.Notification.from_dict(notification)
+        for notification in run["spec"]["notifications"]
+        if "running" in notification["when"]
     ]
 
     workflow_log_message = workflow_name or workflow_path

--- a/server/api/crud/runs.py
+++ b/server/api/crud/runs.py
@@ -125,7 +125,15 @@ class Runs(
     ) -> dict:
         project = project or mlrun.mlconf.default_project
         run = server.api.utils.singletons.db.get_db().read_run(
-            db_session, uid, project, iter
+            db_session,
+            uid,
+            project,
+            iter,
+            with_notifications=format_
+            in [
+                mlrun.common.formatters.RunFormat.notifications,
+                mlrun.common.formatters.RunFormat.full,
+            ],
         )
 
         if format_ == mlrun.common.formatters.RunFormat.full:

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -85,7 +85,7 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def read_run(self, session, uid, project="", iter=0):
+    def read_run(self, session, uid, project="", iter=0, with_notifications=False):
         pass
 
     @abstractmethod

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -41,6 +41,7 @@ import mlrun.common.types
 import mlrun.errors
 import mlrun.k8s_utils
 import mlrun.model
+import server.api.crud
 import server.api.db.session
 import server.api.utils.helpers
 from mlrun.artifacts.base import fill_artifact_object_hash
@@ -335,14 +336,18 @@ class SQLDB(DBInterface):
         )
         session.commit()
 
-    def read_run(self, session, uid, project=None, iter=0):
+    def read_run(self, session, uid, project=None, iter=0, with_notifications=False):
         project = project or config.default_project
         run = self._get_run(session, uid, project, iter)
         if not run:
             raise mlrun.errors.MLRunNotFoundError(
                 f"Run uid {uid} of project {project} not found"
             )
-        return run.struct
+
+        run_struct = run.struct
+        if with_notifications:
+            self._fill_run_struct_with_notifications(run.notifications, run_struct)
+        return run_struct
 
     def list_runs(
         self,
@@ -425,22 +430,23 @@ class SQLDB(DBInterface):
         for run in query:
             run_struct = run.struct
             if with_notifications:
-                run_struct.setdefault("spec", {}).setdefault("notifications", [])
-                run_struct.setdefault("status", {}).setdefault("notifications", {})
-                for notification in run.notifications:
-                    (
-                        notification_spec,
-                        notification_status,
-                    ) = self._transform_notification_record_to_spec_and_status(
-                        notification
-                    )
-                    run_struct["spec"]["notifications"].append(notification_spec)
-                    run_struct["status"]["notifications"][notification.name] = (
-                        notification_status
-                    )
+                self._fill_run_struct_with_notifications(run.notifications, run_struct)
             runs.append(run_struct)
 
         return runs
+
+    def _fill_run_struct_with_notifications(self, notifications, run_struct):
+        run_struct.setdefault("spec", {})["notifications"] = []
+        run_struct.setdefault("status", {})["notifications"] = {}
+        for notification in notifications:
+            (
+                notification_spec,
+                notification_status,
+            ) = self._transform_notification_record_to_spec_and_status(notification)
+            run_struct["spec"]["notifications"].append(notification_spec)
+            run_struct["status"]["notifications"][notification.name] = (
+                notification_status
+            )
 
     def del_run(self, session, uid, project=None, iter=0):
         project = project or config.default_project
@@ -4539,8 +4545,18 @@ class SQLDB(DBInterface):
         query = self._query(session, cls, name=name, project=project, uid=uid)
         return query.one_or_none()
 
-    def _get_run(self, session, uid, project, iteration, with_for_update=False):
+    def _get_run(
+        self,
+        session,
+        uid,
+        project,
+        iteration,
+        with_for_update=False,
+        with_notifications=False,
+    ):
         query = self._query(session, Run, uid=uid, project=project, iteration=iteration)
+        if with_notifications:
+            query = query.join(Run.Notification)
         if with_for_update:
             query = query.populate_existing().with_for_update()
 

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -769,6 +769,69 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
             # run 2 should still have artifact uris even if the producer id is different
             assert "artifact_uris" in run_2["status"]
 
+    def test_get_run_notifications_format(self, db: sqlalchemy.orm.Session):
+        project = "project-name"
+        run_uid = str(uuid.uuid4())
+        notifications = self._generate_notifications()
+
+        server.api.crud.Runs().store_run(
+            db,
+            {
+                "metadata": {
+                    "name": "run-name",
+                    "uid": run_uid,
+                    "labels": {mlrun_constants.MLRunInternalLabels.kind: "job"},
+                },
+            },
+            run_uid,
+            project=project,
+        )
+
+        server.api.crud.Notifications().store_run_notifications(
+            session=db,
+            notification_objects=notifications,
+            run_uid=run_uid,
+            project=project,
+        )
+
+        run = server.api.crud.Runs().get_run(
+            db,
+            run_uid,
+            0,
+            project,
+            format_=mlrun.common.formatters.RunFormat.notifications,
+        )
+
+        assert "notifications" in run["status"]
+        assert "notifications" in run["spec"]
+        for notification in run["spec"]["notifications"]:
+            assert "params" in notification
+
+    @staticmethod
+    def _generate_notifications(
+        notifications_len=2,
+    ):
+        notifications = []
+        i = 0
+        while len(notifications) < notifications_len:
+            notification = {
+                "kind": "webhook",
+                "condition": "",
+                "severity": "verbose",
+                "params": {
+                    "url": "https://webhook.site/3c81ac80-1767-490f-bda3-a241fae47f43",
+                    "method": "POST",
+                    "verify_ssl": True,
+                },
+                "name": str(uuid.uuid4()),
+                "when": ["completed", "error", "running"],
+                "message": "Check1",
+            }
+            notification = mlrun.model.Notification.from_dict(notification)
+            notifications.append(notification)
+            i += 1
+        return notifications
+
     @staticmethod
     def _generate_artifacts(
         project,


### PR DESCRIPTION
On this [pr](https://github.com/mlrun/mlrun/pull/4334/files) we exclude notifications params.
Because of that, the `workflow-runner` pod which should send the `start running` notification didn't send the starting message (the notifications on `MLRUN_EXEC_CONFIG` didn't include the params as I mentioned above).
Here we introduce solution to this problem by getting the notifications from the api (with new `RunFormat.notifications`) which should contains also the params that is missing.

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/3e7a0d2a-966e-4cf4-9f90-e5aacabf011c">

https://iguazio.atlassian.net/browse/ML-6644