### PR TITLE
[Model Monitoring] Delete controller internal stream on disable API

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1077,7 +1077,6 @@ class RunDBInterface(ABC):
         base_period: int = 10,
         image: str = "mlrun/mlrun",
         deploy_histogram_data_drift_app: bool = True,
-        rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
     ) -> None:
         pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3973,7 +3973,6 @@ class HTTPRunDB(RunDBInterface):
         base_period: int = 10,
         image: str = "mlrun/mlrun",
         deploy_histogram_data_drift_app: bool = True,
-        rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
     ) -> None:
         """
@@ -3991,7 +3990,6 @@ class HTTPRunDB(RunDBInterface):
                                                   stream functions, which are real time nuclio functions.
                                                   By default, the image is mlrun/mlrun.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
-        :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images.
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
 
         """
@@ -4002,7 +4000,6 @@ class HTTPRunDB(RunDBInterface):
                 "base_period": base_period,
                 "image": image,
                 "deploy_histogram_data_drift_app": deploy_histogram_data_drift_app,
-                "rebuild_images": rebuild_images,
                 "fetch_credentials_from_sys_config": fetch_credentials_from_sys_config,
             },
         )

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -857,7 +857,6 @@ class NopDB(RunDBInterface):
         base_period: int = 10,
         image: str = "mlrun/mlrun",
         deploy_histogram_data_drift_app: bool = True,
-        rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
     ) -> None:
         pass

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2406,7 +2406,6 @@ class MlrunProject(ModelObj):
         *,
         deploy_histogram_data_drift_app: bool = True,
         wait_for_deployment: bool = False,
-        rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
     ) -> None:
         """
@@ -2428,7 +2427,6 @@ class MlrunProject(ModelObj):
         :param wait_for_deployment:               If true, return only after the deployment is done on the backend.
                                                   Otherwise, deploy the model monitoring infrastructure on the
                                                   background, including the histogram data drift app if selected.
-        :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images.
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
         """
         if default_controller_image != "mlrun/mlrun":
@@ -2451,7 +2449,6 @@ class MlrunProject(ModelObj):
             image=image,
             base_period=base_period,
             deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
-            rebuild_images=rebuild_images,
             fetch_credentials_from_sys_config=fetch_credentials_from_sys_config,
         )
 
@@ -3762,8 +3759,8 @@ class MlrunProject(ModelObj):
                 "Please keep in mind that if you already had model monitoring functions "
                 "/ model monitoring infra / tracked model server "
                 "deployed on your project, you will need to redeploy them. "
-                "For redeploying the model monitoring infra, please use `enable_model_monitoring` API "
-                "and set `rebuild_images=True`"
+                "For redeploying the model monitoring infra, first disable it using "
+                "`project.disable_model_monitoring()` and then enable it using `project.enable_model_monitoring()`."
             )
 
     def list_model_endpoints(

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1242,7 +1242,6 @@ class SQLRunDB(RunDBInterface):
         base_period: int = 10,
         image: str = "mlrun/mlrun",
         deploy_histogram_data_drift_app: bool = True,
-        rebuild_images: bool = False,
         fetch_credentials_from_sys_config: bool = False,
     ) -> None:
         raise NotImplementedError

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, Depends, Header, Path, Query
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
+from mlrun.utils import logger
 
 import framework.api.utils
 import framework.utils.auth.verifier
@@ -121,6 +122,7 @@ async def enable_model_monitoring(
     base_period: int = 10,
     image: str = "mlrun/mlrun",
     deploy_histogram_data_drift_app: bool = True,
+    rebuild_images: bool = False,
     fetch_credentials_from_sys_config: bool = False,
 ):
     """
@@ -138,9 +140,21 @@ async def enable_model_monitoring(
                                               stream functions, which are real time nuclio functions.
                                               By default, the image is mlrun/mlrun.
     :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
+    :param rebuild_images:                    Deprecated. If true, force rebuild of model monitoring infrastructure
+                                              images (controller, writer & stream).
     :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
 
     """
+
+    if rebuild_images:
+        logger.warn(
+            "The `rebuild_images` is no longer supported. "
+            "If you need to rebuild the images, `please call disable_model_monitoring()`, "
+            "followed by enable_model_monitoring() with the new image",
+            # TODO: Remove this in 1.10
+            FutureWarning,
+        )
+
     MonitoringDeployment(
         project=commons.project,
         auth_info=commons.auth_info,

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -150,7 +150,7 @@ async def enable_model_monitoring(
         logger.warn(
             "The `rebuild_images` is no longer supported. "
             "If you need to rebuild the images, `please call disable_model_monitoring()`, "
-            "followed by enable_model_monitoring() with the new image",
+            "followed by `enable_model_monitoring()` with the new image",
             # TODO: Remove this in 1.10
             FutureWarning,
         )

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -121,7 +121,6 @@ async def enable_model_monitoring(
     base_period: int = 10,
     image: str = "mlrun/mlrun",
     deploy_histogram_data_drift_app: bool = True,
-    rebuild_images: bool = False,
     fetch_credentials_from_sys_config: bool = False,
 ):
     """
@@ -139,8 +138,6 @@ async def enable_model_monitoring(
                                               stream functions, which are real time nuclio functions.
                                               By default, the image is mlrun/mlrun.
     :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
-    :param rebuild_images:                    If true, force rebuild of model monitoring infrastructure images
-                                              (controller, writer & stream).
     :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
 
     """
@@ -153,7 +150,6 @@ async def enable_model_monitoring(
         image=image,
         base_period=base_period,
         deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
-        rebuild_images=rebuild_images,
         fetch_credentials_from_sys_config=fetch_credentials_from_sys_config,
     )
 

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -473,6 +473,7 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.STREAM,
             stream_args=config.model_endpoint_monitoring.serving_stream,
+            keep_stream_if_exists=True,
         )
 
         # Apply feature store run configurations on the serving function

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -766,10 +766,7 @@ class MonitoringDeployment:
                     function_name=function_name,
                     auth_info=self.auth_info,
                     delete_app_stream_resources=function_name
-                    not in [
-                        mm_constants.MonitoringFunctionNames.STREAM,
-                        mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-                    ],
+                    != mm_constants.MonitoringFunctionNames.STREAM,
                     access_key=self.model_monitoring_access_key,
                 )
                 tasks.append(task)

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -209,7 +209,7 @@ class MonitoringDeployment:
                 project=self.project,
             )
             fn = self._get_model_monitoring_controller_function(
-                image=controller_image, ignore_stream_already_exist_failure=overwrite
+                image=controller_image, ignore_stream_already_exists_failure=overwrite
             )
             minutes = base_period
             hours = days = 0
@@ -278,7 +278,7 @@ class MonitoringDeployment:
         function: mlrun.runtimes.ServingRuntime,
         function_name: str,
         stream_args: mlrun.config.Config,
-        ignore_stream_already_exist_failure: bool = False,
+        ignore_stream_already_exists_failure: bool = False,
     ) -> mlrun.runtimes.ServingRuntime:
         """
         Add stream source for the nuclio serving function. The function's stream trigger can be
@@ -293,7 +293,7 @@ class MonitoringDeployment:
                                                     trigger.
         :param function_name:                       The name of the function that be applied with the stream trigger.
         :param stream_args:                         Stream args from the config.
-        :param ignore_stream_already_exist_failure: If True, skip the stream creation if it already exists.
+        :param ignore_stream_already_exists_failure: If True, skip the stream creation if it already exists.
 
         :return: `ServingRuntime` object with stream trigger.
         """
@@ -309,7 +309,7 @@ class MonitoringDeployment:
                 stream_path=stream_path,
                 function=function,
                 stream_args=stream_args,
-                ignore_stream_already_exist_failure=ignore_stream_already_exist_failure,
+                ignore_stream_already_exists_failure=ignore_stream_already_exists_failure,
             )
 
         elif stream_path.startswith("v3io://"):
@@ -340,7 +340,7 @@ class MonitoringDeployment:
         stream_path: str,
         function: mlrun.runtimes.ServingRuntime,
         stream_args: mlrun.config.Config,
-        ignore_stream_already_exist_failure: bool,
+        ignore_stream_already_exists_failure: bool,
     ):
         import kafka.errors
 
@@ -360,7 +360,7 @@ class MonitoringDeployment:
                 replication_factor=stream_args.kafka.replication_factor,
             )
         except kafka.errors.TopicAlreadyExistsError as exc:
-            if ignore_stream_already_exist_failure:
+            if ignore_stream_already_exists_failure:
                 logger.info(
                     "Kafka topic of model monitoring stream already exists. "
                     "Skipping topic creation and using `earliest` offset.",
@@ -474,7 +474,7 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.STREAM,
             stream_args=config.model_endpoint_monitoring.serving_stream,
-            ignore_stream_already_exist_failure=True,
+            ignore_stream_already_exists_failure=True,
         )
 
         # Apply feature store run configurations on the serving function
@@ -484,13 +484,13 @@ class MonitoringDeployment:
         return function
 
     def _get_model_monitoring_controller_function(
-        self, image: str, ignore_stream_already_exist_failure: bool
+        self, image: str, ignore_stream_already_exists_failure: bool
     ):
         """
         Initialize model monitoring controller function.
 
         :param image:                               Base docker image to use for building the function container.
-        :param ignore_stream_already_exist_failure: If True, skip the stream creation if it already exists.
+        :param ignore_stream_already_exists_failure: If True, skip the stream creation if it already exists.
         :return:                                    A function object from a mlrun runtime class.
         """
         # Create job function runtime for the controller
@@ -514,7 +514,7 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
             stream_args=config.model_endpoint_monitoring.controller_stream_args,
-            ignore_stream_already_exist_failure=ignore_stream_already_exist_failure,
+            ignore_stream_already_exists_failure=ignore_stream_already_exists_failure,
         )
 
         function = self._apply_access_key_and_mount_function(
@@ -607,7 +607,7 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.WRITER,
             stream_args=config.model_endpoint_monitoring.writer_stream_args,
-            ignore_stream_already_exist_failure=True,
+            ignore_stream_already_exists_failure=True,
         )
 
         # Apply feature store run configurations on the serving function

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -289,11 +289,12 @@ class MonitoringDeployment:
         Note: this method also disables the default HTTP trigger of the function, so it remains
         only with stream trigger(s).
 
-        :param function:                            The serving function object that will be applied with the stream
-                                                    trigger.
-        :param function_name:                       The name of the function that be applied with the stream trigger.
-        :param stream_args:                         Stream args from the config.
-        :param ignore_stream_already_exists_failure: If True, skip the stream creation if it already exists.
+        :param function:                             The serving function object that will be applied with the stream
+                                                     trigger.
+        :param function_name:                        The name of the function that be applied with the stream trigger.
+        :param stream_args:                          Stream args from the config.
+        :param ignore_stream_already_exists_failure: If True, ignores `TopicAlreadyExistsError` error on
+                                                     MM-infra-functions deployment when using kafka.
 
         :return: `ServingRuntime` object with stream trigger.
         """
@@ -490,7 +491,8 @@ class MonitoringDeployment:
         Initialize model monitoring controller function.
 
         :param image:                               Base docker image to use for building the function container.
-        :param ignore_stream_already_exists_failure: If True, skip the stream creation if it already exists.
+        :param ignore_stream_already_exists_failure: If True, ignores `TopicAlreadyExistsError` error on
+                                                     MM-infra-functions deployment when using kafka.
         :return:                                    A function object from a mlrun runtime class.
         """
         # Create job function runtime for the controller


### PR DESCRIPTION
Includes the following changes:

1 . Fix a bug in which the controller internal stream is not being deleted as expected when calling `disable_model_monitoring` API - https://iguazio.atlassian.net/browse/ML-8376.
2. Remove support for `rebuild_images()` in the `enable_model_monitoring()` API due to limitations with rebuilding nuclio functions that use Kafka topics. The expected approach of rebuilding the mm infra is to call `disable_model_monitoring()`, followed by `enable_model_monitoring()` with the new image
3. Fix `TestModelMonitoringInitialize` system test that validates the `disable/enable` APIs flow. Tested with both kafka and v3io resources. 

