### PR TITLE
[Model Monitoring] Fix get labels

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7170,7 +7170,11 @@ class SQLDB(DBInterface):
             )
 
     def _split_mep_update_attr(self, attributes: dict):
-        labels = attributes.pop("labels", None)
+        if "labels" in attributes:
+            # labels can be None, so if labels key exists, return {} and override existing labels.
+            labels = attributes.pop("labels") or {}
+        else:
+            labels = None
         schema_attr = {}
         for key in list(attributes.keys()):
             if hasattr(ModelEndpoint, key):

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7157,9 +7157,9 @@ class SQLDB(DBInterface):
             for key, val in schema_attr.items():
                 setattr(mep_record, key, val)
                 update_in(struct, key, val)
-            if labels and isinstance(labels, dict):
+            if labels is not None and isinstance(labels, dict):
                 update_labels(mep_record, labels)
-            update_in(struct, "labels", labels)
+                update_in(struct, "labels", labels)
             mep_record.struct = struct
             mep_record.updated = updated
             self._upsert(session, [mep_record])
@@ -7170,7 +7170,7 @@ class SQLDB(DBInterface):
             )
 
     def _split_mep_update_attr(self, attributes: dict):
-        labels = attributes.pop("labels", {})
+        labels = attributes.pop("labels", None)
         schema_attr = {}
         for key in list(attributes.keys()):
             if hasattr(ModelEndpoint, key):

--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -963,8 +963,18 @@ with warnings.catch_warnings():
         Label = make_label(__tablename__)
         Tag = make_tag_v2(__tablename__)  # for versioning (latest and empty tags only)
 
-        labels = relationship(Label, cascade="all, delete-orphan")
-        tags = relationship(Tag, cascade="all, delete-orphan")
+        labels = relationship(
+            Label,
+            cascade="all, delete-orphan",
+            back_populates="parent_rel",
+            passive_deletes=True,
+        )
+        tags = relationship(
+            Tag,
+            cascade="all, delete-orphan",
+            back_populates="parent_rel",
+            passive_deletes=True,
+        )
 
         def get_identifier_string(self) -> str:
             return f"{self.project}_{self.name}_{self.created}"

--- a/server/py/services/api/tests/unit/db/test_model_endpoint.py
+++ b/server/py/services/api/tests/unit/db/test_model_endpoint.py
@@ -570,7 +570,11 @@ class TestModelEndpoint(TestDatabaseBase):
 
     def test_insert_without_function(self) -> None:
         model_endpoint = mlrun.common.schemas.ModelEndpoint(
-            metadata={"name": "model-endpoint-1", "project": "project-1"},
+            metadata={
+                "name": "model-endpoint-1",
+                "project": "project-1",
+                "labels": {"K": 57, "V": 44, "f": 43, "v": 4},
+            },
             spec={
                 "function_name": "some-non-mlrun-function",
                 "function_uid": None,
@@ -587,12 +591,17 @@ class TestModelEndpoint(TestDatabaseBase):
             project=model_endpoint.metadata.project,
             uid=mep.metadata.uid,
         )
-        print("model_endpoint_from_db", model_endpoint_from_db.spec.function_name)
         assert model_endpoint_from_db.metadata.name == "model-endpoint-1"
         assert model_endpoint_from_db.metadata.project == "project-1"
         assert model_endpoint_from_db.metadata.uid == mep.metadata.uid
         assert model_endpoint_from_db.spec.model_name == ""
         assert model_endpoint_from_db.spec.function_name == "some-non-mlrun-function"
+        assert model_endpoint_from_db.metadata.labels == {
+            "K": 57,
+            "V": 44,
+            "f": 43,
+            "v": 4,
+        }
 
     def test_2_functions(self) -> None:
         for i in range(2):

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -613,7 +613,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         self._assert_model_endpoint_tags_and_labels(
             endpoint=endpoint,
             model_name=model_name,
-            tag=["some-tag", "latest"],
+            tag="some-tag",
             labels=labels,
         )
         self._assert_model_uri(model_obj=model_obj, endpoint=endpoint)
@@ -649,7 +649,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         self,
         endpoint: mlrun.common.schemas.ModelEndpoint,
         model_name: str,
-        tag: list[str],
+        tag: str,
         labels: dict[str, str],
     ) -> None:
         assert endpoint.metadata.labels == labels

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -364,8 +364,27 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         endpoints_intersect = in_endpoint_names.intersection(out_endpoint_names)
         assert len(endpoints_intersect) == number_of_endpoints
 
-        for endpoint in endpoints_out:
-            assert endpoint.metadata.labels
+    def test_labels(self):
+        db = mlrun.get_run_db()
+        endpoint_name = "testing-endpoint"
+        endpoint = self._mock_random_endpoint(endpoint_name)
+        in_endpoint = db.create_model_endpoint(endpoint)
+        endpoint_id = in_endpoint.metadata.uid
+        out_endpoint = self._run_db.get_model_endpoint(
+            name=endpoint_name, project=self.project_name, endpoint_id=endpoint_id
+        )
+        assert out_endpoint.metadata.labels
+
+        # testing inplace creation strategy:
+        endpoint = self._mock_random_endpoint(endpoint_name, add_labels=False)
+        db.create_model_endpoint(
+            endpoint,
+            creation_strategy=mm_constants.ModelEndpointCreationStrategy.INPLACE,
+        )
+        out_endpoint = self._run_db.get_model_endpoint(
+            name=endpoint_name, project=self.project_name, endpoint_id=endpoint_id
+        )
+        assert not out_endpoint.metadata.labels
 
     def test_max_archive_list_endpoints(self):
         # Validates the process of listing model endpoints with max archive limitation. In this test
@@ -489,6 +508,7 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         function_tag: Optional[str] = "v1",
         model_name: Optional[str] = None,
         model_uid: Optional[str] = None,
+        add_labels=True,
     ) -> mlrun.common.schemas.model_monitoring.ModelEndpoint:
         def random_labels():
             return {
@@ -499,7 +519,7 @@ class TestModelEndpointsOperations(TestMLRunSystem):
             metadata=mlrun.common.schemas.model_monitoring.ModelEndpointMetadata(
                 name=name,
                 project=self.project_name,
-                labels=random_labels(),
+                labels=random_labels() if add_labels else {},
             ),
             spec=mlrun.common.schemas.model_monitoring.ModelEndpointSpec(
                 function_name=function_name,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -364,6 +364,9 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         endpoints_intersect = in_endpoint_names.intersection(out_endpoint_names)
         assert len(endpoints_intersect) == number_of_endpoints
 
+        for endpoint in endpoints_out:
+            assert endpoint.metadata.labels
+
     def test_max_archive_list_endpoints(self):
         # Validates the process of listing model endpoints with max archive limitation. In this test
         # we create 5 model endpoints and then create another one. The oldest one should be deleted


### PR DESCRIPTION
1) Prevent labels overriding when labels are None.
2) Fix tag assert in `test_basic_model_monitoring`.
3) Fix in `ModelEndpoint` db object - add `back_populates` and `passive_deletes` as other classes.
4) Add test for labels in `inplace` creation strategy.

[ML-8625](https://iguazio.atlassian.net/browse/ML-8625)

[ML-8625]: https://iguazio.atlassian.net/browse/ML-8625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ