### PR TITLE
[Vectordb] Use 'db_key' instead of 'key' to indentify artifact

### DIFF
--- a/mlrun/artifacts/document.py
+++ b/mlrun/artifacts/document.py
@@ -384,7 +384,7 @@ class DocumentArtifact(Artifact):
             metadata[self.METADATA_ORIGINAL_SOURCE_KEY] = self.spec.original_source
             metadata[self.METADATA_SOURCE_KEY] = self.get_source()
             metadata[self.METADATA_ARTIFACT_TAG] = self.tag or "latest"
-            metadata[self.METADATA_ARTIFACT_KEY] = self.key
+            metadata[self.METADATA_ARTIFACT_KEY] = self.db_key
             metadata[self.METADATA_ARTIFACT_PROJECT] = self.metadata.project
 
             if self.get_target_path():


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-8939