### PR TITLE
[K8S] Fix bug on read_secret_data

### DIFF
--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -604,6 +604,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         self, secret_name: str, namespace: str = "", load_as_json=False, silent=False
     ) -> dict[str, str]:
         k8s_secret = self.read_secret(secret_name, namespace, silent)
+        if not k8s_secret:
+            return {}
         return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)
 
     def _create_secret(

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -602,10 +602,10 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
     def read_secret_data(
         self, secret_name: str, namespace: str = "", load_as_json=False, silent=False
-    ) -> dict[str, str]:
+    ) -> typing.Optional[dict[str, str]]:
         k8s_secret = self.read_secret(secret_name, namespace, silent)
         if not k8s_secret:
-            return {}
+            return
         return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)
 
     def _create_secret(


### PR DESCRIPTION
Following to [this pr](https://github.com/mlrun/mlrun/pull/6793) fixing bug when `k8s_secret` is None.

```
> 2024-11-28 10:39:12,723 [warning] Failed during periodic function execution: {"exc":"'NoneType' object has no attribute 'data'","func_name":"get_mail_notification_default_params","tb":"Traceback (most recent call last):
  File "/mlrun/server/py/framework/utils/periodic.py", line 34, in _periodic_function_wrapper
    await run_in_threadpool(function, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/starlette/concurrency.py", line 42, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/usr/local/lib/python3.9/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 2441, in run_sync_in_worker_thread
    return await future
  File "/usr/local/lib/python3.9/site-packages/anyio/_backends/_asyncio.py", line 943, in run
    result = context.run(func, *args)
  File "/mlrun/server/py/framework/utils/notifications/notification_pusher.py", line 65, in get_mail_notification_default_params
    RunNotificationPusher._get_mail_notifications_default_params_from_secret()
  File "/mlrun/server/py/framework/utils/notifications/notification_pusher.py", line 80, in _get_mail_notifications_default_params_from_secret
    framework.utils.singletons.k8s.get_k8s_helper().read_secret_data(
  File "/mlrun/server/py/framework/utils/singletons/k8s.py", line 607, in read_secret_data
    return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)
AttributeError: 'NoneType' object has no attribute 'data'
``` 