### PR TITLE
[Pagination] Fix Pagination Cache Serializer

### DIFF
--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import inspect
+import json
 import typing
 
 import pydantic
@@ -226,7 +227,7 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
                     f"Token {token} not found in pagination cache"
                 )
             method = PaginatedMethods.get_method(pagination_cache_record.function)
-            method_kwargs = pagination_cache_record.kwargs
+            method_kwargs = json.loads(pagination_cache_record.kwargs)
             page = page or pagination_cache_record.current_page + 1
             page_size = pagination_cache_record.page_size
             user = pagination_cache_record.user
@@ -238,9 +239,9 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
 
         # upsert pagination cache record to update last_accessed time or create a new record
         method_schema = PaginatedMethods.get_method_schema(method.__name__)
-        serialized_kwargs = method_schema(**method_kwargs).dict()
-        del serialized_kwargs["page"]
-        del serialized_kwargs["page_size"]
+        kwargs_schema = method_schema(**method_kwargs)
+        kwargs_schema.page = None
+        kwargs_schema.page_size = None
         self._logger.debug(
             "Storing pagination cache record",
             method=method.__name__,
@@ -253,6 +254,6 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             method=method,
             current_page=page,
             page_size=page_size,
-            kwargs=serialized_kwargs,
+            kwargs=kwargs_schema.json(exclude_none=True),
         )
-        return token, page, page_size, method, serialized_kwargs
+        return token, page, page_size, method, kwargs_schema.dict(exclude_none=True)

--- a/server/api/utils/pagination.py
+++ b/server/api/utils/pagination.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 import inspect
-import json
 import typing
 
+import orjson
 import pydantic
 import sqlalchemy.orm
 
@@ -227,7 +227,7 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
                     f"Token {token} not found in pagination cache"
                 )
             method = PaginatedMethods.get_method(pagination_cache_record.function)
-            method_kwargs = json.loads(pagination_cache_record.kwargs)
+            method_kwargs = orjson.loads(pagination_cache_record.kwargs)
             page = page or pagination_cache_record.current_page + 1
             page_size = pagination_cache_record.page_size
             user = pagination_cache_record.user


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8036

The mechanism used to serialize the paginated requests into a storable object in the database was using a pydantic schema based on the paginated method's arguments. However, instead of using pydantic's `json` method and converting the arguments to a string, we used `dict` which conserves object types (like `datetime`) which sqlalchmey does not automatically support serializing in the json column. Pydantic's `json` method however produces a 'pure' JSON so any object gets serialized to a int/float/string/list/map in a way that pydantic can then decode back to the original object. (This is the whole point of the mechanism that was missed with using the `dict` method instead of the `json` method)

* Added datetime objects to the unit tests so this higher-level serialization and de-serialization are properly tested as well.