### PR TITLE
[Model Monitoring] add `system_id` to model monitoring resources

### DIFF
--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -47,9 +47,9 @@ def parse_monitoring_stream_path(
             function_name is None
             or function_name == mm_constants.MonitoringFunctionNames.STREAM
         ):
-            stream_uri += f"?topic=monitoring_stream_{project}_v1"
+            stream_uri += f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_v1"
         else:
-            stream_uri += f"?topic=monitoring_stream_{project}_{function_name}_v1"
+            stream_uri += f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_{function_name}_v1"
 
     return stream_uri
 

--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -47,7 +47,9 @@ def parse_monitoring_stream_path(
             function_name is None
             or function_name == mm_constants.MonitoringFunctionNames.STREAM
         ):
-            stream_uri += f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_v1"
+            stream_uri += (
+                f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_v1"
+            )
         else:
             stream_uri += f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_{function_name}_v1"
 

--- a/mlrun/common/model_monitoring/helpers.py
+++ b/mlrun/common/model_monitoring/helpers.py
@@ -48,10 +48,10 @@ def parse_monitoring_stream_path(
             or function_name == mm_constants.MonitoringFunctionNames.STREAM
         ):
             stream_uri += (
-                f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_v1"
+                f"?topic=monitoring_stream_{mlrun.mlconf.system_id}_{project}_v1"
             )
         else:
-            stream_uri += f"?topic=monitoring_stream_{project}_{mlrun.mlconf.system_id}_{function_name}_v1"
+            stream_uri += f"?topic=monitoring_stream_{mlrun.mlconf.system_id}_{project}_{function_name}_v1"
 
     return stream_uri
 

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -40,7 +40,7 @@ class TDEngineConnector(TSDBConnector):
     def __init__(
         self,
         project: str,
-        database: str = tdengine_schemas._MODEL_MONITORING_DATABASE,
+        database: str = None,
         **kwargs,
     ):
         super().__init__(project=project)
@@ -48,8 +48,12 @@ class TDEngineConnector(TSDBConnector):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "connection_string is a required parameter for TDEngineConnector."
             )
+
         self._tdengine_connection_string = kwargs.get("connection_string")
-        self.database = database
+        self.database = (
+            database
+            or f"{tdengine_schemas._MODEL_MONITORING_DATABASE}_{mlrun.mlconf.system_id}"
+        )
 
         self._connection = None
         self._init_super_tables()

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -40,7 +40,7 @@ class TDEngineConnector(TSDBConnector):
     def __init__(
         self,
         project: str,
-        database: str = None,
+        database: typing.Optional[str] = None,
         **kwargs,
     ):
         super().__init__(project=project)

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1151,7 +1151,6 @@ class MonitoringDeployment:
     def _verify_kafka_access(
         kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource,
     ) -> None:
-        import kafka
         import kafka.errors
 
         kafka_brokers = kafka_profile.brokers

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import uuid
 from collections.abc import Iterator
 from datetime import datetime, timezone
@@ -27,8 +26,9 @@ from mlrun.common.schemas.model_monitoring import (
 from mlrun.model_monitoring.db.tsdb.tdengine import TDEngineConnector
 
 project = "test-tdengine-connector"
-connection_string = os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION")
+# connection_string = os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION")
 database = "test_tdengine_connector_" + uuid.uuid4().hex
+connection_string = "taosws://root:taosdata@localhost:6041"
 
 
 def drop_database(connection: taosws.Connection) -> None:

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -26,9 +26,8 @@ from mlrun.common.schemas.model_monitoring import (
 from mlrun.model_monitoring.db.tsdb.tdengine import TDEngineConnector
 
 project = "test-tdengine-connector"
-# connection_string = os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION")
+connection_string = os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION")
 database = "test_tdengine_connector_" + uuid.uuid4().hex
-connection_string = "taosws://root:taosdata@localhost:6041"
 
 
 def drop_database(connection: taosws.Connection) -> None:

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import uuid
 from collections.abc import Iterator
 from datetime import datetime, timezone

--- a/tests/model_monitoring/test_target_path.py
+++ b/tests/model_monitoring/test_target_path.py
@@ -103,5 +103,5 @@ def test_get_kafka_profile_stream_path(kafka_profile_name: str) -> None:
     )
     assert (
         stream_path
-        == f"kafka://some_kafka_broker:8080?topic=monitoring_stream_{TEST_PROJECT}_v1"
+        == f"kafka://some_kafka_broker:8080?topic=monitoring_stream_{mlrun.mlconf.system_id}_{TEST_PROJECT}_v1"
     )

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1020,7 +1020,7 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
                     ignore_cache=True,
                 )
             assert (
-                f"monitoring_stream_{self.project_name}_{mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER}"
+                f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_{mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER}_v1"
                 not in topics
             )
 
@@ -1030,7 +1030,10 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
                 ignore_cache=True,
             )
 
-            assert f"monitoring_stream_{self.project_name}_v1" in topics
+            assert (
+                f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_v1"
+                in topics
+            )
 
             self._disable_stream_function()
 
@@ -1039,7 +1042,10 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
                 bootstrap_servers=brokers,
             )
             topics = consumer.topics()
-            assert f"monitoring_stream_{self.project_name}_v1" in topics
+            assert (
+                f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_v1"
+                in topics
+            )
 
             self._delete_histogram_app()
 
@@ -1049,7 +1055,7 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
             )
             topics = consumer.topics()
             assert (
-                f"monitoring_stream_{self.project_name}_{mm_constants.HistogramDataDriftApplicationConstants.NAME}_v1"
+                f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_{mm_constants.HistogramDataDriftApplicationConstants.NAME}_v1"
                 not in topics
             )
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -433,12 +433,14 @@ class TestMonitoringAppFlow(TestMLRunSystem, _V3IORecordsChecker):
             )
             topics = consumer.topics()
 
-            project_topics_list = [f"monitoring_stream_{self.project_name}"]
+            project_topics_list = [
+                f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}"
+            ]
             for func in func_to_validate + [
                 mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER
             ]:
                 project_topics_list.append(
-                    f"monitoring_stream_{self.project_name}_{func}"
+                    f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_{func}"
                 )
 
             for topic in project_topics_list:
@@ -1009,7 +1011,7 @@ class TestModelMonitoringInitialize(TestMLRunSystem):
                     ignore_cache=True,
                 )
             assert (
-                f"monitoring_stream_{self.project_name}_{mm_constants.MonitoringFunctionNames.WRITER}"
+                f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_{mm_constants.MonitoringFunctionNames.WRITER}"
                 not in topics
             )
 

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1156,7 +1156,7 @@ class TestModelMonitoringKafka(TestMLRunSystem):
         assert function_config["spec.triggers.kafka"]
         assert (
             function_config["spec.triggers.kafka"]["attributes"]["topics"][0]
-            == f"monitoring_stream_{self.project_name}"
+            == f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}"
         )
         assert (
             function_config["spec.triggers.kafka"]["attributes"]["brokers"][0]
@@ -1168,7 +1168,9 @@ class TestModelMonitoringKafka(TestMLRunSystem):
         # Validate that the topic exist as expected
         consumer = kafka.KafkaConsumer(bootstrap_servers=[self.brokers])
         topics = consumer.topics()
-        assert f"monitoring_stream_{self.project_name}" in topics
+        assert (
+            f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}" in topics
+        )
 
         # Simulating Requests
         iris_data = iris["data"].tolist()


### PR DESCRIPTION
To better identify mm resources related to a specific system, we will append the `system_id` (was introduced in #6976 ) to the resource names. This change is currently relevant only to `kafka` topics and `tdengine` databases. With this approach, we can use the same resources across multiple systems, even when the project names are similar (resolves https://iguazio.atlassian.net/browse/ML-7804). 

For instance, we created a project named `test-mm-sys-id-v2` in two different systems, using the same `kafka` and `tdengine` resources. Assuming that the `system_id` of the first setup is `6wgc3w` and the `system_id` of the second setup is `rwmk0g`, we can now explore the resources in the shared `kafka` and `tdengine`:

**tdengine**
 2 databases - 1 for each system:
`mlrun_model_monitoring_6wgc3w`
`mlrun_model_monitoring_rwmk0g`

**kafka**
8 topics (including the histogram application) - 4 per each system:
```
' monitoring_stream_6wgc3w_test-mm-sys-id-v2_histogram-data-drift_v1',
 'monitoring_stream_6wgc3w_test-mm-sys-id-v2_model-monitoring-controller_v1',
 'monitoring_stream_6wgc3w_test-mm-sys-id-v2_model-monitoring-writer_v1',
 'monitoring_stream_6wgc3w_test-mm-sys-id-v2_v1',
 'monitoring_stream_rwmk0g_test-mm-sys-id-v2_histogram-data-drift_v1',
 'monitoring_stream_rwmk0g_test-mm-sys-id-v2_model-monitoring-controller_v1',
 'monitoring_stream_rwmk0g_test-mm-sys-id-v2_model-monitoring-writer_v1',
 'monitoring_stream_rwmk0g_test-mm-sys-id-v2_v1'
```



