### PR TITLE
[Requirements] Fix breakage caused by aiohttp 3.11.8 [1.7.x]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # >=1.28.0,<1.29.0 botocore inside boto3 1.28.17 inside nuclio-jupyter 0.9.13
 urllib3>=1.26.9, <1.27
 GitPython~=3.1, >=3.1.41
-aiohttp~=3.9
+aiohttp>=3.9,<3.11
 aiohttp-retry~=2.8.0
 click~=8.1
 nest-asyncio~=1.0


### PR DESCRIPTION
aiohttp 3.11.8 was released today, breaking `test_raise_for_aiohttp_client_response_status` by [adding a mock-thwarting assertion](https://github.com/aio-libs/aiohttp/compare/v3.11.7...v3.11.8#diff-720910fd022b9ba8b7ddf0cb446ce5e1afe443f4287ad26a1eb4dc4b5b5f4508R864).

#6697 did something similar in development due to another issue.