### PR TITLE
[Model Monitoring] Initialize the project object as part of the mm app pod initialization

### DIFF
--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -126,6 +126,7 @@ class _PrepareMonitoringEvent(StepToDict):
         :param application_name: Application name.
         """
         self.graph_context = context
+        _ = self.graph_context.project_obj  # Ensure project exists
         self.application_name = application_name
         self.model_endpoints: dict[str, mlrun.common.schemas.ModelEndpoint] = {}
 

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -169,9 +169,8 @@ class MonitoringApplicationContext:
         sample_df: Optional[pd.DataFrame] = None,
         feature_stats: Optional[FeatureStats] = None,
     ) -> "MonitoringApplicationContext":
-        project = mlrun.load_project(url=graph_context.project)
         nuclio_logger = graph_context.logger
-        artifacts_logger = project
+        artifacts_logger = graph_context.project_obj
         logger = mlrun.utils.create_logger(
             level=mlrun.mlconf.log_level,
             formatter_kind=mlrun.mlconf.log_formatter,
@@ -180,7 +179,7 @@ class MonitoringApplicationContext:
         return cls(
             application_name=application_name,
             event=event,
-            project=project,
+            project=graph_context.project_obj,
             model_endpoint_dict=model_endpoint_dict,
             logger=logger,
             nuclio_logger=nuclio_logger,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -243,10 +243,7 @@ class MonitoringApplicationController:
     def __init__(self) -> None:
         """Initialize Monitoring Application Controller"""
         self.project = cast(str, mlrun.mlconf.default_project)
-        self.project_obj = mlrun.load_project(
-            name=self.project, url=self.project, save=False
-        )
-
+        self.project_obj = mlrun.get_run_db().get_project(name=self.project)
         logger.debug(f"Initializing {self.__class__.__name__}", project=self.project)
 
         self._window_length = _get_window_length()
@@ -511,10 +508,7 @@ class MonitoringApplicationController:
         """
         logger.info("Starting monitoring controller chief")
         applications_names = []
-        db = mlrun.get_run_db()
-        endpoints = db.list_model_endpoints(
-            project=self.project, tsdb_metrics=True
-        ).endpoints
+        endpoints = self.project_obj.list_model_endpoints(tsdb_metrics=True).endpoints
         if not endpoints:
             logger.info("No model endpoints found", project=self.project)
             return

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3796,6 +3796,7 @@ class MlrunProject(ModelObj):
         top_level: bool = False,
         uids: Optional[list[str]] = None,
         latest_only: bool = False,
+        tsdb_metrics: bool = True,
     ) -> mlrun.common.schemas.ModelEndpointList:
         """
         Returns a list of `ModelEndpoint` objects. Each `ModelEndpoint` object represents the current state of a
@@ -3846,6 +3847,7 @@ class MlrunProject(ModelObj):
             top_level=top_level,
             uids=uids,
             latest_only=latest_only,
+            tsdb_metrics=tsdb_metrics,
         )
 
     def run_function(

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -553,7 +553,7 @@ class GraphContext:
     @property
     def project_obj(self):
         if not self._project_obj:
-            self._project_obj = mlrun.load_project(url=self.project, save=False)
+            self._project_obj = mlrun.get_run_db().get_project(name=self.project)
         return self._project_obj
 
     @property

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -544,10 +544,17 @@ class GraphContext:
         self.get_store_resource = None
         self.get_table = None
         self.is_mock = False
+        self._project_obj = None
 
     @property
     def server(self):
         return self._server
+
+    @property
+    def project_obj(self):
+        if not self._project_obj:
+            self._project_obj = mlrun.load_project(url=self.project, save=False)
+        return self._project_obj
 
     @property
     def project(self) -> str:


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-7407

1. Initialize the project object as part of the pod initialization
2. set `save=False` in order to avoid unnecessary PUT 
3. use `db.get_project` instead of `mlrun.load_project` (app & controller).