### PR TITLE
[Model Monitoring] Improve handling of k8s character limit issue when deleting monitoring resources

### DIFF
--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -876,10 +876,15 @@ class MonitoringDeployment:
         )
         stream_paths = []
         for function_name in function_names:
-            label_selector = f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={project}-{function_name}"
-            if len(label_selector) > 63:
-                # k8s label character limit exceeded, skipping deletion of stream resources"
+            qualified_function_name = f"{project}-{function_name}"
+            if len(qualified_function_name) > 63:
+                logger.info(
+                    "k8s 63 characters limit exceeded, skipping deletion of stream resources",
+                    project_name=project,
+                    function_label_name=qualified_function_name,
+                )
                 continue
+            label_selector = f"{mlrun_constants.MLRunInternalLabels.nuclio_function_name}={qualified_function_name}"
             for i in range(10):
                 # waiting for the function pod to be deleted
                 # max 10 retries (5 sec sleep between each retry)


### PR DESCRIPTION
Cherry pick 
- #6678 

Fix an issue in which instead of checking the length of the full label selector, we should verify the length of the complete function name (project + function name) to ensure it does not exceed the k8s 63 character limit. It's important to note that in general the user should receive an error during the build process if there are issues related to k8s naming limitations.

https://iguazio.atlassian.net/browse/ML-8224