### PR TITLE
[Model Monitoring] Avoid project deletion failure when TDEngine drop tables fails

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -242,9 +242,9 @@ class TDEngineConnector(TSDBConnector):
                 )
             except Exception as e:
                 logger.warning(
-                    "Failed to delete TDEngine resources, you may need to delete them manually."
-                    "Please note that currently, the available project resources can be found "
-                    "under the following supertables: 'app_results,' 'metrics,' and 'predictions.'",
+                    "Failed to drop TDEngine tables. You may need to drop them manually. "
+                    "These can be found under the following supertables: app_results, "
+                    "metrics, and predictions.",
                     project=self.project,
                     error=mlrun.errors.err_to_str(e),
                 )

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -234,9 +234,18 @@ class TDEngineConnector(TSDBConnector):
                 drop_statements.append(
                     self.tables[table]._drop_subtable_query(subtable=subtable[0])
                 )
-            self.connection.run(
-                statements=drop_statements, timeout=self._timeout, retries=self._retries
-            )
+            try:
+                self.connection.run(
+                    statements=drop_statements,
+                    timeout=self._timeout,
+                    retries=self._retries,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete TDEngine resources, you may need to delete them manually",
+                    project=self.project,
+                    error=mlrun.errors.err_to_str(e),
+                )
         logger.debug(
             "Deleted all project resources using the TDEngine connector",
             project=self.project,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -242,7 +242,9 @@ class TDEngineConnector(TSDBConnector):
                 )
             except Exception as e:
                 logger.warning(
-                    "Failed to delete TDEngine resources, you may need to delete them manually",
+                    "Failed to delete TDEngine resources, you may need to delete them manually."
+                    "Please note that currently, the available project resources can be found "
+                    "under the following supertables: 'app_results,' 'metrics,' and 'predictions.'",
                     project=self.project,
                     error=mlrun.errors.err_to_str(e),
                 )


### PR DESCRIPTION
If an issue occurs while deleting TDEngine resources, we will log the error as a warn and ensure it does not disrupt the project deletion API. In this case, we will suggest the user to delete the resources manually. 

https://iguazio.atlassian.net/browse/ML-8246