### PR TITLE
[Microservices] Enable hydra opt-out

### DIFF
--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -81,6 +81,8 @@ RUN python -m pip install .[complete-api] &&\
 
 VOLUME /mlrun/db
 
+ENV MLRUN__SERVICES__SERVICE_NAME=api
+
 # use tini as entrypoint to allow signal handling
 # and avoid zombie processes
 ENTRYPOINT ["tini", "--"]

--- a/dockerfiles/mlrun-api/start_api.sh
+++ b/dockerfiles/mlrun-api/start_api.sh
@@ -39,7 +39,7 @@ if [[ -n "$MLRUN_MEMRAY_LOWER"  && ( "$MLRUN_MEMRAY_LOWER" == "1" || "$MLRUN_MEM
         exec python -m memray run${MLRUN_MEMRAY_EXTRA_FLAGS% } -m services.api.main
     fi
 else
-    exec uvicorn services.api.daemon:app \
+    exec uvicorn services."${MLRUN__SERVICES__SERVICE_NAME}".daemon:app \
         --factory \
         --proxy-headers \
         --host 0.0.0.0 \

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -809,6 +809,17 @@ default_config = {
         "request_timeout": 5,
     },
     "notifications": {"smtp": {"config_secret_name": "mlrun-smtp-config"}},
+    "services": {
+        # The running service name. One of: "api", "alerts"
+        "service_name": "api",
+        "hydra": {
+            # Comma separated list of services to run on the instance.
+            # Currently, this is only considered when the service_name is "api".
+            # "*" starts all services on the same instance,
+            # other options are considered as running only the api service.
+            "services": "*",
+        },
+    },
 }
 _is_running_as_api = None
 

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -45,7 +45,7 @@ class Service(ABC):
         self._logger = mlrun.utils.logger.get_child(self.service_name)
         self._mounted_services: list[Service] = []
 
-    def initialize(self, mounts: typing.Optional[dict] = None):
+    def initialize(self, mounts: typing.Optional[list] = None):
         self._logger.info("Initializing service")
         self._initialize_app()
         self._register_routes()
@@ -53,14 +53,14 @@ class Service(ABC):
         self._add_middlewares()
         self._add_exception_handlers()
 
-    def _mount_services(self, mounts: typing.Optional[dict] = None):
+    def _mount_services(self, mounts: typing.Optional[list] = None):
         if not mounts:
             return
 
-        for path, service in mounts.items():
+        self._mounted_services = mounts
+        for service in self._mounted_services:
             service.initialize()
-            self.app.mount(path, service.app)
-            self._mounted_services.append(service)
+            self.app.mount("/", service.app)
 
     @abstractmethod
     async def move_service_to_online(self):
@@ -249,8 +249,8 @@ class Daemon(ABC):
         container.wire()
 
     @property
-    def mounts(self) -> dict[str, Service]:
-        return {}
+    def mounts(self) -> list[Service]:
+        return []
 
     @property
     def app(self) -> fastapi.FastAPI:

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -36,13 +36,11 @@ from framework.utils.singletons.db import initialize_db
 
 
 class Service(ABC):
-    service_name = None
-
     def __init__(self):
-        # TODO: make the prefixes and service name configurable
-        self.SERVICE_PREFIX = f"/{self.service_name}"
-        self.BASE_VERSIONED_SERVICE_PREFIX = f"{self.SERVICE_PREFIX}/v1"
-        self.V2_SERVICE_PREFIX = f"{self.SERVICE_PREFIX}/v2"
+        self.service_name = mlconf.services.service_name
+        self.service_prefix = f"/{self.service_name}"
+        self.base_versioned_service_prefix = f"{self.service_prefix}/v1"
+        self.v2_service_prefix = f"{self.service_prefix}/v2"
         self.app: fastapi.FastAPI = None
         self._logger = mlrun.utils.logger.get_child(self.service_name)
         self._mounted_services: list[Service] = []
@@ -87,9 +85,9 @@ class Service(ABC):
             description="Machine Learning automation and tracking",  # TODO: configure
             version=mlconf.version,
             debug=mlconf.httpdb.debug,
-            openapi_url=f"{self.SERVICE_PREFIX}/openapi.json",
-            docs_url=f"{self.SERVICE_PREFIX}/docs",
-            redoc_url=f"{self.SERVICE_PREFIX}/redoc",
+            openapi_url=f"{self.service_prefix}/openapi.json",
+            docs_url=f"{self.service_prefix}/docs",
+            redoc_url=f"{self.service_prefix}/redoc",
             default_response_class=fastapi.responses.ORJSONResponse,
             lifespan=self.lifespan,
         )

--- a/server/py/services/alerts/daemon.py
+++ b/server/py/services/alerts/daemon.py
@@ -18,9 +18,6 @@ import services.alerts.main
 
 
 class Daemon(framework.service.Daemon):
-    def __init__(self, service_cls: framework.service.Service.__class__):
-        self._service = service_cls()
-
     @property
     def service(self) -> services.alerts.main.Service:
         return self._service

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -18,6 +18,7 @@ import fastapi
 import semver
 import sqlalchemy.orm
 from fastapi.concurrency import run_in_threadpool
+from starlette.responses import Response
 
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
@@ -44,10 +45,6 @@ from framework.routers import alert_template, alerts, auth, healthz
 
 
 class Service(framework.service.Service):
-    # TODO: Change service name to alerts once they are fully separated - this allows to mount the application on the
-    #  api Router without implementing tunneling
-    service_name = "api"
-
     async def store_alert(
         self,
         request: fastapi.Request,
@@ -72,11 +69,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        # TODO: Remove chief requirement when alerts is standalone
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             data = await request.json()
             return await chief_client.store_alert(
@@ -180,11 +173,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        # TODO: Once alerts runs in its own pod - remove chief check
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             return await chief_client.delete_alert(
                 project=project, name=name, request=request
@@ -218,11 +207,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        # TODO: Once alerts runs in its own pod - remove chief check
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             return await chief_client.reset_alert(
                 project=project, name=name, request=request
@@ -265,11 +250,7 @@ class Service(framework.service.Service):
             )
             return
 
-        # TODO: Once alerts runs in its own pod - remove chief check
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if not self._is_chief_or_standalone():
             data = await request.json()
             chief_client = framework.utils.clients.chief.Client()
             return await chief_client.set_event(
@@ -298,18 +279,14 @@ class Service(framework.service.Service):
         alert_data: mlrun.common.schemas.AlertTemplate,
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
-    ) -> mlrun.common.schemas.AlertTemplate:
+    ) -> Response:
         await framework.utils.auth.verifier.AuthVerifier().query_global_resource_permissions(
             self._get_authorization_resource_for_alert_template(),
             mlrun.common.schemas.AuthorizationAction.create,
             auth_info,
         )
 
-        # TODO: Once alerts runs in its own pod - remove chief check
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if not self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             data = await request.json()
             return await chief_client.store_alert_template(
@@ -370,11 +347,7 @@ class Service(framework.service.Service):
             mlrun.common.schemas.AuthorizationAction.delete,
             auth_info,
         )
-        # TODO: Once alerts runs in its own pod - remove chief check
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if not self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             return await chief_client.delete_alert_template(name=name, request=request)
 
@@ -388,11 +361,7 @@ class Service(framework.service.Service):
 
     async def move_service_to_online(self):
         self._logger.info("Moving alerts to online")
-        # TODO: Once alerts runs in its own pod - remove chief check
-        if (
-            mlconf.httpdb.clusterization.role
-            == mlrun.common.schemas.ClusterizationRole.chief
-        ):
+        if self._is_chief_or_standalone():
             services.alerts.initial_data.update_default_configuration_data(self._logger)
             await self._start_periodic_functions()
 
@@ -418,7 +387,7 @@ class Service(framework.service.Service):
             dependencies=[fastapi.Depends(framework.api.deps.authenticate_request)],
         )
         self.app.include_router(
-            alerts_v1_router, prefix=self.BASE_VERSIONED_SERVICE_PREFIX
+            alerts_v1_router, prefix=self.base_versioned_service_prefix
         )
 
     async def _custom_setup_service(self):
@@ -506,3 +475,11 @@ class Service(framework.service.Service):
                 project=project,
                 validate_event=True,
             )
+
+    @staticmethod
+    def _is_chief_or_standalone():
+        return (
+            mlconf.httpdb.clusterization.role
+            == mlrun.common.schemas.ClusterizationRole.chief
+            or mlconf.services.service_name == "alerts"
+        )

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -478,6 +478,15 @@ class Service(framework.service.Service):
 
     @staticmethod
     def _is_chief_or_standalone():
+        """
+        Check if the service is running as part of a chief instance or as a standalone service.
+        mlconf.services.service_name determines the running service.
+        Possible options are:
+            1. Clusterization role is chief and service name is API - return True
+            2. Clusterization role is worker and service name is API - return False
+            3. Clusterization role is worker and service name is alerts (running as a standalone) - return True.
+               This assumes a single alerts service replica.
+        """
         return (
             mlconf.httpdb.clusterization.role
             == mlrun.common.schemas.ClusterizationRole.chief

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -69,7 +69,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        if self._is_chief_or_standalone():
+        if not self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             data = await request.json()
             return await chief_client.store_alert(
@@ -173,7 +173,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        if self._is_chief_or_standalone():
+        if not self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             return await chief_client.delete_alert(
                 project=project, name=name, request=request
@@ -207,7 +207,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        if self._is_chief_or_standalone():
+        if not self._is_chief_or_standalone():
             chief_client = framework.utils.clients.chief.Client()
             return await chief_client.reset_alert(
                 project=project, name=name, request=request

--- a/server/py/services/alerts/tests/unit/conftest.py
+++ b/server/py/services/alerts/tests/unit/conftest.py
@@ -37,9 +37,11 @@ if str(tests_root_directory) in os.getcwd():
 @pytest.fixture()
 def app() -> fastapi.FastAPI:
     old_service_name = mlconf.services.service_name
-    mlconf.services.service_name = "alert"
-    yield services.alerts.daemon.app()
-    mlconf.services.service_name = old_service_name
+    try:
+        mlconf.services.service_name = "alert"
+        yield services.alerts.daemon.app()
+    finally:
+        mlconf.services.service_name = old_service_name
 
 
 @pytest.fixture()

--- a/server/py/services/alerts/tests/unit/conftest.py
+++ b/server/py/services/alerts/tests/unit/conftest.py
@@ -17,6 +17,8 @@ import pathlib
 import fastapi
 import pytest
 
+from mlrun import mlconf
+
 import services.alerts.daemon
 from services.alerts.daemon import daemon
 
@@ -34,7 +36,10 @@ if str(tests_root_directory) in os.getcwd():
 
 @pytest.fixture()
 def app() -> fastapi.FastAPI:
+    old_service_name = mlconf.services.service_name
+    mlconf.services.service_name = "alert"
     yield services.alerts.daemon.app()
+    mlconf.services.service_name = old_service_name
 
 
 @pytest.fixture()

--- a/server/py/services/alerts/tests/unit/conftest.py
+++ b/server/py/services/alerts/tests/unit/conftest.py
@@ -39,4 +39,4 @@ def app() -> fastapi.FastAPI:
 
 @pytest.fixture()
 def prefix():
-    yield daemon.service.BASE_VERSIONED_SERVICE_PREFIX
+    yield daemon.service.base_versioned_service_prefix

--- a/server/py/services/api/daemon.py
+++ b/server/py/services/api/daemon.py
@@ -28,8 +28,7 @@ class Daemon(framework.service.Daemon):
         if mlconf.services.hydra.services == "*":
             # Mount the alerts application until we have proper hydra
             return {"/": alerts_daemon.service}
-        else:
-            return {}
+        return {}
 
     @property
     def service(self) -> services.api.main.Service:

--- a/server/py/services/api/daemon.py
+++ b/server/py/services/api/daemon.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from mlrun import mlconf
+
 import framework.service
 import services.api.main
 
@@ -21,13 +23,13 @@ from services.alerts.daemon import daemon as alerts_daemon
 
 
 class Daemon(framework.service.Daemon):
-    def __init__(self, service_cls: framework.service.Service.__class__):
-        self._service: framework.service.Service = service_cls()
-
     @property
     def mounts(self) -> dict[str, framework.service.Service]:
-        # Mount the alerts application until we have service routing/tunneling
-        return {"/": alerts_daemon.service}
+        if mlconf.services.hydra.services == "*":
+            # Mount the alerts application until we have proper hydra
+            return {"/": alerts_daemon.service}
+        else:
+            return {}
 
     @property
     def service(self) -> services.api.main.Service:

--- a/server/py/services/api/daemon.py
+++ b/server/py/services/api/daemon.py
@@ -24,11 +24,11 @@ from services.alerts.daemon import daemon as alerts_daemon
 
 class Daemon(framework.service.Daemon):
     @property
-    def mounts(self) -> dict[str, framework.service.Service]:
+    def mounts(self) -> list[framework.service.Service]:
         if mlconf.services.hydra.services == "*":
             # Mount the alerts application until we have proper hydra
-            return {"/": alerts_daemon.service}
-        return {}
+            return [alerts_daemon.service]
+        return []
 
     @property
     def service(self) -> services.api.main.Service:

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -72,8 +72,6 @@ _run_uid_start_log_request_counters: collections.Counter = collections.Counter()
 
 
 class Service(framework.service.Service):
-    service_name = "api"
-
     async def move_service_to_online(self):
         self._logger.info("Moving api to online")
 
@@ -106,14 +104,14 @@ class Service(framework.service.Service):
 
     def _register_routes(self):
         # TODO: This should be configurable and resolved in the base class
-        self.app.include_router(api_router, prefix=self.BASE_VERSIONED_SERVICE_PREFIX)
-        self.app.include_router(api_v2_router, prefix=self.V2_SERVICE_PREFIX)
+        self.app.include_router(api_router, prefix=self.base_versioned_service_prefix)
+        self.app.include_router(api_v2_router, prefix=self.v2_service_prefix)
         # This is for backward compatibility, that is why we still leave it here but not include it in the schema
         # so new users won't use the old un-versioned api.
         # /api points to /api/v1 since it is used externally, and we don't want to break it.
         # TODO: make sure UI and all relevant Iguazio versions uses /api/v1 and deprecate this
         self.app.include_router(
-            api_router, prefix=self.SERVICE_PREFIX, include_in_schema=False
+            api_router, prefix=self.service_prefix, include_in_schema=False
         )
 
     async def _custom_setup_service(self):

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -48,7 +48,7 @@ import services.api.utils.functions
 from services.api.daemon import daemon
 
 PROJECT = "project-name"
-ORIGINAL_VERSIONED_API_PREFIX = daemon.service.BASE_VERSIONED_SERVICE_PREFIX
+ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 FUNCTIONS_API = "projects/{project}/functions/{name}"
 
 

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -67,7 +67,7 @@ from framework.db.sqldb.models import (
 )
 from services.api.daemon import daemon
 
-ORIGINAL_VERSIONED_API_PREFIX = daemon.service.BASE_VERSIONED_SERVICE_PREFIX
+ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 FUNCTIONS_API = "projects/{project}/functions/{name}"
 LIST_FUNCTION_API = "projects/{project}/functions"
 

--- a/server/py/services/api/tests/unit/api/test_schedules.py
+++ b/server/py/services/api/tests/unit/api/test_schedules.py
@@ -30,7 +30,7 @@ import services.api.utils.singletons.scheduler
 from framework.utils.singletons.db import get_db
 from services.api.daemon import daemon
 
-ORIGINAL_VERSIONED_API_PREFIX = daemon.service.BASE_VERSIONED_SERVICE_PREFIX
+ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 
 
 async def do_nothing():

--- a/server/py/services/api/tests/unit/api/test_submit.py
+++ b/server/py/services/api/tests/unit/api/test_submit.py
@@ -36,7 +36,7 @@ import services.api.tests.unit.api.utils
 from services.api.daemon import daemon
 from services.api.tests.unit.conftest import K8sSecretsMock
 
-ORIGINAL_VERSIONED_API_PREFIX = daemon.service.BASE_VERSIONED_SERVICE_PREFIX
+ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 DEFAULT_FUNCTION_OUTPUT_PATH = "/some/fictive/path/to/make/everybody/happy"
 
 

--- a/server/py/services/api/tests/unit/conftest.py
+++ b/server/py/services/api/tests/unit/conftest.py
@@ -78,7 +78,7 @@ def app() -> fastapi.FastAPI:
 
 @pytest.fixture()
 def prefix() -> str:
-    yield daemon.service.BASE_VERSIONED_SERVICE_PREFIX
+    yield daemon.service.base_versioned_service_prefix
 
 
 # TODO: This is a hack to allow sharing fixtures between services in non-root directives because pytest behavior
@@ -128,7 +128,7 @@ def unversioned_client(db, app) -> Generator:
 
         with TestClient(app) as unversioned_test_client:
             set_base_url_for_test_client(
-                unversioned_test_client, daemon.service.SERVICE_PREFIX
+                unversioned_test_client, daemon.service.service_prefix
             )
             yield unversioned_test_client
 


### PR DESCRIPTION
Added minimal configuration to determine wether the API should mount alerts service as well or if it is standalone.
In order to enable running the initial services in a single instance as before, we are creating a dummy hydra which is consolidated in the api. The end goal is to create a hydra daemon and service controller which will be able to manage multiple services in a single instance. Once that is supported, the API will not mount any applications by itself.