### PR TITLE
[Alerts] Exclude updated field from alerts response for old client

### DIFF
--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -895,7 +895,10 @@ class DBInterface(ABC):
 
     @abstractmethod
     def list_alerts(
-        self, session, project: typing.Optional[typing.Union[str, list[str]]] = None
+        self,
+        session,
+        project: typing.Optional[typing.Union[str, list[str]]] = None,
+        exclude_updated: bool = False,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         pass
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -5903,7 +5903,10 @@ class SQLDB(DBInterface):
         self._delete(session, AlertConfig, project=project, name=name)
 
     def list_alerts(
-        self, session, project: typing.Optional[typing.Union[str, list[str]]] = None
+        self,
+        session,
+        project: typing.Optional[typing.Union[str, list[str]]] = None,
+        exclude_updated: bool = False,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         query = self._query(session, AlertConfig)
 
@@ -5925,6 +5928,8 @@ class SQLDB(DBInterface):
                 alert,
                 state=alert_state,
             )
+            if exclude_updated:
+                alert.updated = None
             alerts.append(alert)
         return alerts
 

--- a/server/py/framework/routers/alerts.py
+++ b/server/py/framework/routers/alerts.py
@@ -70,9 +70,6 @@ async def get_alert(
         Provide[framework.service.ServiceContainer.service]
     ),
 ) -> mlrun.common.schemas.AlertConfig:
-    client_version = request.headers.get("x-mlrun-client-version")
-    exclude_updated = client_version < "1.8.0" if client_version else False
-
     return await service.handle_request(
         "get_alert",
         request,
@@ -80,7 +77,6 @@ async def get_alert(
         name,
         auth_info,
         db_session,
-        exclude_updated=exclude_updated,
     )
 
 
@@ -99,16 +95,12 @@ async def list_alerts(
         Provide[framework.service.ServiceContainer.service]
     ),
 ) -> list[mlrun.common.schemas.AlertConfig]:
-    client_version = request.headers.get("x-mlrun-client-version")
-    exclude_updated = client_version < "1.8.0" if client_version else False
-
     return await service.handle_request(
         "list_alerts",
         request,
         project,
         auth_info,
         db_session,
-        exclude_updated=exclude_updated,
     )
 
 

--- a/server/py/framework/routers/alerts.py
+++ b/server/py/framework/routers/alerts.py
@@ -57,6 +57,7 @@ async def store_alert(
 @router.get(
     "/{name}",
     response_model=mlrun.common.schemas.AlertConfig,
+    response_model_exclude_none=True,
 )
 @inject
 async def get_alert(
@@ -69,6 +70,9 @@ async def get_alert(
         Provide[framework.service.ServiceContainer.service]
     ),
 ) -> mlrun.common.schemas.AlertConfig:
+    client_version = request.headers.get("x-mlrun-client-version")
+    exclude_updated = client_version < "1.8.0" if client_version else False
+
     return await service.handle_request(
         "get_alert",
         request,
@@ -76,10 +80,15 @@ async def get_alert(
         name,
         auth_info,
         db_session,
+        exclude_updated=exclude_updated,
     )
 
 
-@router.get("", response_model=list[mlrun.common.schemas.AlertConfig])
+@router.get(
+    "",
+    response_model=list[mlrun.common.schemas.AlertConfig],
+    response_model_exclude_none=True,
+)
 @inject
 async def list_alerts(
     request: Request,
@@ -90,12 +99,16 @@ async def list_alerts(
         Provide[framework.service.ServiceContainer.service]
     ),
 ) -> list[mlrun.common.schemas.AlertConfig]:
+    client_version = request.headers.get("x-mlrun-client-version")
+    exclude_updated = client_version < "1.8.0" if client_version else False
+
     return await service.handle_request(
         "list_alerts",
         request,
         project,
         auth_info,
         db_session,
+        exclude_updated=exclude_updated,
     )
 
 

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -131,12 +131,19 @@ class Alerts(
         self,
         session: sqlalchemy.orm.Session,
         project: typing.Optional[typing.Union[str, list[str]]] = None,
+        exclude_updated: bool = False,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         project = project or mlrun.mlconf.default_project
-        return framework.utils.singletons.db.get_db().list_alerts(session, project)
+        return framework.utils.singletons.db.get_db().list_alerts(
+            session, project, exclude_updated
+        )
 
-    def get_enriched_alert(
-        self, session: sqlalchemy.orm.Session, project: str, name: str
+    def get_alert(
+        self,
+        session: sqlalchemy.orm.Session,
+        project: str,
+        name: str,
+        exclude_updated: bool = False,
     ):
         alert, state = framework.utils.singletons.db.get_db().get_alert(
             session, project, name, with_state=True
@@ -147,16 +154,9 @@ class Alerts(
             )
 
         framework.utils.singletons.db.get_db().enrich_alert(session, alert, state=state)
+        if exclude_updated:
+            alert.updated = None
         return alert
-
-    def get_alert(
-        self,
-        session: sqlalchemy.orm.Session,
-        project: str,
-        name: str,
-    ) -> mlrun.common.schemas.AlertConfig:
-        project = project or mlrun.mlconf.default_project
-        return framework.utils.singletons.db.get_db().get_alert(session, project, name)
 
     def delete_alert(
         self,

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -114,6 +114,7 @@ class Service(framework.service.Service):
         name: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
+        exclude_updated: bool = False,
     ) -> mlrun.common.schemas.AlertConfig:
         # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
         #  not access it directly (ML-8565)
@@ -133,7 +134,11 @@ class Service(framework.service.Service):
         )
 
         return await run_in_threadpool(
-            services.alerts.crud.Alerts().get_enriched_alert, db_session, project, name
+            services.alerts.crud.Alerts().get_alert,
+            db_session,
+            project,
+            name,
+            exclude_updated=exclude_updated,
         )
 
     async def list_alerts(
@@ -142,6 +147,7 @@ class Service(framework.service.Service):
         project: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
+        exclude_updated: bool = False,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         if project != "*":
             # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
@@ -162,6 +168,7 @@ class Service(framework.service.Service):
             services.alerts.crud.Alerts().list_alerts,
             db_session,
             project=allowed_project_names,
+            exclude_updated=exclude_updated,
         )
 
         alerts = await framework.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -118,10 +118,6 @@ class Service(framework.service.Service):
     ) -> mlrun.common.schemas.AlertConfig:
         # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
         #  not access it directly (ML-8565)
-        exclude_updated = self._should_exclude_updated(
-            request.headers.get("x-mlrun-client-version")
-        )
-
         await run_in_threadpool(
             framework.utils.singletons.project_member.get_project_member().ensure_project,
             db_session,
@@ -137,6 +133,9 @@ class Service(framework.service.Service):
             auth_info,
         )
 
+        exclude_updated = self._should_exclude_updated(
+            request.headers.get("x-mlrun-client-version")
+        )
         return await run_in_threadpool(
             services.alerts.crud.Alerts().get_alert,
             db_session,
@@ -152,10 +151,6 @@ class Service(framework.service.Service):
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
     ) -> list[mlrun.common.schemas.AlertConfig]:
-        exclude_updated = self._should_exclude_updated(
-            request.headers.get("x-mlrun-client-version")
-        )
-
         if project != "*":
             # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
             #  not access it directly (ML-8565)
@@ -171,6 +166,9 @@ class Service(framework.service.Service):
             )
         )
 
+        exclude_updated = self._should_exclude_updated(
+            request.headers.get("x-mlrun-client-version")
+        )
         alerts = await run_in_threadpool(
             services.alerts.crud.Alerts().list_alerts,
             db_session,
@@ -476,8 +474,11 @@ class Service(framework.service.Service):
 
     @staticmethod
     def _should_exclude_updated(client_version: str):
-        # Determine whether the `updated` field should be excluded based on the client version.
-        return not framework.utils.helpers.validate_client_version(
+        # The 'updated' field was added in 1.8.0, and earlier versions don't support it, so we exclude it
+        # for compatibility.
+        return bool(
+            client_version
+        ) and not framework.utils.helpers.validate_client_version(
             client_version, "1.8.0"
         )
 

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -133,9 +133,7 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        exclude_updated = self._should_exclude_updated(
-            request.headers.get("x-mlrun-client-version")
-        )
+        exclude_updated = self._should_exclude_updated(request)
         return await run_in_threadpool(
             services.alerts.crud.Alerts().get_alert,
             db_session,
@@ -166,9 +164,7 @@ class Service(framework.service.Service):
             )
         )
 
-        exclude_updated = self._should_exclude_updated(
-            request.headers.get("x-mlrun-client-version")
-        )
+        exclude_updated = self._should_exclude_updated(request)
         alerts = await run_in_threadpool(
             services.alerts.crud.Alerts().list_alerts,
             db_session,
@@ -473,9 +469,10 @@ class Service(framework.service.Service):
             await self._start_periodic_functions()
 
     @staticmethod
-    def _should_exclude_updated(client_version: str):
+    def _should_exclude_updated(request: fastapi.Request):
         # The 'updated' field was added in 1.8.0, and earlier versions don't support it, so we exclude it
         # for compatibility.
+        client_version = request.headers.get("x-mlrun-client-version")
         return bool(
             client_version
         ) and not framework.utils.helpers.validate_client_version(

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -34,6 +34,7 @@ import framework.db.sqldb.db
 import framework.service
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
+import framework.utils.helpers
 import framework.utils.pagination
 import framework.utils.periodic
 import framework.utils.singletons.db
@@ -114,10 +115,13 @@ class Service(framework.service.Service):
         name: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
-        exclude_updated: bool = False,
     ) -> mlrun.common.schemas.AlertConfig:
         # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
         #  not access it directly (ML-8565)
+        exclude_updated = self._should_exclude_updated(
+            request.headers.get("x-mlrun-client-version")
+        )
+
         await run_in_threadpool(
             framework.utils.singletons.project_member.get_project_member().ensure_project,
             db_session,
@@ -147,8 +151,11 @@ class Service(framework.service.Service):
         project: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
-        exclude_updated: bool = False,
     ) -> list[mlrun.common.schemas.AlertConfig]:
+        exclude_updated = self._should_exclude_updated(
+            request.headers.get("x-mlrun-client-version")
+        )
+
         if project != "*":
             # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
             #  not access it directly (ML-8565)
@@ -466,6 +473,13 @@ class Service(framework.service.Service):
         if self._is_chief_or_standalone():
             services.alerts.initial_data.update_default_configuration_data(self._logger)
             await self._start_periodic_functions()
+
+    @staticmethod
+    def _should_exclude_updated(client_version: str):
+        # Determine whether the `updated` field should be excluded based on the client version.
+        return not framework.utils.helpers.validate_client_version(
+            client_version, "1.8.0"
+        )
 
     def _register_routes(self):
         # TODO: Resolve these dynamically from configuration

--- a/server/py/services/alerts/tests/unit/crud/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alerts.py
@@ -91,7 +91,7 @@ class TestAlerts(TestAlertsBase):
             event,
         )
 
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
@@ -314,7 +314,7 @@ class TestAlerts(TestAlertsBase):
             event.kind,
             event,
         )
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
@@ -338,7 +338,7 @@ class TestAlerts(TestAlertsBase):
         )
 
         # fetch the updated alert
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
@@ -393,7 +393,7 @@ class TestAlerts(TestAlertsBase):
             alert_data=alert_data,
         )
 
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
@@ -410,10 +410,65 @@ class TestAlerts(TestAlertsBase):
             alert_data=alert_data,
         )
 
-        alert = services.alerts.crud.Alerts().get_enriched_alert(
+        alert = services.alerts.crud.Alerts().get_alert(
             session=db,
             project=project,
             name=alert_name,
         )
         assert alert.updated is not None
         assert alert.updated > alert.created.replace(tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    @unittest.mock.patch.object(
+        framework.utils.singletons.db.SQLDB, "update_alert_activation"
+    )
+    @unittest.mock.patch.object(
+        services.alerts.crud.AlertActivation, "store_alert_activation"
+    )
+    async def test_get_alerts_exclude_updated(
+        self,
+        mocked_update_alert_activation,
+        mocked_store_alert_activation,
+        db: sqlalchemy.orm.Session,
+        k8s_secrets_mock: K8sSecretsMock,
+    ):
+        mocked_update_alert_activation.return_value = None
+        mocked_store_alert_activation.return_value = None
+        project = "project-name"
+        alert_name = "my-alert"
+
+        alert_data = services.alerts.tests.unit.crud.utils.generate_alert_data(
+            project=project,
+            name=alert_name,
+            entity=services.alerts.tests.unit.crud.utils.generate_alert_entity(
+                project=project
+            ),
+        )
+
+        services.alerts.crud.Alerts().store_alert(
+            session=db,
+            project=project,
+            name=alert_name,
+            alert_data=alert_data,
+        )
+
+        # retrieve alerts without excluding the `updated` field (default behavior)
+        alerts = services.alerts.crud.Alerts().list_alerts(
+            session=db,
+            project=project,
+        )
+        assert alerts[0].updated is not None
+
+        # retrieve alerts with excluding the `updated` field
+        alerts = services.alerts.crud.Alerts().list_alerts(
+            session=db,
+            project=project,
+            exclude_updated=True,
+        )
+        assert alerts[0].updated is None
+
+        # retrieve a specific alert with excluding the `updated` field
+        alert = services.alerts.crud.Alerts().get_alert(
+            session=db, project=project, name=alert_name, exclude_updated=True
+        )
+        assert alert.updated is None

--- a/server/py/services/alerts/tests/unit/crud/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alerts.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import unittest
+import unittest.mock
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
 from datetime import timezone
@@ -41,10 +42,14 @@ def reset_alert_caches():
 class TestAlerts(TestAlertsBase):
     @pytest.mark.asyncio
     @unittest.mock.patch.object(
-        framework.utils.singletons.db.SQLDB, "update_alert_activation"
+        framework.utils.singletons.db.SQLDB,
+        "update_alert_activation",
+        return_value=None,
     )
     @unittest.mock.patch.object(
-        services.alerts.crud.AlertActivation, "store_alert_activation"
+        services.alerts.crud.AlertActivation,
+        "store_alert_activation",
+        return_value=None,
     )
     async def test_process_event_no_cache(
         self,
@@ -53,8 +58,6 @@ class TestAlerts(TestAlertsBase):
         db: sqlalchemy.orm.Session,
         k8s_secrets_mock: K8sSecretsMock,
     ):
-        mocked_update_alert_activation.return_value = None
-        mocked_store_alert_activation.return_value = None
         project = "project-name"
         alert_name = "my-alert"
         alert_summary = "testing 1 2 3"
@@ -113,10 +116,14 @@ class TestAlerts(TestAlertsBase):
         ],
     )
     @unittest.mock.patch.object(
-        framework.utils.singletons.db.SQLDB, "update_alert_activation"
+        framework.utils.singletons.db.SQLDB,
+        "update_alert_activation",
+        return_value=None,
     )
     @unittest.mock.patch.object(
-        services.alerts.crud.AlertActivation, "store_alert_activation"
+        services.alerts.crud.AlertActivation,
+        "store_alert_activation",
+        return_value=None,
     )
     async def test_validate_alert_name(
         self,
@@ -127,8 +134,6 @@ class TestAlerts(TestAlertsBase):
         alert_name: str,
         expectation: AbstractContextManager,
     ):
-        mocked_update_alert_activation.return_value = None
-        mocked_store_alert_activation.return_value = None
         project = "project-name"
         alert_summary = "The job has failed"
         alert_entity = alert_objects.EventEntities(
@@ -259,10 +264,14 @@ class TestAlerts(TestAlertsBase):
         [False, True],
     )
     @unittest.mock.patch.object(
-        framework.utils.singletons.db.SQLDB, "update_alert_activation"
+        framework.utils.singletons.db.SQLDB,
+        "update_alert_activation",
+        return_value=None,
     )
     @unittest.mock.patch.object(
-        services.alerts.crud.AlertActivation, "store_alert_activation"
+        services.alerts.crud.AlertActivation,
+        "store_alert_activation",
+        return_value=None,
     )
     async def test_alert_reset_with_fields_updates(
         self,
@@ -276,8 +285,6 @@ class TestAlerts(TestAlertsBase):
         k8s_secrets_mock: K8sSecretsMock,
         reset_alert_caches,
     ):
-        mocked_update_alert_activation.return_value = None
-        mocked_store_alert_activation.return_value = None
         project = "project-name"
         alert_name = "failed-alert"
         alert_summary = "The job has failed"
@@ -354,10 +361,14 @@ class TestAlerts(TestAlertsBase):
 
     @pytest.mark.asyncio
     @unittest.mock.patch.object(
-        framework.utils.singletons.db.SQLDB, "update_alert_activation"
+        framework.utils.singletons.db.SQLDB,
+        "update_alert_activation",
+        return_value=None,
     )
     @unittest.mock.patch.object(
-        services.alerts.crud.AlertActivation, "store_alert_activation"
+        services.alerts.crud.AlertActivation,
+        "store_alert_activation",
+        return_value=None,
     )
     async def test_store_alert_update_time(
         self,
@@ -366,8 +377,6 @@ class TestAlerts(TestAlertsBase):
         db: sqlalchemy.orm.Session,
         k8s_secrets_mock: K8sSecretsMock,
     ):
-        mocked_update_alert_activation.return_value = None
-        mocked_store_alert_activation.return_value = None
         project = "project-name"
         alert_name = "my-alert"
         alert_summary = "testing 1 2 3"
@@ -420,10 +429,14 @@ class TestAlerts(TestAlertsBase):
 
     @pytest.mark.asyncio
     @unittest.mock.patch.object(
-        framework.utils.singletons.db.SQLDB, "update_alert_activation"
+        framework.utils.singletons.db.SQLDB,
+        "update_alert_activation",
+        return_value=None,
     )
     @unittest.mock.patch.object(
-        services.alerts.crud.AlertActivation, "store_alert_activation"
+        services.alerts.crud.AlertActivation,
+        "store_alert_activation",
+        return_value=None,
     )
     async def test_get_alerts_exclude_updated(
         self,
@@ -432,8 +445,6 @@ class TestAlerts(TestAlertsBase):
         db: sqlalchemy.orm.Session,
         k8s_secrets_mock: K8sSecretsMock,
     ):
-        mocked_update_alert_activation.return_value = None
-        mocked_store_alert_activation.return_value = None
         project = "project-name"
         alert_name = "my-alert"
 


### PR DESCRIPTION
The updated field was added to 1.8.0 but clients using version 1.7.1 do not expect this field. 
As a result, calling `list_alerts_configs` or `get_alert_config` with a 1.7.1 client causes a TypeError due to the unexpected `updated` field being included in the response.

This PR introduces the logic to exclude the `updated` field from the alert responses when client version is < 1.8.0,
This was done by using FastAPI's `response_model_exclude_none=True` to ensure that `None` values are excluded from the response.

Jira:
https://iguazio.atlassian.net/browse/ML-8837

Also a minor refactor was done in this PR: changed the name of get_enriched_alert to get_alert ( as the older get_alert method was not used )