### PR TITLE
[Alert activations] Add group by and aggregate by for alert activations

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -14,6 +14,7 @@
 
 from .alert import (
     AlertActivation,
+    AlertActivations,
     AlertActiveState,
     AlertConfig,
     AlertNotification,

--- a/mlrun/common/schemas/alert.py
+++ b/mlrun/common/schemas/alert.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections import defaultdict
+from collections.abc import Iterator
 from datetime import datetime
-from typing import Annotated, Optional, Union
+from typing import Annotated, Any, Callable, Optional, Union
 
 import pydantic.v1
 
@@ -216,3 +218,77 @@ class AlertActivation(pydantic.v1.BaseModel):
     number_of_events: int
     notifications: list[notification_objects.NotificationState]
     reset_time: Optional[datetime] = None
+
+    def group_key(self, attributes: list[str]) -> tuple:
+        """
+        Dynamically create a key for grouping based on the provided attributes.
+        - If there's only one attribute, return the value directly (not a single-element tuple).
+        - If there are multiple attributes, return them as a tuple for grouping.
+
+        This ensures grouping behaves intuitively without redundant tuple representations.
+        """
+        if len(attributes) == 1:
+            # Avoid single-element tuple like (high,) when only one grouping attribute is used
+            return getattr(self, attributes[0])
+        # Otherwise, return a tuple of all specified attributes
+        return tuple(getattr(self, attr) for attr in attributes)
+
+
+class AlertActivations(pydantic.v1.BaseModel):
+    activations: list[AlertActivation]
+    pagination: Optional[dict]
+
+    def __iter__(self) -> Iterator[AlertActivation]:
+        return iter(self.activations)
+
+    def __getitem__(self, index: int) -> AlertActivation:
+        return self.activations[index]
+
+    def __len__(self) -> int:
+        return len(self.activations)
+
+    def group_by(self, *attributes: str) -> dict:
+        """
+        Group alert activations by specified attributes.
+
+        Args:
+        :param attributes: Attributes to group by.
+
+        :returns: A dictionary where keys are tuples of attribute values and values are lists of
+            AlertActivation objects.
+
+        Example:
+            # Group by project and severity
+            grouped = activations.group_by("project", "severity")
+        """
+        grouped = defaultdict(list)
+        for activation in self.activations:
+            key = activation.group_key(attributes)
+            grouped[key].append(activation)
+        return dict(grouped)
+
+    def aggregate_by(
+        self,
+        group_by_attrs: list[str],
+        aggregation_function: Callable[[list[AlertActivation]], Any],
+    ) -> dict:
+        """
+        Aggregate alert activations by specified attributes using a given aggregation function.
+
+        Args:
+        :param group_by_attrs: Attributes to group by.
+        :param aggregation_function: Function to aggregate grouped activations.
+
+        :returns: A dictionary where keys are tuples of attribute values and values are the result
+            of the aggregation function.
+
+        Example:
+            # Aggregate by name and entity_id and count number of activations in each group
+            activations.aggregate_by(["name", "entity_id"], lambda activations: len(activations))
+        """
+        grouped = self.group_by(*group_by_attrs)
+        aggregated = {
+            key: aggregation_function(activations)
+            for key, activations in grouped.items()
+        }
+        return aggregated

--- a/mlrun/common/schemas/alert.py
+++ b/mlrun/common/schemas/alert.py
@@ -219,7 +219,7 @@ class AlertActivation(pydantic.v1.BaseModel):
     notifications: list[notification_objects.NotificationState]
     reset_time: Optional[datetime] = None
 
-    def group_key(self, attributes: list[str]) -> tuple:
+    def group_key(self, attributes: list[str]) -> Union[Any, tuple]:
         """
         Dynamically create a key for grouping based on the provided attributes.
         - If there's only one attribute, return the value directly (not a single-element tuple).

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -48,6 +48,7 @@ from mlrun.errors import MLRunInvalidArgumentError, err_to_str
 from mlrun_pipelines.utils import compile_pipeline
 
 from ..artifacts import Artifact
+from ..common.schemas import AlertActivations
 from ..config import config
 from ..datastore.datastore_profile import DatastoreProfile2Json
 from ..feature_store import FeatureSet, FeatureVector
@@ -4744,7 +4745,7 @@ class HTTPRunDB(RunDBInterface):
             Union[mlrun.common.schemas.alert.EventEntityKind, str]
         ] = None,
         event_kind: Optional[Union[mlrun.common.schemas.alert.EventKind, str]] = None,
-    ) -> list[mlrun.common.schemas.AlertActivation]:
+    ) -> mlrun.common.schemas.AlertActivations:
         """
         Retrieve a list of all alert activations.
 
@@ -4780,7 +4781,7 @@ class HTTPRunDB(RunDBInterface):
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
         **kwargs,
-    ) -> tuple[list, Optional[str]]:
+    ) -> tuple[AlertActivations, Optional[str]]:
         """List alerts activations with support for pagination and various filtering options.
 
         This method retrieves a paginated list of alert activations based on the specified filter parameters.
@@ -5127,7 +5128,7 @@ class HTTPRunDB(RunDBInterface):
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
         return_all: bool = False,
-    ) -> tuple[list[mlrun.common.schemas.AlertActivation], Optional[str]]:
+    ) -> tuple[mlrun.common.schemas.AlertActivations, Optional[str]]:
         project = project or config.default_project
         params = {
             "name": name,
@@ -5151,9 +5152,12 @@ class HTTPRunDB(RunDBInterface):
         paginated_responses, token = self.process_paginated_responses(
             responses, "activations"
         )
-        paginated_results = [
-            mlrun.common.schemas.AlertActivation(**item) for item in paginated_responses
-        ]
+        paginated_results = mlrun.common.schemas.AlertActivations(
+            activations=[
+                mlrun.common.schemas.AlertActivation(**item)
+                for item in paginated_responses
+            ]
+        )
 
         return paginated_results, token
 

--- a/server/py/framework/routers/alert_activations.py
+++ b/server/py/framework/routers/alert_activations.py
@@ -57,7 +57,7 @@ async def list_alert_activations(
     service: framework.service.Service = Depends(
         Provide[framework.service.ServiceContainer.service]
     ),
-):
+) -> mlrun.common.schemas.AlertActivations:
     return await service.handle_request(
         "list_alert_activations",
         request=request,

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -400,7 +400,7 @@ class Service(framework.service.Service):
         page_token: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session,
-    ):
+    ) -> mlrun.common.schemas.AlertActivations:
         allowed_projects_with_creation_time = await (
             services.api.crud.Projects().list_allowed_project_names_with_creation_time(
                 db_session,
@@ -439,10 +439,10 @@ class Service(framework.service.Service):
             event_kind=event_kind,
         )
 
-        return {
-            "activations": activations,
-            "pagination": page_info,
-        }
+        return mlrun.common.schemas.AlertActivations(
+            activations=activations,
+            pagination=page_info,
+        )
 
     async def _move_service_to_online(self):
         if not get_project_member():

--- a/tests/alerts/__init__.py
+++ b/tests/alerts/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/alerts/test_alert_activations.py
+++ b/tests/alerts/test_alert_activations.py
@@ -1,0 +1,159 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import datetime
+
+import pytest
+
+import mlrun.common.schemas
+
+
+@pytest.fixture
+def sample_alert_activations():
+    return mlrun.common.schemas.AlertActivations(
+        activations=[
+            mlrun.common.schemas.AlertActivation(
+                id=1,
+                name="alert1",
+                project="project1",
+                severity=mlrun.common.schemas.alert.AlertSeverity.LOW,
+                activation_time=datetime.datetime.utcnow(),
+                entity_id="123456",
+                entity_kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                event_kind=mlrun.common.schemas.alert.EventKind.DATA_DRIFT_SUSPECTED,
+                number_of_events=1,
+                notifications=[],
+                criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
+            ),
+            mlrun.common.schemas.AlertActivation(
+                id=2,
+                name="alert1",
+                project="project2",
+                severity=mlrun.common.schemas.alert.AlertSeverity.LOW,
+                activation_time=datetime.datetime.utcnow(),
+                entity_id="123456",
+                entity_kind=mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                event_kind=mlrun.common.schemas.alert.EventKind.DATA_DRIFT_DETECTED,
+                number_of_events=2,
+                notifications=[],
+                criteria=mlrun.common.schemas.alert.AlertCriteria(count=2),
+            ),
+            mlrun.common.schemas.AlertActivation(
+                id=3,
+                name="alert2",
+                project="project3",
+                severity=mlrun.common.schemas.alert.AlertSeverity.HIGH,
+                activation_time=datetime.datetime.utcnow(),
+                entity_id="1234",
+                entity_kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
+                event_kind=mlrun.common.schemas.alert.EventKind.FAILED,
+                number_of_events=1,
+                notifications=[],
+                criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
+            ),
+            mlrun.common.schemas.AlertActivation(
+                id=4,
+                name="alert3",
+                project="project3",
+                severity=mlrun.common.schemas.alert.AlertSeverity.MEDIUM,
+                activation_time=datetime.datetime.utcnow(),
+                entity_id="1234",
+                entity_kind=mlrun.common.schemas.alert.EventEntityKind.JOB,
+                event_kind=mlrun.common.schemas.alert.EventKind.FAILED,
+                number_of_events=1,
+                notifications=[],
+                criteria=mlrun.common.schemas.alert.AlertCriteria(count=1),
+            ),
+        ]
+    )
+
+
+def test_group_by_severity(sample_alert_activations):
+    grouped = sample_alert_activations.group_by("severity")
+    assert len(grouped) == 3
+    assert len(grouped[mlrun.common.schemas.alert.AlertSeverity.LOW]) == 2
+    assert len(grouped[mlrun.common.schemas.alert.AlertSeverity.HIGH]) == 1
+    assert len(grouped[mlrun.common.schemas.alert.AlertSeverity.MEDIUM]) == 1
+
+
+def test_group_by_event_and_entity_kind(sample_alert_activations):
+    grouped = sample_alert_activations.group_by("event_kind", "entity_kind")
+    assert len(grouped) == 3
+    assert (
+        len(
+            grouped[
+                (
+                    mlrun.common.schemas.alert.EventKind.DATA_DRIFT_DETECTED,
+                    mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                )
+            ]
+        )
+        == 1
+    )
+    assert (
+        len(
+            grouped[
+                (
+                    mlrun.common.schemas.alert.EventKind.DATA_DRIFT_SUSPECTED,
+                    mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
+                )
+            ]
+        )
+        == 1
+    )
+    assert (
+        len(
+            grouped[
+                (
+                    mlrun.common.schemas.alert.EventKind.FAILED,
+                    mlrun.common.schemas.alert.EventEntityKind.JOB,
+                )
+            ]
+        )
+        == 2
+    )
+
+
+def test_aggregate_by_severity(sample_alert_activations):
+    aggregated = sample_alert_activations.aggregate_by(
+        ["severity"],
+        lambda activations: sum(
+            activation.number_of_events for activation in activations
+        ),
+    )
+    assert aggregated == {
+        (mlrun.common.schemas.alert.AlertSeverity.HIGH): 1,
+        (mlrun.common.schemas.alert.AlertSeverity.LOW): 3,
+        (mlrun.common.schemas.alert.AlertSeverity.MEDIUM): 1,
+    }
+
+
+def test_aggregate_by_event_and_entity_kind(sample_alert_activations):
+    aggregated = sample_alert_activations.aggregate_by(
+        ["name", "entity_id"], lambda activations: len(activations)
+    )
+    assert aggregated == {
+        ("alert1", "123456"): 2,
+        ("alert2", "1234"): 1,
+        ("alert3", "1234"): 1,
+    }
+    aggregated = sample_alert_activations.aggregate_by(
+        ["name", "entity_id", "project"], lambda activations: len(activations)
+    )
+    assert aggregated == {
+        ("alert1", "123456", "project1"): 1,
+        ("alert1", "123456", "project2"): 1,
+        ("alert2", "1234", "project3"): 1,
+        ("alert3", "1234", "project3"): 1,
+    }


### PR DESCRIPTION
Adds `AlertActivations` object to provide user ability to group and aggregate value. Inspired by the way these methods work in spark/pandas, so it be more intuitive for users who are familiar with them. 
 
Jira - https://iguazio.atlassian.net/browse/ML-8142