### PR TITLE
[SQLRunDB] Create new session in session getter

### DIFF
--- a/mlrun/db/factory.py
+++ b/mlrun/db/factory.py
@@ -54,9 +54,6 @@ class RunDBFactory(
             self._run_db = self._rundb_container.nop(url)
 
         else:
-            # TODO: this practically makes the SQLRunDB a singleton, which mean that its session is shared, needs
-            #  to be refreshed frequently and cannot be used concurrently.
-            #  The SQLRunDB should always get its session from the FastAPI dependency injection.
             self._run_db = self._rundb_container.run_db(url)
 
         self._run_db.connect(secrets=secrets)

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -117,6 +117,8 @@ class ModelObj:
                 # If one of the attributes is a third party object that has to_dict method (such as k8s objects), then
                 # add it to the object's _fields_to_serialize attribute and handle it in the _serialize_field method.
                 if hasattr(field_value, "to_dict"):
+                    # TODO: Allow passing fields to exclude from the parent object to the child object
+                    #  e.g.: run.to_dict(exclude=["status.artifacts"])
                     field_value = field_value.to_dict(strip=strip)
                     if self._is_valid_field_value_for_serialization(
                         field_name, field_value, strip
@@ -1266,6 +1268,8 @@ class RunSpec(ModelObj):
 
 class RunStatus(ModelObj):
     """Run status"""
+
+    _default_fields_to_strip = ModelObj._default_fields_to_strip + ["artifacts"]
 
     def __init__(
         self,

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -176,6 +176,11 @@ class NotificationPusher(_NotificationPusherBase):
                     logger.warning(
                         "Failed to push notification async",
                         error=mlrun.errors.err_to_str(result),
+                        traceback=traceback.format_exception(
+                            etype=type(result),
+                            value=result,
+                            tb=result.__traceback__,
+                        ),
                     )
 
         logger.debug(
@@ -209,7 +214,7 @@ class NotificationPusher(_NotificationPusherBase):
                     and evaluate_condition_in_separate_process(
                         notification.condition,
                         context={
-                            "run": run.to_dict(),
+                            "run": run.to_dict(strip=True),
                             "notification": notification.to_dict(),
                         },
                     )
@@ -249,7 +254,7 @@ class NotificationPusher(_NotificationPusherBase):
             f": {notification_object.message}" if notification_object.message else ""
         )
         resource = "Run"
-        runs = [run.to_dict()]
+        runs = [run.to_dict(strip=True)]
 
         if mlrun_constants.MLRunInternalLabels.workflow in run.metadata.labels:
             resource = mlrun_constants.MLRunInternalLabels.workflow

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -214,7 +214,7 @@ class NotificationPusher(_NotificationPusherBase):
                     and evaluate_condition_in_separate_process(
                         notification.condition,
                         context={
-                            "run": run.to_dict(strip=True),
+                            "run": run.to_dict(),
                             "notification": notification.to_dict(),
                         },
                     )
@@ -254,7 +254,7 @@ class NotificationPusher(_NotificationPusherBase):
             f": {notification_object.message}" if notification_object.message else ""
         )
         resource = "Run"
-        runs = [run.to_dict(strip=True)]
+        runs = [run.to_dict()]
 
         if mlrun_constants.MLRunInternalLabels.workflow in run.metadata.labels:
             resource = mlrun_constants.MLRunInternalLabels.workflow

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -48,15 +48,20 @@ class SQLRunDB(RunDBInterface):
         dsn,
         session=None,
     ):
-        self.session = session
+        self._session = session
         self.dsn = dsn
         self.db = None
 
     def connect(self, secrets=None):
-        if not self.session:
-            self.session = create_session()
         self.db = SQLDB(self.dsn)
         return self
+
+    @property
+    def session(self):
+        # If we were given a session - use it, otherwise we create a new one to keep a fresh snapshot of the db
+        if self._session:
+            return self._session
+        return create_session()
 
     def store_log(self, uid, project="", body=b"", append=False):
         return self._transform_db_error(

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -706,6 +706,7 @@ class Service(framework.service.Service):
             self._logger.warning(
                 "Failed pushing terminal run notifications. Ignoring",
                 exc=err_to_str(exc),
+                traceback=traceback.format_exc(),
             )
 
         return stale_runs


### PR DESCRIPTION
When we send the notifications we create a dictionary from the run in multiple places with run.to_dict() there it tries to fetch the artifacts to fulfill the dict

It fails because it uses a global db session from the run db factory - in the server we assume that the db session is injected from the fastapi endpoint but it’s not the case here.

We decided to keep the artifacts in the run dict but we'll create a new db session before accessing the db

https://iguazio.atlassian.net/browse/ML-8781
https://iguazio.atlassian.net/browse/ML-8463