### PR TITLE
[Model Monitoring] Create TDEngine STABLE per project

### DIFF
--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -23,7 +23,7 @@ import mlrun.model_monitoring.applications.base as mm_base
 import mlrun.model_monitoring.applications.context as mm_context
 from mlrun.errors import MLRunIncompatibleVersionError
 
-SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.32")
+SUPPORTED_EVIDENTLY_VERSION = semver.Version.parse("0.4.39")
 
 
 def _check_evidently_version(*, cur: semver.Version, ref: semver.Version) -> None:

--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -82,9 +82,10 @@ class TDEngineSchema:
         super_table: str,
         columns: dict[str, _TDEngineColumn],
         tags: dict[str, str],
+        project: str,
         database: Optional[str] = None,
     ):
-        self.super_table = super_table
+        self.super_table = f"{super_table}_{project}".replace("-", "_")
         self.columns = columns
         self.tags = tags
         self.database = database or _MODEL_MONITORING_DATABASE
@@ -147,6 +148,11 @@ class TDEngineSchema:
         subtable: str,
     ) -> str:
         return f"DROP TABLE if EXISTS {self.database}.{subtable};"
+
+    def _drop_supertable_query(
+        self,
+    ) -> str:
+        return f"DROP STABLE if EXISTS {self.database}.{self.super_table};"
 
     def _get_subtables_query(
         self,
@@ -227,8 +233,8 @@ class TDEngineSchema:
 
 @dataclass
 class AppResultTable(TDEngineSchema):
-    def __init__(self, database: Optional[str] = None):
-        super_table = mm_schemas.TDEngineSuperTables.APP_RESULTS
+    def __init__(self, project: str, database: Optional[str] = None):
+        super_table = f"{mm_schemas.TDEngineSuperTables.APP_RESULTS}"
         columns = {
             mm_schemas.WriterEvent.END_INFER_TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.WriterEvent.START_INFER_TIME: _TDEngineColumn.TIMESTAMP,
@@ -236,44 +242,59 @@ class AppResultTable(TDEngineSchema):
             mm_schemas.ResultData.RESULT_STATUS: _TDEngineColumn.INT,
         }
         tags = {
-            mm_schemas.EventFieldType.PROJECT: _TDEngineColumn.BINARY_64,
             mm_schemas.WriterEvent.ENDPOINT_ID: _TDEngineColumn.BINARY_64,
             mm_schemas.WriterEvent.APPLICATION_NAME: _TDEngineColumn.BINARY_64,
             mm_schemas.ResultData.RESULT_NAME: _TDEngineColumn.BINARY_64,
             mm_schemas.ResultData.RESULT_KIND: _TDEngineColumn.INT,
         }
-        super().__init__(super_table, columns, tags, database)
+        super().__init__(
+            super_table=super_table,
+            columns=columns,
+            tags=tags,
+            database=database,
+            project=project,
+        )
 
 
 @dataclass
 class Metrics(TDEngineSchema):
-    def __init__(self, database: Optional[str] = None):
-        super_table = mm_schemas.TDEngineSuperTables.METRICS
+    def __init__(self, project: str, database: Optional[str] = None):
+        super_table = f"{mm_schemas.TDEngineSuperTables.METRICS}"
         columns = {
             mm_schemas.WriterEvent.END_INFER_TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.WriterEvent.START_INFER_TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.MetricData.METRIC_VALUE: _TDEngineColumn.FLOAT,
         }
         tags = {
-            mm_schemas.EventFieldType.PROJECT: _TDEngineColumn.BINARY_64,
             mm_schemas.WriterEvent.ENDPOINT_ID: _TDEngineColumn.BINARY_64,
             mm_schemas.WriterEvent.APPLICATION_NAME: _TDEngineColumn.BINARY_64,
             mm_schemas.MetricData.METRIC_NAME: _TDEngineColumn.BINARY_64,
         }
-        super().__init__(super_table, columns, tags, database)
+        super().__init__(
+            super_table=super_table,
+            columns=columns,
+            tags=tags,
+            database=database,
+            project=project,
+        )
 
 
 @dataclass
 class Predictions(TDEngineSchema):
-    def __init__(self, database: Optional[str] = None):
-        super_table = mm_schemas.TDEngineSuperTables.PREDICTIONS
+    def __init__(self, project: str, database: Optional[str] = None):
+        super_table = f"{mm_schemas.TDEngineSuperTables.PREDICTIONS}"
         columns = {
             mm_schemas.EventFieldType.TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.EventFieldType.LATENCY: _TDEngineColumn.FLOAT,
             mm_schemas.EventKeyMetrics.CUSTOM_METRICS: _TDEngineColumn.BINARY_10000,
         }
         tags = {
-            mm_schemas.EventFieldType.PROJECT: _TDEngineColumn.BINARY_64,
             mm_schemas.WriterEvent.ENDPOINT_ID: _TDEngineColumn.BINARY_64,
         }
-        super().__init__(super_table, columns, tags, database)
+        super().__init__(
+            super_table=super_table,
+            columns=columns,
+            tags=tags,
+            database=database,
+            project=project,
+        )

--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -85,7 +85,7 @@ class TDEngineSchema:
         project: str,
         database: Optional[str] = None,
     ):
-        self.super_table = f"{super_table}_{project}".replace("-", "_")
+        self.super_table = f"{super_table}_{project.replace('-', '_')}"
         self.columns = columns
         self.tags = tags
         self.database = database or _MODEL_MONITORING_DATABASE
@@ -149,9 +149,7 @@ class TDEngineSchema:
     ) -> str:
         return f"DROP TABLE if EXISTS {self.database}.{subtable};"
 
-    def _drop_supertable_query(
-        self,
-    ) -> str:
+    def _drop_supertable_query(self) -> str:
         return f"DROP STABLE if EXISTS {self.database}.{self.super_table};"
 
     def _get_subtables_query(
@@ -234,7 +232,7 @@ class TDEngineSchema:
 @dataclass
 class AppResultTable(TDEngineSchema):
     def __init__(self, project: str, database: Optional[str] = None):
-        super_table = f"{mm_schemas.TDEngineSuperTables.APP_RESULTS}"
+        super_table = mm_schemas.TDEngineSuperTables.APP_RESULTS
         columns = {
             mm_schemas.WriterEvent.END_INFER_TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.WriterEvent.START_INFER_TIME: _TDEngineColumn.TIMESTAMP,
@@ -259,7 +257,7 @@ class AppResultTable(TDEngineSchema):
 @dataclass
 class Metrics(TDEngineSchema):
     def __init__(self, project: str, database: Optional[str] = None):
-        super_table = f"{mm_schemas.TDEngineSuperTables.METRICS}"
+        super_table = mm_schemas.TDEngineSuperTables.METRICS
         columns = {
             mm_schemas.WriterEvent.END_INFER_TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.WriterEvent.START_INFER_TIME: _TDEngineColumn.TIMESTAMP,
@@ -282,7 +280,7 @@ class Metrics(TDEngineSchema):
 @dataclass
 class Predictions(TDEngineSchema):
     def __init__(self, project: str, database: Optional[str] = None):
-        super_table = f"{mm_schemas.TDEngineSuperTables.PREDICTIONS}"
+        super_table = mm_schemas.TDEngineSuperTables.PREDICTIONS
         columns = {
             mm_schemas.EventFieldType.TIME: _TDEngineColumn.TIMESTAMP,
             mm_schemas.EventFieldType.LATENCY: _TDEngineColumn.FLOAT,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -149,7 +149,7 @@ class TDEngineSchema:
     ) -> str:
         return f"DROP TABLE if EXISTS {self.database}.{subtable};"
 
-    def _drop_supertable_query(self) -> str:
+    def drop_supertable_query(self) -> str:
         return f"DROP STABLE if EXISTS {self.database}.{self.super_table};"
 
     def _get_subtables_query(

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -289,13 +289,6 @@ class TDEngineConnector(TSDBConnector):
         :raise:  MLRunInvalidArgumentError if query the provided table failed.
         """
 
-        # project_condition = f"project = '{self.project}'"
-        # filter_query = (
-        #     f"({filter_query}) AND ({project_condition})"
-        #     if filter_query
-        #     else project_condition
-        # )
-
         full_query = tdengine_schemas.TDEngineSchema._get_records_query(
             table=table,
             start=start,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -82,13 +82,13 @@ class TDEngineConnector(TSDBConnector):
         """Initialize the super tables for the TSDB."""
         self.tables = {
             mm_schemas.TDEngineSuperTables.APP_RESULTS: tdengine_schemas.AppResultTable(
-                self.database
+                project=self.project, database=self.database
             ),
             mm_schemas.TDEngineSuperTables.METRICS: tdengine_schemas.Metrics(
-                self.database
+                project=self.project, database=self.database
             ),
             mm_schemas.TDEngineSuperTables.PREDICTIONS: tdengine_schemas.Predictions(
-                self.database
+                project=self.project, database=self.database
             ),
         }
 
@@ -112,11 +112,11 @@ class TDEngineConnector(TSDBConnector):
         """
 
         table_name = (
-            f"{self.project}_"
+            # f"{self.project}_"
             f"{event[mm_schemas.WriterEvent.ENDPOINT_ID]}_"
             f"{event[mm_schemas.WriterEvent.APPLICATION_NAME]}_"
         )
-        event[mm_schemas.EventFieldType.PROJECT] = self.project
+        # event[mm_schemas.EventFieldType.PROJECT] = self.project
 
         if kind == mm_schemas.WriterEventKind.RESULT:
             # Write a new result
@@ -220,23 +220,24 @@ class TDEngineConnector(TSDBConnector):
             "Deleting all project resources using the TDEngine connector",
             project=self.project,
         )
+        drop_statements = []
         for table in self.tables:
-            get_subtable_names_query = self.tables[table]._get_subtables_query(
-                values={mm_schemas.EventFieldType.PROJECT: self.project}
-            )
-            subtables = self.connection.run(
-                query=get_subtable_names_query,
-                timeout=self._timeout,
-                retries=self._retries,
-            ).data
-            drop_statements = []
-            for subtable in subtables:
-                drop_statements.append(
-                    self.tables[table]._drop_subtable_query(subtable=subtable[0])
+            drop_statements.append(self.tables[table]._drop_supertable_query())
+
+            try:
+                self.connection.run(
+                    statements=drop_statements,
+                    timeout=self._timeout,
+                    retries=self._retries,
                 )
-            self.connection.run(
-                statements=drop_statements, timeout=self._timeout, retries=self._retries
-            )
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete TDEngine resources, you may need to delete them manually"
+                    "Please note that currently, the available project resources can be found "
+                    "under the following supertables: 'app_results,' 'metrics,' and 'predictions.'",
+                    project=self.project,
+                    error=mlrun.errors.err_to_str(e),
+                )
         logger.debug(
             "Deleted all project resources using the TDEngine connector",
             project=self.project,
@@ -288,12 +289,12 @@ class TDEngineConnector(TSDBConnector):
         :raise:  MLRunInvalidArgumentError if query the provided table failed.
         """
 
-        project_condition = f"project = '{self.project}'"
-        filter_query = (
-            f"({filter_query}) AND ({project_condition})"
-            if filter_query
-            else project_condition
-        )
+        # project_condition = f"project = '{self.project}'"
+        # filter_query = (
+        #     f"({filter_query}) AND ({project_condition})"
+        #     if filter_query
+        #     else project_condition
+        # )
 
         full_query = tdengine_schemas.TDEngineSchema._get_records_query(
             table=table,
@@ -346,12 +347,12 @@ class TDEngineConnector(TSDBConnector):
         timestamp_column = mm_schemas.WriterEvent.END_INFER_TIME
         columns = [timestamp_column, mm_schemas.WriterEvent.APPLICATION_NAME]
         if type == "metrics":
-            table = mm_schemas.TDEngineSuperTables.METRICS
+            table = self.tables[mm_schemas.TDEngineSuperTables.METRICS].super_table
             name = mm_schemas.MetricData.METRIC_NAME
             columns += [name, mm_schemas.MetricData.METRIC_VALUE]
             df_handler = self.df_to_metrics_values
         elif type == "results":
-            table = mm_schemas.TDEngineSuperTables.APP_RESULTS
+            table = self.tables[mm_schemas.TDEngineSuperTables.APP_RESULTS].super_table
             name = mm_schemas.ResultData.RESULT_NAME
             columns += [
                 name,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -112,11 +112,9 @@ class TDEngineConnector(TSDBConnector):
         """
 
         table_name = (
-            # f"{self.project}_"
             f"{event[mm_schemas.WriterEvent.ENDPOINT_ID]}_"
-            f"{event[mm_schemas.WriterEvent.APPLICATION_NAME]}_"
+            f"{event[mm_schemas.WriterEvent.APPLICATION_NAME]}"
         )
-        # event[mm_schemas.EventFieldType.PROJECT] = self.project
 
         if kind == mm_schemas.WriterEventKind.RESULT:
             # Write a new result
@@ -224,20 +222,20 @@ class TDEngineConnector(TSDBConnector):
         for table in self.tables:
             drop_statements.append(self.tables[table]._drop_supertable_query())
 
-            try:
-                self.connection.run(
-                    statements=drop_statements,
-                    timeout=self._timeout,
-                    retries=self._retries,
-                )
-            except Exception as e:
-                logger.warning(
-                    "Failed to delete TDEngine resources, you may need to delete them manually"
-                    "Please note that currently, the available project resources can be found "
-                    "under the following supertables: 'app_results,' 'metrics,' and 'predictions.'",
-                    project=self.project,
-                    error=mlrun.errors.err_to_str(e),
-                )
+        try:
+            self.connection.run(
+                statements=drop_statements,
+                timeout=self._timeout,
+                retries=self._retries,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to drop TDEngine tables. You may need to drop them manually. "
+                "These can be found under the following supertables: app_results, "
+                "metrics, and predictions.",
+                project=self.project,
+                error=mlrun.errors.err_to_str(e),
+            )
         logger.debug(
             "Deleted all project resources using the TDEngine connector",
             project=self.project,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -185,7 +185,7 @@ class TDEngineConnector(TSDBConnector):
                 name=name,
                 after=after,
                 url=self._tdengine_connection_string,
-                supertable=mm_schemas.TDEngineSuperTables.PREDICTIONS,
+                supertable=self.tables[mm_schemas.TDEngineSuperTables.PREDICTIONS].super_table,
                 table_col=mm_schemas.EventFieldType.TABLE_COLUMN,
                 time_col=mm_schemas.EventFieldType.TIME,
                 database=self.database,
@@ -409,7 +409,7 @@ class TDEngineConnector(TSDBConnector):
                 "both or neither of `aggregation_window` and `agg_funcs` must be provided"
             )
         df = self._get_records(
-            table=mm_schemas.TDEngineSuperTables.PREDICTIONS,
+            table=self.tables[mm_schemas.TDEngineSuperTables.PREDICTIONS].super_table,
             start=start,
             end=end,
             columns=[mm_schemas.EventFieldType.LATENCY],

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -220,7 +220,7 @@ class TDEngineConnector(TSDBConnector):
         )
         drop_statements = []
         for table in self.tables:
-            drop_statements.append(self.tables[table]._drop_supertable_query())
+            drop_statements.append(self.tables[table].drop_supertable_query())
 
         try:
             self.connection.run(

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -185,7 +185,9 @@ class TDEngineConnector(TSDBConnector):
                 name=name,
                 after=after,
                 url=self._tdengine_connection_string,
-                supertable=self.tables[mm_schemas.TDEngineSuperTables.PREDICTIONS].super_table,
+                supertable=self.tables[
+                    mm_schemas.TDEngineSuperTables.PREDICTIONS
+                ].super_table,
                 table_col=mm_schemas.EventFieldType.TABLE_COLUMN,
                 time_col=mm_schemas.EventFieldType.TIME,
                 database=self.database,

--- a/tests/model_monitoring/test_tdengine.py
+++ b/tests/model_monitoring/test_tdengine.py
@@ -31,6 +31,7 @@ _COLUMNS_TEST = {
     "column3": _TDEngineColumn.BINARY_40,
 }
 _TAG_TEST = {"tag1": _TDEngineColumn.INT, "tag2": _TDEngineColumn.BINARY_64}
+_PROJECT = "project-test"
 
 
 class TestTDEngineSchema:
@@ -41,7 +42,10 @@ class TestTDEngineSchema:
     @pytest.fixture
     def super_table() -> TDEngineSchema:
         return TDEngineSchema(
-            super_table=_SUPER_TABLE_TEST, columns=_COLUMNS_TEST, tags=_TAG_TEST
+            super_table=_SUPER_TABLE_TEST,
+            columns=_COLUMNS_TEST,
+            tags=_TAG_TEST,
+            project=_PROJECT,
         )
 
     @staticmethod
@@ -117,6 +121,14 @@ class TestTDEngineSchema:
         assert (
             super_table._drop_subtable_query(subtable="subtable_1")
             == f"DROP TABLE if EXISTS {_MODEL_MONITORING_DATABASE}.subtable_1;"
+        )
+
+    def test_drop_supertable(self, super_table: TDEngineSchema):
+        assert (
+            super_table._drop_supertable_query()
+            == f"DROP STABLE if EXISTS {_MODEL_MONITORING_DATABASE}.{_SUPER_TABLE_TEST}_{_PROJECT};".replace(
+                "-", "_"
+            )
         )
 
     @pytest.mark.parametrize(

--- a/tests/model_monitoring/test_tdengine.py
+++ b/tests/model_monitoring/test_tdengine.py
@@ -125,7 +125,7 @@ class TestTDEngineSchema:
 
     def test_drop_supertable(self, super_table: TDEngineSchema):
         assert (
-            super_table._drop_supertable_query()
+            super_table.drop_supertable_query()
             == f"DROP STABLE if EXISTS {_MODEL_MONITORING_DATABASE}.{_SUPER_TABLE_TEST}_{_PROJECT};".replace(
                 "-", "_"
             )

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -177,7 +177,9 @@ class _V3IORecordsChecker:
         else:
             # TDEngine
             df: pd.DataFrame = cls._tsdb_storage._get_records(
-                table=mm_constants.TDEngineSuperTables.APP_RESULTS,
+                table=cls._tsdb_storage.tables[
+                    mm_constants.TDEngineSuperTables.APP_RESULTS
+                ].super_table,
                 start=datetime.now().astimezone()
                 - timedelta(minutes=10 * cls.app_interval),
                 end=datetime.now().astimezone(),
@@ -240,7 +242,9 @@ class _V3IORecordsChecker:
         else:
             # TDEngine
             predictions_df: pd.DataFrame = cls._tsdb_storage._get_records(
-                table=mm_constants.TDEngineSuperTables.PREDICTIONS,
+                table=cls._tsdb_storage.tables[
+                    mm_constants.TDEngineSuperTables.PREDICTIONS
+                ].super_table,
                 start=datetime.min,
                 end=datetime.now().astimezone(),
             )
@@ -285,8 +289,9 @@ class _V3IORecordsChecker:
         error_count: float = None,
     ) -> None:
         cls._test_parquet(ep_id, inputs, outputs)
-        cls._test_results_kv_record(ep_id)
-        cls._test_metrics_kv_record(ep_id)
+        if cls._kv_storage.type == mm_constants.ModelEndpointTargetSchemas.V3IO:
+            cls._test_results_kv_record(ep_id)
+            cls._test_metrics_kv_record(ep_id)
         cls._test_tsdb_record(ep_id, last_request=last_request, error_count=error_count)
 
     @classmethod


### PR DESCRIPTION
Following an issue introduced in https://iguazio.atlassian.net/browse/ML-8246, in this PR we generate a supertable for each project. This approach significantly improves efficiency when deleting TSDB resources during project deletion and when querying data. Additionally, separating projects into distinct supertables offers more advantages such as treating each project as an independent entity in the db and removing the need to store the project label under each subtable.

To clarify, until now the system had three supertables:

- `predictions`, `app_results`, `metrics`

Under each supertable, subtables were used to store the resources for individual projects.  

After this PR is merged, each project will have its own set of three supertables:

- `predictions_pro_v1`, `app_results_pro_v1`, `metrics_pro_v1`
- `predictions_pro_v2`, `app_results_pro_v2`, `metrics_pro_v2`

The total number of subtables containing the data will remain the same (less a project label), but the project querying process will be much more efficient. 
