### PR TITLE
[Model Monitoring] Fix getting the project in appication context

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -166,7 +166,7 @@ def set_environment(
 def get_current_project(silent: bool = False) -> Optional[MlrunProject]:
     if not pipeline_context.project and not silent:
         raise MLRunInvalidArgumentError(
-            "current project is not initialized, use new, get or load project methods first"
+            "No current project is initialized. Use new, get or load project functions first."
         )
     return pipeline_context.project
 

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -138,7 +138,7 @@ class _PrepareMonitoringEvent(StepToDict):
             application_name=self.application_name,
             event=event,
             model_endpoint_dict=self.model_endpoints,
-            nuclio_logger=self.graph_context,
+            graph_context=self.graph_context,
         )
 
         self.model_endpoints.setdefault(

--- a/tests/model_monitoring/test_application_steps.py
+++ b/tests/model_monitoring/test_application_steps.py
@@ -46,9 +46,9 @@ class TestEventPreparation:
 
     @staticmethod
     @pytest.fixture
-    def mock_get_current_project(tmp_path: Path) -> typing.Iterator[None]:
+    def mock_load_project(tmp_path: Path) -> typing.Iterator[None]:
         with patch(
-            "mlrun.get_current_project",
+            "mlrun.load_project",
             Mock(
                 return_value=mlrun.projects.MlrunProject(
                     spec=mlrun.projects.ProjectSpec(artifact_path=str(tmp_path))
@@ -66,7 +66,7 @@ class TestEventPreparation:
         }
 
     @classmethod
-    @pytest.mark.usefixtures("mock_get_current_project")
+    @pytest.mark.usefixtures("mock_load_project")
     @patch("mlrun.model_monitoring.applications.context.get_endpoint_record")
     def test_prepare_monitoring_event(
         cls, mock_get_endpoint_record: Mock, controller_event: dict[str, typing.Any]

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -32,7 +32,9 @@ class InProgressApp0(ModelMonitoringApplicationBase):
     def do_tracking(
         self, monitoring_context: MonitoringApplicationContext
     ) -> ModelMonitoringApplicationResult:
-        monitoring_context.logger.info("Ok let's try")
+        monitoring_context.logger.info(
+            "This test app is failing on purpose - ignore the failure!"
+        )
         raise ValueError
 
 
@@ -64,6 +66,6 @@ class TestEvaluate:
     def test_local_no_params() -> None:
         func_name = "test-app"
         run = InProgressApp0.evaluate(func_path=__file__, func_name=func_name)
-        assert run.state() == "created"  # Should be "error"
+        assert run.state() == "created"  # Should be "error", see ML-8507
         run = InProgressApp1.evaluate(func_path=__file__, func_name=func_name)
         assert run.state() == "completed"

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -89,12 +89,12 @@ def plot_produce(context: mlrun.MLClientCtx):
     ):
         with mocked_graph_context_project():
             monitoring_context = mm_context.MonitoringApplicationContext(
-                application_name="histogram-data-drift", event={}
+                application_name="histogram-data-drift",
+                event={},
+                artifacts_logger=context,
             )
             monitoring_context._feature_stats = inputs_statistics
             monitoring_context._sample_df_stats = sample_data_statistics
-    # Patching `log_artifact` only for this test
-    monitoring_context.log_artifact = context.log_artifact
     # Initialize the app
     application = histogram_data_drift.HistogramDataDriftApplication()
     # Calculate drift


### PR DESCRIPTION
Fixes an error from #6795 - the context did not work in serving graphs.
The context is now supported in serving graphs and local/workflow runs.
I ran the system test and added a unit test.