### PR TITLE
[Datastore] delete additional filters warning from spark merger

### DIFF
--- a/mlrun/feature_store/retrieval/spark_merger.py
+++ b/mlrun/feature_store/retrieval/spark_merger.py
@@ -206,10 +206,6 @@ class SparkFeatureMerger(BaseMerger):
         time_column=None,
         additional_filters=None,
     ):
-        mlrun.utils.helpers.additional_filters_warning(
-            additional_filters, self.__class__
-        )
-
         source_kwargs = {}
         if feature_set.spec.passthrough:
             if not feature_set.spec.source:


### PR DESCRIPTION
Additional filters warning should be on non-parquet sources, not by the whole merger.
In this code  we already raise this warning for no-parquet sources.