### PR TITLE
[Artifacts] Retrieve Artifacts with "None" Tag When Listing Artifacts for Producer ID

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1617,20 +1617,24 @@ class SQLDB(DBInterface):
         if producer_id:
             query = query.filter(ArtifactV2.producer_id == producer_id)
 
-        query = query.join(ArtifactV2.Tag, ArtifactV2.Tag.obj_id == ArtifactV2.id)
+        # To get all artifacts, even if they don't have tags
+        query = query.outerjoin(ArtifactV2.Tag, ArtifactV2.Tag.obj_id == ArtifactV2.id)
 
         tuples_filter = []
         for key, tag, iteration, uid in artifact_identifiers:
-            iteration = iteration or 0
-            tag = tag or mlrun.common.constants.RESERVED_TAG_NAME_LATEST
-            base_filter = (
-                (ArtifactV2.key == key)
-                & (ArtifactV2.Tag.name == tag)
-                & (ArtifactV2.iteration == iteration)
-            )
-            # Add UID filter only if UID is not None
+            base_filter = ArtifactV2.key == key
+
+            # Prioritize filtering by UID if provided
             if uid is not None:
                 base_filter = base_filter & (ArtifactV2.uid == uid)
+            else:
+                iteration = iteration or 0
+                tag = tag or mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+                base_filter = (
+                    base_filter
+                    & (ArtifactV2.Tag.name == tag)
+                    & (ArtifactV2.iteration == iteration)
+                )
             tuples_filter.append(base_filter)
 
         query = query.filter(or_(*tuples_filter))

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1629,12 +1629,9 @@ class SQLDB(DBInterface):
                 base_filter = base_filter & (ArtifactV2.uid == uid)
             else:
                 iteration = iteration or 0
-                tag = tag or mlrun.common.constants.RESERVED_TAG_NAME_LATEST
-                base_filter = (
-                    base_filter
-                    & (ArtifactV2.Tag.name == tag)
-                    & (ArtifactV2.iteration == iteration)
-                )
+                base_filter = base_filter & (ArtifactV2.iteration == iteration)
+                if tag is not None:
+                    base_filter = base_filter & (ArtifactV2.Tag.name == tag)
             tuples_filter.append(base_filter)
 
         query = query.filter(or_(*tuples_filter))

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -2401,6 +2401,56 @@ class TestArtifacts(TestDatabaseBase):
         )
         assert 1 == len(arts), "since/until t2"
 
+    def test_list_artifacts_for_producer_id(self):
+        project = "project_name"
+        artifact_name = "artifact_name"
+        tree1 = "artifact_tree_1"
+        tree2 = "artifact_tree_2"
+
+        # Generate and store two artifacts with the same name and different producer id
+        artifact_1 = self._generate_artifact(artifact_name, tree=tree1)
+        artifact_2 = self._generate_artifact(artifact_name, project=project, tree=tree2)
+        self._db.store_artifact(
+            self._db_session,
+            artifact_name,
+            artifact_1,
+            project=project,
+        )
+        self._db.store_artifact(
+            self._db_session,
+            artifact_name,
+            artifact_2,
+            project=project,
+        )
+        artifacts = self._db.list_artifacts(
+            self._db_session, project=project, name=artifact_name
+        )
+        assert len(artifacts) == 2
+
+        # Retrieve the first artifact without tag (None) and with specific UID
+        artifact_identifiers = [(artifact_name, None, 0, artifact_1["metadata"]["uid"])]
+        artifacts = self._db.list_artifacts_for_producer_id(
+            self._db_session,
+            project=project,
+            producer_id=tree1,
+            artifact_identifiers=artifact_identifiers,
+        )
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["uid"] == artifact_1["metadata"]["uid"]
+        assert artifacts[0]["metadata"]["tag"] is None
+
+        # Retrieve the second artifact with tag "latest" and no UID
+        artifact_identifiers = [(artifact_name, None, 0, None)]
+        artifacts = self._db.list_artifacts_for_producer_id(
+            self._db_session,
+            project=project,
+            producer_id=tree2,
+            artifact_identifiers=artifact_identifiers,
+        )
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["uid"] == artifact_2["metadata"]["uid"]
+        assert artifacts[0]["metadata"]["tag"] == "latest"
+
     def _generate_artifact_with_iterations(
         self, key, tree, num_iters, best_iter, kind, project=""
     ):

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -2439,6 +2439,18 @@ class TestArtifacts(TestDatabaseBase):
         assert artifacts[0]["metadata"]["uid"] == artifact_1["metadata"]["uid"]
         assert artifacts[0]["metadata"]["tag"] is None
 
+        # Retrieve same artifact without tag (None) and without specific UID
+        artifact_identifiers = [(artifact_name, None, 0, None)]
+        artifacts = self._db.list_artifacts_for_producer_id(
+            self._db_session,
+            project=project,
+            producer_id=tree1,
+            artifact_identifiers=artifact_identifiers,
+        )
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["uid"] == artifact_1["metadata"]["uid"]
+        assert artifacts[0]["metadata"]["tag"] is None
+
         # Retrieve the second artifact with tag "latest" and no UID
         artifact_identifiers = [(artifact_name, None, 0, None)]
         artifacts = self._db.list_artifacts_for_producer_id(


### PR DESCRIPTION
When running a workflow that logs artifacts with no tag by default, the last artifact is stored with the "latest" tag, and older artifacts are stored with the "None" tag.

When attempting to retrieve the run, the function retrieves all the artifacts based on artifact_uri and stores them in the run. The issue arose when the artifact_uri included an artifact without a tag. In this case, we were using a JOIN on the Tag table, which did not retrieve all the artifacts that did not have a tag. To fix this, we are now using a LEFT OUTER JOIN to retrieve all artifacts.

Moreover, if the artifact_uri includes the UID, we can retrieve the artifact by its UID, ensuring that a unique artifact is fetched.

https://iguazio.atlassian.net/browse/ML-8571