### PR TITLE
[DB] Mask DSN Username and Password When Logging [1.7.x]

### DIFF
--- a/server/api/utils/singletons/db.py
+++ b/server/api/utils/singletons/db.py
@@ -15,7 +15,7 @@
 import re
 
 import mlrun.db
-import services.api.utils.db.mysql
+import server.api.utils.db.mysql
 from mlrun.common.db.sql_session import create_session
 from mlrun.config import config
 from mlrun.utils import logger
@@ -52,7 +52,7 @@ def initialize_db(override_db=None):
 
 
 def _mask_dsn(dsn):
-    match = re.match(services.api.utils.db.mysql.MySQLUtil.dsn_regex, dsn)
+    match = re.match(server.api.utils.db.mysql.MySQLUtil.dsn_regex, dsn)
     if match:
         # Mask the username and password
         masked_dsn = dsn.replace(match.group("username"), "***")

--- a/server/py/services/api/tests/unit/utils/singletons/test_db_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_db_utils.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import services.api.utils.singletons.db
+
+
+@pytest.mark.parametrize(
+    "dsn,expected_masked_dsn",
+    [
+        (
+            "mysql+pymysql://root:pass@localhost:3307/mlrun",
+            "mysql+pymysql://***:***@localhost:3307/mlrun",
+        ),
+        (
+            "mysql+pymysql://root@localhost:3307/mlrun",
+            "mysql+pymysql://***@localhost:3307/mlrun",
+        ),
+        (
+            "sqlite:///db/mlrun.db?check_same_thread=false",
+            "sqlite:///db/mlrun.db?check_same_thread=false",
+        ),
+    ],
+)
+def test_masked_dsn(dsn, expected_masked_dsn):
+    masked_dsn = services.api.utils.singletons.db._mask_dsn(dsn)
+    assert masked_dsn == expected_masked_dsn

--- a/tests/api/utils/singletons/test_db_utils.py
+++ b/tests/api/utils/singletons/test_db_utils.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-import services.api.utils.singletons.db
+import server.api.utils.singletons.db
 
 
 @pytest.mark.parametrize(
@@ -35,5 +35,5 @@ import services.api.utils.singletons.db
     ],
 )
 def test_masked_dsn(dsn, expected_masked_dsn):
-    masked_dsn = services.api.utils.singletons.db._mask_dsn(dsn)
+    masked_dsn = server.api.utils.singletons.db._mask_dsn(dsn)
     assert masked_dsn == expected_masked_dsn


### PR DESCRIPTION
SQL credentials are exposed in MLRun logs. To address this, I masked the username and password for MySQL connections
https://iguazio.atlassian.net/browse/ML-8175

porting https://github.com/mlrun/mlrun/pull/6627 to 1.7.x