### PR TITLE
[Application] Populate resources only on sidecar container

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1039,9 +1039,7 @@ class RemoteRuntime(KubeResource):
         # put the configured resources on the sidecar container instead of the reverse proxy container
         if self.spec.resources:
             sidecar["resources"] = self.spec.resources
-            self.spec.resources = self.spec.enrich_resources_with_default_pod_resources(
-                "resources", None
-            )
+            self.spec.resources = None
 
     def _set_sidecar(self, name: str) -> dict:
         self.spec.config.setdefault("spec.sidecars", [])

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1036,9 +1036,12 @@ class RemoteRuntime(KubeResource):
         if args and sidecar.get("command"):
             sidecar["args"] = mlrun.utils.helpers.as_list(args)
 
-        # populate the sidecar resources from the function spec
+        # put the configured resources on the sidecar container instead of the reverse proxy container
         if self.spec.resources:
             sidecar["resources"] = self.spec.resources
+            self.spec.resources = self.spec.enrich_resources_with_default_pod_resources(
+                "resources", None
+            )
 
     def _set_sidecar(self, name: str) -> dict:
         self.spec.config.setdefault("spec.sidecars", [])

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -522,9 +522,7 @@ class KubeResourceSpec(FunctionSpec):
         self._verify_and_set_requests("resources", mem, cpu, patch)
 
     def enrich_resources_with_default_pod_resources(
-        self,
-        resources_field_name: str,
-        resources: typing.Optional[dict] = None,
+        self, resources_field_name: str, resources: dict
     ):
         resources_types = ["cpu", "memory"]
         resource_requirements = ["requests", "limits"]

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -522,7 +522,9 @@ class KubeResourceSpec(FunctionSpec):
         self._verify_and_set_requests("resources", mem, cpu, patch)
 
     def enrich_resources_with_default_pod_resources(
-        self, resources_field_name: str, resources: dict
+        self,
+        resources_field_name: str,
+        resources: typing.Optional[dict] = None,
     ):
         resources_types = ["cpu", "memory"]
         resource_requirements = ["requests", "limits"]

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -319,6 +319,12 @@ def test_application_runtime_resources(rundb_mock, igz_version_mock):
         }
     ]
 
+    # assert the resources for the function itself remain the defaults
+    assert fn.spec.resources == {
+        "limits": {"cpu": "2", "memory": "20Gi"},
+        "requests": {"cpu": "25m", "memory": "1Mi"},
+    }
+
 
 def test_deploy_reverse_proxy_image(rundb_mock, igz_version_mock):
     mlrun.runtimes.ApplicationRuntime.deploy_reverse_proxy_image()
@@ -371,6 +377,10 @@ def _assert_application_post_deploy_spec(fn, image):
                     "protocol": "TCP",
                 }
             ],
+            "resources": {
+                "limits": {"cpu": "2", "memory": "20Gi"},
+                "requests": {"cpu": "25m", "memory": "1Mi"},
+            },
         }
     ]
     assert fn.get_env("SIDECAR_PORT") == "8050"

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -320,10 +320,7 @@ def test_application_runtime_resources(rundb_mock, igz_version_mock):
     ]
 
     # assert the resources for the function itself remain the defaults
-    assert fn.spec.resources == {
-        "limits": {"cpu": "2", "memory": "20Gi"},
-        "requests": {"cpu": "25m", "memory": "1Mi"},
-    }
+    assert fn.spec.resources == {}
 
 
 def test_deploy_reverse_proxy_image(rundb_mock, igz_version_mock):
@@ -377,10 +374,6 @@ def _assert_application_post_deploy_spec(fn, image):
                     "protocol": "TCP",
                 }
             ],
-            "resources": {
-                "limits": {"cpu": "2", "memory": "20Gi"},
-                "requests": {"cpu": "25m", "memory": "1Mi"},
-            },
         }
     ]
     assert fn.get_env("SIDECAR_PORT") == "8050"


### PR DESCRIPTION
When setting resources and limits on an application runtime, they are populated on both the reverse proxy container and the application sidecar container.
The problem is that Kubernetes considers the requests and limits of the pod as the SUM for all containers (see [example form k8s docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-1)).
Thus, the pods can be stuck on insufficient resources, although there are sufficient resources for the application sidecar container to run.

In this PR, when setting custom resources on the application runtime object they are configured only on the sidecar container, as the reverse proxy nuclio function container doesn't actually require these resources.

https://iguazio.atlassian.net/browse/ML-8796