### PR TITLE
[Serving] Save serving spec as json when mlrun client < 1.8.0-rc20

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -431,6 +431,15 @@ def _configure_serving_spec(
                 )
             else:
                 # TODO: remove in 1.10.0.
+                if (
+                    serving_spec_len >= SERVING_SPEC_MAX_LENGTH / 10
+                ):  # 1MB limitation as it were before the zip
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"The serving spec length exceeds the limit of {SERVING_SPEC_MAX_LENGTH}. "
+                        + "Run `mlrun.runtimes.nuclio.serving.ServingRuntime._get_serving_spec`, delete a large field "
+                        + "in the returned json, and check if the function runs successfully. "
+                        + "Repeat as necessary to get the spec to an allowed size"
+                    )
                 logger.info(
                     "Client version does not support passing serving spec as zip via ConfigMap",
                     FutureWarning,


### PR DESCRIPTION
[ML-9051](https://iguazio.atlassian.net/browse/ML-9051)

[ML-9051]: https://iguazio.atlassian.net/browse/ML-9051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ