### PR TITLE
[Alerts] Fix reset alert reason logging

### DIFF
--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -407,12 +407,11 @@ class Alerts(
         # reset the alert if the policy was modified from manual to auto while the state is active
         old_reset_policy = getattr(old_alert_data, "reset_policy")
         new_reset_policy = getattr(alert_data, "reset_policy")
-        reset_due_to_policy_change = (
+        if (
             old_alert_data.state == mlrun.common.schemas.AlertActiveState.ACTIVE
             and old_reset_policy == mlrun.common.schemas.alert.ResetPolicy.MANUAL
             and new_reset_policy == mlrun.common.schemas.alert.ResetPolicy.AUTO
-        )
-        if reset_due_to_policy_change:
+        ):
             return "reset-policy changed from manual to auto"
 
         # reset the alert if a functional parameter (entities, trigger, or criteria) has changed, as these affect the

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -102,10 +102,10 @@ class Alerts(
 
         # if the alert already exists we should check if it should be reset or not
         if existing_alert is not None:
-            reset_reason = self._should_reset_alert(
+            should_reset, reset_reason = self._should_reset_alert(
                 existing_alert, alert_data, force_reset
             )
-            if reset_reason:
+            if should_reset:
                 logger.debug(
                     "Resetting alert before storing",
                     project=project,
@@ -402,7 +402,7 @@ class Alerts(
     @staticmethod
     def _should_reset_alert(old_alert_data, alert_data, force_reset):
         if force_reset:
-            return "force_reset being True"
+            return True, "force_reset being True"
 
         # reset the alert if the policy was modified from manual to auto while the state is active
         old_reset_policy = getattr(old_alert_data, "reset_policy")
@@ -412,16 +412,16 @@ class Alerts(
             and old_reset_policy == mlrun.common.schemas.alert.ResetPolicy.MANUAL
             and new_reset_policy == mlrun.common.schemas.alert.ResetPolicy.AUTO
         ):
-            return "reset-policy changed from manual to auto"
+            return True, "reset-policy changed from manual to auto"
 
         # reset the alert if a functional parameter (entities, trigger, or criteria) has changed, as these affect the
         # conditions for alert activation.
         functional_parameters = ["entities", "trigger", "criteria"]
         for attr in functional_parameters:
             if getattr(old_alert_data, attr) != getattr(alert_data, attr):
-                return f"changes in {attr}"
+                return True, f"changes in {attr}"
 
-        return None
+        return False, None
 
     @staticmethod
     def _delete_notifications(alert: mlrun.common.schemas.AlertConfig):

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -101,16 +101,13 @@ class Alerts(
             )
 
         # if the alert already exists we should check if it should be reset or not
-        if existing_alert is not None and self._should_reset_alert(
-            existing_alert, alert_data, force_reset
-        ):
-            logger.debug(
-                "Resetting alert due to %s",
-                "force_reset being True"
-                if force_reset
-                else "changes in entities, criteria, or trigger of the alert",
+        if existing_alert is not None:
+            should_reset, reset_reason = self._should_reset_alert(
+                existing_alert, alert_data, force_reset
             )
-            self.reset_alert(session, project, new_alert.name)
+            if should_reset:
+                logger.debug("Resetting alert due to %s", reset_reason)
+                self.reset_alert(session, project, new_alert.name)
 
         framework.utils.singletons.db.get_db().enrich_alert(session, new_alert)
 
@@ -400,8 +397,9 @@ class Alerts(
     @staticmethod
     def _should_reset_alert(old_alert_data, alert_data, force_reset):
         if force_reset:
-            return True
+            return True, "force_reset being True"
 
+        reasons = []
         # reset the alert if the policy was modified from manual to auto while the state is active
         old_reset_policy = getattr(old_alert_data, "reset_policy")
         new_reset_policy = getattr(alert_data, "reset_policy")
@@ -410,19 +408,20 @@ class Alerts(
             and old_reset_policy == mlrun.common.schemas.alert.ResetPolicy.MANUAL
             and new_reset_policy == mlrun.common.schemas.alert.ResetPolicy.AUTO
         )
+        if reset_due_to_policy_change:
+            reasons.append("reset-policy changed from manual to auto")
 
         # reset the alert if a functional parameter (entities, trigger, or criteria) has changed, as these affect the
         # conditions for alert activation.
-        reset_due_to_functional_parameters_changed = any(
-            getattr(old_alert_data, attr) != getattr(alert_data, attr)
-            for attr in [
-                "entities",
-                "trigger",
-                "criteria",
-            ]
-        )
+        functional_parameters = ["entities", "trigger", "criteria"]
+        for attr in functional_parameters:
+            if getattr(old_alert_data, attr) != getattr(alert_data, attr):
+                reasons.append(f"changes in {attr}")
 
-        return reset_due_to_policy_change or reset_due_to_functional_parameters_changed
+        if reasons:
+            return True, ", ".join(reasons)
+
+        return False, ""
 
     @staticmethod
     def _delete_notifications(alert: mlrun.common.schemas.AlertConfig):

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -106,7 +106,12 @@ class Alerts(
                 existing_alert, alert_data, force_reset
             )
             if should_reset:
-                logger.debug("Resetting alert due to %s", reset_reason)
+                logger.debug(
+                    "Resetting alert before storing",
+                    project=project,
+                    alert_name=name,
+                    reason=reset_reason,
+                )
                 self.reset_alert(session, project, new_alert.name)
 
         framework.utils.singletons.db.get_db().enrich_alert(session, new_alert)

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -102,10 +102,10 @@ class Alerts(
 
         # if the alert already exists we should check if it should be reset or not
         if existing_alert is not None:
-            should_reset, reset_reason = self._should_reset_alert(
+            reset_reason = self._should_reset_alert(
                 existing_alert, alert_data, force_reset
             )
-            if should_reset:
+            if reset_reason:
                 logger.debug(
                     "Resetting alert before storing",
                     project=project,
@@ -402,9 +402,8 @@ class Alerts(
     @staticmethod
     def _should_reset_alert(old_alert_data, alert_data, force_reset):
         if force_reset:
-            return True, "force_reset being True"
+            return "force_reset being True"
 
-        reasons = []
         # reset the alert if the policy was modified from manual to auto while the state is active
         old_reset_policy = getattr(old_alert_data, "reset_policy")
         new_reset_policy = getattr(alert_data, "reset_policy")
@@ -414,19 +413,16 @@ class Alerts(
             and new_reset_policy == mlrun.common.schemas.alert.ResetPolicy.AUTO
         )
         if reset_due_to_policy_change:
-            reasons.append("reset-policy changed from manual to auto")
+            return "reset-policy changed from manual to auto"
 
         # reset the alert if a functional parameter (entities, trigger, or criteria) has changed, as these affect the
         # conditions for alert activation.
         functional_parameters = ["entities", "trigger", "criteria"]
         for attr in functional_parameters:
             if getattr(old_alert_data, attr) != getattr(alert_data, attr):
-                reasons.append(f"changes in {attr}")
+                return f"changes in {attr}"
 
-        if reasons:
-            return True, ", ".join(reasons)
-
-        return False, ""
+        return None
 
     @staticmethod
     def _delete_notifications(alert: mlrun.common.schemas.AlertConfig):


### PR DESCRIPTION
Updated the _should_reset_alert method to handle reset policy changes more explicitly. 
Now, the log correctly reports changes in reset-policy when the reset is triggered by a change in the alert's reset policy. 

Resolves : 
https://iguazio.atlassian.net/browse/ML-8434