### PR TITLE
[Artifacts] Create new artifact category `document`

### DIFF
--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -25,6 +25,7 @@ from .object import ObjectStatus
 class ArtifactCategories(mlrun.common.types.StrEnum):
     model = "model"
     dataset = "dataset"
+    document = "document"
     other = "other"
 
     # we define the link as a category to prevent import cycles, but it's not a real category
@@ -38,6 +39,8 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             return [ArtifactCategories.model.value, link_kind], False
         if self.value == ArtifactCategories.dataset.value:
             return [ArtifactCategories.dataset.value, link_kind], False
+        if self.value == ArtifactCategories.document.value:
+            return [ArtifactCategories.document.value, link_kind], False
         if self.value == ArtifactCategories.other.value:
             return (
                 [

--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -46,6 +46,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
                 [
                     ArtifactCategories.model.value,
                     ArtifactCategories.dataset.value,
+                    ArtifactCategories.document.value,
                 ],
                 True,
             )

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -28,6 +28,7 @@ import mlrun.lists
 import mlrun.utils
 from mlrun.artifacts.base import LinkArtifact
 from mlrun.artifacts.dataset import DatasetArtifact
+from mlrun.artifacts.document import DocumentArtifact
 from mlrun.artifacts.model import ModelArtifact
 from mlrun.artifacts.plots import PlotArtifact, PlotlyArtifact
 from mlrun.common.schemas.artifact import ArtifactCategories
@@ -158,25 +159,21 @@ class TestArtifacts(TestDatabaseBase):
         artifact_kind_3 = ModelArtifact.kind
         artifact_name_4 = "artifact_name_4"
         artifact_kind_4 = DatasetArtifact.kind
-        tree = "artifact_tree"
-        artifact_1 = self._generate_artifact(
-            artifact_name_1, kind=artifact_kind_1, tree=tree
-        )
-        artifact_2 = self._generate_artifact(
-            artifact_name_2, kind=artifact_kind_2, tree=tree
-        )
-        artifact_3 = self._generate_artifact(
-            artifact_name_3, kind=artifact_kind_3, tree=tree
-        )
-        artifact_4 = self._generate_artifact(
-            artifact_name_4, kind=artifact_kind_4, tree=tree
-        )
+        artifact_name_5 = "artifact_name_5"
+        artifact_kind_5 = DocumentArtifact.kind
+
+        artifact_1 = self._generate_artifact(artifact_name_1, kind=artifact_kind_1)
+        artifact_2 = self._generate_artifact(artifact_name_2, kind=artifact_kind_2)
+        artifact_3 = self._generate_artifact(artifact_name_3, kind=artifact_kind_3)
+        artifact_4 = self._generate_artifact(artifact_name_4, kind=artifact_kind_4)
+        artifact_5 = self._generate_artifact(artifact_name_5, kind=artifact_kind_5)
 
         for artifact_name, artifact_object in [
             (artifact_name_1, artifact_1),
             (artifact_name_2, artifact_2),
             (artifact_name_3, artifact_3),
             (artifact_name_4, artifact_4),
+            (artifact_name_5, artifact_5),
         ]:
             self._db.store_artifact(
                 self._db_session,
@@ -185,7 +182,7 @@ class TestArtifacts(TestDatabaseBase):
             )
 
         artifacts = self._db.list_artifacts(self._db_session)
-        assert len(artifacts) == 4
+        assert len(artifacts) == 5
 
         artifacts = self._db.list_artifacts(
             self._db_session, category=mlrun.common.schemas.ArtifactCategories.model
@@ -198,6 +195,12 @@ class TestArtifacts(TestDatabaseBase):
         )
         assert len(artifacts) == 1
         assert artifacts[0]["metadata"]["key"] == artifact_name_4
+
+        artifacts = self._db.list_artifacts(
+            self._db_session, category=mlrun.common.schemas.ArtifactCategories.document
+        )
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["key"] == artifact_name_5
 
         artifacts = self._db.list_artifacts(
             self._db_session, category=mlrun.common.schemas.ArtifactCategories.other
@@ -1986,12 +1989,30 @@ class TestArtifacts(TestDatabaseBase):
             project="p2",
         )
 
+        self._db.store_artifact(
+            self._db_session,
+            "k4",
+            {"kind": "document"},
+            producer_id="5",
+            tag="t5",
+            project="p2",
+        )
+
         tags = self._db.list_artifact_tags(self._db_session, "p1")
         expected_tags = [
             "t1",
             "latest",
             "t2",
             "t3",
+        ]
+        assert deepdiff.DeepDiff(tags, expected_tags, ignore_order=True) == {}
+
+        tags = self._db.list_artifact_tags(self._db_session, "p2")
+        expected_tags = [
+            "t2",
+            "t4",
+            "latest",
+            "t5",
         ]
         assert deepdiff.DeepDiff(tags, expected_tags, ignore_order=True) == {}
 
@@ -2002,11 +2023,17 @@ class TestArtifacts(TestDatabaseBase):
         expected_tags = ["t3", "latest"]
         assert deepdiff.DeepDiff(expected_tags, model_tags, ignore_order=True) == {}
 
-        model_tags = self._db.list_artifact_tags(
+        dataset_tags = self._db.list_artifact_tags(
             self._db_session, "p2", mlrun.common.schemas.ArtifactCategories.dataset
         )
         expected_tags = ["t4", "latest"]
-        assert deepdiff.DeepDiff(expected_tags, model_tags, ignore_order=True) == {}
+        assert deepdiff.DeepDiff(expected_tags, dataset_tags, ignore_order=True) == {}
+
+        document_tags = self._db.list_artifact_tags(
+            self._db_session, "p2", mlrun.common.schemas.ArtifactCategories.document
+        )
+        expected_tags = ["t5", "latest"]
+        assert deepdiff.DeepDiff(expected_tags, document_tags, ignore_order=True) == {}
 
     def test_list_artifact_date(self):
         t1 = datetime.datetime(2020, 2, 16)


### PR DESCRIPTION
For the VectorDB effort and to support the new document artifacts screen in the UI, we created a new category called "Document" to facilitate artifact filtering by this category.

Categories are a higher-level construct built on top of the "kind" attribute. They primarily exist to simplify the UI, which displays a separate screen for each category. For example, the "Other" category encompasses everything that is not a model, dataset, or document, and it includes many different kinds.

https://iguazio.atlassian.net/browse/ML-8476