### PR TITLE
[Notification] Set event loop when creating a new one

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -55,6 +55,7 @@ class _NotificationPusherBase:
                 event_loop = asyncio.get_event_loop()
             except RuntimeError:
                 event_loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(event_loop)
 
             if not event_loop.is_running():
                 event_loop.run_until_complete(async_push_callback())

--- a/server/py/framework/utils/clients/iguazio.py
+++ b/server/py/framework/utils/clients/iguazio.py
@@ -131,6 +131,7 @@ class JobCache:
             event_loop = asyncio.get_event_loop()
         except RuntimeError:
             event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
 
         event_loop.call_later(self._ttl, self.invalidate_cache, project, job_id)
 


### PR DESCRIPTION
When new event loop is created, it should always be assigned to the thread. Otherwise, it may lead to undefined behaviour.

Jira - https://iguazio.atlassian.net/browse/ML-8402