### PR TITLE
[Monitoring] Fix get or create run conflict attempt 2 [1.7.x]

### DIFF
--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -61,6 +61,16 @@ class DBInterface(ABC):
     ):
         pass
 
+    def create_or_get_run(
+        self,
+        session,
+        run_data: dict,
+        uid: str,
+        project: str = "",
+        iter: int = 0,
+    ):
+        pass
+
     @abstractmethod
     def update_run(self, session, updates: dict, uid, project="", iter=0):
         pass

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -227,20 +227,47 @@ class SQLDB(DBInterface):
                 start_time=run_start_time(run_data) or now,
                 requested_logs=False,
             )
-        self._ensure_run_name_on_update(run, run_data)
-        labels = run_labels(run_data)
-        self._update_run_state(run, run_data)
-        update_labels(run, labels)
-        # Note that this code basically allowing anyone to override the run's start time after it was already set
-        # This is done to enable the context initialization to set the start time to when the user's code actually
-        # started running, and not when the run record was initially created (happening when triggering the job)
-        # In the future we might want to limit who can actually do that
-        start_time = run_start_time(run_data) or SQLDB._add_utc_timezone(run.start_time)
-        run_data.setdefault("status", {})["start_time"] = start_time.isoformat()
-        run.start_time = start_time
-        self._update_run_updated_time(run, run_data, now=now)
-        run.struct = run_data
+        self._enrich_run_model(now, run, run_data)
         self._upsert(session, [run], ignore=True)
+
+    def create_or_get_run(
+        self,
+        session: Session,
+        run_data: dict,
+        uid: str,
+        project: str = "",
+        iter: int = 0,
+    ):
+        """
+        This method is used to ensure a specific run is in the DB.
+        Due to isolation levels, it is possible that a certain session is unable to read a run from the DB since it
+        has an outdated snapshot. Here, we try to create a run, if we get a conflict, the session was rollbacked, and
+        we can now read the run from the DB.
+        """
+        logger.debug(
+            "Creating or getting run in DB",
+            project=project,
+            uid=uid,
+            iter=iter,
+            run_name=run_data["metadata"]["name"],
+        )
+        now = datetime.now(timezone.utc)
+        run = Run(
+            name=run_data["metadata"]["name"],
+            uid=uid,
+            project=project,
+            iteration=iter,
+            state=run_state(run_data),
+            start_time=run_start_time(run_data) or now,
+            requested_logs=False,
+        )
+        self._enrich_run_model(now, run, run_data)
+        try:
+            self._upsert(session, [run], silent=True)
+        except mlrun.errors.MLRunConflictError:
+            # Session was rollbacked and we now get a new snapshot
+            return self.read_run(session, uid=uid, project=project, iter=iter)
+        return run_data
 
     def update_run(self, session, updates: dict, uid, project="", iter=0):
         project = project or config.default_project
@@ -450,21 +477,6 @@ class SQLDB(DBInterface):
 
         return runs
 
-    def _fill_run_struct_with_notifications(self, notifications, run_struct):
-        if not notifications:
-            return
-        run_struct.setdefault("spec", {})["notifications"] = []
-        run_struct.setdefault("status", {})["notifications"] = {}
-        for notification in notifications:
-            (
-                notification_spec,
-                notification_status,
-            ) = self._transform_notification_record_to_spec_and_status(notification)
-            run_struct["spec"]["notifications"].append(notification_spec)
-            run_struct["status"]["notifications"][notification.name] = (
-                notification_status
-            )
-
     def del_run(self, session, uid, project=None, iter=0):
         project = project or config.default_project
         # We currently delete *all* iterations
@@ -485,6 +497,36 @@ class SQLDB(DBInterface):
         for run in query:  # Can not use query.delete with join
             session.delete(run)
         session.commit()
+
+    def _fill_run_struct_with_notifications(self, notifications, run_struct):
+        if not notifications:
+            return
+        run_struct.setdefault("spec", {})["notifications"] = []
+        run_struct.setdefault("status", {})["notifications"] = {}
+        for notification in notifications:
+            (
+                notification_spec,
+                notification_status,
+            ) = self._transform_notification_record_to_spec_and_status(notification)
+            run_struct["spec"]["notifications"].append(notification_spec)
+            run_struct["status"]["notifications"][notification.name] = (
+                notification_status
+            )
+
+    def _enrich_run_model(self, now: datetime, run: Run, run_data: dict):
+        self._ensure_run_name_on_update(run, run_data)
+        labels = run_labels(run_data)
+        self._update_run_state(run, run_data)
+        update_labels(run, labels)
+        # Note that this code basically allowing anyone to override the run's start time after it was already set
+        # This is done to enable the context initialization to set the start time to when the user's code actually
+        # started running, and not when the run record was initially created (happening when triggering the job)
+        # In the future we might want to limit who can actually do that
+        start_time = run_start_time(run_data) or SQLDB._add_utc_timezone(run.start_time)
+        run_data.setdefault("status", {})["start_time"] = start_time.isoformat()
+        run.start_time = start_time
+        self._update_run_updated_time(run, run_data, now=now)
+        run.struct = run_data
 
     def _add_run_name_query(self, query, name):
         exact_name = self._escape_characters_for_like_query(name)
@@ -4561,15 +4603,15 @@ class SQLDB(DBInterface):
         session.query(cls).filter(cls.parent == NULL).delete()
         session.commit()
 
-    def _upsert(self, session, objects, ignore=False):
+    def _upsert(self, session, objects, ignore=False, silent=False):
         if not objects:
             return
         for object_ in objects:
             session.add(object_)
-        self._commit(session, objects, ignore)
+        self._commit(session, objects, ignore, silent)
 
     @staticmethod
-    def _commit(session, objects, ignore=False):
+    def _commit(session, objects, ignore=False, silent=False):
         def _try_commit_obj():
             try:
                 session.commit()
@@ -4590,11 +4632,12 @@ class SQLDB(DBInterface):
 
                 # the error is not retryable, so we try to identify weather there was a conflict or not
                 # either way - we wrap the error with a fatal error so the retry mechanism will stop
-                logger.warning(
-                    "Failed committing changes to DB",
-                    classes=classes,
-                    err=err_to_str(sql_err),
-                )
+                if not silent:
+                    logger.warning(
+                        "Failed committing changes to DB",
+                        classes=classes,
+                        err=err_to_str(sql_err),
+                    )
                 if not ignore:
                     # get the identifiers of the objects that failed to commit, for logging purposes
                     identifiers = ",".join(


### PR DESCRIPTION
During monitoring runs we try to create a run for an existing pod when we didn't find it by listing runs previously. This is prune to session isolation level errors as it may have been created after the transaction started and therefore we can't read it.
Trying to catch sql integrity errors and then getting the run instead of presumably committing the session to get a new snapshot / new transaction.

https://iguazio.atlassian.net/browse/ML-8028