### PR TITLE
[Nuclio] Use invoke_url instead spec.host when getting invocation urls

### DIFF
--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -697,7 +697,7 @@ async def _get_api_gateways_urls_for_function(
         # TODO: optimise the way we request api gateways by filtering on Nuclio side
         return (
             [
-                api_gateway.spec.host
+                api_gateway.get_invoke_url()
                 for api_gateway in api_gateways.values()
                 if function_uri in api_gateway.get_function_names()
             ]


### PR DESCRIPTION
we always saved the host (without path) to external invocation urls. In all the other places where we enrich invocation url, we use invoke_url(not host). 
I don't see any real reason why would we do that, so using invoke_url instead spec.host when getting invocation urls for function. 
Jira - https://iguazio.atlassian.net/browse/ML-7913