### PR TITLE
[Requirements] Bump igz-mgmt version

### DIFF
--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -4,7 +4,7 @@ dask-kubernetes~=0.11.0
 # 3.10.2 is bugged for python 3.9
 apscheduler>=3.10.3,<4
 objgraph~=3.6
-igz-mgmt~=0.2.0
+igz-mgmt~=0.4.0
 humanfriendly~=10.0
 fastapi~=0.110.0
 # in sqlalchemy>=2.0 there is breaking changes (such as in Table class autoload argument is removed)


### PR DESCRIPTION
Bump igz-mgmt version to version 0.4.0:
1. Add support for SMTP configuration
2. Upgrade to Pydantic v1 to support multiple Pydantic environments
