### PR TITLE
[K8S] Quietly fail on read secret

### DIFF
--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -78,9 +78,9 @@ class RunNotificationPusher(NotificationPusher):
             try:
                 mail_notification_default_params = (
                     framework.utils.singletons.k8s.get_k8s_helper().read_secret_data(
-                        smtp_config_secret_name, load_as_json=True
+                        smtp_config_secret_name, load_as_json=True, silent=True
                     )
-                )
+                ) or {}
             except ApiException as exc:
                 logger.warning(
                     "Failed to read SMTP configuration secret",

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -580,10 +580,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return mlrun.common.schemas.SecretEventActions.updated
 
     def read_secret(
-        self,
-        secret_name: str,
-        namespace: str = "",
-    ) -> client.V1Secret:
+        self, secret_name: str, namespace: str = "", silent=False
+    ) -> typing.Optional[client.V1Secret]:
         namespace = self.resolve_namespace(namespace)
         logger.debug("Reading secret", secret_name=secret_name, namespace=namespace)
         try:
@@ -592,6 +590,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 namespace=namespace,
             )
         except k8s_client_rest.ApiException as exc:
+            if silent:
+                return
             logger.error(
                 "Failed to retrieve k8s secret",
                 secret_name=secret_name,
@@ -601,9 +601,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return k8s_secret
 
     def read_secret_data(
-        self, secret_name: str, namespace: str = "", load_as_json=False
+        self, secret_name: str, namespace: str = "", load_as_json=False, silent=False
     ) -> dict[str, str]:
-        k8s_secret = self.read_secret(secret_name, namespace)
+        k8s_secret = self.read_secret(secret_name, namespace, silent)
         return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)
 
     def _create_secret(


### PR DESCRIPTION
We have periodic task for [refreshing the smtp configuration from the secret](https://github.com/mlrun/mlrun/blob/9bc379edb0d8756198f3d2d56b6299ce3b60d1bc/server/py/services/api/main.py#L568).
If the secret doesn’t exists on the system the logs are flooded with Failed to retrieve k8s secret.
Fix it by adding `silent` flag to `read_secret`.

https://iguazio.atlassian.net/browse/ML-8480