### PR TITLE
[Model Monitoring] Controller fix- allow 'cron' event.trigger.type

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -481,3 +481,6 @@ INTERSECT_DICT_KEYS = {
     ModelEndpointMonitoringMetricType.METRIC: "intersect_metrics",
     ModelEndpointMonitoringMetricType.RESULT: "intersect_results",
 }
+
+CRON_TRIGGER_KINDS = ("http", "cron")
+STREAM_TRIGGER_KINDS = ("v3io-stream", "kafka-cluster")

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -685,12 +685,16 @@ def handler(context: nuclio_sdk.Context, event: nuclio_sdk.Event) -> None:
         trigger_kind=event.trigger.kind,
     )
 
-    if event.trigger.kind == "http":
+    if event.trigger.kind in mm_constants.CRON_TRIGGER_KINDS:
         # Runs controller chief:
         context.user_data.monitor_app_controller.push_regular_event_to_controller_stream()
-    else:
+    elif event.trigger.kind in mm_constants.STREAM_TRIGGER_KINDS:
         # Runs controller worker:
         context.user_data.monitor_app_controller.run(event)
+    else:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Wrong trigger kind for model monitoring controller"
+        )
 
 
 def init_context(context):

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1259,12 +1259,15 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
         feature_set = self._get_monitoring_feature_set()
         features = feature_set.spec.features
         feature_names = [feat.name for feat in features]
-        assert feature_names == [
+        feature_names.sort()
+        columns_feature_names = [
             mlrun.feature_store.api.norm_column_name(feat)
             for feat in self.columns
             + [self.y_name]
             + mm_constants.FeatureSetFeatures.list()
         ]
+        columns_feature_names.sort()
+        assert feature_names == columns_feature_names
 
         df = pd.read_parquet(
             f"v3io:///projects/{self.project.name}/artifacts/model-endpoints/parquet"


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/CEML-325
Fix adding 'cron' option for cron trigger type other than 'http' more over checking for all trigger kinds including stream to prevent wrong event handling.
includes small fix for test_inference_feature_set