### PR TITLE
[Logs] Ensure err-to-str truncation takes the last part as well [1.7.x]

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -145,7 +145,7 @@ def err_to_str(err):
     # in case the error string is longer than 32k, we truncate it
     # the truncation takes the first 16k, then the last 16k characters
     if len(err_msg) > 32_000:
-        err_msg = err_msg[:16_000] + "...truncated..." + err_msg[-16_000]
+        err_msg = err_msg[:16_000] + "...truncated..." + err_msg[-16_000:]
     return err_msg
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -31,6 +31,15 @@ def test_error_none():
     assert err_to_str(None) == ""
 
 
+def test_long_error_message_truncated():
+    err_msg = "a" * 16_000
+    err_msg += "deleteme"
+    err_msg += "b" * 16_000
+    truncated_err_msg = err_to_str(Exception(err_msg))
+    assert len(truncated_err_msg) == 32_000 + len("...truncated...")
+    assert "deleteme" not in truncated_err_msg
+
+
 def test_error_is_already_string():
     assert err_to_str("this is already a string") == "this is already a string"
 


### PR DESCRIPTION
reducing spammy logs - part of https://iguazio.atlassian.net/browse/ML-8080