### PR TITLE
[API] Allow filtering schedules by its next run time

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1701,6 +1701,8 @@ class HTTPRunDB(RunDBInterface):
         name: Optional[str] = None,
         kind: mlrun.common.schemas.ScheduleKinds = None,
         include_last_run: bool = False,
+        next_run_time_since: Optional[datetime] = None,
+        next_run_time_until: Optional[datetime] = None,
     ) -> mlrun.common.schemas.SchedulesOutput:
         """Retrieve list of schedules of specific name or kind.
 
@@ -1709,10 +1711,18 @@ class HTTPRunDB(RunDBInterface):
         :param kind: Kind of schedule objects to retrieve, can be either ``job`` or ``pipeline``.
         :param include_last_run: Whether to return for each schedule returned also the results of the last run of
             that schedule.
+        :param next_run_time_since: Return only schedules with next run time after this date.
+        :param next_run_time_until: Return only schedules with next run time before this date.
         """
 
         project = project or config.default_project
-        params = {"kind": kind, "name": name, "include_last_run": include_last_run}
+        params = {
+            "kind": kind,
+            "name": name,
+            "include_last_run": include_last_run,
+            "next_run_time_since": datetime_to_iso(next_run_time_since),
+            "next_run_time_until": datetime_to_iso(next_run_time_until),
+        }
         path = f"projects/{project}/schedules"
         error_message = f"Failed listing schedules for {project} ? {kind} {name}"
         resp = self.api_call("GET", path, error_message, params=params)

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -452,6 +452,8 @@ class DBInterface(ABC):
         name: Optional[str] = None,
         labels: Optional[list[str]] = None,
         kind: mlrun.common.schemas.ScheduleKinds = None,
+        next_run_time_since: Optional[datetime.datetime] = None,
+        next_run_time_until: Optional[datetime.datetime] = None,
     ) -> list[mlrun.common.schemas.ScheduleRecord]:
         pass
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2459,12 +2459,20 @@ class SQLDB(DBInterface):
         name: typing.Optional[str] = None,
         labels: typing.Optional[list[str]] = None,
         kind: mlrun.common.schemas.ScheduleKinds = None,
+        next_run_time_since: Optional[datetime] = None,
+        next_run_time_until: Optional[datetime] = None,
         as_records: bool = False,
     ) -> list[mlrun.common.schemas.ScheduleRecord]:
         logger.debug("Getting schedules from db", project=project, name=name, kind=kind)
         query = self._query(session, Schedule, kind=kind)
         query = self._filter_query_by_resource_project(query, Schedule, project)
-
+        if next_run_time_since or next_run_time_until:
+            query = generate_time_range_query(
+                query=query,
+                field=Schedule.next_run_time,
+                since=next_run_time_since,
+                until=next_run_time_until,
+            )
         if name is not None:
             query = query.filter(generate_query_predicate_for_name(Schedule.name, name))
         labels = label_set(labels)

--- a/server/py/services/api/api/endpoints/schedules.py
+++ b/server/py/services/api/api/endpoints/schedules.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import datetime
+import typing
 from http import HTTPStatus
 from typing import Optional
 
@@ -157,6 +159,12 @@ async def list_schedules(
     kind: mlrun.common.schemas.ScheduleKinds = None,
     include_last_run: bool = False,
     include_credentials: bool = fastapi.Query(False, alias="include-credentials"),
+    next_run_time_since: typing.Annotated[
+        typing.Optional[datetime.datetime], "Schedules to run from specific datetime"
+    ] = None,
+    next_run_time_until: typing.Annotated[
+        typing.Optional[datetime.datetime], "Schedules to run until specific datetime"
+    ] = None,
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
 ):
@@ -175,6 +183,8 @@ async def list_schedules(
         labels=labels or _labels,
         include_last_run=include_last_run,
         include_credentials=include_credentials,
+        next_run_time_since=next_run_time_since,
+        next_run_time_until=next_run_time_until,
     )
     filtered_schedules = await framework.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.schedule,

--- a/server/py/services/api/utils/scheduler.py
+++ b/server/py/services/api/utils/scheduler.py
@@ -255,8 +255,18 @@ class Scheduler:
         labels: Optional[list[str]] = None,
         include_last_run: bool = False,
         include_credentials: bool = False,
+        next_run_time_since: Optional[datetime] = None,
+        next_run_time_until: Optional[datetime] = None,
     ) -> mlrun.common.schemas.SchedulesOutput:
-        db_schedules = get_db().list_schedules(db_session, project, name, labels, kind)
+        db_schedules = get_db().list_schedules(
+            db_session,
+            project,
+            name,
+            labels,
+            kind,
+            next_run_time_since,
+            next_run_time_until,
+        )
         schedules = []
         for db_schedule in db_schedules:
             schedule = self._transform_and_enrich_db_schedule(


### PR DESCRIPTION
Implementing https://iguazio.atlassian.net/browse/ML-8362 - allowing sdk / api to filter schedules by range of next schedule runtime
