### PR TITLE
[Alerts] Add support for future schema fields

### DIFF
--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -123,7 +123,6 @@ class AlertConfig(ModelObj):
         :param count:          Internal counter of the alert (user should not supply it)
         :param updated:        The last update time of the alert (user should not supply it)
         """
-        super().__init__(**kwargs)
         self.project = project
         self.name = name
         self.description = description

--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -57,6 +57,7 @@ class AlertConfig(ModelObj):
         created: Optional[str] = None,
         count: Optional[int] = None,
         updated: Optional[str] = None,
+        **kwargs,
     ):
         """Alert config object
 
@@ -122,6 +123,7 @@ class AlertConfig(ModelObj):
         :param count:          Internal counter of the alert (user should not supply it)
         :param updated:        The last update time of the alert (user should not supply it)
         """
+        super().__init__(**kwargs)
         self.project = project
         self.name = name
         self.description = description

--- a/mlrun/common/schemas/alert.py
+++ b/mlrun/common/schemas/alert.py
@@ -160,6 +160,9 @@ class AlertConfig(pydantic.v1.BaseModel):
     count: Optional[int] = 0
     updated: datetime = None
 
+    class Config:
+        extra = pydantic.v1.Extra.allow
+
     def get_raw_notifications(self) -> list[notification_objects.Notification]:
         return [
             alert_notification.notification for alert_notification in self.notifications


### PR DESCRIPTION
This PR enhances the flexibility of the AlertConfig schema by:
1. Adding **kwargs to the AlertConfig client schema to ensure that future fields added to the schema won't cause errors.
2. Allowing extra fields in the server-side schema.

The client side fix can be a solution for: https://iguazio.atlassian.net/browse/ML-8837 with 1.7.2 client.