### PR TITLE
[Artifact] Enhance artifact key validation regex

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -246,6 +246,8 @@ class ArtifactManager:
                 # otherwise, we do not want to override it.
                 # this is mainly relevant for imported artifacts that have an explicit db_key value already set
                 db_key = item.db_key or key
+        if db_key != key:
+            validate_artifact_key_name(db_key, "artifact.db_key")
         item.db_key = db_key or ""
         item.viewer = viewer or item.viewer
         item.tree = producer.tag

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -268,16 +268,13 @@ def validate_tag_name(
 def validate_artifact_key_name(
     artifact_key: str, field_name: str, raise_on_failure: bool = True
 ) -> bool:
-    if field_name == "artifact.key":
-        type = "key"
-    else:
-        type = "db_key"
+    field_type = "key" if field_name == "artifact.key" else "db_key"
     return mlrun.utils.helpers.verify_field_regex(
         field_name,
         artifact_key,
         mlrun.utils.regex.artifact_key,
         raise_on_failure=raise_on_failure,
-        log_message=f"The artifact {type} must start and end with an alphanumeric character and may only contain "
+        log_message=f"Artifact {field_type} must start and end with an alphanumeric character, and may only contain "
         "letters, numbers, hyphens, underscores, and dots.",
     )
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -268,13 +268,17 @@ def validate_tag_name(
 def validate_artifact_key_name(
     artifact_key: str, field_name: str, raise_on_failure: bool = True
 ) -> bool:
+    if field_name == "artifact.key":
+        type = "key"
+    else:
+        type = "db_key"
     return mlrun.utils.helpers.verify_field_regex(
         field_name,
         artifact_key,
         mlrun.utils.regex.artifact_key,
         raise_on_failure=raise_on_failure,
-        log_message="The artifact key must start and end with an alphanumeric character and may only contain letters, "
-        "numbers, hyphens, underscores, and dots.",
+        log_message=f"The artifact {type} must start and end with an alphanumeric character and may only contain "
+        "letters, numbers, hyphens, underscores, and dots.",
     )
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -273,7 +273,8 @@ def validate_artifact_key_name(
         artifact_key,
         mlrun.utils.regex.artifact_key,
         raise_on_failure=raise_on_failure,
-        log_message="Slashes are not permitted in the artifact key (both \\ and /)",
+        log_message="The artifact key must start and end with an alphanumeric character and may only contain letters, "
+        "numbers, hyphens, underscores, and dots.",
     )
 
 

--- a/mlrun/utils/regex.py
+++ b/mlrun/utils/regex.py
@@ -86,7 +86,7 @@ tag_name = label_value
 
 secret_key = k8s_secret_and_config_map_key
 
-artifact_key = [r"[^\/\\]+$"]
+artifact_key = [r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$"]
 
 # must not start with _
 # must be alphanumeric or _

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -1242,6 +1242,8 @@ class SQLDB(DBInterface):
         db_key = artifact_dict.get("spec", {}).get("db_key")
         if not db_key:
             artifact_dict.setdefault("spec", {})["db_key"] = key
+        else:
+            validate_artifact_key_name(db_key, "artifact.db_key")
 
         # remove the tag from the metadata, as it is stored in a separate table
         artifact_dict["metadata"].pop("tag", None)

--- a/tests/api/db/test_artifacts.py
+++ b/tests/api/db/test_artifacts.py
@@ -574,6 +574,7 @@ class TestArtifacts:
 
         # store the artifact with invalid db_key
         artifact_invalid_db_key = "artifact#!key"
+        artifact_body = self._generate_artifact(artifact_valid_key)
         artifact_body["spec"]["db_key"] = artifact_invalid_db_key
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             db.store_artifact(

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -387,6 +387,14 @@ def test_log_artifact_with_invalid_key(artifact_key, expected):
     with expected:
         project.log_artifact(artifact)
 
+    # when storing an artifact with producer.kind="run", the value of db_key is modified to: producer.name + "_" + key
+    # and in this case since key="some-key", the db_key will always be valid
+    context = mlrun.get_or_create_ctx("test")
+    try:
+        context.log_artifact(item=artifact)
+    except Exception as e:
+        pytest.fail(f"Unexpected exception raised: {e}")
+
 
 @pytest.mark.parametrize(
     "local_path, fail",

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -329,6 +329,7 @@ def test_validate_tag_name(tag_name, expected):
         ("artifact#name", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         ("artifact-name#", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         ("artifact:name", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        ("artifact_name$", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         # Valid names
         ("artifact-name2.0", does_not_raise()),
         ("artifact-name3", does_not_raise()),
@@ -342,6 +343,11 @@ def test_validate_artifact_name(artifact_name, expected):
         validate_artifact_key_name(
             artifact_name,
             field_name="artifact.key",
+        )
+    with expected:
+        validate_artifact_key_name(
+            artifact_name,
+            field_name="artifact.db_key",
         )
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -321,11 +321,19 @@ def test_validate_tag_name(tag_name, expected):
             pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
         ),
         ("", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        (
+            "artifact-name#",
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        ("artifact@name", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        ("artifact#name", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        ("artifact-name#", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
+        ("artifact:name", pytest.raises(mlrun.errors.MLRunInvalidArgumentError)),
         # Valid names
         ("artifact-name2.0", does_not_raise()),
-        ("artifact-name", does_not_raise()),
-        ("artifact-name", does_not_raise()),
-        ("artifact-name_chars@#$", does_not_raise()),
+        ("artifact-name3", does_not_raise()),
+        ("artifact_name", does_not_raise()),
+        ("artifact.name", does_not_raise()),
         ("artifactNAME", does_not_raise()),
     ],
 )


### PR DESCRIPTION
This PR enhances the validation for artifact key and db_key in the backend by updating the regex pattern.
The artifact key needs to start and end with alphanumeric character, and can contain -_. in the middle. This is basically the same validation the UI currently has.

Existing artifacts will remain valid; this change applies only to newly created artifacts.

resolves:
https://iguazio.atlassian.net/browse/ML-5809