### PR TITLE
[GitHub Actions] Do not run the update uv lock files on forks

### DIFF
--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -23,6 +23,7 @@ jobs:
   upgrade:
     name: Upgrade uv lock files
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'mlrun'
     steps:
     - uses: actions/checkout@v4
     - name: Get uv version from the Makefile


### PR DESCRIPTION
For reference, see:
* https://github.com/orgs/community/discussions/26704#discussioncomment-3252979
* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context