### PR TITLE
[Model Monitoring] Fix for checking infer data on the controller

### DIFF
--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -420,7 +420,7 @@ class MonitoringApplicationController:
                         end_time=end_infer_time,
                         time_column=mm_constants.EventFieldType.TIMESTAMP,
                     )
-                    if df.empty():
+                    if len(df) == 0:
                         logger.info(
                             "No data found for the given interval",
                             start=start_infer_time,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import concurrent.futures
 import datetime
 import json
@@ -27,6 +26,7 @@ import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.data_types.infer
 import mlrun.feature_store as fstore
 import mlrun.model_monitoring.db.stores
+from mlrun.config import config as mlconf
 from mlrun.datastore import get_stream_pusher
 from mlrun.errors import err_to_str
 from mlrun.model_monitoring.helpers import (
@@ -288,9 +288,7 @@ class MonitoringApplicationController:
 
         self.model_monitoring_access_key = self._get_model_monitoring_access_key()
         self.storage_options = None
-        if not mlrun.mlconf.is_ce_mode():
-            self._initialize_v3io_configurations()
-        elif os.environ.get("MLRUN_ARTIFACT_PATH").startswith("s3://"):
+        if mlconf.artifact_path.startswith("s3://"):
             self.storage_options = mlrun.mlconf.get_s3_storage_options()
 
     @staticmethod
@@ -300,12 +298,6 @@ class MonitoringApplicationController:
         if access_key is None:
             access_key = mlrun.mlconf.get_v3io_access_key()
         return access_key
-
-    def _initialize_v3io_configurations(self) -> None:
-        self.storage_options = dict(
-            v3io_access_key=self.model_monitoring_access_key,
-            v3io_api=mlrun.mlconf.v3io_api,
-        )
 
     def run(self) -> None:
         """


### PR DESCRIPTION
Resolved two issues introduced i https://iguazio.atlassian.net/browse/ML-8046 which were caused by the use of batch inference. These issues led to incorrect behavior: either the applications were triggered with no data, or they weren’t triggered at all when the MEP was deployed from a model server and invoked only by the batch inference process. For a detailed RCA, please refer to the ticket.

**Solution**
The controller will now check the infer parquet files directly, instead of querying the TSDB. This ensures that applications are triggered only when the model has actually been invoked.
