### PR TITLE
[Notifications] Send running notification from BE

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -63,9 +63,6 @@ class RunDBInterface(ABC):
         self,
         uid,
         project="",
-        iter=0,
-        custom_message=None,
-        custom_html=None,
         timeout=45,
     ):
         pass

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -59,7 +59,15 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+    def push_run_notifications(
+        self,
+        uid,
+        project="",
+        iter=0,
+        custom_message=None,
+        custom_html=None,
+        timeout=45,
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -59,6 +59,10 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
+    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+        pass
+
+    @abstractmethod
     def read_run(
         self,
         uid: str,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -755,6 +755,28 @@ class HTTPRunDB(RunDBInterface):
             )
         return None
 
+    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+        """
+        Push notifications for a run.
+        :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
+        """
+        project = project or config.default_project
+        params = {"iter": iter}
+
+        response = self.api_call(
+            "POST",
+            path=f"projects/{project}/runs/{uid}/push_notifications",
+            error="Failed push notifications",
+            params=params,
+            timeout=timeout,
+        )
+        if response.status_code == http.HTTPStatus.ACCEPTED:
+            background_task = mlrun.common.schemas.BackgroundTask(**response.json())
+            return self._wait_for_background_task_to_reach_terminal_state(
+                background_task.metadata.name, project=project
+            )
+        return None
+
     def read_run(
         self,
         uid,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -759,27 +759,23 @@ class HTTPRunDB(RunDBInterface):
         self,
         uid,
         project="",
-        iter=0,
-        custom_message=None,
-        custom_html=None,
         timeout=45,
     ):
         """
         Push notifications for a run.
+
+        :param uid: Unique ID of the run.
+        :param project: Project that the run belongs to.
+        :param custom_message: Custom message to send in the notification.
+        :param custom_html: Custom HTML to send in the notification.
         :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
         """
         project = project or config.default_project
-        params = {
-            "iter": iter,
-            "custom_html": custom_html,
-            "custom_message": custom_message,
-        }
 
         response = self.api_call(
             "POST",
             path=f"projects/{project}/runs/{uid}/push_notifications",
             error="Failed push notifications",
-            params=params,
             timeout=timeout,
         )
         if response.status_code == http.HTTPStatus.ACCEPTED:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -755,13 +755,25 @@ class HTTPRunDB(RunDBInterface):
             )
         return None
 
-    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+    def push_run_notifications(
+        self,
+        uid,
+        project="",
+        iter=0,
+        custom_message=None,
+        custom_html=None,
+        timeout=45,
+    ):
         """
         Push notifications for a run.
         :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
         """
         project = project or config.default_project
-        params = {"iter": iter}
+        params = {
+            "iter": iter,
+            "custom_html": custom_html,
+            "custom_message": custom_message,
+        }
 
         response = self.api_call(
             "POST",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -766,8 +766,6 @@ class HTTPRunDB(RunDBInterface):
 
         :param uid: Unique ID of the run.
         :param project: Project that the run belongs to.
-        :param custom_message: Custom message to send in the notification.
-        :param custom_html: Custom HTML to send in the notification.
         :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
         """
         project = project or config.default_project

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -75,7 +75,15 @@ class NopDB(RunDBInterface):
     def abort_run(self, uid, project="", iter=0, timeout=45, status_text=""):
         pass
 
-    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+    def push_run_notifications(
+        self,
+        uid,
+        project="",
+        iter=0,
+        custom_message=None,
+        custom_html=None,
+        timeout=45,
+    ):
         pass
 
     def list_runtime_resources(

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -75,6 +75,9 @@ class NopDB(RunDBInterface):
     def abort_run(self, uid, project="", iter=0, timeout=45, status_text=""):
         pass
 
+    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+        pass
+
     def list_runtime_resources(
         self,
         project: Optional[str] = None,

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -79,9 +79,6 @@ class NopDB(RunDBInterface):
         self,
         uid,
         project="",
-        iter=0,
-        custom_message=None,
-        custom_html=None,
         timeout=45,
     ):
         pass

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -471,7 +471,7 @@ class _PipelineRunner(abc.ABC):
         namespace=None,
         source=None,
         notifications: typing.Optional[list[mlrun.model.Notification]] = None,
-            context: typing.Optional[mlrun.execution.MLClientCtx] = None,
+        context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> _PipelineRunStatus:
         pass
 
@@ -724,7 +724,7 @@ class _LocalRunner(_PipelineRunner):
         namespace=None,
         source=None,
         notifications: typing.Optional[list[mlrun.model.Notification]] = None,
-            context: typing.Optional[mlrun.execution.MLClientCtx] = None,
+        context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> _PipelineRunStatus:
         pipeline_context.set(project, workflow_spec)
         workflow_handler = _PipelineRunner._get_handler(

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -471,6 +471,7 @@ class _PipelineRunner(abc.ABC):
         namespace=None,
         source=None,
         notifications: typing.Optional[list[mlrun.model.Notification]] = None,
+            context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> _PipelineRunStatus:
         pass
 
@@ -595,6 +596,7 @@ class _KFPRunner(_PipelineRunner):
         namespace=None,
         source=None,
         notifications: typing.Optional[list[mlrun.model.Notification]] = None,
+        context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> _PipelineRunStatus:
         pipeline_context.set(project, workflow_spec)
         workflow_handler = _PipelineRunner._get_handler(
@@ -647,7 +649,7 @@ class _KFPRunner(_PipelineRunner):
         project.notifiers.push_pipeline_start_message(
             project.metadata.name,
             project.get_param("commit_id", None),
-            run_id,
+            context.uid,
             True,
         )
         pipeline_context.clear()
@@ -722,6 +724,7 @@ class _LocalRunner(_PipelineRunner):
         namespace=None,
         source=None,
         notifications: typing.Optional[list[mlrun.model.Notification]] = None,
+            context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> _PipelineRunStatus:
         pipeline_context.set(project, workflow_spec)
         workflow_handler = _PipelineRunner._get_handler(
@@ -744,7 +747,7 @@ class _LocalRunner(_PipelineRunner):
         pipeline_context.workflow_artifact_path = artifact_path
 
         project.notifiers.push_pipeline_start_message(
-            project.metadata.name, pipeline_id=workflow_id
+            project.metadata.name, pipeline_id=context.uid
         )
         err = None
         try:
@@ -805,6 +808,7 @@ class _RemoteRunner(_PipelineRunner):
         namespace: typing.Optional[str] = None,
         source: typing.Optional[str] = None,
         notifications: typing.Optional[list[mlrun.model.Notification]] = None,
+        context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> typing.Optional[_PipelineRunStatus]:
         workflow_name = normalize_workflow_name(name=name, project_name=project.name)
         workflow_id = None
@@ -1127,6 +1131,7 @@ def load_and_run_workflow(
         engine=engine,
         local=local,
         notifications=start_notifications,
+        context=context,
     )
     context.log_result(key="workflow_id", value=run.run_id)
     context.log_result(key="engine", value=run._engine.engine, commit=True)

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -648,9 +648,7 @@ class _KFPRunner(_PipelineRunner):
                 )
         project.notifiers.push_pipeline_start_message(
             project.metadata.name,
-            project.get_param("commit_id", None),
             context.uid,
-            True,
         )
         pipeline_context.clear()
         return _PipelineRunStatus(run_id, cls, project=project, workflow=workflow_spec)
@@ -747,7 +745,7 @@ class _LocalRunner(_PipelineRunner):
         pipeline_context.workflow_artifact_path = artifact_path
 
         project.notifiers.push_pipeline_start_message(
-            project.metadata.name, pipeline_id=context.uid
+            project.metadata.name, pipeline_id=workflow_id
         )
         err = None
         try:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2585,6 +2585,24 @@ class MlrunProject(ModelObj):
         self._set_function(resolved_function_name, tag, function_object, func)
         return function_object
 
+    def push_run_notifications(
+        self,
+        uid,
+        timeout=45,
+    ):
+        """
+        Push notifications for a run.
+
+        :param uid: Unique ID of the run.
+        :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
+        """
+        db = mlrun.db.get_run_db(secrets=self._secrets)
+        return db.push_run_notifications(
+            project=self.name,
+            uid=uid,
+            timeout=timeout,
+        )
+
     def _instantiate_function(
         self,
         func: typing.Union[str, mlrun.runtimes.BaseRuntime] = None,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3238,6 +3238,7 @@ class MlrunProject(ModelObj):
         cleanup_ttl: Optional[int] = None,
         notifications: Optional[list[mlrun.model.Notification]] = None,
         workflow_runner_node_selector: typing.Optional[dict[str, str]] = None,
+        context: typing.Optional[mlrun.execution.MLClientCtx] = None,
     ) -> _PipelineRunStatus:
         """Run a workflow using kubeflow pipelines
 
@@ -3280,6 +3281,7 @@ class MlrunProject(ModelObj):
                           This allows you to control and specify where the workflow runner pod will be scheduled.
                           This setting is only relevant when the engine is set to 'remote' or for scheduled workflows,
                           and it will be ignored if the workflow is not run on a remote engine.
+        :param context:             mlrun context.
         :returns: ~py:class:`~mlrun.projects.pipelines._PipelineRunStatus` instance
         """
 
@@ -3366,6 +3368,7 @@ class MlrunProject(ModelObj):
             namespace=namespace,
             source=source,
             notifications=notifications,
+            context=context,
         )
         # run is None when scheduling
         if run and run.state == mlrun_pipelines.common.models.RunStatuses.failed:

--- a/mlrun/utils/notifications/notification/base.py
+++ b/mlrun/utils/notifications/notification/base.py
@@ -57,7 +57,7 @@ class NotificationBase:
             typing.Union[mlrun.common.schemas.NotificationSeverity, str]
         ] = mlrun.common.schemas.NotificationSeverity.INFO,
         runs: typing.Optional[typing.Union[mlrun.lists.RunList, list]] = None,
-        custom_html: typing.Optional[typing.Optional[str]] = None,
+        custom_html: typing.Optional[str] = None,
         alert: typing.Optional[mlrun.common.schemas.AlertConfig] = None,
         event_data: typing.Optional[mlrun.common.schemas.Event] = None,
     ):

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -97,6 +97,7 @@ class NotificationPusher(_NotificationPusherBase):
         "completed": "{resource} completed",
         "error": "{resource} failed",
         "aborted": "{resource} aborted",
+        "running": "{resource} started",
     }
 
     def __init__(
@@ -150,7 +151,11 @@ class NotificationPusher(_NotificationPusherBase):
         if self._should_notify(run, notification):
             self._load_notification(run, notification)
 
-    def push(self):
+    def push(
+        self,
+        custom_html: typing.Optional[str] = None,
+        custom_message: typing.Optional[str] = None,
+    ):
         """
         Asynchronously push notifications for all runs in the initialized runs list (if they should be pushed).
         When running from a sync environment, the notifications will be pushed asynchronously however the function will
@@ -167,6 +172,8 @@ class NotificationPusher(_NotificationPusherBase):
                         notification_data[0],
                         notification_data[1],
                         notification_data[2],
+                        custom_html,
+                        custom_message,
                     )
                 except Exception as exc:
                     logger.warning(
@@ -182,6 +189,8 @@ class NotificationPusher(_NotificationPusherBase):
                         notification_data[0],
                         notification_data[1],
                         notification_data[2],
+                        custom_html,
+                        custom_message,
                     )
                 )
 
@@ -285,6 +294,7 @@ class NotificationPusher(_NotificationPusherBase):
 
         message = (
             self.messages.get(run.state(), "").format(resource=resource)
+            + f" in project {run.metadata.project}"
             + custom_message
         )
 
@@ -299,10 +309,16 @@ class NotificationPusher(_NotificationPusherBase):
         notification: base.NotificationBase,
         run: mlrun.model.RunObject,
         notification_object: mlrun.model.Notification,
+        custom_html: typing.Optional[str] = None,
+        custom_message: typing.Optional[str] = None,
     ):
         message, severity, runs = self._prepare_notification_args(
             run, notification_object
         )
+
+        if custom_message:
+            message = custom_message
+
         logger.debug(
             "Pushing sync notification",
             notification=sanitize_notification(notification_object.to_dict()),
@@ -313,9 +329,10 @@ class NotificationPusher(_NotificationPusherBase):
             "project": run.metadata.project,
             "notification": notification_object,
             "status": mlrun.common.schemas.NotificationStatus.SENT,
+            "run_state": run.state(),
         }
         try:
-            notification.push(message, severity, runs)
+            notification.push(message, severity, runs, custom_html=custom_html)
             logger.debug(
                 "Notification sent successfully",
                 notification=sanitize_notification(notification_object.to_dict()),
@@ -347,10 +364,15 @@ class NotificationPusher(_NotificationPusherBase):
         notification: base.NotificationBase,
         run: mlrun.model.RunObject,
         notification_object: mlrun.model.Notification,
+        custom_html: typing.Optional[str] = None,
+        custom_message: typing.Optional[str] = None,
     ):
         message, severity, runs = self._prepare_notification_args(
             run, notification_object
         )
+        if custom_message:
+            message = custom_message
+
         logger.debug(
             "Pushing async notification",
             notification=sanitize_notification(notification_object.to_dict()),
@@ -360,10 +382,11 @@ class NotificationPusher(_NotificationPusherBase):
             "run_uid": run.metadata.uid,
             "project": run.metadata.project,
             "notification": notification_object,
+            "run_state": run.state(),
             "status": mlrun.common.schemas.NotificationStatus.SENT,
         }
         try:
-            await notification.push(message, severity, runs)
+            await notification.push(message, severity, runs, custom_html=custom_html)
             logger.debug(
                 "Notification sent successfully",
                 notification=sanitize_notification(notification_object.to_dict()),
@@ -397,10 +420,20 @@ class NotificationPusher(_NotificationPusherBase):
         run_uid: str,
         project: str,
         notification: mlrun.model.Notification,
+        run_state: runtimes_constants.RunStates,
         status: typing.Optional[str] = None,
         sent_time: typing.Optional[datetime.datetime] = None,
         reason: typing.Optional[str] = None,
     ):
+        if run_state not in runtimes_constants.RunStates.terminal_states():
+            # we want to update the notification status only if the run is in a terminal state for BC
+            logger.debug(
+                "Skip updating notification status - run not in terminal state",
+                run_uid=run_uid,
+                state=run_state,
+            )
+            return
+
         db = mlrun.get_run_db()
         notification.status = status or notification.status
         notification.sent_time = sent_time or notification.sent_time
@@ -668,28 +701,29 @@ class CustomNotificationPusher(_NotificationPusherBase):
         pipeline_id: typing.Optional[str] = None,
         has_workflow_url: bool = False,
     ):
+        message = f"Workflow started in project {project}"
+        if pipeline_id:
+            message += f" id={pipeline_id}"
+        commit_id = (
+            commit_id or os.environ.get("GITHUB_SHA") or os.environ.get("CI_COMMIT_SHA")
+        )
+        if commit_id:
+            message += f", commit={commit_id}"
+        if has_workflow_url:
+            url = mlrun.utils.helpers.get_workflow_url(project, pipeline_id)
+        else:
+            url = mlrun.utils.helpers.get_ui_url(project)
+        html = ""
+        if url:
+            html = (
+                message
+                + f'<div><a href="{url}" target="_blank">click here to view progress</a></div>'
+            )
+            message = message + f", check progress in {url}"
         db = mlrun.get_run_db()
-        db.push_run_notifications(pipeline_id, project)
-        # message = f"Workflow started in project {project}"
-        # if pipeline_id:
-        #     message += f" id={pipeline_id}"
-        # commit_id = (
-        #     commit_id or os.environ.get("GITHUB_SHA") or os.environ.get("CI_COMMIT_SHA")
-        # )
-        # if commit_id:
-        #     message += f", commit={commit_id}"
-        # if has_workflow_url:
-        #     url = mlrun.utils.helpers.get_workflow_url(project, pipeline_id)
-        # else:
-        #     url = mlrun.utils.helpers.get_ui_url(project)
-        # html = ""
-        # if url:
-        #     html = (
-        #         message
-        #         + f'<div><a href="{url}" target="_blank">click here to view progress</a></div>'
-        #     )
-        #     message = message + f", check progress in {url}"
-        # self.push(message, "info", custom_html=html)
+        db.push_run_notifications(
+            pipeline_id, project, custom_message=message, custom_html=html
+        )
 
     def push_pipeline_run_results(
         self,

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -668,26 +668,28 @@ class CustomNotificationPusher(_NotificationPusherBase):
         pipeline_id: typing.Optional[str] = None,
         has_workflow_url: bool = False,
     ):
-        message = f"Workflow started in project {project}"
-        if pipeline_id:
-            message += f" id={pipeline_id}"
-        commit_id = (
-            commit_id or os.environ.get("GITHUB_SHA") or os.environ.get("CI_COMMIT_SHA")
-        )
-        if commit_id:
-            message += f", commit={commit_id}"
-        if has_workflow_url:
-            url = mlrun.utils.helpers.get_workflow_url(project, pipeline_id)
-        else:
-            url = mlrun.utils.helpers.get_ui_url(project)
-        html = ""
-        if url:
-            html = (
-                message
-                + f'<div><a href="{url}" target="_blank">click here to view progress</a></div>'
-            )
-            message = message + f", check progress in {url}"
-        self.push(message, "info", custom_html=html)
+        db = mlrun.get_run_db()
+        db.push_run_notifications(pipeline_id, project)
+        # message = f"Workflow started in project {project}"
+        # if pipeline_id:
+        #     message += f" id={pipeline_id}"
+        # commit_id = (
+        #     commit_id or os.environ.get("GITHUB_SHA") or os.environ.get("CI_COMMIT_SHA")
+        # )
+        # if commit_id:
+        #     message += f", commit={commit_id}"
+        # if has_workflow_url:
+        #     url = mlrun.utils.helpers.get_workflow_url(project, pipeline_id)
+        # else:
+        #     url = mlrun.utils.helpers.get_ui_url(project)
+        # html = ""
+        # if url:
+        #     html = (
+        #         message
+        #         + f'<div><a href="{url}" target="_blank">click here to view progress</a></div>'
+        #     )
+        #     message = message + f", check progress in {url}"
+        # self.push(message, "info", custom_html=html)
 
     def push_pipeline_run_results(
         self,

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import datetime
-import os
 import re
 import traceback
 import typing
@@ -151,11 +150,7 @@ class NotificationPusher(_NotificationPusherBase):
         if self._should_notify(run, notification):
             self._load_notification(run, notification)
 
-    def push(
-        self,
-        custom_html: typing.Optional[str] = None,
-        custom_message: typing.Optional[str] = None,
-    ):
+    def push(self):
         """
         Asynchronously push notifications for all runs in the initialized runs list (if they should be pushed).
         When running from a sync environment, the notifications will be pushed asynchronously however the function will
@@ -172,8 +167,6 @@ class NotificationPusher(_NotificationPusherBase):
                         notification_data[0],
                         notification_data[1],
                         notification_data[2],
-                        custom_html,
-                        custom_message,
                     )
                 except Exception as exc:
                     logger.warning(
@@ -189,8 +182,6 @@ class NotificationPusher(_NotificationPusherBase):
                         notification_data[0],
                         notification_data[1],
                         notification_data[2],
-                        custom_html,
-                        custom_message,
                     )
                 )
 
@@ -309,15 +300,10 @@ class NotificationPusher(_NotificationPusherBase):
         notification: base.NotificationBase,
         run: mlrun.model.RunObject,
         notification_object: mlrun.model.Notification,
-        custom_html: typing.Optional[str] = None,
-        custom_message: typing.Optional[str] = None,
     ):
         message, severity, runs = self._prepare_notification_args(
             run, notification_object
         )
-
-        if custom_message:
-            message = custom_message
 
         logger.debug(
             "Pushing sync notification",
@@ -332,7 +318,7 @@ class NotificationPusher(_NotificationPusherBase):
             "run_state": run.state(),
         }
         try:
-            notification.push(message, severity, runs, custom_html=custom_html)
+            notification.push(message, severity, runs)
             logger.debug(
                 "Notification sent successfully",
                 notification=sanitize_notification(notification_object.to_dict()),
@@ -364,14 +350,10 @@ class NotificationPusher(_NotificationPusherBase):
         notification: base.NotificationBase,
         run: mlrun.model.RunObject,
         notification_object: mlrun.model.Notification,
-        custom_html: typing.Optional[str] = None,
-        custom_message: typing.Optional[str] = None,
     ):
         message, severity, runs = self._prepare_notification_args(
             run, notification_object
         )
-        if custom_message:
-            message = custom_message
 
         logger.debug(
             "Pushing async notification",
@@ -386,7 +368,7 @@ class NotificationPusher(_NotificationPusherBase):
             "status": mlrun.common.schemas.NotificationStatus.SENT,
         }
         try:
-            await notification.push(message, severity, runs, custom_html=custom_html)
+            await notification.push(message, severity, runs)
             logger.debug(
                 "Notification sent successfully",
                 notification=sanitize_notification(notification_object.to_dict()),
@@ -697,33 +679,10 @@ class CustomNotificationPusher(_NotificationPusherBase):
     def push_pipeline_start_message(
         self,
         project: str,
-        commit_id: typing.Optional[str] = None,
         pipeline_id: typing.Optional[str] = None,
-        has_workflow_url: bool = False,
     ):
-        message = f"Workflow started in project {project}"
-        if pipeline_id:
-            message += f" id={pipeline_id}"
-        commit_id = (
-            commit_id or os.environ.get("GITHUB_SHA") or os.environ.get("CI_COMMIT_SHA")
-        )
-        if commit_id:
-            message += f", commit={commit_id}"
-        if has_workflow_url:
-            url = mlrun.utils.helpers.get_workflow_url(project, pipeline_id)
-        else:
-            url = mlrun.utils.helpers.get_ui_url(project)
-        html = ""
-        if url:
-            html = (
-                message
-                + f'<div><a href="{url}" target="_blank">click here to view progress</a></div>'
-            )
-            message = message + f", check progress in {url}"
         db = mlrun.get_run_db()
-        db.push_run_notifications(
-            pipeline_id, project, custom_message=message, custom_html=html
-        )
+        db.push_run_notifications(pipeline_id, project)
 
     def push_pipeline_run_results(
         self,

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -105,7 +105,15 @@ class SQLRunDB(RunDBInterface):
     def abort_run(self, uid, project="", iter=0, timeout=45, status_text=""):
         raise NotImplementedError()
 
-    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+    def push_run_notifications(
+        self,
+        uid,
+        project="",
+        iter=0,
+        custom_message=None,
+        custom_html=None,
+        timeout=45,
+    ):
         raise NotImplementedError()
 
     def read_run(

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -105,6 +105,9 @@ class SQLRunDB(RunDBInterface):
     def abort_run(self, uid, project="", iter=0, timeout=45, status_text=""):
         raise NotImplementedError()
 
+    def push_run_notifications(self, uid, project="", iter=0, timeout=45, status_text=""):
+        raise NotImplementedError()
+
     def read_run(
         self,
         uid: str,

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -109,9 +109,6 @@ class SQLRunDB(RunDBInterface):
         self,
         uid,
         project="",
-        iter=0,
-        custom_message=None,
-        custom_html=None,
         timeout=45,
     ):
         raise NotImplementedError()

--- a/server/py/services/api/api/endpoints/runs.py
+++ b/server/py/services/api/api/endpoints/runs.py
@@ -533,6 +533,8 @@ async def push_notifications(
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
     iter: int = 0,
+    custom_html: str = None,
+    custom_message: str = None,
 ):
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
@@ -564,11 +566,13 @@ async def push_notifications(
         ),
         db_session,
         run,
+        custom_html,
+        custom_message,
     )
     return background_task
 
 
-def _push_notifications(db_session, run):
+def _push_notifications(db_session, run, custom_html, custom_message):
     db = db_singleton.get_db()
     framework.utils.notifications.unmask_notification_params_secret_on_task(
         db, db_session, run
@@ -579,4 +583,4 @@ def _push_notifications(db_session, run):
     run_notification_pusher_class(
         [run],
         run_notification_pusher_class.resolve_notifications_default_params(),
-    ).push()
+    ).push(custom_html, custom_message)

--- a/server/py/services/api/api/endpoints/runs.py
+++ b/server/py/services/api/api/endpoints/runs.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import datetime
+import typing
 import uuid
 from http import HTTPStatus
 from typing import Optional
@@ -533,8 +534,8 @@ async def push_notifications(
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
     iter: int = 0,
-    custom_html: str = None,
-    custom_message: str = None,
+    custom_html: typing.Optional[str] = None,
+    custom_message: typing.Optional[str] = None,
 ):
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(

--- a/server/py/services/api/api/endpoints/runs.py
+++ b/server/py/services/api/api/endpoints/runs.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import datetime
-import typing
 import uuid
 from http import HTTPStatus
 from typing import Optional
@@ -533,9 +532,6 @@ async def push_notifications(
     background_tasks: BackgroundTasks,
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
-    iter: int = 0,
-    custom_html: typing.Optional[str] = None,
-    custom_message: typing.Optional[str] = None,
 ):
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
@@ -550,7 +546,7 @@ async def push_notifications(
         services.api.crud.Runs().get_run,
         db_session,
         uid,
-        iter,
+        0,
         project,
         mlrun.common.formatters.RunFormat.notifications,
     )
@@ -567,13 +563,11 @@ async def push_notifications(
         ),
         db_session,
         run,
-        custom_html,
-        custom_message,
     )
     return background_task
 
 
-def _push_notifications(db_session, run, custom_html, custom_message):
+def _push_notifications(db_session, run):
     db = db_singleton.get_db()
     framework.utils.notifications.unmask_notification_params_secret_on_task(
         db, db_session, run
@@ -584,4 +578,4 @@ def _push_notifications(db_session, run, custom_html, custom_message):
     run_notification_pusher_class(
         [run],
         run_notification_pusher_class.resolve_notifications_default_params(),
-    ).push(custom_html, custom_message)
+    ).push()

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -323,6 +323,14 @@ class RunDBMock:
     def read_run(self, uid, project, iter=0, format_=None):
         return self._runs.get(uid, {})
 
+    def push_run_notifications(
+            self,
+            uid,
+            project="",
+            timeout=45,
+    ):
+        pass
+
     def list_runs(
         self,
         name: Optional[str] = None,

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -324,10 +324,10 @@ class RunDBMock:
         return self._runs.get(uid, {})
 
     def push_run_notifications(
-            self,
-            uid,
-            project="",
-            timeout=45,
+        self,
+        uid,
+        project="",
+        timeout=45,
     ):
         pass
 


### PR DESCRIPTION
When pipeline start running, call the `push_notifications` endpoint so the notification will send from the BE.

https://iguazio.atlassian.net/browse/ML-8536
Example:

Running:
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/401ed536-9d95-49f7-b041-44dbfea49306" />

Error:
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/b141550c-ae44-4e57-af9e-fa647b8cdbf8" />

