### PR TITLE
[Notifications] Fill notification params from project secrets [1.7.x]

### DIFF
--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -142,7 +142,25 @@ project.run(..., notifications=[notification])
 
 MLRun can also send a `pipeline started` notification. To do that, configure a notification that includes
 `when=running`. The `pipeline started` notification uses its own parameters, for
-example the webhook, credentials, etc., for the notification message.</br>
+example the webhook, credentials, etc., for the notification message.
+
+If the webhook for the running notification is stored in the secret_params, you should first set the project secret
+and then use this project secret in the notification. For example:
+```python
+import mlrun
+
+project = mlrun.get_or_create_project("ycvqowgpie")
+project.set_secrets({"SLACK_SECRET1": '{"webhook":"<WEBHOOK_URL>"}'})
+slack_notification = mlrun.model.Notification(
+    kind="slack",
+    when=["running"],
+    name="name",
+    message="message",
+    condition="",
+    severity="verbose",
+    secret_params={"secret": "SLACK_SECRET1"},
+)
+```
 
 ### Remote pipeline notifications
 In remote pipelines, the pipeline end notifications are sent from the MLRun API. This means you don't need to watch the pipeline in order for its notifications to be sent.

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -940,8 +940,8 @@ class MLClientCtx:
             notification: mlrun.model.Notification = mlrun.model.Notification.from_dict(
                 notification
             )
-            # We fill the secret params from the project secret params to allow the  get what it need for sending
-            # the notification(the webhook for example).
+            # Fill the secret params from the project secret. We cannot use the server side internal secret mechanism
+            # here as it is the client side.
             # TODO: This is a workaround to allow the notification to get the secret params from project secret
             #       instead of getting them from the internal project secret that should be mounted.
             #       We should mount the internal project secret that was created to the workflow-runner

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -943,13 +943,13 @@ class MLClientCtx:
             # Fill the secret params from the project secret. We cannot use the server side internal secret mechanism
             # here as it is the client side.
             # TODO: This is a workaround to allow the notification to get the secret params from project secret
-            #       instead of getting them from the internal project secret that should be mounted.
+            #       instead of getting them from the intmernal project secret that should be mounted.
             #       We should mount the internal project secret that was created to the workflow-runner
             #       and get the secret from there.
             try:
                 notification.fill_secret_params_from_project_secret()
                 notifications.append(notification)
-            except Exception:
+            except mlrun.errors.MLRunValueError:
                 logger.warning(
                     "Failed to fill secret params from project secret for notification."
                     "Skip this notification.",

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -940,12 +940,13 @@ class MLClientCtx:
             notification: mlrun.model.Notification = mlrun.model.Notification.from_dict(
                 notification
             )
-            # We fill the params from the secret params to allow the notification to get the project secret
-            # TODO: This is a workaround to allow the notification to get the secret params from project instead of
-            #       getting them from the internal project secret that should be mounted.
+            # We fill the secret params from the project secret params to allow the  get what it need for sending
+            # the notification(the webhook for example).
+            # TODO: This is a workaround to allow the notification to get the secret params from project secret
+            #       instead of getting them from the internal project secret that should be mounted.
             #       We should mount the internal project secret that was created to the workflow-runner
             #       and get the secret from there.
-            notification.fill_params_from_secret_params()
+            notification.fill_secret_params_from_project_secret()
             notifications.append(notification)
 
         return notifications

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -946,8 +946,15 @@ class MLClientCtx:
             #       instead of getting them from the internal project secret that should be mounted.
             #       We should mount the internal project secret that was created to the workflow-runner
             #       and get the secret from there.
-            notification.fill_secret_params_from_project_secret()
-            notifications.append(notification)
+            try:
+                notification.fill_secret_params_from_project_secret()
+                notifications.append(notification)
+            except Exception:
+                logger.warning(
+                    "Failed to fill secret params from project secret for notification."
+                    "Skip this notification.",
+                    notification=notification.name,
+                )
 
         return notifications
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -942,8 +942,9 @@ class MLClientCtx:
             )
             # We fill the params from the secret params to allow the notification to get the project secret
             # TODO: This is a workaround to allow the notification to get the secret params from project instead of
-            #       getting them from from the k8s secret. We should mount the internal project secret that was created
-            #       to the workflow-runner and get the secret from there.
+            #       getting them from the internal project secret that should be mounted.
+            #       We should mount the internal project secret that was created to the workflow-runner
+            #       and get the secret from there.
             notification.fill_params_from_secret_params()
             notifications.append(notification)
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -774,20 +774,22 @@ class Notification(ModelObj):
 
         notification_class.validate_params(secret_params | params)
 
-    def fill_params_from_secret_params(self):
+    def fill_secret_params_from_project_secret(self):
         """
-        Fill the notification params from the secret_params.
+        Fill the notification secret params from the project secret.
+        We are using this function instead of unmask_secret_params_from_project_secret when we run inside the
+        workflow runner pod that doesn't have access to the k8s secrets (but have access to the project secret)
         """
         secret = self.secret_params.get("secret")
         if secret:
             secret_value = mlrun.get_secret_or_env(secret)
             if secret_value:
                 try:
-                    self.params.update(json.loads(secret_value))
+                    self.secret_params = json.loads(secret_value)
                 except ValueError:
                     logger.warning(
-                        "Failed to load secret value to params",
-                        secret_value=secret_value,
+                        "Failed to load secret",
+                        secret=secret,
                     )
 
     @staticmethod

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -774,7 +774,7 @@ class Notification(ModelObj):
 
         notification_class.validate_params(secret_params | params)
 
-    def fill_secret_params_from_project_secret(self):
+    def enrich_unmasked_secret_params_from_project_secret(self):
         """
         Fill the notification secret params from the project secret.
         We are using this function instead of unmask_secret_params_from_project_secret when we run inside the
@@ -786,8 +786,10 @@ class Notification(ModelObj):
             if secret_value:
                 try:
                     self.secret_params = json.loads(secret_value)
-                except ValueError:
-                    raise mlrun.errors.MLRunValueError("Failed to parse secret value")
+                except ValueError as exc:
+                    raise mlrun.errors.MLRunValueError(
+                        "Failed to parse secret value"
+                    ) from exc
 
     @staticmethod
     def validate_notification_uniqueness(notifications: list["Notification"]):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -774,6 +774,22 @@ class Notification(ModelObj):
 
         notification_class.validate_params(secret_params | params)
 
+    def fill_params_from_secret_params(self):
+        """
+        Fill the notification params from the secret_params.
+        """
+        if "secret" in self.secret_params:
+            secret = self.secret_params["secret"]
+            secret_value = mlrun.get_secret_or_env(secret)
+            if secret_value:
+                try:
+                    self.params.update(json.loads(secret_value))
+                except ValueError:
+                    logger.warning(
+                        "Failed to load secret value to params",
+                        secret_value=secret_value,
+                    )
+
     @staticmethod
     def validate_notification_uniqueness(notifications: list["Notification"]):
         """Validate that all notifications in the list are unique by name"""

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -784,7 +784,10 @@ class Notification(ModelObj):
         if secret:
             secret_value = mlrun.get_secret_or_env(secret)
             if secret_value:
-                self.secret_params = json.loads(secret_value)
+                try:
+                    self.secret_params = json.loads(secret_value)
+                except ValueError:
+                    raise mlrun.errors.MLRunValueError("Failed to parse secret value")
 
     @staticmethod
     def validate_notification_uniqueness(notifications: list["Notification"]):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -784,13 +784,7 @@ class Notification(ModelObj):
         if secret:
             secret_value = mlrun.get_secret_or_env(secret)
             if secret_value:
-                try:
-                    self.secret_params = json.loads(secret_value)
-                except ValueError:
-                    logger.warning(
-                        "Failed to load secret",
-                        secret=secret,
-                    )
+                self.secret_params = json.loads(secret_value)
 
     @staticmethod
     def validate_notification_uniqueness(notifications: list["Notification"]):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -778,8 +778,8 @@ class Notification(ModelObj):
         """
         Fill the notification params from the secret_params.
         """
-        if "secret" in self.secret_params:
-            secret = self.secret_params["secret"]
+        secret = self.secret_params.get("secret")
+        if secret:
             secret_value = mlrun.get_secret_or_env(secret)
             if secret_value:
                 try:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -597,9 +597,9 @@ class _KFPRunner(_PipelineRunner):
             )
             # for start message, fallback to old notification behavior
             for notification in notifications or []:
-                project.notifiers.add_notification(
-                    notification.kind, notification.params
-                )
+                params = notification.params
+                params.update(notification.secret_params)
+                project.notifiers.add_notification(notification.kind, params)
 
         run_id = _run_pipeline(
             workflow_handler,

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -1081,7 +1081,7 @@ def load_and_run(
     # extract "start" notification if exists
     start_notifications = [
         notification
-        for notification in context.get_notifications()
+        for notification in context.get_notifications(unmask_secret_params=True)
         if "running" in notification.when
     ]
 

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -976,7 +976,7 @@ def test_validate_notification_params(monkeypatch, notification_kwargs, expectat
         ({"secret": "Hello"}, '{"webhook": "Hello"}', {"webhook": "Hello"}, False),
     ],
 )
-def test_fill_secret_params_from_project_secret(
+def test_enrich_unmasked_secret_params_from_project_secret(
     secret_params, get_secret_or_env_return_value, expected_params, should_raise
 ):
     with unittest.mock.patch(
@@ -988,9 +988,9 @@ def test_fill_secret_params_from_project_secret(
         )
         if should_raise:
             with pytest.raises(mlrun.errors.MLRunValueError):
-                notification.fill_secret_params_from_project_secret()
+                notification.enrich_unmasked_secret_params_from_project_secret()
         else:
-            notification.fill_secret_params_from_project_secret()
+            notification.enrich_unmasked_secret_params_from_project_secret()
             assert notification.secret_params == expected_params
 
 

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -969,21 +969,21 @@ def test_validate_notification_params(monkeypatch, notification_kwargs, expectat
         (
             {"web": "secret-web"},
             "check",
-            {"a": "b"},
+            {"web": "secret-web"},
         ),
         (
             {"secret": "Hello"},
             "Hello",
-            {"a": "b"},
+            {"secret": "Hello"},
         ),
         (
             {"secret": "Hello"},
             '{"webhook": "Hello"}',
-            {"a": "b", "webhook": "Hello"},
+            {"webhook": "Hello"},
         ),
     ],
 )
-def test_fill_params_from_secret_params(
+def test_fill_secret_params_from_project_secret(
     secret_params, get_secret_or_env_return_value, expected_params
 ):
     with unittest.mock.patch(
@@ -991,11 +991,10 @@ def test_fill_params_from_secret_params(
     ):
         notification = mlrun.model.Notification(
             kind=mlrun.common.schemas.notification.NotificationKind.slack,
-            params={"a": "b"},
             secret_params=secret_params,
         )
-        notification.fill_params_from_secret_params()
-        assert notification.params == expected_params
+        notification.fill_secret_params_from_project_secret()
+        assert notification.secret_params == expected_params
 
 
 def _mock_async_response(monkeypatch, method, result):

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -986,12 +986,12 @@ def test_fill_secret_params_from_project_secret(
             kind=mlrun.common.schemas.notification.NotificationKind.slack,
             secret_params=secret_params,
         )
-        try:
+        if should_raise:
+            with pytest.raises(mlrun.errors.MLRunValueError):
+                notification.fill_secret_params_from_project_secret()
+        else:
             notification.fill_secret_params_from_project_secret()
-        except Exception:
-            assert should_raise
-            return
-        assert notification.secret_params == expected_params
+            assert notification.secret_params == expected_params
 
 
 def _mock_async_response(monkeypatch, method, result):


### PR DESCRIPTION
Fixing bug that we didn't send `running` notification when webhook defined on the `secret_params` of the notification.
The `workflow-runner` should send the `running` notification when start running the workflow.
We got the notifications for the specific run from the db (see [here](https://github.com/mlrun/mlrun/pull/6451))
When we define the webhook inside the `secret_params`, the entity in the db doesn't contains the secret param itself but reference to the **internal project secret** that was created. Currently, the `workflow-runner` pod doesn't mount this internal project secret.

For getting the webhook(and the other secret params), for this version, we introduce the following workaround:
1. The user should create **project secret** the contains all the `secret_params` of that notification.
2. Define the notification with `secret_params={"secret": "<PROJECT_SECRET_NAME>"`}`

And then he should get the `running` notification.

In this solution, we read the notification from the db and filling the notification params from the project secret key that was provided as the secret_params.

https://iguazio.atlassian.net/browse/ML-8029