### PR TITLE
[Framework] Fix proxying duplicate query params

### DIFF
--- a/server/py/framework/utils/clients/messaging.py
+++ b/server/py/framework/utils/clients/messaging.py
@@ -254,7 +254,8 @@ class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
                         "Failed to read request body, expected json body"
                     ) from exc
             request_kwargs.update({"headers": dict(request.headers)})
-            request_kwargs.update({"params": dict(request.query_params)})
+            # Preserve duplicate query params as a list of (key, value) tuples
+            request_kwargs.update({"params": list(request.query_params.multi_items())})
             request_kwargs.update({"cookies": request.cookies})
             request_kwargs["headers"].setdefault(
                 "x-request-id", request.state.request_id

--- a/server/py/services/api/tests/unit/utils/clients/test_messaging.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_messaging.py
@@ -79,7 +79,7 @@ async def test_messaging_client_forward_request_with_body(
         )
 
     aioresponses_mock.post(
-        "http://test/success-service/v1/success",
+        "http://test/success-service/v1/success?x=1&x=2",
         callback=_f,
     )
     fastapi_app = unittest.mock.Mock()
@@ -102,8 +102,8 @@ async def test_messaging_client_forward_request_with_body(
                 (b"content-length", b"1"),
                 (b"authorization", b"Bearer test"),
             ],
+            "query_string": b"x=1&x=2",
             # Below are mandatory fields, although they are irrelevant for the test
-            "query_string": "",
             "state": {"request_id": "test"},
             "app": fastapi_app,
         },


### PR DESCRIPTION
FastAPI translates a `list` query param as duplicates of the same param with multiple values.
When the worker proxies a request to a service (e.g. alerts), it converts the request's query params to a dictionary, which inherently cannot have duplicate keys - so it dropped the duplicates, and wrongly converted a list query to a single item.

This was seen in the `test_job_failure_alert` system test that failed listing alert activations with a severity filter as a list of values:
```
activations = project.list_alert_activations(
    severity=[
        alert_constants.AlertSeverity.LOW,
        alert_constants.AlertSeverity.HIGH,
    ]
)
```
Translated to:
```
/alerts/v1/projects/alerts-test-project/alert-activations?severity=high&page=1&page-size=200
```

To fix this, use params as a list of `multi_items`, which is a list of key-value tuples.
Now, the proxy params look like:
```
"params":[["severity","high"],["severity","low"],["page","1"],["page-size","200"]]
```
And the request:
```
/alerts/v1/projects/test-alerts/alert-activations?severity=high&severity=low&page=1&page-size=200
```