### PR TITLE
[Operations] Refresh smtp - raise exception on fail

### DIFF
--- a/server/py/services/api/api/endpoints/operations.py
+++ b/server/py/services/api/api/endpoints/operations.py
@@ -205,7 +205,7 @@ async def _perform_refresh_smtp(session: str):
             "Failed to get SMTP configuration from Iguazio",
             exc=mlrun.errors.err_to_str(exc),
         )
-        return
+        raise
 
     updated_params = {
         "server_host": returned_smtp_configuration.host,

--- a/server/py/services/api/tests/unit/api/test_operations.py
+++ b/server/py/services/api/tests/unit/api/test_operations.py
@@ -165,6 +165,22 @@ async def test_perform_refresh_smtp(
     }
 
 
+@pytest.mark.asyncio
+async def test_failed_perform_refresh_smtp(
+    monkeypatch, k8s_secrets_mock: tests_unit_conftest.APIK8sSecretsMock
+):
+    def raise_exception(*args, **kwargs):
+        raise mlrun.errors.MLRunInternalServerError("Forbidden")
+
+    monkeypatch.setattr(
+        iguazio_client.Client,
+        "get_smtp_configuration",
+        raise_exception,
+    )
+    with pytest.raises(mlrun.errors.MLRunInternalServerError):
+        await services.api.api.endpoints.operations._perform_refresh_smtp("")
+
+
 def _generate_background_task_schema(
     background_task_name,
 ) -> mlrun.common.schemas.BackgroundTask:


### PR DESCRIPTION
If we got exception when trying to get the smtp configuration - we should raise it.

After the fix:
```
kind=BackgroundTask metadata=BackgroundTaskMetadata(name='7a6fd6f0-08db-4274-a6f9-befd59b23578', kind='smtp.configuration.refresh', project=None, created=datetime.datetime(2024, 11, 28, 16, 1, 32, 86733), updated=datetime.datetime(2024, 11, 28, 16, 1, 32, 590093), timeout=None) spec=BackgroundTaskSpec() status=BackgroundTaskStatus(state=failed, error="Failed getting SMTP configuration from Iguazio, caused by: Failed to list smtp_connections: [{'status': 403, 'detail': 'Access denied'}]")
``` 

https://iguazio.atlassian.net/browse/ML-8455