### PR TITLE
[Requirements] Fix aiohttp-retry following release of 2.9.0 [1.7.x]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 urllib3>=1.26.9, <1.27
 GitPython~=3.1, >=3.1.41
 aiohttp~=3.9
-aiohttp-retry~=2.8
+aiohttp-retry~=2.8.0
 click~=8.1
 nest-asyncio~=1.0
 ipython~=8.10

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -135,6 +135,7 @@ def test_requirement_specifiers_convention():
         "pyopenssl": {">=23"},
         "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
         "google-cloud-bigquery": {"[pandas, bqstorage]==3.14.1"},
+        "aiohttp-retry": {"~=2.8.0"},
         # due to a bug in apscheduler with python 3.9 https://github.com/agronholm/apscheduler/issues/770
         "apscheduler": {"~=3.6, !=3.10.2"},
         # used in tests


### PR DESCRIPTION
aiohttp-retry 2.9.0, released a few hours ago, at 2024-10-27 01:23:20 UTC, [replaces](https://github.com/inyutin/aiohttp_retry/pull/85/files#diff-7027d072f17c0637f41af49ed64023fd93d6484df689a8a3ac2472c8202a1ba8L83) `_is_status_code_ok`, an internal method we call.

As a quick and safe solution, this PR limits aiohttp-retry to <2.9.