### PR TITLE
[Builder] Ensure unzip on mlrun base images

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -33,6 +33,7 @@ RUN apt update -qqq \
     git-core \
     graphviz \
     wget \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /mlrun

--- a/dockerfiles/gpu/prebaked.Dockerfile
+++ b/dockerfiles/gpu/prebaked.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG CUDA_VER
+ARG CUDA_VER=11.8.0-cudnn8-devel-ubuntu22.04
 
 # CUDA Based image (including cudnn and cuda-toolkit):
 FROM gcr.io/iguazio/nvidia/cuda:$CUDA_VER
@@ -31,6 +31,7 @@ RUN apt update -qqq --fix-missing \
     wget \
     bzip2 \
     ca-certificates \
+    unzip \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update  \
       graphviz \
       curl \
       apt-transport-https \
+      unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and install kubectl

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   gcc \
   wget \
   git-core \
+  unzip \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /mlrun

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -860,7 +860,7 @@ def test_builder_source(monkeypatch, source, expectation, expected_v3io_remote):
                 expected_output_re = re.compile(
                     rf"COPY {expected_source} /home/mlrun_code/source"
                 )
-                expected_line_index = 3
+                expected_line_index = 2
 
             else:
                 expected_output_re = re.compile(

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -107,12 +107,12 @@ def make_dockerfile(
     if source:
         args = args.rstrip("\n")
         # 'ADD' command does not extract zip files - add extraction stage to the dockerfile
+        # it is up to base image to have unzip included in case source is zip
         if source.endswith(".zip"):
             source_dir = os.path.join(target_dir, "source")
             stage_lines = [
                 f"FROM {base_image} AS extractor",
                 args,
-                "RUN apt-get update -qqy && apt install --assume-yes unzip",
                 f"RUN mkdir -p {source_dir}",
                 f"COPY {source} {source_dir}",
                 f"RUN cd {source_dir} && unzip {source} && rm {source}",


### PR DESCRIPTION
according to https://iguazio.atlassian.net/browse/ML-8331 - it is the responsibility of the base image to provide the unzip binary to ensure that zip sources can be unzipped.