### PR TITLE
[RemoteRuntime] Don't always override handler in with_source_archive

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -369,8 +369,9 @@ class RemoteRuntime(KubeResource):
                 )
         """
         self.spec.build.source = source
-        # update handler in function_handler
-        self.spec.function_handler = handler
+        # update handler in function_handler if needed
+        if handler:
+            self.spec.function_handler = handler
         if workdir:
             self.spec.workdir = workdir
         if runtime:

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1326,9 +1326,10 @@ class TestNuclioRuntime(TestRuntimeBase):
 
     def test_load_function_with_source_archive_git(self):
         fn = self._generate_runtime(self.runtime_kind)
+        handler = "main:handler"
         fn.with_source_archive(
             "git://github.com/org/repo#my-branch",
-            handler="main:handler",
+            handler=handler,
             workdir="path/inside/repo",
         )
         secrets = {"GIT_PASSWORD": "my-access-token"}
@@ -1336,7 +1337,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         get_archive_spec(fn, secrets)
         assert get_archive_spec(fn, secrets) == {
             "spec": {
-                "handler": "main:handler",
+                "handler": handler,
                 "build": {
                     "path": "https://github.com/org/repo",
                     "codeEntryType": "git",
@@ -1353,13 +1354,13 @@ class TestNuclioRuntime(TestRuntimeBase):
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
             "git://github.com/org/repo#refs/heads/my-branch",
-            handler="main:handler",
+            handler=handler,
             workdir="path/inside/repo",
         )
 
         assert get_archive_spec(fn, secrets) == {
             "spec": {
-                "handler": "main:handler",
+                "handler": handler,
                 "build": {
                     "path": "https://github.com/org/repo",
                     "codeEntryType": "git",
@@ -1372,6 +1373,12 @@ class TestNuclioRuntime(TestRuntimeBase):
                 },
             },
         }
+
+        # ensure handler is not overridden if not passed
+        fn.with_source_archive(
+            "git://github.com/org/repo#refs/heads/my-other-branch",
+        )
+        assert fn.spec.function_handler == handler
 
     def test_nuclio_run_without_specifying_resources(
         self, db: Session, client: TestClient


### PR DESCRIPTION
Only override if passed as an argument.

https://iguazio.atlassian.net/browse/ML-8748