### PR TITLE
[Alert activation] Fix notification saving logic

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -894,6 +894,14 @@ class RunDBInterface(ABC):
     ):
         pass
 
+    def update_alert_activation(
+        self,
+        activation_id: int,
+        activation_time: datetime.datetime,
+        notifications_states,
+    ):
+        pass
+
     @abstractmethod
     def get_builder_status(
         self,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -26,7 +26,7 @@ import sys
 import typing
 import uuid
 import warnings
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from importlib import import_module, reload
 from os import path
 from types import ModuleType
@@ -403,6 +403,28 @@ def get_pretty_types_names(types):
 
 def now_date(tz: timezone = timezone.utc) -> datetime:
     return datetime.now(tz=tz)
+
+
+def datetime_to_mysql_ts(datetime_object: datetime) -> datetime:
+    """
+    Convert a Python datetime object to a MySQL-compatible timestamp string,
+    rounded to the nearest millisecond.
+    Example: 2024-12-18T16:36:05.235687+00:00 -> 2024-12-18T16:36:05.236000
+
+    :param datetime_object: A Python datetime object.
+
+    :return: A MySQL-compatible timestamp string with millisecond precision.
+    """
+    if not datetime_object.tzinfo:
+        datetime_object = datetime_object.replace(tzinfo=timezone.utc)
+
+    # Round to the nearest millisecond
+    ms = round(datetime_object.microsecond / 1000) * 1000
+    if ms == 1000000:
+        datetime_object += timedelta(seconds=1)
+        ms = 0
+
+    return datetime_object.replace(microsecond=ms)
 
 
 def datetime_min(tz: timezone = timezone.utc) -> datetime:

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -984,7 +984,6 @@ class DBInterface(ABC):
         session,
         alert_data: mlrun.common.schemas.AlertConfig,
         event_data: mlrun.common.schemas.Event,
-        notifications_states: list[mlrun.common.schemas.NotificationState],
     ):
         pass
 
@@ -994,7 +993,11 @@ class DBInterface(ABC):
         session,
         activation_id: int,
         activation_time: datetime.datetime,
-        number_of_events: Optional[int],
+        number_of_events: Optional[int] = None,
+        notifications_states: Optional[
+            list[mlrun.common.schemas.NotificationState]
+        ] = None,
+        update_reset_time: bool = False,
     ):
         pass
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6140,8 +6140,8 @@ class SQLDB(DBInterface):
 
         # we need to keep id to be able to update number_of_events for manual reset policy
         # and to update notification state when notification is sent
-        # activation time is retrieved to get the cut activation_time from db
-        # because 2024-12-18T16:06:09.083606+00:00 will be saved as 2024-12-18T16:06:09.084000+00:00
+        # NOTE: activation time is truncated to milliseconds when being saved to the database as we use mysql.DATETIME
+        # example: 2024-12-18T16:06:09.083606+00:00 will be saved as 2024-12-18T16:06:09.084000+00:00
         return self._upsert_object_and_flush_to_get_field(
             session, alert_activation_record, "id"
         )

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -43,6 +43,7 @@ from sqlalchemy import (
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Session, aliased
+from sqlalchemy.orm.attributes import flag_modified
 
 import mlrun
 import mlrun.common.constants as mlrun_constants
@@ -6107,13 +6108,9 @@ class SQLDB(DBInterface):
         session,
         alert_data: mlrun.common.schemas.AlertConfig,
         event_data: mlrun.common.schemas.Event,
-        notifications_states: list[mlrun.common.schemas.NotificationState],
-    ) -> Optional[str]:
+    ) -> int:
         extra_data = {
-            "notifications": [
-                notification.dict() for notification in notifications_states
-            ],
-            "criteria": alert_data.criteria.dict() if alert_data.criteria else None,
+            "criteria": alert_data.criteria.dict(),
         }
 
         # For JOB entities, construct entity_id as "name.uid" format
@@ -6136,17 +6133,18 @@ class SQLDB(DBInterface):
             data=extra_data,
         )
 
-        # if reset_policy is MANUAL, we need to keep id to be able to update number_of_events
-        # when the alert is reset
-        if alert_data.reset_policy == mlrun.common.schemas.alert.ResetPolicy.MANUAL:
-            return self._upsert_object_and_flush_to_get_field(
-                session, alert_activation_record, "id"
-            )
-        else:
-            # for auto reset policy reset_time is the same as the activation time
-            # for manual reset policy, we keep it empty until the alert is reset
+        # for auto reset policy reset_time is the same as the activation time
+        # for manual reset policy, we keep it empty until the alert is reset
+        if alert_data.reset_policy == mlrun.common.schemas.alert.ResetPolicy.AUTO:
             alert_activation_record.reset_time = alert_activation_record.activation_time
-            self._upsert(session, [alert_activation_record])
+
+        # we need to keep id to be able to update number_of_events for manual reset policy
+        # and to update notification state when notification is sent
+        # activation time is retrieved to get the cut activation_time from db
+        # because 2024-12-18T16:06:09.083606+00:00 will be saved as 2024-12-18T16:06:09.084000+00:00
+        return self._upsert_object_and_flush_to_get_field(
+            session, alert_activation_record, "id"
+        )
 
     def update_alert_activation(
         self,
@@ -6154,18 +6152,37 @@ class SQLDB(DBInterface):
         activation_id: int,
         activation_time: datetime,
         number_of_events: Optional[int] = None,
+        notifications_states: Optional[
+            list[mlrun.common.schemas.NotificationState]
+        ] = None,
+        update_reset_time: bool = False,
     ):
         query = self._query(
             session, AlertActivation, id=activation_id, activation_time=activation_time
         )
         activation = query.one_or_none()
         if not activation:
-            raise mlrun.errors.MLRunNotFoundError(
-                f"Alert activation not found for id: {activation_id}"
-            )
+            # if the activation is not found, we try to find it again by id only
+            # (in case if something happened with activation time)
+            # usually it won't really happen, but just stay in safe side
+            query = self._query(session, AlertActivation, id=activation_id)
+            activation = query.one_or_none()
+            if not activation:
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Alert activation not found for id: {activation_id}"
+                )
         if number_of_events:
             activation.number_of_events = number_of_events
-        activation.reset_time = mlrun.utils.now_date()
+        if update_reset_time:
+            activation.reset_time = mlrun.utils.now_date()
+        if notifications_states:
+            data = activation.data or {}
+            data["notifications"] = [
+                notification.dict() for notification in notifications_states
+            ]
+            activation.data = data
+            # is needed for proper update of JSON field
+            flag_modified(activation, "data")
         self._upsert(session, [activation])
 
     def list_alert_activations(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6163,7 +6163,7 @@ class SQLDB(DBInterface):
         activation = query.one_or_none()
         if not activation:
             # if the activation is not found, we try to find it again by id only
-            # (in case if something happened with activation time)
+            # (in case something happened with activation time)
             # usually it won't really happen, but just stay in safe side
             query = self._query(session, AlertActivation, id=activation_id)
             activation = query.one_or_none()

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -28,6 +28,7 @@ from mlrun.common.db.sql_session import create_session
 from mlrun.db import RunDBInterface
 
 import framework.db.session
+import services.alerts.crud
 import services.api.crud
 from framework.db.base import DBError
 from framework.db.sqldb.db import SQLDB
@@ -1303,6 +1304,22 @@ class SQLRunDB(RunDBInterface):
         event_kind: Optional[str] = None,
     ):
         raise NotImplementedError
+
+    def update_alert_activation(
+        self,
+        activation_id: int,
+        activation_time: datetime.datetime,
+        notifications_states,
+    ):
+        # We run this function with a new session because it may run concurrently.
+        # Older sessions will not be able to see the changes made by this function until they are committed.
+        return self._transform_db_error(
+            framework.db.session.run_function_with_new_db_session,
+            services.alerts.crud.AlertActivation().update_alert_activation,
+            activation_id=activation_id,
+            activation_time=activation_time,
+            notifications_states=notifications_states,
+        )
 
     def paginated_list_alert_activations(
         self,

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -166,6 +166,8 @@ class AlertNotificationPusher(_NotificationPusherBase):
                         error=mlrun.errors.err_to_str(result),
                     )
             if activation_id and activation_time:
+                # after notifications are sent, update the alert activation state
+                # because only then the alert object had all the necessary data
                 try:
                     self._update_alert_activation_notification_state(
                         activation_id=activation_id,

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import collections
 import datetime
 import typing
 
@@ -113,6 +114,8 @@ class AlertNotificationPusher(_NotificationPusherBase):
         self,
         alert: mlrun.common.schemas.AlertConfig,
         event_data: mlrun.common.schemas.Event,
+        activation_id: typing.Optional[int] = None,
+        activation_time: typing.Optional[datetime.datetime] = None,
     ):
         """
         Asynchronously push notification.
@@ -162,8 +165,36 @@ class AlertNotificationPusher(_NotificationPusherBase):
                         "Failed to push notification async",
                         error=mlrun.errors.err_to_str(result),
                     )
+            if activation_id and activation_time:
+                try:
+                    self._update_alert_activation_notification_state(
+                        activation_id=activation_id,
+                        activation_time=activation_time,
+                        alert=alert,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to update alert activation state", error=str(e)
+                    )
 
         self._push(sync_push, async_push)
+
+    def _update_alert_activation_notification_state(
+        self,
+        activation_id: int,
+        activation_time: datetime.datetime,
+        alert: mlrun.common.schemas.AlertConfig,
+    ):
+        normalized_activation_time = mlrun.utils.helpers.datetime_to_mysql_ts(
+            activation_time
+        )
+        notification_states = self._prepare_notification_states(alert.notifications)
+        db = mlrun.get_run_db()
+        db.update_alert_activation(
+            activation_id=activation_id,
+            activation_time=normalized_activation_time,
+            notifications_states=notification_states,
+        )
 
     async def _push_notification_async(
         self,
@@ -225,6 +256,74 @@ class AlertNotificationPusher(_NotificationPusherBase):
 
         severity = alert.severity
         return message, severity
+
+    @staticmethod
+    def _prepare_notification_states(
+        notifications: list[mlrun.common.schemas.AlertNotification],
+    ) -> list[mlrun.common.schemas.NotificationState]:
+        """
+        Processes a list of alert notifications to construct a list of NotificationState objects.
+
+        Each NotificationState represents a unique type of notification (e.g., "slack", "email") and its status.
+        For each notification type, this method aggregates error messages if any notifications of that type have failed.
+        The resulting NotificationState has:
+        - An empty 'err' if all notifications of that type succeeded.
+        - An 'err' with all unique errors if all notifications of that type failed.
+        - An 'err' with unique errors if some, but not all, notifications of that type failed.
+        """
+
+        notification_errors = collections.defaultdict(
+            lambda: {
+                "errors": set(),
+                "success_count": 0,
+                "failed_count": 0,
+            },
+        )
+
+        # process each notification and gather errors by type
+        for alert_notification in notifications:
+            kind = alert_notification.notification.kind
+            reason = alert_notification.notification.reason
+
+            # count successes, failures and collect unique errors for failures
+            if reason:
+                notification_errors[kind]["errors"].add(reason)
+                notification_errors[kind]["failed_count"] += 1
+            else:
+                notification_errors[kind]["success_count"] += 1
+
+        # construct NotificationState objects based on the aggregated error data
+        notification_states = []
+        for kind, status_info in notification_errors.items():
+            errors = list(status_info["errors"])
+            success_count = status_info.get("success_count", 0)
+            failed_count = status_info.get("failed_count", 0)
+
+            if errors:
+                if success_count == 0:
+                    error_message = (
+                        f"All {kind} notifications failed. Errors: {', '.join(errors)}"
+                    )
+                else:
+                    error_message = (
+                        f"Some {kind} notifications failed. Errors: {', '.join(errors)}"
+                    )
+            else:
+                # indicates success if there are no errors
+                error_message = ""
+
+            notification_states.append(
+                mlrun.common.schemas.NotificationState(
+                    kind=kind,
+                    err=error_message,
+                    summary=mlrun.common.schemas.NotificationSummary(
+                        failed=failed_count,
+                        succeeded=success_count,
+                    ),
+                )
+            )
+
+        return notification_states
 
     @staticmethod
     def _update_notification_status(

--- a/server/py/services/alerts/crud/alert_activation.py
+++ b/server/py/services/alerts/crud/alert_activation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import collections
 import datetime
 from typing import Optional, Union
 
@@ -88,71 +87,3 @@ class AlertActivation(
             offset=offset,
             limit=limit,
         )
-
-    @staticmethod
-    def _prepare_notification_states(
-        notifications: list[mlrun.common.schemas.AlertNotification],
-    ) -> list[mlrun.common.schemas.NotificationState]:
-        """
-        Processes a list of alert notifications to construct a list of NotificationState objects.
-
-        Each NotificationState represents a unique type of notification (e.g., "slack", "email") and its status.
-        For each notification type, this method aggregates error messages if any notifications of that type have failed.
-        The resulting NotificationState has:
-        - An empty 'err' if all notifications of that type succeeded.
-        - An 'err' with all unique errors if all notifications of that type failed.
-        - An 'err' with unique errors if some, but not all, notifications of that type failed.
-        """
-
-        notification_errors = collections.defaultdict(
-            lambda: {
-                "errors": set(),
-                "success_count": 0,
-                "failed_count": 0,
-            },
-        )
-
-        # process each notification and gather errors by type
-        for alert_notification in notifications:
-            kind = alert_notification.notification.kind
-            reason = alert_notification.notification.reason
-
-            # count successes, failures and collect unique errors for failures
-            if reason:
-                notification_errors[kind]["errors"].add(reason)
-                notification_errors[kind]["failed_count"] += 1
-            else:
-                notification_errors[kind]["success_count"] += 1
-
-        # construct NotificationState objects based on the aggregated error data
-        notification_states = []
-        for kind, status_info in notification_errors.items():
-            errors = list(status_info["errors"])
-            success_count = status_info.get("success_count", 0)
-            failed_count = status_info.get("failed_count", 0)
-
-            if errors:
-                if success_count == 0:
-                    error_message = (
-                        f"All {kind} notifications failed. Errors: {', '.join(errors)}"
-                    )
-                else:
-                    error_message = (
-                        f"Some {kind} notifications failed. Errors: {', '.join(errors)}"
-                    )
-            else:
-                # indicates success if there are no errors
-                error_message = ""
-
-            notification_states.append(
-                mlrun.common.schemas.NotificationState(
-                    kind=kind,
-                    err=error_message,
-                    summary=mlrun.common.schemas.NotificationSummary(
-                        failed=failed_count,
-                        succeeded=success_count,
-                    ),
-                )
-            )
-
-        return notification_states

--- a/server/py/services/alerts/crud/alert_activation.py
+++ b/server/py/services/alerts/crud/alert_activation.py
@@ -32,12 +32,61 @@ class AlertActivation(
         session: sqlalchemy.orm.Session,
         alert_data: mlrun.common.schemas.AlertConfig,
         event_data: mlrun.common.schemas.Event,
-    ) -> Optional[str]:
-        notifications_states = self._prepare_notification_states(
-            alert_data.notifications
-        )
+    ) -> int:
         return framework.utils.singletons.db.get_db().store_alert_activation(
-            session, alert_data, event_data, notifications_states
+            session, alert_data, event_data
+        )
+
+    def update_alert_activation(
+        self,
+        session,
+        activation_id: int,
+        activation_time: datetime.datetime,
+        number_of_events: Optional[int] = None,
+        notifications_states: Optional[
+            list[mlrun.common.schemas.NotificationState]
+        ] = None,
+        update_reset_time: bool = False,
+    ):
+        framework.utils.singletons.db.get_db().update_alert_activation(
+            session=session,
+            activation_id=activation_id,
+            activation_time=activation_time,
+            number_of_events=number_of_events,
+            notifications_states=notifications_states,
+            update_reset_time=update_reset_time,
+        )
+
+    def list_alert_activations(
+        self,
+        session: sqlalchemy.orm.Session,
+        projects_with_creation_time: list[tuple[str, datetime.datetime]],
+        name: Optional[str] = None,
+        since: Optional[datetime.datetime] = None,
+        until: Optional[datetime.datetime] = None,
+        entity: Optional[str] = None,
+        severity: Optional[
+            list[Union[mlrun.common.schemas.alert.AlertSeverity, str]]
+        ] = None,
+        entity_kind: Optional[
+            Union[mlrun.common.schemas.alert.EventEntityKind, str]
+        ] = None,
+        event_kind: Optional[Union[mlrun.common.schemas.alert.EventKind, str]] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> list[mlrun.common.schemas.AlertActivation]:
+        return framework.utils.singletons.db.get_db().list_alert_activations(
+            session=session,
+            projects_with_creation_time=projects_with_creation_time,
+            name=name,
+            since=since,
+            until=until,
+            entity=entity,
+            severity=severity,
+            entity_kind=entity_kind,
+            event_kind=event_kind,
+            offset=offset,
+            limit=limit,
         )
 
     @staticmethod
@@ -107,35 +156,3 @@ class AlertActivation(
             )
 
         return notification_states
-
-    def list_alert_activations(
-        self,
-        session: sqlalchemy.orm.Session,
-        projects_with_creation_time: list[tuple[str, datetime.datetime]],
-        name: Optional[str] = None,
-        since: Optional[datetime.datetime] = None,
-        until: Optional[datetime.datetime] = None,
-        entity: Optional[str] = None,
-        severity: Optional[
-            list[Union[mlrun.common.schemas.alert.AlertSeverity, str]]
-        ] = None,
-        entity_kind: Optional[
-            Union[mlrun.common.schemas.alert.EventEntityKind, str]
-        ] = None,
-        event_kind: Optional[Union[mlrun.common.schemas.alert.EventKind, str]] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-    ) -> list[mlrun.common.schemas.AlertActivation]:
-        return framework.utils.singletons.db.get_db().list_alert_activations(
-            session=session,
-            projects_with_creation_time=projects_with_creation_time,
-            name=name,
-            since=since,
-            until=until,
-            entity=entity,
-            severity=severity,
-            entity_kind=entity_kind,
-            event_kind=event_kind,
-            offset=offset,
-            limit=limit,
-        )

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -253,24 +253,25 @@ class Alerts(
         keep_cache = True
         active = False
         state["count"] += 1
-        logger.debug("Sending notifications for alert", name=alert.name)
-        AlertNotificationPusher().push(alert, event_data)
 
         if alert.reset_policy == "auto":
             self.reset_alert(session, alert.project, alert.name)
-            services.alerts.crud.AlertActivation().store_alert_activation(
-                session, alert, event_data
-            )
             keep_cache = False
-        else:
+        activation_id = services.alerts.crud.AlertActivation().store_alert_activation(
+            session, alert, event_data
+        )
+
+        if alert.reset_policy == "manual":
             active = True
             state["active"] = True
-            activation_id = (
-                services.alerts.crud.AlertActivation().store_alert_activation(
-                    session, alert, event_data
-                )
-            )
             state_obj["last_activation_id"] = activation_id
+
+        AlertNotificationPusher().push(
+            alert,
+            event_data,
+            activation_id=activation_id,
+            activation_time=event_data.timestamp,
+        )
 
         framework.utils.singletons.db.get_db().store_alert_state(
             session,
@@ -460,6 +461,7 @@ class Alerts(
                 number_of_events=number_of_events
                 if number_of_events > alert.criteria.count
                 else None,
+                update_reset_time=True,
             )
         else:
             logger.warning(

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -266,6 +266,7 @@ class Alerts(
             state["active"] = True
             state_obj["last_activation_id"] = activation_id
 
+        logger.debug("Sending notifications for alert", name=alert.name)
         AlertNotificationPusher().push(
             alert,
             event_data,

--- a/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
@@ -21,7 +21,7 @@ from mlrun.common.schemas import (
     NotificationSummary,
 )
 
-import services.api.crud
+import framework.utils.notifications.notification_pusher
 
 
 @pytest.mark.parametrize(
@@ -125,7 +125,7 @@ import services.api.crud
     ],
 )
 def test_prepare_notifications_states(notifications, expected_states):
-    result = services.alerts.crud.AlertActivation._prepare_notification_states(
+    result = framework.utils.notifications.notification_pusher.AlertNotificationPusher._prepare_notification_states(
         notifications
     )
 

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -627,7 +627,11 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
         )
         for i in range(1, 4):
             self._post_event(project_name, event_name, alert_entity)
+            # we ensure that activation already has its notification state updated right after the event was posted
             activations = project.list_alert_activations(name=alert_name)
+
+            # if fails, it means that the notification state was not updated fast enough and adding sleep is needed
+            # or some performance optimisation required (for sending notifications)
             assert (
                 activations[0].notifications[0].err
                 == "All webhook notifications failed. Errors: incorrect-url"

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import time
 from datetime import timezone
 
 import pytest

--- a/tests/integration/sdk_api/alerts/test_alerts.py
+++ b/tests/integration/sdk_api/alerts/test_alerts.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import time
 from datetime import timezone
 
 import pytest
@@ -594,6 +595,46 @@ class TestAlerts(tests.integration.sdk_api.base.TestMLRunIntegration):
             alert_reset_policy=alert_reset_policy,
             alert_criteria=alert_criteria,
         )
+
+    def test_alert_activation_notification_state(self):
+        project_name = "my-new-project"
+        project = mlrun.new_project(project_name)
+
+        alert_name = "alert1"
+        alert_entity = alert_objects.EventEntityKind.JOB
+        event_name = alert_objects.EventKind.FAILED
+
+        failure_webhook_notification = mlrun.common.schemas.Notification(
+            name="webhook1",
+            kind="webhook",
+            params={"url": "incorrect-url"},
+            when=["error"],
+            message="fail",
+            condition="",
+        )
+        self._create_alert(
+            project_name,
+            alert_name,
+            alert_entity,
+            project_name,
+            "Alert summary",
+            event_name,
+            reset_policy=mlrun.common.schemas.alert.ResetPolicy.AUTO,
+            notifications=[
+                mlrun.common.schemas.AlertNotification(
+                    notification=failure_webhook_notification
+                )
+            ],
+        )
+        for i in range(1, 4):
+            self._post_event(project_name, event_name, alert_entity)
+            activations = project.list_alert_activations(name=alert_name)
+            assert (
+                activations[0].notifications[0].err
+                == "All webhook notifications failed. Errors: incorrect-url"
+            )
+            assert activations[0].notifications[0].summary.failed == 1
+            assert activations[0].notifications[0].summary.succeeded == 0
 
     def _create_alerts_test(self, project_name, alert1, alert2):
         invalid_notification = [


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8683

Fixes the undefined behaviour bug which was caused by race condition where in one thread we were sending a notification and updating `alert` object with notification state and in another thread, using the information about notification from alert, we were saving the alert activation. New logic will not save notification when storing notification. Instead, notification state will be populated by notification pusher when notifications are sent. 