### PR TITLE
[Docs] Running notification send only the default notification [1.7.x]

### DIFF
--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -161,6 +161,8 @@ slack_notification = mlrun.model.Notification(
     secret_params={"secret": "SLACK_SECRET1"},
 )
 ```
+> ℹ️ **Info:** On running notification you can set only the webhook, and the message will be the default message.
+
 
 ### Remote pipeline notifications
 In remote pipelines, the pipeline end notifications are sent from the MLRun API. This means you don't need to watch the pipeline in order for its notifications to be sent.

--- a/docs/concepts/notifications.md
+++ b/docs/concepts/notifications.md
@@ -140,12 +140,15 @@ notification = mlrun.model.Notification(
 project.run(..., notifications=[notification])
 ```
 
+### Running notifications
 MLRun can also send a `pipeline started` notification. To do that, configure a notification that includes
 `when=running`. The `pipeline started` notification uses its own parameters, for
 example the webhook, credentials, etc., for the notification message.
 
-If the webhook for the running notification is stored in the secret_params, you should first set the project secret
-and then use this project secret in the notification. For example:
+You can set only the webhook; the message is the default message.
+
+If the webhook is stored in the secret_params, you should first set the project secret and then use this project secret
+in the notification. For example:
 ```python
 import mlrun
 
@@ -155,13 +158,10 @@ slack_notification = mlrun.model.Notification(
     kind="slack",
     when=["running"],
     name="name",
-    message="message",
     condition="",
-    severity="verbose",
     secret_params={"secret": "SLACK_SECRET1"},
 )
 ```
-> ℹ️ **Info:** On running notification you can set only the webhook, and the message will be the default message.
 
 
 ### Remote pipeline notifications

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -593,7 +593,7 @@ class _KFPRunner(_PipelineRunner):
             logger.warning(
                 "Setting notifications on kfp pipeline runner uses old notification behavior. "
                 "Notifications will only be sent if you wait for pipeline completion. "
-                "Some of the features (like setting message or severity level)."
+                "Some of the features (like setting message or severity level) are not supported."
             )
             # for start message, fallback to old notification behavior
             for notification in notifications or []:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -593,7 +593,7 @@ class _KFPRunner(_PipelineRunner):
             logger.warning(
                 "Setting notifications on kfp pipeline runner uses old notification behavior. "
                 "Notifications will only be sent if you wait for pipeline completion. "
-                "To use the new notification behavior, use the remote pipeline runner."
+                "Some of the features (like setting message or severity level)."
             )
             # for start message, fallback to old notification behavior
             for notification in notifications or []:


### PR DESCRIPTION
When we send running notification it sent from the old notification mechanism where we cannot set the message and the severity.
Clarify it on the docs.

https://iguazio.atlassian.net/browse/ML-8063
