### PR TITLE
[KFP] Don't show error messages from skipped workflow steps

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mixins.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mixins.py
@@ -106,6 +106,6 @@ class PipelineProviderMixin:
             ).get("status", {})
             for node in workflow_status.get("nodes", {}).values():
                 # The "DAG" node is the parent node of the pipeline so we skip it for getting the detailed error
-                if node["type"] != "DAG":
+                if node["type"] not in ["DAG", "Skipped"]:
                     if message := node.get("message"):
                         return message


### PR DESCRIPTION
[KFP] When formatting a KFP workflow run for presentation in the UI, don't include error messages from skipped KFP steps. [[ML-8006]](https://iguazio.atlassian.net/browse/ML-8006
)

[ML-8006]: https://iguazio.atlassian.net/browse/ML-8006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ