### PR TITLE
[Alerts] Refine alert configuration to skip reset on non-functional changes

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -763,6 +763,7 @@ class RunDBInterface(ABC):
         alert_name: str,
         alert_data: Union[dict, mlrun.alerts.alert.AlertConfig],
         project="",
+        force_reset: bool = False,
     ):
         pass
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4327,6 +4327,7 @@ class HTTPRunDB(RunDBInterface):
         alert_name: str,
         alert_data: Union[dict, AlertConfig],
         project="",
+        force_reset: bool = False,
     ) -> AlertConfig:
         """
         Create/modify an alert.
@@ -4334,6 +4335,7 @@ class HTTPRunDB(RunDBInterface):
         :param alert_name: The name of the alert.
         :param alert_data: The data of the alert.
         :param project:    The project that the alert belongs to.
+        :param force_reset: If true and the alert already exist then we should force reset the alert.
         :returns:          The created/modified alert.
         """
         if not alert_data:
@@ -4358,7 +4360,10 @@ class HTTPRunDB(RunDBInterface):
 
         alert_data = alert_instance.to_dict()
         body = _as_json(alert_data)
-        response = self.api_call("PUT", endpoint_path, error_message, body=body)
+        params = {"force_reset": bool2str(force_reset)}
+        response = self.api_call(
+            "PUT", endpoint_path, error_message, params=params, body=body
+        )
         return AlertConfig.from_dict(response.json())
 
     def get_alert_config(self, alert_name: str, project="") -> AlertConfig:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4335,7 +4335,7 @@ class HTTPRunDB(RunDBInterface):
         :param alert_name: The name of the alert.
         :param alert_data: The data of the alert.
         :param project:    The project that the alert belongs to.
-        :param force_reset: If true and the alert already exist then we should force reset the alert.
+        :param force_reset: If True and the alert already exists, the alert would be reset.
         :returns:          The created/modified alert.
         """
         if not alert_data:
@@ -4360,7 +4360,7 @@ class HTTPRunDB(RunDBInterface):
 
         alert_data = alert_instance.to_dict()
         body = _as_json(alert_data)
-        params = {"force_reset": bool2str(force_reset)}
+        params = {"force_reset": bool2str(force_reset)} if force_reset else {}
         response = self.api_call(
             "PUT", endpoint_path, error_message, params=params, body=body
         )

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -801,6 +801,7 @@ class NopDB(RunDBInterface):
         alert_name: str,
         alert_data: Union[dict, mlrun.alerts.alert.AlertConfig],
         project="",
+        force_reset: bool = False,
     ):
         pass
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4213,7 +4213,7 @@ class MlrunProject(ModelObj):
 
         :param alert_data: The data of the alert.
         :param alert_name: The name of the alert.
-        :param force_reset: If true and the alert already exist then we should force reset the alert.
+        :param force_reset: If True and the alert already exists, the alert would be reset.
         :return: the created/modified alert.
         """
         if not alert_data:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4203,13 +4203,17 @@ class MlrunProject(ModelObj):
         mlrun.db.get_run_db().delete_api_gateway(name=name, project=self.name)
 
     def store_alert_config(
-        self, alert_data: AlertConfig, alert_name: typing.Optional[str] = None
+        self,
+        alert_data: AlertConfig,
+        alert_name: typing.Optional[str] = None,
+        force_reset: bool = False,
     ) -> AlertConfig:
         """
         Create/modify an alert.
 
         :param alert_data: The data of the alert.
         :param alert_name: The name of the alert.
+        :param force_reset: If true and the alert already exist then we should force reset the alert.
         :return: the created/modified alert.
         """
         if not alert_data:
@@ -4223,7 +4227,9 @@ class MlrunProject(ModelObj):
                 project=alert_data.project,
             )
         alert_data.project = self.metadata.name
-        return db.store_alert_config(alert_name, alert_data, project=self.metadata.name)
+        return db.store_alert_config(
+            alert_name, alert_data, project=self.metadata.name, force_reset=force_reset
+        )
 
     def get_alert_config(self, alert_name: str) -> AlertConfig:
         """

--- a/server/api/api/endpoints/alerts.py
+++ b/server/api/api/endpoints/alerts.py
@@ -36,6 +36,7 @@ async def store_alert(
     project: str,
     name: str,
     alert_data: mlrun.common.schemas.AlertConfig,
+    force_reset: bool = False,
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ) -> mlrun.common.schemas.AlertConfig:
@@ -71,6 +72,7 @@ async def store_alert(
         project,
         name,
         alert_data,
+        force_reset,
     )
 
 

--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -46,7 +46,7 @@ class Alerts(
     ):
         project = project or mlrun.mlconf.default_project
 
-        alert = server.api.utils.singletons.db.get_db().get_alert(
+        existing_alert = server.api.utils.singletons.db.get_db().get_alert(
             session, project, name
         )
 
@@ -55,16 +55,18 @@ class Alerts(
         if alert_data.criteria is None:
             alert_data.criteria = mlrun.common.schemas.alert.AlertCriteria()
 
-        if alert is not None:
-            self._delete_notifications(alert)
-            self._get_alert_by_id_cached().cache_remove(session, alert.id)
+        if existing_alert is not None:
+            self._delete_notifications(existing_alert)
+            self._get_alert_by_id_cached().cache_remove(session, existing_alert.id)
 
-            for kind in alert.trigger.events:
+            for kind in existing_alert.trigger.events:
                 server.api.crud.Events().remove_event_configuration(
-                    project, kind, alert.id
+                    project, kind, existing_alert.id
                 )
-            alert_data.created = alert.created
-            alert_data.id = alert.id
+
+            # preserve the original creation time and id of the alert so that modifying the alert does not change them
+            alert_data.created = existing_alert.created
+            alert_data.id = existing_alert.id
         else:
             num_alerts = (
                 server.api.utils.singletons.db.get_db().get_num_configured_alerts(
@@ -87,9 +89,9 @@ class Alerts(
                 project, kind, new_alert.id
             )
 
-        # if the alert already exist we should check if it should be reset or not
-        if alert is not None and self._should_reset_alert(
-            alert, alert_data, force_reset
+        # if the alert already exists we should check if it should be reset or not
+        if existing_alert is not None and self._should_reset_alert(
+            existing_alert, alert_data, force_reset
         ):
             logger.debug(
                 "Resetting alert due to %s",
@@ -390,14 +392,16 @@ class Alerts(
         if force_reset:
             return True
 
-        # if one of these fields was modified then we should reset the alert
-        if (
-            old_alert_data.entities != alert_data.entities
-            or old_alert_data.trigger != alert_data.trigger
-            or old_alert_data.criteria != alert_data.criteria
-        ):
-            return True
-        return False
+        # reset the alert if a functional parameter (entities, trigger, or criteria) has changed, as these affect the
+        # conditions for alert activation.
+        return any(
+            getattr(old_alert_data, attr) != getattr(alert_data, attr)
+            for attr in [
+                "entities",
+                "trigger",
+                "criteria",
+            ]
+        )
 
     @staticmethod
     def _delete_notifications(alert: mlrun.common.schemas.AlertConfig):

--- a/server/api/crud/alerts.py
+++ b/server/api/crud/alerts.py
@@ -42,6 +42,7 @@ class Alerts(
         project: str,
         name: str,
         alert_data: mlrun.common.schemas.AlertConfig,
+        force_reset: bool = False,
     ):
         project = project or mlrun.mlconf.default_project
 
@@ -57,6 +58,13 @@ class Alerts(
         if alert is not None:
             self._delete_notifications(alert)
             self._get_alert_by_id_cached().cache_remove(session, alert.id)
+
+            for kind in alert.trigger.events:
+                server.api.crud.Events().remove_event_configuration(
+                    project, kind, alert.id
+                )
+            alert_data.created = alert.created
+            alert_data.id = alert.id
         else:
             num_alerts = (
                 server.api.utils.singletons.db.get_db().get_num_configured_alerts(
@@ -70,14 +78,6 @@ class Alerts(
 
         self._validate_and_mask_notifications(alert_data)
 
-        if alert is not None:
-            for kind in alert.trigger.events:
-                server.api.crud.Events().remove_event_configuration(
-                    project, kind, alert.id
-                )
-            alert_data.created = alert.created
-            alert_data.id = alert.id
-
         new_alert = server.api.utils.singletons.db.get_db().store_alert(
             session, alert_data
         )
@@ -87,7 +87,17 @@ class Alerts(
                 project, kind, new_alert.id
             )
 
-        self.reset_alert(session, project, new_alert.name)
+        # if the alert already exist we should check if it should be reset or not
+        if alert is not None and self._should_reset_alert(
+            alert, alert_data, force_reset
+        ):
+            logger.debug(
+                "Resetting alert due to %s",
+                "force_reset being True"
+                if force_reset
+                else "changes in entities, criteria, or trigger of the alert",
+            )
+            self.reset_alert(session, project, new_alert.name)
 
         server.api.utils.singletons.db.get_db().enrich_alert(session, new_alert)
 
@@ -374,6 +384,20 @@ class Alerts(
         )
         self._get_alert_state_cached().cache_remove(session, alert.id)
         self._clear_alert_states(alert)
+
+    @staticmethod
+    def _should_reset_alert(old_alert_data, alert_data, force_reset):
+        if force_reset:
+            return True
+
+        # if one of these fields was modified then we should reset the alert
+        if (
+            old_alert_data.entities != alert_data.entities
+            or old_alert_data.trigger != alert_data.trigger
+            or old_alert_data.criteria != alert_data.criteria
+        ):
+            return True
+        return False
 
     @staticmethod
     def _delete_notifications(alert: mlrun.common.schemas.AlertConfig):

--- a/server/api/db/base.py
+++ b/server/api/db/base.py
@@ -1040,6 +1040,7 @@ class DBInterface(ABC):
         alert_name: str,
         alert_data: Union[dict, mlrun.alerts.alert.AlertConfig],
         project="",
+        force_reset: bool = False,
     ):
         pass
 

--- a/server/api/rundb/sqldb.py
+++ b/server/api/rundb/sqldb.py
@@ -1195,6 +1195,7 @@ class SQLRunDB(RunDBInterface):
         alert_name: str,
         alert_data: Union[dict, mlrun.alerts.alert.AlertConfig],
         project="",
+        force_reset: bool = False,
     ):
         pass
 

--- a/tests/api/crud/test_alerts.py
+++ b/tests/api/crud/test_alerts.py
@@ -21,6 +21,7 @@ import pytest
 import sqlalchemy.orm
 
 import mlrun.common.schemas.alert
+import mlrun.common.schemas.alert as alert_objects
 import server.api.crud
 import tests.api.conftest
 
@@ -32,55 +33,44 @@ async def test_process_event_no_cache(
 ):
     project = "project-name"
     alert_name = "my-alert"
-    entity = mlrun.common.schemas.alert.EventEntities(
-        kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+    alert_summary = "testing 1 2 3"
+    alert_reset_policy = alert_objects.ResetPolicy.MANUAL
+    alert_entity = alert_objects.EventEntities(
+        kind=alert_objects.EventEntityKind.MODEL_ENDPOINT_RESULT,
         project=project,
         ids=[123],
     )
-    event_kind = mlrun.common.schemas.alert.EventKind.DATA_DRIFT_SUSPECTED
+    event_kind = alert_objects.EventKind.DATA_DRIFT_SUSPECTED
+    alert_trigger = alert_objects.AlertTrigger(events=[event_kind])
 
-    alert = mlrun.common.schemas.alert.AlertConfig(
+    alert_data = _generate_alert_data(
         project=project,
         name=alert_name,
-        summary="testing 1 2 3",
-        severity=mlrun.common.schemas.alert.AlertSeverity.MEDIUM,
-        entities=entity,
-        trigger=mlrun.common.schemas.alert.AlertTrigger(events=[event_kind]),
-        reset_policy=mlrun.common.schemas.alert.ResetPolicy.MANUAL,
-        notifications=[
-            {
-                "notification": {
-                    "kind": "slack",
-                    "name": "slack_drift",
-                    "message": "Ay ay ay!",
-                    "severity": "warning",
-                    "when": ["now"],
-                    "condition": "failed",
-                    "secret_params": {
-                        "webhook": "https://hooks.slack.com/services/",
-                    },
-                },
-            },
-        ],
+        entity=alert_entity,
+        summary=alert_summary,
+        trigger=alert_trigger,
+        reset_policy=alert_reset_policy,
     )
 
     server.api.crud.Alerts().store_alert(
-        db, project=project, name=alert_name, alert_data=alert
+        session=db,
+        project=project,
+        name=alert_name,
+        alert_data=alert_data,
     )
 
-    event = mlrun.common.schemas.alert.Event(
-        kind=event_kind,
-        entity=entity,
-    )
+    event = alert_objects.Event(kind=event_kind, entity=alert_entity)
 
     await fastapi.concurrency.run_in_threadpool(
         server.api.crud.Alerts().process_event_no_cache, db, event.kind, event
     )
 
     alert = server.api.crud.Alerts().get_enriched_alert(
-        db, project=project, name=alert_name
+        session=db,
+        project=project,
+        name=alert_name,
     )
-    assert alert.state == mlrun.common.schemas.alert.AlertActiveState.ACTIVE
+    assert alert.state == alert_objects.AlertActiveState.ACTIVE
 
 
 @pytest.mark.asyncio
@@ -104,33 +94,198 @@ async def test_validate_alert_name(
     expectation: AbstractContextManager,
 ):
     project = "project-name"
-    entity = mlrun.common.schemas.alert.EventEntities(
-        kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
+    alert_summary = "The job has failed"
+    alert_entity = alert_objects.EventEntities(
+        kind=alert_objects.EventEntityKind.JOB,
         project=project,
         ids=[123],
     )
-    event_kind = mlrun.common.schemas.alert.EventKind.FAILED
-    notification = mlrun.common.schemas.Notification(
-        kind="slack",
-        name="slack_notification",
-        secret_params={
-            "webhook": "https://hooks.slack.com/services/",
-        },
-        condition="oops",
-    )
+    event_kind = alert_objects.EventKind.FAILED
+    alert_trigger = alert_objects.AlertTrigger(events=[event_kind])
 
-    alert_data = mlrun.common.schemas.alert.AlertConfig(
+    alert_data = _generate_alert_data(
         project=project,
         name=alert_name,
-        summary="The job has failed",
-        severity=mlrun.common.schemas.alert.AlertSeverity.MEDIUM,
-        entities=entity,
-        trigger=mlrun.common.schemas.alert.AlertTrigger(events=[event_kind]),
-        notifications=[
-            mlrun.common.schemas.AlertNotification(notification=notification)
-        ],
+        entity=alert_entity,
+        summary=alert_summary,
+        trigger=alert_trigger,
     )
     with expectation:
         server.api.crud.Alerts().store_alert(
-            db, project=project, name=alert_name, alert_data=alert_data
+            session=db,
+            project=project,
+            name=alert_name,
+            alert_data=alert_data,
         )
+
+
+@pytest.mark.parametrize(
+    "modify_field, modified_value, should_reset",
+    [
+        # Non-functional fields:
+        ("summary", "The job has failed again", False),
+        ("description", "Job failure detected", False),
+        ("severity", alert_objects.AlertSeverity.HIGH, False),
+        (
+            "notifications",
+            [
+                alert_objects.AlertNotification(
+                    notification=mlrun.common.schemas.Notification(
+                        kind="webhook",
+                        name="webhook_notification",
+                        params={
+                            "url": "some-webhook-url",
+                        },
+                    )
+                )
+            ],
+            False,
+        ),
+        ("reset_policy", alert_objects.ResetPolicy.AUTO, False),
+        # Functional fields:
+        (
+            "entities",
+            alert_objects.EventEntities(
+                kind=alert_objects.EventEntityKind.JOB,
+                project="project-name",
+                ids=[456],
+            ),
+            True,
+        ),
+        (
+            "trigger",
+            alert_objects.AlertTrigger(
+                events=[alert_objects.EventKind.DATA_DRIFT_DETECTED]
+            ),
+            True,
+        ),
+        (
+            "criteria",
+            alert_objects.AlertCriteria(
+                count=5,
+                period="10m",
+            ),
+            True,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "force_reset",
+    [False, True],
+)
+async def test_alert_reset_with_fields_updates(
+    db: sqlalchemy.orm.Session,
+    modify_field,
+    modified_value,
+    should_reset,
+    force_reset,
+    k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+):
+    project = "project-name"
+    alert_name = "failed-alert"
+    alert_summary = "The job has failed"
+    alert_reset_policy = alert_objects.ResetPolicy.MANUAL
+    alert_entity = alert_objects.EventEntities(
+        kind=alert_objects.EventEntityKind.JOB,
+        project=project,
+        ids=[123],
+    )
+    event_kind = alert_objects.EventKind.FAILED
+    alert_trigger = alert_objects.AlertTrigger(events=[event_kind])
+
+    alert_data = _generate_alert_data(
+        project=project,
+        name=alert_name,
+        entity=alert_entity,
+        summary=alert_summary,
+        trigger=alert_trigger,
+        reset_policy=alert_reset_policy,
+    )
+
+    # store the initial alert
+    server.api.crud.Alerts().store_alert(
+        session=db,
+        project=project,
+        name=alert_name,
+        alert_data=alert_data,
+    )
+
+    # activate the alert
+    event = alert_objects.Event(kind=event_kind, entity=alert_entity)
+    await fastapi.concurrency.run_in_threadpool(
+        server.api.crud.Alerts().process_event_no_cache,
+        db,
+        event.kind,
+        event,
+    )
+    alert = server.api.crud.Alerts().get_enriched_alert(
+        session=db,
+        project=project,
+        name=alert_name,
+    )
+    assert alert.state == alert_objects.AlertActiveState.ACTIVE
+
+    # modify the alert data based on the parameterized field
+    setattr(alert_data, modify_field, modified_value)
+
+    # store the modified alert
+    server.api.crud.Alerts().store_alert(
+        session=db,
+        project=project,
+        name=alert_name,
+        alert_data=alert_data,
+        force_reset=force_reset,
+    )
+
+    # fetch the updated alert
+    alert = server.api.crud.Alerts().get_enriched_alert(
+        session=db,
+        project=project,
+        name=alert_name,
+    )
+
+    # validate the state based on whether it should have reset
+    expected_state = (
+        alert_objects.AlertActiveState.INACTIVE
+        if should_reset or force_reset
+        else alert_objects.AlertActiveState.ACTIVE
+    )
+    assert alert.state == expected_state
+
+    # reset the alert so the next test starts clean
+    server.api.crud.Alerts().reset_alert(session=db, project=project, name=alert_name)
+
+
+def _generate_alert_data(
+    project,
+    name,
+    entity,
+    summary,
+    trigger,
+    description=None,
+    severity=alert_objects.AlertSeverity.LOW,
+    notifications=None,
+    criteria=None,
+    reset_policy=alert_objects.ResetPolicy.AUTO,
+):
+    if notifications is None:
+        notification = mlrun.common.schemas.Notification(
+            kind="slack",
+            name="slack_notification",
+            secret_params={
+                "webhook": "https://hooks.slack.com/services/",
+            },
+        )
+        notifications = [alert_objects.AlertNotification(notification=notification)]
+    return alert_objects.AlertConfig(
+        project=project,
+        name=name,
+        description=description,
+        summary=summary,
+        severity=severity,
+        entities=entity,
+        trigger=trigger,
+        criteria=criteria,
+        notifications=notifications,
+        reset_policy=reset_policy,
+    )

--- a/tests/api/crud/test_alerts.py
+++ b/tests/api/crud/test_alerts.py
@@ -26,6 +26,12 @@ import server.api.crud
 import tests.api.conftest
 
 
+@pytest.fixture
+def reset_alert(db, project="project-name", alert_name="failed-alert"):
+    yield
+    server.api.crud.Alerts().reset_alert(session=db, project=project, name=alert_name)
+
+
 @pytest.mark.asyncio
 async def test_process_event_no_cache(
     db: sqlalchemy.orm.Session,
@@ -153,6 +159,15 @@ async def test_validate_alert_name(
             True,
         ),
         (
+            "entities",
+            alert_objects.EventEntities(
+                kind=alert_objects.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                project="project-name",
+                ids=[123],
+            ),
+            True,
+        ),
+        (
             "trigger",
             alert_objects.AlertTrigger(
                 events=[alert_objects.EventKind.DATA_DRIFT_DETECTED]
@@ -165,6 +180,48 @@ async def test_validate_alert_name(
                 count=5,
                 period="10m",
             ),
+            True,
+        ),
+        # Test multiple modifications
+        (
+            ["summary", "severity"],
+            [
+                "Job has failed again",
+                alert_objects.AlertSeverity.HIGH,
+            ],
+            False,
+        ),
+        (
+            ["summary", "severity", "reset_policy"],
+            [
+                "Job has failed again",
+                alert_objects.AlertSeverity.HIGH,
+                alert_objects.ResetPolicy.AUTO,
+            ],
+            False,
+        ),
+        (
+            ["summary", "severity", "trigger"],
+            [
+                "Job has failed again",
+                alert_objects.AlertSeverity.HIGH,
+                alert_objects.AlertTrigger(
+                    events=[alert_objects.EventKind.DATA_DRIFT_SUSPECTED]
+                ),
+            ],
+            True,
+        ),
+        (
+            ["criteria", "trigger"],
+            [
+                alert_objects.AlertCriteria(
+                    count=3,
+                    period="10m",
+                ),
+                alert_objects.AlertTrigger(
+                    events=[alert_objects.EventKind.DATA_DRIFT_SUSPECTED]
+                ),
+            ],
             True,
         ),
     ],
@@ -180,6 +237,7 @@ async def test_alert_reset_with_fields_updates(
     should_reset,
     force_reset,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
+    reset_alert,
 ):
     project = "project-name"
     alert_name = "failed-alert"
@@ -226,7 +284,11 @@ async def test_alert_reset_with_fields_updates(
     assert alert.state == alert_objects.AlertActiveState.ACTIVE
 
     # modify the alert data based on the parameterized field
-    setattr(alert_data, modify_field, modified_value)
+    if isinstance(modify_field, list):
+        for field, value in zip(modify_field, modified_value):
+            setattr(alert_data, field, value)
+    else:
+        setattr(alert_data, modify_field, modified_value)
 
     # store the modified alert
     server.api.crud.Alerts().store_alert(
@@ -251,9 +313,6 @@ async def test_alert_reset_with_fields_updates(
         else alert_objects.AlertActiveState.ACTIVE
     )
     assert alert.state == expected_state
-
-    # reset the alert so the next test starts clean
-    server.api.crud.Alerts().reset_alert(session=db, project=project, name=alert_name)
 
 
 def _generate_alert_data(

--- a/tests/api/crud/test_alerts.py
+++ b/tests/api/crud/test_alerts.py
@@ -27,9 +27,10 @@ import tests.api.conftest
 
 
 @pytest.fixture
-def reset_alert(db, project="project-name", alert_name="failed-alert"):
+def reset_alert_caches():
     yield
-    server.api.crud.Alerts().reset_alert(session=db, project=project, name=alert_name)
+    server.api.crud.Alerts()._alert_cache.cache_clear()
+    server.api.crud.Alerts()._alert_state_cache.cache_clear()
 
 
 @pytest.mark.asyncio
@@ -237,7 +238,7 @@ async def test_alert_reset_with_fields_updates(
     should_reset,
     force_reset,
     k8s_secrets_mock: tests.api.conftest.K8sSecretsMock,
-    reset_alert,
+    reset_alert_caches,
 ):
     project = "project-name"
     alert_name = "failed-alert"


### PR DESCRIPTION
Resolves:
https://iguazio.atlassian.net/browse/ML-7749

This PR addresses the behavior where existing alert configurations were being reset on every modification, regardless of the type of change. 
To improve functionality, the reset behavior now only applies to modifications that impact the alert's decision logic.

Key changes:
1. Non-functional changes – Adjustments to fields such as Description, Summary, Severity, Notifications, and Reset-policy no longer trigger an alert reset.

2. Functional changes – Changes to fields tied to alert conditions: Entity, Trigger, Criteria will reset the alert.
3. Force Reset Option – Added a force_reset parameter (default: False) to allow optional reset even when modifying non-functional fields. This parameter is accessible via the SDK and REST API.