### PR TITLE
[CI] Fix dependabot go services location [part 2]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
   # go modules
   - package-ecosystem: gomod
     directories:
-      - "server/go/services/log-collector/go.mod"
+      - "server/go/services/**/*"
     schedule:
       interval: daily
     commit-message:


### PR DESCRIPTION
instead of using direct `go.mod` file, just recursively find all go mod under go services