### PR TITLE
[ProjectSummaries] Fixing schedule count logic #2 [1.7.1]

### DIFF
--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2961,13 +2961,18 @@ class SQLDB(DBInterface):
             .exists()
         )
 
-        query = session.query(
-            Schedule.project.label("project_name"),
-            Schedule.name.label("schedule_name"),
-            case([(workflow_label_exists, True)], else_=False).label(
-                "has_workflow_label"
-            ),
-        ).filter(Schedule.next_run_time < next_day).filter(Schedule.next_run_time >= datetime.now(timezone.utc)).all()
+        query = (
+            session.query(
+                Schedule.project.label("project_name"),
+                Schedule.name.label("schedule_name"),
+                case([(workflow_label_exists, True)], else_=False).label(
+                    "has_workflow_label"
+                ),
+            )
+            .filter(Schedule.next_run_time < next_day)
+            .filter(Schedule.next_run_time >= datetime.now(timezone.utc))
+            .all()
+        )
 
         project_to_schedule_pending_jobs_count = collections.defaultdict(int)
         project_to_schedule_pending_workflows_count = collections.defaultdict(int)

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2949,67 +2949,32 @@ class SQLDB(DBInterface):
 
         next_day = datetime.now(timezone.utc) + timedelta(hours=24)
 
-        schedules_pending_count_per_project = (
-            session.query(
-                Schedule.project,
-                Schedule.name,
-                # The logic here is the following:
-                # If the schedule has a label with the name "workflow" then we take the value of that label
-                # name. Otherwise, we take the value of the label with the name "kind".
-                # The reason for that is that for schedule workflow we have both workflow label and kind label
-                # with job, and on schedule job we have only kind label with job and because of that we first
-                # want to check for workflow label and if it doesn't exist then we take the kind label.
-                func.coalesce(
-                    func.max(
-                        case(
-                            [
-                                (
-                                    Schedule.Label.name
-                                    == mlrun_constants.MLRunInternalLabels.workflow,
-                                    Schedule.Label.name,
-                                )
-                            ],
-                            else_=None,
-                        )
-                    ),
-                    func.max(
-                        case(
-                            [
-                                (
-                                    Schedule.Label.name
-                                    == mlrun_constants.MLRunInternalLabels.kind,
-                                    Schedule.Label.value,
-                                )
-                            ],
-                            else_=None,
-                        )
-                    ),
-                ).label("preferred_label_value"),
+        # We check the workflow label because the schedule kind
+        # is not used properly (not setting pipelines kind for workflow schedules)
+        # TODO: fix the schedule kind to be pipeline when scheduling workflows
+        workflow_label_exists = (
+            select(Schedule.Label.parent)
+            .where(
+                (Schedule.Label.parent == Schedule.id)
+                & (Schedule.Label.name == mlrun_constants.MLRunInternalLabels.workflow)
             )
-            .join(Schedule.Label, Schedule.Label.parent == Schedule.id)
-            .filter(Schedule.next_run_time < next_day)
-            .filter(Schedule.next_run_time >= datetime.now(timezone.utc))
-            .filter(
-                Schedule.Label.name.in_(
-                    [
-                        mlrun_constants.MLRunInternalLabels.workflow,
-                        mlrun_constants.MLRunInternalLabels.kind,
-                    ]
-                )
-            )
-            .group_by(Schedule.project, Schedule.name)
-            .all()
+            .exists()
         )
+
+        query = session.query(
+            Schedule.project.label("project_name"),
+            Schedule.name.label("schedule_name"),
+            case([(workflow_label_exists, True)], else_=False).label(
+                "has_workflow_label"
+            ),
+        ).filter(Schedule.next_run_time < next_day).filter(Schedule.next_run_time >= datetime.now(timezone.utc)).all()
 
         project_to_schedule_pending_jobs_count = collections.defaultdict(int)
         project_to_schedule_pending_workflows_count = collections.defaultdict(int)
 
-        for result in schedules_pending_count_per_project:
-            project_name, schedule_name, kind = result
-            if kind == mlrun_constants.MLRunInternalLabels.workflow:
-                # We check the workflow label because the schedule kind
-                # is not used properly (not setting pipelines kind for workflow schedules)
-                # TODO: fix the schedule kind to be pipeline when scheduling workflows
+        for result in query:
+            project_name, schedule_name, is_workflow = result
+            if is_workflow:
                 project_to_schedule_pending_workflows_count[project_name] += 1
             else:
                 project_to_schedule_pending_jobs_count[project_name] += 1

--- a/tests/api/db/test_schedule.py
+++ b/tests/api/db/test_schedule.py
@@ -108,9 +108,22 @@ def test_calculate_schedules_counters(db: DBInterface, db_session: Session):
             next_run_time=next_minute,
         )
 
+    db.store_schedule(
+        db_session,
+        project="project3",
+        name="no_kind_label",
+        kind=mlrun.common.schemas.ScheduleKinds.job,
+        cron_trigger=mlrun.common.schemas.ScheduleCronTrigger(minute=10),
+        next_run_time=next_minute,
+    )
+
     counters = SQLDB._calculate_schedules_counters(db_session)
     assert counters == (
-        {"project1": 1, "project2": 3},  # total schedule count per project
-        {"project1": 1},  # pending jobs count per project
+        {
+            "project1": 1,
+            "project2": 3,
+            "project3": 1,
+        },  # total schedule count per project
+        {"project1": 1, "project3": 1},  # pending jobs count per project
         {"project2": 3},  # pending pipelines count per project
     )


### PR DESCRIPTION
Fixed the logic for counting schedule as the following:

1. Create new subquery that checks if one of the labels name of the current schedule is workflow, if yes it is workflow, else it is job
2. Select the all schedules for the next 24 hours with the subquery.

(Before that we used join between Schedules and Labels and select only the kind and workflow labels. It worked good as far as the Schedule have kind label, but if it doesn't have it we don't count it)
https://iguazio.atlassian.net/browse/ML-8110 