### PR TITLE
[CI] Ensure running against latest pr commit only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,12 @@ on:
   # rare scenario where the combination of merged PRs won't pass CI
   push:
     branches:
-    - master
     - '[0-9]+.[0-9]+.x'
+
+concurrency:
+  group:
+    ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
when pushing consecutive commits after pr has opened, few workflows are running simultaneously 

no need to run ci when pushing to master, as master has no real development meaning