### PR TITLE
[Images] Fix mlrun/mlrun conda solver [1.7.x]

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -55,10 +55,6 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
 
 ENV PATH /opt/conda/bin:$PATH
 
-RUN conda install -y -n base conda-libmamba-solver && \
-    conda config --set solver libmamba && \
-    conda clean -aqy
-
 # Install Open-MPI:
 ARG OMPI_VERSION=4.1.5
 RUN conda install -y -c conda-forge openmpi-mpicc=${OMPI_VERSION} && \


### PR DESCRIPTION
For some unclear reason the libmamba solver fails to get openmpi 1.0 with conda 23.1
This reverts to use the default solver which is slower
We should probably upgrade packages for 1.8 to solve this better