### PR TITLE
[Labels] Add label length validation

### DIFF
--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -59,6 +59,11 @@ def update_labels(obj, labels: dict):
     old = {label.name: label for label in obj.labels}
     obj.labels.clear()
     for name, value in labels.items():
+        if len(value) > max_str_length:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Value of `{name}` label is too long. "
+                f"Maximum allowed length is {max_str_length} characters."
+            )
         if name in old:
             old[name].value = value
             obj.labels.append(old[name])

--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -59,7 +59,7 @@ def update_labels(obj, labels: dict):
     old = {label.name: label for label in obj.labels}
     obj.labels.clear()
     for name, value in labels.items():
-        if len(value) > max_str_length:
+        if len(str(value)) > max_str_length:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Value of `{name}` label is too long. "
                 f"Maximum allowed length is {max_str_length} characters."

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -421,6 +421,21 @@ class TestRuns(TestDatabaseBase):
         run = self._db.read_run(self._db_session, uid, project, iteration)
         assert run["metadata"]["labels"] == {"a": "b"}
 
+        run["metadata"]["labels"] = {"a": "b" * 256}
+        # too long value
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="Value of `a` label is too long. "
+            "Maximum allowed length is 255 characters.",
+        ):
+            self._db.update_run(
+                self._db_session,
+                run,
+                uid,
+                project,
+                iteration,
+            )
+
     def test_store_and_update_run_update_name_failure(self):
         project, name, uid, iteration, run = self._create_new_run()
 


### PR DESCRIPTION
Label's value maximum length is 255. This may be checked and validated in advance, so we fail fast and avoid trying to write to db.
Jira - https://iguazio.atlassian.net/browse/ML-9041