### PR TITLE
[CI] Fix system tests kubeconfig injection

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -242,7 +242,6 @@ jobs:
           --mlrun-ui-version "${{ steps.computed_params.outputs.mlrun_ui_version }}" \
           --mlrun-commit "${{ steps.computed_params.outputs.mlrun_hash }}" \
           --override-image-registry "${{ steps.computed_params.outputs.mlrun_docker_registry }}"
-          --kubeconfig-content "${{ secrets.LATEST_SYSTEM_TEST_KUBECONFIG }}"
 
     - name: Prepare System Test env.yml and MLRun installation from current branch
       timeout-minutes: 5
@@ -256,7 +255,8 @@ jobs:
           --slack-webhook-url "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
           --branch "${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}" \
           --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" \
-          --save-to-path "$GITHUB_WORKSPACE/env.yml"
+          --save-to-path "$GITHUB_WORKSPACE/env.yml" \
+          --kubeconfig-content "${{ secrets.LATEST_SYSTEM_TEST_KUBECONFIG }}"
 
     - name: Encrypt file
       id: encrypt_file

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -111,7 +111,6 @@ class SystemTestPreparer:
         self._mlrun_dbpath = mlrun_dbpath
 
         self._env_config = {
-            "SYSTEM_TEST_KUBECONFIG": kubeconfig_content,
             "MLRUN_DBPATH": mlrun_dbpath,
             "V3IO_USERNAME": username,
             "V3IO_ACCESS_KEY": access_key,
@@ -120,6 +119,7 @@ class SystemTestPreparer:
             # Setting to MLRUN_SYSTEM_TESTS_GIT_TOKEN instead of GIT_TOKEN, to not affect tests which doesn't need it
             # (e.g. tests which use public repos, therefor doesn't need that access token)
             "MLRUN_SYSTEM_TESTS_GIT_TOKEN": github_access_token,
+            "MLRUN_SYSTEM_TEST_KUBECONFIG": kubeconfig_content,
         }
 
     def prepare_local_env(self, save_to_path: str = ""):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -12,66 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import base64
 import collections
 import os
 import time
-from tempfile import NamedTemporaryFile
 
 import humanfriendly
-import kubernetes.client as k8s_client
 import pytest
 import requests
 from _pytest.terminal import TerminalReporter
-from kubernetes import config
 from pytest import CallInfo, ExitCode, Function, TestReport
-
-from mlrun.utils import create_test_logger
-
-logger = create_test_logger(name="test-system")
 
 
 def pytest_sessionstart(
     session: pytest.Session,
 ):
-    setup_k8s_client(
-        session=session,
-    )  # Setup K8S client for use in system tests.
-
     # caching test results
     session.results = collections.defaultdict(TestReport)
-
-
-def setup_k8s_client(
-    session: pytest.Session,
-):
-    kubeconfig_content = None
-    try:
-        base64_kubeconfig_content = os.environ["MLRUN_SYSTEM_TEST_KUBECONFIG"]
-        kubeconfig_content = base64.b64decode(base64_kubeconfig_content)
-    except (ValueError, KeyError) as exc:
-        logger.warning("Kubeconfig was empty or invalid.", exc_info=exc)
-        session.kube_client = property(missing_kubeclient)
-    if kubeconfig_content:
-        with NamedTemporaryFile() as tempfile:
-            tempfile.write(kubeconfig_content)
-            tempfile.flush()
-            try:
-                config.load_kube_config(
-                    config_file=tempfile.name,
-                )
-                session.kube_client = k8s_client.CoreV1Api()
-            except config.config_exception.ConfigException:
-                logger.warning(
-                    "Failed to load kubeconfig, kube_client will be unavailable."
-                )
-                session.kube_client = property(missing_kubeclient)
-    else:
-        session.kube_client = property(missing_kubeclient)
-
-
-def missing_kubeclient(self):
-    raise AttributeError("Kubeclient was not setup and is unavailable")
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -47,7 +47,7 @@ def setup_k8s_client(
 ):
     kubeconfig_content = None
     try:
-        base64_kubeconfig_content = os.environ["SYSTEM_TEST_KUBECONFIG"]
+        base64_kubeconfig_content = os.environ["MLRUN_SYSTEM_TEST_KUBECONFIG"]
         kubeconfig_content = base64.b64decode(base64_kubeconfig_content)
     except (ValueError, KeyError) as exc:
         logger.warning("Kubeconfig was empty or invalid.", exc_info=exc)

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -540,10 +540,6 @@ class TestProject(TestMLRunSystem):
         self._test_new_pipeline("lclpipe", engine="local")
 
     def test_kfp_pipeline(self):
-        k8s_secret: V1Secret = self.kube_client.read_namespaced_secret(
-            name="asda",
-            namespace="default-tenant",
-        )
         self._test_new_pipeline("kfppipe", engine="kfp")
 
     def test_kfp_runs_getting_deleted_on_project_deletion(self):

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -530,7 +530,7 @@ class TestProject(TestMLRunSystem):
         assert fn.status.state == "ready"
         assert fn.spec.image, "image path got cleared"
         for secret_name, env_var_name in project._secrets.get_k8s_secrets().items():
-            k8s_secret: V1Secret = pytest.Session.kube_client.read_namespaced_secret(
+            k8s_secret: V1Secret = self.kube_client.read_namespaced_secret(
                 name=secret_name,
                 namespace="default-tenant",
             )
@@ -540,6 +540,10 @@ class TestProject(TestMLRunSystem):
         self._test_new_pipeline("lclpipe", engine="local")
 
     def test_kfp_pipeline(self):
+        k8s_secret: V1Secret = self.kube_client.read_namespaced_secret(
+            name="asda",
+            namespace="default-tenant",
+        )
         self._test_new_pipeline("kfppipe", engine="kfp")
 
     def test_kfp_runs_getting_deleted_on_project_deletion(self):


### PR DESCRIPTION
The issue was there was a missing `\` before the new flag line.
I also moved it to the correct place where we prepare the env and moved the client setup to be after we read the env.yml file