### PR TITLE
[Model Monitoring] Fix credentials exposure in YAML

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -253,6 +253,7 @@ class TSDBTarget(MonitoringStrEnum):
 class DefaultProfileName(StrEnum):
     STREAM = "mm-infra-stream"
     TSDB = "mm-infra-tsdb"
+    PARQUET = "mm-infra-parquet"
 
 
 class ProjectSecretKeys:

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -253,7 +253,6 @@ class TSDBTarget(MonitoringStrEnum):
 class DefaultProfileName(StrEnum):
     STREAM = "mm-infra-stream"
     TSDB = "mm-infra-tsdb"
-    PARQUET = "mm-infra-parquet"
 
 
 class ProjectSecretKeys:

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1366,35 +1366,6 @@ class Config:
             ver in mlrun.mlconf.ce.mode for ver in ["lite", "full"]
         )
 
-    def get_s3_storage_options(self) -> dict[str, typing.Any]:
-        """
-        Generate storage options dictionary as required for handling S3 path in fsspec. The model monitoring stream
-        graph uses this method for generating the storage options for S3 parquet target path.
-        :return: A storage options dictionary in which each key-value pair  represents a particular configuration,
-        such as endpoint_url or aws access key.
-        """
-        key = mlrun.get_secret_or_env("AWS_ACCESS_KEY_ID")
-        secret = mlrun.get_secret_or_env("AWS_SECRET_ACCESS_KEY")
-
-        force_non_anonymous = mlrun.get_secret_or_env("S3_NON_ANONYMOUS")
-        profile = mlrun.get_secret_or_env("AWS_PROFILE")
-
-        storage_options = dict(
-            anon=not (force_non_anonymous or (key and secret)),
-            key=key,
-            secret=secret,
-        )
-
-        endpoint_url = mlrun.get_secret_or_env("S3_ENDPOINT_URL")
-        if endpoint_url:
-            client_kwargs = {"endpoint_url": endpoint_url}
-            storage_options["client_kwargs"] = client_kwargs
-
-        if profile:
-            storage_options["profile"] = profile
-
-        return storage_options
-
     def is_explicit_ack_enabled(self) -> bool:
         return self.httpdb.nuclio.explicit_ack == "enabled" and (
             not self.nuclio_version

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -42,11 +42,10 @@ def get_url_and_storage_options(path, external_storage_options=None):
 
 
 class TDEngineStoreyTarget(storey.TDEngineTarget):
-    def __init__(self, *args, **kwargs):
-        path = kwargs.pop("url")
-        if path and path.startswith("ds://"):
+    def __init__(self, *args, url: str, **kwargs):
+        if url.startswith("ds://"):
             datastore_profile = (
-                mlrun.datastore.datastore_profile.datastore_profile_read(path)
+                mlrun.datastore.datastore_profile.datastore_profile_read(url)
             )
             if not isinstance(
                 datastore_profile,
@@ -56,9 +55,8 @@ class TDEngineStoreyTarget(storey.TDEngineTarget):
                     f"Unexpected datastore profile type:{datastore_profile.type}."
                     "Only TDEngineDatastoreProfile is supported"
                 )
-            path = datastore_profile.dsn()
-        kwargs["url"] = path
-        super().__init__(*args, **kwargs)
+            url = datastore_profile.dsn()
+        super().__init__(*args, url=url, **kwargs)
 
 
 class StoreyTargetUtils:

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -43,7 +43,13 @@ def get_url_and_storage_options(path, external_storage_options=None):
 
 class TDEngineStoreyTarget(storey.TDEngineTarget):
     def __init__(self, *args, **kwargs):
-        kwargs["url"] = mlrun.model_monitoring.helpers.get_tsdb_connection_string()
+        path = kwargs.pop("url")
+        if path and path.startswith("ds://"):
+            datastore_profile = (
+                mlrun.datastore.datastore_profile.datastore_profile_read(path)
+            )
+            path = datastore_profile.dsn()
+        kwargs["url"] = path
         super().__init__(*args, **kwargs)
 
 

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -48,6 +48,14 @@ class TDEngineStoreyTarget(storey.TDEngineTarget):
             datastore_profile = (
                 mlrun.datastore.datastore_profile.datastore_profile_read(path)
             )
+            if not isinstance(
+                datastore_profile,
+                mlrun.datastore.datastore_profile.TDEngineDatastoreProfile,
+            ):
+                raise ValueError(
+                    f"Unexpected datastore profile type:{datastore_profile.type}."
+                    "Only TDEngineDatastoreProfile is supported"
+                )
             path = datastore_profile.dsn()
         kwargs["url"] = path
         super().__init__(*args, **kwargs)
@@ -75,7 +83,12 @@ class StoreyTargetUtils:
 
 class ParquetStoreyTarget(storey.ParquetTarget):
     def __init__(self, *args, **kwargs):
+        alt_key_name = kwargs.pop("alternative_v3io_access_key", None)
         args, kwargs = StoreyTargetUtils.process_args_and_kwargs(args, kwargs)
+        storage_options = kwargs.get("storage_options", {})
+        if storage_options and storage_options.get("v3io_access_key") and alt_key_name:
+            if alt_key := mlrun.get_secret_or_env(alt_key_name):
+                storage_options["v3io_access_key"] = alt_key
         super().__init__(*args, **kwargs)
 
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -250,9 +250,10 @@ class MonitoringApplicationController:
 
         self.model_monitoring_access_key = self._get_model_monitoring_access_key()
         self.v3io_access_key = mlrun.mlconf.get_v3io_access_key()
-        self.storage_options = None
-        if mlrun.mlconf.artifact_path.startswith("s3://"):
-            self.storage_options = mlrun.mlconf.get_s3_storage_options()
+        store, _, _ = mlrun.store_manager.get_or_create_store(
+            mlrun.mlconf.artifact_path
+        )
+        self.storage_options = store.get_storage_options()
 
     @staticmethod
     def _get_model_monitoring_access_key() -> Optional[str]:

--- a/mlrun/model_monitoring/db/tsdb/__init__.py
+++ b/mlrun/model_monitoring/db/tsdb/__init__.py
@@ -19,6 +19,7 @@ import mlrun.common.schemas.secret
 import mlrun.datastore.datastore_profile
 import mlrun.errors
 import mlrun.model_monitoring.helpers
+from mlrun.datastore.datastore_profile import DatastoreProfile
 
 from .base import TSDBConnector
 
@@ -30,11 +31,12 @@ class ObjectTSDBFactory(enum.Enum):
     tdengine = "tdengine"
 
     def to_tsdb_connector(
-        self, project: str, connection_profile, **kwargs
+        self, project: str, profile: DatastoreProfile, **kwargs
     ) -> TSDBConnector:
         """
         Return a TSDBConnector object based on the provided enum value.
         :param project: The name of the project.
+        :param profile: Datastore profile containing DSN and credentials for TSDB connection
         :return: `TSDBConnector` object.
         """
 
@@ -53,9 +55,7 @@ class ObjectTSDBFactory(enum.Enum):
 
         from .tdengine.tdengine_connector import TDEngineConnector
 
-        return TDEngineConnector(
-            project=project, connection_profile=connection_profile, **kwargs
-        )
+        return TDEngineConnector(project=project, profile=profile, **kwargs)
 
     @classmethod
     def _missing_(cls, value: typing.Any):
@@ -91,7 +91,6 @@ def get_tsdb_connector(
     kwargs = {}
     if isinstance(profile, mlrun.datastore.datastore_profile.DatastoreProfileV3io):
         tsdb_connector_type = mlrun.common.schemas.model_monitoring.TSDBTarget.V3IO_TSDB
-        kwargs["v3io_access_key"] = profile.v3io_access_key
     elif isinstance(
         profile, mlrun.datastore.datastore_profile.TDEngineDatastoreProfile
     ):
@@ -113,5 +112,5 @@ def get_tsdb_connector(
 
     # Convert into TSDB connector object
     return tsdb_connector_factory.to_tsdb_connector(
-        project=project, connection_profile=profile, **kwargs
+        project=project, profile=profile, **kwargs
     )

--- a/mlrun/model_monitoring/db/tsdb/__init__.py
+++ b/mlrun/model_monitoring/db/tsdb/__init__.py
@@ -29,7 +29,9 @@ class ObjectTSDBFactory(enum.Enum):
     v3io_tsdb = "v3io-tsdb"
     tdengine = "tdengine"
 
-    def to_tsdb_connector(self, project: str, **kwargs) -> TSDBConnector:
+    def to_tsdb_connector(
+        self, project: str, connection_profile, **kwargs
+    ) -> TSDBConnector:
         """
         Return a TSDBConnector object based on the provided enum value.
         :param project: The name of the project.
@@ -51,7 +53,9 @@ class ObjectTSDBFactory(enum.Enum):
 
         from .tdengine.tdengine_connector import TDEngineConnector
 
-        return TDEngineConnector(project=project, **kwargs)
+        return TDEngineConnector(
+            project=project, connection_profile=connection_profile, **kwargs
+        )
 
     @classmethod
     def _missing_(cls, value: typing.Any):
@@ -92,7 +96,6 @@ def get_tsdb_connector(
         profile, mlrun.datastore.datastore_profile.TDEngineDatastoreProfile
     ):
         tsdb_connector_type = mlrun.common.schemas.model_monitoring.TSDBTarget.TDEngine
-        kwargs["connection_string"] = profile.dsn()
     else:
         extra_message = (
             ""
@@ -109,4 +112,6 @@ def get_tsdb_connector(
     tsdb_connector_factory = ObjectTSDBFactory(tsdb_connector_type)
 
     # Convert into TSDB connector object
-    return tsdb_connector_factory.to_tsdb_connector(project=project, **kwargs)
+    return tsdb_connector_factory.to_tsdb_connector(
+        project=project, connection_profile=profile, **kwargs
+    )

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -41,13 +41,13 @@ class TDEngineConnector(TSDBConnector):
     def __init__(
         self,
         project: str,
-        connection_profile: DatastoreProfile,
+        profile: DatastoreProfile,
         database: typing.Optional[str] = None,
         **kwargs,
     ):
         super().__init__(project=project)
 
-        self._tdengine_connection_profile = connection_profile
+        self._tdengine_connection_profile = profile
         self.database = (
             database
             or f"{tdengine_schemas._MODEL_MONITORING_DATABASE}_{mlrun.mlconf.system_id}"

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -25,6 +25,7 @@ from taoswswrap.tdengine_connection import (
 import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.schemas as tdengine_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.stream_graph_steps
+from mlrun.datastore.datastore_profile import DatastoreProfile
 from mlrun.model_monitoring.db import TSDBConnector
 from mlrun.model_monitoring.helpers import get_invocations_fqn
 from mlrun.utils import logger
@@ -40,16 +41,13 @@ class TDEngineConnector(TSDBConnector):
     def __init__(
         self,
         project: str,
+        connection_profile: DatastoreProfile,
         database: typing.Optional[str] = None,
         **kwargs,
     ):
         super().__init__(project=project)
-        if "connection_string" not in kwargs:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "connection_string is a required parameter for TDEngineConnector."
-            )
 
-        self._tdengine_connection_string = kwargs.get("connection_string")
+        self._tdengine_connection_profile = connection_profile
         self.database = (
             database
             or f"{tdengine_schemas._MODEL_MONITORING_DATABASE}_{mlrun.mlconf.system_id}"
@@ -70,7 +68,7 @@ class TDEngineConnector(TSDBConnector):
     def _create_connection(self) -> TDEngineConnection:
         """Establish a connection to the TSDB server."""
         logger.debug("Creating a new connection to TDEngine", project=self.project)
-        conn = TDEngineConnection(self._tdengine_connection_string)
+        conn = TDEngineConnection(self._tdengine_connection_profile.dsn())
         conn.run(
             statements=f"CREATE DATABASE IF NOT EXISTS {self.database}",
             timeout=self._timeout,
@@ -200,10 +198,10 @@ class TDEngineConnector(TSDBConnector):
 
         def apply_tdengine_target(name, after):
             graph.add_step(
-                "storey.TDEngineTarget",
+                "mlrun.datastore.storeytargets.TDEngineStoreyTarget",
                 name=name,
                 after=after,
-                url=self._tdengine_connection_string,
+                url=f"ds://{self._tdengine_connection_profile.name}",
                 supertable=self.tables[
                     mm_schemas.TDEngineSuperTables.PREDICTIONS
                 ].super_table,
@@ -242,10 +240,10 @@ class TDEngineConnector(TSDBConnector):
             after="ForwardError",
         )
         graph.add_step(
-            "storey.TDEngineTarget",
+            "mlrun.datastore.storeytargets.TDEngineStoreyTarget",
             name="tsdb_error",
             after="error_extractor",
-            url=self._tdengine_connection_string,
+            url=f"ds://{self._tdengine_connection_profile.name}",
             supertable=self.tables[mm_schemas.TDEngineSuperTables.ERRORS].super_table,
             table_col=mm_schemas.EventFieldType.TABLE_COLUMN,
             time_col=mm_schemas.EventFieldType.TIME,

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -246,21 +246,6 @@ def get_monitoring_drift_measures_data(project: str, endpoint_id: str) -> "DataI
     )
 
 
-def get_tsdb_connection_string(
-    secret_provider: Optional[Callable[[str], str]] = None,
-) -> str:
-    """Get TSDB connection string from the project secret. If wasn't set, take it from the system
-    configurations.
-    :param secret_provider: An optional secret provider to get the connection string secret.
-    :return:                Valid TSDB connection string.
-    """
-
-    return mlrun.get_secret_or_env(
-        key=mm_constants.ProjectSecretKeys.TSDB_CONNECTION,
-        secret_provider=secret_provider,
-    )
-
-
 def _get_profile(
     project: str,
     secret_provider: Optional[Callable[[str], str]],

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -243,6 +243,7 @@ class EventStreamProcessor:
         def apply_parquet_target():
             graph.add_step(
                 "mlrun.datastore.storeytargets.ParquetStoreyTarget",
+                alternative_v3io_access_key=mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY,
                 name="ParquetTarget",
                 after="ProcessBeforeParquet",
                 graph_shape="cylinder",

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -65,14 +65,11 @@ class EventStreamProcessor:
             parquet_batching_max_events=self.parquet_batching_max_events,
         )
 
-        self.storage_options = None
         self.tsdb_configurations = {}
         if not mlrun.mlconf.is_ce_mode():
             self._initialize_v3io_configurations(
                 model_monitoring_access_key=model_monitoring_access_key
             )
-        elif self.parquet_path.startswith("s3://"):
-            self.storage_options = mlrun.mlconf.get_s3_storage_options()
 
     def _initialize_v3io_configurations(
         self,
@@ -94,9 +91,6 @@ class EventStreamProcessor:
             model_monitoring_access_key
             or os.environ.get(ProjectSecretKeys.ACCESS_KEY)
             or self.v3io_access_key
-        )
-        self.storage_options = dict(
-            v3io_access_key=self.model_monitoring_access_key, v3io_api=self.v3io_api
         )
 
         # TSDB path and configurations
@@ -248,12 +242,11 @@ class EventStreamProcessor:
         # Write the Parquet target file, partitioned by key (endpoint_id) and time.
         def apply_parquet_target():
             graph.add_step(
-                "storey.ParquetTarget",
+                "mlrun.datastore.storeytargets.ParquetStoreyTarget",
                 name="ParquetTarget",
                 after="ProcessBeforeParquet",
                 graph_shape="cylinder",
                 path=self.parquet_path,
-                storage_options=self.storage_options,
                 max_events=self.parquet_batching_max_events,
                 flush_after_seconds=self.parquet_batching_timeout_secs,
                 attributes={"infer_columns_from_data": True},

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3788,6 +3788,24 @@ class MlrunProject(ModelObj):
             self.register_datastore_profile(stream_profile)
             stream_profile_name = stream_profile.name
 
+            if mlrun.mlconf.artifact_path.startswith("v3io://"):
+                profile = mlrun.datastore.datastore_profile.DatastoreProfileV3io(
+                    name=mm_constants.DefaultProfileName.PARQUET,
+                    v3io_access_key=mlrun.get_secret_or_env("V3IO_ACCESS_KEY"),
+                )
+                self.register_datastore_profile(profile)
+            elif mlrun.mlconf.artifact_path.startswith("s3://"):
+                profile = mlrun.datastore.datastore_profile.DatastoreProfileS3(
+                    name=mm_constants.DefaultProfileName.PARQUET,
+                    access_key_id=mlrun.get_secret_or_env("AWS_ACCESS_KEY_ID"),
+                    secret_key=mlrun.get_secret_or_env("AWS_SECRET_ACCESS_KEY"),
+                    endpoint_url=mlrun.get_secret_or_env("S3_ENDPOINT_URL"),
+                    force_non_anonymous=mlrun.get_secret_or_env("S3_NON_ANONYMOUS"),
+                    profile_name=mlrun.get_secret_or_env("AWS_PROFILE"),
+                    assume_role_arn=mlrun.get_secret_or_env("MLRUN_AWS_ROLE_ARN"),
+                )
+                self.register_datastore_profile(profile)
+
         db.set_model_monitoring_credentials(
             project=self.name,
             credentials={

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3671,7 +3671,6 @@ class MlrunProject(ModelObj):
 
     def set_model_monitoring_credentials(
         self,
-        access_key: Optional[str] = None,
         stream_path: Optional[str] = None,  # Deprecated
         tsdb_connection: Optional[str] = None,  # Deprecated
         replace_creds: bool = False,
@@ -3684,11 +3683,6 @@ class MlrunProject(ModelObj):
         infrastructure functions. Important to note that you have to set the credentials before deploying any
         model monitoring or serving function.
 
-        :param access_key:                Model monitoring access key for managing user permissions.
-
-                                          * None - will be set from the system configuration.
-                                          * v3io - for v3io endpoint store, pass `v3io` and the system will generate the
-                                            exact path.
         :param stream_path:               (Deprecated) This argument is deprecated. Use ``stream_profile_name`` instead.
                                           Path to the model monitoring stream. By default, None. Options:
 
@@ -3788,28 +3782,10 @@ class MlrunProject(ModelObj):
             self.register_datastore_profile(stream_profile)
             stream_profile_name = stream_profile.name
 
-            if mlrun.mlconf.artifact_path.startswith("v3io://"):
-                profile = mlrun.datastore.datastore_profile.DatastoreProfileV3io(
-                    name=mm_constants.DefaultProfileName.PARQUET,
-                    v3io_access_key=mlrun.get_secret_or_env("V3IO_ACCESS_KEY"),
-                )
-                self.register_datastore_profile(profile)
-            elif mlrun.mlconf.artifact_path.startswith("s3://"):
-                profile = mlrun.datastore.datastore_profile.DatastoreProfileS3(
-                    name=mm_constants.DefaultProfileName.PARQUET,
-                    access_key_id=mlrun.get_secret_or_env("AWS_ACCESS_KEY_ID"),
-                    secret_key=mlrun.get_secret_or_env("AWS_SECRET_ACCESS_KEY"),
-                    endpoint_url=mlrun.get_secret_or_env("S3_ENDPOINT_URL"),
-                    force_non_anonymous=mlrun.get_secret_or_env("S3_NON_ANONYMOUS"),
-                    profile_name=mlrun.get_secret_or_env("AWS_PROFILE"),
-                    assume_role_arn=mlrun.get_secret_or_env("MLRUN_AWS_ROLE_ARN"),
-                )
-                self.register_datastore_profile(profile)
-
         db.set_model_monitoring_credentials(
             project=self.name,
             credentials={
-                "access_key": access_key,
+                "access_key": None,
                 "tsdb_profile_name": tsdb_profile_name,
                 "stream_profile_name": stream_profile_name,
             },

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -181,6 +181,22 @@ class MonitoringDeployment:
                     db_session=self.db_session, project=self.project
                 )
             )
+
+            if parquet_target.startswith("v3io://"):
+                parquet_target = parquet_target.replace(
+                    "v3io:///", f"ds://{mm_constants.DefaultProfileName.PARQUET}/"
+                )
+            elif parquet_target.startswith("s3://"):
+                parquet_target = parquet_target.replace(
+                    "s3://", f"ds://{mm_constants.DefaultProfileName.PARQUET}/"
+                )
+            elif parquet_target.startswith("ds://"):
+                pass
+            else:
+                raise mlrun.errors.MLRunValueError(
+                    f"Unsupported model monitoring parquet type: '{parquet_target}'."
+                )
+
             fn = self._initial_model_monitoring_stream_processing_function(
                 stream_image=stream_image, parquet_target=parquet_target
             )

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -182,21 +182,6 @@ class MonitoringDeployment:
                 )
             )
 
-            if parquet_target.startswith("v3io://"):
-                parquet_target = parquet_target.replace(
-                    "v3io:///", f"ds://{mm_constants.DefaultProfileName.PARQUET}/"
-                )
-            elif parquet_target.startswith("s3://"):
-                parquet_target = parquet_target.replace(
-                    "s3://", f"ds://{mm_constants.DefaultProfileName.PARQUET}/"
-                )
-            elif parquet_target.startswith("ds://"):
-                pass
-            else:
-                raise mlrun.errors.MLRunValueError(
-                    f"Unsupported model monitoring parquet type: '{parquet_target}'."
-                )
-
             fn = self._initial_model_monitoring_stream_processing_function(
                 stream_image=stream_image, parquet_target=parquet_target
             )

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -124,12 +124,6 @@ class TestAppDeployment:
             )
 
             secrets = monitoring_deployment._get_monitoring_mandatory_project_secrets()
-            assert (
-                secrets[
-                    mlrun.common.schemas.model_monitoring.ProjectSecretKeys.TSDB_CONNECTION
-                ]
-                == "v3io"
-            )
 
             monitoring_deployment.set_credentials(
                 tsdb_connection="v3io",

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -24,6 +24,7 @@ from mlrun.common.schemas.model_monitoring import (
     ModelEndpointMonitoringMetric,
     ModelEndpointMonitoringMetricType,
 )
+from mlrun.datastore.datastore_profile import TDEngineDatastoreProfile
 from mlrun.model_monitoring.db.tsdb.tdengine import TDEngineConnector
 
 project = "test-tdengine-connector"
@@ -43,9 +44,10 @@ def is_tdengine_defined() -> bool:
 def connector() -> Iterator[TDEngineConnector]:
     connection = taosws.connect()
     drop_database(connection)
-    conn = TDEngineConnector(
-        project, connection_string=connection_string, database=database
+    profile = TDEngineDatastoreProfile.from_dsn(
+        profile_name="mm-profile", dsn=connection_string
     )
+    conn = TDEngineConnector(project, connection_profile=profile, database=database)
     try:
         yield conn
     finally:

--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -42,12 +42,12 @@ def is_tdengine_defined() -> bool:
 
 @pytest.fixture
 def connector() -> Iterator[TDEngineConnector]:
-    connection = taosws.connect()
+    connection = taosws.connect(connection_string)
     drop_database(connection)
     profile = TDEngineDatastoreProfile.from_dsn(
         profile_name="mm-profile", dsn=connection_string
     )
-    conn = TDEngineConnector(project, connection_profile=profile, database=database)
+    conn = TDEngineConnector(project, profile=profile, database=database)
     try:
         yield conn
     finally:

--- a/tests/model_monitoring/test_tdengine.py
+++ b/tests/model_monitoring/test_tdengine.py
@@ -22,6 +22,7 @@ import pytest
 from dateutil import parser
 
 import mlrun.common.schemas
+from mlrun.datastore.datastore_profile import TDEngineDatastoreProfile
 from mlrun.model_monitoring.db.tsdb.tdengine import TDEngineConnector
 from mlrun.model_monitoring.db.tsdb.tdengine.schemas import (
     _MODEL_MONITORING_DATABASE,
@@ -493,9 +494,10 @@ class TestTDEngineSchema:
 class TestTDEngineConnector:
     @pytest.fixture
     def connector(self):
-        return TDEngineConnector(
-            project="test-project", connection_string="taosws://localhost:6041"
+        profile = TDEngineDatastoreProfile(
+            name="mm-profile", host="localhost", port=6041, user="root"
         )
+        return TDEngineConnector(project="test-project", connection_profile=profile)
 
     def test_get_last_request(self, connector):
         df = pd.DataFrame(

--- a/tests/model_monitoring/test_tdengine.py
+++ b/tests/model_monitoring/test_tdengine.py
@@ -497,7 +497,7 @@ class TestTDEngineConnector:
         profile = TDEngineDatastoreProfile(
             name="mm-profile", host="localhost", port=6041, user="root"
         )
-        return TDEngineConnector(project="test-project", connection_profile=profile)
+        return TDEngineConnector(project="test-project", profile=profile)
 
     def test_get_last_request(self, connector):
         df = pd.DataFrame(


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-7622

When building model monitoring graphs, we previously used TDEngine and Parquet targets with their corresponding private credentials encoded directly in the Python YAML code. To improve security, this PR implements datastore profiles instead of direct DSN names and credentials, preventing the exposure of sensitive authentication information.