### PR TITLE
[CI] Fix mlrun-api dockerfile cache layers

### DIFF
--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -55,7 +55,10 @@ COPY ./dockerfiles/mlrun-api/requirements.txt ./mlrun-api-requirements.txt
 COPY ./extras-requirements.txt ./extras-requirements.txt
 COPY ./requirements.txt ./
 
-
+RUN python -m pip install \
+    -r requirements.txt \
+    -r extras-requirements.txt \
+    -r mlrun-api-requirements.txt
 
 ENV MLRUN_HTTPDB__DSN='sqlite:////mlrun/db/mlrun.db?check_same_thread=false'
 ENV MLRUN_HTTPDB__LOGS_PATH=/mlrun/db/logs
@@ -76,13 +79,7 @@ RUN pip install ./pipeline-adapters/mlrun-pipelines-kfp-common && pip install ./
 COPY . .
 ENV PYTHONPATH=/mlrun/server/py
 
-
-RUN python -m pip install \
-    -r requirements.txt \
-    -r extras-requirements.txt \
-    -r mlrun-api-requirements.txt
 RUN pip install .[complete-api]
-
 
 VOLUME /mlrun/db
 


### PR DESCRIPTION
install requirement before adding rest of code (code . .) to avoid pip deps cache invalidation