### PR TITLE
[Notifications] Mask notification secret params on submit_workflow [1.7.x]

### DIFF
--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -223,22 +223,58 @@ def mask_notification_params_on_task(
     action: server.api.constants.MaskOperations,
 ):
     """
+    Mask notification config params from the task dictionary
+    :param task:    The task object to mask
+    :param action:  The masking operation to perform on the notification config params (conceal/redact)
+    """
+    run_uid = get_in(task, "metadata.uid")
+    project = get_in(task, "metadata.project")
+    notifications = task.get("spec", {}).get("notifications", [])
+    if notifications:
+        task.setdefault("spec", {})["notifications"] = _mask_notifications_params(
+            run_uid,
+            project,
+            [
+                mlrun.model.Notification.from_dict(notification)
+                for notification in notifications
+            ],
+            action,
+        )
+
+
+def mask_notification_params_on_task_object(
+    task: mlrun.model.RunObject,
+    action: server.api.constants.MaskOperations,
+):
+    """
     Mask notification config params from the task object
     :param task:    The task object to mask
     :param action:  The masking operation to perform on the notification config params (conceal/redact)
     """
-    mask_op = _notification_params_mask_op(action)
-    run_uid = get_in(task, "metadata.uid")
-    project = get_in(task, "metadata.project")
-    notifications = task.get("spec", {}).get("notifications", [])
-    masked_notifications = []
+    run_uid = task.metadata.uid
+    project = task.metadata.project
+    notifications = task.spec.notifications
     if notifications:
-        for notification in notifications:
-            notification_object = mlrun.model.Notification.from_dict(notification)
-            masked_notifications.append(
-                mask_op(project, run_uid, notification_object).to_dict()
-            )
-        task.setdefault("spec", {})["notifications"] = masked_notifications
+        task.spec.notifications = _mask_notifications_params(
+            run_uid, project, notifications, action
+        )
+
+
+def _mask_notifications_params(
+    run_uid: str,
+    project: str,
+    notifications: list[mlrun.model.Notification],
+    action: server.api.constants.MaskOperations,
+):
+    """
+    Mask notification config params from notifications list
+    :param run_uid:         The run UID
+    :param project:         The project name
+    :param notifications:   The list of notification objects to mask
+    :param action:          The masking operation to perform on the notification config params (conceal/redact)
+    """
+    mask_op = _notification_params_mask_op(action)
+    return [mask_op(project, run_uid, notification) for notification in notifications]
 
 
 def _notification_params_mask_op(

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -231,7 +231,7 @@ def mask_notification_params_on_task(
     project = get_in(task, "metadata.project")
     notifications = task.get("spec", {}).get("notifications", [])
     if notifications:
-        task.setdefault("spec", {})["notifications"] = _mask_notifications_params(
+        notifications_objects = _mask_notifications_params(
             run_uid,
             project,
             [
@@ -240,6 +240,7 @@ def mask_notification_params_on_task(
             ],
             action,
         )
+        task.setdefault("spec", {})["notifications"] = [notification.to_dict() for notification in notifications_objects]
 
 
 def mask_notification_params_on_task_object(

--- a/server/api/api/utils.py
+++ b/server/api/api/utils.py
@@ -240,7 +240,9 @@ def mask_notification_params_on_task(
             ],
             action,
         )
-        task.setdefault("spec", {})["notifications"] = [notification.to_dict() for notification in notifications_objects]
+        task.setdefault("spec", {})["notifications"] = [
+            notification.to_dict() for notification in notifications_objects
+        ]
 
 
 def mask_notification_params_on_task_object(

--- a/server/api/crud/workflows.py
+++ b/server/api/crud/workflows.py
@@ -22,6 +22,7 @@ import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 import mlrun.utils.singleton
 import server.api.api.utils
+import server.api.constants
 from mlrun.config import config
 from mlrun.model import Credentials, RunMetadata, RunObject, RunSpec
 from mlrun.utils import template_artifact_path
@@ -96,6 +97,12 @@ class WorkflowRunners(
             project=project,
             workflow_request=workflow_request,
             labels=labels,
+        )
+
+        # We want to store the secret params as k8s secret, so later we can access them with the project internal secret
+        # key that was created.
+        server.api.api.utils.mask_notification_params_on_task_object(
+            run_spec, server.api.constants.MaskOperations.CONCEAL
         )
         workflow_spec = workflow_request.spec
         if workflow_spec.workflow_runner_node_selector:
@@ -232,6 +239,11 @@ class WorkflowRunners(
             workflow_request=workflow_request,
             run_name=runner.metadata.name,
             load_only=load_only,
+        )
+        # We want to store the secret params as k8s secret, so later we can access them with the project internal secret
+        # key that was created.
+        server.api.api.utils.mask_notification_params_on_task_object(
+            run_spec, server.api.constants.MaskOperations.CONCEAL
         )
 
         artifact_path = workflow_request.artifact_path if workflow_request else ""

--- a/tests/api/crud/test_workflows.py
+++ b/tests/api/crud/test_workflows.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import os.path
+import unittest.mock
 
 import pytest
 import sqlalchemy.orm
@@ -23,6 +24,53 @@ import tests.api.conftest
 
 
 class TestWorkflows(tests.api.conftest.MockedK8sHelper):
+    def test_schedule_workflow_with_local_source(
+        self,
+        db: sqlalchemy.orm.Session,
+        k8s_secrets_mock,
+    ):
+        project = mlrun.common.schemas.ProjectOut(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+            spec=mlrun.common.schemas.ProjectSpecOut(),
+        )
+
+        server.api.crud.Projects().create_project(db, project)
+
+        run_name = "run-name"
+        runner = server.api.crud.WorkflowRunners().create_runner(
+            run_name=run_name,
+            project=project.metadata.name,
+            db_session=db,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            image="mlrun/mlrun",
+        )
+
+        with unittest.mock.patch("server.api.api.utils.get_scheduler"):
+            server.api.crud.WorkflowRunners().schedule(
+                runner=runner,
+                project=project,
+                workflow_request=mlrun.common.schemas.WorkflowRequest(
+                    spec=mlrun.common.schemas.WorkflowSpec(
+                        name=run_name,
+                        engine="remote",
+                        image="mlrun/mlrun",
+                    ),
+                    source="/home/mlrun/project-name/",
+                    artifact_path="/home/mlrun/artifacts",
+                    notifications=[
+                        mlrun.common.schemas.Notification(
+                            name="notification-name",
+                            kind="slack",
+                            secret_params={"webhook": "http://slack.com/webhook"},
+                        )
+                    ],
+                ),
+                auth_info=mlrun.common.schemas.AuthInfo(),
+            )
+            assert list(k8s_secrets_mock.project_secrets_map["project-name"].keys())[
+                0
+            ].startswith("mlrun.notifications.")
+
     @pytest.mark.parametrize(
         "source_code_target_dir",
         [
@@ -74,6 +122,13 @@ class TestWorkflows(tests.api.conftest.MockedK8sHelper):
                 ),
                 source=source,
                 artifact_path="/home/mlrun/artifacts",
+                notifications=[
+                    mlrun.common.schemas.Notification(
+                        name="notification-name",
+                        kind="slack",
+                        secret_params={"webhook": "http://slack.com/webhook"},
+                    )
+                ],
             ),
             auth_info=mlrun.common.schemas.AuthInfo(),
         )
@@ -94,7 +149,11 @@ class TestWorkflows(tests.api.conftest.MockedK8sHelper):
             else:
                 assert run.spec.parameters["project_context"] == source
             assert "url" not in run.spec.parameters
-
+        assert (
+            run.spec.notifications[0]
+            .secret_params.get("secret", "")
+            .startswith("mlrun.notifications.")
+        )
         assert run.spec.handler == "mlrun.projects.load_and_run"
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
We need to mask  notification secret params on submit_workflow so we can store the notification secret params as k8s secret.

https://iguazio.atlassian.net/browse/ML-8029