### PR TITLE
[Serving] Fix creation of queue step stream [1.7.x]

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -607,7 +607,7 @@ class ServingRuntime(RemoteRuntime):
         ):
             # initialize or create required streams/queues
             self.spec.graph.check_and_process_graph()
-            self.spec.graph.init_queues()
+            self.spec.graph.create_queue_streams()
             functions_in_steps = self.spec.graph.list_child_functions()
             child_functions = list(self._spec.function_refs.keys())
             for function in functions_in_steps:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -839,6 +839,8 @@ class QueueStep(BaseStep):
                 retention_in_hours=self.retention_in_hours,
                 **self.options,
             )
+            if hasattr(self._stream, "create_stream"):
+                self._stream.create_stream()
         self._set_error_handler()
 
     @property
@@ -1247,8 +1249,8 @@ class FlowStep(BaseStep):
                     links[next_step.function] = step
         return links
 
-    def init_queues(self):
-        """init/create the streams used in this flow"""
+    def create_queue_streams(self):
+        """create the streams used in this flow"""
         for step in self.get_children():
             if step.kind == StepKinds.queue:
                 step.init_object(self.context, None)


### PR DESCRIPTION
[ML-8222](https://iguazio.atlassian.net/browse/ML-8222)

Fixes regression in #6294.

The child (downstream) function is deployed first, requiring us to create the queue stream ahead of time, as the parent (upstream) function that would create it will only be started later.

[ML-8222]: https://iguazio.atlassian.net/browse/ML-8222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ