### PR TITLE
[Model Monitoring] Fix TDEngine client version and add logs to delete resources

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -76,7 +76,7 @@ def extra_requirements() -> dict[str, list[str]]:
             "distributed~=2023.12.1",
         ],
         "alibaba-oss": ["ossfs==2023.12.0", "oss2==2.18.1"],
-        "tdengine": ["taos-ws-py~=0.3.3"],
+        "tdengine": ["taos-ws-py==0.3.2"],
         "snowflake": ["snowflake-connector-python~=3.7"],
     }
 

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -47,5 +47,5 @@ databricks-sdk~=0.13.0
 sqlalchemy~=1.4
 dask~=2023.12.1
 distributed~=2023.12.1
-taos-ws-py~=0.3.3
+taos-ws-py==0.3.2
 snowflake-connector-python~=3.7

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -59,6 +59,7 @@ class TDEngineConnector(TSDBConnector):
 
     def _create_connection(self) -> taosws.Connection:
         """Establish a connection to the TSDB server."""
+        logger.debug("Creating a new connection to TDEngine", project=self.project)
         conn = taosws.connect(self._tdengine_connection_string)
         try:
             conn.execute(f"CREATE DATABASE {self.database}")
@@ -71,6 +72,7 @@ class TDEngineConnector(TSDBConnector):
             raise mlrun.errors.MLRunTSDBConnectionFailureError(
                 f"Failed to use TDEngine database {self.database}, {mlrun.errors.err_to_str(e)}"
             )
+        logger.debug("Connected to TDEngine", project=self.project)
         return conn
 
     def _init_super_tables(self):
@@ -200,6 +202,10 @@ class TDEngineConnector(TSDBConnector):
         """
         Delete all project resources in the TSDB connector, such as model endpoints data and drift results.
         """
+        logger.debug(
+            "Deleting all project resources using the TDEngine connector",
+            project=self.project,
+        )
         for table in self.tables:
             get_subtable_names_query = self.tables[table]._get_subtables_query(
                 values={mm_schemas.EventFieldType.PROJECT: self.project}
@@ -210,8 +216,9 @@ class TDEngineConnector(TSDBConnector):
                     subtable=subtable[0]
                 )
                 self.connection.execute(drop_query)
-        logger.info(
-            f"Deleted all project resources in the TSDB connector for project {self.project}"
+        logger.debug(
+            "Deleted all project resources using the TDEngine connector",
+            project=self.project,
         )
 
     def get_model_endpoint_real_time_metrics(


### PR DESCRIPTION
Cherry-pick 
- #6467 

Downgrade the TDengine client (`taos-ws-py`) to version 0.3.2 due to breaking changes introduced in version 0.3.3. Additionally, this PR adds more logging to enhance debugging when deleting TDengine resources.


https://iguazio.atlassian.net/browse/ML-8010
https://iguazio.atlassian.net/browse/ML-7807