### PR TITLE
[KFP] Bump kfp-server-api

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-v2",
-    version="0.2.3",
+    version="0.2.4",
     description="MLRun Pipelines package for providing KFP 2.* compatibility",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",
@@ -40,7 +40,7 @@ setup(
     ],
     python_requires=">=3.9, <3.12",
     install_requires=[
-        "kfp_server_api~=2.0.0",
+        "kfp_server_api~=2.3.0",
         "kfp[kubernetes]~=2.10.1",
     ],
     long_description="MLRun Pipelines package for providing KFP 2.* compatibility",


### PR DESCRIPTION
Bump `kfp-server-api` to the latest version (2.3.0) to resolve the conflict:
```
#22 7.840 The conflict is caused by:
#22 7.840     mlrun-pipelines-kfp-v2 0.2.3 depends on kfp_server_api~=2.0.0
#22 7.840     kfp 2.10.1 depends on kfp-server-api<2.4.0 and >=2.1.0
```

This change was made to support running unit tests with Python 3.11. [Link to job](https://github.com/mlrun/mlrun/actions/runs/12117370521/job/33779667906?pr=6824)