### PR TITLE
[ProjectSummaries] Add alert activations counters

### DIFF
--- a/mlrun/common/schemas/project.py
+++ b/mlrun/common/schemas/project.py
@@ -159,6 +159,9 @@ class ProjectSummary(pydantic.v1.BaseModel):
     pipelines_failed_recent_count: typing.Optional[int] = None
     pipelines_running_count: typing.Optional[int] = None
     updated: typing.Optional[datetime.datetime] = None
+    endpoint_alerts_count: int = 0
+    job_alerts_count: int = 0
+    other_alerts_count: int = 0
 
 
 class IguazioProject(pydantic.v1.BaseModel):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1057,3 +1057,7 @@ class RunDBInterface(ABC):
         replace_creds: bool,
     ) -> None:
         pass
+
+    @abstractmethod
+    def get_project_summary(self, project: str) -> mlrun.common.schemas.ProjectSummary:
+        pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4836,7 +4836,9 @@ class HTTPRunDB(RunDBInterface):
             **kwargs,
         )
 
-    def get_project_summary(self, project="") -> mlrun.common.schemas.ProjectSummary:
+    def get_project_summary(
+        self, project: Optional[str] = None
+    ) -> mlrun.common.schemas.ProjectSummary:
         """
         Retrieve the summary of a project.
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4836,6 +4836,20 @@ class HTTPRunDB(RunDBInterface):
             **kwargs,
         )
 
+    def get_project_summary(self, project="") -> mlrun.common.schemas.ProjectSummary:
+        """
+        Retrieve the summary of a project.
+
+        :param project: Project name for which the summary belongs.
+        :returns: A summary of the project.
+        """
+        project = project or config.default_project
+
+        endpoint_path = f"project-summaries/{project}"
+        error_message = f"Failed retrieving project summary for {project}"
+        response = self.api_call("GET", endpoint_path, error_message)
+        return mlrun.common.schemas.ProjectSummary(**response.json())
+
     @staticmethod
     def _parse_labels(
         labels: Optional[Union[str, dict[str, Optional[str]], list[str]]],

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -918,3 +918,6 @@ class NopDB(RunDBInterface):
         **kwargs,
     ):
         pass
+
+    def get_project_summary(self, project: str):
+        pass

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -523,6 +523,9 @@ class DBInterface(ABC):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
+        dict[str, int],
+        dict[str, int],
     ]:
         pass
 

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -513,6 +513,7 @@ class DBInterface(ABC):
     @abstractmethod
     async def get_project_resources_counters(
         self,
+        projects_with_creation_time: list[tuple[str, datetime]],
     ) -> tuple[
         dict[str, int],
         dict[str, int],

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2952,6 +2952,9 @@ class SQLDB(DBInterface):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
+        dict[str, int],
+        dict[str, int],
     ]:
         results = await asyncio.gather(
             fastapi.concurrency.run_in_threadpool(
@@ -2974,6 +2977,10 @@ class SQLDB(DBInterface):
                 framework.db.session.run_function_with_new_db_session,
                 self._calculate_runs_counters,
             ),
+            fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
+                self._calculate_alerts_activations_counters,
+            ),
         )
         (
             project_to_files_count,
@@ -2989,6 +2996,11 @@ class SQLDB(DBInterface):
                 project_to_recent_failed_runs_count,
                 project_to_running_runs_count,
             ),
+            (
+                project_to_endpoint_alerts_count,
+                project_to_job_alerts_count,
+                project_to_other_alerts_count,
+            ),
         ) = results
         return (
             project_to_files_count,
@@ -3000,6 +3012,9 @@ class SQLDB(DBInterface):
             project_to_recent_completed_runs_count,
             project_to_recent_failed_runs_count,
             project_to_running_runs_count,
+            project_to_endpoint_alerts_count,
+            project_to_job_alerts_count,
+            project_to_other_alerts_count,
         )
 
     @staticmethod
@@ -3183,6 +3198,45 @@ class SQLDB(DBInterface):
             project_to_recent_completed_runs_count,
             project_to_recent_failed_runs_count,
             project_to_running_runs_count,
+        )
+
+    def _calculate_alerts_activations_counters(
+        self,
+        session,
+    ) -> tuple[
+        dict[str, int],
+        dict[str, int],
+        dict[str, int],
+    ]:
+        projects_with_creation_time = self.list_projects(
+            session,
+            format_=mlrun.common.formatters.ProjectFormat.name_and_creation_time,
+        ).projects
+
+        project_to_endpoint_alerts_count = collections.defaultdict(int)
+        project_to_job_alerts_count = collections.defaultdict(int)
+        project_to_other_alerts_count = collections.defaultdict(int)
+
+        alert_activations = self.list_alert_activations(
+            session=session, projects_with_creation_time=projects_with_creation_time
+        )
+
+        for alert in alert_activations:
+            project = alert.project
+            if (
+                alert.entity_kind
+                == mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT
+            ):
+                project_to_endpoint_alerts_count[project] += 1
+            elif alert.entity_kind == mlrun.common.schemas.alert.EventEntityKind.JOB:
+                project_to_job_alerts_count[project] += 1
+            else:
+                project_to_other_alerts_count[project] += 1
+
+        return (
+            project_to_endpoint_alerts_count,
+            project_to_job_alerts_count,
+            project_to_other_alerts_count,
         )
 
     def _update_project_record_from_project(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3217,24 +3217,55 @@ class SQLDB(DBInterface):
         project_to_job_alerts_count = collections.defaultdict(int)
         project_to_other_alerts_count = collections.defaultdict(int)
 
-        last_day = datetime.now() - timedelta(hours=24)
-        alert_activations = self.list_alert_activations(
-            session=session,
-            projects_with_creation_time=projects_with_creation_time,
-            since=last_day,
-        )
+        project_filter_conditions = [
+            and_(
+                AlertActivation.project == project,
+                AlertActivation.activation_time > created,
+            )
+            for project, created in projects_with_creation_time
+        ]
 
-        for alert in alert_activations:
-            project = alert.project
-            if (
-                alert.entity_kind
-                == mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT
-            ):
-                project_to_endpoint_alerts_count[project] += 1
-            elif alert.entity_kind == mlrun.common.schemas.alert.EventEntityKind.JOB:
-                project_to_job_alerts_count[project] += 1
-            else:
-                project_to_other_alerts_count[project] += 1
+        last_day = datetime.now() - timedelta(hours=24)
+
+        (
+            session.query(
+                AlertActivation.project,
+                func.count(
+                    case(
+                        (
+                            AlertActivation.entity_kind
+                            == mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                            1,
+                        )
+                    )
+                ).label("model_endpoint_alerts_count"),
+                func.count(
+                    case(
+                        (
+                            AlertActivation.entity_kind
+                            == mlrun.common.schemas.alert.EventEntityKind.JOB,
+                            1,
+                        )
+                    )
+                ).label("job_alerts_count"),
+                func.count(
+                    case(
+                        (
+                            ~AlertActivation.entity_kind.in_(
+                                [
+                                    mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                                    mlrun.common.schemas.alert.EventEntityKind.JOB,
+                                ]
+                            ),
+                            1,
+                        )
+                    )
+                ).label("other_alerts_count"),
+            )
+            .filter(or_(*project_filter_conditions))
+            .filter(AlertActivation.activation_time > last_day)
+            .group_by(AlertActivation.project)
+        )
 
         return (
             project_to_endpoint_alerts_count,

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -43,7 +43,6 @@ from sqlalchemy import (
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Session, aliased
-from sqlalchemy.sql.elements import BinaryExpression
 
 import mlrun
 import mlrun.common.constants as mlrun_constants
@@ -3216,52 +3215,54 @@ class SQLDB(DBInterface):
         project_to_job_alerts_count = collections.defaultdict(int)
         project_to_other_alerts_count = collections.defaultdict(int)
 
-        project_filter_conditions = self._generate_project_filter_conditions(
-            projects_with_creation_time
-        )
-
         last_day = mlrun.utils.datetime_now() - timedelta(hours=24)
 
+        # construct a base query to count different types of alert activations
+        query = session.query(
+            AlertActivation.project,
+            func.count(
+                case(
+                    (
+                        AlertActivation.entity_kind
+                        == mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                        1,
+                    )
+                )
+            ).label("model_endpoint_alerts_count"),
+            func.count(
+                case(
+                    (
+                        AlertActivation.entity_kind
+                        == mlrun.common.schemas.alert.EventEntityKind.JOB,
+                        1,
+                    )
+                )
+            ).label("job_alerts_count"),
+            func.count(
+                case(
+                    (
+                        AlertActivation.entity_kind.not_in(
+                            [
+                                mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                                mlrun.common.schemas.alert.EventEntityKind.JOB,
+                            ]
+                        ),
+                        1,
+                    )
+                )
+            ).label("other_alerts_count"),
+        )
+
+        # filter by project, creation time, and activations within the last 24 hours
         query_results = (
-            session.query(
-                AlertActivation.project,
-                func.count(
-                    case(
-                        (
-                            AlertActivation.entity_kind
-                            == mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
-                            1,
-                        )
-                    )
-                ).label("model_endpoint_alerts_count"),
-                func.count(
-                    case(
-                        (
-                            AlertActivation.entity_kind
-                            == mlrun.common.schemas.alert.EventEntityKind.JOB,
-                            1,
-                        )
-                    )
-                ).label("job_alerts_count"),
-                func.count(
-                    case(
-                        (
-                            ~AlertActivation.entity_kind.in_(
-                                [
-                                    mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
-                                    mlrun.common.schemas.alert.EventEntityKind.JOB,
-                                ]
-                            ),
-                            1,
-                        )
-                    )
-                ).label("other_alerts_count"),
+            self._apply_alert_activation_project_filters(
+                query, projects_with_creation_time
             )
-            .filter(or_(*project_filter_conditions))
             .filter(AlertActivation.activation_time > last_day)
             .group_by(AlertActivation.project)
             .all()
         )
+
         for project, endpoint_counter, job_counter, other_counter in query_results:
             project_to_endpoint_alerts_count[project] = endpoint_counter
             project_to_job_alerts_count[project] = job_counter
@@ -3274,16 +3275,18 @@ class SQLDB(DBInterface):
         )
 
     @staticmethod
-    def _generate_project_filter_conditions(
+    def _apply_alert_activation_project_filters(
+        query: sqlalchemy.orm.query.Query,
         projects_with_creation_time: list[tuple[str, datetime]],
-    ) -> list[BinaryExpression]:
-        return [
+    ) -> sqlalchemy.orm.query.Query:
+        project_filter_conditions = [
             and_(
                 AlertActivation.project == project,
                 AlertActivation.activation_time > created,
             )
             for project, created in projects_with_creation_time
         ]
+        return query.filter(or_(*project_filter_conditions))
 
     def _update_project_record_from_project(
         self,
@@ -6131,11 +6134,9 @@ class SQLDB(DBInterface):
         # Filter alert activations for the project created after the project creation date,
         # excluding activations linked to any previous instances of the project.
         # TODO: reconsider this approach when we move alerts out of main MLRun db
-        project_filter_conditions = self._generate_project_filter_conditions(
-            projects_with_creation_time
+        query = self._apply_alert_activation_project_filters(
+            query, projects_with_creation_time
         )
-
-        query = query.filter(or_(*project_filter_conditions))
 
         if name:
             query = query.filter(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3217,8 +3217,11 @@ class SQLDB(DBInterface):
         project_to_job_alerts_count = collections.defaultdict(int)
         project_to_other_alerts_count = collections.defaultdict(int)
 
+        last_day = datetime.now() - timedelta(hours=24)
         alert_activations = self.list_alert_activations(
-            session=session, projects_with_creation_time=projects_with_creation_time
+            session=session,
+            projects_with_creation_time=projects_with_creation_time,
+            since=last_day,
         )
 
         for alert in alert_activations:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -43,6 +43,7 @@ from sqlalchemy import (
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Session, aliased
+from sqlalchemy.sql.elements import BinaryExpression
 
 import mlrun
 import mlrun.common.constants as mlrun_constants
@@ -2942,6 +2943,7 @@ class SQLDB(DBInterface):
 
     async def get_project_resources_counters(
         self,
+        projects_with_creation_time: list[tuple[str, datetime]],
     ) -> tuple[
         dict[str, int],
         dict[str, int],
@@ -2979,7 +2981,8 @@ class SQLDB(DBInterface):
             ),
             fastapi.concurrency.run_in_threadpool(
                 framework.db.session.run_function_with_new_db_session,
-                self._calculate_alerts_activations_counters,
+                self._calculate_alert_activations_counters,
+                projects_with_creation_time,
             ),
         )
         (
@@ -3200,34 +3203,26 @@ class SQLDB(DBInterface):
             project_to_running_runs_count,
         )
 
-    def _calculate_alerts_activations_counters(
+    def _calculate_alert_activations_counters(
         self,
         session,
+        projects_with_creation_time: list[tuple[str, datetime]],
     ) -> tuple[
         dict[str, int],
         dict[str, int],
         dict[str, int],
     ]:
-        projects_with_creation_time = self.list_projects(
-            session,
-            format_=mlrun.common.formatters.ProjectFormat.name_and_creation_time,
-        ).projects
-
         project_to_endpoint_alerts_count = collections.defaultdict(int)
         project_to_job_alerts_count = collections.defaultdict(int)
         project_to_other_alerts_count = collections.defaultdict(int)
 
-        project_filter_conditions = [
-            and_(
-                AlertActivation.project == project,
-                AlertActivation.activation_time > created,
-            )
-            for project, created in projects_with_creation_time
-        ]
+        project_filter_conditions = self._generate_project_filter_conditions(
+            projects_with_creation_time
+        )
 
-        last_day = datetime.now() - timedelta(hours=24)
+        last_day = mlrun.utils.datetime_now() - timedelta(hours=24)
 
-        (
+        query_results = (
             session.query(
                 AlertActivation.project,
                 func.count(
@@ -3265,13 +3260,30 @@ class SQLDB(DBInterface):
             .filter(or_(*project_filter_conditions))
             .filter(AlertActivation.activation_time > last_day)
             .group_by(AlertActivation.project)
+            .all()
         )
+        for project, endpoint_counter, job_counter, other_counter in query_results:
+            project_to_endpoint_alerts_count[project] = endpoint_counter
+            project_to_job_alerts_count[project] = job_counter
+            project_to_other_alerts_count[project] = other_counter
 
         return (
             project_to_endpoint_alerts_count,
             project_to_job_alerts_count,
             project_to_other_alerts_count,
         )
+
+    @staticmethod
+    def _generate_project_filter_conditions(
+        projects_with_creation_time: list[tuple[str, datetime]],
+    ) -> list[BinaryExpression]:
+        return [
+            and_(
+                AlertActivation.project == project,
+                AlertActivation.activation_time > created,
+            )
+            for project, created in projects_with_creation_time
+        ]
 
     def _update_project_record_from_project(
         self,
@@ -6119,13 +6131,9 @@ class SQLDB(DBInterface):
         # Filter alert activations for the project created after the project creation date,
         # excluding activations linked to any previous instances of the project.
         # TODO: reconsider this approach when we move alerts out of main MLRun db
-        project_filter_conditions = [
-            and_(
-                AlertActivation.project == project,
-                AlertActivation.activation_time > created,
-            )
-            for project, created in projects_with_creation_time
-        ]
+        project_filter_conditions = self._generate_project_filter_conditions(
+            projects_with_creation_time
+        )
 
         query = query.filter(or_(*project_filter_conditions))
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3217,7 +3217,7 @@ class SQLDB(DBInterface):
 
         last_day = mlrun.utils.datetime_now() - timedelta(hours=24)
 
-        # construct a base query to count different types of alert activations
+        # construct a base query to count different types of alert activations, labels are added to improve readability
         query = session.query(
             AlertActivation.project,
             func.count(

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1310,6 +1310,9 @@ class SQLRunDB(RunDBInterface):
     ):
         raise NotImplementedError
 
+    def get_project_summary(self, project: str):
+        raise NotImplementedError
+
 
 # Once this file is imported it will override the default RunDB implementation (RunDBContainer)
 @containers.override(mlrun.db.factory.RunDBContainer)

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -446,11 +446,13 @@ class Projects(
         projects_output = await fastapi.concurrency.run_in_threadpool(
             self.list_projects,
             session,
-            format_=mlrun.common.formatters.ProjectFormat.name_only,
+            format_=mlrun.common.formatters.ProjectFormat.name_and_creation_time,
         )
 
         project_counters, pipeline_counters = await asyncio.gather(
-            framework.utils.singletons.db.get_db().get_project_resources_counters(),
+            framework.utils.singletons.db.get_db().get_project_resources_counters(
+                projects_output.projects
+            ),
             self._calculate_pipelines_counters(),
         )
         (
@@ -474,7 +476,8 @@ class Projects(
         ) = pipeline_counters
 
         project_summaries = []
-        for project_name in projects_output.projects:
+        for project_data in projects_output.projects:
+            project_name = project_data[0]
             project_summaries.append(
                 mlrun.common.schemas.ProjectSummary(
                     name=project_name,

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -463,6 +463,9 @@ class Projects(
             project_to_recent_completed_runs_count,
             project_to_recent_failed_runs_count,
             project_to_running_runs_count,
+            project_to_endpoint_alerts_count,
+            project_to_job_alerts_count,
+            project_to_other_alerts_count,
         ) = project_counters
         (
             project_to_recent_completed_pipelines_count,
@@ -509,6 +512,13 @@ class Projects(
                     distinct_scheduled_pipelines_pending_count=project_to_schedule_pending_workflows_count[
                         project_name
                     ],
+                    endpoint_alerts_count=project_to_endpoint_alerts_count.get(
+                        project_name, 0
+                    ),
+                    job_alerts_count=project_to_job_alerts_count.get(project_name, 0),
+                    other_alerts_count=project_to_other_alerts_count.get(
+                        project_name, 0
+                    ),
                 )
             )
         await fastapi.concurrency.run_in_threadpool(

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -413,6 +413,16 @@ async def test_list_and_get_project_summaries(
         project_name,
     )
 
+    # mock alert activations logic as it requires MySQL-specific logic not supported by SQLite.
+    framework.utils.singletons.db.SQLDB._calculate_alert_activations_counters = (
+        unittest.mock.Mock(
+            return_value=(
+                {},
+                {},
+                {},
+            )
+        )
+    )
     await services.api.crud.Projects().refresh_project_resources_counters_cache(db)
 
     # list project summaries
@@ -471,6 +481,17 @@ async def test_list_project_summaries_different_installation_modes(
 
     services.api.crud.Pipelines().list_pipelines = unittest.mock.Mock(
         return_value=(0, None, [])
+    )
+
+    # mock alert activations logic as it requires MySQL-specific logic not supported by SQLite.
+    framework.utils.singletons.db.SQLDB._calculate_alert_activations_counters = (
+        unittest.mock.Mock(
+            return_value=(
+                {},
+                {},
+                {},
+            )
+        )
     )
     # Enterprise installation configuration post 3.4.0
     mlrun.mlconf.igz_version = "3.6.0-b26.20210904121245"

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -42,6 +42,7 @@ import mlrun.errors
 import mlrun_pipelines.common.models
 
 import framework.api.utils
+import framework.db.sqldb.db
 import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.clients.log_collector
@@ -413,6 +414,13 @@ async def test_list_and_get_project_summaries(
         project_name,
     )
 
+    # create alerts activations for the project
+    (
+        endpoint_alerts_count,
+        job_alerts_count,
+        other_alerts_count,
+    ) = _create_alerts_activations(project_name)
+
     await services.api.crud.Projects().refresh_project_resources_counters_cache(db)
 
     # list project summaries
@@ -422,7 +430,9 @@ async def test_list_and_get_project_summaries(
     )
     for index, project_summary in enumerate(project_summaries_output.project_summaries):
         if project_summary.name == empty_project_name:
-            _assert_project_summary(project_summary, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            _assert_project_summary(
+                project_summary, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            )
         elif project_summary.name == project_name:
             _assert_project_summary(
                 project_summary,
@@ -436,6 +446,9 @@ async def test_list_and_get_project_summaries(
                 distinct_scheduled_jobs_pending_count,
                 distinct_scheduled_pipelines_pending_count,
                 running_pipelines_count,
+                endpoint_alerts_count,
+                job_alerts_count,
+                other_alerts_count,
             )
         else:
             pytest.fail(f"Unexpected project summary returned: {project_summary}")
@@ -455,6 +468,9 @@ async def test_list_and_get_project_summaries(
         distinct_scheduled_jobs_pending_count,
         distinct_scheduled_pipelines_pending_count,
         running_pipelines_count,
+        endpoint_alerts_count,
+        job_alerts_count,
+        other_alerts_count,
     )
 
 
@@ -472,6 +488,11 @@ async def test_list_project_summaries_different_installation_modes(
     services.api.crud.Pipelines().list_pipelines = unittest.mock.Mock(
         return_value=(0, None, [])
     )
+
+    framework.utils.singletons.db.SQLDB.list_alert_activations = unittest.mock.Mock(
+        return_value=[]
+    )
+
     # Enterprise installation configuration post 3.4.0
     mlrun.mlconf.igz_version = "3.6.0-b26.20210904121245"
     mlrun.mlconf.kfp_url = "https://somekfp-url.com"
@@ -487,6 +508,9 @@ async def test_list_project_summaries_different_installation_modes(
     _assert_project_summary(
         # accessing the zero index as there's only one project
         project_summaries_output.project_summaries[0],
+        0,
+        0,
+        0,
         0,
         0,
         0,
@@ -522,6 +546,9 @@ async def test_list_project_summaries_different_installation_modes(
         0,
         0,
         0,
+        0,
+        0,
+        0,
     )
 
     # Kubernetes installation configuration (mlrun-kit)
@@ -547,6 +574,9 @@ async def test_list_project_summaries_different_installation_modes(
         0,
         0,
         0,
+        0,
+        0,
+        0,
     )
 
     # Docker installation configuration
@@ -562,6 +592,9 @@ async def test_list_project_summaries_different_installation_modes(
     _assert_project_summary(
         # accessing the zero index as there's only one project
         project_summaries_output.project_summaries[0],
+        0,
+        0,
+        0,
         0,
         0,
         0,
@@ -1747,6 +1780,9 @@ def _assert_project_summary(
     distinct_scheduled_jobs_pending_count: int,
     distinct_scheduled_pipelines_pending_count: int,
     pipelines_running_count: int,
+    endpoint_alerts_count: int,
+    job_alerts_count: int,
+    other_alerts_count: int,
 ):
     assert project_summary.files_count == files_count
     assert project_summary.feature_sets_count == feature_sets_count
@@ -1764,6 +1800,9 @@ def _assert_project_summary(
         == distinct_scheduled_pipelines_pending_count
     )
     assert project_summary.pipelines_running_count == pipelines_running_count
+    assert project_summary.endpoint_alerts_count == endpoint_alerts_count
+    assert project_summary.job_alerts_count == job_alerts_count
+    assert project_summary.other_alerts_count == other_alerts_count
 
 
 def _assert_project(
@@ -1953,3 +1992,73 @@ def _create_project(client: TestClient, name: str):
     assert response.status_code == HTTPStatus.CREATED.value
     _assert_project_response(project, response)
     return project
+
+
+def _create_alerts_activations(project_name):
+    endpoint_alerts_count = 1
+    job_alerts_count = 2
+    other_alerts_count = 1
+
+    activations = [
+        mlrun.common.schemas.AlertActivation(
+            id=1,
+            name="alert1",
+            project=project_name,
+            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+            activation_time=datetime.datetime.utcnow(),
+            entity_id="1111",
+            entity_kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
+            event_kind=mlrun.common.schemas.alert.EventKind.FAILED,
+            number_of_events=1,
+            notifications=[],
+            criteria=mlrun.common.schemas.alert.AlertCriteria(count=3),
+        ),
+        mlrun.common.schemas.AlertActivation(
+            id=2,
+            name="alert2",
+            project=project_name,
+            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+            activation_time=datetime.datetime.utcnow(),
+            entity_id="2222",
+            entity_kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
+            event_kind=mlrun.common.schemas.alert.EventKind.FAILED,
+            number_of_events=1,
+            notifications=[],
+            criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
+        ),
+        mlrun.common.schemas.AlertActivation(
+            id=3,
+            name="alert3",
+            project=project_name,
+            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+            activation_time=datetime.datetime.utcnow(),
+            entity_id="3333",
+            entity_kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+            event_kind=mlrun.common.schemas.alert.EventKind.DATA_DRIFT_SUSPECTED,
+            number_of_events=1,
+            notifications=[],
+            criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
+        ),
+        mlrun.common.schemas.AlertActivation(
+            id=3,
+            name="alert4",
+            project=project_name,
+            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+            activation_time=datetime.datetime.utcnow(),
+            entity_id="4444",
+            entity_kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_MONITORING_APPLICATION,
+            event_kind=mlrun.common.schemas.alert.EventKind.MM_APP_FAILED,
+            number_of_events=1,
+            notifications=[],
+            criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
+        ),
+    ]
+
+    # mock the `list_alert_activations` method
+    # Note: This is necessary because the unit tests use SQLite, and `alert_activations` logic relies on MySQL-specific
+    # functionality that is not supported by SQLite.
+    framework.utils.singletons.db.SQLDB.list_alert_activations = unittest.mock.Mock(
+        return_value=activations
+    )
+
+    return endpoint_alerts_count, job_alerts_count, other_alerts_count

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -42,7 +42,6 @@ import mlrun.errors
 import mlrun_pipelines.common.models
 
 import framework.api.utils
-import framework.db.sqldb.db
 import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.clients.log_collector
@@ -414,13 +413,6 @@ async def test_list_and_get_project_summaries(
         project_name,
     )
 
-    # create alerts activations for the project
-    (
-        endpoint_alerts_count,
-        job_alerts_count,
-        other_alerts_count,
-    ) = _create_alerts_activations(project_name)
-
     await services.api.crud.Projects().refresh_project_resources_counters_cache(db)
 
     # list project summaries
@@ -430,9 +422,7 @@ async def test_list_and_get_project_summaries(
     )
     for index, project_summary in enumerate(project_summaries_output.project_summaries):
         if project_summary.name == empty_project_name:
-            _assert_project_summary(
-                project_summary, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-            )
+            _assert_project_summary(project_summary, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         elif project_summary.name == project_name:
             _assert_project_summary(
                 project_summary,
@@ -446,9 +436,6 @@ async def test_list_and_get_project_summaries(
                 distinct_scheduled_jobs_pending_count,
                 distinct_scheduled_pipelines_pending_count,
                 running_pipelines_count,
-                endpoint_alerts_count,
-                job_alerts_count,
-                other_alerts_count,
             )
         else:
             pytest.fail(f"Unexpected project summary returned: {project_summary}")
@@ -468,9 +455,6 @@ async def test_list_and_get_project_summaries(
         distinct_scheduled_jobs_pending_count,
         distinct_scheduled_pipelines_pending_count,
         running_pipelines_count,
-        endpoint_alerts_count,
-        job_alerts_count,
-        other_alerts_count,
     )
 
 
@@ -488,11 +472,6 @@ async def test_list_project_summaries_different_installation_modes(
     services.api.crud.Pipelines().list_pipelines = unittest.mock.Mock(
         return_value=(0, None, [])
     )
-
-    framework.utils.singletons.db.SQLDB.list_alert_activations = unittest.mock.Mock(
-        return_value=[]
-    )
-
     # Enterprise installation configuration post 3.4.0
     mlrun.mlconf.igz_version = "3.6.0-b26.20210904121245"
     mlrun.mlconf.kfp_url = "https://somekfp-url.com"
@@ -508,9 +487,6 @@ async def test_list_project_summaries_different_installation_modes(
     _assert_project_summary(
         # accessing the zero index as there's only one project
         project_summaries_output.project_summaries[0],
-        0,
-        0,
-        0,
         0,
         0,
         0,
@@ -546,9 +522,6 @@ async def test_list_project_summaries_different_installation_modes(
         0,
         0,
         0,
-        0,
-        0,
-        0,
     )
 
     # Kubernetes installation configuration (mlrun-kit)
@@ -574,9 +547,6 @@ async def test_list_project_summaries_different_installation_modes(
         0,
         0,
         0,
-        0,
-        0,
-        0,
     )
 
     # Docker installation configuration
@@ -592,9 +562,6 @@ async def test_list_project_summaries_different_installation_modes(
     _assert_project_summary(
         # accessing the zero index as there's only one project
         project_summaries_output.project_summaries[0],
-        0,
-        0,
-        0,
         0,
         0,
         0,
@@ -1780,9 +1747,6 @@ def _assert_project_summary(
     distinct_scheduled_jobs_pending_count: int,
     distinct_scheduled_pipelines_pending_count: int,
     pipelines_running_count: int,
-    endpoint_alerts_count: int,
-    job_alerts_count: int,
-    other_alerts_count: int,
 ):
     assert project_summary.files_count == files_count
     assert project_summary.feature_sets_count == feature_sets_count
@@ -1800,9 +1764,6 @@ def _assert_project_summary(
         == distinct_scheduled_pipelines_pending_count
     )
     assert project_summary.pipelines_running_count == pipelines_running_count
-    assert project_summary.endpoint_alerts_count == endpoint_alerts_count
-    assert project_summary.job_alerts_count == job_alerts_count
-    assert project_summary.other_alerts_count == other_alerts_count
 
 
 def _assert_project(
@@ -1992,73 +1953,3 @@ def _create_project(client: TestClient, name: str):
     assert response.status_code == HTTPStatus.CREATED.value
     _assert_project_response(project, response)
     return project
-
-
-def _create_alerts_activations(project_name):
-    endpoint_alerts_count = 1
-    job_alerts_count = 2
-    other_alerts_count = 1
-
-    activations = [
-        mlrun.common.schemas.AlertActivation(
-            id=1,
-            name="alert1",
-            project=project_name,
-            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
-            activation_time=datetime.datetime.utcnow(),
-            entity_id="1111",
-            entity_kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
-            event_kind=mlrun.common.schemas.alert.EventKind.FAILED,
-            number_of_events=1,
-            notifications=[],
-            criteria=mlrun.common.schemas.alert.AlertCriteria(count=3),
-        ),
-        mlrun.common.schemas.AlertActivation(
-            id=2,
-            name="alert2",
-            project=project_name,
-            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
-            activation_time=datetime.datetime.utcnow(),
-            entity_id="2222",
-            entity_kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
-            event_kind=mlrun.common.schemas.alert.EventKind.FAILED,
-            number_of_events=1,
-            notifications=[],
-            criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
-        ),
-        mlrun.common.schemas.AlertActivation(
-            id=3,
-            name="alert3",
-            project=project_name,
-            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
-            activation_time=datetime.datetime.utcnow(),
-            entity_id="3333",
-            entity_kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
-            event_kind=mlrun.common.schemas.alert.EventKind.DATA_DRIFT_SUSPECTED,
-            number_of_events=1,
-            notifications=[],
-            criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
-        ),
-        mlrun.common.schemas.AlertActivation(
-            id=3,
-            name="alert4",
-            project=project_name,
-            severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
-            activation_time=datetime.datetime.utcnow(),
-            entity_id="4444",
-            entity_kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_MONITORING_APPLICATION,
-            event_kind=mlrun.common.schemas.alert.EventKind.MM_APP_FAILED,
-            number_of_events=1,
-            notifications=[],
-            criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
-        ),
-    ]
-
-    # mock the `list_alert_activations` method
-    # Note: This is necessary because the unit tests use SQLite, and `alert_activations` logic relies on MySQL-specific
-    # functionality that is not supported by SQLite.
-    framework.utils.singletons.db.SQLDB.list_alert_activations = unittest.mock.Mock(
-        return_value=activations
-    )
-
-    return endpoint_alerts_count, job_alerts_count, other_alerts_count

--- a/server/py/services/api/tests/unit/utils/projects/test_follower_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_follower_member.py
@@ -415,6 +415,9 @@ async def test_list_project_summaries(
         pipelines_running_count=2,
         distinct_scheduled_jobs_pending_count=3,
         distinct_scheduled_pipelines_pending_count=4,
+        endpoint_alerts_count=5,
+        job_alerts_count=6,
+        other_alerts_count=7,
     )
     created_project, _ = projects_follower.store_project(
         db,
@@ -466,7 +469,9 @@ async def test_list_project_summaries_fails_to_list_pipeline_runs(
         project,
     )
     framework.utils.singletons.db.get_db().get_project_resources_counters = (
-        unittest.mock.AsyncMock(return_value=tuple({project_name: i} for i in range(9)))
+        unittest.mock.AsyncMock(
+            return_value=tuple({project_name: i} for i in range(12))
+        )
     )
     await services.api.crud.Projects().refresh_project_resources_counters_cache(db)
     project_summaries = await projects_follower.list_project_summaries(db)

--- a/server/py/services/api/tests/unit/utils/projects/test_follower_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_follower_member.py
@@ -415,9 +415,6 @@ async def test_list_project_summaries(
         pipelines_running_count=2,
         distinct_scheduled_jobs_pending_count=3,
         distinct_scheduled_pipelines_pending_count=4,
-        endpoint_alerts_count=5,
-        job_alerts_count=6,
-        other_alerts_count=7,
     )
     created_project, _ = projects_follower.store_project(
         db,

--- a/server/py/services/api/tests/unit/utils/projects/test_follower_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_follower_member.py
@@ -453,9 +453,12 @@ async def test_list_project_summaries_fails_to_list_pipeline_runs(
     nop_leader: framework.utils.projects.remotes.leader.Member,
 ):
     project_name = "project-name"
+    project_creation_time = mlrun.utils.datetime_now()
     project = _generate_project(name=project_name)
     framework.utils.singletons.db.get_db().list_projects = unittest.mock.Mock(
-        return_value=mlrun.common.schemas.ProjectsOutput(projects=[project_name])
+        return_value=mlrun.common.schemas.ProjectsOutput(
+            projects=[(project_name, project_creation_time)]
+        )
     )
     services.api.crud.projects.Projects()._list_pipelines = unittest.mock.Mock(
         side_effect=mlrun.errors.MLRunNotFoundError("not found")

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -82,6 +82,14 @@ class TestAlerts(TestMLRunSystem):
         # in order to trigger the periodic monitor runs function, to detect the failed run and send an event on it
         time.sleep(35)
 
+        # get project summary to validate the alert activations counters
+        project_summary = mlrun.get_run_db().get_project_summary(
+            project=self.project_name
+        )
+        assert project_summary.job_alerts_count == 2
+        assert project_summary.endpoint_alerts_count == 0
+        assert project_summary.other_alerts_count == 0
+
         # Validate that the notifications was sent on the failed job
         expected_notifications = ["notification failure"]
         self._validate_notifications_on_nuclio(
@@ -357,6 +365,14 @@ class TestAlerts(TestMLRunSystem):
         self._validate_notifications_on_nuclio(
             nuclio_function_url, expected_notifications
         )
+
+        # get project summary to validate the alert activations counters
+        project_summary = mlrun.get_run_db().get_project_summary(
+            project=self.project_name
+        )
+        assert project_summary.job_alerts_count == 0
+        assert project_summary.endpoint_alerts_count == 4
+        assert project_summary.other_alerts_count == 0
 
     def test_job_failure_alert_sliding_window(self):
         """

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -366,7 +366,9 @@ class TestAlerts(TestMLRunSystem):
             nuclio_function_url, expected_notifications
         )
 
-        # get project summary to validate the alert activations counters
+        # wait for the periodic project summaries calculation to start
+        time.sleep(20)
+        # validate the alert activations counters
         project_summary = mlrun.get_run_db().get_project_summary(
             project=self.project_name
         )


### PR DESCRIPTION
Added the following counters to the project summaries:
- endpoint_alerts_count
- job_alerts_count
- other_alerts_count

Also, added a new method to httpdb: 
`get_project_summary`: This method retrieves the summary of a specific project, including the newly added alert counters, by making an API call to fetch the data. 

This was added to test the counters of the alert activations which cant be done in unit tests since unit tests are in SQLite.
This change was tested in a system test since the update of the project resources is done in the periodic flow of the system.

Jira:
https://iguazio.atlassian.net/browse/ML-8136

<img width="1410" alt="Screenshot 2024-12-05 at 9 44 09" src="https://github.com/user-attachments/assets/e72b0a92-f6ac-4e14-9534-004908af0d05">
