### PR TITLE
[Model Monitoring] add name to the `_dict_fields` of the `RouterStep`

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -718,7 +718,7 @@ class RouterStep(TaskStep):
             class_name,
             class_args,
             handler,
-            name=get_name(name, class_name),
+            name=get_name(name, class_name or RouterStep.kind),
             function=function,
             input_path=input_path,
             result_path=result_path,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -700,7 +700,7 @@ class RouterStep(TaskStep):
 
     kind = "router"
     default_shape = "doubleoctagon"
-    _dict_fields = _task_step_fields + ["routes"]
+    _dict_fields = _task_step_fields + ["routes", "name"]
     _default_class = "mlrun.serving.ModelRouter"
 
     def __init__(

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1739,6 +1739,7 @@ def params_to_step(
         step.full_event = full_event or step.full_event
         step.input_path = input_path or step.input_path
         step.result_path = result_path or step.result_path
+        step.name = name
         if kind == StepKinds.task:
             step.model_endpoint_creation_strategy = model_endpoint_creation_strategy
             step.endpoint_type = endpoint_type

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1707,7 +1707,7 @@ def get_name(name, class_name):
         raise MLRunInvalidArgumentError("name or class_name must be provided")
     if isinstance(class_name, type):
         return class_name.__name__
-    return class_name
+    return class_name.split(".")[-1]
 
 
 def params_to_step(
@@ -1739,7 +1739,6 @@ def params_to_step(
         step.full_event = full_event or step.full_event
         step.input_path = input_path or step.input_path
         step.result_path = result_path or step.result_path
-        step.name = name
         if kind == StepKinds.task:
             step.model_endpoint_creation_strategy = model_endpoint_creation_strategy
             step.endpoint_type = endpoint_type

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -718,7 +718,7 @@ class RouterStep(TaskStep):
             class_name,
             class_args,
             handler,
-            name=name,
+            name=get_name(name, class_name),
             function=function,
             input_path=input_path,
             result_path=result_path,

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -96,7 +96,7 @@ class V2ModelServer(StepToDict):
         self.name = name
         self.version = ""
         if name and ":" in name:
-            self.name, self.version = name.split(":", 1)
+            self.version = name.split(":", 1)[-1]
         self.context = context
         self.ready = False
         self.error = ""

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -277,7 +277,7 @@ class V2ModelServer(StepToDict):
 
             response = {
                 "id": event_id,
-                "model_name": self.name,
+                "model_name": self.name.split(":")[0],
                 "outputs": outputs,
                 "timestamp": start.isoformat(sep=" ", timespec="microseconds"),
             }
@@ -308,7 +308,7 @@ class V2ModelServer(StepToDict):
             # get model metadata operation
             setattr(event, "terminated", True)
             event_body = {
-                "name": self.name,
+                "name": self.name.split(":")[0],
                 "version": self.version or "",
                 "inputs": [],
                 "outputs": [],

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -254,6 +254,10 @@ def test_ensemble_get_models():
     #           "weights": None}
     assert len(resp["models"]) == 5, f"wrong get models response {resp}"
 
+    assert fn.spec.graph.name == "VotingEnsemble"
+    fn_dict = fn.to_dict()
+    assert fn_dict.get("spec", {}).get("graph", {}).get("name", "") == "VotingEnsemble"
+
 
 def test_ensemble_get_metadata_of_models():
     fn = mlrun.new_function("tests", kind="serving")


### PR DESCRIPTION
fix https://iguazio.atlassian.net/browse/ML-8899

Also make sure the name of the model endpoint is the same as the name of the `V2ModelServer` class