### PR TITLE
[Model Monitoring] Block `.to_mock_server` on applications' serving functions

### DIFF
--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -622,4 +622,13 @@ def _create_model_monitoring_function_base(
         project=project,
         writer_application_name=mm_constants.MonitoringFunctionNames.WRITER,
     )
+
+    def block_to_mock_server(*args, **kwargs) -> typing.NoReturn:
+        raise NotImplementedError(
+            "Model monitoring serving functions do not support `.to_mock_server`. "
+            "You may call your model monitoring application object logic via the `.evaluate` method."
+        )
+
+    func_obj.to_mock_server = block_to_mock_server  # Until ML-7643 is implemented
+
     return func_obj

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2117,10 +2117,9 @@ class MlrunProject(ModelObj):
 
     def set_model_monitoring_function(
         self,
-        func: typing.Union[str, mlrun.runtimes.BaseRuntime, None] = None,
+        func: typing.Union[str, mlrun.runtimes.RemoteRuntime, None] = None,
         application_class: typing.Union[
-            str,
-            mm_app.ModelMonitoringApplicationBase,
+            str, mm_app.ModelMonitoringApplicationBase, None
         ] = None,
         name: Optional[str] = None,
         image: Optional[str] = None,
@@ -2130,7 +2129,7 @@ class MlrunProject(ModelObj):
         requirements: Optional[typing.Union[str, list[str]]] = None,
         requirements_file: str = "",
         **application_kwargs,
-    ) -> mlrun.runtimes.BaseRuntime:
+    ) -> mlrun.runtimes.RemoteRuntime:
         """
         Update or add a monitoring function to the project.
         Note: to deploy the function after linking it to the project,
@@ -2142,7 +2141,8 @@ class MlrunProject(ModelObj):
                 name="myApp", application_class="MyApp", image="mlrun/mlrun"
             )
 
-        :param func:                    Function object or spec/code url, None refers to current Notebook
+        :param func:                    Remote function object or spec/code URL. :code:`None` refers to the current
+                                        notebook.
         :param name:                    Name of the function (under the project), can be specified with a tag to support
                                         versions (e.g. myfunc:v1)
                                         Default: job
@@ -2158,6 +2158,7 @@ class MlrunProject(ModelObj):
         :param application_class:       Name or an Instance of a class that implements the monitoring application.
         :param application_kwargs:      Additional keyword arguments to be passed to the
                                         monitoring application's constructor.
+        :returns:                       The model monitoring remote function object.
         """
         (
             resolved_function_name,
@@ -2195,7 +2196,7 @@ class MlrunProject(ModelObj):
         requirements: Optional[typing.Union[str, list[str]]] = None,
         requirements_file: str = "",
         **application_kwargs,
-    ) -> mlrun.runtimes.BaseRuntime:
+    ) -> mlrun.runtimes.RemoteRuntime:
         """
         Create a monitoring function object without setting it to the project
 
@@ -2205,7 +2206,7 @@ class MlrunProject(ModelObj):
                 application_class_name="MyApp", image="mlrun/mlrun", name="myApp"
             )
 
-        :param func:                    Code url, None refers to current Notebook
+        :param func:                    The function's code URL. :code:`None` refers to the current notebook.
         :param name:                    Name of the function, can be specified with a tag to support
                                         versions (e.g. myfunc:v1)
                                         Default: job
@@ -2221,6 +2222,7 @@ class MlrunProject(ModelObj):
         :param application_class:       Name or an Instance of a class that implementing the monitoring application.
         :param application_kwargs:      Additional keyword arguments to be passed to the
                                         monitoring application's constructor.
+        :returns:                       The model monitoring remote function object.
         """
 
         _, function_object, _ = self._instantiate_model_monitoring_function(
@@ -2253,7 +2255,7 @@ class MlrunProject(ModelObj):
         requirements: typing.Union[str, list[str], None] = None,
         requirements_file: str = "",
         **application_kwargs,
-    ) -> tuple[str, mlrun.runtimes.BaseRuntime, dict]:
+    ) -> tuple[str, mlrun.runtimes.RemoteRuntime, dict]:
         import mlrun.model_monitoring.api
 
         kind = None

--- a/tests/model_monitoring/test_monitoring_api.py
+++ b/tests/model_monitoring/test_monitoring_api.py
@@ -14,7 +14,7 @@
 
 import datetime
 import pathlib
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import Mock, patch
 
 import pytest
@@ -202,7 +202,7 @@ def test_project_create_model_monitoring_alert_configs() -> None:
         },
     ],
 )
-def test_create_model_monitoring_function(function) -> None:
+def test_create_model_monitoring_function(function: dict[str, Any]) -> None:
     app = mlrun.model_monitoring.api._create_model_monitoring_function_base(
         project="", name="my-app", **function
     )
@@ -217,3 +217,6 @@ def test_create_model_monitoring_function(function) -> None:
 
     app_step = steps["DemoMonitoringApp"]
     assert app_step.class_args == {"param_1": 1, "param_2": 2}
+
+    with pytest.raises(NotImplementedError):
+        app.to_mock_server()


### PR DESCRIPTION
Implements [ML-8665](https://iguazio.atlassian.net/browse/ML-8665).

[ML-8665]: https://iguazio.atlassian.net/browse/ML-8665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ