### PR TITLE
[Docs] Remove the MM tutorial from gen AI list [1.7.x]

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -36,7 +36,7 @@ demos
 
 `````{div}
 
-````{grid} 3
+````{grid} 2
 :gutter: 2
 
 ```{grid-item-card} Deploy LLM using MLRun


### PR DESCRIPTION
(cherry picked from commit 9bbfc432d15ca43fd5d4855dd48ab4492265ae8f)