### PR TITLE
[K8s] Fix None secret check

### DIFF
--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -604,7 +604,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         self, secret_name: str, namespace: str = "", load_as_json=False, silent=False
     ) -> typing.Optional[dict[str, str]]:
         k8s_secret = self.read_secret(secret_name, namespace, silent)
-        if not k8s_secret:
+        if k8s_secret is None:
             return
         return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)
 


### PR DESCRIPTION
Without the fix, we would get errors like this:
```
File \"/mlrun/server/py/framework/utils/singletons/k8s.py\", line 607, in read_secret_data
    return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)
AttributeError: 'NoneType' object has no attribute 'data'","uri":"/api/v1/projects/test/alerts/my-alert"}
```