### PR TITLE
[Notifications] Fix push terminal run notifications - unmasked runs

### DIFF
--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -757,7 +757,7 @@ class Service(framework.service.Service):
         unmasked_runs = []
         for run in runs:
             try:
-                framework.utils.notifications.unmask_notification_params_secret_on_task(
+                run = framework.utils.notifications.unmask_notification_params_secret_on_task(
                     db, db_session, run
                 )
                 unmasked_runs.append(run)


### PR DESCRIPTION
Fixing bug introduced [here](https://github.com/mlrun/mlrun/commit/f6545026f874a819bd270551800fda0e68ab6f25#diff-7430a66849887136c5802c51c164ed481387f22bd56d24fa2e242f585de76d89R762-R765) - we should add the returned value of `unmask_notification_params_secret_on_task` to the `unmasked_runs`.