### PR TITLE
[Requirements] Limit aiohttp to 3.10 to fix CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # >=1.28.0,<1.29.0 botocore inside boto3 1.28.17 inside nuclio-jupyter 0.9.13
 urllib3>=1.26.9, <1.27
 GitPython~=3.1, >=3.1.41
-aiohttp~=3.9
+aiohttp~=3.10.0
 # 2.9.0 removes _is_status_code_ok method, which is used in mlrun/utils/async_http.py
 aiohttp-retry~=2.8.0
 click~=8.1

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -134,6 +134,8 @@ def test_requirement_specifiers_convention():
         "pyopenssl": {">=23"},
         "protobuf": {"~=3.20.3", ">=3.20.3, <4"},
         "google-cloud-bigquery": {"[pandas, bqstorage]==3.14.1"},
+        # due to a bug in 3.11
+        "aiohttp": {"~=3.10.0"},
         "aiohttp-retry": {"~=2.8.0"},
         # due to a bug in apscheduler with python 3.9 https://github.com/agronholm/apscheduler/issues/770
         "apscheduler": {"~=3.6, !=3.10.2"},


### PR DESCRIPTION
This broke CI with this error
```
>       kwargs['request_info'] = RequestInfo(
            url=url,
            method=method,
            headers=CIMultiDictProxy(CIMultiDict(**request_headers)),
        )
E       TypeError: <lambda>() missing 1 required positional argument: 'real_url'
```