### PR TITLE
[Runs] Adjust listing by end time filter in system test

### DIFF
--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -415,12 +415,12 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
         assert len(runs) == 1
 
         # update the filter to start from the run's end_time
-        run_end_time = datetime.fromisoformat(run.status.end_time).replace(
-            tzinfo=timezone.utc
+        run_end_time = mlrun.utils.helpers.datetime_to_mysql_ts(
+            datetime.fromisoformat(run.status.end_time)
         )
         runs = mlrun.get_run_db().list_runs(
             project=self.project_name,
-            end_time_from=run_end_time - timedelta(milliseconds=100),
+            end_time_from=run_end_time,
         )
         assert len(runs) == 1
 

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -419,7 +419,8 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             tzinfo=timezone.utc
         )
         runs = mlrun.get_run_db().list_runs(
-            project=self.project_name, end_time_from=run_end_time
+            project=self.project_name,
+            end_time_from=run_end_time - timedelta(milliseconds=100),
         )
         assert len(runs) == 1
 


### PR DESCRIPTION
The system test failure was because the database stores timestamps with lower precision (milliseconds rounded to three decimal places), while the test uses higher precision (six decimal places). 
This mismatch sometimes caused the filtering to exclude the expected run.

For example, if we had:
Timestamp in the DB: `2025-02-02 09:30:41.056`
filter by run_end_time in the test: `2025-02-02T09:30:41.056300`
This tiny difference can cause the test’s filtering logic (end_time_from) to miss runs.