### PR TITLE
[DB] Fix default timestamp fields to ensure unique values for each record insertion

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -5825,8 +5825,7 @@ class SQLDB(DBInterface):
             version=version,
         )
 
-        now = datetime.now(timezone.utc)
-        data_version_record = DataVersion(version=version, created=now)
+        data_version_record = DataVersion(version=version)
         self._upsert(session, [data_version_record])
 
     def store_alert_template(
@@ -7035,7 +7034,6 @@ class SQLDB(DBInterface):
                 current_page=current_page,
                 page_size=page_size,
                 kwargs=kwargs,
-                last_accessed=datetime.now(timezone.utc),
             )
 
         self._upsert(session, [param_record])

--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -259,11 +259,11 @@ with warnings.catch_warnings():
         uid = Column(String(255, collation=SQLTypesUtil.collation()))
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         updated = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         _full_object = Column("object", SQLTypesUtil.blob())
 
@@ -387,11 +387,11 @@ with warnings.catch_warnings():
         )
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         updated = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         state = Column(String(255, collation=SQLTypesUtil.collation()))
         error = Column(String(255, collation=SQLTypesUtil.collation()))
@@ -566,11 +566,11 @@ with warnings.catch_warnings():
         project = Column(String(255, collation=SQLTypesUtil.collation()))
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         updated = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         state = Column(String(255, collation=SQLTypesUtil.collation()))
         uid = Column(String(255, collation=SQLTypesUtil.collation()))
@@ -630,11 +630,11 @@ with warnings.catch_warnings():
         project = Column(String(255, collation=SQLTypesUtil.collation()))
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         updated = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         state = Column(String(255, collation=SQLTypesUtil.collation()))
         uid = Column(String(255, collation=SQLTypesUtil.collation()))
@@ -679,11 +679,11 @@ with warnings.catch_warnings():
         index = Column(Integer)
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         updated = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
 
         _full_object = Column("object", JSON)
@@ -709,7 +709,7 @@ with warnings.catch_warnings():
         version = Column(String(255, collation=SQLTypesUtil.collation()))
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
 
         def get_identifier_string(self) -> str:
@@ -750,7 +750,7 @@ with warnings.catch_warnings():
         kwargs = Column(JSON)
         last_accessed = Column(
             SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
 
         def get_identifier_string(self) -> str:
@@ -764,7 +764,7 @@ with warnings.catch_warnings():
         count = Column(Integer)
         created = Column(
             SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
-            default=datetime.utcnow,
+            default=lambda: datetime.now(timezone.utc),
         )
         last_updated = Column(
             SQLTypesUtil.timestamp(),  # TODO: change to `datetime`, see ML-6921
@@ -896,7 +896,9 @@ with warnings.catch_warnings():
 
         key = Column(String(255, collation=SQLTypesUtil.collation()), primary_key=True)
         timestamp = Column(
-            SQLTypesUtil.datetime(), nullable=False, default=datetime.now(timezone.utc)
+            SQLTypesUtil.datetime(),
+            nullable=False,
+            default=lambda: datetime.now(timezone.utc),
         )
         max_window_size_seconds = Column(Integer)
 
@@ -931,11 +933,11 @@ with warnings.catch_warnings():
 
         created = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         updated = Column(
             SQLTypesUtil.timestamp(),
-            default=datetime.now(timezone.utc),
+            default=lambda: datetime.now(timezone.utc),
         )
         name = Column(String(255, collation=SQLTypesUtil.collation()))
         function = relationship(


### PR DESCRIPTION
Timestamp fields in several database tables were set with `default=datetime.now(timezone.utc)`, causing all records to have the same timestamp since SQLAlchemy evaluates the default value only once when the first object is inserted, leading to identical timestamps across all entries.

So in this PR I updated the default value to use a callable func: `default=lambda: datetime.now(timezone.utc)`, ensuring a new timestamp is generated for each record upon insertion.

Note:
`datetime.utcnow()` was not used since it is deprecated in Python 3.12+ :
https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

Jira:
https://iguazio.atlassian.net/browse/ML-8857