### PR TITLE
[Serving] Limit the number of models to 5K per Router

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -174,6 +174,10 @@ class MLRunInvalidArgumentError(MLRunHTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 
+class MLRunModelLimitExceededError(MLRunHTTPStatusError, ValueError):
+    error_status_code = HTTPStatus.BAD_REQUEST.value
+
+
 class MLRunInvalidArgumentTypeError(MLRunHTTPStatusError, TypeError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -31,6 +31,7 @@ import storey.utils
 
 import mlrun
 import mlrun.common.schemas as schemas
+from mlrun.utils import logger
 
 from ..config import config
 from ..datastore import get_stream_pusher
@@ -754,7 +755,7 @@ class RouterStep(TaskStep):
         creation_strategy: schemas.ModelEndpointCreationStrategy = schemas.ModelEndpointCreationStrategy.INPLACE,
         **class_args,
     ):
-        """add child route step or class to the router
+        """add child route step or class to the router, if key exists it will be updated
 
         :param key:        unique name (and route path) for the child step
         :param route:      child step object (Task, ..)
@@ -779,6 +780,8 @@ class RouterStep(TaskStep):
                 f"Router cannot support more than {MAX_MODELS_PER_ROUTER} model endpoints. "
                 f"To add a new route, edit an existing one by passing the same key."
             )
+        if key in self.routes:
+            logger.info(f"Model {key} already exists, updating it.")
         if not route and not class_name and not handler:
             raise MLRunInvalidArgumentError("route or class_name must be specified")
         if not route:

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -811,10 +811,17 @@ def test_mock_invoke():
     mlrun.mlconf.mock_nuclio_deployment = mock_nuclio_config
 
 
-def test_add_route_exceeds_max_steps():
-    """Test adding a route when the maximum number of steps is exceeded."""
-    host = create_graph_server(graph=RouterStep())
-    max_steps = mlrun.serving.states.MAX_ALLOWED_STEPS
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-        for key in range(max_steps + 1):
-            host.graph.add_route(f"test_key_{key}", class_name=ModelTestingClass)
+def test_add_route_exceeds_max_models():
+    """Test adding a route when the maximum number of models is exceeded."""
+    server = create_graph_server(graph=RouterStep())
+    max_models = mlrun.serving.states.MAX_MODELS_PER_ROUTER
+    with pytest.raises(mlrun.errors.MLRunModelLimitExceededError):
+        for key in range(max_models + 1):
+            server.graph.add_route(f"test_key_{key}", class_name=ModelTestingClass)
+
+    # edit existing model
+    server.graph.add_route(f"test_key_{key-1}", class_name=ModelTestingClass)
+
+    assert (
+        len(server.graph.routes) == max_models
+    ), f"expected to have {max_models} models"


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8992

Note: I removed `MAX_ALLOWED_STEPS` since we are only validating the number of models per router.

Add log when updating a model  (https://iguazio.atlassian.net/browse/ML-8388?focusedCommentId=164105) 