### PR TITLE
[Alerts] Fix the alert state created field timestamp

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6189,8 +6189,7 @@ class SQLDB(DBInterface):
             return state.to_dict()
 
     def create_alert_state(self, session, alert_record):
-        current_time = datetime.now(timezone.utc)
-        state = AlertState(count=0, parent_id=alert_record.id, created=current_time)
+        state = AlertState(count=0, parent_id=alert_record.id)
         self._upsert(session, [state])
 
     def delete_alert_notifications(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6189,7 +6189,8 @@ class SQLDB(DBInterface):
             return state.to_dict()
 
     def create_alert_state(self, session, alert_record):
-        state = AlertState(count=0, parent_id=alert_record.id)
+        current_time = datetime.now(timezone.utc)
+        state = AlertState(count=0, parent_id=alert_record.id, created=current_time)
         self._upsert(session, [state])
 
     def delete_alert_notifications(

--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -762,7 +762,7 @@ with warnings.catch_warnings():
         count = Column(Integer)
         created = Column(
             SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
-            default=datetime.now(timezone.utc),
+            default=datetime.utcnow,
         )
         last_updated = Column(
             SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921

--- a/server/py/services/alerts/tests/unit/db/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/db/test_alerts.py
@@ -33,7 +33,7 @@ class TestAlerts(TestDatabaseBase):
         alert_summary = "testing 1 2 3"
         event_kind = alert_objects.EventKind.DATA_DRIFT_DETECTED
 
-        new_alert = services.alerts.tests.unit.crud.utils.generate_alert_data(
+        alert1 = services.alerts.tests.unit.crud.utils.generate_alert_data(
             project=project,
             name=alert_name,
             entity=alert_entity,
@@ -41,10 +41,27 @@ class TestAlerts(TestDatabaseBase):
             event_kind=event_kind,
         )
 
-        self._db.store_alert(self._db_session, new_alert)
+        self._db.store_alert(self._db_session, alert1)
         alerts = self._db.list_alerts(self._db_session, project)
         assert len(alerts) == 1
 
         assert alerts[0].created.replace(tzinfo=timezone.utc) < datetime.now(
             tz=timezone.utc
         )
+
+        alert2_name = "test_alert2"
+        alert2 = services.alerts.tests.unit.crud.utils.generate_alert_data(
+            project=project,
+            name=alert2_name,
+            entity=alert_entity,
+            summary=alert_summary,
+            event_kind=event_kind,
+        )
+
+        self._db.store_alert(self._db_session, alert2)
+        alerts = self._db.list_alerts(self._db_session, project)
+        assert len(alerts) == 2
+        alert1_created_time = alerts[0].created
+        alert2_created_time = alerts[1].created
+
+        assert alert1_created_time < alert2_created_time


### PR DESCRIPTION
This PR addresses a bug where the created timestamp for new alert states was incorrectly set to the timestamp of the first alert state created in the database. 
The issue occurred because the default value for the created field in the AlertState SQLAlchemy model was being evaluated only once when the class was first loaded, rather than for each new instance causing the value to be the same for each newly added record.

Jira:
https://iguazio.atlassian.net/browse/ML-8378