### PR TITLE
[Alert activations] Fix list activations by severity

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5038,7 +5038,11 @@ class HTTPRunDB(RunDBInterface):
         until: Optional[datetime] = None,
         entity: Optional[str] = None,
         severity: Optional[
-            list[Union[mlrun.common.schemas.alert.AlertSeverity, str]]
+            Union[
+                mlrun.common.schemas.alert.AlertSeverity,
+                str,
+                list[Union[mlrun.common.schemas.alert.AlertSeverity, str]],
+            ]
         ] = None,
         entity_kind: Optional[
             Union[mlrun.common.schemas.alert.EventEntityKind, str]
@@ -5055,7 +5059,7 @@ class HTTPRunDB(RunDBInterface):
             "since": datetime_to_iso(since),
             "until": datetime_to_iso(until),
             "entity": entity,
-            "severity": severity,
+            "severity": mlrun.utils.helpers.as_list(severity) if severity else None,
             "entity-kind": entity_kind,
             "event-kind": event_kind,
             "page": page,

--- a/server/py/services/api/api/endpoints/alert_activations.py
+++ b/server/py/services/api/api/endpoints/alert_activations.py
@@ -40,7 +40,7 @@ async def list_alert_activations(
     entity: Optional[str] = None,
     severity: Optional[
         list[Union[mlrun.common.schemas.alert.AlertSeverity, str]]
-    ] = None,
+    ] = Query([], alias="severity"),
     entity_kind: Optional[
         Union[mlrun.common.schemas.alert.EventEntityKind, str]
     ] = Query(None, alias="entity-kind"),

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -269,6 +269,63 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             number_of_events=1,
         )
 
+    def test_list_alert_activations_by_severity(self):
+        project_name = "my-new-project"
+        event_name = alert_objects.EventKind.DATA_DRIFT_DETECTED
+        alert_name = "drift"
+        alert_summary = "Model {{project}}/{{entity}} is drifting."
+        alert_entity_kind = alert_objects.EventEntityKind.MODEL_ENDPOINT_RESULT
+        alert_entity_project = project_name
+
+        project = mlrun.new_project(alert_entity_project)
+        self._create_alert(
+            alert_entity_project,
+            alert_name,
+            alert_entity_kind,
+            alert_entity_project,
+            alert_summary,
+            event_name,
+            reset_policy=mlrun.common.schemas.alert.ResetPolicy.AUTO,
+        )
+        self._post_event(alert_entity_project, event_name, alert_entity_kind)
+        self._create_alert(
+            alert_entity_project,
+            alert_name,
+            alert_entity_kind,
+            alert_entity_project,
+            alert_summary,
+            event_name,
+            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+            reset_policy=mlrun.common.schemas.alert.ResetPolicy.AUTO,
+        )
+        self._post_event(alert_entity_project, event_name, alert_entity_kind)
+
+        activations = project.list_alert_activations(name=alert_name)
+        assert len(activations) == 2
+
+        activations = project.list_alert_activations(
+            name=alert_name, severity=mlrun.common.schemas.alert.AlertSeverity.LOW
+        )
+        assert len(activations) == 1
+        self._validate_alert_activation(
+            activations[0],
+            project_name,
+            alert_name,
+            alert_severity=mlrun.common.schemas.alert.AlertSeverity.LOW,
+        )
+
+        activations = project.list_alert_activations(
+            name=alert_name, severity=mlrun.common.schemas.alert.AlertSeverity.HIGH
+        )
+        assert len(activations) == 1
+        self._validate_alert_activation(
+            activations[0],
+            project_name,
+            alert_name,
+            alert_severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+        )
+        mlrun.get_run_db().delete_project(project_name, "cascade")
+
     def test_alert_templates(self):
         project_name = "my-project"
         project = mlrun.new_project(project_name)

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -304,7 +304,9 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             mlrun.common.schemas.alert.AlertSeverity.HIGH,
         ]
 
-        activations = project.list_alert_activations(name=alert_name, severity=severity_list)
+        activations = project.list_alert_activations(
+            name=alert_name, severity=severity_list
+        )
         assert len(activations) == 2
 
         for severity in severity_list:

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -278,7 +278,7 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         alert_entity_project = project_name
 
         project = mlrun.new_project(alert_entity_project)
-        self._create_alert(
+        alert = self._create_alert(
             alert_entity_project,
             alert_name,
             alert_entity_kind,
@@ -288,42 +288,32 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             reset_policy=mlrun.common.schemas.alert.ResetPolicy.AUTO,
         )
         self._post_event(alert_entity_project, event_name, alert_entity_kind)
-        self._create_alert(
-            alert_entity_project,
-            alert_name,
-            alert_entity_kind,
-            alert_entity_project,
-            alert_summary,
-            event_name,
+        self._modify_alert(
+            project_name=project_name,
+            alert=alert,
             severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
-            reset_policy=mlrun.common.schemas.alert.ResetPolicy.AUTO,
+            event_name=event_name,
         )
         self._post_event(alert_entity_project, event_name, alert_entity_kind)
 
         activations = project.list_alert_activations(name=alert_name)
         assert len(activations) == 2
 
-        activations = project.list_alert_activations(
-            name=alert_name, severity=mlrun.common.schemas.alert.AlertSeverity.LOW
-        )
-        assert len(activations) == 1
-        self._validate_alert_activation(
-            activations[0],
-            project_name,
-            alert_name,
-            alert_severity=mlrun.common.schemas.alert.AlertSeverity.LOW,
-        )
-
-        activations = project.list_alert_activations(
-            name=alert_name, severity=mlrun.common.schemas.alert.AlertSeverity.HIGH
-        )
-        assert len(activations) == 1
-        self._validate_alert_activation(
-            activations[0],
-            project_name,
-            alert_name,
-            alert_severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
-        )
+        for severity in [
+            mlrun.common.schemas.alert.AlertSeverity.LOW,
+            mlrun.common.schemas.alert.AlertSeverity.HIGH,
+        ]:
+            activations = project.list_alert_activations(
+                name=alert_name,
+                severity=severity,
+            )
+            assert len(activations) == 1
+            self._validate_alert_activation(
+                activations[0],
+                project_name,
+                alert_name,
+                alert_severity=severity,
+            )
         mlrun.get_run_db().delete_project(project_name, "cascade")
 
     def test_alert_templates(self):
@@ -625,7 +615,7 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         # modify alert with invalid data
         invalid_event_name = "not_permitted_event"
         with pytest.raises(mlrun.errors.MLRunHTTPError):
-            self._modify_alert(
+            self._create_alert(
                 project_name,
                 alert_name,
                 alert1["entity"]["kind"],
@@ -636,7 +626,7 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # modify alert with no errors
         new_summary = "Aye ya yay {{project}}"
-        modified_alert = self._modify_alert(
+        modified_alert = self._create_alert(
             project_name,
             alert_name,
             alert1["entity"]["kind"],
@@ -690,30 +680,32 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
     def _modify_alert(
         self,
         project_name,
-        alert_name,
-        alert_entity_kind,
-        alert_entity_project,
-        alert_summary,
-        event_name,
-        severity=alert_objects.AlertSeverity.LOW,
+        alert: mlrun.common.schemas.alert.AlertConfig,
+        alert_entity_kind=None,
+        alert_entity_project=None,
+        alert_summary=None,
+        event_name=None,
+        severity=None,
         criteria=None,
         notifications=None,
-        reset_policy=alert_objects.ResetPolicy.MANUAL,
+        reset_policy=None,
     ):
+        # Use provided values or fallback to the current alert's attributes
         alert_data = self._generate_alert_create_request(
             project_name,
-            alert_name,
-            alert_entity_kind,
-            alert_entity_project,
-            alert_summary,
-            event_name,
-            severity,
-            criteria,
+            alert.name,
+            alert_entity_kind or alert.entities.kind,
+            alert_entity_project or alert.project,
+            alert_summary or alert.summary,
+            event_name or alert.trigger.events[0].name,
+            severity or alert.severity,
+            criteria or alert.criteria,
+            # notification needs to be sent every time due to not having secret params in the client side
             notifications,
-            reset_policy,
+            reset_policy or alert.reset_policy,
         )
         return mlrun.get_run_db().store_alert_config(
-            alert_name, alert_data, project_name
+            alert.name, alert_data, project_name
         )
 
     def _post_event(self, project_name, event_name, alert_entity_kind):

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -299,10 +299,15 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         activations = project.list_alert_activations(name=alert_name)
         assert len(activations) == 2
 
-        for severity in [
+        severity_list = [
             mlrun.common.schemas.alert.AlertSeverity.LOW,
             mlrun.common.schemas.alert.AlertSeverity.HIGH,
-        ]:
+        ]
+
+        activations = project.list_alert_activations(name=alert_name, severity=severity_list)
+        assert len(activations) == 2
+
+        for severity in severity_list:
             activations = project.list_alert_activations(
                 name=alert_name,
                 severity=severity,
@@ -692,17 +697,17 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
     ):
         # Use provided values or fallback to the current alert's attributes
         alert_data = self._generate_alert_create_request(
-            project_name,
-            alert.name,
-            alert_entity_kind or alert.entities.kind,
-            alert_entity_project or alert.project,
-            alert_summary or alert.summary,
-            event_name or alert.trigger.events[0].name,
-            severity or alert.severity,
-            criteria or alert.criteria,
+            project=project_name,
+            name=alert.name,
+            entity_kind=alert_entity_kind or alert.entities.kind,
+            entity_project=alert_entity_project or alert.project,
+            summary=alert_summary or alert.summary,
+            event_name=event_name or alert.trigger.events[0].name,
+            severity=severity or alert.severity,
+            criteria=criteria or alert.criteria,
             # notification needs to be sent every time due to not having secret params in the client side
-            notifications,
-            reset_policy or alert.reset_policy,
+            notifications=notifications,
+            reset_policy=reset_policy or alert.reset_policy,
         )
         return mlrun.get_run_db().store_alert_config(
             alert.name, alert_data, project_name


### PR DESCRIPTION
Request params isn't passed correctly without `Query([], alias="severity")`

jira - https://iguazio.atlassian.net/browse/ML-8430

BC tests fail exactly because of this change. Filter by severity has never worked and api is new, so we are safe.