### PR TITLE
[Model Monitoring] Remove the explicit V3IO mount in app instantiation

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1995,8 +1995,6 @@ class MlrunProject(ModelObj):
         :param application_kwargs:      Additional keyword arguments to be passed to the
                                         monitoring application's constructor.
         """
-
-        function_object: RemoteRuntime = None
         (
             resolved_function_name,
             function_object,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2094,7 +2094,6 @@ class MlrunProject(ModelObj):
     ) -> tuple[str, mlrun.runtimes.BaseRuntime, dict]:
         import mlrun.model_monitoring.api
 
-        function_object: RemoteRuntime = None
         kind = None
         if (isinstance(func, str) or func is None) and application_class is not None:
             kind = mlrun.run.RuntimeKinds.serving
@@ -2132,9 +2131,6 @@ class MlrunProject(ModelObj):
             mm_constants.ModelMonitoringAppLabel.KEY,
             mm_constants.ModelMonitoringAppLabel.VAL,
         )
-
-        if not mlrun.mlconf.is_ce_mode():
-            function_object.apply(mlrun.mount_v3io())
 
         return resolved_function_name, function_object, func
 


### PR DESCRIPTION
A small part of [ML-8357](https://iguazio.atlassian.net/browse/ML-8357).
This mount blocks local jobs and is done by default on remote runtimes.
I tested it, and it doesn't affect the existing behavior.

[ML-8357]: https://iguazio.atlassian.net/browse/ML-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ