### PR TITLE
[Tutorials] Fix a scikit-learn requirement

### DIFF
--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -186,7 +186,7 @@
     "# enable monitoring on this serving function\n",
     "serving_fn.set_tracking()\n",
     "\n",
-    "serving_fn.spec.build.requirements = [\"scikit-learn==1.0.2\"]\n",
+    "serving_fn.spec.build.requirements = [\"scikit-learn==1.5.1\"]\n",
     "\n",
     "# Deploy the serving function\n",
     "project.deploy_function(serving_fn)"


### PR DESCRIPTION
Align with the supported 1.5.1 version.
It was caught in #6677 by running this test locally:
```sh
pytest tests/test_requirements.py::test_scikit_learn_requirements_are_aligned
```