### PR TITLE
[Model Monitoring] Fix default `sampling_percentage` on serving deployment when monitoring is disabled 

### DIFF
--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1309,9 +1309,9 @@ class MonitoringDeployment:
             function_tag=function.metadata.tag,
             track_models=function.spec.track_models,
             graph=function.spec.graph,
-            sampling_percentage=function.spec.parameters[
-                mm_constants.EventFieldType.SAMPLING_PERCENTAGE
-            ],
+            sampling_percentage=function.spec.parameters.get(
+                mm_constants.EventFieldType.SAMPLING_PERCENTAGE, 100
+            ),
         )  # model endpoint, creation strategy, model path
         router_model_endpoints_instructions: list[
             tuple[


### PR DESCRIPTION
When a user deploys a serving func without mm, the model endpoint is generated with `monitoring mode` set to `disabled`. However, in this case, the serving func has no `sampling_percentage` configuration, which led to a bug during mep creation. This PR fixes this issue by setting a default `sampling_percentage` value of 100 when it is not specified in the serving spec. 

https://iguazio.atlassian.net/browse/ML-8997