### PR TITLE
[Model Monitoring] Remove `error_count` from feature set

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -146,7 +146,6 @@ class EventFieldType:
 
 class FeatureSetFeatures(MonitoringStrEnum):
     LATENCY = EventFieldType.LATENCY
-    ERROR_COUNT = EventFieldType.ERROR_COUNT
     METRICS = EventFieldType.METRICS
 
     @classmethod

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1266,6 +1266,11 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
             + mm_constants.FeatureSetFeatures.list()
         ]
 
+        df = pd.read_parquet(
+            f"v3io:///projects/{self.project.name}/artifacts/model-endpoints/parquet"
+        )
+        assert all(feature in df.columns for feature in feature_names)
+
     def test_inference_feature_set(self) -> None:
         self.project.log_model(  # pyright: ignore[reportOptionalMemberAccess]
             self.model_name,


### PR DESCRIPTION
Remove the `error_count` feature from the model monitoring set, as it is no longer stored in the Parquet files.

**Background**
Following #7117   we removed the `error_count` column from the infer parquets. However, this column still exists in the monitoring feature set and as a result the application gets an error when trying to call `get_offline_features`.

Resolves https://iguazio.atlassian.net/browse/ML-9170
