### PR TITLE
[Artifacts] Propagate iteration when deleting artifact

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -403,6 +403,7 @@ class ArtifactManager:
             project=item.project,
             tag=item.tag,
             tree=item.tree,
+            iter=item.iter,
             deletion_strategy=deletion_strategy,
             secrets=secrets,
         )

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -306,6 +306,21 @@ class RunDBMock:
 
         return ArtifactList(filter(filter_artifact, self._artifacts.values()))
 
+    def del_artifact(
+        self,
+        key,
+        tag="",
+        project="",
+        tree=None,
+        uid=None,
+        deletion_strategy: mlrun.common.schemas.artifact.ArtifactsDeletionStrategies = (
+            mlrun.common.schemas.artifact.ArtifactsDeletionStrategies.metadata_only
+        ),
+        secrets: Optional[dict] = None,
+        iter=None,
+    ):
+        self._artifacts.pop((key, iter or 0), None)
+
     def store_run(self, struct, uid, project="", iter=0):
         if hasattr(struct, "to_dict"):
             struct = struct.to_dict()

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import os.path
 import pathlib
@@ -1191,6 +1190,33 @@ def test_artifact_owner(
         assert artifact.producer.get("owner") == username
     else:
         assert artifact.producer.get("owner") == project_owner
+
+
+def test_delete_artifacts_with_iteration(rundb_mock):
+    project_name = "my-project"
+    project = mlrun.new_project(project_name, save=False)
+
+    artifact_key = "my-artifact"
+    for iteration in range(1, 4):
+        artifact = mlrun.artifacts.Artifact(
+            key=artifact_key,
+            body="123",
+        )
+        artifact.db_key = artifact_key
+        artifact.iter = iteration
+        # store the artifacts directly to the rundb as with project iteration is always 0
+        rundb_mock.store_artifact(artifact_key, artifact.to_dict(), iter=iteration)
+
+    artifacts = project.list_artifacts()
+    assert len(artifacts) == 3
+
+    artifact_2 = project.get_artifact(artifact_key, iter=2)
+    assert artifact_2.iter == 2
+
+    project.delete_artifact(artifact_2)
+
+    artifacts = project.list_artifacts()
+    assert len(artifacts) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When deleting an artifact via project, the item's iteration wasn't passed by the artifact manager to `httpdb`'s `del_artifact`.

https://iguazio.atlassian.net/browse/ML-9099

