### PR TITLE
[Docs] Update dockerfile reference

### DIFF
--- a/hack/local/README.md
+++ b/hack/local/README.md
@@ -23,7 +23,7 @@ To use MLRun with your local Docker registry, run the MLRun API service, dashboa
 > - Using Docker is limited to local runtimes.
 > - By default the MLRun API service will run inside the Jupyter server, set the MLRUN_DBPATH env var in Jupyter to point to an alternative service address.
 > - The artifacts and DB will be stored under **/home/jovyan/data**, use docker -v option to persist the content on the host (e.g. `-v ${SHARED_DIR}:/home/jovyan/data`)
-> - If Docker is running on Windows with WSL 2, you must create SHARED_DIR before running these commadns. Provide the full path when executing  (e.g. `mkdir /mnt/c/mlrun-data`  `SHARED_DIR=/mnt/c/mlrun-data`)
+> - If Docker is running on Windows with WSL 2, you must create SHARED_DIR before running these commands. Provide the full path when executing  (e.g. `mkdir /mnt/c/mlrun-data`  `SHARED_DIR=/mnt/c/mlrun-data`)
 
 ```
 SHARED_DIR=~/mlrun-data
@@ -98,7 +98,7 @@ Copy the [**mljupy.yaml**](mljupy.yaml) file to you cluster and run the followin
 kubectl apply -n <namespace> -f mljupy.yaml
 ```
 
-To change or add packages, see the Jupyter Dockerfile ([**Dockerfile.jupy**](dockerfiles/jupyter/Dockerfile)).
+To change or add packages, see the Jupyter Dockerfile ([**Dockerfile.jupy**](/dockerfiles/jupyter/Dockerfile)).
 
 <a id="k8s-install-start-working"></a>
 ### Start Working


### PR DESCRIPTION
# PR Summary
Small PR - fixes the `/dockerfiles/jupyter/Dockerfile` reference in `hack/local/README.md` alongside with a small typo.