### PR TITLE
[Vectordb] Remove 'doc' prefix from artifact_key_instance() default key name

### DIFF
--- a/mlrun/artifacts/document.py
+++ b/mlrun/artifacts/document.py
@@ -97,7 +97,7 @@ class MLRunLoader:
     Args:
         artifact_key (str, optional): The key for the artifact to be logged. Special characters and symbols
             not valid in artifact names will be encoded as their hexadecimal representation. The '%%' pattern
-            in the key will be replaced by the hex-encoded version of the source path. Defaults to "doc%%".
+            in the key will be replaced by the hex-encoded version of the source path. Defaults to "%%".
         local_path (str): The source path of the document to be loaded.
         loader_spec (DocumentLoaderSpec): Specification for the document loader.
         producer (Optional[Union[MlrunProject, str, MLClientCtx]], optional): The producer of the document.
@@ -129,7 +129,7 @@ class MLRunLoader:
         >>> loader = MLRunLoader(
         ...     source_path="/path/to/document.txt",
         ...     loader_spec=loader_spec,
-        ...     artifact_key="doc%%",  # %% will be replaced with encoded path
+        ...     artifact_key="%%",  # %% will be replaced with encoded path
         ...     producer=project,
         ... )
         >>> documents = loader.load()
@@ -141,7 +141,7 @@ class MLRunLoader:
         ...     loader_cls=MLRunLoader,
         ...     loader_kwargs={
         ...         "loader_spec": loader_spec,
-        ...         "artifact_key": "doc%%",
+        ...         "artifact_key": "%%",
         ...         "producer": project,
         ...         "upload": True,
         ...     },
@@ -154,7 +154,7 @@ class MLRunLoader:
         cls,
         source_path: str,
         loader_spec: "DocumentLoaderSpec",
-        artifact_key="doc%%",
+        artifact_key="%%",
         producer: Optional[Union["MlrunProject", str, "MLClientCtx"]] = None,  # noqa: F821
         upload: bool = False,
         tag: str = "",

--- a/tests/system/datastore/test_vectorstore.py
+++ b/tests/system/datastore/test_vectorstore.py
@@ -176,7 +176,7 @@ class TestDatastoreProfile(TestMLRunSystem):
         sample_content1 = generate_random_text(1000)
         sample_content2 = generate_random_text(1000)
 
-        artifact_key = "doc%%"
+        artifact_key = "%%"
         artifact_key1 = MLRunLoader.artifact_key_instance(
             artifact_key, f"{temp_dir}/sample1.txt"
         )


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-9180