### PR TITLE
[Notifications] Mail - set body from message param

### DIFF
--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -69,8 +69,9 @@ class MailNotification(base.NotificationBase):
         alert: typing.Optional[mlrun.common.schemas.AlertConfig] = None,
         event_data: typing.Optional[mlrun.common.schemas.Event] = None,
     ):
+        message = self.params.get("message", message)
         self.params.setdefault("subject", f"[{severity}] {message}")
-        self.params.setdefault("body", self.params.get("message", message))
+        self.params.setdefault("body", message)
         await self._send_email(**self.params)
 
     @classmethod

--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -70,7 +70,7 @@ class MailNotification(base.NotificationBase):
         event_data: typing.Optional[mlrun.common.schemas.Event] = None,
     ):
         self.params.setdefault("subject", f"[{severity}] {message}")
-        self.params.setdefault("body", message)
+        self.params.setdefault("body", self.params.get("message", message))
         await self._send_email(**self.params)
 
     @classmethod

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1179,3 +1179,36 @@ class TestMailNotification:
         default_params_copy = TestMailNotification.DEFAULT_PARAMS.copy()
         default_params_copy.update(expected_params)
         assert enriched_params == default_params_copy
+
+    @pytest.mark.parametrize(
+        ["name", "params", "message", "severity", "expected"],
+        [
+            (
+                "empty_params",
+                {},
+                "test-message",
+                "info",
+                {
+                    "body": "test-message",
+                    "subject": "[info] test-message",
+                },
+            ),
+            (
+                "with_params_message",
+                {"message": "params_message"},
+                "test-message",
+                "warning",
+                {
+                    "body": "params_message",
+                    "subject": "[warning] params_message",
+                },
+            ),
+        ],
+    )
+    async def test_push(self, name, params, message, severity, expected):
+        logger.debug(f"Testing {name}")
+        notification = mail.MailNotification(params=params)
+        notification._send_email = unittest.mock.AsyncMock()
+        await notification.push(message, severity, [])
+        assert notification.params["subject"] == expected["subject"]
+        assert notification.params["body"] == expected["body"]


### PR DESCRIPTION
When message param provided, we should override the message to be the message param that was provided.

https://iguazio.atlassian.net/browse/ML-8517