### PR TITLE
[K8S] Fix K8S client error handling when storing secrets [1.7.x]

### DIFF
--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -599,6 +599,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         type_: str = SecretTypes.opaque,
         labels: typing.Optional[dict] = None,
     ):
+        logger.info("Creating secret", secret_name=secret_name)
         k8s_secret = client.V1Secret(
             type=type_,
             metadata=client.V1ObjectMeta(
@@ -613,14 +614,15 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 namespace=namespace,
                 body=k8s_secret,
             )
-        except k8s_dynamic_exceptions.ConflictError as exc:
+        except k8s_client_rest.ApiException as exc:
             # There was a conflict while we tried to create the secret.
-            logger.warning(
-                "Secret was created while we tried to create it,",
-                secret_name=k8s_secret.metadata.name,
-                exc=mlrun.errors.err_to_str(exc),
-            )
-            raise
+            if isinstance(exc, k8s_dynamic_exceptions.ConflictError):
+                logger.warning(
+                    "Secret was created while we tried to create it,",
+                    secret_name=k8s_secret.metadata.name,
+                    exc=mlrun.errors.err_to_str(exc),
+                )
+            raise k8s_dynamic_exceptions.api_exception(exc)
 
     def _update_secret(
         self,
@@ -629,17 +631,22 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         secrets: dict[str, str],
         namespace: str = "",
     ):
+        logger.info("Updating secret", secret_name=secret_name)
         secret_data = k8s_secret.data.copy() if k8s_secret.data else {}
         for key, value in secrets.items():
             secret_data[key] = base64.b64encode(value.encode()).decode("utf-8")
         k8s_secret.data = secret_data
-        self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
+        try:
+            self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
+        except k8s_client_rest.ApiException as exc:
+            raise k8s_dynamic_exceptions.api_exception(exc)
 
     def _read_secret(
         self,
         secret_name: str,
         namespace: str = "",
     ) -> client.V1Secret:
+        logger.info("Reading secret", secret_name=secret_name)
         try:
             k8s_secret = self.v1api.read_namespaced_secret(
                 name=secret_name,
@@ -651,18 +658,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 secret_name=secret_name,
                 exc=mlrun.errors.err_to_str(exc),
             )
-            raise exc
+            raise k8s_dynamic_exceptions.api_exception(exc)
         return k8s_secret
-
-    def load_secret(self, secret_name, namespace=""):
-        namespace = namespace or self.resolve_namespace(namespace)
-
-        try:
-            k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
-        except k8s_client_rest.ApiException:
-            return None
-
-        return k8s_secret.data
 
     def delete_project_secrets(
         self, project, secrets, namespace=""

--- a/server/api/utils/singletons/k8s.py
+++ b/server/api/utils/singletons/k8s.py
@@ -599,7 +599,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         type_: str = SecretTypes.opaque,
         labels: typing.Optional[dict] = None,
     ):
-        logger.info("Creating secret", secret_name=secret_name)
+        logger.debug("Creating secret", secret_name=secret_name)
         k8s_secret = client.V1Secret(
             type=type_,
             metadata=client.V1ObjectMeta(
@@ -618,7 +618,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             # There was a conflict while we tried to create the secret.
             if isinstance(exc, k8s_dynamic_exceptions.ConflictError):
                 logger.warning(
-                    "Secret was created while we tried to create it,",
+                    "Failed to create secret, Secret might have been created while we tried to create it",
                     secret_name=k8s_secret.metadata.name,
                     exc=mlrun.errors.err_to_str(exc),
                 )
@@ -631,7 +631,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         secrets: dict[str, str],
         namespace: str = "",
     ):
-        logger.info("Updating secret", secret_name=secret_name)
+        logger.debug("Updating secret", secret_name=secret_name)
         secret_data = k8s_secret.data.copy() if k8s_secret.data else {}
         for key, value in secrets.items():
             secret_data[key] = base64.b64encode(value.encode()).decode("utf-8")
@@ -646,7 +646,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         secret_name: str,
         namespace: str = "",
     ) -> client.V1Secret:
-        logger.info("Reading secret", secret_name=secret_name)
+        logger.debug("Reading secret", secret_name=secret_name)
         try:
             k8s_secret = self.v1api.read_namespaced_secret(
                 name=secret_name,

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -153,13 +153,25 @@ def test_validate_node_selectors(node_selectors, expected):
 
 @pytest.fixture
 def k8s_helper():
-    k8s_helper = K8sHelper()
-    k8s_helper.v1api = create_autospec(CoreV1Api, instance=True, spec_set=True)
-    k8s_helper.crdapi = create_autospec(CustomObjectsApi, instance=True, spec_set=True)
-    k8s_helper._create_secret = mock.MagicMock()
-    k8s_helper._update_secret = mock.MagicMock()
-    k8s_helper._read_secret = mock.MagicMock()
-    return k8s_helper
+    with mock.patch(
+        "server.api.utils.singletons.k8s.K8sHelper._init_k8s_config",
+        return_value=None,
+    ):
+        k8s_helper = K8sHelper()
+        k8s_helper.v1api = create_autospec(
+            CoreV1Api,
+            instance=True,
+            spec_set=True,
+        )
+        k8s_helper.crdapi = create_autospec(
+            CustomObjectsApi,
+            instance=True,
+            spec_set=True,
+        )
+        k8s_helper._create_secret = mock.MagicMock()
+        k8s_helper._update_secret = mock.MagicMock()
+        k8s_helper._read_secret = mock.MagicMock()
+        return k8s_helper
 
 
 def test_create_new_secret(k8s_helper):


### PR DESCRIPTION
1. Fix the exception handling for the K8S client was not working correctly.
This is due to trying to catch exceptions inheriting from DynamicApiError, which require a call to
kubernetes.dynamic.exceptions.api_exception to convert to the correct exception class.
2. Improve the cache mechanism used in the secret creation, preventing redundant API calls.
3. Add unit tests for K8sHelper

https://iguazio.atlassian.net/browse/ML-8041