### PR TITLE
[KFP] If we got empty secret value skip the replacing of the env vars [1.7.x]

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.1.8",
+    version="0.1.9",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
@@ -947,6 +947,7 @@ def _replace_env_vars_with_secrets(
                 value = env_var.get("value")
                 if value is None:
                     logger.warning("Skipping empty secret value")
+                    continue
                 secret_env_var = _create_secret_env_var_for_pipeline(
                     name=env_var_name,
                     value=value,

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,5 @@ deprecated~=1.2
 jinja2~=3.1, >=3.1.3
 orjson>=3.9.15, <4
 # mlrun pipeline adapters
-mlrun-pipelines-kfp-common~=0.1.9
+mlrun-pipelines-kfp-common~=0.1.8
 mlrun-pipelines-kfp-v1-8~=0.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,5 @@ deprecated~=1.2
 jinja2~=3.1, >=3.1.3
 orjson>=3.9.15, <4
 # mlrun pipeline adapters
-mlrun-pipelines-kfp-common~=0.1.8
+mlrun-pipelines-kfp-common~=0.1.9
 mlrun-pipelines-kfp-v1-8~=0.1.6


### PR DESCRIPTION
In case we got empty secret value, we should skip the `_create_secret_env_var_for_pipeline`