### PR TITLE
[System id] Add system id initialization

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -825,6 +825,7 @@ default_config = {
             "refresh_interval": "30",
         }
     },
+    "system_id": "",
 }
 _is_running_as_api = None
 

--- a/server/py/framework/constants.py
+++ b/server/py/framework/constants.py
@@ -24,6 +24,7 @@ MINIMUM_CLIENT_VERSION_FOR_MM = (
 )
 
 internal_abort_task_id = "internal-abort"
+SYSTEM_ID_KEY = "system_id"
 
 
 class LogSources(Enum):

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7086,8 +7086,8 @@ class SQLDB(DBInterface):
             return None
         return system_id_record.value
 
-    def create_system_id(self, session: Session, system_id: str):
-        logger.debug("Creating a new system id in DB", system_id=system_id)
+    def store_system_id(self, session: Session, system_id: str):
+        logger.debug("Storing a new system id in DB", system_id=system_id)
 
         system_id_record = SystemMetadata(key="system_id", value=system_id)
         self._upsert(session, [system_id_record])

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -78,6 +78,7 @@ from mlrun.utils import (
     validate_tag_name,
 )
 
+import framework.constants
 import framework.db.session
 import framework.utils.helpers
 from framework.db.base import DBInterface
@@ -7078,18 +7079,17 @@ class SQLDB(DBInterface):
     def get_system_id(self, session: Session) -> typing.Optional[str]:
         system_id_record = (
             self._query(session, SystemMetadata)
-            .filter(SystemMetadata.key == "system_id")
+            .filter(SystemMetadata.key == framework.constants.SYSTEM_ID_KEY)
             .one_or_none()
         )
-        if not system_id_record:
-            logger.debug("System id not found in DB")
-            return None
-        return system_id_record.value
+        return system_id_record.value if system_id_record else None
 
     def store_system_id(self, session: Session, system_id: str):
         logger.debug("Storing a new system id in DB", system_id=system_id)
 
-        system_id_record = SystemMetadata(key="system_id", value=system_id)
+        system_id_record = SystemMetadata(
+            key=framework.constants.SYSTEM_ID_KEY, value=system_id
+        )
         self._upsert(session, [system_id_record])
 
     # ---- Utils ----

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -115,6 +115,7 @@ from framework.db.sqldb.models import (
     ProjectSummary,
     Run,
     Schedule,
+    SystemMetadata,
     TimeWindowTracker,
     _labeled,
     _tagged,
@@ -7073,6 +7074,23 @@ class SQLDB(DBInterface):
             main_table_identifier=ModelEndpoint.uid if uids else None,
             main_table_identifier_values=uids,
         )
+
+    def get_system_id(self, session: Session) -> typing.Optional[str]:
+        system_id_record = (
+            self._query(session, SystemMetadata)
+            .filter(SystemMetadata.key == "system_id")
+            .one_or_none()
+        )
+        if not system_id_record:
+            logger.debug("System id not found in DB")
+            return None
+        return system_id_record.value
+
+    def create_system_id(self, session: Session, system_id: str):
+        logger.debug("Creating a new system id in DB", system_id=system_id)
+
+        system_id_record = SystemMetadata(key="system_id", value=system_id)
+        self._upsert(session, [system_id_record])
 
     # ---- Utils ----
     def delete_table_records(

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -101,24 +101,20 @@ def init_data(
     logger.info("Creating initial data")
     config.httpdb.state = mlrun.common.schemas.APIStates.migrations_in_progress
 
-    if is_migration_from_scratch or is_migration_needed:
-        try:
-            _perform_schema_migrations(alembic_util)
-            init_db()
-            db_session = create_session()
-            try:
-                _add_initial_data(db_session)
-                _perform_data_migrations(db_session)
-            finally:
-                close_session(db_session)
-        except Exception:
-            state = mlrun.common.schemas.APIStates.migrations_failed
-            logger.warning("Migrations failed, changing API state", state=state)
-            config.httpdb.state = state
-            raise
-
     db_session = create_session()
     try:
+        if is_migration_from_scratch or is_migration_needed:
+            try:
+                _perform_schema_migrations(alembic_util)
+                init_db()
+                _add_initial_data(db_session)
+                _perform_data_migrations(db_session)
+            except Exception:
+                state = mlrun.common.schemas.APIStates.migrations_failed
+                logger.warning("Migrations failed, changing API state", state=state)
+                config.httpdb.state = state
+                raise
+
         # initialize system id
         _init_system_id(db_session)
     finally:
@@ -1003,9 +999,12 @@ def _create_project_summaries(db, db_session):
 
 
 def _init_system_id(db_session: sqlalchemy.orm.Session):
-    # Initializes a system id for MLRun deployment.
-    # The system id is first checked in the database. If it does not exist, the function checks for a configured id
-    # (from environment variables or config), and if neither is found, a new random one is generated and stored.
+    """
+    Initializes a system id for MLRun deployment.
+    The system id is first checked in the database. If it does not exist, the function checks for a configured id
+    (from environment variables or config), and if neither is found, a new random one is generated and stored.
+    """
+
     db = framework.db.sqldb.db.SQLDB()
 
     # check if a system id already exists in the database
@@ -1013,32 +1012,30 @@ def _init_system_id(db_session: sqlalchemy.orm.Session):
 
     if system_id is not None:
         logger.info("Existing system id found in the database", system_id=system_id)
-        return
+    else:
+        # check if the system id is already set in the config
+        system_id = _get_configured_system_id()
 
-    # check if the system id is configured via environment variables or configmap
-    system_id = _get_configured_system_id()
+        if system_id is not None:
+            logger.info("Using configured system id", system_id=system_id)
+            db.store_system_id(db_session, system_id)
+        else:
+            # if no system id is found, generate a new one
+            system_id = _generate_system_id()
+            db.store_system_id(db_session, system_id)
 
-    if system_id is not None:
-        logger.info("Using configured system id", system_id=system_id)
-        db.create_system_id(db_session, system_id)
-        return
-
-    # if no system id is found, generate a new one
-    system_id_str = _generate_system_id()
-    db.create_system_id(db_session, system_id_str)
+    # set the system id in mlrun config
+    mlrun.mlconf.system_id = system_id
 
 
 def _get_configured_system_id() -> typing.Optional[str]:
-    system_id = os.environ.get("SYSTEM_ID")
-    if system_id:
-        return system_id
     return mlrun.mlconf.system_id or None
 
 
 def _generate_system_id() -> str:
-    # Generate a random 32-bit unsigned integer and encode it as base64 string without padding
-    random_int = os.urandom(4)
-    base64_str = base64.b64encode(random_int).decode("utf-8").rstrip("=")
+    # Generate 4 random bytes and encode them as base64 string without padding
+    random_bytes = os.urandom(4)
+    base64_str = base64.b64encode(random_bytes).decode("utf-8").rstrip("=")
     return base64_str
 
 

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -17,6 +17,7 @@ import datetime
 import json
 import os
 import pathlib
+import random
 import typing
 
 import dateutil.parser
@@ -1001,8 +1002,8 @@ def _create_project_summaries(db, db_session):
 def _init_system_id(db_session: sqlalchemy.orm.Session):
     """
     Initializes a system id for MLRun deployment.
-    The system id is first checked in the database. If it does not exist, the function checks for a configured id
-    (from environment variables or config), and if neither is found, a new random one is generated and stored.
+    The system id is first checked in the database. If it does not exist, the function checks if an id was set in the
+    config, and if neither is found, a new random one is generated and stored.
     """
 
     db = framework.db.sqldb.db.SQLDB()
@@ -1011,21 +1012,25 @@ def _init_system_id(db_session: sqlalchemy.orm.Session):
     system_id = db.get_system_id(db_session)
 
     if system_id is not None:
-        logger.info("Existing system id found in the database", system_id=system_id)
-    else:
-        # check if the system id is already set in the config
-        system_id = _get_configured_system_id()
+        logger.debug("Existing system id found in the database", system_id=system_id)
+        mlrun.mlconf.system_id = system_id
+        return
 
-        if system_id is not None:
-            logger.info("Using configured system id", system_id=system_id)
-            db.store_system_id(db_session, system_id)
-        else:
-            # if no system id is found, generate a new one
-            system_id = _generate_system_id()
-            db.store_system_id(db_session, system_id)
+    logger.debug("System id not found in DB")
+    # check if the system id is already set in the config
+    system_id = _get_configured_system_id()
+
+    if system_id:
+        logger.debug("Using configured system id", system_id=system_id)
+    else:
+        # if no system id is found, generate a new one
+        system_id = _generate_system_id()
+    db.store_system_id(db_session, system_id)
 
     # set the system id in mlrun config
     mlrun.mlconf.system_id = system_id
+
+    logger.info("Initialized system ID", system_id=system_id)
 
 
 def _get_configured_system_id() -> typing.Optional[str]:
@@ -1033,8 +1038,9 @@ def _get_configured_system_id() -> typing.Optional[str]:
 
 
 def _generate_system_id() -> str:
-    # Generate 4 random bytes and encode them as base64 string without padding
-    random_bytes = os.urandom(4)
+    # Generate a random 32-bit unsigned integer, convert it to 4 bytes, and encode as a Base64 string without padding
+    random_number = random.getrandbits(32)
+    random_bytes = random_number.to_bytes(4, "big")
     base64_str = base64.b64encode(random_bytes).decode("utf-8").rstrip("=")
     return base64_str
 

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -117,9 +117,9 @@ def init_data(
             config.httpdb.state = state
             raise
 
-    # initialize system id
     db_session = create_session()
     try:
+        # initialize system id
         _init_system_id(db_session)
     finally:
         close_session(db_session)
@@ -1003,6 +1003,9 @@ def _create_project_summaries(db, db_session):
 
 
 def _init_system_id(db_session: sqlalchemy.orm.Session):
+    # Initializes a system id for MLRun deployment.
+    # The system id is first checked in the database. If it does not exist, the function checks for a configured id
+    # (from environment variables or config), and if neither is found, a new random one is generated and stored.
     db = framework.db.sqldb.db.SQLDB()
 
     # check if a system id already exists in the database

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -29,6 +29,7 @@ import mlrun.artifacts
 import mlrun.artifacts.base
 import mlrun.common.formatters
 import mlrun.common.schemas
+import mlrun.utils.regex
 from mlrun.artifacts.base import fill_artifact_object_hash
 from mlrun.config import config
 from mlrun.errors import MLRunPreconditionFailedError, err_to_str
@@ -1044,10 +1045,17 @@ def _generate_system_id() -> str:
         random_bytes = random_number.to_bytes(4, "big")
         base64_str = base64.urlsafe_b64encode(random_bytes).decode("utf-8").rstrip("=")
 
-        # ensure the string does not start with '-' or '_', as these characters are not allowed at the start of DNS
-        # names or Kubernetes resource names
-        if not base64_str.startswith(("-", "_")):
-            return base64_str
+        # convert to lowercase and remove underscores for compatibility with Kubernetes names
+        sanitized_str = base64_str.lower().replace("_", "-")
+
+        # validate the result against the qualified_name regex
+        try:
+            mlrun.utils.helpers.verify_field_regex(
+                "system_id", sanitized_str, mlrun.utils.regex.qualified_name
+            )
+            return sanitized_str
+        except mlrun.errors.MLRunInvalidArgumentError:
+            continue
 
 
 def main() -> None:

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -1038,11 +1038,16 @@ def _get_configured_system_id() -> typing.Optional[str]:
 
 
 def _generate_system_id() -> str:
-    # Generate a random 32-bit unsigned integer, convert it to 4 bytes, and encode as a Base64 string without padding
-    random_number = random.getrandbits(32)
-    random_bytes = random_number.to_bytes(4, "big")
-    base64_str = base64.b64encode(random_bytes).decode("utf-8").rstrip("=")
-    return base64_str
+    # Generate a random 32-bit unsigned integer and encode as a URL-safe Base64 string without padding
+    while True:
+        random_number = random.getrandbits(32)
+        random_bytes = random_number.to_bytes(4, "big")
+        base64_str = base64.urlsafe_b64encode(random_bytes).decode("utf-8").rstrip("=")
+
+        # ensure the string does not start with '-' or '_', as these characters are not allowed at the start of DNS
+        # names or Kubernetes resource names
+        if not base64_str.startswith(("-", "_")):
+            return base64_str
 
 
 def main() -> None:

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import base64
 import datetime
 import json
 import os
@@ -115,6 +116,14 @@ def init_data(
             logger.warning("Migrations failed, changing API state", state=state)
             config.httpdb.state = state
             raise
+
+    # initialize system id
+    db_session = create_session()
+    try:
+        _init_system_id(db_session)
+    finally:
+        close_session(db_session)
+
     # if the above process actually ran a migration - initializations that were skipped on the API initialization
     # should happen - we can't do it here because it requires an asyncio loop which can't be accessible here
     # therefore moving to migration_completed state, and other component will take care of moving to online
@@ -991,6 +1000,43 @@ def _create_project_summaries(db, db_session):
         for project_name in projects.projects
     ]
     db._upsert(db_session, project_summaries, ignore=True)
+
+
+def _init_system_id(db_session: sqlalchemy.orm.Session):
+    db = framework.db.sqldb.db.SQLDB()
+
+    # check if a system id already exists in the database
+    system_id = db.get_system_id(db_session)
+
+    if system_id is not None:
+        logger.info("Existing system id found in the database", system_id=system_id)
+        return
+
+    # check if the system id is configured via environment variables or configmap
+    system_id = _get_configured_system_id()
+
+    if system_id is not None:
+        logger.info("Using configured system id", system_id=system_id)
+        db.create_system_id(db_session, system_id)
+        return
+
+    # if no system id is found, generate a new one
+    system_id_str = _generate_system_id()
+    db.create_system_id(db_session, system_id_str)
+
+
+def _get_configured_system_id() -> typing.Optional[str]:
+    system_id = os.environ.get("SYSTEM_ID")
+    if system_id:
+        return system_id
+    return mlrun.mlconf.system_id or None
+
+
+def _generate_system_id() -> str:
+    # Generate a random 32-bit unsigned integer and encode it as base64 string without padding
+    random_int = os.urandom(4)
+    base64_str = base64.b64encode(random_int).decode("utf-8").rstrip("=")
+    return base64_str
 
 
 def main() -> None:

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -375,6 +375,48 @@ def test_add_producer_uri_to_artifact():
     _verify_artifact_producer_uri(db, db_session, "name-11", "")
 
 
+@pytest.mark.parametrize(
+    "system_id_source, expected_system_id",
+    [
+        # system id should be generated
+        ("random", None),
+        # simulated configmap system id
+        ("configmap", "111111"),
+        # simulated mlconf system id
+        ("mlconf", "222222"),
+    ],
+)
+def test_system_id(
+    system_id_source, expected_system_id, monkeypatch: pytest.MonkeyPatch
+):
+    if system_id_source == "configmap":
+        monkeypatch.setenv("SYSTEM_ID", "111111")
+    elif system_id_source == "mlconf":
+        mlrun.mlconf.system_id = "222222"
+
+    db, db_session = _initialize_db_without_migrations()
+
+    # start with no system id
+    system_id = db.get_system_id(db_session)
+    assert system_id is None
+
+    # initialize the system id
+    services.api.initial_data._init_system_id(db_session)
+    system_id = db.get_system_id(db_session)
+    assert system_id is not None
+
+    # ensure that the system id has the correct length (6 characters, as it is base64 encoded without padding)
+    assert len(system_id) == 6
+
+    if system_id_source != "random":
+        assert system_id == expected_system_id
+
+    # ensure reinitialization does not change an existing system id
+    services.api.initial_data._init_system_id(db_session)
+    system_id_after_second_init = db.get_system_id(db_session)
+    assert system_id_after_second_init == system_id
+
+
 def _initialize_db_without_migrations() -> (
     tuple[framework.db.sqldb.db.SQLDB, sqlalchemy.orm.Session]
 ):

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -381,18 +381,18 @@ def test_add_producer_uri_to_artifact():
         # system id should be generated
         ("random", None),
         # simulated configmap system id
-        ("configmap", "111111"),
+        ("configmap", "1111"),
         # simulated mlconf system id
-        ("mlconf", "222222"),
+        ("mlconf", "123"),
     ],
 )
-def test_system_id(
+def test_init_system_id(
     system_id_source, expected_system_id, monkeypatch: pytest.MonkeyPatch
 ):
     if system_id_source == "configmap":
-        monkeypatch.setenv("SYSTEM_ID", "111111")
+        monkeypatch.setenv("SYSTEM_ID", "1111")
     elif system_id_source == "mlconf":
-        mlrun.mlconf.system_id = "222222"
+        mlrun.mlconf.system_id = "123"
 
     db, db_session = _initialize_db_without_migrations()
 
@@ -405,10 +405,10 @@ def test_system_id(
     system_id = db.get_system_id(db_session)
     assert system_id is not None
 
-    # ensure that the system id has the correct length (6 characters, as it is base64 encoded without padding)
-    assert len(system_id) == 6
-
-    if system_id_source != "random":
+    if system_id_source == "random":
+        # ensure that the generated id has the correct length (6 characters, as it is base64 encoded without padding)
+        assert len(system_id) == 6
+    else:
         assert system_id == expected_system_id
 
     # ensure reinitialization does not change an existing system id

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -378,21 +378,17 @@ def test_add_producer_uri_to_artifact():
 @pytest.mark.parametrize(
     "system_id_source, expected_system_id",
     [
-        # system id should be generated
+        # when no system id is configured, a new random one should be generated
         ("random", None),
-        # simulated configmap system id
-        ("configmap", "1111"),
-        # simulated mlconf system id
+        # when a system id is set in mlconf, it should be used
         ("mlconf", "123"),
     ],
 )
 def test_init_system_id(
     system_id_source, expected_system_id, monkeypatch: pytest.MonkeyPatch
 ):
-    if system_id_source == "configmap":
-        monkeypatch.setenv("SYSTEM_ID", "1111")
-    elif system_id_source == "mlconf":
-        mlrun.mlconf.system_id = "123"
+    if system_id_source == "mlconf":
+        monkeypatch.setattr(mlrun.mlconf, "system_id", "123")
 
     db, db_session = _initialize_db_without_migrations()
 
@@ -410,6 +406,8 @@ def test_init_system_id(
         assert len(system_id) == 6
     else:
         assert system_id == expected_system_id
+
+    assert mlrun.mlconf.system_id == system_id
 
     # ensure reinitialization does not change an existing system id
     services.api.initial_data._init_system_id(db_session)

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -24,6 +24,7 @@ import mlrun.common.db.sql_session
 import mlrun.common.schemas
 from mlrun.config import config
 
+import framework.constants
 import framework.db.init_db
 import framework.db.sqldb.db
 import framework.db.sqldb.models
@@ -388,7 +389,9 @@ def test_init_system_id(
     system_id_source, expected_system_id, monkeypatch: pytest.MonkeyPatch
 ):
     if system_id_source == "mlconf":
-        monkeypatch.setattr(mlrun.mlconf, "system_id", "123")
+        monkeypatch.setattr(
+            mlrun.mlconf, framework.constants.SYSTEM_ID_KEY, expected_system_id
+        )
 
     db, db_session = _initialize_db_without_migrations()
 


### PR DESCRIPTION
This PR introduces the initialization and management of a unique system ID in the database.

Added logic to initialize and persist a unique 6-character base64-encoded system ID, following this order during initialization:

- Database value 
- Configuration
- Newly generated ID

Example of the database state after initializing the system id in a fresh deployment:

![image](https://github.com/user-attachments/assets/e7c4a3a4-5476-4d94-b9aa-7ac3b321df01)


Jira :
https://iguazio.atlassian.net/browse/ML-8716