### PR TITLE
[Alerts] Fix alert state count reset when storing existing alerts

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -5568,6 +5568,7 @@ class SQLDB(DBInterface):
             return self._create_alert(session, alert)
         alert_record.full_object = alert.dict()
         alert_state = self.get_alert_state(session, alert_record.id)
+        alert_state.count = 0
 
         self._delete_alert_notifications(session, alert.name, alert, alert.project)
         self._store_notifications(

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -117,9 +117,7 @@ class Alerts(
         project = project or mlrun.mlconf.default_project
         return framework.utils.singletons.db.get_db().list_alerts(session, project)
 
-    def get_enriched_alert(
-        self, session: sqlalchemy.orm.Session, project: str, name: str
-    ):
+    def get_alert(self, session: sqlalchemy.orm.Session, project: str, name: str):
         alert = framework.utils.singletons.db.get_db().get_alert(session, project, name)
         if alert is None:
             raise mlrun.errors.MLRunNotFoundError(
@@ -128,15 +126,6 @@ class Alerts(
 
         framework.utils.singletons.db.get_db().enrich_alert(session, alert)
         return alert
-
-    def get_alert(
-        self,
-        session: sqlalchemy.orm.Session,
-        project: str,
-        name: str,
-    ) -> mlrun.common.schemas.AlertConfig:
-        project = project or mlrun.mlconf.default_project
-        return framework.utils.singletons.db.get_db().get_alert(session, project, name)
 
     def delete_alert(
         self,

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -116,7 +116,7 @@ class Service(framework.service.Service):
         )
 
         return await run_in_threadpool(
-            services.alerts.crud.Alerts().get_enriched_alert, db_session, project, name
+            services.alerts.crud.Alerts().get_alert, db_session, project, name
         )
 
     async def list_alerts(

--- a/server/py/services/alerts/tests/unit/crud/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alerts.py
@@ -78,7 +78,7 @@ class TestAlerts(TestServiceBase):
             event,
         )
 
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
@@ -281,12 +281,13 @@ class TestAlerts(TestServiceBase):
             event.kind,
             event,
         )
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
         )
         assert alert.state == alert_objects.AlertActiveState.ACTIVE
+        assert alert.count == 1
 
         # modify the alert data based on the parameterized field
         if isinstance(modify_field, list):
@@ -305,11 +306,13 @@ class TestAlerts(TestServiceBase):
         )
 
         # fetch the updated alert
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
         )
+        # validate that the counter of the alert was reset after storing it again
+        assert alert.count == 0
 
         # validate the state based on whether it should have reset
         expected_state = (


### PR DESCRIPTION
- Fixed an issue where storing an existing alert did not reset its state count correctly.
- Renamed the method `get_enriched_alert` to `get_alert` to improve clarity and reduce confusion.
- Removed unused `get_alert` method from crud.

Jira:
https://iguazio.atlassian.net/browse/ML-8315