### PR TITLE
[Nuclio] Fix function annotations not passed to Nuclio

### DIFF
--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -47,6 +47,7 @@ def test_compiled_function_config_nuclio_python():
     fn = mlrun.code_to_function(
         "nuclio", filename=name, kind="nuclio", handler="my_hand"
     )
+    fn.metadata.annotations = {"something": "somewhat"}
     (
         name,
         project,
@@ -60,6 +61,7 @@ def test_compiled_function_config_nuclio_python():
     assert (
         mlrun.utils.get_in(config, "spec.handler") == "training-nuclio:my_hand"
     ), "wrong handler"
+    assert mlrun.utils.get_in(config, "metadata.annotations.something") == "somewhat"
 
 
 def test_compiled_function_config_sidecar_image_enrichment():


### PR DESCRIPTION
Function metadata annotations were ignored when compiling the function config to send to nuclio.
This PR aligns the annotations enrichment with label enrichment.

Additionally - move serving spec configmap creation to a method for better readability on the `_compile_function_config` method. Logic remains the same.

https://iguazio.atlassian.net/browse/ML-8810