### PR TITLE
[Schedule] Enrich kind label on upgrade [1.7.x]

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2416,13 +2416,20 @@ class SQLDB(DBInterface):
             main_table_identifier_values=names,
         )
 
-    def align_schedule_labels(self, session: Session):
+    def align_schedule_labels(self, session: Session, enrich_kind: bool = False):
         schedules_update = []
         for db_schedule in self.list_schedules(session=session, as_records=True):
             schedule_record = self._transform_schedule_record_to_scheme(db_schedule)
             db_schedule_labels = {
                 label.name: label.value for label in db_schedule.labels
             }
+            if (
+                enrich_kind
+                and mlrun_constants.MLRunInternalLabels.kind not in db_schedule_labels
+            ):
+                # We will assume that if the kind of schedule is empty, it should be job
+                # because currently we only support job schedules
+                db_schedule_labels[mlrun_constants.MLRunInternalLabels.kind] = "job"
             merged_labels = (
                 server.api.utils.helpers.merge_schedule_and_schedule_object_labels(
                     labels=db_schedule_labels,

--- a/server/api/initial_data.py
+++ b/server/api/initial_data.py
@@ -140,7 +140,7 @@ def init_data(
 data_version_prior_to_table_addition = 1
 
 # NOTE: Bump this number when adding a new data migration
-latest_data_version = 8
+latest_data_version = 9
 
 
 def update_default_configuration_data():
@@ -248,6 +248,8 @@ def _perform_data_migrations(db_session: sqlalchemy.orm.Session):
                 _perform_version_7_data_migrations(db, db_session)
             if current_data_version < 8:
                 _perform_version_8_data_migrations(db, db_session)
+            if current_data_version < 9:
+                _perform_version_9_data_migrations(db, db_session)
 
             db.create_data_version(db_session, str(latest_data_version))
 
@@ -884,6 +886,12 @@ def _perform_version_8_data_migrations(
     db: server.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
 ):
     db.align_schedule_labels(session=db_session)
+
+
+def _perform_version_9_data_migrations(
+    db: server.api.db.sqldb.db.SQLDB, db_session: sqlalchemy.orm.Session
+):
+    db.align_schedule_labels(session=db_session, enrich_kind=True)
 
 
 def _create_project_summaries(db, db_session):

--- a/tests/api/test_initial_data.py
+++ b/tests/api/test_initial_data.py
@@ -238,32 +238,44 @@ def test_create_project_summaries():
 
 
 @pytest.mark.parametrize(
-    "scheduled_object_labels, schedule_labels, expected_labels",
+    "scheduled_object_labels, schedule_labels, enrich_kind, expected_labels",
     [
         (
             {"label1": "value1"},
             {"label2": "value2"},
+            False,
             {"label1": "value1", "label2": "value2"},
         ),
-        ({"label1": "value1"}, {}, {"label1": "value1"}),
-        ({}, {"label2": "value2"}, {"label2": "value2"}),
+        ({"label1": "value1"}, {}, False, {"label1": "value1"}),
+        ({}, {"label2": "value2"}, False, {"label2": "value2"}),
         (
             {"label1": "value1", "label3": "value3"},
             {"label2": "value2"},
+            False,
             {"label1": "value1", "label2": "value2", "label3": "value3"},
         ),
         (
             {"label1": "value1", "label2": "value3"},
             {"label2": "value2"},
+            False,
             {"label1": "value1", "label2": "value3"},
         ),
-        (None, {"label2": "value2"}, {"label2": "value2"}),
-        ({"label1": "value1"}, None, {"label1": "value1"}),
-        (None, None, None),
+        (None, {"label2": "value2"}, False, {"label2": "value2"}),
+        ({"label1": "value1"}, None, False, {"label1": "value1"}),
+        (None, None, False, None),
+        # Enrich kind
+        ({}, {}, True, {"kind": "job"}),
+        ({"kind": "customkind"}, {}, True, {"kind": "customkind"}),
+        (
+            {"label1": "value1"},
+            {"label2": "value2"},
+            True,
+            {"label1": "value1", "label2": "value2", "kind": "job"},
+        ),
     ],
 )
 def test_align_schedule_labels(
-    scheduled_object_labels, schedule_labels, expected_labels
+    scheduled_object_labels, schedule_labels, enrich_kind, expected_labels
 ):
     db, db_session = _initialize_db_without_migrations()
 
@@ -280,7 +292,7 @@ def test_align_schedule_labels(
     )
 
     # Align schedule.labels and schedule.scheduled_object.task.metadata.labels
-    db.align_schedule_labels(db_session)
+    db.align_schedule_labels(db_session, enrich_kind)
 
     # Get updated schedules
     migrated_schedules = db.list_schedules(db_session)


### PR DESCRIPTION
On [this commit](https://github.com/mlrun/mlrun/commit/bc86a7db897614b86193e38952683aaf70acafc4) we fixed the problem with enriching kind label of schedule during submit job. Meaning it fixed only from 1.7.
On this pr we created new data migration (from 1.6) that enrich the kind of the schedule.

https://iguazio.atlassian.net/browse/ML-8110