### PR TITLE
[CI] Fix system tests image sha abbrev to 8 chars

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -179,7 +179,7 @@ jobs:
           cd /tmp && \
           git clone --single-branch --branch ${{ steps.current-branch.outputs.name }} https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
           cd mlrun-upstream && \
-          git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit HEAD && \
+          git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit --abbrev=8 HEAD && \
           cd .. && \
           rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
 
@@ -188,7 +188,7 @@ jobs:
           cd /tmp && \
           git clone --single-branch --branch ${{ steps.current-branch.outputs.name }} https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
           cd mlrun-ui && \
-          git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit HEAD && \
+          git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit --abbrev=8 HEAD && \
           cd .. && \
           rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -84,7 +84,7 @@ jobs:
               cd /tmp && \
               git clone --single-branch --branch development https://github.com/mlrun/mlrun.git mlrun-upstream 2> /dev/null && \
               cd mlrun-upstream && \
-              git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit HEAD && \
+              git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit --abbrev=8 HEAD && \
               cd .. && \
               rm -rf mlrun-upstream)" >> $GITHUB_OUTPUT
           fi
@@ -95,7 +95,7 @@ jobs:
               cd /tmp && \
               git clone --single-branch --branch development https://github.com/mlrun/ui.git mlrun-ui 2> /dev/null && \
               cd mlrun-ui && \
-              git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit HEAD && \
+              git rev-list --until="1 hour ago" --max-count 1 --abbrev-commit --abbrev=8 HEAD && \
               cd .. && \
               rm -rf mlrun-ui)" >> $GITHUB_OUTPUT
           echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT

--- a/server/py/services/api/api/endpoints/alert_template.py
+++ b/server/py/services/api/api/endpoints/alert_template.py
@@ -130,7 +130,7 @@ async def delete_alert_template(
         mlrun.mlconf.httpdb.clusterization.role
         != mlrun.common.schemas.ClusterizationRole.chief
     ):
-        chief_client = services.api.utils.clients.chief.Client()
+        chief_client = framework.utils.clients.chief.Client()
         return await chief_client.delete_alert_template(name=name, request=request)
 
     logger.debug("Deleting alert template", name=name)


### PR DESCRIPTION
In the build job we fixate the version sha to 8 characters while the `--abbrev-commit` length is dynamic
https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev