### PR TITLE
[CI] Fix failing system test

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -260,9 +260,14 @@ class TestMLRunSystem:
 
         kubeconfig_content = None
         try:
-            base64_kubeconfig_content = os.environ["MLRUN_SYSTEM_TEST_KUBECONFIG"]
-            kubeconfig_content = base64.b64decode(base64_kubeconfig_content)
-        except (ValueError, KeyError) as exc:
+            if kubeconfig_path := os.environ.get("MLRUN_SYSTEM_TEST_KUBECONFIG_PATH"):
+                with open(kubeconfig_path, "rb") as file:
+                    kubeconfig_content = file.read()
+            elif base64_kubeconfig_content := os.environ.get(
+                "MLRUN_SYSTEM_TEST_KUBECONFIG"
+            ):
+                kubeconfig_content = base64.b64decode(base64_kubeconfig_content)
+        except ValueError as exc:
             logger.warning(
                 "Kubeconfig was empty or invalid.",
                 exc_info=mlrun.errors.err_to_str(exc),

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -44,7 +44,7 @@ class TestDask(TestMLRunSystem):
             filename=str(self.assets_path / "dask_function.py"),
         ).apply(mount_v3io())
 
-        self.dask_function.spec.image = "mlrun/ml-base"
+        self.dask_function.spec.image = "mlrun/mlrun"
         self.dask_function.spec.remote = True
         self.dask_function.spec.replicas = 1
         self.dask_function.spec.service_type = "NodePort"
@@ -159,7 +159,7 @@ class TestDask(TestMLRunSystem):
         # wait for the dask cluster to completely shut down
         mlrun.utils.retry_until_successful(
             5,
-            60,
+            5 * 60,
             self._logger,
             True,
             self._wait_for_dask_cluster_to_shutdown,
@@ -183,6 +183,10 @@ class TestDask(TestMLRunSystem):
         resources = runtime_resources[0].resources
         # Waiting for workers to be removed and scheduler status to completed
         if len(resources.pod_resources) > 1:
+            self._logger.info(
+                "Waiting for cluster to shut down",
+                pod_resources=resources.pod_resources,
+            )
             raise mlrun.errors.MLRunRuntimeError("Cluster did not completely clean up")
 
         for pod in resources.pod_resources:


### PR DESCRIPTION
1. project secret verification was wrong
2. dask need more timeout for shutting down its cluster on cloud envs

in addition, added the ability to read kubeconfig from path