### PR TITLE
[Notifications] Update notification state for running

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -414,14 +414,14 @@ class NotificationPusher(_NotificationPusherBase):
     ):
         # Skip update the notification state if the following conditions are met:
         # 1. the run is not in a terminal state
-        # 2. the notification is not only for running state
+        # 2. the when contains only one state (which is the current state)
         # Skip updating because currently each notification has only one row in the db, even if it has multiple when.
         # This means that if the notification is updated to sent for running state for example, it will not send for
         # The terminal state
         # TODO: Change this behavior after implementing ML-8723
         if (
             run_state not in runtimes_constants.RunStates.terminal_states()
-            and notification.when != [runtimes_constants.RunStates.running]
+            and len(notification.when) > 1
         ):
             logger.debug(
                 "Skip updating notification status - run not in terminal state",

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -412,8 +412,17 @@ class NotificationPusher(_NotificationPusherBase):
         sent_time: typing.Optional[datetime.datetime] = None,
         reason: typing.Optional[str] = None,
     ):
-        if run_state not in runtimes_constants.RunStates.terminal_states():
-            # we want to update the notification status only if the run is in a terminal state for BC
+        # Skip update notification state if the following conditions are met:
+        # 1. the run is not in a terminal state
+        # 2. the notification is not only for running state
+        # Skip updating because currently each notification has only one row in the db, even if it has multiple when.
+        # This means that if the notification is updated to sent for running state for example, it will not send for
+        # The terminal state
+        # TODO: Change this behavior after implementing ML-8723
+        if (
+            run_state not in runtimes_constants.RunStates.terminal_states()
+            and notification.when != ["running"]
+        ):
             logger.debug(
                 "Skip updating notification status - run not in terminal state",
                 run_uid=run_uid,

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -412,7 +412,7 @@ class NotificationPusher(_NotificationPusherBase):
         sent_time: typing.Optional[datetime.datetime] = None,
         reason: typing.Optional[str] = None,
     ):
-        # Skip update notification state if the following conditions are met:
+        # Skip update the notification state if the following conditions are met:
         # 1. the run is not in a terminal state
         # 2. the notification is not only for running state
         # Skip updating because currently each notification has only one row in the db, even if it has multiple when.
@@ -421,7 +421,7 @@ class NotificationPusher(_NotificationPusherBase):
         # TODO: Change this behavior after implementing ML-8723
         if (
             run_state not in runtimes_constants.RunStates.terminal_states()
-            and notification.when != ["running"]
+            and notification.when != [runtimes_constants.RunStates.running]
         ):
             logger.debug(
                 "Skip updating notification status - run not in terminal state",

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -377,6 +377,67 @@ def test_notification_reason(notification_kind):
 
 
 @pytest.mark.parametrize(
+    "when, run_state, store_count",
+    [
+        (
+            ["running"],
+            runtimes_constants.RunStates.running,
+            1,
+        ),
+        (
+            ["running", "completed"],
+            runtimes_constants.RunStates.running,
+            0,
+        ),
+        (
+            ["running", "completed"],
+            runtimes_constants.RunStates.completed,
+            1,
+        ),
+    ],
+)
+def test_notification_update_notification_status(when, run_state, store_count):
+    notification_kind = mlrun.common.schemas.notification.NotificationKind.mail
+    run = mlrun.model.RunObject.from_dict({"status": {"state": run_state}})
+    run.spec.notifications = [
+        mlrun.model.Notification.from_dict(
+            {
+                "kind": notification_kind,
+                "status": "pending",
+                "message": "test-abc",
+                "when": when,
+            }
+        ),
+    ]
+
+    db = mlrun.get_run_db()
+    db.store_run_notifications = unittest.mock.MagicMock()
+
+    notification_pusher = (
+        mlrun.utils.notifications.notification_pusher.NotificationPusher([run])
+    )
+
+    # mock the push method to raise an exception
+    notification_kind_type = getattr(
+        mlrun.utils.notifications.NotificationTypes, notification_kind
+    ).get_notification()
+    if asyncio.iscoroutinefunction(notification_kind_type.push):
+        concrete_notification = notification_pusher._async_notifications[0][0]
+    else:
+        concrete_notification = notification_pusher._sync_notifications[0][0]
+
+    concrete_notification.push = unittest.mock.MagicMock()
+
+    # send notifications
+    notification_pusher.push()
+
+    # asserts
+    concrete_notification.push.assert_called_once()
+
+    assert db.store_run_notifications.call_count == store_count
+
+
+@pytest.mark.parametrize(
     "notification_kind",
     [
         mlrun.common.schemas.notification.NotificationKind.console,

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -380,17 +380,23 @@ def test_notification_reason(notification_kind):
     "when, run_state, store_count",
     [
         (
-            ["running"],
+            [runtimes_constants.RunStates.running],
             runtimes_constants.RunStates.running,
             1,
         ),
         (
-            ["running", "completed"],
+            [
+                runtimes_constants.RunStates.running,
+                runtimes_constants.RunStates.completed,
+            ],
             runtimes_constants.RunStates.running,
             0,
         ),
         (
-            ["running", "completed"],
+            [
+                runtimes_constants.RunStates.running,
+                runtimes_constants.RunStates.completed,
+            ],
             runtimes_constants.RunStates.completed,
             1,
         ),


### PR DESCRIPTION
Change the logic regarding when we should update notification state in db:
Skip updating only if the following conditions met:

1. The run isn't in terminal state (=> "running").
2. The when contains only one state (which is the current state)

Doing it as a workaround for updating running notification state if the when contains only "running".

https://iguazio.atlassian.net/browse/ML-8630