### PR TITLE
[Datastore] Fix Kafka source SASL configuration

### DIFF
--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -211,9 +211,10 @@ class DatastoreProfileKafkaSource(DatastoreProfile):
             attributes["partitions"] = self.partitions
         sasl = attributes.pop("sasl", {})
         if self.sasl_user and self.sasl_pass:
-            sasl["enabled"] = True
+            sasl["enable"] = True
             sasl["user"] = self.sasl_user
             sasl["password"] = self.sasl_pass
+            sasl["mechanism"] = "PLAIN"
         if sasl:
             attributes["sasl"] = sasl
         return attributes

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -1089,9 +1089,10 @@ class KafkaSource(OnlineSource):
             attributes["partitions"] = partitions
         sasl = attributes.pop("sasl", {})
         if sasl_user and sasl_pass:
-            sasl["enabled"] = True
+            sasl["enable"] = True
             sasl["user"] = sasl_user
             sasl["password"] = sasl_pass
+            sasl["mechanism"] = sasl.get("mechanism", "PLAIN")
         if sasl:
             attributes["sasl"] = sasl
         super().__init__(attributes=attributes, **kwargs)

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -1092,7 +1092,7 @@ class KafkaSource(OnlineSource):
             sasl["enable"] = True
             sasl["user"] = sasl_user
             sasl["password"] = sasl_pass
-            sasl["mechanism"] = sasl.get("mechanism", "PLAIN")
+            sasl["mechanism"] = "PLAIN"
         if sasl:
             attributes["sasl"] = sasl
         super().__init__(attributes=attributes, **kwargs)

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -81,9 +81,10 @@ def test_kafka_source_with_attributes():
     assert attributes["topics"] == ["mytopic"]
     assert attributes["consumerGroup"] == "mygroup"
     assert attributes["sasl"] == {
-        "enabled": True,
+        "enable": True,
         "user": "myuser",
         "password": "mypassword",
+        "mechanism": "PLAIN",
         "handshake": True,
     }
 
@@ -116,9 +117,10 @@ def test_kafka_source_with_attributes_as_ds_profile():
     assert attributes["topics"] == ["mytopic"]
     assert attributes["consumerGroup"] == "mygroup"
     assert attributes["sasl"] == {
-        "enabled": True,
+        "enable": True,
         "user": "myuser",
         "password": "mypassword",
+        "mechanism": "PLAIN",
         "handshake": True,
     }
 
@@ -173,9 +175,10 @@ def test_kafka_source_without_attributes():
     assert attributes["topics"] == ["mytopic"]
     assert attributes["consumerGroup"] == "mygroup"
     assert attributes["sasl"] == {
-        "enabled": True,
+        "enable": True,
         "user": "myuser",
         "password": "mypassword",
+        "mechanism": "PLAIN",
     }
 
 


### PR DESCRIPTION
Fix how Kafka source configures SASL to align with how Nuclio expects [SASL configuration](https://github.com/nuclio/nuclio/blob/development/pkg/processor/trigger/kafka/types.go#L47).
Mainly - `enable` instead of `enabled`.

Additionally, add explicit `PLAIN` mechanism when using username-password SASL.

https://iguazio.atlassian.net/browse/ML-8968