### PR TITLE
[Images] Ignore test folders on non testing deidcated images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@ mlrun.egg-info
 **/test-google-cloud-storage.yml
 **/test-dbfs-store.yml
 **/test-redis.yml
+**/tests
 
 **/google-big-query-credentials.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ dist/
 mlrun.egg-info/
 mlrun/utils/version/version.json
 Dockerfile.mlrun-test-nb
+**/Dockerfile.dockerignore
 
 # Dask worker spaces
 dask-worker-space/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 ## Creating a development environment
 
+> Configure your project `PYTHONPATH=<project-root>:<project-root>/server/py` to direct python to the server side packages as well.  
+> Some IDEs can manage this for you, for example on PyCharm - right click on `server/py`  folder ➜ mark directory as ➜ source root.
+
 If you are working with an ARM64 machine, please see  [Developing with ARM64 machines](#developing-with-arm64-machines).
 
 We recommend using [pyenv](https://github.com/pyenv/pyenv#installation) to manage your python versions.

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,25 @@ endif
 update-version-file: ## Update the version file
 	python ./automation/version/version_file.py ensure --mlrun-version $(MLRUN_VERSION)
 
+.PHONY: generate-dockerignore
+generate-dockerignore: ## Copies the root .dockerignore and alters it
+	$(eval TARGET := dockerfiles/${DEST}/Dockerfile.dockerignore)
+	@if [ -f "$(TARGET)" ]; then \
+		temp_file=$$(mktemp) && \
+		sed '/\*\*\/tests/d' .dockerignore > $$temp_file && \
+		if cmp -s $$temp_file "$(TARGET)"; then \
+			echo "File $(TARGET) already exists and content is identical"; \
+			rm $$temp_file; \
+			exit 0; \
+		else \
+			echo "File $(TARGET) exists but content differs, updating..."; \
+			mv $$temp_file "$(TARGET)"; \
+		fi; \
+	else \
+		sed '/\*\*\/tests/d' .dockerignore > "$(TARGET)"; \
+	fi
+
+
 .PHONY: build
 build: docker-images package-wheel ## Build all artifacts
 	@echo Done.
@@ -399,6 +418,7 @@ MLRUN_TEST_CACHE_IMAGE_PUSH_COMMAND := $(if $(and $(MLRUN_DOCKER_CACHE_FROM_TAG)
 
 .PHONY: build-test
 build-test: compile-schemas update-version-file ## Build test docker image
+	$(MAKE) generate-dockerignore DEST=test
 	$(MLRUN_TEST_CACHE_IMAGE_PULL_COMMAND)
 	docker build \
 		--file dockerfiles/test/Dockerfile \
@@ -417,6 +437,7 @@ MLRUN_SYSTEM_TEST_IMAGE_NAME := $(MLRUN_DOCKER_IMAGE_PREFIX)/test-system:$(MLRUN
 
 .PHONY: build-test-system
 build-test-system: compile-schemas update-version-file ## Build system tests docker image
+	$(MAKE) generate-dockerignore DEST=test-system
 	docker build \
 		--file dockerfiles/test-system/Dockerfile \
 		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ update-version-file: ## Update the version file
 	python ./automation/version/version_file.py ensure --mlrun-version $(MLRUN_VERSION)
 
 .PHONY: generate-dockerignore
-generate-dockerignore: ## Copies the root .dockerignore and alters it
+generate-dockerignore: ## Copies the root .dockerignore and removes the tests pattern from it
 	$(eval TARGET := dockerfiles/${DEST}/Dockerfile.dockerignore)
 	@if [ -f "$(TARGET)" ]; then \
 		temp_file=$$(mktemp) && \


### PR DESCRIPTION
Added `make generate-dockerignore` - needs `DEST` variable which corresponds to the destination dockerfile folder.
It generates a new `.dockerignore` file and removes the `**/tests` from it .
If the file exists and is identical - does nothing to leverage docker cache.
if the file exists and is different - override it.
if the file does not exist - create it.