### PR TITLE
[Object Counters] Introduce Feature Gates For The Various Object Counters [1.7.x]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -127,7 +127,6 @@ default_config = {
                     "models": "enabled",
                     "runs": "enabled",
                     "pipelines": "enabled",
-                    "functions": "enabled",
                 },
             },
         },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -127,7 +127,7 @@ default_config = {
                     "models": "enabled",
                     "runs": "enabled",
                     "pipelines": "enabled",
-                }
+                },
             },
         },
     },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -127,6 +127,7 @@ default_config = {
                     "models": "enabled",
                     "runs": "enabled",
                     "pipelines": "enabled",
+                    "functions": "enabled",
                 },
             },
         },

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -120,6 +120,14 @@ default_config = {
         "projects": {
             "summaries": {
                 "cache_interval": "30",
+                "feature_gates": {
+                    "artifacts": "enabled",
+                    "schedules": "enabled",
+                    "feature_sets": "enabled",
+                    "models": "enabled",
+                    "runs": "enabled",
+                    "pipelines": "enabled",
+                }
             },
         },
     },

--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -451,7 +451,10 @@ class Projects(
         dict[str, typing.Union[int, None]],
         dict[str, typing.Union[int, None]],
     ):
-        if mlrun.mlconf.monitoring.projects.summaries.pipelines != "enabled":
+        if (
+            mlrun.mlconf.monitoring.projects.summaries.feature_gates.pipelines
+            != "enabled"
+        ):
             return (
                 collections.defaultdict(lambda: 0),
                 collections.defaultdict(lambda: 0),

--- a/server/api/crud/projects.py
+++ b/server/api/crud/projects.py
@@ -451,6 +451,13 @@ class Projects(
         dict[str, typing.Union[int, None]],
         dict[str, typing.Union[int, None]],
     ):
+        if mlrun.mlconf.monitoring.projects.summaries.pipelines != "enabled":
+            return (
+                collections.defaultdict(lambda: 0),
+                collections.defaultdict(lambda: 0),
+                collections.defaultdict(lambda: 0),
+            )
+
         # creating defaultdict instead of a regular dict, because it possible that not all projects have pipelines
         # and we want to return 0 for those projects, or None if we failed to get the information
         project_to_running_pipelines_count = collections.defaultdict(lambda: 0)

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2923,21 +2923,6 @@ class SQLDB(DBInterface):
         )
 
     @staticmethod
-    def _calculate_functions_counters(session) -> dict[str, int]:
-        if mlrun.mlconf.monitoring.projects.summaries.functions != "enabled":
-            return collections.defaultdict(lambda: 0)
-
-        functions_count_per_project = (
-            session.query(Function.project, func.count(distinct(Function.name)))
-            .group_by(Function.project)
-            .all()
-        )
-        project_to_function_count = {
-            result[0]: result[1] for result in functions_count_per_project
-        }
-        return project_to_function_count
-
-    @staticmethod
     def _calculate_schedules_counters(
         session,
     ) -> [dict[str, int], dict[str, int], dict[str, int]]:

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2938,7 +2938,6 @@ class SQLDB(DBInterface):
     def _calculate_schedules_counters(
         session,
     ) -> [dict[str, int], dict[str, int], dict[str, int]]:
-
         if mlrun.mlconf.monitoring.projects.summaries.schedules != "enabled":
             return [
                 collections.defaultdict(lambda: 0),
@@ -3031,7 +3030,6 @@ class SQLDB(DBInterface):
         return project_to_models_count
 
     def _calculate_files_counters(self, session) -> dict[str, int]:
-
         if mlrun.mlconf.monitoring.projects.summaries.artifacts != "enabled":
             return collections.defaultdict(lambda: 0)
 

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2926,7 +2926,10 @@ class SQLDB(DBInterface):
     def _calculate_schedules_counters(
         session,
     ) -> [dict[str, int], dict[str, int], dict[str, int]]:
-        if mlrun.mlconf.monitoring.projects.summaries.schedules != "enabled":
+        if (
+            mlrun.mlconf.monitoring.projects.summaries.feature_gates.schedules
+            != "enabled"
+        ):
             return [
                 collections.defaultdict(lambda: 0),
                 collections.defaultdict(lambda: 0),
@@ -2987,7 +2990,10 @@ class SQLDB(DBInterface):
 
     @staticmethod
     def _calculate_feature_sets_counters(session) -> dict[str, int]:
-        if mlrun.mlconf.monitoring.projects.summaries.feature_sets != "enabled":
+        if (
+            mlrun.mlconf.monitoring.projects.summaries.feature_gates.feature_sets
+            != "enabled"
+        ):
             return collections.defaultdict(lambda: 0)
 
         feature_sets_count_per_project = (
@@ -3001,7 +3007,7 @@ class SQLDB(DBInterface):
         return project_to_feature_set_count
 
     def _calculate_models_counters(self, session) -> dict[str, int]:
-        if mlrun.mlconf.monitoring.projects.summaries.models != "enabled":
+        if mlrun.mlconf.monitoring.projects.summaries.feature_gates.models != "enabled":
             return collections.defaultdict(lambda: 0)
 
         # We're using the "most_recent" which gives us only one version of each artifact key, which is what we want to
@@ -3018,7 +3024,10 @@ class SQLDB(DBInterface):
         return project_to_models_count
 
     def _calculate_files_counters(self, session) -> dict[str, int]:
-        if mlrun.mlconf.monitoring.projects.summaries.artifacts != "enabled":
+        if (
+            mlrun.mlconf.monitoring.projects.summaries.feature_gates.artifacts
+            != "enabled"
+        ):
             return collections.defaultdict(lambda: 0)
 
         # We're using the "most_recent" flag which gives us only one version of each artifact key, which is what we
@@ -3042,7 +3051,7 @@ class SQLDB(DBInterface):
         dict[str, int],
         dict[str, int],
     ]:
-        if mlrun.mlconf.monitoring.projects.summaries.runs != "enabled":
+        if mlrun.mlconf.monitoring.projects.summaries.feature_gates.runs != "enabled":
             return (
                 collections.defaultdict(lambda: 0),
                 collections.defaultdict(lambda: 0),

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2938,6 +2938,14 @@ class SQLDB(DBInterface):
     def _calculate_schedules_counters(
         session,
     ) -> [dict[str, int], dict[str, int], dict[str, int]]:
+
+        if mlrun.mlconf.monitoring.projects.summaries.schedules != "enabled":
+            return [
+                collections.defaultdict(lambda: 0),
+                collections.defaultdict(lambda: 0),
+                collections.defaultdict(lambda: 0),
+            ]
+
         schedules_count_per_project = (
             session.query(Schedule.project, func.count(distinct(Schedule.name)))
             .group_by(Schedule.project)
@@ -2992,6 +3000,9 @@ class SQLDB(DBInterface):
 
     @staticmethod
     def _calculate_feature_sets_counters(session) -> dict[str, int]:
+        if mlrun.mlconf.monitoring.projects.summaries.feature_sets != "enabled":
+            return collections.defaultdict(lambda: 0)
+
         feature_sets_count_per_project = (
             session.query(FeatureSet.project, func.count(distinct(FeatureSet.name)))
             .group_by(FeatureSet.project)
@@ -3003,6 +3014,9 @@ class SQLDB(DBInterface):
         return project_to_feature_set_count
 
     def _calculate_models_counters(self, session) -> dict[str, int]:
+        if mlrun.mlconf.monitoring.projects.summaries.models != "enabled":
+            return collections.defaultdict(lambda: 0)
+
         # We're using the "most_recent" which gives us only one version of each artifact key, which is what we want to
         # count (artifact count, not artifact versions count)
         model_artifacts = self._find_artifacts(
@@ -3017,6 +3031,10 @@ class SQLDB(DBInterface):
         return project_to_models_count
 
     def _calculate_files_counters(self, session) -> dict[str, int]:
+
+        if mlrun.mlconf.monitoring.projects.summaries.artifacts != "enabled":
+            return collections.defaultdict(lambda: 0)
+
         # We're using the "most_recent" flag which gives us only one version of each artifact key, which is what we
         # want to count (artifact count, not artifact versions count)
         file_artifacts = self._find_artifacts(
@@ -3038,6 +3056,13 @@ class SQLDB(DBInterface):
         dict[str, int],
         dict[str, int],
     ]:
+        if mlrun.mlconf.monitoring.projects.summaries.runs != "enabled":
+            return (
+                collections.defaultdict(lambda: 0),
+                collections.defaultdict(lambda: 0),
+                collections.defaultdict(lambda: 0),
+            )
+
         running_runs_count_per_project = (
             session.query(Run.project, func.count(distinct(Run.name)))
             .filter(

--- a/server/api/db/sqldb/db.py
+++ b/server/api/db/sqldb/db.py
@@ -2924,6 +2924,9 @@ class SQLDB(DBInterface):
 
     @staticmethod
     def _calculate_functions_counters(session) -> dict[str, int]:
+        if mlrun.mlconf.monitoring.projects.summaries.functions != "enabled":
+            return collections.defaultdict(lambda: 0)
+
         functions_count_per_project = (
             session.query(Function.project, func.count(distinct(Function.name)))
             .group_by(Function.project)


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8556

Our current counter logic is naive and can cause unwanted database locks which prevent backups from completing. We are working on a more robust counter system, though for now we are introducing feature gates to disable the problematic counter queries on very heavy systems.

Remove `_calculate_functions_counters` as it is not used anywhere and is private and internal.