### PR TITLE
[API] Ensure getting correct clusterization spec

### DIFF
--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -312,7 +312,7 @@ class Service(ABC):
         clusterization_spec: mlrun.common.schemas.ClusterizationSpec,
     ):
         # if clusterization_spec has different version (take out unstable)
-        # deny the response as it may come from a stable chief
+        # deny the response as it may come from an older, stable chief
         worker_version = semver.version.Version.parse(
             mlrun.utils.version.Version().get()["version"]
         )

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -22,6 +22,7 @@ from abc import ABC, abstractmethod
 import fastapi
 import fastapi.concurrency
 import fastapi.exception_handlers
+import semver
 from dependency_injector import containers, providers
 
 import mlrun.common.schemas
@@ -298,19 +299,34 @@ class Service(ABC):
             clusterization_spec = await chief_client.get_clusterization_spec(
                 return_fastapi_response=False, raise_on_failure=True
             )
+            await self._align_worker_state_with_chief_state(clusterization_spec)
         except Exception as exc:
             self._logger.debug(
                 "Failed receiving clusterization spec",
                 exc=mlrun.errors.err_to_str(exc),
                 traceback=traceback.format_exc(),
             )
-        else:
-            await self._align_worker_state_with_chief_state(clusterization_spec)
 
     async def _align_worker_state_with_chief_state(
         self,
         clusterization_spec: mlrun.common.schemas.ClusterizationSpec,
     ):
+        # if clusterization_spec has different version (take out unstable)
+        # deny the response as it may come from a stable chief
+        worker_version = semver.version.Version.parse(
+            mlrun.utils.version.Version().get()["version"]
+        )
+        chief_version = semver.version.Version.parse(clusterization_spec.chief_version)
+        unstable_chief = chief_version.build == "unstable"
+        unstable_worker = worker_version.build == "unstable"
+        if not (unstable_chief or unstable_worker) and worker_version != chief_version:
+            self._logger.warning(
+                "Chief version is different than worker version, denying response",
+                chief_version=chief_version,
+                worker_version=worker_version,
+            )
+            return
+
         chief_state = clusterization_spec.chief_api_state
         if not chief_state:
             self._logger.warning("Chief did not return any state")

--- a/server/py/framework/utils/mlrunuvicorn.py
+++ b/server/py/framework/utils/mlrunuvicorn.py
@@ -35,6 +35,7 @@ def run(httpdb_config, service_name="api"):
     uvicorn.run(
         f"services.{service_name}.daemon:app",
         host="0.0.0.0",
+        factory=True,
         port=httpdb_config.port,
         access_log=False,
         timeout_keep_alive=httpdb_config.http_connection_timeout_keep_alive,


### PR DESCRIPTION
When worker / alerts service comes up they try to clusterize with chief while getting the current state. In same edge cases it may be possible that the alerts service comes up before new-chief and it fires up a GET request to older one, seeing it in "online" mode and that kicks in the move_to_online functionality of alerts service that involves data changes.
Issue is, when upgrading from version < 1.8, alerts service cannot have any access to DB because .. no schemas migrations were done by new chief.
this fix intend to ensure that alerts coming up gets the clusterization spec from its ally chief by performing version checkups.

https://iguazio.atlassian.net/browse/ML-8919