### PR TITLE
[Notifications] Fix notification caching and terminal state notifications for Dask functions

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -763,7 +763,7 @@ class HTTPRunDB(RunDBInterface):
         :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
         """
         project = project or config.default_project
-
+        logger.info("Yaellll in httpdb")
         response = self.api_call(
             "POST",
             path=f"projects/{project}/runs/{uid}/push-notifications",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -763,7 +763,6 @@ class HTTPRunDB(RunDBInterface):
         :returns: :py:class:`~mlrun.common.schemas.BackgroundTask`.
         """
         project = project or config.default_project
-        logger.info("Yaellll in httpdb")
         response = self.api_call(
             "POST",
             path=f"projects/{project}/runs/{uid}/push-notifications",

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -281,5 +281,9 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
         # once the run is completed, and we can just push the notifications.
         # Only push from jupyter, not from the CLI.
         # "handler" and "dask" kinds are special cases of local runs which don't set local=True
-        if self._is_run_local or runtime.kind in ["handler", "dask"]:
+        if self._is_run_local or runtime.kind in ["handler"]:
             mlrun.utils.notifications.NotificationPusher([runobj]).push()
+        elif runtime.kind in ["dask"]:
+            logger.info("Yaellll in if dask")
+            runtime._get_db().push_run_notifications(uid=runobj.metadata.uid, project=runobj.metadata.project)
+

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -284,6 +284,5 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
         if self._is_run_local or runtime.kind in ["handler"]:
             mlrun.utils.notifications.NotificationPusher([runobj]).push()
         elif runtime.kind in ["dask"]:
-            logger.info("Yaellll in if dask")
             runtime._get_db().push_run_notifications(uid=runobj.metadata.uid, project=runobj.metadata.project)
 

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -284,5 +284,6 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
         if self._is_run_local or runtime.kind in ["handler"]:
             mlrun.utils.notifications.NotificationPusher([runobj]).push()
         elif runtime.kind in ["dask"]:
-            runtime._get_db().push_run_notifications(uid=runobj.metadata.uid, project=runobj.metadata.project)
-
+            runtime._get_db().push_run_notifications(
+                uid=runobj.metadata.uid, project=runobj.metadata.project
+            )

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -58,19 +58,19 @@ class RunNotificationPusher(NotificationPusher):
 
     @staticmethod
     def get_mail_notification_default_params(refresh=False):
-        logger.info("Yaellll in get_mail_notification_default_params")
+        # Check if the `refresh` flag is not set and the default mail notification parameters are already set.
+        # Ensure `mail_notification_default_params` is not None or empty,
+        # as an empty dictionary might indicate configuration changes we would like to reload.
+        # This avoids unnecessary re-fetching unless a refresh is explicitly requested.
         if (
             not refresh
             and RunNotificationPusher.mail_notification_default_params
         ):
-            logger.info("Yaellll in if")
             return RunNotificationPusher.mail_notification_default_params
 
-        logger.info("Yaellll after if")
         mail_notification_default_params = (
             RunNotificationPusher._get_mail_notifications_default_params_from_secret()
         )
-        logger.info("Yaellll default params", default=mail_notification_default_params)
 
         RunNotificationPusher.mail_notification_default_params = (
             mail_notification_default_params

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -58,15 +58,19 @@ class RunNotificationPusher(NotificationPusher):
 
     @staticmethod
     def get_mail_notification_default_params(refresh=False):
+        logger.info("Yaellll in get_mail_notification_default_params")
         if (
             not refresh
-            and RunNotificationPusher.mail_notification_default_params is not None
+            and RunNotificationPusher.mail_notification_default_params
         ):
+            logger.info("Yaellll in if")
             return RunNotificationPusher.mail_notification_default_params
 
+        logger.info("Yaellll after if")
         mail_notification_default_params = (
             RunNotificationPusher._get_mail_notifications_default_params_from_secret()
         )
+        logger.info("Yaellll default params", default=mail_notification_default_params)
 
         RunNotificationPusher.mail_notification_default_params = (
             mail_notification_default_params

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -62,10 +62,7 @@ class RunNotificationPusher(NotificationPusher):
         # Ensure `mail_notification_default_params` is not None or empty,
         # as an empty dictionary might indicate configuration changes we would like to reload.
         # This avoids unnecessary re-fetching unless a refresh is explicitly requested.
-        if (
-            not refresh
-            and RunNotificationPusher.mail_notification_default_params
-        ):
+        if not refresh and RunNotificationPusher.mail_notification_default_params:
             return RunNotificationPusher.mail_notification_default_params
 
         mail_notification_default_params = (


### PR DESCRIPTION
This PR fixes two issues:
- Resolves incorrect caching of server default parameters when a secret exists and server parameters are not provided in the notification ([ML-9116](https://iguazio.atlassian.net/browse/ML-9116)).
 - Ensures terminal state notifications (`error`, `completed`) are sent correctly for `Dask` functions, including mail notifications without explicit server details ([ML-8552](https://iguazio.atlassian.net/browse/ML-8552
))

Technical debts:
 - Add system test coverage for mail notifications.
 - Add test coverage for the caching process.
These will be addressed in a separate PR.

[ML-9116]: https://iguazio.atlassian.net/browse/ML-9116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-8552]: https://iguazio.atlassian.net/browse/ML-8552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ