### PR TITLE
[Alerts] Add condition for resetting alert on reset policy change

### DIFF
--- a/docs/concepts/alerts.md
+++ b/docs/concepts/alerts.md
@@ -157,7 +157,8 @@ The `ResetPolicy` options are:
 - manual &mdash; for manual reset of the alert
 - auto &mdash; if the criteria contains a time period such that the alert is reset once there are no more invocations in the relevant time window.
 
-
+**Note:** If an alert is in an active state and its reset policy is changed from manual to auto, the alert is immediately reset. 
+This ensures that the behavior aligns with the new reset policy and avoids leaving the alert in an inconsistent state.
 
 ## Alert templates
 Alert templates simplify the creation of alerts by providing a predefined set of configurations. The system comes with several 

--- a/server/py/services/alerts/tests/unit/crud/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alerts.py
@@ -152,7 +152,7 @@ class TestAlerts(TestServiceBase):
                 ],
                 False,
             ),
-            ("reset_policy", alert_objects.ResetPolicy.AUTO, False),
+            ("reset_policy", alert_objects.ResetPolicy.AUTO, True),
             # Functional fields:
             (
                 "entities",
@@ -203,7 +203,7 @@ class TestAlerts(TestServiceBase):
                     alert_objects.AlertSeverity.HIGH,
                     alert_objects.ResetPolicy.AUTO,
                 ],
-                False,
+                True,
             ),
             (
                 ["summary", "severity", "trigger"],


### PR DESCRIPTION
Added logic to handle reset policy changes from "manual" to "auto" when the alert is in an active state. 
This ensures the alert is reset appropriately in such scenarios, improving the alignment of alert behavior with reset policy transitions.

Jira:
https://iguazio.atlassian.net/browse/ML-7749

