### PR TITLE
[Artifacts] Minimal status format

### DIFF
--- a/mlrun/common/formatters/artifact.py
+++ b/mlrun/common/formatters/artifact.py
@@ -32,7 +32,7 @@ class ArtifactFormat(ObjectFormat, mlrun.common.types.StrEnum):
                 [
                     "kind",
                     "metadata",
-                    "status",
+                    "status.state",
                     "project",
                     "spec.producer",
                     "spec.db_key",


### PR DESCRIPTION
When listing artifacts with `format=minimal`, the returned artifact objects contain the full status field. For example, in the case of dataset artifacts, this includes a preview of the artifact.
Only the `status.state` field is relevant.

https://iguazio.atlassian.net/browse/ML-8759