### PR TITLE
[Notifications] Fix refresh smtp configuration endpoint

### DIFF
--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -82,7 +82,7 @@ class Client(
         To avoid raise condition we want only that the chief will store the secret in the k8s secret store
         """
         return await self._proxy_request_to_chief(
-            "POST", "operations/refresh_smtp_configuration", request
+            "POST", "operations/refresh-smtp-configuration", request
         )
 
     async def create_schedule(

--- a/server/py/services/api/api/endpoints/operations.py
+++ b/server/py/services/api/api/endpoints/operations.py
@@ -84,7 +84,7 @@ async def trigger_migrations(
 
 
 @router.post(
-    "/refresh_smtp_configuration",
+    "/refresh-smtp-configuration",
     responses={
         http.HTTPStatus.OK.value: {},
         http.HTTPStatus.ACCEPTED.value: {"model": mlrun.common.schemas.BackgroundTask},


### PR DESCRIPTION
convention is `-` and not `_`
