### PR TITLE
[Datastore] Fix reading datastore profiles

### DIFF
--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -29,7 +29,7 @@ from ..secrets import get_secret_or_env
 
 
 class DatastoreProfile(pydantic.v1.BaseModel):
-    type: typing.ClassVar[str]
+    type: str
     name: str
     _private_attributes: list = ()
 
@@ -220,7 +220,7 @@ class DatastoreProfileKafkaSource(DatastoreProfile):
 
 
 class DatastoreProfileV3io(DatastoreProfile):
-    type: typing.ClassVar[str] = "v3io"
+    type: str = pydantic.v1.Field("v3io")
     v3io_access_key: typing.Optional[str] = None
     _private_attributes = "v3io_access_key"
 

--- a/tests/datastore/test_datastore_profile.py
+++ b/tests/datastore/test_datastore_profile.py
@@ -11,11 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+from collections.abc import Iterator
+
 import pytest
 
+import mlrun.common.schemas
 import mlrun.errors
-from mlrun.datastore.datastore_profile import DatastoreProfileKafkaTarget
+from mlrun.datastore.datastore_profile import (
+    DatastoreProfile2Json,
+    DatastoreProfileKafkaTarget,
+    DatastoreProfileV3io,
+    datastore_profile_read,
+    register_temporary_client_datastore_profile,
+    remove_temporary_client_datastore_profile,
+)
 
 
 def test_kafka_target_datastore():
@@ -62,3 +72,29 @@ def test_kafka_target_datastore_brokers_and_bootstrap_servers():
             brokers="localhost:9092",
             bootstrap_servers="localhost:9092",
         )
+
+
+@pytest.fixture
+def v3io_profile_name() -> Iterator[str]:
+    profile_name = "temp-prof"
+    profile = DatastoreProfileV3io(name=profile_name)
+    register_temporary_client_datastore_profile(profile)
+    yield f"ds://{profile_name}"
+    remove_temporary_client_datastore_profile(profile_name)
+
+
+def test_temp_v3io_profile(v3io_profile_name: str) -> None:
+    profile = datastore_profile_read(v3io_profile_name)
+    assert profile.type == "v3io", "Wrong profile type"
+
+
+def test_from_public_json() -> None:
+    public_profile_schema = mlrun.common.schemas.DatastoreProfile(
+        name="mm-infra-tsdb",
+        type="v3io",
+        object='{"type":"djNpbw==","name":"bW0taW5mcmEtc3RyZWFt"}',
+        private=None,
+        project="proj-11",
+    )
+    profile = DatastoreProfile2Json.create_from_json(public_profile_schema.object)
+    assert isinstance(profile, DatastoreProfileV3io), "Not the right profile"


### PR DESCRIPTION
Revert annotating profile type as a class var introduced last minute in https://github.com/mlrun/mlrun/pull/6983/files#diff-bc8241f5e2a7f99f358724045e66a1a9945c73a31c5d01d9be4272dd786146e1.
Fixes [ML-8897](https://iguazio.atlassian.net/browse/ML-8897).

[ML-8897]: https://iguazio.atlassian.net/browse/ML-8897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ