### PR TITLE
[Pipelines] Move get_workflow_steps to helpers

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -15,7 +15,6 @@
 import asyncio
 import datetime
 import os
-import re
 import traceback
 import typing
 from concurrent.futures import ThreadPoolExecutor
@@ -31,11 +30,7 @@ import mlrun.model
 import mlrun.utils.helpers
 import mlrun.utils.notifications.notification as notification_module
 import mlrun.utils.notifications.notification.base as base
-import mlrun_pipelines.common.constants
-import mlrun_pipelines.common.ops
-import mlrun_pipelines.models
-import mlrun_pipelines.utils
-from mlrun.utils import logger
+from mlrun.utils import Workflow, logger
 from mlrun.utils.condition_evaluator import evaluate_condition_in_separate_process
 
 
@@ -283,7 +278,9 @@ class NotificationPusher(_NotificationPusherBase):
             custom_message = (
                 f" (workflow: {run.metadata.labels['workflow']}){custom_message}"
             )
-            runs.extend(self.get_workflow_steps(run))
+            project = run.metadata.project
+            workflow_id = run.status.results.get("workflow_id", None)
+            runs.extend(Workflow.get_workflow_steps(workflow_id, project))
 
         message = (
             self.messages.get(run.state(), "").format(resource=resource)
@@ -441,131 +438,6 @@ class NotificationPusher(_NotificationPusherBase):
             project,
             mask_params=False,
         )
-
-    def get_workflow_steps(self, run: mlrun.model.RunObject) -> list:
-        steps = []
-        db = mlrun.get_run_db()
-
-        def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):
-            try:
-                _run = db.list_runs(
-                    project=run.metadata.project,
-                    labels=f"{mlrun_constants.MLRunInternalLabels.runner_pod}={_step.node_name}",
-                )[0]
-            except IndexError:
-                _run = {
-                    "metadata": {
-                        "name": _step.display_name,
-                        "project": run.metadata.project,
-                    },
-                }
-            _run["step_kind"] = _step.step_type
-            if _step.skipped:
-                _run.setdefault("status", {})["state"] = (
-                    runtimes_constants.RunStates.skipped
-                )
-            steps.append(_run)
-
-        def _add_deploy_function_step(_step: mlrun_pipelines.models.PipelineStep):
-            project, name, hash_key = self._extract_function_uri(
-                _step.get_annotation("mlrun/function-uri")
-            )
-            if name:
-                try:
-                    function = db.get_function(
-                        project=project, name=name, hash_key=hash_key
-                    )
-                except mlrun.errors.MLRunNotFoundError:
-                    # If the function is not found (if build failed for example), we will create a dummy
-                    # function object for the notification to display the function name
-                    function = {
-                        "metadata": {
-                            "name": name,
-                            "project": project,
-                            "hash_key": hash_key,
-                        },
-                    }
-                pod_phase = _step.phase
-                if _step.skipped:
-                    state = mlrun.common.schemas.FunctionState.skipped
-                else:
-                    state = runtimes_constants.PodPhases.pod_phase_to_run_state(
-                        pod_phase
-                    )
-                function["status"] = {"state": state}
-                if isinstance(function["metadata"].get("updated"), datetime.datetime):
-                    function["metadata"]["updated"] = function["metadata"][
-                        "updated"
-                    ].isoformat()
-                function["step_kind"] = _step.step_type
-                steps.append(function)
-
-        step_methods = {
-            mlrun_pipelines.common.constants.PipelineRunType.run: _add_run_step,
-            mlrun_pipelines.common.constants.PipelineRunType.build: _add_deploy_function_step,
-            mlrun_pipelines.common.constants.PipelineRunType.deploy: _add_deploy_function_step,
-        }
-
-        workflow_id = run.status.results.get("workflow_id", None)
-        if not workflow_id:
-            return steps
-
-        workflow_manifest = self._get_workflow_manifest(workflow_id)
-        if not workflow_manifest:
-            return steps
-
-        try:
-            for step in workflow_manifest.get_steps():
-                step_method = step_methods.get(step.step_type)
-                if step_method:
-                    step_method(step)
-            return steps
-        except Exception:
-            # If we fail to read the pipeline steps, we will return the list of runs that have the same workflow id
-            logger.warning(
-                "Failed to extract workflow steps from workflow manifest, "
-                "returning all runs with the workflow id label",
-                workflow_id=workflow_id,
-                traceback=traceback.format_exc(),
-            )
-            return db.list_runs(
-                project=run.metadata.project,
-                labels=f"workflow={workflow_id}",
-            )
-
-    @staticmethod
-    def _get_workflow_manifest(
-        workflow_id: str,
-    ) -> typing.Optional[mlrun_pipelines.models.PipelineManifest]:
-        kfp_client = mlrun_pipelines.utils.get_client(mlrun.mlconf.kfp_url)
-
-        # arbitrary timeout of 5 seconds, the workflow should be done by now
-        kfp_run = kfp_client.wait_for_run_completion(workflow_id, 5)
-        if not kfp_run:
-            return None
-
-        kfp_run = mlrun_pipelines.models.PipelineRun(kfp_run)
-        return kfp_run.workflow_manifest()
-
-    def _extract_function_uri(self, function_uri: str) -> tuple[str, str, str]:
-        """
-        Extract the project, name, and hash key from a function uri.
-        Examples:
-            - "project/name@hash_key" returns project, name, hash_key
-            - "project/name returns" project, name, ""
-        """
-        project, name, hash_key = None, None, None
-        hashed_pattern = r"^(.+)/(.+)@(.+)$"
-        pattern = r"^(.+)/(.+)$"
-        match = re.match(hashed_pattern, function_uri)
-        if match:
-            project, name, hash_key = match.groups()
-        else:
-            match = re.match(pattern, function_uri)
-            if match:
-                project, name = match.groups()
-                hash_key = ""
-        return project, name, hash_key
 
 
 class CustomNotificationPusher(_NotificationPusherBase):

--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -21,8 +21,6 @@ import fastapi
 import fastapi.concurrency
 import sqlalchemy.orm
 import yaml
-from fastapi import BackgroundTasks, Depends
-from sqlalchemy.orm import Session
 
 import mlrun.common.formatters
 import mlrun.common.schemas
@@ -35,7 +33,6 @@ import framework.api
 import framework.api.deps
 import framework.api.utils
 import framework.utils.auth.verifier
-import framework.utils.singletons.db as db_singleton
 import framework.utils.singletons.k8s
 import services.api.crud
 

--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -21,6 +21,8 @@ import fastapi
 import fastapi.concurrency
 import sqlalchemy.orm
 import yaml
+from fastapi import BackgroundTasks, Depends
+from sqlalchemy.orm import Session
 
 import mlrun.common.formatters
 import mlrun.common.schemas
@@ -33,6 +35,7 @@ import framework.api
 import framework.api.deps
 import framework.api.utils
 import framework.utils.auth.verifier
+import framework.utils.singletons.db as db_singleton
 import framework.utils.singletons.k8s
 import services.api.crud
 
@@ -158,6 +161,61 @@ async def retry_pipeline(
         namespace,
     )
     return run_id
+
+
+@router.post(
+    "{run_id}/push-notifications",
+    response_model=mlrun.common.schemas.BackgroundTask,
+)
+async def push_notifications(
+    project: str,
+    run_id: str,
+    background_tasks: BackgroundTasks,
+    db_session: Session = Depends(framework.api.deps.get_db_session),
+    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
+        framework.api.deps.authenticate_request
+    ),
+    namespace: str = fastapi.Query(mlrun.config.config.namespace),
+    notifications: typing.Optional[
+        typing.List[mlrun.common.schemas.Notification]
+    ] = None,
+):
+    if not notifications:
+        return
+
+    await (
+        framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
+            mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
+            project,
+            run_id,
+            mlrun.common.schemas.AuthorizationAction.read,
+            auth_info,
+        )
+    )
+
+    pipeline = await fastapi.concurrency.run_in_threadpool(
+        services.api.crud.Pipelines().get_pipeline,
+        db_session,
+        run_id,
+        project,
+        namespace,
+    )
+
+    # background_task = await fastapi.concurrency.run_in_threadpool(
+    #     framework.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task,
+    #     db_session,
+    #     project,
+    #     background_tasks,
+    #     _push_notifications,
+    #     mlrun.mlconf.background_tasks.default_timeouts.push_notifications,
+    #     framework.utils.background_tasks.BackgroundTaskKinds.push_notification.format(
+    #         project, uid
+    #     ),
+    #     db_session,
+    #     run,
+    # )
+    # return background_task
+    return
 
 
 @router.get("/{run_id}")
@@ -308,3 +366,17 @@ def _try_resolve_project_from_body(
     return services.api.crud.Pipelines().resolve_project_from_workflow_manifest(
         mlrun_pipelines.models.PipelineManifest(workflow_manifest)
     )
+
+
+def _push_notifications(db_session, run):
+    db = db_singleton.get_db()
+    framework.utils.notifications.unmask_notification_params_secret_on_task(
+        db, db_session, run
+    )
+    run_notification_pusher_class = (
+        framework.utils.notifications.notification_pusher.RunNotificationPusher
+    )
+    run_notification_pusher_class(
+        [run],
+        run_notification_pusher_class.resolve_notifications_default_params(),
+    ).push()

--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -311,17 +311,3 @@ def _try_resolve_project_from_body(
     return services.api.crud.Pipelines().resolve_project_from_workflow_manifest(
         mlrun_pipelines.models.PipelineManifest(workflow_manifest)
     )
-
-
-def _push_notifications(db_session, run):
-    db = db_singleton.get_db()
-    framework.utils.notifications.unmask_notification_params_secret_on_task(
-        db, db_session, run
-    )
-    run_notification_pusher_class = (
-        framework.utils.notifications.notification_pusher.RunNotificationPusher
-    )
-    run_notification_pusher_class(
-        [run],
-        run_notification_pusher_class.resolve_notifications_default_params(),
-    ).push()

--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -163,61 +163,6 @@ async def retry_pipeline(
     return run_id
 
 
-@router.post(
-    "{run_id}/push-notifications",
-    response_model=mlrun.common.schemas.BackgroundTask,
-)
-async def push_notifications(
-    project: str,
-    run_id: str,
-    background_tasks: BackgroundTasks,
-    db_session: Session = Depends(framework.api.deps.get_db_session),
-    auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
-        framework.api.deps.authenticate_request
-    ),
-    namespace: str = fastapi.Query(mlrun.config.config.namespace),
-    notifications: typing.Optional[
-        typing.List[mlrun.common.schemas.Notification]
-    ] = None,
-):
-    if not notifications:
-        return
-
-    await (
-        framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-            mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
-            project,
-            run_id,
-            mlrun.common.schemas.AuthorizationAction.read,
-            auth_info,
-        )
-    )
-
-    pipeline = await fastapi.concurrency.run_in_threadpool(
-        services.api.crud.Pipelines().get_pipeline,
-        db_session,
-        run_id,
-        project,
-        namespace,
-    )
-
-    # background_task = await fastapi.concurrency.run_in_threadpool(
-    #     framework.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task,
-    #     db_session,
-    #     project,
-    #     background_tasks,
-    #     _push_notifications,
-    #     mlrun.mlconf.background_tasks.default_timeouts.push_notifications,
-    #     framework.utils.background_tasks.BackgroundTaskKinds.push_notification.format(
-    #         project, uid
-    #     ),
-    #     db_session,
-    #     run,
-    # )
-    # return background_task
-    return
-
-
 @router.get("/{run_id}")
 async def get_pipeline(
     run_id: str,


### PR DESCRIPTION
First pr for sending notifications from BE:
Move get_workflow_steps to helpers so we can use it on the new endpoint for push_notifications on workflow id.

https://iguazio.atlassian.net/browse/ML-8905