### PR TITLE
[Batch Infer Tutorial] Fix data drift result artifact name [1.7.x]

### DIFF
--- a/docs/tutorials/06-batch-infer.ipynb
+++ b/docs/tutorials/06-batch-infer.ipynb
@@ -1481,7 +1481,7 @@
     "import json\n",
     "\n",
     "json.loads(\n",
-    "    project.get_artifact(\"histogram-data-drift-logger_features_drift_results\")\n",
+    "    project.get_artifact(\"features_drift_results\")\n",
     "    .to_dataitem()\n",
     "    .get()\n",
     ")"

--- a/docs/tutorials/06-batch-infer.ipynb
+++ b/docs/tutorials/06-batch-infer.ipynb
@@ -1480,11 +1480,7 @@
     "# Data/concept drift per feature\n",
     "import json\n",
     "\n",
-    "json.loads(\n",
-    "    project.get_artifact(\"features_drift_results\")\n",
-    "    .to_dataitem()\n",
-    "    .get()\n",
-    ")"
+    "json.loads(project.get_artifact(\"features_drift_results\").to_dataitem().get())"
    ]
   },
   {


### PR DESCRIPTION
Rename `histogram-data-drift-logger_features_drift_results` to the appropriate artifact name `features_drift_results`.

https://iguazio.atlassian.net/browse/ML-7989