### PR TITLE
[Notifications] Make notification pusher resilient to errors

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -118,39 +118,43 @@ class NotificationPusher(_NotificationPusherBase):
         ] = []
 
         for run in self._runs:
+            self._process_run(run)
+
+    def _process_run(self, run):
+        try:
+            if isinstance(run, dict):
+                run = mlrun.model.RunObject.from_dict(run)
+
+            for notification in run.spec.notifications:
+                self._process_notification(notification, run)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load notification from run",
+                run_uid=run.metadata.uid,
+                error=mlrun.errors.err_to_str(exc),
+            )
+
+    def _process_notification(self, notification, run):
+        try:
             try:
-                if isinstance(run, dict):
-                    run = mlrun.model.RunObject.from_dict(run)
-
-                for notification in run.spec.notifications:
-                    try:
-                        try:
-                            notification.status = run.status.notifications.get(
-                                notification.name
-                            ).get(
-                                "status",
-                                mlrun.common.schemas.NotificationStatus.PENDING,
-                            )
-                        except (AttributeError, KeyError):
-                            notification.status = (
-                                mlrun.common.schemas.NotificationStatus.PENDING
-                            )
-
-                        if self._should_notify(run, notification):
-                            self._load_notification(run, notification)
-                    except Exception as exc:
-                        logger.warning(
-                            "Failed to load notification",
-                            run_uid=run.metadata.uid,
-                            notification=notification,
-                            error=mlrun.errors.err_to_str(exc),
-                        )
-            except Exception as exc:
-                logger.warning(
-                    "Failed to load notification from run",
-                    run_uid=run.metadata.uid,
-                    error=mlrun.errors.err_to_str(exc),
+                notification.status = run.status.notifications.get(
+                    notification.name
+                ).get(
+                    "status",
+                    mlrun.common.schemas.NotificationStatus.PENDING,
                 )
+            except (AttributeError, KeyError):
+                notification.status = mlrun.common.schemas.NotificationStatus.PENDING
+
+            if self._should_notify(run, notification):
+                self._load_notification(run, notification)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load notification",
+                run_uid=run.metadata.uid,
+                notification=notification,
+                error=mlrun.errors.err_to_str(exc),
+            )
 
     def push(self):
         """

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -118,21 +118,39 @@ class NotificationPusher(_NotificationPusherBase):
         ] = []
 
         for run in self._runs:
-            if isinstance(run, dict):
-                run = mlrun.model.RunObject.from_dict(run)
+            try:
+                if isinstance(run, dict):
+                    run = mlrun.model.RunObject.from_dict(run)
 
-            for notification in run.spec.notifications:
-                try:
-                    notification.status = run.status.notifications.get(
-                        notification.name
-                    ).get("status", mlrun.common.schemas.NotificationStatus.PENDING)
-                except (AttributeError, KeyError):
-                    notification.status = (
-                        mlrun.common.schemas.NotificationStatus.PENDING
-                    )
+                for notification in run.spec.notifications:
+                    try:
+                        try:
+                            notification.status = run.status.notifications.get(
+                                notification.name
+                            ).get(
+                                "status",
+                                mlrun.common.schemas.NotificationStatus.PENDING,
+                            )
+                        except (AttributeError, KeyError):
+                            notification.status = (
+                                mlrun.common.schemas.NotificationStatus.PENDING
+                            )
 
-                if self._should_notify(run, notification):
-                    self._load_notification(run, notification)
+                        if self._should_notify(run, notification):
+                            self._load_notification(run, notification)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to load notification",
+                            run_uid=run.metadata.uid,
+                            notification=notification,
+                            error=mlrun.errors.err_to_str(exc),
+                        )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load notification from run",
+                    run_uid=run.metadata.uid,
+                    error=mlrun.errors.err_to_str(exc),
+                )
 
     def push(self):
         """

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -118,39 +118,37 @@ class NotificationPusher(_NotificationPusherBase):
         ] = []
 
         for run in self._runs:
-            self._process_run(run)
+            try:
+                self._process_run(run)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to process run",
+                    run_uid=run.metadata.uid,
+                    error=mlrun.errors.err_to_str(exc),
+                )
 
     def _process_run(self, run):
-        try:
-            if isinstance(run, dict):
-                run = mlrun.model.RunObject.from_dict(run)
+        if isinstance(run, dict):
+            run = mlrun.model.RunObject.from_dict(run)
 
-            for notification in run.spec.notifications:
+        for notification in run.spec.notifications:
+            try:
                 self._process_notification(notification, run)
-        except Exception as exc:
-            logger.warning(
-                "Failed to load notification from run",
-                run_uid=run.metadata.uid,
-                error=mlrun.errors.err_to_str(exc),
-            )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to process notification",
+                    run_uid=run.metadata.uid,
+                    notification=notification,
+                    error=mlrun.errors.err_to_str(exc),
+                )
 
     def _process_notification(self, notification, run):
-        try:
-            notification.status = run.status.notifications.get(
-                notification.name, {}
-            ).get(
-                "status",
-                mlrun.common.schemas.NotificationStatus.PENDING,
-            )
-            if self._should_notify(run, notification):
-                self._load_notification(run, notification)
-        except Exception as exc:
-            logger.warning(
-                "Failed to load notification",
-                run_uid=run.metadata.uid,
-                notification=notification,
-                error=mlrun.errors.err_to_str(exc),
-            )
+        notification.status = run.status.notifications.get(notification.name, {}).get(
+            "status",
+            mlrun.common.schemas.NotificationStatus.PENDING,
+        )
+        if self._should_notify(run, notification):
+            self._load_notification(run, notification)
 
     def push(self):
         """

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -136,16 +136,12 @@ class NotificationPusher(_NotificationPusherBase):
 
     def _process_notification(self, notification, run):
         try:
-            try:
-                notification.status = run.status.notifications.get(
-                    notification.name
-                ).get(
-                    "status",
-                    mlrun.common.schemas.NotificationStatus.PENDING,
-                )
-            except (AttributeError, KeyError):
-                notification.status = mlrun.common.schemas.NotificationStatus.PENDING
-
+            notification.status = run.status.notifications.get(
+                notification.name, {}
+            ).get(
+                "status",
+                mlrun.common.schemas.NotificationStatus.PENDING,
+            )
             if self._should_notify(run, notification):
                 self._load_notification(run, notification)
         except Exception as exc:

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -755,12 +755,20 @@ class Service(framework.service.Service):
 
         # Unmasking the run parameters from secrets before handing them over to the notification handler
         # as importing the `Secrets` crud in the notification handler will cause a circular import
-        unmasked_runs = [
-            framework.utils.notifications.unmask_notification_params_secret_on_task(
-                db, db_session, run
-            )
-            for run in runs
-        ]
+        unmasked_runs = []
+        for run in runs:
+            try:
+                framework.utils.notifications.unmask_notification_params_secret_on_task(
+                    db, db_session, run
+                )
+                unmasked_runs.append(run)
+            except Exception as exc:
+                self._logger.warning(
+                    "Failed unmasking notification params secret. Ignoring",
+                    project=run.metadata.project,
+                    run_uid=run.metadata.uid,
+                    exc=err_to_str(exc),
+                )
 
         self._logger.debug(
             "Got terminal runs with configured notifications", runs_amount=len(runs)


### PR DESCRIPTION
We want to make the notification pusher more resistant to exceptions so even if one of the notification cannot be send the others will send.

https://iguazio.atlassian.net/browse/ML-8482