### PR TITLE
[Notifications] Rename push notifications endpoint

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -773,7 +773,7 @@ class HTTPRunDB(RunDBInterface):
 
         response = self.api_call(
             "POST",
-            path=f"projects/{project}/runs/{uid}/push_notifications",
+            path=f"projects/{project}/runs/{uid}/push-notifications",
             error="Failed push notifications",
             timeout=timeout,
         )

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -647,7 +647,7 @@ class _KFPRunner(_PipelineRunner):
                     exc_info=err_to_str(exc),
                 )
 
-        # TODO: we should check how can we get the run uid when we don't the the context (for example on
+        # TODO: we should check how can we get the run uid when we don't have the context (for example on
         #  mlrun.load_project() and later call directly to project.run)
         if context:
             project.notifiers.push_pipeline_start_message(

--- a/server/py/services/api/api/endpoints/runs.py
+++ b/server/py/services/api/api/endpoints/runs.py
@@ -523,7 +523,7 @@ async def abort_run(
 
 
 @router.post(
-    "/projects/{project}/runs/{uid}/push_notifications",
+    "/projects/{project}/runs/{uid}/push-notifications",
     response_model=mlrun.common.schemas.BackgroundTask,
 )
 async def push_notifications(

--- a/server/py/services/api/tests/unit/api/test_runs.py
+++ b/server/py/services/api/tests/unit/api/test_runs.py
@@ -265,7 +265,7 @@ def test_push_notifications(db: Session, client: TestClient) -> None:
     run_uid = "run-uid-notifications"
     services.api.crud.Runs().store_run(db, run, run_uid, project=project)
     response = client.post(
-        f"projects/{project}/runs/{run_uid}/push_notifications",
+        f"projects/{project}/runs/{run_uid}/push-notifications",
     )
 
     assert response.status_code == HTTPStatus.OK.value


### PR DESCRIPTION
Changing `push_notifications` to be `push-notifications` (conventions). 