### PR TITLE
[Serving] Require nuclio 1.12.10 and use storey `AsyncSource`

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -951,8 +951,7 @@ class OnlineSource(BaseSourceDriver):
             is_explicit_ack_supported(context)
             and mlrun.mlconf.is_explicit_ack_enabled()
         )
-        # TODO: Change to AsyncEmitSource once we can drop support for nuclio<1.12.10
-        src_class = storey.SyncEmitSource(
+        src_class = storey.AsyncEmitSource(
             context=context,
             key_field=self.key_field or key_field,
             full_event=True,

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -547,7 +547,6 @@ class RemoteRuntime(KubeResource):
             self.spec.min_replicas = shards
             self.spec.max_replicas = shards
 
-    @min_nuclio_versions("1.12.10")
     def deploy(
         self,
         project="",

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -547,6 +547,7 @@ class RemoteRuntime(KubeResource):
             self.spec.min_replicas = shards
             self.spec.max_replicas = shards
 
+    @min_nuclio_versions("1.12.10")
     def deploy(
         self,
         project="",

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -39,7 +39,7 @@ from mlrun.serving.states import (
 )
 from mlrun.utils import get_caller_globals, logger, set_paths
 
-from .function import NuclioSpec, RemoteRuntime
+from .function import NuclioSpec, RemoteRuntime, min_nuclio_versions
 
 serving_subkind = "serving_v2"
 
@@ -577,6 +577,7 @@ class ServingRuntime(RemoteRuntime):
         self.spec.secret_sources.append({"kind": kind, "source": source})
         return self
 
+    @min_nuclio_versions("1.12.10")
     def deploy(
         self,
         project="",


### PR DESCRIPTION
[ML-4421](https://iguazio.atlassian.net/browse/ML-4421)

For `AsyncSource` to work, we need this nuclio fix – https://github.com/nuclio/nuclio/pull/3094, which was first released in nuclio 1.12.10.

According to @TomerShor, mlrun 1.7.0 already effectively requires nuclio>=1.13.1, and therefore we can safely require nuclio 1.12.10 to deploy a serving function.

[ML-4421]: https://iguazio.atlassian.net/browse/ML-4421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ