### PR TITLE
[Notifications] Return always background task on push-notifications of pipeline

### DIFF
--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -180,9 +180,6 @@ async def push_notifications(
     ),
     notifications: typing.Optional[list[mlrun.common.schemas.Notification]] = None,
 ):
-    if not notifications:
-        return
-
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
             mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
@@ -361,6 +358,8 @@ def _try_resolve_project_from_body(
 
 
 def _push_notifications(run_id, project, notifications):
+    if not notifications:
+        return
     unmasked_notifications = []
     for notification in notifications:
         try:


### PR DESCRIPTION
Fix bug introduce on [this pr](https://github.com/mlrun/mlrun/pull/7043).
We define that `push-notifications` endpoint should always return background task, but if no notifications detected, we returned None and not background task.

https://iguazio.atlassian.net/browse/ML-8995