### PR TITLE
[CI] Only KFP 1.8 is running on Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,7 +189,7 @@ jobs:
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
 
   package-tests:
-    name: Run package tests (Python ${{ matrix.python-version }}; Pipeline ${{ matrix.pipeline-adapter }})
+    name: Run package tests (Python ${{ matrix.python-version }}; Pipeline kfp-v1-8 )
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,9 +194,7 @@ jobs:
     strategy:
       matrix:
         # 3.9 is the current >= 1.3.0 python version
-        python-version: [3.9]
-        default-pipeline-adapter: ["kfp-v1-8"]
-        pipeline-adapter: ["kfp-v1-8", "kfp-v2"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up python ${{ matrix.python-version }}
@@ -204,9 +202,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
-    - name: Change default pipeline adapter for MLRun
-      if: matrix.default-pipeline-adapter != matrix.pipeline-adapter
-      run: sed -i -e 's/${{ matrix.default-pipeline-adapter }}/${{ matrix.pipeline-adapter }}/g' requirements.txt
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: pip install -r automation/requirements.txt && pip install -e .
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,12 +189,14 @@ jobs:
         run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized
 
   package-tests:
-    name: Run package tests (Python ${{ matrix.python-version }}; Pipeline kfp-v1-8 )
+    name: Run package tests (Python ${{ matrix.python-version }}, Pipelines ${{ matrix.pipeline-adapter }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 3.9 is the current >= 1.3.0 python version
-        python-version: ["3.9"]
+        # Explicitly define combinations: KFP v1.8 with Python 3.9
+        include:
+          - python-version: "3.9"
+            pipeline-adapter: "kfp-v1-8"
     steps:
     - uses: actions/checkout@v4
     - name: Set up python ${{ matrix.python-version }}
@@ -204,6 +206,12 @@ jobs:
         cache: 'pip'
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: pip install -r automation/requirements.txt && pip install -e .
+      # Install KFP v2 only when the adapter is kfp-v2
+    - name: Install KFP Adapter if required
+      run: |
+        if [[ "${{ matrix.pipeline-adapter }}" == "kfp-v2" ]]; then
+          pip install mlrun-pipelines-kfp-v2
+        fi
 
     - name: Test package
       run: MLRUN_PYTHON_VERSION=${{ matrix.python-version }} make test-package


### PR DESCRIPTION
KFP v1.8 requires protobuf 3, while KFP v2 requires protobuf 4. 
KFP v2 should only run on Python 3.11 and not on Python 3.9. 
MLRun comes with the default pipeline adapter set to KFP v1.8, so there is no need to change the default pipeline adapter in the requirements.

This will fix the failing CI. [Link to job](https://github.com/mlrun/mlrun/actions/runs/12119781093/job/33787067806?pr=6824)
I will add a CI test to verify Python 3.11 with KFP v2 in a separate PR, which is part of this PR: [#6824](https://github.com/mlrun/mlrun/pull/6824)