### PR TITLE
[Notifications] Mail - Merge between default addresses and the provided addresses

### DIFF
--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -95,7 +95,7 @@ class MailNotification(base.NotificationBase):
         cls,
         default_mail_address: typing.Union[str, list],
         email_addresses: typing.Union[str, list],
-    ):
+    ) -> str:
         if isinstance(default_mail_address, str):
             default_mail_address = (
                 default_mail_address.split(",") if default_mail_address else []

--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -84,12 +84,27 @@ class MailNotification(base.NotificationBase):
         params.setdefault("server_port", DEFAULT_SMTP_PORT)
 
         default_mail_address = params.pop("default_email_addresses", "")
-        email_addresses = params.get("email_addresses", default_mail_address)
-        if isinstance(email_addresses, list):
-            email_addresses = ",".join(email_addresses)
-        params["email_addresses"] = email_addresses
+        params["email_addresses"] = cls._merge_mail_addresses(
+            default_mail_address, params.get("email_addresses", "")
+        )
 
         return params
+
+    @classmethod
+    def _merge_mail_addresses(
+        cls,
+        default_mail_address: typing.Union[str, list],
+        email_addresses: typing.Union[str, list],
+    ):
+        if isinstance(default_mail_address, str):
+            default_mail_address = (
+                default_mail_address.split(",") if default_mail_address else []
+            )
+        if isinstance(email_addresses, str):
+            email_addresses = email_addresses.split(",") if email_addresses else []
+        email_addresses.extend(default_mail_address)
+        email_addresses_str = ",".join(email_addresses)
+        return email_addresses_str
 
     @classmethod
     def _validate_emails(cls, params):

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1022,7 +1022,7 @@ class TestMailNotification:
         "sender_address": "sender@example.com",
         "username": "user",
         "password": "pass",
-        "email_addresses": "a@example.com",
+        "default_email_addresses": "a@example.com",
         "use_tls": True,
         "validate_certs": True,
         "start_tls": False,
@@ -1149,7 +1149,7 @@ class TestMailNotification:
             (
                 "missing_all_params",
                 {},
-                DEFAULT_PARAMS,
+                {},
             ),
             (
                 "overriding_some_params",
@@ -1167,7 +1167,7 @@ class TestMailNotification:
                 {
                     "email_addresses": ["a@b.com", "b@b.com", "c@c.com"],
                 },
-                {"email_addresses": "a@b.com,b@b.com,c@c.com"},
+                {"email_addresses": "a@b.com,b@b.com,c@c.com,a@example.com"},
             ),
         ],
     )
@@ -1177,5 +1177,8 @@ class TestMailNotification:
             params, TestMailNotification.DEFAULT_PARAMS
         )
         default_params_copy = TestMailNotification.DEFAULT_PARAMS.copy()
+        default_params_copy["email_addresses"] = default_params_copy.pop(
+            "default_email_addresses"
+        )
         default_params_copy.update(expected_params)
         assert enriched_params == default_params_copy


### PR DESCRIPTION
Currently, when there are `default_mail_addresses` and in the notification declaration the user specify `email_addresses`, the `email_addresses` will override the  `default_mail_addresses`.
Instead of overriding we want to **merge** between them.

https://iguazio.atlassian.net/browse/ML-8519