### PR TITLE
[Requirements] Limit storey version [1.7.x]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2023.9.2, <2024.7
 v3iofs~=0.1.17
-storey~=1.7.27
+# limit storey version in mlrun 1.7.0 to make space for separate storey releases for mlrun 1.7.1
+storey>1.7.27,<1.7.50
 inflection~=0.5.0
 python-dotenv~=0.17.0
 # older version of setuptools contains vulnerabilities, see `GHSA-r9hx-vwmv-q579`, so we limit to 65.5 and above

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -112,7 +112,7 @@ def test_requirement_specifiers_convention():
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "aiobotocore": {">=2.5.0,<2.16"},
-        "storey": {"~=1.7.27"},
+        "storey": {">1.7.27,<1.7.50"},
         "nuclio-sdk": {">=0.5"},
         "bokeh": {"~=2.4, >=2.4.2"},
         # protobuf is limited just for docs


### PR DESCRIPTION
To allow for separate releases for mlrun 1.7.0 and mlrun 1.7.1.