### PR TITLE
[Model Monitoring] Fix getting a model endpoint without a TSDB profile

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/__init__.py
+++ b/mlrun/model_monitoring/db/tsdb/__init__.py
@@ -75,10 +75,11 @@ def get_tsdb_connector(
     :param secret_provider:         An optional secret provider to get the connection string secret.
     :param profile:                 An optional profile to initialize the TSDB connector from.
 
-    :return: `TSDBConnector` object. The main goal of this object is to handle different operations on the
+    :return: ``TSDBConnector`` object. The main goal of this object is to handle different operations on the
              TSDB connector such as updating drift metrics or write application record result.
-    :raise: `MLRunInvalidMMStoreTypeError` if the user didn't provide TSDB connection
-            or the provided TSDB connection is invalid.
+    :raise: ``MLRunNotFoundError`` if the user didn't set the TSDB datastore profile and didn't provide it through
+            the ``profile`` parameter.
+    :raise: ``MLRunInvalidMMStoreTypeError`` if the TSDB datastore profile is of an invalid type.
     """
     profile = profile or mlrun.model_monitoring.helpers._get_tsdb_profile(
         project=project, secret_provider=secret_provider
@@ -93,9 +94,15 @@ def get_tsdb_connector(
         tsdb_connector_type = mlrun.common.schemas.model_monitoring.TSDBTarget.TDEngine
         kwargs["connection_string"] = profile.dsn()
     else:
+        extra_message = (
+            ""
+            if profile
+            else " by using `project.set_model_monitoring_credentials` API"
+        )
         raise mlrun.errors.MLRunInvalidMMStoreTypeError(
-            "You must provide a valid tsdb store connection by using "
-            "set_model_monitoring_credentials API."
+            "You must provide a valid TSDB datastore profile"
+            f"{extra_message}. "
+            f"Found an unexpected profile of class: {type(profile)}"
         )
 
     # Get connector type value from ObjectTSDBFactory enum class

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -598,10 +598,10 @@ async def get_model_endpoint_monitoring_metrics_values(
                 project=params.project
             ),
         )
-    except mlrun.errors.MLRunInvalidMMStoreTypeError as e:
+    except mlrun.errors.MLRunNotFoundError as e:
         logger.debug(
-            "Failed to retrieve model endpoint metrics-values because tsdb connection is not defined."
-            " Returning an empty list of metric-values",
+            "Failed to retrieve model endpoint metrics-values because the TSDB datastore profile was not found. "
+            "Returning an empty list of metric-values",
             error=mlrun.errors.err_to_str(e),
         )
         return []

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -591,20 +591,13 @@ async def get_model_endpoint_monitoring_metrics_values(
     invocations_full_name = mlrun.model_monitoring.helpers.get_invocations_fqn(
         params.project
     )
-    try:
-        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-            project=params.project,
-            secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                project=params.project
-            ),
-        )
-    except mlrun.errors.MLRunNotFoundError as e:
-        logger.debug(
-            "Failed to retrieve model endpoint metrics-values because the TSDB datastore profile was not found. "
-            "Returning an empty list of metric-values",
-            error=mlrun.errors.err_to_str(e),
-        )
-        return []
+
+    tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+        project=params.project,
+        secret_provider=services.api.crud.secrets.get_project_secret_provider(
+            project=params.project
+        ),
+    )
 
     for metrics, type in [(params.results, "results"), (params.metrics, "metrics")]:
         if metrics:

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -591,13 +591,20 @@ async def get_model_endpoint_monitoring_metrics_values(
     invocations_full_name = mlrun.model_monitoring.helpers.get_invocations_fqn(
         params.project
     )
-
-    tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-        project=params.project,
-        secret_provider=services.api.crud.secrets.get_project_secret_provider(
-            project=params.project
-        ),
-    )
+    try:
+        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+            project=params.project,
+            secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                project=params.project
+            ),
+        )
+    except mlrun.errors.MLRunNotFoundError as e:
+        logger.debug(
+            "Failed to retrieve model endpoint metrics-values because the TSDB datastore profile was not found. "
+            "Returning an empty list of metric-values",
+            error=mlrun.errors.err_to_str(e),
+        )
+        return []
 
     for metrics, type in [(params.results, "results"), (params.metrics, "metrics")]:
         if metrics:

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1096,10 +1096,10 @@ class ModelEndpoints:
                     project=project
                 ),
             )
-        except mlrun.errors.MLRunInvalidMMStoreTypeError as e:
+        except mlrun.errors.MLRunNotFoundError as e:
             logger.debug(
-                f"Failed to list model endpoint {type}s because tsdb connection is not defined."
-                " Returning an empty list of metrics",
+                f"Failed to list model endpoint {type}s because TSDB profile was not found. "
+                "Returning an empty list of metrics",
                 error=mlrun.errors.err_to_str(e),
             )
             return []
@@ -1242,7 +1242,7 @@ class ModelEndpoints:
                     project=model_endpoint_object.metadata.project
                 ),
             )
-        except mlrun.errors.MLRunInvalidMMStoreTypeError as e:
+        except mlrun.errors.MLRunNotFoundError as e:
             logger.debug(
                 "Failed to add real time metrics because tsdb connection is not defined."
                 " Returning without adding real time metrics.",
@@ -1321,10 +1321,10 @@ class ModelEndpoints:
                     project=project
                 ),
             )
-        except mlrun.errors.MLRunInvalidMMStoreTypeError as e:
+        except mlrun.errors.MLRunNotFoundError as e:
             logger.debug(
-                "Failed to add basic metrics because tsdb connection is not defined."
-                " Returning without adding basic metrics.",
+                "Failed to add basic metrics because the TSDB profile was not found. "
+                "Returning without adding the basic metrics.",
                 error=mlrun.errors.err_to_str(e),
             )
             return model_endpoint_objects

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1089,20 +1089,13 @@ class ModelEndpoints:
         :param metrics_format:  Determines the format of the result. Can be either 'list' or 'dict'.
         :return: metrics in the chosen format.
         """
-        try:
-            tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-                project=project,
-                secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                    project=project
-                ),
-            )
-        except mlrun.errors.MLRunNotFoundError as e:
-            logger.debug(
-                f"Failed to list model endpoint {type}s because TSDB profile was not found. "
-                "Returning an empty list of metrics",
-                error=mlrun.errors.err_to_str(e),
-            )
-            return []
+        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+            project=project,
+            secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                project=project
+            ),
+        )
+
         if type == "metric":
             df = tsdb_connector.get_metrics_metadata(endpoint_id=endpoint_id)
         elif type == "result":
@@ -1235,20 +1228,12 @@ class ModelEndpoints:
         if model_endpoint_object.status.metrics is None:
             model_endpoint_object.status.metrics = {}
 
-        try:
-            tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-                project=model_endpoint_object.metadata.project,
-                secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                    project=model_endpoint_object.metadata.project
-                ),
-            )
-        except mlrun.errors.MLRunNotFoundError as e:
-            logger.debug(
-                "Failed to add real time metrics because tsdb connection is not defined."
-                " Returning without adding real time metrics.",
-                error=mlrun.errors.err_to_str(e),
-            )
-            return model_endpoint_object
+        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+            project=model_endpoint_object.metadata.project,
+            secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                project=model_endpoint_object.metadata.project
+            ),
+        )
 
         endpoint_metrics = tsdb_connector.get_model_endpoint_real_time_metrics(
             endpoint_id=model_endpoint_object.metadata.uid,
@@ -1314,20 +1299,12 @@ class ModelEndpoints:
 
             return mep
 
-        try:
-            tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-                project=project,
-                secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                    project=project
-                ),
-            )
-        except mlrun.errors.MLRunNotFoundError as e:
-            logger.debug(
-                "Failed to add basic metrics because the TSDB profile was not found. "
-                "Returning without adding the basic metrics.",
-                error=mlrun.errors.err_to_str(e),
-            )
-            return model_endpoint_objects
+        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+            project=project,
+            secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                project=project
+            ),
+        )
 
         uids = [mep.metadata.uid for mep in model_endpoint_objects]
         tasks = [

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1089,13 +1089,20 @@ class ModelEndpoints:
         :param metrics_format:  Determines the format of the result. Can be either 'list' or 'dict'.
         :return: metrics in the chosen format.
         """
-        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-            project=project,
-            secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                project=project
-            ),
-        )
-
+        try:
+            tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+                project=project,
+                secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                    project=project
+                ),
+            )
+        except mlrun.errors.MLRunNotFoundError as e:
+            logger.debug(
+                f"Failed to list model endpoint {type}s because TSDB profile was not found. "
+                "Returning an empty list of metrics",
+                error=mlrun.errors.err_to_str(e),
+            )
+            return []
         if type == "metric":
             df = tsdb_connector.get_metrics_metadata(endpoint_id=endpoint_id)
         elif type == "result":
@@ -1228,12 +1235,20 @@ class ModelEndpoints:
         if model_endpoint_object.status.metrics is None:
             model_endpoint_object.status.metrics = {}
 
-        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-            project=model_endpoint_object.metadata.project,
-            secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                project=model_endpoint_object.metadata.project
-            ),
-        )
+        try:
+            tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+                project=model_endpoint_object.metadata.project,
+                secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                    project=model_endpoint_object.metadata.project
+                ),
+            )
+        except mlrun.errors.MLRunNotFoundError as e:
+            logger.debug(
+                "Failed to add real time metrics because tsdb connection is not defined."
+                " Returning without adding real time metrics.",
+                error=mlrun.errors.err_to_str(e),
+            )
+            return model_endpoint_object
 
         endpoint_metrics = tsdb_connector.get_model_endpoint_real_time_metrics(
             endpoint_id=model_endpoint_object.metadata.uid,
@@ -1299,12 +1314,20 @@ class ModelEndpoints:
 
             return mep
 
-        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
-            project=project,
-            secret_provider=services.api.crud.secrets.get_project_secret_provider(
-                project=project
-            ),
-        )
+        try:
+            tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+                project=project,
+                secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                    project=project
+                ),
+            )
+        except mlrun.errors.MLRunNotFoundError as e:
+            logger.debug(
+                "Failed to add basic metrics because the TSDB profile was not found. "
+                "Returning without adding the basic metrics.",
+                error=mlrun.errors.err_to_str(e),
+            )
+            return model_endpoint_objects
 
         uids = [mep.metadata.uid for mep in model_endpoint_objects]
         tasks = [

--- a/server/py/services/api/tests/unit/api/test_model_endpoints.py
+++ b/server/py/services/api/tests/unit/api/test_model_endpoints.py
@@ -260,12 +260,16 @@ def get_project_secret_mock() -> Iterator[Mock]:
 
 async def test_get_metrics_values_no_tsdb(get_project_secret_mock: Mock) -> None:
     """Test getting model endpoint metrics values when the TSDB datastore profile is not set"""
-    metrics_values = await services.api.api.endpoints.model_endpoints.get_model_endpoint_monitoring_metrics_values(
+    params = (
         await services.api.api.endpoints.model_endpoints._get_metrics_values_params(
             project=TEST_PROJECT,
             endpoint_id="123",
             name=[f"{TEST_PROJECT}.app2.result.res1"],
         )
     )
-    assert metrics_values == []
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        await services.api.api.endpoints.model_endpoints.get_model_endpoint_monitoring_metrics_values(
+            params
+        )
+
     assert get_project_secret_mock.call_count == 1

--- a/server/py/services/api/tests/unit/api/test_model_endpoints.py
+++ b/server/py/services/api/tests/unit/api/test_model_endpoints.py
@@ -260,16 +260,12 @@ def get_project_secret_mock() -> Iterator[Mock]:
 
 async def test_get_metrics_values_no_tsdb(get_project_secret_mock: Mock) -> None:
     """Test getting model endpoint metrics values when the TSDB datastore profile is not set"""
-    params = (
+    metrics_values = await services.api.api.endpoints.model_endpoints.get_model_endpoint_monitoring_metrics_values(
         await services.api.api.endpoints.model_endpoints._get_metrics_values_params(
             project=TEST_PROJECT,
             endpoint_id="123",
             name=[f"{TEST_PROJECT}.app2.result.res1"],
         )
     )
-    with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        await services.api.api.endpoints.model_endpoints.get_model_endpoint_monitoring_metrics_values(
-            params
-        )
-
+    assert metrics_values == []
     assert get_project_secret_mock.call_count == 1


### PR DESCRIPTION
Fixes [ML-9049](https://iguazio.atlassian.net/browse/ML-9049).

This PR makes sure the following APIs work, even without a TSDB datastore profile credential:

* `get_model_endpoint` and `list_model_endpoints`, also with `tsdb_metrics=True`.
* `get_model_endpoint_monitoring_metrics` and `get_model_endpoint_monitoring_metrics_values`. I added a unit test.

Make sure to catch the correct `MLRunNotFoundError`.  
`MLRunInvalidMMStoreTypeError` is raised only when the datastore profile is of an invalid type, not when it is not set.

Set `tsdb_metrics=False` in the serving functions `get_model_endpoint`.

[ML-9049]: https://iguazio.atlassian.net/browse/ML-9049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ