### PR TITLE
[KFP] Support MLRun without KFP dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,10 @@ jobs:
       id: git_info
       run: |
         echo "branch=$(echo ${GITHUB_BASE_REF#refs/heads/})" >> $GITHUB_OUTPUT
+    # since github-actions gives us 14G only, and fills it up with some garbage
+    - name: Freeing up disk space
+      run: |
+        "${GITHUB_WORKSPACE}/automation/scripts/github_workflow_free_space.sh"
     - name: Resolve docker cache tag
       id: docker_cache
       run: |

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -55,10 +55,7 @@ COPY ./dockerfiles/mlrun-api/requirements.txt ./mlrun-api-requirements.txt
 COPY ./extras-requirements.txt ./extras-requirements.txt
 COPY ./requirements.txt ./
 
-RUN python -m pip install \
-    -r requirements.txt \
-    -r extras-requirements.txt \
-    -r mlrun-api-requirements.txt
+
 
 ENV MLRUN_HTTPDB__DSN='sqlite:////mlrun/db/mlrun.db?check_same_thread=false'
 ENV MLRUN_HTTPDB__LOGS_PATH=/mlrun/db/logs
@@ -72,12 +69,20 @@ ENV MLRUN_IGNORE_ENV_FILE=true
 ENV UVICORN_PORT=${MLRUN_HTTPDB__PORT}
 ENV UVICORN_TIMEOUT_KEEP_ALIVE=${MLRUN_HTTPDB__HTTP_CONNECTION_TIMEOUT_KEEP_ALIVE}
 
+COPY ./pipeline-adapters ./pipeline-adapters
+
+RUN pip install ./pipeline-adapters/mlrun-pipelines-kfp-common && pip install ./pipeline-adapters/mlrun-pipelines-kfp-v1-8
+
 COPY . .
 ENV PYTHONPATH=/mlrun/server/py
 
-RUN python -m pip install .[complete-api] &&\
-    pip install ./pipeline-adapters/mlrun-pipelines-kfp-common &&\
-    pip install ./pipeline-adapters/mlrun-pipelines-kfp-v1-8
+
+RUN python -m pip install \
+    -r requirements.txt \
+    -r extras-requirements.txt \
+    -r mlrun-api-requirements.txt
+RUN pip install .[complete-api]
+
 
 VOLUME /mlrun/db
 

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.2.1",
+    version="0.2.2",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
@@ -1,0 +1,143 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any, Callable, Optional, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# Define a generic type variable for decorators
+Decoratable = TypeVar("Decoratable", bound=Callable[..., Any])
+
+
+@dataclass
+class DummyPipelineParam:
+    name: str
+    value: Any = None
+
+
+@dataclass
+class DummyPipelineConf:
+    enable_caching: bool = True
+    retries: int = 0
+
+    def set_timeout(self, timeout: int) -> None:
+        logger.debug(f"[NoOp] set_timeout called with timeout={timeout}")
+
+    def set_ttl_seconds_after_finished(self, ttl_seconds: int) -> None:
+        logger.debug(
+            f"[NoOp] set_ttl_seconds_after_finished called with ttl_seconds={ttl_seconds}"
+        )
+
+    def add_op_transformer(self, transformer: Callable[[Any], Any]) -> None:
+        logger.debug(f"[NoOp] add_op_transformer called with transformer={transformer}")
+
+
+@dataclass
+class DummyPipelineDecorator:
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+    def __call__(self, func: Decoratable) -> Decoratable:
+        logger.debug(f"[NoOp] Pipeline function '{func.__name__}' defined.")
+        return func
+
+
+class DummyCompiler:
+    @dataclass
+    class Compiler:
+        def compile(self, pipeline_func: Callable[..., Any], package_path: str) -> None:
+            logger.debug(
+                f"[NoOp] Compiling pipeline to func '{pipeline_func}' '{package_path}'"
+            )
+
+        def _create_workflow(self, *args: Any, **kwargs: Any) -> None:
+            logger.debug("[NoOp] _create_workflow called.")
+
+
+class DummyRunPipelineResult:
+    def get_output_file(self, op_name: str, output: Optional[str] = None) -> str:
+        return ""
+
+    def success(self) -> bool:
+        return True
+
+
+class V1ListRunsResponse:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    @property
+    def runs(self):
+        return []
+
+    @property
+    def next_page_token(self):
+        return ""
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def create_run_from_pipeline_func(
+        self,
+        pipeline_func: Callable[..., Any],
+        arguments: Optional[dict[str, Any]] = None,
+        run_name: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "DummyRunPipelineResult":
+        logger.debug("[NoOp] create_run_from_pipeline_func called but does nothing.")
+        return DummyRunPipelineResult()
+
+    def list_runs(
+        self,
+        page_token: str = "",
+        page_size: int = 100,
+        sort_by: Optional[str] = None,
+        filter: Optional[str] = None,
+    ) -> list[Any]:
+        logger.debug("[NoOp] list_runs called")
+        return V1ListRunsResponse()
+
+
+# Assign dummy implementations to kfp modules
+compiler = ModuleType("compiler")
+Compiler = DummyCompiler.Compiler()
+compiler.Compiler = Compiler
+dsl = ModuleType("dsl")
+dsl.pipeline = DummyPipelineDecorator
+dsl.PipelineParam = DummyPipelineParam
+dsl.PipelineConf = DummyPipelineConf
+kfp = ModuleType("kfp")
+kfp.compiler = compiler
+kfp.dsl = dsl
+kfp.Client = DummyClient
+Client = DummyClient
+PipelineParam = DummyPipelineParam
+PipelineConf = DummyPipelineConf
+
+
+__all__ = [
+    "Client",
+    "Compiler",
+    "PipelineConf",
+    "PipelineParam",
+    "compiler",
+    "dsl",
+    "kfp",
+]

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-v1-8",
-    version="0.2.0",
+    version="0.2.1",
     description="MLRun Pipelines package for providing KFP 1.8 compatibility",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",
@@ -40,6 +40,7 @@ setup(
     ],
     python_requires=">=3.9, <3.12",
     install_requires=[
+        "kfp_server_api~=1.8.5",
         "kfp~=1.8",
     ],
     long_description="MLRun Pipelines package for providing KFP 1.8 compatibility",

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/helpers.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/helpers.py
@@ -15,9 +15,8 @@
 
 import typing
 
-from kfp.dsl import PipelineConf
-
 from mlrun.config import config
+from mlrun_pipelines.imports import PipelineConf
 
 
 def new_pipe_metadata(

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/imports.py
@@ -1,0 +1,172 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from kubernetes.client import V1VolumeMount
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ContainerResources:
+    resources: dict[str, Any] = field(default_factory=dict)
+    limit: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DummyContainer:
+    env: list[dict[str, str]] = field(default_factory=list)
+    command: list[str] = field(default_factory=list)
+    args: list[str] = field(default_factory=list)
+    image: str = ""
+    resources: ContainerResources = field(default_factory=ContainerResources)
+    volume_mounts: list[V1VolumeMount] = field(default_factory=list)
+
+    def add_volume_mount(self, volume_mount: V1VolumeMount) -> "DummyContainer":
+        self.volumes.append(volume_mount)
+        return self
+
+    def set_command(self, command: list[str]) -> "DummyContainer":
+        self.command = command
+        return self
+
+    def set_args(self, args: list[str]) -> "DummyContainer":
+        self.args = args
+        return self
+
+    def set_image(self, image: str) -> "DummyContainer":
+        self.image = image
+        return self
+
+    def set_env_variable(self, name: str, value: str) -> "DummyContainer":
+        self.env.append({"name": name, "value": value})
+        return self
+
+    def set_resources(self, resources: dict[str, Any]) -> "DummyContainer":
+        self.resources = resources
+        return self
+
+    def add_resource_limit(self, resource_name, value) -> "DummyContainer":
+        self.resources.limits = self.resources.limits or {}
+        self.resources.limits.update({resource_name: value})
+        return self
+
+    def add_resource_request(self, resource_name, value) -> "DummyContainer":
+        self.resources.requests = self.resources.requests or {}
+        self.resources.requests.update({resource_name: value})
+        return self
+
+
+@dataclass
+class DummyContainerOp:
+    name: str
+    image: str
+    command: list[str] = field(default_factory=list)
+    file_outputs: Optional[dict[str, str]] = field(default_factory=dict)
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    pod_labels: dict[str, str] = field(default_factory=dict)
+    pod_annotations: dict[str, str] = field(default_factory=dict)
+    node_selector: dict[str, str] = field(default_factory=dict)
+    affinity: dict[str, str] = field(default_factory=dict)
+    tolerations: dict[str, str] = field(default_factory=dict)
+    volumes: list[dict[str, Any]] = field(default_factory=list)
+    container: DummyContainer = field(default_factory=DummyContainer)
+
+    def _register_op_handler(self) -> str:
+        return ""
+
+    def add_pod_label(self, key: str, value: str):
+        self.pod_labels[key] = value
+        return self
+
+    def add_pod_annotation(self, key: str, value: str):
+        self.pod_annotations[key] = value
+        return self
+
+    def add_volume(self, volume: Any):
+        self.volumes.append(volume)
+        return self
+
+    def add_env_variable(self, env_var: Any):
+        self.container.env.append(env_var)
+        return self
+
+    def add_node_selector(self, key: str, value: str):
+        self.node_selector[key] = value
+        return self
+
+    def add_affinity(self, key: str, value: str):
+        self.affinity[key] = value
+        return self
+
+    def add_toleration(self, key: str, value: str):
+        self.tolerations[key] = value
+        return self
+
+    def add_file_output(self, key: str, value: str):
+        self.file_outputs[key] = value
+        return self
+
+
+try:
+    import kfp as real_kfp
+    import kfp.compiler as real_compiler
+    import kfp.dsl as real_dsl
+    from kfp import Client as real_Client
+    from kfp.dsl import ContainerOp as real_ContainerOp
+    from kfp.dsl import PipelineConf as real_PipelineConf
+    from kfp.dsl import PipelineParam as real_PipelineParam
+
+    # Assign real KFP components
+    kfp = real_kfp
+    dsl = real_dsl
+    compiler = real_compiler
+    Compiler = real_compiler.Compiler
+    ContainerOp = real_ContainerOp
+    Client = real_Client
+    PipelineParam = real_PipelineParam
+    PipelineConf = real_PipelineConf
+
+    if hasattr(ContainerOp, "_DISABLE_REUSABLE_COMPONENT_WARNING"):
+        ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+
+except ImportError:
+    logger.warning(
+        "Kubeflow Pipelines (KFP) is not installed. Using noop implementations."
+    )
+    from mlrun_pipelines.common.imports import (
+        Client,
+        Compiler,
+        PipelineConf,
+        PipelineParam,
+        compiler,
+        dsl,
+        kfp,
+    )
+
+    ContainerOp = DummyContainerOp
+
+__all__ = [
+    "Client",
+    "Compiler",
+    "ContainerOp",
+    "PipelineConf",
+    "PipelineParam",
+    "compiler",
+    "dsl",
+    "kfp",
+]

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mixins.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mixins.py
@@ -14,15 +14,11 @@
 #
 import json
 
-import kfp
-
 import mlrun
 from mlrun_pipelines.common.helpers import PROJECT_ANNOTATION
 from mlrun_pipelines.common.models import RunStatuses
+from mlrun_pipelines.imports import ContainerOp, kfp
 from mlrun_pipelines.utils import apply_kfp
-
-# Disable the warning about reusing components
-kfp.dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
 
 
 class KfpAdapterMixin:
@@ -41,7 +37,7 @@ class KfpAdapterMixin:
         # we remove the hook to suppress kubeflow op registration and return it after the apply()
         old_op_handler = kfp.dsl._container_op._register_op_handler
         kfp.dsl._container_op._register_op_handler = lambda x: self.metadata.name
-        cop = kfp.dsl.ContainerOp("name", "image")
+        cop = ContainerOp("name", "image")
         kfp.dsl._container_op._register_op_handler = old_op_handler
 
         return apply_kfp(modify, cop, self)

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/models.py
@@ -17,14 +17,10 @@ import json
 import typing
 from typing import Any, Union
 
-from kfp.dsl import ContainerOp
 from kfp_server_api.models.api_run_detail import ApiRunDetail
 
 from mlrun_pipelines.common.helpers import FlexibleMapper
-
-# Disable the warning about reusing components
-ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
-
+from mlrun_pipelines.imports import ContainerOp
 
 # class pointer for type checking on the main MLRun codebase
 PipelineNodeWrapper = ContainerOp

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mounts.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/mounts.py
@@ -15,7 +15,6 @@
 import os
 from typing import Optional
 
-import kfp.dsl
 import semver
 
 from mlrun.config import config
@@ -24,9 +23,7 @@ from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.platforms.iguazio import v3io_to_vol
 from mlrun.utils import logger
 from mlrun_pipelines.common.mounts import _enrich_and_validate_v3io_mounts
-
-# Disable the warning about reusing components
-kfp.dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+from mlrun_pipelines.imports import kfp
 
 
 def v3io_cred(api="", user="", access_key=""):

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py
@@ -17,7 +17,6 @@ import os
 import os.path
 
 import inflection
-from kfp import dsl
 from kubernetes import client as k8s_client
 
 import mlrun
@@ -33,9 +32,7 @@ from mlrun_pipelines.common.helpers import (
     RUN_ANNOTATION,
 )
 from mlrun_pipelines.common.ops import KFPMETA_DIR, PipelineRunType
-
-# Disable the warning about reusing components
-dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+from mlrun_pipelines.imports import dsl
 
 
 def generate_deployer_pipeline_node(

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/patcher.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/patcher.py
@@ -15,15 +15,10 @@
 
 import typing
 
-import kfp.compiler
-from kfp import dsl
-
 import mlrun
 from mlrun.errors import err_to_str
 from mlrun.utils import logger
-
-# Disable the warning about reusing components
-kfp.dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+from mlrun_pipelines.imports import dsl, kfp
 
 
 # When we run pipelines, the kfp.compile.Compile.compile() method takes the decorated function with @dsl.pipeline and

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/utils.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/utils.py
@@ -15,17 +15,20 @@
 import tempfile
 import typing
 
-import kfp
-import kfp.compiler
 from kubernetes import client
 
 from mlrun_pipelines.helpers import new_pipe_metadata
+from mlrun_pipelines.imports import compiler, kfp  # noqa: F401
 
-# Disable the warning about reusing components
-kfp.dsl.ContainerOp._DISABLE_REUSABLE_COMPONENT_WARNING = True
+if typing.TYPE_CHECKING:
+    from mlrun.runtimes import BaseRuntime
 
 
-def apply_kfp(modify, cop, runtime):
+def apply_kfp(
+    modify: typing.Callable,
+    cop: kfp.dsl.ContainerOp,
+    runtime: "BaseRuntime",
+) -> kfp.dsl.ContainerOp:
     modify(cop)
 
     # Have to do it here to avoid circular dependencies
@@ -77,7 +80,7 @@ def compile_pipeline(
         cleanup_ttl=cleanup_ttl,
         op_transformers=ops,
     )
-    kfp.compiler.Compiler().compile(
+    compiler.Compiler().compile(
         pipeline, pipe_file, type_check=type_check, pipeline_conf=conf
     )
     return pipe_file

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-v2",
-    version="0.2.0",
+    version="0.2.1",
     description="MLRun Pipelines package for providing KFP 2.* compatibility",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",
@@ -40,6 +40,7 @@ setup(
     ],
     python_requires=">=3.9, <3.12",
     install_requires=[
+        "kfp_server_api~=2.0.0",
         "kfp[kubernetes]~=2.5.0",
     ],
     long_description="MLRun Pipelines package for providing KFP 2.* compatibility",

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/imports.py
@@ -1,0 +1,98 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+from types import ModuleType
+from typing import Any, Optional
+
+from mlrun_pipelines.common.imports import (
+    dsl,
+    kfp,
+)
+
+logger = logging.getLogger(__name__)
+
+# Initialize placeholders for KFP v2 components
+kubernetes: ModuleType = ModuleType("kubernetes")
+PipelineTask: Optional[type["PipelineTaskBase"]] = None
+
+
+class PipelineTaskBase:
+    name: str
+    command: list
+    args: list[Any]
+    file_outputs: dict[str, str]
+
+    def add_env_variable(self, env_var: Any) -> "PipelineTaskBase":
+        self.container.env.append(env_var)
+        return self
+
+
+class DummyPipelineTask(PipelineTaskBase):
+    def __init__(
+        self,
+        name: str,
+        command: list,
+        args: Optional[list[Any]] = None,
+        file_outputs: Optional[dict[str, str]] = None,
+    ) -> None:
+        self.name = name
+        self.command = command
+        self.args = args or []
+        self.file_outputs = file_outputs or {}
+
+    def add_env_variable(self, env_var: Any):
+        self.container.env.append(env_var)
+        return self
+
+
+# Try importing the actual KFP v2 components
+try:
+    import kfp as real_kfp
+    import kfp.compiler as real_compiler
+    import kfp.dsl as real_dsl
+    from kfp import Client as real_Client
+    from kfp.dsl import PipelineTask as real_PipelineTask
+
+    # Assign real KFP components
+    kfp = real_kfp
+    dsl = real_dsl
+    compiler = real_compiler
+    Compiler = real_compiler.Compiler
+    PipelineTask = real_PipelineTask
+    Client = real_Client
+
+except ImportError:
+    logger.warning(
+        "Kubeflow Pipelines (KFP) is not installed. Using noop implementations."
+    )
+    from mlrun_pipelines.common.imports import (
+        Client,
+        Compiler,
+        compiler,
+        dsl,
+        kfp,
+    )
+
+    PipelineTask = DummyPipelineTask
+    dsl.PipelineTask = DummyPipelineTask
+
+__all__ = [
+    "Client",
+    "Compiler",
+    "PipelineTask",
+    "compiler",
+    "dsl",
+    "kfp",
+]

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/models.py
@@ -14,9 +14,8 @@
 #
 import typing
 
-from kfp.dsl import PipelineTask
-
 from mlrun_pipelines.common.helpers import FlexibleMapper
+from mlrun_pipelines.imports import PipelineTask
 
 # class pointer for type checking on the main MLRun codebase
 PipelineNodeWrapper = PipelineTask

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
@@ -16,9 +16,6 @@
 import os
 from typing import Optional
 
-from kfp import dsl
-from kfp import kubernetes as kfp_k8s
-
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.runtimes.constants
@@ -32,6 +29,8 @@ from mlrun_pipelines.common.helpers import (
     RUN_ANNOTATION,
 )
 from mlrun_pipelines.common.ops import PipelineRunType
+from mlrun_pipelines.imports import dsl
+from mlrun_pipelines.imports import kubernetes as kfp_k8s
 
 
 def generate_kfp_dag_and_resolve_project(run, project=None):

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/utils.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/utils.py
@@ -16,8 +16,7 @@
 import tempfile
 import typing
 
-import kfp
-from kfp.compiler import Compiler
+from mlrun_pipelines.imports import Compiler, kfp
 
 
 def compile_pipeline(

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,5 +42,6 @@ orjson>=3.9.15, <4
 # mlrun pipeline adapters
 mlrun-pipelines-kfp-common~=0.2.1
 mlrun-pipelines-kfp-v1-8~=0.2.0
+docstring_parser~=0.16
 # TODO: Remove it after moving notificaions to the server side(ML-8069)
 aiosmtplib~=3.0

--- a/server/py/services/api/tests/unit/conftest.py
+++ b/server/py/services/api/tests/unit/conftest.py
@@ -36,6 +36,7 @@ import mlrun.runtimes.utils
 import mlrun.utils.singleton
 from mlrun import mlconf
 from mlrun.utils import logger
+from mlrun_pipelines.imports import kfp
 
 import framework.utils.clients.iguazio
 import framework.utils.projects.remotes.leader
@@ -54,7 +55,6 @@ from framework.tests.unit.common_fixtures import (
 from services.api.daemon import daemon
 
 # Importing here since mlrun_pipelines imports mlconf and it causes circular import
-import mlrun_pipelines.utils  # isort:skip
 
 tests_root_directory = pathlib.Path(__file__).absolute().parent
 assets_path = tests_root_directory.joinpath("assets")
@@ -148,14 +148,12 @@ async def async_client(db, app, prefix) -> typing.AsyncIterator[httpx.AsyncClien
 
 
 @pytest.fixture
-def kfp_client_mock(monkeypatch) -> mlrun_pipelines.utils.kfp.Client:
+def kfp_client_mock(monkeypatch) -> kfp.Client:
     framework.utils.singletons.k8s.get_k8s_helper().is_running_inside_kubernetes_cluster = unittest.mock.Mock(
         return_value=True
     )
     kfp_client_mock = unittest.mock.Mock()
-    monkeypatch.setattr(
-        mlrun_pipelines.utils.kfp, "Client", lambda *args, **kwargs: kfp_client_mock
-    )
+    monkeypatch.setattr(kfp, "Client", lambda *args, **kwargs: kfp_client_mock)
     mlrun.mlconf.kfp_url = "http://ml-pipeline.custom_namespace.svc.cluster.local:8888"
     return kfp_client_mock
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -126,6 +126,7 @@ def test_requirement_specifiers_convention():
             " @ git+https://github.com/v3io/data-science.git#subdirectory=generator"
         },
         "databricks-sdk": {"~=0.13.0"},
+        "docstring_parser": {"~=0.16"},
         "distributed": {"~=2023.12.1"},
         "dask": {"~=2023.12.1"},
         "gitpython": {"~=3.1, >=3.1.41"},


### PR DESCRIPTION
[KFP] Support MLRun without KFP dependency

This PR lays the groundwork for decoupling MLRun from the Kubeflow Pipelines (KFP) dependency, enabling MLRun to operate independently.
Updates include standardized import handling in imports.py files within the pipeline-adapters/mlrun-pipelines-kfp-common directory, designed to support this shift.
These changes enhance MLRun’s flexibility, making core functionalities available to users who prefer not to install KFP.

https://iguazio.atlassian.net/browse/ML-6118