### PR TITLE
[Model Monitoring] Fix assert in metrics test

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -353,7 +353,10 @@ class TestBasicModelMonitoring(TestMLRunSystem):
             self.project_name, endpoint.metadata.uid
         )
         assert len(metrics) == 1
-        assert metrics[0] == f"{self.project_name}.mlrun-infra.metric.invocations"
+        assert (
+            metrics[0].full_name
+            == f"{self.project_name}.mlrun-infra.metric.invocations"
+        )
 
     def _assert_model_uri(
         self,


### PR DESCRIPTION
Should check the assertion from string to string, not from string to metrics object.

[original PR](https://github.com/mlrun/mlrun/pull/6711)