### PR TITLE
[Config] Use orderdict to preserve key order in env parsing

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "VolumeMount",
 ]
 
+import collections
 from os import environ, path
 from typing import Optional
 
@@ -238,7 +239,7 @@ def order_env_vars(env_vars: dict[str, str]) -> dict[str, str]:
     """
     ordered_keys = mlconf.get_ordered_keys()
 
-    ordered_env_vars: dict[str, str] = {}
+    ordered_env_vars = collections.OrderedDict()
 
     # First, add the ordered keys to the dictionary
     for key in ordered_keys:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -589,7 +589,6 @@ def test_env_from_file():
     env_path = str(assets_path / "envfile")
     env_dict = mlrun.set_env_from_file(env_path, return_dict=True)
 
-    assert isinstance(env_dict, collections.OrderedDict)
     assert env_dict == collections.OrderedDict(
         {
             "MLRUN_HTTPDB__HTTP__VERIFY": "false",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import os
 import pathlib
 import subprocess
@@ -587,12 +588,16 @@ def test_set_environment_cred():
 def test_env_from_file():
     env_path = str(assets_path / "envfile")
     env_dict = mlrun.set_env_from_file(env_path, return_dict=True)
-    assert env_dict == {
-        "ENV_ARG1": "123",
-        "ENV_ARG2": "abc",
-        "MLRUN_HTTPDB__HTTP__VERIFY": "false",
-        "MLRUN_KFP_TTL": "12345",
-    }
+
+    assert isinstance(env_dict, collections.OrderedDict)
+    assert env_dict == collections.OrderedDict(
+        {
+            "MLRUN_HTTPDB__HTTP__VERIFY": "false",
+            "MLRUN_KFP_TTL": "12345",
+            "ENV_ARG1": "123",
+            "ENV_ARG2": "abc",
+        }
+    )
     assert mlrun.mlconf.kfp_ttl == 12345
     for key, value in env_dict.items():
         assert os.environ[key] == value


### PR DESCRIPTION
Using dict did not guarantee key order, which caused inconsistent behavior. Replacing it with OrderedDict ensures that environment variables are processed in the correct sequence.

Jira:
https://iguazio.atlassian.net/browse/ML-8460