### PR TITLE
[Notification] Improve notification validation to be done on client side

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -768,15 +768,12 @@ class Notification(ModelObj):
         """
         Validates the notification parameters for the current notification instance.
 
-        Args:
-            default_notification_params (dict, optional): A dictionary of default notification
-                                                          parameters that can be used to enrich
-                                                          the existing params. Defaults to None.
-            skip_empty_check (bool, optional): A flag indicating whether to skip validation for
-                                                required fields that are empty. Defaults to False.
-                                                Set to True only on init of the object on the client side.
+        :param default_notification_params: A dictionary of default notification
+            parameters that can be used to enrich the existing params. Defaults to None.
+        :param skip_empty_check: A flag indicating whether to skip validation for
+            required fields that are empty. Defaults to False.
+            Set to True only on init of the object on the client side.
         """
-
         default_notification_params = default_notification_params or {}
         notification_type = mlrun.utils.notifications.NotificationTypes(self.kind)
         notification_class = notification_type.get_notification()

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -760,7 +760,21 @@ class Notification(ModelObj):
                 "Notification params size exceeds max size of 1 MB"
             )
 
-    def validate_notification_params(self, default_notification_params=None):
+        self.validate_notification_params(skip_empty_check=True)
+
+    def validate_notification_params(self, default_notification_params=None, skip_empty_check=False):
+        """
+        Validates the notification parameters for the current notification instance.
+
+        Args:
+            default_notification_params (dict, optional): A dictionary of default notification
+                                                          parameters that can be used to enrich
+                                                          the existing params. Defaults to None.
+            skip_empty_check (bool, optional): A flag indicating whether to skip validation for
+                                                required fields that are empty. Defaults to False.
+                                                Set to True only on init of the object on the client side.
+        """
+
         default_notification_params = default_notification_params or {}
         notification_type = mlrun.utils.notifications.NotificationTypes(self.kind)
         notification_class = notification_type.get_notification()
@@ -777,12 +791,12 @@ class Notification(ModelObj):
                 )
             return
 
-        if not secret_params and not params:
+        if not secret_params and not params and not skip_empty_check:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Both 'secret_params' and 'params' are empty, at least one must be defined."
             )
 
-        notification_class.validate_params(secret_params | params)
+        notification_class.validate_params(secret_params | params, skip_empty_check=skip_empty_check)
 
     def enrich_unmasked_secret_params_from_project_secret(self):
         """

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -762,7 +762,9 @@ class Notification(ModelObj):
 
         self.validate_notification_params(skip_empty_check=True)
 
-    def validate_notification_params(self, default_notification_params=None, skip_empty_check=False):
+    def validate_notification_params(
+        self, default_notification_params=None, skip_empty_check=False
+    ):
         """
         Validates the notification parameters for the current notification instance.
 
@@ -796,7 +798,9 @@ class Notification(ModelObj):
                 "Both 'secret_params' and 'params' are empty, at least one must be defined."
             )
 
-        notification_class.validate_params(secret_params | params, skip_empty_check=skip_empty_check)
+        notification_class.validate_params(
+            secret_params | params, skip_empty_check=skip_empty_check
+        )
 
     def enrich_unmasked_secret_params_from_project_secret(self):
         """

--- a/mlrun/utils/notifications/notification/base.py
+++ b/mlrun/utils/notifications/notification/base.py
@@ -39,7 +39,7 @@ class NotificationBase:
         self.params = self.enrich_default_params(self.params, default_params)
 
     @classmethod
-    def validate_params(cls, params):
+    def validate_params(cls, params, skip_empty_check=False):
         pass
 
     @property

--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -31,7 +31,7 @@ class GitNotification(NotificationBase):
     """
 
     @classmethod
-    def validate_params(cls, params):
+    def validate_params(cls, params, skip_empty_check=False):
         git_repo = params.get("repo", None)
         git_issue = params.get("issue", None)
         git_merge_request = params.get("merge_request", None)
@@ -40,6 +40,9 @@ class GitNotification(NotificationBase):
             or params.get("GIT_TOKEN", None)
             or params.get("GITHUB_TOKEN", None)
         )
+        if skip_empty_check:
+            return
+
         if not git_repo:
             raise ValueError("Parameter 'repo' is required for GitNotification")
 

--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -21,6 +21,7 @@ import aiohttp
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.lists
+import mlrun.utils.logger
 
 from .base import NotificationBase
 
@@ -41,6 +42,7 @@ class GitNotification(NotificationBase):
             or params.get("GITHUB_TOKEN", None)
         )
         if skip_empty_check:
+            mlrun.utils.logger.debug("Skipping emptiness check for notification params")
             return
 
         if not git_repo:

--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -44,7 +44,10 @@ class MailNotification(base.NotificationBase):
     ] + boolean_params
 
     @classmethod
-    def validate_params(cls, params):
+    def validate_params(cls, params, skip_empty_check=False):
+        cls._validate_emails(params)
+        if skip_empty_check:
+            return
         for required_param in cls.required_params:
             if required_param not in params:
                 raise ValueError(
@@ -56,8 +59,6 @@ class MailNotification(base.NotificationBase):
                 raise ValueError(
                     f"Parameter '{boolean_param}' must be a boolean for MailNotification"
                 )
-
-        cls._validate_emails(params)
 
     async def push(
         self,
@@ -120,18 +121,20 @@ class MailNotification(base.NotificationBase):
 
     @classmethod
     def _validate_emails(cls, params):
-        cls._validate_email_address(params["sender_address"])
+        sender_address = params.get("sender_address")
+        if sender_address:
+            cls._validate_email_address(sender_address)
 
-        if not isinstance(params["email_addresses"], (str, list)):
-            raise ValueError(
-                "Parameter 'email_addresses' must be a string or a list of strings"
-            )
-
-        email_addresses = params["email_addresses"]
-        if isinstance(email_addresses, str):
-            email_addresses = email_addresses.split(",")
-        for email_address in email_addresses:
-            cls._validate_email_address(email_address)
+        email_addresses = params.get("email_addresses")
+        if email_addresses:
+            if not isinstance(email_addresses, (str, list)):
+                raise ValueError(
+                    "Parameter 'email_addresses' must be a string or a list of strings"
+                )
+            if isinstance(email_addresses, str):
+                email_addresses = email_addresses.split(",")
+            for email_address in email_addresses:
+                cls._validate_email_address(email_address)
 
     @classmethod
     def _validate_email_address(cls, email_address):

--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -21,6 +21,7 @@ import aiosmtplib
 import mlrun.common.schemas
 import mlrun.lists
 import mlrun.utils.helpers
+import mlrun.utils.logger
 import mlrun.utils.notifications.notification.base as base
 import mlrun.utils.regex
 
@@ -47,6 +48,7 @@ class MailNotification(base.NotificationBase):
     def validate_params(cls, params, skip_empty_check=False):
         cls._validate_emails(params)
         if skip_empty_check:
+            mlrun.utils.logger.debug("Skipping emptiness check for notification params")
             return
         for required_param in cls.required_params:
             if required_param not in params:

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -36,7 +36,9 @@ class SlackNotification(NotificationBase):
     }
 
     @classmethod
-    def validate_params(cls, params):
+    def validate_params(cls, params, skip_empty_check=False):
+        if skip_empty_check:
+            return
         webhook = params.get("webhook", None) or mlrun.get_secret_or_env(
             "SLACK_WEBHOOK"
         )

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -19,6 +19,7 @@ import aiohttp
 import mlrun.common.schemas
 import mlrun.lists
 import mlrun.utils.helpers
+import mlrun.utils.logger
 
 from .base import NotificationBase
 
@@ -38,6 +39,7 @@ class SlackNotification(NotificationBase):
     @classmethod
     def validate_params(cls, params, skip_empty_check=False):
         if skip_empty_check:
+            mlrun.utils.logger.debug("Skipping emptiness check for notification params")
             return
         webhook = params.get("webhook", None) or mlrun.get_secret_or_env(
             "SLACK_WEBHOOK"

--- a/mlrun/utils/notifications/notification/webhook.py
+++ b/mlrun/utils/notifications/notification/webhook.py
@@ -20,6 +20,7 @@ import aiohttp
 import mlrun.common.schemas
 import mlrun.lists
 import mlrun.utils.helpers
+import mlrun.utils.logger
 
 from .base import NotificationBase
 
@@ -32,6 +33,7 @@ class WebhookNotification(NotificationBase):
     @classmethod
     def validate_params(cls, params, skip_empty_check=False):
         if skip_empty_check:
+            mlrun.utils.logger.debug("Skipping emptiness check for notification params")
             return
         url = params.get("url", None)
         if not url:

--- a/mlrun/utils/notifications/notification/webhook.py
+++ b/mlrun/utils/notifications/notification/webhook.py
@@ -30,7 +30,9 @@ class WebhookNotification(NotificationBase):
     """
 
     @classmethod
-    def validate_params(cls, params):
+    def validate_params(cls, params, skip_empty_check=False):
+        if skip_empty_check:
+            return
         url = params.get("url", None)
         if not url:
             raise ValueError("Parameter 'url' is required for WebhookNotification")

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1211,6 +1211,18 @@ def test_validate_notification_params(monkeypatch, notification_kwargs, expectat
         notification.validate_notification_params()
 
 
+def test_validate_notification_params_client_side():
+    email_address = "wrong@email"
+    with pytest.raises(ValueError, match=f"Invalid email address '{email_address}'"):
+        mlrun.model.Notification(
+            name="mail",
+            kind=mlrun.common.schemas.notification.NotificationKind.mail,
+            when=["completed"],
+            params={'email_addresses': email_address, 'subject': 'email_notification_subject',
+                    'use_tls': False, 'start_tls': True, 'validate_certs': False}
+        ),
+
+
 @pytest.mark.parametrize(
     "secret_params, get_secret_or_env_return_value, expected_params, should_raise",
     [

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1454,7 +1454,7 @@ class TestMailNotification:
                     "sender_address": "sender@example.com",
                     "username": "user",
                     "password": "pass",
-                    "email_addresses": ["a@example.com", "aaa"],
+                    "email_addresses": ["a@example.com"],
                     "use_tls": "True",
                     "validate_certs": True,
                     "start_tls": False,

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1214,13 +1214,20 @@ def test_validate_notification_params(monkeypatch, notification_kwargs, expectat
 def test_validate_notification_params_client_side():
     email_address = "wrong@email"
     with pytest.raises(ValueError, match=f"Invalid email address '{email_address}'"):
-        mlrun.model.Notification(
-            name="mail",
-            kind=mlrun.common.schemas.notification.NotificationKind.mail,
-            when=["completed"],
-            params={'email_addresses': email_address, 'subject': 'email_notification_subject',
-                    'use_tls': False, 'start_tls': True, 'validate_certs': False}
-        ),
+        (
+            mlrun.model.Notification(
+                name="mail",
+                kind=mlrun.common.schemas.notification.NotificationKind.mail,
+                when=["completed"],
+                params={
+                    "email_addresses": email_address,
+                    "subject": "email_notification_subject",
+                    "use_tls": False,
+                    "start_tls": True,
+                    "validate_certs": False,
+                },
+            ),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The issue was that a server-side run could fail during the notification step because the notification wasn't properly validated (see screenshot). While validation was already implemented, it only occurred on the server side. This PR adds a validation call to the Notification object initialization and introduces a skip_empty_check flag. When set, this flag bypasses the emptiness check for required fields. This functionality is necessary to avoid failures when certain fields, which are expected to be populated server-side, are not provided initially.

Jira - https://iguazio.atlassian.net/browse/ML-8660

![image](https://github.com/user-attachments/assets/6c5a1189-81c1-4a7b-9329-e1ced144ee9c)