### PR TITLE
[API] Move Unversioned Functions Filtering To SQL Query

### DIFF
--- a/server/py/services/api/db/sqldb/db.py
+++ b/server/py/services/api/db/sqldb/db.py
@@ -4824,6 +4824,8 @@ class SQLDB(DBInterface):
                 # Filter on the specific tag
                 query = query.filter(Function.Tag.name == tag)
 
+        # filter out untagged unversioned functions, or in other words:
+        # include only functions that are tagged OR their uid does not start with `unversioned-`
         query = query.filter(
             or_(
                 Function.Tag.name != NULL,

--- a/server/py/services/api/db/sqldb/db.py
+++ b/server/py/services/api/db/sqldb/db.py
@@ -1938,12 +1938,6 @@ class SQLDB(DBInterface):
                 #  will need to understand how to display functions in UI, because if we do not remove the status here,
                 #  UI shows two function as `ready` which belong to the same Nuclio function
                 function_dict["status"] = None
-
-                # the unversioned uid is only a placeholder for tagged instances that are versioned.
-                # if another instance "took" the tag, we're left with an unversioned untagged instance
-                # don't list it
-                if function.uid.startswith(unversioned_tagged_object_uid_prefix):
-                    continue
             else:
                 function_dict["metadata"]["tag"] = function_tag
 
@@ -4829,6 +4823,13 @@ class SQLDB(DBInterface):
             if tag != "*":
                 # Filter on the specific tag
                 query = query.filter(Function.Tag.name == tag)
+
+        query = query.filter(
+            or_(
+                Function.Tag.name != NULL,
+                Function.uid.notlike(f"{unversioned_tagged_object_uid_prefix}%"),
+            )
+        )
 
         labels = label_set(labels)
         query = self._add_labels_filter(session, query, Function, labels)


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8257

Instead of filtering afterwards in python code, as this is both inefficient and also creates issues with pagination making the page size inconsistent in the results.

The existing unit test `test_list_functions_filtering_unversioned_untagged` ensures the logic is still sound.