### PR TITLE
[Artifacts ] Modify del_artifacts logic to reassign the "latest" tag when deleting multiple artifacts keys

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -169,6 +169,7 @@ default_config = {
             "max_chunk_size": 1024 * 1024 * 1,  # 1MB
             "max_preview_size": 1024 * 1024 * 10,  # 10MB
             "max_download_size": 1024 * 1024 * 100,  # 100MB
+            "max_deletions": 200,
         },
     },
     # FIXME: Adding these defaults here so we won't need to patch the "installing component" (provazio-controller) to

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -967,7 +967,7 @@ class SQLDB(DBInterface):
                 f"is {max_deletions}. Refine the filter and try again with a smaller batch."
             )
 
-        logger.info(f"Deleting {total_artifacts} artifacts")
+        logger.info("Deleting artifacts", total_artifacts=total_artifacts)
 
         failed_deletions_count = 0
 
@@ -996,7 +996,7 @@ class SQLDB(DBInterface):
             raise mlrun.errors.MLRunInternalServerError(
                 f"Failed to delete {failed_deletions_count} artifacts"
             )
-        logger.info(f"Successfully deleted {total_artifacts} artifacts")
+        logger.info("Successfully deleted artifacts", total_artifacts=total_artifacts)
 
     def list_artifact_tags(
         self, session, project, category: mlrun.common.schemas.ArtifactCategories = None

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -958,44 +958,41 @@ class SQLDB(DBInterface):
             producer_id=producer_id,
             with_entities=[ArtifactV2.key, ArtifactV2.uid],
         )
+        total_artifacts = len(distinct_keys_and_uids)
+        max_deletions = config.artifacts.limits.max_deletions
 
-        artifact_column_identifiers = {}
-        for key, uid in distinct_keys_and_uids:
-            artifact_column_identifier, column_value = self._delete_tagged_object(
-                session,
-                ArtifactV2,
-                project=project,
-                uid=uid,
-                key=key,
-                commit=False,
-                producer_id=producer_id,
+        if total_artifacts > max_deletions:
+            raise mlrun.errors.MLRunInternalServerError(
+                f"Cannot delete {total_artifacts} artifacts. The maximum allowed artifacts deletions "
+                f"is {max_deletions}. Refine the filter and try again with a smaller batch."
             )
-            if artifact_column_identifier is None:
-                # record was not found
+
+        logger.info(f"Deleting {total_artifacts} artifacts")
+
+        deleted_artifacts = 0
+
+        for key, uid in distinct_keys_and_uids:
+            try:
+                self._delete_tagged_object(
+                    session,
+                    ArtifactV2,
+                    project=project,
+                    uid=uid,
+                    key=key,
+                    producer_id=producer_id,
+                )
+                deleted_artifacts += 1
+            except Exception as exc:
+                logger.error(
+                    "Failed to delete artifact",
+                    project=project,
+                    key=key,
+                    uid=uid,
+                    error=str(exc),
+                )
                 continue
 
-            artifact_column_identifiers.setdefault(
-                artifact_column_identifier, []
-            ).append(column_value)
-
-        failed_deletions_count = 0
-        for (
-            artifact_column_identifier,
-            column_values,
-        ) in artifact_column_identifiers.items():
-            deletions_count = self._delete_multi_objects(
-                session=session,
-                main_table=ArtifactV2,
-                project=project,
-                main_table_identifier=getattr(ArtifactV2, artifact_column_identifier),
-                main_table_identifier_values=column_values,
-            )
-            failed_deletions_count += len(column_values) - deletions_count
-
-        if failed_deletions_count:
-            raise mlrun.errors.MLRunInternalServerError(
-                f"Failed to delete {failed_deletions_count} artifacts"
-            )
+        logger.info(f"Successfully deleted {deleted_artifacts} artifacts.")
 
     def list_artifact_tags(
         self, session, project, category: mlrun.common.schemas.ArtifactCategories = None
@@ -4793,7 +4790,6 @@ class SQLDB(DBInterface):
         uid=None,
         name=None,
         key=None,
-        commit=True,
         **kwargs,
     ):
         # TODO: Tag is now cascaded in the DB level so this should not be needed anymore
@@ -4842,19 +4838,12 @@ class SQLDB(DBInterface):
             # get the object id from the object record
             object_id = object_record.id
 
-            if cls == ArtifactV2 and commit:
-                # TODO: Handle the case when commit=False (e.g., deleting multiple artifact keys)
+            if cls == ArtifactV2:
                 self._update_artifact_latest_tag_on_deletion(session, object_record)
 
         if object_id:
-            if not commit:
-                return "id", object_id
             self._delete(session, cls, id=object_id)
         else:
-            if not commit:
-                if name:
-                    return "name", obj_name
-                return "key", obj_name
             # If we got here, neither tag nor uid were provided - delete all references by name.
             identifier = {"name": obj_name} if name else {"key": obj_name}
             self._delete(session, cls, project=project, **identifier)

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -969,7 +969,7 @@ class SQLDB(DBInterface):
 
         logger.info(f"Deleting {total_artifacts} artifacts")
 
-        deleted_artifacts = 0
+        failed_deletions_count = 0
 
         for key, uid in distinct_keys_and_uids:
             try:
@@ -981,18 +981,22 @@ class SQLDB(DBInterface):
                     key=key,
                     producer_id=producer_id,
                 )
-                deleted_artifacts += 1
             except Exception as exc:
                 logger.error(
                     "Failed to delete artifact",
                     project=project,
                     key=key,
                     uid=uid,
-                    error=str(exc),
+                    err=err_to_str(exc),
                 )
+                failed_deletions_count += 1
                 continue
 
-        logger.info(f"Successfully deleted {deleted_artifacts} artifacts.")
+        if failed_deletions_count:
+            raise mlrun.errors.MLRunInternalServerError(
+                f"Failed to delete {failed_deletions_count} artifacts"
+            )
+        logger.info(f"Successfully deleted {total_artifacts} artifacts")
 
     def list_artifact_tags(
         self, session, project, category: mlrun.common.schemas.ArtifactCategories = None

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -847,7 +847,9 @@ class TestArtifacts(TestDatabaseBase):
         )
         with (
             unittest.mock.patch.object(
-                self._db, "_delete_multi_objects", return_value=0
+                self._db,
+                "_delete",
+                side_effect=mlrun.errors.MLRunInternalServerError("some error"),
             ),
             pytest.raises(mlrun.errors.MLRunInternalServerError) as exc,
         ):
@@ -856,7 +858,9 @@ class TestArtifacts(TestDatabaseBase):
 
         with (
             unittest.mock.patch.object(
-                self._db, "_delete_multi_objects", return_value=1
+                self._db,
+                "_delete",
+                side_effect=[mlrun.errors.MLRunInternalServerError("some error"), None],
             ),
             pytest.raises(mlrun.errors.MLRunInternalServerError) as exc,
         ):

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -873,6 +873,42 @@ class TestArtifacts(TestDatabaseBase):
         artifacts = self._db.list_artifacts(self._db_session)
         assert len(artifacts) == 0
 
+    def test_delete_artifacts_exceeds_max_allowed_deletions(self):
+        project = "artifact_project"
+        artifact_key = "artifact_key"
+        artifact_body = self._generate_artifact(artifact_key)
+
+        # Store two artifacts with the same project and key
+        self._db.store_artifact(
+            self._db_session,
+            key=artifact_key,
+            project=project,
+            iter=0,
+            artifact=artifact_body,
+        )
+        self._db.store_artifact(
+            self._db_session,
+            key=artifact_key,
+            project=project,
+            iter=1,
+            artifact=artifact_body,
+        )
+        artifacts = self._db.list_artifacts(
+            self._db_session, project=project, name=artifact_key
+        )
+        assert len(artifacts) == 2
+
+        mlrun.mlconf.artifacts.limits.max_deletions = 1
+
+        with (
+            pytest.raises(mlrun.errors.MLRunInternalServerError) as exc,
+        ):
+            self._db.del_artifacts(self._db_session, project=project, name=artifact_key)
+        assert (
+            "Cannot delete 2 artifacts. The maximum allowed artifacts deletions"
+            in str(exc.value)
+        )
+
     def test_delete_artifacts_with_specific_iteration(self):
         project = "artifact_project"
         artifact_key = "artifact_key"


### PR DESCRIPTION
Change the process of deleting multiple artifacts to a simpler implementation that reassigns the "latest" tag when deleting multiple artifact keys. Limit the number of artifacts allowed for deletion in this manner (based on the number of artifacts returned by the query). If the user requests the deletion of more than 200 artifacts, fail the command and prompt them to use a more granular filter. This value is configurable via `mlrun.mlconf.artifacts.limits.max_deletions`

**The logic remains the same as before:** if the deletion of one artifact fails, the process continues with the next artifact, but now errors are logged. At the end, if not all artifacts are deleted, an error will be raised. This logic will probably need to be changed when enabling the deletion of artifact data for multiple artifact keys.

https://iguazio.atlassian.net/browse/ML-8821