### PR TITLE
[Notifications] Use push_pipeline_start_message_from_client function for local runs

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -748,9 +748,11 @@ class _LocalRunner(_PipelineRunner):
             project.set_source(source=source)
         pipeline_context.workflow_artifact_path = artifact_path
 
-        project.notifiers.push_pipeline_start_message(
-            project.metadata.name, pipeline_id=workflow_id
-        )
+        # TODO: currently push notifications for local runs not support
+        # TODO: we should create endpoint for sending custom notification from BE
+        # project.notifiers.push_pipeline_start_message(
+        #     project.metadata.name, pipeline_id=workflow_id
+        # )
         err = None
         try:
             workflow_handler(**workflow_spec.args)

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -748,11 +748,10 @@ class _LocalRunner(_PipelineRunner):
             project.set_source(source=source)
         pipeline_context.workflow_artifact_path = artifact_path
 
-        # TODO: currently push notifications for local runs not support
         # TODO: we should create endpoint for sending custom notification from BE
-        # project.notifiers.push_pipeline_start_message(
-        #     project.metadata.name, pipeline_id=workflow_id
-        # )
+        project.notifiers.push_pipeline_start_message_from_client(
+            project.metadata.name, pipeline_id=workflow_id
+        )
         err = None
         try:
             workflow_handler(**workflow_spec.args)


### PR DESCRIPTION
For current phase, we should use the old way for sending notifications (from client and not from BE).
Later we should think how we should make these notifications also sent from BE (for example adding endpoint for sending custom notification directly from the BE).

https://iguazio.atlassian.net/browse/ML-8883