### PR TITLE
[Pagination] Fix log

### DIFF
--- a/server/py/services/api/utils/pagination.py
+++ b/server/py/services/api/utils/pagination.py
@@ -165,7 +165,8 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
 
         if page_size is None and token is None:
             self._logger.debug(
-                "No token or page size provided, returning all records", method=method.__name__
+                "No token or page size provided, returning all records",
+                method=method.__name__,
             )
             return await framework.utils.asyncio.await_or_call_in_threadpool(
                 method, session, **method_kwargs

--- a/server/py/services/api/utils/pagination.py
+++ b/server/py/services/api/utils/pagination.py
@@ -160,12 +160,12 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
     ]:
         if not PaginatedMethods.method_is_supported(method):
             raise NotImplementedError(
-                f"Pagination is not supported for method {method}"
+                f"Pagination is not supported for method {method.__name__}"
             )
 
         if page_size is None and token is None:
             self._logger.debug(
-                "No token or page size provided, returning all records", method=method
+                "No token or page size provided, returning all records", method=method.__name__
             )
             return await framework.utils.asyncio.await_or_call_in_threadpool(
                 method, session, **method_kwargs


### PR DESCRIPTION
The log was with the method object instead of the name:
```
No token or page size provided, returning all records: {"method":"<bound method Artifacts.list_artifacts of <services.api.crud.artifacts.Artifacts object at 0x7fad71631d90>>"}
```