### PR TITLE
[Logs] Return log collection legacy fallback and fix periodic collection

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -403,7 +403,7 @@ async def _initiate_logs_collection(start_logs_limit: asyncio.Semaphore):
     """
     db_session = await fastapi.concurrency.run_in_threadpool(create_session)
     try:
-        # list all the runs in the system which we didn't request logs collection for yet
+        # list all the runs currently still running in the system which we didn't request logs collection for yet
         runs_uids = await fastapi.concurrency.run_in_threadpool(
             get_db().list_distinct_runs_uids,
             db_session,
@@ -418,7 +418,8 @@ async def _initiate_logs_collection(start_logs_limit: asyncio.Semaphore):
             seconds=int(config.runtime_resources_deletion_grace_period)
         )
 
-        # aborted means the pods were deleted and logs were already fetched
+        # Add all the completed/failed runs in the system which we didn't request logs collection for yet.
+        # Aborted means the pods were deleted and logs were already fetched.
         run_states = mlrun.common.runtimes.constants.RunStates.terminal_states()
         run_states.remove(mlrun.common.runtimes.constants.RunStates.aborted)
         runs_uids.extend(

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -403,17 +403,31 @@ async def _initiate_logs_collection(start_logs_limit: asyncio.Semaphore):
     """
     db_session = await fastapi.concurrency.run_in_threadpool(create_session)
     try:
-        # we don't want initiate logs collection for aborted runs
-        run_states = mlrun.common.runtimes.constants.RunStates.all()
-        run_states.remove(mlrun.common.runtimes.constants.RunStates.aborted)
-
         # list all the runs in the system which we didn't request logs collection for yet
         runs_uids = await fastapi.concurrency.run_in_threadpool(
             get_db().list_distinct_runs_uids,
             db_session,
             requested_logs_modes=[False],
             only_uids=True,
-            states=run_states,
+            states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
+        )
+
+        last_update_time = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(
+            seconds=int(config.runtime_resources_deletion_grace_period)
+        )
+        runs_uids.extend(
+            await fastapi.concurrency.run_in_threadpool(
+                get_db().list_distinct_runs_uids,
+                db_session,
+                requested_logs_modes=[False],
+                # get only uids as there might be many runs which reached terminal state while the API was down, the
+                # run objects will be fetched in the next step
+                only_uids=True,
+                last_update_time_from=last_update_time,
+                states=mlrun.common.runtimes.constants.RunStates.terminal_states(),
+            )
         )
         if runs_uids:
             logger.debug(

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -1653,8 +1653,11 @@ class BaseRuntimeHandler(ABC):
                 server.api.crud.Logs().store_log(
                     logs_from_k8s, project, uid, append=False
                 )
-                # Tell the periodic log collection to not request logs (this assumes the run is in terminal state)
-                db.update_runs_requested_logs(db_session, [uid], requested_logs=True)
+                if run.get("status", {}).get("state") in RunStates.terminal_states():
+                    # Tell the periodic log collection to not request logs
+                    db.update_runs_requested_logs(
+                        db_session, [uid], requested_logs=True
+                    )
 
     def _ensure_run_state(
         self,

--- a/server/api/runtime_handlers/base.py
+++ b/server/api/runtime_handlers/base.py
@@ -244,10 +244,10 @@ class BaseRuntimeHandler(ABC):
     ) -> str:
         default_label_selector = self._get_default_label_selector(class_mode=class_mode)
 
-        if label_selector:
-            label_selector = ",".join([default_label_selector, label_selector])
-        else:
+        if not label_selector:
             label_selector = default_label_selector
+        elif default_label_selector not in label_selector:
+            label_selector = ",".join([default_label_selector, label_selector])
 
         if project and project != "*":
             label_selector = ",".join(

--- a/tests/api/crud/test_runs.py
+++ b/tests/api/crud/test_runs.py
@@ -84,6 +84,10 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                 ],
             ),
             unittest.mock.patch.object(
+                server.api.runtime_handlers.BaseRuntimeHandler,
+                "_ensure_run_logs_collected",
+            ),
+            unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
             ) as delete_logs_mock,
         ):
@@ -131,6 +135,10 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                 return_value=k8s_client.V1PodList(
                     items=[], metadata=k8s_client.V1ListMeta()
                 ),
+            ),
+            unittest.mock.patch.object(
+                server.api.runtime_handlers.BaseRuntimeHandler,
+                "_ensure_run_logs_collected",
             ),
             unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"
@@ -182,6 +190,10 @@ class TestRuns(tests.api.conftest.MockedK8sHelper):
                     Exception("Boom!"),
                     k8s_client.V1PodList(items=[], metadata=k8s_client.V1ListMeta()),
                 ],
+            ),
+            unittest.mock.patch.object(
+                server.api.runtime_handlers.BaseRuntimeHandler,
+                "_ensure_run_logs_collected",
             ),
             unittest.mock.patch.object(
                 server.api.utils.clients.log_collector.LogCollectorClient, "delete_logs"

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -593,9 +593,19 @@ class TestRuntimeHandlerBase:
         uid: str,
         expected_state: str,
         expected_status_attrs: dict = None,
+        requested_logs: bool = None,
     ):
         expected_status_attrs = expected_status_attrs or {}
-        run = get_db().read_run(db, uid, project)
+
+        if requested_logs is not None:
+            runs = get_db().list_runs(
+                db, uid=uid, project=project, requested_logs=requested_logs
+            )
+            assert len(runs) == 1
+            run = runs[0]
+        else:
+            run = get_db().read_run(db, uid, project)
+
         assert run["status"]["state"] == expected_state
 
         for key, val in expected_status_attrs.items():

--- a/tests/api/runtime_handlers/base.py
+++ b/tests/api/runtime_handlers/base.py
@@ -31,6 +31,7 @@ import server.api.crud
 import server.api.utils.clients.chief
 from mlrun.common.runtimes.constants import PodPhases, RunStates
 from mlrun.utils import create_test_logger, now_date
+from server.api.constants import LogSources
 from server.api.runtime_handlers import get_runtime_handler
 from server.api.utils.singletons.db import get_db
 from server.api.utils.singletons.k8s import get_k8s_helper
@@ -162,10 +163,6 @@ class TestRuntimeHandlerBase:
         return labels
 
     @staticmethod
-    def _generate_run_pod_label_selector(run_uid):
-        return f"{mlrun_constants.MLRunInternalLabels.uid}={run_uid}"
-
-    @staticmethod
     def _generate_config_map(name, labels, data=None):
         metadata = client.V1ObjectMeta(
             name=name, labels=labels, namespace=get_k8s_helper().resolve_namespace()
@@ -173,6 +170,12 @@ class TestRuntimeHandlerBase:
         if data is None:
             data = {"key": "value"}
         return client.V1ConfigMap(metadata=metadata, data=data)
+
+    def _generate_get_logger_pods_label_selector(self, runtime_handler):
+        run_label_selector = runtime_handler._get_run_label_selector(
+            self.project, self.run_uid
+        )
+        return f"mlrun/class,{run_label_selector}"
 
     def _assert_runtime_handler_list_resources(
         self,
@@ -523,7 +526,6 @@ class TestRuntimeHandlerBase:
             f"Unexpected number of calls to list_namespaced_pod "
             f"{get_k8s_helper().v1api.list_namespaced_pod.call_count}, expected {expected_number_of_calls}"
         )
-        # if expected_label_selector and expected_label_selector != "":
         expected_label_selector = (
             expected_label_selector or runtime_handler._get_default_label_selector()
         )
@@ -564,6 +566,25 @@ class TestRuntimeHandlerBase:
             label_selector=runtime_handler._get_default_label_selector(),
             **kwargs,
         )
+
+    @staticmethod
+    async def _assert_run_logs(
+        db: Session,
+        project: str,
+        uid: str,
+        expected_log: str,
+        logger_pod_name: str = None,
+    ):
+        if logger_pod_name is not None:
+            get_k8s_helper().v1api.read_namespaced_pod_log.assert_called_once_with(
+                name=logger_pod_name,
+                namespace=get_k8s_helper().resolve_namespace(),
+            )
+        _, logs = await server.api.crud.Logs().get_logs(
+            db, project, uid, source=LogSources.PERSISTENCY
+        )
+        async for log_line in logs:
+            assert log_line == expected_log.encode()
 
     @staticmethod
     def _assert_run_reached_state(

--- a/tests/api/runtime_handlers/test_kubejob.py
+++ b/tests/api/runtime_handlers/test_kubejob.py
@@ -125,6 +125,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=0)
         self._assert_delete_namespaced_pods(
             [self.completed_job_pod.metadata.name],
@@ -135,6 +136,13 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
+        )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.completed_job_pod.metadata.name,
         )
 
     def test_delete_resources_completed_builder_pod(
@@ -321,14 +329,18 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                     )
                 get_db().del_run(db, self.run_uid, self.project)
 
-    def test_delete_resources_with_force(self, db: Session, client: TestClient):
+    @pytest.mark.asyncio
+    async def test_delete_resources_with_force(self, db: Session, client: TestClient):
         list_namespaced_pods_calls = [
+            [self.running_job_pod],
+            # additional time for the get_logger_pods
             [self.running_job_pod],
             # additional time for wait for pods deletion - simulate pod gone
             [],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_delete_namespaced_pods()
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, grace_period=10, force=True)
         self._assert_delete_namespaced_pods(
             [self.running_job_pod.metadata.name],
@@ -340,17 +352,28 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
         )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.running_job_pod.metadata.name,
+        )
 
-    def test_monitor_run_completed_pod(self, db: Session, client: TestClient):
+    @pytest.mark.asyncio
+    async def test_monitor_run_completed_pod(self, db: Session, client: TestClient):
         list_namespaced_pods_calls = [
             [self.pending_job_pod],
             [self.running_job_pod],
             [self.completed_job_pod],
+            # additional time for the get_logger_pods
+            [self.completed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls
+            expected_number_of_list_pods_calls - 1
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -360,6 +383,13 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.completed_job_pod.metadata.name,
+        )
 
     @pytest.mark.asyncio
     async def test_monitor_run_failed_pod(self, db: Session, client: TestClient):
@@ -367,11 +397,14 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [self.pending_job_pod],
             [self.running_job_pod],
             [self.failed_job_pod],
+            # additional time for the get_logger_pods
+            [self.failed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls
+            expected_number_of_list_pods_calls - 1
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -387,6 +420,46 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
                 "reason": "Some reason",
                 "status_text": "Failed message",
             },
+        )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.failed_job_pod.metadata.name,
+        )
+
+    @pytest.mark.asyncio
+    async def test_monitor_run_overriding_terminal_state(
+        self, db: Session, client: TestClient
+    ):
+        list_namespaced_pods_calls = [
+            [self.failed_job_pod],
+            # additional time for the get_logger_pods
+            [self.failed_job_pod],
+        ]
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
+        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
+        log = self._mock_read_namespaced_pod_log()
+        self.run["status"]["state"] = RunStates.completed
+        server.api.crud.Runs().store_run(
+            db, self.run, self.run_uid, project=self.project
+        )
+        expected_monitor_cycles_to_reach_expected_state = (
+            expected_number_of_list_pods_calls - 1
+        )
+        for _ in range(expected_monitor_cycles_to_reach_expected_state):
+            self.runtime_handler.monitor_runs(get_db(), db)
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler, expected_number_of_list_pods_calls
+        )
+        self._assert_run_reached_state(db, self.project, self.run_uid, RunStates.error)
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.completed_job_pod.metadata.name,
         )
 
     @pytest.mark.asyncio
@@ -453,12 +526,23 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             [[self.completed_job_pod], [self.completed_job_pod]]
         )
 
+        # Mocking read log calls
+        log = self._mock_read_namespaced_pod_log()
+
         # Triggering monitor cycle
         self.runtime_handler.monitor_runs(get_db(), db)
 
         # verifying monitoring was not debounced
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
+        )
+
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.completed_job_pod.metadata.name,
         )
 
     @pytest.mark.asyncio
@@ -468,11 +552,15 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         get_db().del_run(db, self.run_uid, self.project)
         list_namespaced_pods_calls = [
             [self.running_job_pod],
+            [self.completed_job_pod],
+            # additional time for the get_logger_pods
+            [self.completed_job_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
-            expected_number_of_list_pods_calls
+            expected_number_of_list_pods_calls - 1
         )
         for _ in range(expected_monitor_cycles_to_reach_expected_state):
             self.runtime_handler.monitor_runs(get_db(), db)
@@ -481,6 +569,13 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
+        )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.completed_job_pod.metadata.name,
         )
 
     @pytest.mark.asyncio

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -103,6 +103,10 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             PodPhases.running,
         )
 
+        self.pod_label_selector = self._generate_get_logger_pods_label_selector(
+            self.runtime_handler
+        )
+
         self.config_map = self._generate_config_map(
             name="my-spark-jdbc",
             labels={mlrun_constants.MLRunInternalLabels.uid: self.run_uid},
@@ -133,7 +137,10 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
                 group_by=group_by,
             )
 
-    def test_delete_resources_completed_crd(self, db: Session, client: TestClient):
+    @pytest.mark.asyncio
+    async def test_delete_resources_completed_crd(
+        self, db: Session, client: TestClient
+    ):
         list_namespaced_crds_calls = [
             [self.completed_crd_dict],
             # 2 additional time for wait for pods deletion
@@ -142,7 +149,9 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for wait for pods deletion - simulate pods not removed yet
+            # for the get_logger_pods with proper selector
+            [self.driver_pod],
+            # additional time for wait for pods deletion - simulate pods not removed yet
             [self.executor_pod, self.driver_pod],
             # additional time for wait for pods deletion - simulate pods gone
             [],
@@ -150,6 +159,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_namespaced_config_map([self.config_map])
         self._mock_delete_namespaced_custom_objects()
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -164,11 +174,18 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            f"{mlrun_constants.MLRunInternalLabels.mlrun_class}=spark",
+            self.pod_label_selector,
             paginated=False,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
+        )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.driver_pod.metadata.name,
         )
 
     def test_delete_resources_running_crd(self, db: Session, client: TestClient):
@@ -216,7 +233,8 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             paginated=False,
         )
 
-    def test_delete_resources_with_force(self, db: Session, client: TestClient):
+    @pytest.mark.asyncio
+    async def test_delete_resources_with_force(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             # additional time for wait for pods deletion
@@ -224,12 +242,15 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
         list_namespaced_pods_calls = [
-            # for wait for pods deletion - simulate pods gone
+            # for the get_logger_pods with proper selector
+            [self.driver_pod],
+            # additional time for wait for pods deletion - simulate pods gone
             [],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_list_namespaced_config_map([self.config_map])
         self._mock_delete_namespaced_custom_objects()
+        log = self._mock_read_namespaced_pod_log()
         self.runtime_handler.delete_resources(get_db(), db, force=True)
         self._assert_delete_namespaced_custom_objects(
             self.runtime_handler,
@@ -241,22 +262,38 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             len(list_namespaced_crds_calls),
             paginated=False,
         )
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler,
+            len(list_namespaced_pods_calls),
+            self.pod_label_selector,
+        )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running
         )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.driver_pod.metadata.name,
+        )
 
-    def test_monitor_run_completed_crd(self, db: Session, client: TestClient):
+    @pytest.mark.asyncio
+    async def test_monitor_run_completed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             [self.completed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
+        # for the get_logger_pods with proper selector
         list_namespaced_pods_calls = [
-            # 1 call per threshold state verification
+            # 1 call per threshold state verification or for logs collection (runs in terminal state)
             [],
+            [self.driver_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -269,25 +306,36 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            expected_label_selector=f"{mlrun_constants.MLRunInternalLabels.uid}={self.run_uid}",
+            self.pod_label_selector,
             paginated=False,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.driver_pod.metadata.name,
+        )
 
-    def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
+    @pytest.mark.asyncio
+    async def test_monitor_run_failed_crd(self, db: Session, client: TestClient):
         list_namespaced_crds_calls = [
             [self.running_crd_dict],
             [self.failed_crd_dict],
         ]
         self._mock_list_namespaced_crds(list_namespaced_crds_calls)
+        # for the get_logger_pods with proper selector
         list_namespaced_pods_calls = [
-            # 1 call per threshold state verification
+            # 1 call per threshold state verification or for logs collection (runs in terminal state)
             [],
+            [self.driver_pod],
         ]
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         expected_number_of_list_crds_calls = len(list_namespaced_crds_calls)
+        log = self._mock_read_namespaced_pod_log()
         expected_monitor_cycles_to_reach_expected_state = (
             expected_number_of_list_crds_calls
         )
@@ -300,7 +348,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
         self._assert_list_namespaced_pods_calls(
             self.runtime_handler,
             len(list_namespaced_pods_calls),
-            expected_label_selector=f"{mlrun_constants.MLRunInternalLabels.uid}={self.run_uid}",
+            expected_label_selector=self.pod_label_selector,
             paginated=False,
         )
         self._assert_run_reached_state(
@@ -309,6 +357,13 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.run_uid,
             RunStates.error,
             expected_status_attrs={"status_text": "Some message"},
+        )
+        await self._assert_run_logs(
+            db,
+            self.project,
+            self.run_uid,
+            log,
+            self.driver_pod.metadata.name,
         )
 
     def test_monitor_run_update_ui_url(self, db: Session, client: TestClient):
@@ -469,7 +524,9 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             # additional time for wait for pods deletion
             list_namespaced_crds_calls.append([self.completed_crd_dict])
             list_namespaced_pods_calls = [
-                # for wait for pods deletion - simulate pods gone
+                # for the get_logger_pods with proper selector
+                [self.driver_pod],
+                # additional time for wait for pods deletion - simulate pods gone
                 [],
             ]
             self._mock_list_namespaced_pods(list_namespaced_pods_calls)
@@ -495,11 +552,18 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self._assert_list_namespaced_pods_calls(
                 self.runtime_handler,
                 len(list_namespaced_pods_calls),
+                self.pod_label_selector,
                 paginated=False,
             )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.created
         )
+
+    def _generate_get_logger_pods_label_selector(self, runtime_handler):
+        logger_pods_label_selector = super()._generate_get_logger_pods_label_selector(
+            runtime_handler
+        )
+        return f"{logger_pods_label_selector},spark-role=driver"
 
     def _mock_list_resources_pods(self):
         mocked_responses = self._mock_list_namespaced_pods(

--- a/tests/api/runtime_handlers/test_sparkjob.py
+++ b/tests/api/runtime_handlers/test_sparkjob.py
@@ -266,6 +266,7 @@ class TestSparkjobRuntimeHandler(TestRuntimeHandlerBase):
             self.runtime_handler,
             len(list_namespaced_pods_calls),
             self.pod_label_selector,
+            paginated=False,
         )
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.running


### PR DESCRIPTION
1. Revert the legacy log collection fallback in case periodic job malfunctions.
2. Change get runs filter for periodic collection to get last 4 hours so that it doesn't collect logs for removed pods

https://iguazio.atlassian.net/browse/ML-8027