### PR TITLE
[Model Monitoring] Support running applications locally with `app.evaluate()`

### DIFF
--- a/docs/api/mlrun.model_monitoring/index.rst
+++ b/docs/api/mlrun.model_monitoring/index.rst
@@ -22,7 +22,6 @@ mlrun.model_monitoring
 
 .. autoclass:: mlrun.model_monitoring.applications.EvidentlyModelMonitoringApplicationBase
    :members:
-   :exclude-members: do
 
 .. automodule:: mlrun.model_monitoring.applications.histogram_data_drift
    :members:

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -183,7 +183,7 @@ def get_sample_path(subpath=""):
     return samples_path
 
 
-def set_env_from_file(env_file: str, return_dict: bool = False):
+def set_env_from_file(env_file: str, return_dict: bool = False) -> Optional[dict]:
     """Read and set and/or return environment variables from a file
     the env file should have lines in the form KEY=VALUE, comment line start with "#"
 

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -39,6 +39,7 @@ from .execution import MLClientCtx
 from .model import RunObject, RunTemplate, new_task
 from .package import ArtifactType, DefaultPackager, Packager, handler
 from .projects import (
+    MlrunProject,
     ProjectMetadata,
     build_function,
     deploy_function,
@@ -162,7 +163,7 @@ def set_environment(
     return mlconf.default_project, mlconf.artifact_path
 
 
-def get_current_project(silent=False):
+def get_current_project(silent: bool = False) -> Optional[MlrunProject]:
     if not pipeline_context.project and not silent:
         raise MLRunInvalidArgumentError(
             "current project is not initialized, use new, get or load project methods first"

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -17,7 +17,7 @@ import os
 import uuid
 import warnings
 from copy import deepcopy
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import numpy as np
 import yaml
@@ -42,6 +42,7 @@ from .features import Feature
 from .model import HyperParamOptions
 from .secrets import SecretsStore
 from .utils import (
+    Logger,
     RunKeys,
     dict_to_json,
     dict_to_yaml,
@@ -158,7 +159,7 @@ class MLClientCtx:
         return self._project
 
     @property
-    def logger(self):
+    def logger(self) -> Logger:
         """Built-in logger interface
 
         Example::
@@ -628,7 +629,7 @@ class MLClientCtx:
         format=None,
         db_key=None,
         **kwargs,
-    ):
+    ) -> Artifact:
         """Log an output artifact and optionally upload it to datastore
 
         Example::
@@ -698,7 +699,7 @@ class MLClientCtx:
         extra_data=None,
         label_column: Optional[str] = None,
         **kwargs,
-    ):
+    ) -> DatasetArtifact:
         """Log a dataset artifact and optionally upload it to datastore
 
         If the dataset exists with the same key and tag, it will be overwritten.
@@ -736,7 +737,7 @@ class MLClientCtx:
         :param db_key:        The key to use in the artifact DB table, by default its run name + '_' + key
                               db_key=False will not register it in the artifacts table
 
-        :returns: Artifact object
+        :returns: Dataset artifact object
         """
         ds = DatasetArtifact(
             key,
@@ -749,16 +750,19 @@ class MLClientCtx:
             **kwargs,
         )
 
-        item = self._artifacts_manager.log_artifact(
-            self,
-            ds,
-            local_path=local_path,
-            artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
-            target_path=target_path,
-            tag=tag,
-            upload=upload,
-            db_key=db_key,
-            labels=labels,
+        item = cast(
+            DatasetArtifact,
+            self._artifacts_manager.log_artifact(
+                self,
+                ds,
+                local_path=local_path,
+                artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
+                target_path=target_path,
+                tag=tag,
+                upload=upload,
+                db_key=db_key,
+                labels=labels,
+            ),
         )
         self._update_run()
         return item
@@ -786,7 +790,7 @@ class MLClientCtx:
         extra_data=None,
         db_key=None,
         **kwargs,
-    ):
+    ) -> ModelArtifact:
         """Log a model artifact and optionally upload it to datastore
 
         Example::
@@ -828,7 +832,7 @@ class MLClientCtx:
         :param db_key:          The key to use in the artifact DB table, by default its run name + '_' + key
                                 db_key=False will not register it in the artifacts table
 
-        :returns: Artifact object
+        :returns: Model artifact object
         """
 
         if training_set is not None and inputs:
@@ -855,14 +859,17 @@ class MLClientCtx:
         if training_set is not None:
             model.infer_from_df(training_set, label_column)
 
-        item = self._artifacts_manager.log_artifact(
-            self,
-            model,
-            artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
-            tag=tag,
-            upload=upload,
-            db_key=db_key,
-            labels=labels,
+        item = cast(
+            ModelArtifact,
+            self._artifacts_manager.log_artifact(
+                self,
+                model,
+                artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
+                tag=tag,
+                upload=upload,
+                db_key=db_key,
+                labels=labels,
+            ),
         )
         self._update_run()
         return item

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -135,10 +135,10 @@ class _PrepareMonitoringEvent(StepToDict):
         :return: Application context.
         """
         application_context = MonitoringApplicationContext(
-            graph_context=self.graph_context,
             application_name=self.application_name,
             event=event,
             model_endpoint_dict=self.model_endpoints,
+            nuclio_logger=self.graph_context,
         )
 
         self.model_endpoints.setdefault(

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -22,12 +22,12 @@ from mlrun.serving.utils import MonitoringApplicationToDict
 
 class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
     """
-    A base class for a model monitoring application.
+    The base class for a model monitoring application.
     Inherit from this class to create a custom model monitoring application.
 
-    example for very simple custom application::
+    For example, :code:`MyApp` below is a simplistic custom application::
 
-        class MyApp(ApplicationBase):
+        class MyApp(ModelMonitoringApplicationBase):
             def do_tracking(
                 self,
                 monitoring_context: mm_context.MonitoringApplicationContext,
@@ -43,8 +43,6 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                     kind=mm_constant.ResultKindApp.data_drift,
                     status=mm_constant.ResultStatusApp.detected,
                 )
-
-
     """
 
     kind = "monitoring_application"
@@ -62,6 +60,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
     ]:
         """
         Process the monitoring event and return application results & metrics.
+        Note: this method is internal and should not be called directly or overridden.
 
         :param monitoring_context:   (MonitoringApplicationContext) The monitoring application context.
         :returns:                    A tuple of:

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -103,7 +103,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         func_name: Optional[str] = None,
         tag: Optional[str] = None,
         run_local: bool = True,
-    ) -> mlrun.RunObject:
+    ) -> "mlrun.RunObject":
         """
         Call this function to run the application's
         :py:meth:`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.do_tracking`
@@ -121,7 +121,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         if not run_local:
             raise NotImplementedError  # ML-8360
 
-        project = cast(mlrun.MlrunProject, mlrun.get_current_project())
+        project = cast("mlrun.MlrunProject", mlrun.get_current_project())
         class_name = cls.__name__
         name = func_name if func_name is not None else class_name
         handler = f"{class_name}::{cls._handler.__name__}"

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from typing import Any, Optional, Union, cast
 
+import mlrun
 import mlrun.model_monitoring.applications.context as mm_context
 import mlrun.model_monitoring.applications.results as mm_results
 from mlrun.serving.utils import MonitoringApplicationToDict
@@ -78,6 +79,65 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             ]
         results = results if isinstance(results, list) else [results]
         return results, monitoring_context
+
+    def _handler(self, context: "mlrun.MLClientCtx"):
+        """
+        A custom handler that wraps the application's logic implemented in
+        :py:meth:`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.do_tracking`
+        for an MLRun job.
+        This method should not be called directly.
+        """
+        monitoring_context = mm_context.MonitoringApplicationContext(
+            event={},
+            application_name=self.__class__.__name__,
+            logger=context.logger,
+            artifacts_logger=context,
+        )
+        result = self.do_tracking(monitoring_context)
+        return result
+
+    @classmethod
+    def evaluate(
+        cls,
+        func_path: Optional[str] = None,
+        func_name: Optional[str] = None,
+        tag: Optional[str] = None,
+        run_local: bool = True,
+    ) -> mlrun.RunObject:
+        """
+        Call this function to run the application's
+        :py:meth:`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.do_tracking`
+        model monitoring logic as a :py:class:`~mlrun.runtimes.KubejobRuntime`, which is an MLRun function.
+
+        :param func_path: The path to the function. If not passed, the current notebook is used.
+        :param func_name: The name of the function. If not passed, the class name is used.
+        :param tag:       An optional tag for the function.
+        :param run_local: Whether to run the function locally or remotely.
+
+        :returns: The output of the
+                  :py:meth:`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.do_tracking`
+                  method wrapped in a :py:class:`~mlrun.model.RunObject`.
+        """
+        if not run_local:
+            raise NotImplementedError  # ML-8360
+
+        project = cast(mlrun.MlrunProject, mlrun.get_current_project())
+        class_name = cls.__name__
+        name = func_name if func_name is not None else class_name
+        handler = f"{class_name}::{cls._handler.__name__}"
+
+        job = cast(
+            mlrun.runtimes.KubejobRuntime,
+            project.set_function(
+                func=func_path,
+                name=name,
+                kind=mlrun.runtimes.KubejobRuntime.kind,
+                handler=handler,
+                tag=tag,
+            ),
+        )
+        run_result = job.run(local=run_local)
+        return run_result
 
     @abstractmethod
     def do_tracking(

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -14,8 +14,9 @@
 
 import json
 import socket
-from typing import Any, Optional, cast
+from typing import Any, Optional, Protocol, cast
 
+import nuclio.request
 import numpy as np
 import pandas as pd
 
@@ -32,6 +33,16 @@ from mlrun.model_monitoring.helpers import (
     get_endpoint_record,
 )
 from mlrun.model_monitoring.model_endpoint import ModelEndpoint
+
+
+class _ArtifactsLogger(Protocol):
+    """
+    Classes that implement this protocol are :code:`MlrunProject` and :code:`MLClientCtx`.
+    """
+
+    def log_artifact(self, *args, **kwargs) -> Artifact: ...
+    def log_dataset(self, *args, **kwargs) -> DatasetArtifact: ...
+    def log_model(self, *args, **kwargs) -> ModelArtifact: ...
 
 
 class MonitoringApplicationContext:
@@ -60,13 +71,17 @@ class MonitoringApplicationContext:
                                     and a list of extra data items.
     """
 
+    _logger_name = "monitoring-application"
+
     def __init__(
         self,
         *,
-        graph_context: mlrun.serving.GraphContext,
         application_name: str,
         event: dict[str, Any],
-        model_endpoint_dict: dict[str, ModelEndpoint],
+        model_endpoint_dict: Optional[dict[str, ModelEndpoint]] = None,
+        logger: Optional[mlrun.utils.Logger] = None,
+        nuclio_logger: Optional[nuclio.request.Logger] = None,
+        artifacts_logger: Optional[_ArtifactsLogger] = None,
     ) -> None:
         """
         Initialize a `MonitoringApplicationContext` object.
@@ -74,22 +89,29 @@ class MonitoringApplicationContext:
 
         :param application_name:    The application name.
         :param event:               The instance data dictionary.
-        :param model_endpoint_dict: Dictionary of model endpoints.
+        :param model_endpoint_dict: Optional - dictionary of model endpoints.
+        :param logger:              Optional - MLRun logger instance.
+        :param nuclio_logger:       Optional - Nuclio logger instance.
+        :param artifacts_logger:    Optional - an object that can log artifacts, typically MlrunProject or MLClientCtx.
         """
         self.application_name = application_name
 
-        self.project_name = graph_context.project
-        self.project = mlrun.load_project(url=self.project_name)
+        self.project = cast("mlrun.MlrunProject", mlrun.get_current_project())
+        self.project_name = self.project.name
+
+        self._artifacts_logger: _ArtifactsLogger = artifacts_logger or self.project
 
         # MLRun Logger
-        self.logger = mlrun.utils.create_logger(
+        self.logger = logger or mlrun.utils.create_logger(
             level=mlrun.mlconf.log_level,
             formatter_kind=mlrun.mlconf.log_formatter,
-            name="monitoring-application",
+            name=self._logger_name,
         )
         # Nuclio logger - `nuclio.request.Logger`.
-        # Note: this logger does not accept keyword arguments.
-        self.nuclio_logger = graph_context.logger
+        # Note: this logger accepts keyword arguments only in its `_with` methods, e.g. `info_with`.
+        self.nuclio_logger = nuclio_logger or nuclio.request.Logger(
+            level=mlrun.mlconf.log_level, name=self._logger_name
+        )
 
         # event data
         self.start_infer_time = pd.Timestamp(
@@ -113,8 +135,8 @@ class MonitoringApplicationContext:
 
         # Persistent data - fetched when needed
         self._sample_df: Optional[pd.DataFrame] = None
-        self._model_endpoint: Optional[ModelEndpoint] = model_endpoint_dict.get(
-            self.endpoint_id
+        self._model_endpoint: Optional[ModelEndpoint] = (
+            model_endpoint_dict.get(self.endpoint_id) if model_endpoint_dict else None
         )
 
     def _get_default_labels(self) -> dict[str, str]:
@@ -237,7 +259,7 @@ class MonitoringApplicationContext:
         See :func:`~mlrun.projects.MlrunProject.log_artifact` for the documentation.
         """
         labels = self._add_default_labels(labels)
-        return self.project.log_artifact(
+        return self._artifacts_logger.log_artifact(
             item,
             body=body,
             tag=tag,
@@ -272,7 +294,7 @@ class MonitoringApplicationContext:
         See :func:`~mlrun.projects.MlrunProject.log_dataset` for the documentation.
         """
         labels = self._add_default_labels(labels)
-        return self.project.log_dataset(
+        return self._artifacts_logger.log_dataset(
             key,
             df,
             tag=tag,
@@ -317,7 +339,7 @@ class MonitoringApplicationContext:
         See :func:`~mlrun.projects.MlrunProject.log_model` for the documentation.
         """
         labels = self._add_default_labels(labels)
-        return self.project.log_model(
+        return self._artifacts_logger.log_model(
             key,
             body=body,
             framework=framework,

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -84,7 +84,7 @@ class MonitoringApplicationContext:
         artifacts_logger: Optional[_ArtifactsLogger] = None,
     ) -> None:
         """
-        Initialize a `MonitoringApplicationContext` object.
+        Initialize a :code:`MonitoringApplicationContext` object.
         Note: this object should not be instantiated manually.
 
         :param application_name:    The application name.
@@ -92,7 +92,9 @@ class MonitoringApplicationContext:
         :param model_endpoint_dict: Optional - dictionary of model endpoints.
         :param logger:              Optional - MLRun logger instance.
         :param nuclio_logger:       Optional - Nuclio logger instance.
-        :param artifacts_logger:    Optional - an object that can log artifacts, typically MlrunProject or MLClientCtx.
+        :param artifacts_logger:    Optional - an object that can log artifacts,
+                                    typically :py:class:`~mlrun.projects.MlrunProject` or
+                                    :py:class:`~mlrun.execution.MLClientCtx`.
         """
         self.application_name = application_name
 

--- a/mlrun/model_monitoring/applications/evidently_base.py
+++ b/mlrun/model_monitoring/applications/evidently_base.py
@@ -76,7 +76,6 @@ class EvidentlyModelMonitoringApplicationBase(
 
         :param evidently_workspace_path:    (str) The path to the Evidently workspace.
         :param evidently_project_id:        (str) The ID of the Evidently project.
-
         """
 
         # TODO : more then one project (mep -> project)

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -113,7 +113,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
 
         project.enable_model_monitoring()
 
-    To avoid it, pass `deploy_histogram_data_drift_app=False`.
+    To avoid it, pass :code:`deploy_histogram_data_drift_app=False`.
     """
 
     NAME: Final[str] = HistogramDataDriftApplicationConstants.NAME
@@ -331,8 +331,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         )
 
     def do_tracking(
-        self,
-        monitoring_context: mm_context.MonitoringApplicationContext,
+        self, monitoring_context: mm_context.MonitoringApplicationContext
     ) -> list[
         Union[
             mm_results.ModelMonitoringApplicationResult,
@@ -342,9 +341,6 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     ]:
         """
         Calculate and return the data drift metrics, averaged over the features.
-
-        Refer to `ModelMonitoringApplicationBaseV2` for the meaning of the
-        function arguments.
         """
         monitoring_context.logger.debug("Starting to run the application")
         if not monitoring_context.feature_stats:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -28,7 +28,7 @@ import warnings
 import zipfile
 from copy import deepcopy
 from os import environ, makedirs, path
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, cast
 
 import dotenv
 import git
@@ -1732,7 +1732,7 @@ class MlrunProject(ModelObj):
         :param upload:        upload to datastore (default is True)
         :param labels:        a set of key/value labels to tag the artifact with
 
-        :returns: artifact object
+        :returns: dataset artifact object
         """
         ds = DatasetArtifact(
             key,
@@ -1745,14 +1745,17 @@ class MlrunProject(ModelObj):
             **kwargs,
         )
 
-        item = self.log_artifact(
-            ds,
-            local_path=local_path,
-            artifact_path=artifact_path,
-            target_path=target_path,
-            tag=tag,
-            upload=upload,
-            labels=labels,
+        item = cast(
+            DatasetArtifact,
+            self.log_artifact(
+                ds,
+                local_path=local_path,
+                artifact_path=artifact_path,
+                target_path=target_path,
+                tag=tag,
+                upload=upload,
+                labels=labels,
+            ),
         )
         return item
 
@@ -1820,7 +1823,7 @@ class MlrunProject(ModelObj):
         :param extra_data:      key/value list of extra files/charts to link with this dataset
                                 value can be absolute path | relative path (to model dir) | bytes | artifact object
 
-        :returns: artifact object
+        :returns: model artifact object
         """
 
         if training_set is not None and inputs:
@@ -1847,12 +1850,15 @@ class MlrunProject(ModelObj):
         if training_set is not None:
             model.infer_from_df(training_set, label_column)
 
-        item = self.log_artifact(
-            model,
-            artifact_path=artifact_path,
-            tag=tag,
-            upload=upload,
-            labels=labels,
+        item = cast(
+            ModelArtifact,
+            self.log_artifact(
+                model,
+                artifact_path=artifact_path,
+                tag=tag,
+                upload=upload,
+                labels=labels,
+            ),
         )
         return item
 
@@ -2408,7 +2414,7 @@ class MlrunProject(ModelObj):
 
     def set_function(
         self,
-        func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,
+        func: typing.Union[str, mlrun.runtimes.BaseRuntime, None] = None,
         name: str = "",
         kind: str = "job",
         image: Optional[str] = None,

--- a/tests/model_monitoring/test_application_steps.py
+++ b/tests/model_monitoring/test_application_steps.py
@@ -46,9 +46,9 @@ class TestEventPreparation:
 
     @staticmethod
     @pytest.fixture
-    def mock_load_project(tmp_path: Path) -> typing.Iterator[None]:
+    def mock_get_current_project(tmp_path: Path) -> typing.Iterator[None]:
         with patch(
-            "mlrun.load_project",
+            "mlrun.get_current_project",
             Mock(
                 return_value=mlrun.projects.MlrunProject(
                     spec=mlrun.projects.ProjectSpec(artifact_path=str(tmp_path))
@@ -66,7 +66,7 @@ class TestEventPreparation:
         }
 
     @classmethod
-    @pytest.mark.usefixtures("mock_load_project")
+    @pytest.mark.usefixtures("mock_get_current_project")
     @patch("mlrun.model_monitoring.applications.context.get_endpoint_record")
     def test_prepare_monitoring_event(
         cls, mock_get_endpoint_record: Mock, controller_event: dict[str, typing.Any]

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -84,15 +84,12 @@ def plot_produce(context: mlrun.MLClientCtx):
         )
     )
     with patch(
-        "mlrun.load_project",
+        "mlrun.get_current_project",
         Mock(return_value=Mock(spec=mlrun.projects.project.MlrunProject)),
     ):
         with mocked_graph_context_project():
             monitoring_context = mm_context.MonitoringApplicationContext(
-                graph_context=mlrun.serving.GraphContext(),
-                application_name="histogram-data-drift",
-                event={},
-                model_endpoint_dict={},
+                application_name="histogram-data-drift", event={}
             )
             monitoring_context._feature_stats = inputs_statistics
             monitoring_context._sample_df_stats = sample_data_statistics


### PR DESCRIPTION
Add the `evaluate` method to `ModelMonitoringApplicationBase` class, currently without parameters/inputs.
Implements [ML-8357](https://iguazio.atlassian.net/browse/ML-8357).

[ML-8357]: https://iguazio.atlassian.net/browse/ML-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ