### PR TITLE
[Model Monitoring] Fix `evaluate` with `datetime` in remote runs

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -95,8 +95,8 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         sample_data: Optional[pd.DataFrame] = None,
         reference_data: Optional[pd.DataFrame] = None,
         endpoints: Optional[list[tuple[str, str]]] = None,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
+        start: Optional[str] = None,
+        end: Optional[str] = None,
         base_period: Optional[int] = None,
     ):
         """
@@ -124,7 +124,6 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             return self.do_tracking(monitoring_context)
 
         if endpoints is not None:
-            start, end = self._validate_times(start, end, base_period)
             for window_start, window_end in self._window_generator(
                 start, end, base_period
             ):
@@ -137,43 +136,40 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                             mm_constants.ApplicationEvent.END_INFER_TIME: window_end,
                         }
                     )
-                    context.log_result(
-                        f"{endpoint_name}_{window_start.isoformat()}_{window_end.isoformat()}",
-                        result,
+                    result_key = (
+                        f"{endpoint_name}_{window_start.isoformat()}_{window_end.isoformat()}"
+                        if window_start and window_end
+                        else endpoint_name
                     )
+                    context.log_result(result_key, result)
         else:
             return call_do_tracking()
 
     @staticmethod
-    def _validate_times(
-        start: Optional[datetime],
-        end: Optional[datetime],
-        base_period: Optional[int],
-    ) -> tuple[datetime, datetime]:
-        if (start is None) or (end is None):
-            raise mlrun.errors.MLRunValueError(
-                "When `endpoint_names` is provided, you must also pass the start and end times"
-            )
-        if (base_period is not None) and not (
-            isinstance(base_period, int) and base_period > 0
-        ):
+    def _window_generator(
+        start: Optional[str], end: Optional[str], base_period: Optional[int]
+    ) -> Iterator[tuple[Optional[datetime], Optional[datetime]]]:
+        if start is None or end is None:
+            # A single window based on the `sample_data` input - see `_handler`.
+            yield None, None
+            return
+
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end)
+
+        if base_period is None:
+            yield start_dt, end_dt
+            return
+
+        if not isinstance(base_period, int) or base_period <= 0:
             raise mlrun.errors.MLRunValueError(
                 "`base_period` must be a nonnegative integer - the number of minutes in a monitoring window"
             )
-        return start, end
-
-    @staticmethod
-    def _window_generator(
-        start: datetime, end: datetime, base_period: Optional[int]
-    ) -> Iterator[tuple[datetime, datetime]]:
-        if base_period is None:
-            yield start, end
-            return
 
         window_length = timedelta(minutes=base_period)
-        current_start_time = start
-        while current_start_time < end:
-            current_end_time = min(current_start_time + window_length, end)
+        current_start_time = start_dt
+        while current_start_time < end_dt:
+            current_end_time = min(current_start_time + window_length, end_dt)
             yield current_start_time, current_end_time
             current_start_time = current_end_time
 
@@ -395,16 +391,23 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             project=project,
         )
 
-        params: dict[str, Union[list[tuple[str, str]], datetime, int, None]] = {}
+        params: dict[str, Union[list[tuple[str, str]], str, int, None]] = {}
         if endpoints:
-            start, end = cls._validate_times(start, end, base_period)
             params["endpoints"] = endpoints
-            params["start"] = start
-            params["end"] = end
-            params["base_period"] = base_period
+            if not sample_data:
+                if start is None or end is None:
+                    raise mlrun.errors.MLRunValueError(
+                        "`start` and `end` times must be provided when `endpoints` "
+                        "is provided without `sample_data`"
+                    )
+                params["start"] = (
+                    start.isoformat() if isinstance(start, datetime) else start
+                )
+                params["end"] = end.isoformat() if isinstance(end, datetime) else end
+                params["base_period"] = base_period
         elif start or end or base_period:
             raise mlrun.errors.MLRunValueError(
-                "Custom start and end times or base_period are supported only with endpoints data"
+                "Custom `start` and `end` times or base_period are supported only with endpoints data"
             )
 
         inputs: dict[str, str] = {}

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -394,7 +394,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         params: dict[str, Union[list[tuple[str, str]], str, int, None]] = {}
         if endpoints:
             params["endpoints"] = endpoints
-            if not sample_data:
+            if sample_data is None:
                 if start is None or end is None:
                     raise mlrun.errors.MLRunValueError(
                         "`start` and `end` times must be provided when `endpoints` "

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -88,24 +88,16 @@ class TestEvaluate:
 @pytest.mark.parametrize(
     ("start", "end", "base_period", "expectation"),
     [
+        (None, None, None, does_not_raise()),
         (
-            None,
-            None,
-            None,
-            pytest.raises(
-                mlrun.errors.MLRunValueError,
-                match=".* you must also pass the start and end times",
-            ),
-        ),
-        (
-            datetime(2008, 9, 1, 10, 2, 1, tzinfo=timezone.utc),
-            datetime(2008, 9, 2, 10, 2, 1, tzinfo=timezone.utc),
+            datetime(2008, 9, 1, 10, 2, 1, tzinfo=timezone.utc).isoformat(),
+            datetime(2008, 9, 2, 10, 2, 1, tzinfo=timezone.utc).isoformat(),
             None,
             does_not_raise(),
         ),
         (
-            datetime(2008, 9, 1, 10, 2, 1, tzinfo=timezone.utc),
-            datetime(2008, 9, 2, 10, 2, 1, tzinfo=timezone.utc),
+            datetime(2008, 9, 1, 10, 2, 1, tzinfo=timezone.utc).isoformat(),
+            datetime(2008, 9, 2, 10, 2, 1, tzinfo=timezone.utc).isoformat(),
             0,
             pytest.raises(
                 mlrun.errors.MLRunValueError,
@@ -114,14 +106,14 @@ class TestEvaluate:
         ),
     ],
 )
-def test_validate_times(
-    start: Optional[datetime],
-    end: Optional[datetime],
+def test_window_generator_validation(
+    start: Optional[str],
+    end: Optional[str],
     base_period: Optional[int],
     expectation: AbstractContextManager,
 ) -> None:
     with expectation:
-        ModelMonitoringApplicationBase._validate_times(start, end, base_period)
+        next(ModelMonitoringApplicationBase._window_generator(start, end, base_period))
 
 
 @pytest.mark.parametrize(
@@ -191,7 +183,7 @@ def test_windows(
     assert (
         list(
             ModelMonitoringApplicationBase._window_generator(
-                start=start, end=end, base_period=base_period
+                start=start.isoformat(), end=end.isoformat(), base_period=base_period
             )
         )
         == expected_windows

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1551,7 +1551,8 @@ class TestAppJobModelEndpointData(TestMLRunSystem):
             executor.submit(self._deploy_model_serving)
             executor.submit(self._set_infra)
 
-    def test_count_app(self) -> None:
+    @pytest.mark.parametrize("run_local", [False, True])
+    def test_count_app(self, run_local: bool) -> None:
         # Set up the serving function with a model endpoint, and the necessary infrastructure
         self._setup_resources()
 
@@ -1601,7 +1602,7 @@ class TestAppJobModelEndpointData(TestMLRunSystem):
             endpoints=[(model_endpoint.metadata.name, model_endpoint.metadata.uid)],
             start=start,
             end=end,
-            run_local=True,  # `False` does not work, see ML-8817
+            run_local=run_local,
             image=self.image,
             base_period=1,
         )


### PR DESCRIPTION
As a simpler alternative to #6973, fix [ML-8817](https://iguazio.atlassian.net/browse/ML-8817).
The solution: serialize the `datetime` variables - `start` and `end` to strings.

In addition, support the following combination: model endpoints with sample data (without times) - fix [ML-8914](https://iguazio.atlassian.net/browse/ML-8914).

[ML-8817]: https://iguazio.atlassian.net/browse/ML-8817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-8914]: https://iguazio.atlassian.net/browse/ML-8914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ