### PR TITLE
[API] Support Listing Functions For All Projects w/ `*` Token [1.7.x]

### DIFF
--- a/server/api/api/endpoints/functions.py
+++ b/server/api/api/endpoints/functions.py
@@ -219,11 +219,12 @@ async def list_functions(
     if project is None:
         project = config.default_project
 
-    await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
-        project,
-        mlrun.common.schemas.AuthorizationAction.read,
-        auth_info,
-    )
+    if project != "*":
+        await server.api.utils.auth.verifier.AuthVerifier().query_project_permissions(
+            project,
+            mlrun.common.schemas.AuthorizationAction.read,
+            auth_info,
+        )
 
     paginator = server.api.utils.pagination.Paginator()
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -4764,7 +4764,9 @@ class SQLDB(DBInterface):
         :param page_size: The page size to query.
         """
         query = session.query(Function, Function.Tag.name)
-        query = query.filter(Function.project == project)
+
+        if project != "*":
+            query = query.filter(Function.project == project)
 
         if name:
             query = query.filter(generate_query_predicate_for_name(Function.name, name))

--- a/tests/api/api/test_functions.py
+++ b/tests/api/api/test_functions.py
@@ -90,6 +90,41 @@ def test_build_status_pod_not_found(
 
 
 @pytest.mark.asyncio
+async def test_list_functions_for_all_projects(
+    db: sqlalchemy.orm.Session, async_client: httpx.AsyncClient
+):
+    project_1 = PROJECT + "-1"
+    project_2 = PROJECT + "-2"
+    await tests.api.api.utils.create_project_async(async_client, project_1)
+    await tests.api.api.utils.create_project_async(async_client, project_2)
+
+    number_of_functions = 10
+    for project in [project_1, project_2]:
+        for counter in range(number_of_functions):
+            function_name = f"{project}-function-name-{counter}"
+            function = {
+                "kind": "job",
+                "metadata": {
+                    "name": function_name,
+                    "project": project,
+                    "tag": "function-tag",
+                },
+                "spec": {"image": "mlrun/mlrun"},
+            }
+
+            post_function_response = await async_client.post(
+                f"projects/{project}/functions/{function_name}",
+                json=function,
+            )
+
+            assert post_function_response.status_code == HTTPStatus.OK.value
+
+    response = await async_client.get("projects/*/functions")
+    assert response.status_code == HTTPStatus.OK.value
+    assert len(response.json()["funcs"]) == number_of_functions * 2
+
+
+@pytest.mark.asyncio
 async def test_list_functions_with_pagination(
     db: sqlalchemy.orm.Session, async_client: httpx.AsyncClient
 ):


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8215

- API now supports the GET method on the `/projects/*/functions` path
- Skip initial permission verification if project token is `*`, functions will be filtered out later by permissions once retrieved from the db
- HTTPDB requires no changes
- Added unit test to ensure token works