### PR TITLE
[K8S] Improve secret creation retry mechanism

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1782,3 +1782,43 @@ def _reload(module, max_recursion_depth):
         attribute = getattr(module, attribute_name)
         if type(attribute) is ModuleType:
             _reload(attribute, max_recursion_depth - 1)
+
+
+def run_with_retry(
+    retry_count: int,
+    func: typing.Callable,
+    retry_on_exceptions: typing.Union[
+        type[Exception],
+        tuple[type[Exception]],
+    ] = None,
+    *args,
+    **kwargs,
+):
+    """
+    Executes a function with retry logic upon encountering specified exceptions.
+
+    :param retry_count: The number of times to retry the function execution.
+    :param func: The function to execute.
+    :param retry_on_exceptions: Exception(s) that trigger a retry. Can be a single exception or a tuple of exceptions.
+    :param args: Positional arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+    :return: The result of the function execution if successful.
+    :raises Exception: Re-raises the last exception encountered after all retries are exhausted.
+    """
+    if retry_on_exceptions is None:
+        retry_on_exceptions = (Exception,)
+    elif isinstance(retry_on_exceptions, list):
+        retry_on_exceptions = tuple(retry_on_exceptions)
+
+    last_exception = None
+    for attempt in range(retry_count + 1):
+        try:
+            return func(*args, **kwargs)
+        except retry_on_exceptions as exc:
+            last_exception = exc
+            logger.warning(
+                f"Attempt {{{attempt}/ {retry_count}}} failed with exception: {exc}",
+            )
+            if attempt == retry_count:
+                raise
+    raise last_exception

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -18,8 +18,9 @@ import string
 import time
 import typing
 
+import kubernetes.client.rest as k8s_client_rest
+import kubernetes.dynamic.exceptions as k8s_dynamic_exceptions
 from kubernetes import client, config
-from kubernetes.client.rest import ApiException
 
 import mlrun
 import mlrun.common.constants as mlrun_constants
@@ -33,7 +34,7 @@ import mlrun.runtimes
 import mlrun.runtimes.pod
 import server.api.runtime_handlers
 from mlrun.utils import logger
-from mlrun.utils.helpers import to_non_empty_values_dict
+from mlrun.utils.helpers import run_with_retry, to_non_empty_values_dict
 
 _k8s = None
 
@@ -61,7 +62,7 @@ def raise_for_status_code(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             raise mlrun.errors.err_for_status_code(
                 exc.status, message=mlrun.errors.err_to_str(exc)
             ) from exc
@@ -155,7 +156,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     limit=limit,
                     _continue=_continue,
                 )
-            except ApiException as exc:
+            except k8s_client_rest.ApiException as exc:
                 self._validate_paginated_list_retry(
                     exc, retry_count, max_retry, resource_name="pods"
                 )
@@ -210,7 +211,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     _continue=_continue,
                     watch=False,
                 )
-            except ApiException as exc:
+            except k8s_client_rest.ApiException as exc:
                 # ignore error if crd is not defined
                 if exc.status != 404:
                     self._validate_paginated_list_retry(
@@ -239,7 +240,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         while True:
             try:
                 resp = self.v1api.create_namespaced_pod(pod.metadata.namespace, pod)
-            except ApiException as exc:
+            except k8s_client_rest.ApiException as exc:
                 if retry_count > max_retry:
                     logger.error(
                         "Failed to create pod after max retries",
@@ -281,7 +282,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 propagation_policy="Background",
             )
             return api_response
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             # ignore error if pod is already removed
             if exc.status != 404:
                 logger.error(
@@ -299,7 +300,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 name=name, namespace=self.resolve_namespace(namespace)
             )
             return api_response
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             if exc.status != 404:
                 logger.error(
                     "Failed to get pod", pod_name=name, exc=mlrun.errors.err_to_str(exc)
@@ -341,7 +342,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 crd_name=name,
                 namespace=namespace,
             )
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             # ignore error if crd is already removed
             if exc.status != 404:
                 logger.error(
@@ -361,7 +362,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             resp = self.v1api.read_namespaced_pod_log(
                 name=name, namespace=self.resolve_namespace(namespace)
             )
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             logger.error("Failed to get pod logs", exc=mlrun.errors.err_to_str(exc))
             raise exc
 
@@ -408,7 +409,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             service_account = self.v1api.read_namespaced_service_account(
                 service_account_name, namespace
             )
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             # It's valid for the service account to not exist. Simply return None
             if exc.status != 404:
                 logger.error(
@@ -443,9 +444,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         self, project, secrets, namespace=""
     ) -> (str, typing.Optional[mlrun.common.schemas.SecretEventActions]):
         secret_name = self.get_project_secret_name(project)
-        action = self.store_secrets(
-            secret_name, secrets, namespace, retry_on_conflict=True
-        )
+        action = self.store_secrets_with_retry(secret_name, secrets, namespace)
         return secret_name, action
 
     def read_auth_secret(self, secret_name, namespace="", raise_on_not_found=False):
@@ -453,7 +452,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         try:
             secret_data = self.v1api.read_namespaced_secret(secret_name, namespace).data
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             logger.error(
                 "Failed to read secret",
                 secret_name=secret_name,
@@ -500,7 +499,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 "access_key"
             ): access_key,
         }
-        action = self.store_secrets(
+        action = self.store_secrets_with_retry(
             secret_name,
             secret_data,
             namespace,
@@ -510,6 +509,40 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         )
         return secret_name, action
 
+    def store_secrets_with_retry(
+        self,
+        secret_name: str,
+        secrets: dict[str, str],
+        namespace: str = "",
+        type_: str = SecretTypes.opaque,
+        labels: typing.Optional[dict] = None,
+        retry_on_conflict_count: int = 5,
+    ):
+        """
+        Stores secrets in a Kubernetes secret object with retry logic.
+
+        This function wraps `store_secrets` and retries the operation upon encountering
+        specified exceptions, such as `ConflictError`.
+
+        :param secret_name: The name of the Kubernetes secret.
+        :param secrets: The secrets to store, as a dictionary.
+        :param namespace: The Kubernetes namespace.
+        :param type_: The type of the Kubernetes secret.
+        :param labels: Labels to add to the Kubernetes secret.
+        :param retry_on_conflict_count: Number of times to retry in case of a conflict error.
+        :return: The action performed: created or updated, or None if nothing changed.
+        :raises Exception: Re-raises the last exception encountered after all retries are exhausted.
+        """
+        return run_with_retry(
+            retry_count=retry_on_conflict_count,
+            func=self.store_secrets,
+            secret_name=secret_name,
+            secrets=secrets,
+            namespace=namespace,
+            type_=type_,
+            labels=labels,
+        )
+
     @raise_for_status_code
     def store_secrets(
         self,
@@ -518,7 +551,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         namespace="",
         type_=SecretTypes.opaque,
         labels: typing.Optional[dict] = None,
-        retry_on_conflict: bool = False,
     ) -> typing.Optional[mlrun.common.schemas.SecretEventActions]:
         """
         Store secrets in a kubernetes secret object
@@ -527,7 +559,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param namespace:   k8s namespace
         :param type_:       k8s secret type
         :param labels:      k8s labels for the secret
-        :param retry_on_conflict:   if True, will retry to create the secret for race conditions
         :return: returns the action if the secret was created or updated, None if nothing changed
         """
         if not secrets:
@@ -536,56 +567,100 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         namespace = self.resolve_namespace(namespace)
         try:
-            k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
-        except ApiException as exc:
-            # If secret doesn't exist, we'll simply create it
-            if exc.status != 404:
-                logger.error(
-                    "Failed to retrieve k8s secret",
-                    secret_name=secret_name,
-                    exc=mlrun.errors.err_to_str(exc),
-                )
-                raise exc
-            k8s_secret = client.V1Secret(type=type_)
-            k8s_secret.metadata = client.V1ObjectMeta(
-                name=secret_name, namespace=namespace, labels=labels
+            k8s_secret = self._read_secret(
+                secret_name=secret_name,
+                namespace=namespace,
             )
-            k8s_secret.string_data = secrets
-            try:
-                self.v1api.create_namespaced_secret(namespace, k8s_secret)
-                return mlrun.common.schemas.SecretEventActions.created
-            except ApiException as exc:
-                if exc.status == 409 and retry_on_conflict:
-                    logger.warning(
-                        "Secret was created while we tried to create it, retrying...",
-                        secret_name=secret_name,
-                        exc=mlrun.errors.err_to_str(exc),
-                    )
-                    return self.store_secrets(
-                        secret_name,
-                        secrets,
-                        namespace,
-                        type_,
-                        labels,
-                        retry_on_conflict=False,
-                    )
-                raise exc
+        except (
+            k8s_dynamic_exceptions.NotFoundError
+        ):  # If secret doesn't exist, we'll simply create it
+            self._create_secret(
+                labels=labels,
+                namespace=namespace,
+                secret_name=secret_name,
+                secrets=secrets,
+                type_=type_,
+            )
+            return mlrun.common.schemas.SecretEventActions.created
 
+        # Secret exists and we are updating it.
+        self._update_secret(
+            k8s_secret=k8s_secret,
+            namespace=namespace,
+            secret_name=secret_name,
+            secrets=secrets,
+        )
+        return mlrun.common.schemas.SecretEventActions.updated
+
+    def _create_secret(
+        self,
+        secret_name: str,
+        secrets: dict[str, str],
+        namespace: str = "",
+        type_: str = SecretTypes.opaque,
+        labels: typing.Optional[dict] = None,
+    ):
+        k8s_secret = client.V1Secret(
+            type=type_,
+            metadata=client.V1ObjectMeta(
+                name=secret_name,
+                namespace=namespace,
+                labels=labels,
+            ),
+            string_data=secrets,
+        )
+        try:
+            self.v1api.create_namespaced_secret(
+                namespace=namespace,
+                body=k8s_secret,
+            )
+        except k8s_dynamic_exceptions.ConflictError as exc:
+            # There was a conflict while we tried to create the secret.
+            logger.warning(
+                "Secret was created while we tried to create it,",
+                secret_name=k8s_secret.metadata.name,
+                exc=mlrun.errors.err_to_str(exc),
+            )
+            raise
+
+    def _update_secret(
+        self,
+        k8s_secret: client.V1Secret,
+        secret_name: str,
+        secrets: dict[str, str],
+        namespace: str = "",
+    ):
         secret_data = k8s_secret.data.copy() if k8s_secret.data else {}
-
         for key, value in secrets.items():
             secret_data[key] = base64.b64encode(value.encode()).decode("utf-8")
-
         k8s_secret.data = secret_data
         self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
-        return mlrun.common.schemas.SecretEventActions.updated
+
+    def _read_secret(
+        self,
+        secret_name: str,
+        namespace: str = "",
+    ) -> client.V1Secret:
+        try:
+            k8s_secret = self.v1api.read_namespaced_secret(
+                name=secret_name,
+                namespace=namespace,
+            )
+        except k8s_client_rest.ApiException as exc:
+            logger.error(
+                "Failed to retrieve k8s secret",
+                secret_name=secret_name,
+                exc=mlrun.errors.err_to_str(exc),
+            )
+            raise exc
+        return k8s_secret
 
     def load_secret(self, secret_name, namespace=""):
         namespace = namespace or self.resolve_namespace(namespace)
 
         try:
             k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
-        except ApiException:
+        except k8s_client_rest.ApiException:
             return None
 
         return k8s_secret.data
@@ -619,7 +694,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         try:
             k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             if exc.status == 404:
                 logger.info(
                     "Project secret does not exist, nothing to delete",
@@ -710,7 +785,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 self.v1api.replace_namespaced_config_map(
                     configmap_name, namespace=namespace, body=body
                 )
-            except ApiException as exc:
+            except k8s_client_rest.ApiException as exc:
                 logger.error(
                     "Failed to replace k8s config map",
                     name=configmap_name,
@@ -720,7 +795,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         else:
             try:
                 self.v1api.create_namespaced_config_map(namespace=namespace, body=body)
-            except ApiException as exc:
+            except k8s_client_rest.ApiException as exc:
                 logger.error(
                     "Failed to create k8s config map",
                     name=configmap_name,
@@ -752,7 +827,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 name=name,
                 namespace=namespace,
             )
-        except ApiException as exc:
+        except k8s_client_rest.ApiException as exc:
             logger.error(
                 "Failed to delete k8s config map",
                 name=name,
@@ -768,13 +843,16 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
     @staticmethod
     @raise_for_status_code
     def _validate_paginated_list_retry(
-        exc: ApiException, retry_count: int, max_retry: int, resource_name: str
+        exc: k8s_client_rest.ApiException,
+        retry_count: int,
+        max_retry: int,
+        resource_name: str,
     ):
         """
         Validates 410 Gone retries.
         Raises `exc` if error is not 410 or retries are exhausted.
         Otherwise, logs an appropriate warning.
-        :param exc:             The ApiException raised by the list query
+        :param exc:             The k8s_client_rest.ApiException raised by the list query
         :param retry_count:     The current retry count
         :param max_retry:       The maximum retries allowed
         :param resource_name:   The resource that was listed
@@ -807,7 +885,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         try:
             k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
-        except ApiException:
+        except k8s_client_rest.ApiException:
             return None
 
         return k8s_secret.data

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -505,7 +505,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             namespace,
             type_=SecretTypes.v3io_fuse,
             labels=self._resolve_secret_labels(username),
-            retry_on_conflict=True,
         )
         return secret_name, action
 
@@ -546,10 +545,10 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
     @raise_for_status_code
     def store_secrets(
         self,
-        secret_name,
-        secrets,
-        namespace="",
-        type_=SecretTypes.opaque,
+        secret_name: str,
+        secrets: dict[str, str],
+        namespace: str = "",
+        type_: str = SecretTypes.opaque,
         labels: typing.Optional[dict] = None,
     ) -> typing.Optional[mlrun.common.schemas.SecretEventActions]:
         """


### PR DESCRIPTION
In cases where more than one flow in the system is trying to store a secret, there can be a race between the fetching and creation of the secret.
This changes allows this process to retry multiple times, ensuring it succeeds.
[[ML-8025](https://iguazio.atlassian.net/browse/ML-8025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)](https://iguazio.atlassian.net/browse/ML-8025)

[ML-8025]: https://iguazio.atlassian.net/browse/ML-8025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ