### PR TITLE
[Monitoring] Fix reading newly created runs

### DIFF
--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -85,7 +85,14 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def read_run(self, session, uid, project="", iter=0):
+    def read_run(
+        self,
+        session,
+        uid: str,
+        project: str = None,
+        iter: int = 0,
+        populate_existing: bool = False,
+    ):
         pass
 
     @abstractmethod

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -335,9 +335,18 @@ class SQLDB(DBInterface):
         )
         session.commit()
 
-    def read_run(self, session, uid, project=None, iter=0):
+    def read_run(
+        self,
+        session: Session,
+        uid: str,
+        project: str = None,
+        iter: int = 0,
+        populate_existing: bool = False,
+    ):
         project = project or config.default_project
-        run = self._get_run(session, uid, project, iter)
+        run = self._get_run(
+            session, uid, project, iter, populate_existing=populate_existing
+        )
         if not run:
             raise mlrun.errors.MLRunNotFoundError(
                 f"Run uid {uid} of project {project} not found"
@@ -4539,10 +4548,20 @@ class SQLDB(DBInterface):
         query = self._query(session, cls, name=name, project=project, uid=uid)
         return query.one_or_none()
 
-    def _get_run(self, session, uid, project, iteration, with_for_update=False):
+    def _get_run(
+        self,
+        session,
+        uid,
+        project,
+        iteration,
+        with_for_update=False,
+        populate_existing=False,
+    ):
         query = self._query(session, Run, uid=uid, project=project, iteration=iteration)
         if with_for_update:
             query = query.populate_existing().with_for_update()
+        elif populate_existing:
+            query = query.populate_existing()
 
         return query.one_or_none()
 

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1727,7 +1727,9 @@ class BaseRuntimeHandler(ABC):
             run = {}
         if not run and search_run:
             try:
-                run = db.read_run(db_session, uid, project)
+                # Session may be stale at this point since runs are being created in the background
+                # populate_existing ensures we get an up-to-date version of the run
+                run = db.read_run(db_session, uid, project, populate_existing=True)
             except mlrun.errors.MLRunNotFoundError:
                 run = {}
         if not run:


### PR DESCRIPTION
Monitor runs can be a long job and therefore the db session may be stale. Due to isolation level we might not see runs that were created by other sessions. Using `populate_existing` to ignore the in-memory state.

https://docs.sqlalchemy.org/en/14/faq/sessions.html#i-m-re-loading-data-with-my-session-but-it-isn-t-seeing-changes-that-i-committed-elsewhere

https://iguazio.atlassian.net/browse/ML-8028