### PR TITLE
[Model Monitoring] Improve TDEngine subtable query 

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -159,7 +159,7 @@ class TDEngineSchema:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"values must contain at least one tag: {self.tags.keys()}"
             )
-        return f"SELECT tbname FROM {self.database}.{self.super_table} WHERE {values};"
+        return f"SELECT DISTINCT tbname FROM {self.database}.{self.super_table} WHERE {values};"
 
     @staticmethod
     def _get_records_query(

--- a/tests/model_monitoring/test_tdengine.py
+++ b/tests/model_monitoring/test_tdengine.py
@@ -131,7 +131,7 @@ class TestTDEngineSchema:
     ):
         assert (
             super_table._get_subtables_query(values=values)
-            == f"SELECT tbname FROM {_MODEL_MONITORING_DATABASE}.{super_table.super_table} "
+            == f"SELECT DISTINCT tbname FROM {_MODEL_MONITORING_DATABASE}.{super_table.super_table} "
             f"WHERE tag1 LIKE '{values['tag1']}' AND tag2 LIKE '{values['tag2']}';"
         )
 
@@ -140,7 +140,7 @@ class TestTDEngineSchema:
             values.pop("tag1")
             assert (
                 super_table._get_subtables_query(values=values)
-                == f"SELECT tbname FROM {_MODEL_MONITORING_DATABASE}.{super_table.super_table} "
+                == f"SELECT DISTINCT tbname FROM {_MODEL_MONITORING_DATABASE}.{super_table.super_table} "
                 f"WHERE tag2 LIKE '{values['tag2']}';"
             )
 


### PR DESCRIPTION
This PR addresses an issue where deleting TSDB resources resulted in the subtable query returning duplicate table names. This redundancy caused the delete process to fail due to a timeout (https://iguazio.atlassian.net/browse/ML-8082). To resolve this, we've added the `DISTINCT` clause to the query, ensuring that only unique table names are retrieved. This change significantly reduces processing time.