### PR TITLE
[Tests] Remove unnecessary mock that breaks with aiohttp 3.11.8

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -89,7 +89,7 @@ def test_raise_for_aiohttp_client_response_status():
 
     response = ClientResponse(
         method="GET",
-        url=mock.MagicMock(spec=URL),
+        url=URL(),
         writer=mock.MagicMock(),
         continue100=None,
         timer=mock.MagicMock(),


### PR DESCRIPTION
aiohttp 3.11.8 was released today, [breaking](https://github.com/aio-libs/aiohttp/compare/v3.11.7...v3.11.8#diff-720910fd022b9ba8b7ddf0cb446ce5e1afe443f4287ad26a1eb4dc4b5b5f4508R864) the ability to mock the URL class.

Relates to #6806.