### PR TITLE
[Runs] Enhancements to preemption handling

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1207,9 +1207,9 @@ class KubeResource(BaseRuntime):
         """
         preemptible_tolerations = [
             k8s_client.V1Toleration(
-                key=toleration["key"],
-                value=toleration["value"],
-                effect=toleration["effect"],
+                key=toleration.get("key"),
+                value=toleration.get("value"),
+                effect=toleration.get("effect"),
             )
             for toleration in mlconf.get_preemptible_tolerations()
         ]

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -17,6 +17,7 @@ import os
 import re
 import time
 import typing
+import warnings
 from collections.abc import Iterable
 from enum import Enum
 
@@ -720,12 +721,6 @@ class KubeResourceSpec(FunctionSpec):
                 affinity_field_name=affinity_field_name,
             )
 
-            # remove preemptible nodes constrain
-            self._prune_node_selector(
-                mlconf.get_preemptible_node_selector(),
-                node_selector_field_name=node_selector_field_name,
-            )
-
             # enrich with tolerations
             self._merge_tolerations(
                 generate_preemptible_tolerations(),
@@ -1201,93 +1196,86 @@ class KubeResource(BaseRuntime):
         """
         self.spec.with_requests(mem, cpu, patch=patch)
 
-    def _detect_overlap(
-            self,
-            provided: Iterable,
-            preemptible: Iterable,
-            key_fn: typing.Callable[[typing.Any], typing.Any],
-            warn_msg_fn: typing.Callable[[typing.Any], str],
-    ) -> None:
-        """
-        Logs a warning for each provided item whose key (as given by key_fn)
-        appears in the set of preemptible items.
-        """
-        preemptible_keys = {key_fn(item) for item in preemptible}
-        for item in provided:
-            if key_fn(item) in preemptible_keys:
-                warnings.warn(warn_msg_fn(item))
-
-    def detect_preemptible_node_selector(self, node_selector: dict[str, str]) -> None:
+    def detect_preemptible_node_selector(self, node_selector: dict[str, str]):
         """
         Checks if any provided node selector matches the preemptible node selectors.
         Issues a warning if a selector may be pruned at runtime depending on preemption mode.
+
+        :param node_selector: The user-provided node selector dictionary.
         """
         preemptible_node_selector = mlconf.get_preemptible_node_selector()
-        # Convert both dicts to lists of key-value tuples.
-        provided = list(node_selector.items())
-        preemptible = list(preemptible_node_selector.items())
 
-        self._detect_overlap(
-            provided=provided,
-            preemptible=preemptible,
-            key_fn=lambda pair: pair,
-            warn_msg_fn=lambda pair: (
-                f"The node selector '{pair[0]}: {pair[1]}' may be pruned at runtime depending "
-                "on the function's preemption mode."
-            ),
-        )
+        for key, value in node_selector.items():
+            if preemptible_node_selector.get(key) == value:
+                warnings.warn(
+                    f"The node selector '{key}: {value}' may be pruned at runtime,"
+                    f" depending on the function's preemption mode."
+                )
 
-    def detect_preemptible_tolerations(self, tolerations: list[k8s_client.V1Toleration]) -> None:
+    def detect_preemptible_tolerations(
+        self, tolerations: list[k8s_client.V1Toleration]
+    ):
         """
         Checks if any provided toleration matches preemptible tolerations.
         Issues a warning if a toleration may be pruned at runtime depending on preemption mode.
+
+        :param tolerations: The user-provided list of tolerations.
         """
         preemptible_tolerations = mlconf.get_preemptible_tolerations()
 
-        self._detect_overlap(
-            provided=tolerations,
-            preemptible=preemptible_tolerations,
-            key_fn=lambda t: (t.key, t.value, t.effect),
-            warn_msg_fn=lambda t: (
-                f"The toleration '{t.key}: {t.value}' with effect '{t.effect}' may be pruned at "
-                "runtime depending on the function's preemption mode."
-            ),
-        )
+        for toleration in tolerations:
+            for preemptible_toleration in preemptible_tolerations:
+                if (
+                    toleration.key == preemptible_toleration["key"]
+                    and toleration.value == preemptible_toleration["value"]
+                    and toleration.effect == preemptible_toleration["effect"]
+                ):
+                    warnings.warn(
+                        f"The toleration '{toleration.key}: {toleration.value}' with effect '{toleration.effect}' "
+                        "may be pruned at runtime depending on the function's preemption mode."
+                    )
 
-    def detect_preemptible_affinity(self, affinity: typing.Optional[k8s_client.V1Affinity]) -> None:
+    def detect_preemptible_affinity(self, affinity: k8s_client.V1Affinity):
         """
         Checks if any provided affinity rules match preemptible affinity configurations.
         Issues a warning if an affinity rule may be pruned at runtime depending on preemption mode.
-        """
-        # Ensure affinity is provided and contains the required node affinity.
-        if (
-                affinity
-                and affinity.node_affinity
-                and affinity.node_affinity.required_during_scheduling_ignored_during_execution
-        ):
-            user_terms = (
-                affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms
-            )
-            preemptible_affinity_terms = generate_preemptible_nodes_affinity_terms()
 
-            self._detect_overlap(
-                provided=user_terms,
-                preemptible=preemptible_affinity_terms,
-                # Here we assume that each term’s match_expressions is a list. Converting to tuple
-                # makes it hashable.
-                key_fn=lambda term: tuple(term.match_expressions),
-                warn_msg_fn=lambda term: (
-                    "The provided node affinity may be pruned at runtime depending on the function's "
-                    "preemption mode."
-                ),
-            )
+        :param affinity: The user-provided affinity object.
+        """
+        preemptible_affinity_terms = generate_preemptible_nodes_affinity_terms()
+
+        if (
+            affinity
+            and affinity.node_affinity
+            and affinity.node_affinity.required_during_scheduling_ignored_during_execution
+        ):
+            user_terms = affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms
+
+            for user_term in user_terms:
+                user_expressions = {
+                    (expr.key, expr.operator, tuple(expr.values or []))
+                    for expr in user_term.match_expressions or []
+                }
+
+                for preemptible_term in preemptible_affinity_terms:
+                    preemptible_expressions = {
+                        (expr.key, expr.operator, tuple(expr.values or []))
+                        for expr in preemptible_term.match_expressions or []
+                    }
+
+                    # Ensure operators match and preemptible expressions are present
+                    if user_expressions & preemptible_expressions:
+                        warnings.warn(
+                            "The provided node affinity may be pruned at runtime,"
+                            " depending on the function's preemption mode."
+                        )
 
     def with_node_selection(
-            self,
-            node_name: typing.Optional[str] = None,
-            node_selector: typing.Optional[dict[str, str]] = None,
-            affinity: typing.Optional[k8s_client.V1Affinity] = None,
-            tolerations: typing.Optional[list[k8s_client.V1Toleration]] = None,
+        self,
+        node_name: typing.Optional[str] = None,
+        node_selector: typing.Optional[dict[str, str]] = None,
+        affinity: typing.Optional[k8s_client.V1Affinity] = None,
+        tolerations: typing.Optional[list[k8s_client.V1Toleration]] = None,
     ):
         """
         Enables control over which Kubernetes node the job will run on.

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -704,7 +704,6 @@ class KubeResourceSpec(FunctionSpec):
                 ),
                 affinity_field_name=affinity_field_name,
             )
-        # enrich with preemptible tolerations
         elif self_preemption_mode == PreemptionModes.allow.value:
             # enrich with tolerations
             self._merge_tolerations(
@@ -1181,7 +1180,9 @@ class KubeResource(BaseRuntime):
         """
         self.spec.with_requests(mem, cpu, patch=patch)
 
-    def detect_preemptible_node_selector(self, node_selector: dict[str, str]) -> None:
+    def detect_preemptible_node_selector(
+        self, node_selector: dict[str, str]
+    ) -> list[str]:
         """
         Checks if any provided node selector matches the preemptible node selectors.
         Issues a warning if a selector may be pruned at runtime depending on preemption mode.
@@ -1190,15 +1191,15 @@ class KubeResource(BaseRuntime):
         """
         preemptible_node_selector = mlconf.get_preemptible_node_selector()
 
-        for key, value in node_selector.items():
-            if preemptible_node_selector.get(key) == value:
-                self.raise_preemptible_warning(
-                    message=f"Node selector '{key}: {value}' may be removed at runtime"
-                )
+        return [
+            f"'{key}': '{val}'"
+            for key, val in node_selector.items()
+            if preemptible_node_selector.get(key) == val
+        ]
 
     def detect_preemptible_tolerations(
         self, tolerations: list[k8s_client.V1Toleration]
-    ) -> None:
+    ) -> list[str]:
         """
         Checks if any provided toleration matches preemptible tolerations.
         Issues a warning if a toleration may be pruned at runtime depending on preemption mode.
@@ -1214,23 +1215,25 @@ class KubeResource(BaseRuntime):
             for toleration in mlconf.get_preemptible_tolerations()
         ]
 
-        transform_attribute_to_k8s_class_instance("tolerations", tolerations)
+        def _format_toleration(toleration):
+            return f"'{toleration.key}'='{toleration.value}' (effect: '{toleration.effect}')"
 
-        for toleration in tolerations:
-            if toleration in preemptible_tolerations:
-                self.raise_preemptible_warning(
-                    message=f"Toleration '{toleration.key}: {toleration.value}' "
-                    f"(effect: '{toleration.effect}') may be removed at runtime"
-                )
+        return [
+            _format_toleration(toleration)
+            for toleration in tolerations
+            if toleration in preemptible_tolerations
+        ]
 
-    def detect_preemptible_affinity(self, affinity: k8s_client.V1Affinity) -> None:
+    def detect_preemptible_affinity(self, affinity: k8s_client.V1Affinity) -> list[str]:
         """
         Checks if any provided affinity rules match preemptible affinity configurations.
         Issues a warning if an affinity rule may be pruned at runtime depending on preemption mode.
 
         :param affinity: The user-provided affinity object.
         """
+
         preemptible_affinity_terms = generate_preemptible_nodes_affinity_terms()
+        conflicting_affinities = []
 
         if (
             affinity
@@ -1238,7 +1241,6 @@ class KubeResource(BaseRuntime):
             and affinity.node_affinity.required_during_scheduling_ignored_during_execution
         ):
             user_terms = affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms
-
             for user_term in user_terms:
                 user_expressions = {
                     (expr.key, expr.operator, tuple(expr.values or []))
@@ -1252,19 +1254,57 @@ class KubeResource(BaseRuntime):
                     }
 
                     # Ensure operators match and preemptible expressions are present
-                    if user_expressions & preemptible_expressions:
-                        self.raise_preemptible_warning(
-                            message="The selected node affinity constraints may be adjusted at runtime"
+                    common_exprs = user_expressions & preemptible_expressions
+                    if common_exprs:
+                        formatted = ", ".join(
+                            f"'{key}  {operator}  {list(values)}'"
+                            for key, operator, values in common_exprs
                         )
+                        conflicting_affinities.append(formatted)
+        return conflicting_affinities
 
-    def raise_preemptible_warning(self, message: str) -> None:
-        warnings.warn(
-            f"Warning: {message} based on the preemptible node settings configured in your MLRun configuration. "
-            f"This adjustment depends on the function's preemption mode. "
-            f"The list of potential adjusted preemptible selectors can be viewed here: "
-            f"mlrun.mlconf.get_preemptible_node_selector() and mlrun.mlconf.get_preemptible_tolerations()."
-            f"For more information about preemptible mode, see:  "
-        )
+    def raise_preemptible_warning(
+        self,
+        node_selector: typing.Optional[dict[str, str]],
+        tolerations: typing.Optional[list[k8s_client.V1Toleration]],
+        affinity: typing.Optional[k8s_client.V1Affinity],
+    ) -> None:
+        """
+        Detects conflicts and issues a single warning if necessary.
+
+        :param node_selector: The user-provided node selector dictionary.
+        :param tolerations: The user-provided list of tolerations.
+        :param affinity: The user-provided affinity object.
+        """
+        conflict_messages = []
+
+        if node_selector:
+            ns_conflicts = ", ".join(
+                self.detect_preemptible_node_selector(node_selector)
+            )
+            if ns_conflicts:
+                conflict_messages.append(f"Node selectors: {ns_conflicts}")
+
+        if tolerations:
+            tol_conflicts = ", ".join(self.detect_preemptible_tolerations(tolerations))
+            if tol_conflicts:
+                conflict_messages.append(f"Tolerations: {tol_conflicts}")
+
+        if affinity:
+            affinity_conflicts = ", ".join(self.detect_preemptible_affinity(affinity))
+            if affinity_conflicts:
+                conflict_messages.append(f"Affinity: {affinity_conflicts}")
+
+        if conflict_messages:
+            warning_componentes = "; \n".join(conflict_messages)
+            warnings.warn(
+                f"Warning: {warning_componentes}"
+                f" may be removed or adjusted at runtime based on the preemptible node settings"
+                f" configured in your MLRun configuration. "
+                "This adjustment depends on the function's preemption mode. "
+                "The list of potential adjusted preemptible selectors can be viewed here: "
+                "mlrun.mlconf.get_preemptible_node_selector() and mlrun.mlconf.get_preemptible_tolerations()."
+            )
 
     def with_node_selection(
         self,
@@ -1287,13 +1327,16 @@ class KubeResource(BaseRuntime):
         if node_selector is not None:
             validate_node_selectors(node_selectors=node_selector, raise_on_error=False)
             self.spec.node_selector = node_selector
-            self.detect_preemptible_node_selector(self.spec.node_selector)
         if affinity is not None:
             self.spec.affinity = affinity
-            self.detect_preemptible_affinity(self.spec.affinity)
         if tolerations is not None:
             self.spec.tolerations = tolerations
-            self.detect_preemptible_tolerations(self.spec.tolerations)
+
+        self.raise_preemptible_warning(
+            node_selector=self.spec.node_selector,
+            tolerations=self.spec.tolerations,
+            affinity=self.spec.affinity,
+        )
 
     def with_priority_class(self, name: typing.Optional[str] = None):
         """

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1254,15 +1254,16 @@ class KubeResource(BaseRuntime):
                     # Ensure operators match and preemptible expressions are present
                     if user_expressions & preemptible_expressions:
                         self.raise_preemptible_warning(
-                            message="Node affinity constraints may be adjusted at runtime"
+                            message="The selected node affinity constraints may be adjusted at runtime"
                         )
 
     def raise_preemptible_warning(self, message: str) -> None:
         warnings.warn(
             f"Warning: {message} based on the preemptible node settings configured in your MLRun configuration. "
             f"This adjustment depends on the function's preemption mode. "
-            f"To review or modify these settings, check: "
+            f"The list of potential adjusted preemptible selectors can be viewed here: "
             f"mlrun.mlconf.get_preemptible_node_selector() and mlrun.mlconf.get_preemptible_tolerations()."
+            f"For more information about preemptible mode, see:  "
         )
 
     def with_node_selection(

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1192,9 +1192,8 @@ class KubeResource(BaseRuntime):
 
         for key, value in node_selector.items():
             if preemptible_node_selector.get(key) == value:
-                warnings.warn(
-                    f"The node selector '{key}: {value}' may be pruned at runtime,"
-                    f" depending on the function's preemption mode."
+                self.raise_preemptible_warning(
+                    message=f"Node selector '{key}: {value}' may be removed at runtime"
                 )
 
     def detect_preemptible_tolerations(
@@ -1206,19 +1205,23 @@ class KubeResource(BaseRuntime):
 
         :param tolerations: The user-provided list of tolerations.
         """
-        preemptible_tolerations = mlconf.get_preemptible_tolerations()
+        preemptible_tolerations = [
+            k8s_client.V1Toleration(
+                key=toleration["key"],
+                value=toleration["value"],
+                effect=toleration["effect"],
+            )
+            for toleration in mlconf.get_preemptible_tolerations()
+        ]
+
+        transform_attribute_to_k8s_class_instance("tolerations", tolerations)
 
         for toleration in tolerations:
-            for preemptible_toleration in preemptible_tolerations:
-                if (
-                    toleration.key == preemptible_toleration["key"]
-                    and toleration.value == preemptible_toleration["value"]
-                    and toleration.effect == preemptible_toleration["effect"]
-                ):
-                    warnings.warn(
-                        f"The toleration '{toleration.key}: {toleration.value}' with effect '{toleration.effect}' "
-                        "may be pruned at runtime depending on the function's preemption mode."
-                    )
+            if toleration in preemptible_tolerations:
+                self.raise_preemptible_warning(
+                    message=f"Toleration '{toleration.key}: {toleration.value}' "
+                    f"(effect: '{toleration.effect}') may be removed at runtime"
+                )
 
     def detect_preemptible_affinity(self, affinity: k8s_client.V1Affinity):
         """
@@ -1250,10 +1253,17 @@ class KubeResource(BaseRuntime):
 
                     # Ensure operators match and preemptible expressions are present
                     if user_expressions & preemptible_expressions:
-                        warnings.warn(
-                            "The provided node affinity may be pruned at runtime,"
-                            " depending on the function's preemption mode."
+                        self.raise_preemptible_warning(
+                            message="Node affinity constraints may be adjusted at runtime"
                         )
+
+    def raise_preemptible_warning(self, message):
+        warnings.warn(
+            f"Warning: {message} based on the preemptible node settings configured in your MLRun configuration. "
+            f"This adjustment depends on the function's preemption mode. "
+            f"To review or modify these settings, check: "
+            f"mlrun.mlconf.get_preemptible_node_selector() and mlrun.mlconf.get_preemptible_tolerations()."
+        )
 
     def with_node_selection(
         self,
@@ -1270,24 +1280,19 @@ class KubeResource(BaseRuntime):
         :param affinity:        Defines scheduling constraints.
         :param tolerations:     Allows scheduling onto nodes with matching taints.
         """
-
-        if node_selector:
-            self.detect_preemptible_node_selector(node_selector)
-        if tolerations:
-            self.detect_preemptible_tolerations(tolerations)
-        if affinity:
-            self.detect_preemptible_affinity(affinity)
-
         # Apply values as before
         if node_name:
             self.spec.node_name = node_name
         if node_selector is not None:
             validate_node_selectors(node_selectors=node_selector, raise_on_error=False)
             self.spec.node_selector = node_selector
+            self.detect_preemptible_node_selector(self.spec.node_selector)
         if affinity is not None:
             self.spec.affinity = affinity
+            self.detect_preemptible_affinity(self.spec.affinity)
         if tolerations is not None:
             self.spec.tolerations = tolerations
+            self.detect_preemptible_tolerations(self.spec.tolerations)
 
     def with_priority_class(self, name: typing.Optional[str] = None):
         """

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -704,7 +704,7 @@ class KubeResourceSpec(FunctionSpec):
                 ),
                 affinity_field_name=affinity_field_name,
             )
-        # purge any affinity / anti-affinity preemption related configuration and enrich with preemptible tolerations
+        # enrich with preemptible tolerations
         elif self_preemption_mode == PreemptionModes.allow.value:
             # enrich with tolerations
             self._merge_tolerations(
@@ -1181,7 +1181,7 @@ class KubeResource(BaseRuntime):
         """
         self.spec.with_requests(mem, cpu, patch=patch)
 
-    def detect_preemptible_node_selector(self, node_selector: dict[str, str]):
+    def detect_preemptible_node_selector(self, node_selector: dict[str, str]) -> None:
         """
         Checks if any provided node selector matches the preemptible node selectors.
         Issues a warning if a selector may be pruned at runtime depending on preemption mode.
@@ -1198,7 +1198,7 @@ class KubeResource(BaseRuntime):
 
     def detect_preemptible_tolerations(
         self, tolerations: list[k8s_client.V1Toleration]
-    ):
+    ) -> None:
         """
         Checks if any provided toleration matches preemptible tolerations.
         Issues a warning if a toleration may be pruned at runtime depending on preemption mode.
@@ -1223,7 +1223,7 @@ class KubeResource(BaseRuntime):
                     f"(effect: '{toleration.effect}') may be removed at runtime"
                 )
 
-    def detect_preemptible_affinity(self, affinity: k8s_client.V1Affinity):
+    def detect_preemptible_affinity(self, affinity: k8s_client.V1Affinity) -> None:
         """
         Checks if any provided affinity rules match preemptible affinity configurations.
         Issues a warning if an affinity rule may be pruned at runtime depending on preemption mode.
@@ -1257,7 +1257,7 @@ class KubeResource(BaseRuntime):
                             message="Node affinity constraints may be adjusted at runtime"
                         )
 
-    def raise_preemptible_warning(self, message):
+    def raise_preemptible_warning(self, message: str) -> None:
         warnings.warn(
             f"Warning: {message} based on the preemptible node settings configured in your MLRun configuration. "
             f"This adjustment depends on the function's preemption mode. "

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -706,21 +706,6 @@ class KubeResourceSpec(FunctionSpec):
             )
         # purge any affinity / anti-affinity preemption related configuration and enrich with preemptible tolerations
         elif self_preemption_mode == PreemptionModes.allow.value:
-            # remove preemptible anti-affinity
-            self._prune_affinity_node_selector_requirement(
-                generate_preemptible_node_selector_requirements(
-                    NodeSelectorOperator.node_selector_op_not_in.value
-                ),
-                affinity_field_name=affinity_field_name,
-            )
-            # remove preemptible affinity
-            self._prune_affinity_node_selector_requirement(
-                generate_preemptible_node_selector_requirements(
-                    NodeSelectorOperator.node_selector_op_in.value
-                ),
-                affinity_field_name=affinity_field_name,
-            )
-
             # enrich with tolerations
             self._merge_tolerations(
                 generate_preemptible_tolerations(),

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1298,10 +1298,10 @@ class KubeResource(BaseRuntime):
         if conflict_messages:
             warning_componentes = "; \n".join(conflict_messages)
             warnings.warn(
-                f"Warning: Warning: based on the preemptible node settings configured in your MLRun configuration,\n"
-                f"{warning_componentes}"
+                f"Warning: based on the preemptible node settings configured in your MLRun configuration,\n"
+                f"{warning_componentes}\n"
                 f" may be removed or adjusted at runtime.\n"
-                "This adjustment depends on the function's preemption mode. "
+                "This adjustment depends on the function's preemption mode. \n"
                 "The list of potential adjusted preemptible selectors can be viewed here: "
                 "mlrun.mlconf.get_preemptible_node_selector() and mlrun.mlconf.get_preemptible_tolerations()."
             )

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1298,9 +1298,9 @@ class KubeResource(BaseRuntime):
         if conflict_messages:
             warning_componentes = "; \n".join(conflict_messages)
             warnings.warn(
-                f"Warning: {warning_componentes}"
-                f" may be removed or adjusted at runtime based on the preemptible node settings"
-                f" configured in your MLRun configuration. "
+                f"Warning: Warning: based on the preemptible node settings configured in your MLRun configuration,\n"
+                f"{warning_componentes}"
+                f" may be removed or adjusted at runtime.\n"
                 "This adjustment depends on the function's preemption mode. "
                 "The list of potential adjusted preemptible selectors can be viewed here: "
                 "mlrun.mlconf.get_preemptible_node_selector() and mlrun.mlconf.get_preemptible_tolerations()."

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -1201,27 +1201,111 @@ class KubeResource(BaseRuntime):
         """
         self.spec.with_requests(mem, cpu, patch=patch)
 
+    def _detect_overlap(
+            self,
+            provided: Iterable,
+            preemptible: Iterable,
+            key_fn: typing.Callable[[typing.Any], typing.Any],
+            warn_msg_fn: typing.Callable[[typing.Any], str],
+    ) -> None:
+        """
+        Logs a warning for each provided item whose key (as given by key_fn)
+        appears in the set of preemptible items.
+        """
+        preemptible_keys = {key_fn(item) for item in preemptible}
+        for item in provided:
+            if key_fn(item) in preemptible_keys:
+                warnings.warn(warn_msg_fn(item))
+
+    def detect_preemptible_node_selector(self, node_selector: dict[str, str]) -> None:
+        """
+        Checks if any provided node selector matches the preemptible node selectors.
+        Issues a warning if a selector may be pruned at runtime depending on preemption mode.
+        """
+        preemptible_node_selector = mlconf.get_preemptible_node_selector()
+        # Convert both dicts to lists of key-value tuples.
+        provided = list(node_selector.items())
+        preemptible = list(preemptible_node_selector.items())
+
+        self._detect_overlap(
+            provided=provided,
+            preemptible=preemptible,
+            key_fn=lambda pair: pair,
+            warn_msg_fn=lambda pair: (
+                f"The node selector '{pair[0]}: {pair[1]}' may be pruned at runtime depending "
+                "on the function's preemption mode."
+            ),
+        )
+
+    def detect_preemptible_tolerations(self, tolerations: list[k8s_client.V1Toleration]) -> None:
+        """
+        Checks if any provided toleration matches preemptible tolerations.
+        Issues a warning if a toleration may be pruned at runtime depending on preemption mode.
+        """
+        preemptible_tolerations = mlconf.get_preemptible_tolerations()
+
+        self._detect_overlap(
+            provided=tolerations,
+            preemptible=preemptible_tolerations,
+            key_fn=lambda t: (t.key, t.value, t.effect),
+            warn_msg_fn=lambda t: (
+                f"The toleration '{t.key}: {t.value}' with effect '{t.effect}' may be pruned at "
+                "runtime depending on the function's preemption mode."
+            ),
+        )
+
+    def detect_preemptible_affinity(self, affinity: typing.Optional[k8s_client.V1Affinity]) -> None:
+        """
+        Checks if any provided affinity rules match preemptible affinity configurations.
+        Issues a warning if an affinity rule may be pruned at runtime depending on preemption mode.
+        """
+        # Ensure affinity is provided and contains the required node affinity.
+        if (
+                affinity
+                and affinity.node_affinity
+                and affinity.node_affinity.required_during_scheduling_ignored_during_execution
+        ):
+            user_terms = (
+                affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms
+            )
+            preemptible_affinity_terms = generate_preemptible_nodes_affinity_terms()
+
+            self._detect_overlap(
+                provided=user_terms,
+                preemptible=preemptible_affinity_terms,
+                # Here we assume that each term’s match_expressions is a list. Converting to tuple
+                # makes it hashable.
+                key_fn=lambda term: tuple(term.match_expressions),
+                warn_msg_fn=lambda term: (
+                    "The provided node affinity may be pruned at runtime depending on the function's "
+                    "preemption mode."
+                ),
+            )
+
     def with_node_selection(
-        self,
-        node_name: typing.Optional[str] = None,
-        node_selector: typing.Optional[dict[str, str]] = None,
-        affinity: typing.Optional[k8s_client.V1Affinity] = None,
-        tolerations: typing.Optional[list[k8s_client.V1Toleration]] = None,
+            self,
+            node_name: typing.Optional[str] = None,
+            node_selector: typing.Optional[dict[str, str]] = None,
+            affinity: typing.Optional[k8s_client.V1Affinity] = None,
+            tolerations: typing.Optional[list[k8s_client.V1Toleration]] = None,
     ):
         """
-        Enables to control on which k8s node the job will run
+        Enables control over which Kubernetes node the job will run on.
 
-        :param node_name:       The name of the k8s node
-        :param node_selector:   Label selector, only nodes with matching labels will be eligible to be picked
-        :param affinity:        Expands the types of constraints you can express - see
-                                https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-                                for details
-        :param tolerations:     Tolerations are applied to pods, and allow (but do not require) the pods to schedule
-                                onto nodes with matching taints - see
-                                https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-                                for details
-
+        :param node_name:       The name of the Kubernetes node.
+        :param node_selector:   Label selector, only nodes with matching labels will be eligible.
+        :param affinity:        Defines scheduling constraints.
+        :param tolerations:     Allows scheduling onto nodes with matching taints.
         """
+
+        if node_selector:
+            self.detect_preemptible_node_selector(node_selector)
+        if tolerations:
+            self.detect_preemptible_tolerations(tolerations)
+        if affinity:
+            self.detect_preemptible_affinity(affinity)
+
+        # Apply values as before
         if node_name:
             self.spec.node_name = node_name
         if node_selector is not None:

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import base64
 import inspect
+import json
+import warnings
 
-import kubernetes.client
+import kubernetes.client as k8s_client
 import pytest
 from deepdiff import DeepDiff
 
@@ -204,9 +207,7 @@ def test_resource_enrichment_in_resource_spec_initialization():
 
 
 def test_to_dict():
-    volume_mount = kubernetes.client.V1VolumeMount(
-        mount_path="some-path", name="volume-name"
-    )
+    volume_mount = k8s_client.V1VolumeMount(mount_path="some-path", name="volume-name")
     function = mlrun.new_function(kind=mlrun.runtimes.RuntimeKinds.job)
     # For sanitization
     function.spec.volume_mounts = [volume_mount]
@@ -232,12 +233,10 @@ def test_to_dict():
 
 
 def test_volume_mounts_addition():
-    volume_mount = kubernetes.client.V1VolumeMount(
-        mount_path="some-path", name="volume-name"
-    )
+    volume_mount = k8s_client.V1VolumeMount(mount_path="some-path", name="volume-name")
     dict_volume_mount = volume_mount.to_dict()
-    sanitized_dict_volume_mount = (
-        kubernetes.client.ApiClient().sanitize_for_serialization(volume_mount)
+    sanitized_dict_volume_mount = k8s_client.ApiClient().sanitize_for_serialization(
+        volume_mount
     )
     function = mlrun.new_function(kind=mlrun.runtimes.RuntimeKinds.job)
     function.spec.volume_mounts = [
@@ -272,3 +271,414 @@ def test_build_config_preserve_order():
         function.spec.build.commands = []
         function.build_config(commands=commands)
         assert function.spec.build.commands == commands
+
+
+# Common Preemptible Affinity Terms
+preemptible_affinity_iguazio = [
+    [
+        k8s_client.V1NodeSelectorRequirement(
+            key="app.iguazio.com/lifecycle", operator="In", values=["preemptible"]
+        )
+    ]
+]
+
+preemptible_affinity_cloud_provider = [
+    [
+        k8s_client.V1NodeSelectorRequirement(
+            key="cloud.google.com/gke-spot", operator="In", values=["true"]
+        )
+    ]
+]
+
+
+def create_node_affinity_with_terms(terms):
+    """Helper function to create a V1Affinity with specific node selector terms."""
+    return k8s_client.V1Affinity(
+        node_affinity=k8s_client.V1NodeAffinity(
+            required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
+                node_selector_terms=[
+                    k8s_client.V1NodeSelectorTerm(match_expressions=term)
+                    for term in terms
+                ]
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "mode, tolerations, node_selector, affinity, expected_tolerations, expected_node_selector, expected_affinity",
+    [
+        # Mode "none" – no change.
+        (
+            "none",
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                },
+                {
+                    "key": "some-key",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                },
+            ],
+            {"user-node-selector": "some-value", "cloud.google.com/gke-spot": "true"},
+            k8s_client.V1Affinity(),
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                },
+                {
+                    "key": "some-key",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                },
+            ],
+            {"user-node-selector": "some-value", "cloud.google.com/gke-spot": "true"},
+            k8s_client.V1Affinity(),
+        ),
+        # Mode "prevent" – preemptible settings are removed, affinity is cleared.
+        (
+            "prevent",
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                },
+                {
+                    "key": "some-key",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                },
+            ],
+            {
+                "app.iguazio.com/lifecycle": "preemptible",
+                "some-node-selector": "some-value",
+            },
+            create_node_affinity_with_terms(preemptible_affinity_iguazio),
+            [
+                {
+                    "key": "some-key",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                },
+            ],  # Preemptible tolerations cleared
+            {"some-node-selector": "some-value"},  # Preemptible node selector cleared
+            None,  # Affinity removed
+        ),
+        # Mode "constrain" – preemptible toleration is merged, affinity is set to preemptible.
+        (
+            "constrain",
+            [],
+            {"user-node-selector": "some-value"},
+            None,  # No affinity set initially
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                },
+            ],
+            {"user-node-selector": "some-value"},
+            create_node_affinity_with_terms(
+                preemptible_affinity_iguazio + preemptible_affinity_cloud_provider
+            ),
+        ),
+        # Mode "allow" – conflicting node selector settings are purged, affinity is cleared.
+        (
+            "allow",
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                }
+            ],
+            {
+                "user-node-selector": "some-value",
+                "app.iguazio.com/lifecycle": "preemptible",
+            },
+            create_node_affinity_with_terms(
+                preemptible_affinity_iguazio + preemptible_affinity_cloud_provider
+            ),
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                }
+            ],
+            {
+                "user-node-selector": "some-value",
+                "app.iguazio.com/lifecycle": "preemptible",
+            },  # Node selector is preserved
+            None,  # Affinity cleared
+        ),
+        # Mode "allow" with no preemptible toleration.
+        (
+            "allow",
+            [],
+            {"user-node-selector": "some-value"},
+            None,
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                }
+            ],
+            {"user-node-selector": "some-value"},
+            None,  # No affinity changes
+        ),
+        # Mode "prevent" without initial tolerations.
+        (
+            "prevent",
+            [],
+            {
+                "user-node-selector": "some-value",
+                "app.iguazio.com/lifecycle": "preemptible",
+            },
+            None,
+            [],  # No tolerations remain
+            {
+                "user-node-selector": "some-value"
+            },  # Preemptible node selector is cleared
+            None,  # Affinity remains unchanged (None)
+        ),
+        # Mode "constrain" with tolerations already set.
+        (
+            "constrain",
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                }
+            ],
+            {"user-node-selector": "some-value"},
+            None,
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "toleration_seconds": None,
+                    "effect": "NoSchedule",
+                }
+            ],  # Tolerations unchanged
+            {"user-node-selector": "some-value"},
+            create_node_affinity_with_terms(
+                preemptible_affinity_iguazio + preemptible_affinity_cloud_provider
+            ),
+        ),
+        # Mode "none" with no tolerations or selectors provided.
+        (
+            "none",
+            [],
+            {},
+            None,
+            [],
+            {},  # No changes
+            None,  # Affinity remains unchanged (None)
+        ),
+    ],
+)
+def test_enrich_function_preemption_spec2(
+    mode,
+    tolerations,
+    node_selector,
+    affinity,
+    expected_tolerations,
+    expected_node_selector,
+    expected_affinity,
+):
+    function = mlrun.new_function("some-function", kind="job")
+
+    # Set the preemption mode.
+    function.spec.preemption_mode = mode
+
+    # Set initial values to simulate user-provided configuration.
+    function.with_node_selection(
+        node_selector=node_selector,
+        tolerations=tolerations,
+        affinity=affinity,
+    )
+
+    # Simulated mlconf preemptible settings
+    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
+        json.dumps(
+            {
+                "app.iguazio.com/lifecycle": "preemptible",
+                "cloud.google.com/gke-spot": "true",
+            }
+        ).encode("utf-8")
+    )
+    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
+        json.dumps(
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                }
+            ]
+        ).encode("utf-8")
+    )
+
+    # Call the enrichment logic.
+    function.spec.enrich_function_preemption_spec()
+
+    # Verify the results.
+    assert (
+        [t.to_dict() for t in function.spec.tolerations]
+        if function.spec.tolerations
+        else [] == expected_tolerations
+    )
+    assert function.spec.node_selector == expected_node_selector
+    assert function.spec.affinity == expected_affinity
+
+
+@pytest.mark.parametrize(
+    "node_selector, tolerations, affinity, expected_warning_substrings",
+    [
+        # Case 1: Only node_selector matches the preemptible configuration.
+        (
+            {"app.iguazio.com/lifecycle": "preemptible", "other": "value"},
+            None,
+            None,
+            ["node selector 'app.iguazio.com/lifecycle: preemptible'"],
+        ),
+        # Case 2: Only tolerations match the preemptible configuration.
+        (
+            None,
+            [
+                k8s_client.V1Toleration(
+                    key="cloud.google.com/gke-spot", value="true", effect="NoSchedule"
+                )
+            ],
+            None,
+            ["toleration 'cloud.google.com/gke-spot: true'"],
+        ),
+        # Case 3: Only affinity matches the preemptible configuration.
+        (
+            None,
+            None,
+            create_node_affinity_with_terms(preemptible_affinity_iguazio),
+            ["node affinity may be pruned"],
+        ),
+        # Case 4: All three match.
+        (
+            {"app.iguazio.com/lifecycle": "preemptible", "other": "value"},
+            [
+                k8s_client.V1Toleration(
+                    key="cloud.google.com/gke-spot", value="true", effect="NoSchedule"
+                ),
+                k8s_client.V1Toleration(key="custom", value="yes", effect="NoSchedule"),
+            ],
+            create_node_affinity_with_terms(preemptible_affinity_iguazio),
+            [
+                "node selector 'app.iguazio.com/lifecycle: preemptible'",
+                "toleration 'cloud.google.com/gke-spot: true'",
+                "node affinity may be pruned",
+            ],
+        ),
+        # Case 5: No matching values.
+        (
+            {"custom": "value"},
+            [k8s_client.V1Toleration(key="custom", value="yes", effect="NoSchedule")],
+            create_node_affinity_with_terms(
+                [
+                    [
+                        k8s_client.V1NodeSelectorRequirement(
+                            key="custom-key", operator="In", values=["non-match"]
+                        )
+                    ]
+                ],
+            ),
+            [],
+        ),
+    ],
+)
+def test_with_node_selection_warnings(
+    monkeypatch,
+    caplog,
+    node_selector,
+    tolerations,
+    affinity,
+    expected_warning_substrings,
+):
+    """
+    This test verifies that mlrun.Function.with_node_selection logs the expected warnings when
+    user-provided configuration (node_selector, tolerations, affinity) matches the preemptible settings.
+    """
+    # Simulated mlconf preemptible settings
+    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
+        json.dumps(
+            {
+                "app.iguazio.com/lifecycle": "preemptible",
+                "cloud.google.com/gke-spot": "true",
+            }
+        ).encode("utf-8")
+    )
+    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
+        json.dumps(
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                }
+            ]
+        ).encode("utf-8")
+    )
+
+    # Create a new function instance.
+    function = mlrun.new_function("test-func", kind="job")
+
+    # Capture warnings raised during with_node_selection.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        function.with_node_selection(
+            node_selector=node_selector,
+            tolerations=tolerations,
+            affinity=affinity,
+        )
+
+    # Extract warning messages.
+    warning_messages = [str(w.message) for w in caught]
+
+    # Assert that each expected warning substring is found in the warnings.
+    for expected in expected_warning_substrings:
+        assert any(
+            expected in message for message in warning_messages
+        ), f"Expected warning substring '{expected}' not found in warnings: {warning_messages}"
+    # If no warnings are expected, assert that none were raised.
+    if not expected_warning_substrings:
+        assert len(warning_messages) == 0, (
+            f"Expected no warnings, but found: {warning_messages}"
+            "Expected no warnings, but found: {warning_messages}"
+        )

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -304,6 +304,28 @@ def create_node_affinity_with_terms(terms):
         )
     )
 
+def mock_preemptible_config():
+    """Fixture to set up mock preemptible configurations before each test."""
+    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
+        json.dumps(
+            {
+                "app.iguazio.com/lifecycle": "preemptible",
+                "cloud.google.com/gke-spot": "true",
+            }
+        ).encode("utf-8")
+    )
+    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
+        json.dumps(
+            [
+                {
+                    "key": "cloud.google.com/gke-spot",
+                    "value": "true",
+                    "operator": "Equal",
+                    "effect": "NoSchedule",
+                }
+            ]
+        ).encode("utf-8")
+    )
 
 @pytest.mark.parametrize(
     "mode, tolerations, node_selector, affinity, expected_tolerations, expected_node_selector, expected_affinity",
@@ -505,7 +527,7 @@ def create_node_affinity_with_terms(terms):
         ),
     ],
 )
-def test_enrich_function_preemption_spec2(
+def test_enrich_function_preemption_spec(
     mode,
     tolerations,
     node_selector,
@@ -527,26 +549,7 @@ def test_enrich_function_preemption_spec2(
     )
 
     # Simulated mlconf preemptible settings
-    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
-        json.dumps(
-            {
-                "app.iguazio.com/lifecycle": "preemptible",
-                "cloud.google.com/gke-spot": "true",
-            }
-        ).encode("utf-8")
-    )
-    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
-        json.dumps(
-            [
-                {
-                    "key": "cloud.google.com/gke-spot",
-                    "value": "true",
-                    "operator": "Equal",
-                    "effect": "NoSchedule",
-                }
-            ]
-        ).encode("utf-8")
-    )
+    mock_preemptible_config()
 
     # Call the enrichment logic.
     function.spec.enrich_function_preemption_spec()
@@ -623,8 +626,6 @@ def test_enrich_function_preemption_spec2(
     ],
 )
 def test_with_node_selection_warnings(
-    monkeypatch,
-    caplog,
     node_selector,
     tolerations,
     affinity,
@@ -634,27 +635,7 @@ def test_with_node_selection_warnings(
     This test verifies that mlrun.Function.with_node_selection logs the expected warnings when
     user-provided configuration (node_selector, tolerations, affinity) matches the preemptible settings.
     """
-    # Simulated mlconf preemptible settings
-    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
-        json.dumps(
-            {
-                "app.iguazio.com/lifecycle": "preemptible",
-                "cloud.google.com/gke-spot": "true",
-            }
-        ).encode("utf-8")
-    )
-    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
-        json.dumps(
-            [
-                {
-                    "key": "cloud.google.com/gke-spot",
-                    "value": "true",
-                    "operator": "Equal",
-                    "effect": "NoSchedule",
-                }
-            ]
-        ).encode("utf-8")
-    )
+    mock_preemptible_config()
 
     # Create a new function instance.
     function = mlrun.new_function("test-func", kind="job")

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -304,6 +304,7 @@ def create_node_affinity_with_terms(terms):
         )
     )
 
+
 def mock_preemptible_config():
     """Fixture to set up mock preemptible configurations before each test."""
     mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
@@ -326,6 +327,7 @@ def mock_preemptible_config():
             ]
         ).encode("utf-8")
     )
+
 
 @pytest.mark.parametrize(
     "mode, tolerations, node_selector, affinity, expected_tolerations, expected_node_selector, expected_affinity",

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -590,7 +590,7 @@ def test_enrich_function_preemption_spec(
             None,
             None,
             create_node_affinity_with_terms(preemptible_affinity_iguazio),
-            ["Node affinity constraints may be adjusted at runtime"],
+            ["The selected node affinity constraints may be adjusted at runtime"],
         ),
         # All three match.
         (
@@ -605,7 +605,7 @@ def test_enrich_function_preemption_spec(
             [
                 "Node selector 'app.iguazio.com/lifecycle: preemptible'",
                 "Toleration 'cloud.google.com/gke-spot: true'",
-                "Node affinity constraints may be adjusted at runtime",
+                "The selected node affinity constraints may be adjusted at runtime",
             ],
         ),
         # No matching values.

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -400,16 +400,16 @@ def mock_preemptible_config():
                     "toleration_seconds": None,
                     "effect": "NoSchedule",
                 },
-            ],  # Preemptible tolerations cleared
-            {"some-node-selector": "some-value"},  # Preemptible node selector cleared
-            None,  # Affinity removed
+            ],
+            {"some-node-selector": "some-value"},
+            None,
         ),
         # Mode "constrain" – preemptible toleration is merged, affinity is set to preemptible.
         (
             "constrain",
             [],
             {"user-node-selector": "some-value"},
-            None,  # No affinity set initially
+            None,
             [
                 {
                     "key": "cloud.google.com/gke-spot",
@@ -454,8 +454,8 @@ def mock_preemptible_config():
             {
                 "user-node-selector": "some-value",
                 "app.iguazio.com/lifecycle": "preemptible",
-            },  # Node selector is preserved
-            None,  # Affinity cleared
+            },
+            None,
         ),
         # Mode "allow" with no preemptible toleration.
         (
@@ -473,7 +473,7 @@ def mock_preemptible_config():
                 }
             ],
             {"user-node-selector": "some-value"},
-            None,  # No affinity changes
+            None,
         ),
         # Mode "prevent" without initial tolerations.
         (
@@ -484,11 +484,9 @@ def mock_preemptible_config():
                 "app.iguazio.com/lifecycle": "preemptible",
             },
             None,
-            [],  # No tolerations remain
-            {
-                "user-node-selector": "some-value"
-            },  # Preemptible node selector is cleared
-            None,  # Affinity remains unchanged (None)
+            [],
+            {"user-node-selector": "some-value"},
+            None,
         ),
         # Mode "constrain" with tolerations already set.
         (
@@ -511,7 +509,7 @@ def mock_preemptible_config():
                     "toleration_seconds": None,
                     "effect": "NoSchedule",
                 }
-            ],  # Tolerations unchanged
+            ],
             {"user-node-selector": "some-value"},
             create_node_affinity_with_terms(
                 preemptible_affinity_iguazio + preemptible_affinity_cloud_provider
@@ -524,8 +522,8 @@ def mock_preemptible_config():
             {},
             None,
             [],
-            {},  # No changes
-            None,  # Affinity remains unchanged (None)
+            {},
+            None,
         ),
     ],
 )
@@ -553,10 +551,8 @@ def test_enrich_function_preemption_spec(
     # Simulated mlconf preemptible settings
     mock_preemptible_config()
 
-    # Call the enrichment logic.
     function.spec.enrich_function_preemption_spec()
 
-    # Verify the results.
     assert (
         [t.to_dict() for t in function.spec.tolerations]
         if function.spec.tolerations
@@ -569,14 +565,16 @@ def test_enrich_function_preemption_spec(
 @pytest.mark.parametrize(
     "node_selector, tolerations, affinity, expected_warning_substrings",
     [
-        # Case 1: Only node_selector matches the preemptible configuration.
+        # Only node_selector matches the preemptible configuration.
         (
             {"app.iguazio.com/lifecycle": "preemptible", "other": "value"},
             None,
             None,
-            ["node selector 'app.iguazio.com/lifecycle: preemptible'"],
+            [
+                "Node selector 'app.iguazio.com/lifecycle: preemptible' may be removed at runtime"
+            ],
         ),
-        # Case 2: Only tolerations match the preemptible configuration.
+        # Only tolerations match the preemptible configuration.
         (
             None,
             [
@@ -585,16 +583,16 @@ def test_enrich_function_preemption_spec(
                 )
             ],
             None,
-            ["toleration 'cloud.google.com/gke-spot: true'"],
+            ["Toleration 'cloud.google.com/gke-spot: true'"],
         ),
-        # Case 3: Only affinity matches the preemptible configuration.
+        # Only affinity matches the preemptible configuration.
         (
             None,
             None,
             create_node_affinity_with_terms(preemptible_affinity_iguazio),
-            ["node affinity may be pruned"],
+            ["Node affinity constraints may be adjusted at runtime"],
         ),
-        # Case 4: All three match.
+        # All three match.
         (
             {"app.iguazio.com/lifecycle": "preemptible", "other": "value"},
             [
@@ -605,12 +603,12 @@ def test_enrich_function_preemption_spec(
             ],
             create_node_affinity_with_terms(preemptible_affinity_iguazio),
             [
-                "node selector 'app.iguazio.com/lifecycle: preemptible'",
-                "toleration 'cloud.google.com/gke-spot: true'",
-                "node affinity may be pruned",
+                "Node selector 'app.iguazio.com/lifecycle: preemptible'",
+                "Toleration 'cloud.google.com/gke-spot: true'",
+                "Node affinity constraints may be adjusted at runtime",
             ],
         ),
-        # Case 5: No matching values.
+        # No matching values.
         (
             {"custom": "value"},
             [k8s_client.V1Toleration(key="custom", value="yes", effect="NoSchedule")],
@@ -639,7 +637,6 @@ def test_with_node_selection_warnings(
     """
     mock_preemptible_config()
 
-    # Create a new function instance.
     function = mlrun.new_function("test-func", kind="job")
 
     # Capture warnings raised during with_node_selection.
@@ -651,7 +648,6 @@ def test_with_node_selection_warnings(
             affinity=affinity,
         )
 
-    # Extract warning messages.
     warning_messages = [str(w.message) for w in caught]
 
     # Assert that each expected warning substring is found in the warnings.

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -572,9 +572,7 @@ def test_enrich_function_preemption_spec(
             {"app.iguazio.com/lifecycle": "preemptible", "other": "value"},
             None,
             None,
-            [
-                "Node selector 'app.iguazio.com/lifecycle: preemptible' may be removed at runtime"
-            ],
+            ["Node selectors: 'app.iguazio.com/lifecycle': 'preemptible'"],
         ),
         # Only tolerations match the preemptible configuration.
         (
@@ -585,14 +583,14 @@ def test_enrich_function_preemption_spec(
                 )
             ],
             None,
-            ["Toleration 'cloud.google.com/gke-spot: true'"],
+            ["Tolerations: 'cloud.google.com/gke-spot'='true' (effect: 'NoSchedule')"],
         ),
         # Only affinity matches the preemptible configuration.
         (
             None,
             None,
             create_node_affinity_with_terms(preemptible_affinity_iguazio),
-            ["The selected node affinity constraints may be adjusted at runtime"],
+            ["Affinity: 'app.iguazio.com/lifecycle  In  ['preemptible']'"],
         ),
         # All three match.
         (
@@ -605,9 +603,9 @@ def test_enrich_function_preemption_spec(
             ],
             create_node_affinity_with_terms(preemptible_affinity_iguazio),
             [
-                "Node selector 'app.iguazio.com/lifecycle: preemptible'",
-                "Toleration 'cloud.google.com/gke-spot: true'",
-                "The selected node affinity constraints may be adjusted at runtime",
+                "Node selectors: 'app.iguazio.com/lifecycle': 'preemptible'",
+                "Tolerations: 'cloud.google.com/gke-spot'='true' (effect: 'NoSchedule')",
+                "Affinity: 'app.iguazio.com/lifecycle  In  ['preemptible']'",
             ],
         ),
         # No matching values.

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -424,7 +424,7 @@ def mock_preemptible_config():
                 preemptible_affinity_iguazio + preemptible_affinity_cloud_provider
             ),
         ),
-        # Mode "allow" – conflicting node selector settings are purged, affinity is cleared.
+        # Mode "allow" – conflicting node selector settings are purged.
         (
             "allow",
             [
@@ -455,7 +455,9 @@ def mock_preemptible_config():
                 "user-node-selector": "some-value",
                 "app.iguazio.com/lifecycle": "preemptible",
             },
-            None,
+            create_node_affinity_with_terms(
+                preemptible_affinity_iguazio + preemptible_affinity_cloud_provider
+            ),
         ),
         # Mode "allow" with no preemptible toleration.
         (


### PR DESCRIPTION
resolves: 
In this PR: https://iguazio.atlassian.net/browse/ML-8601
- Expanded test coverage for `enrich_function_preemption_spec`, ensuring expected behavior across different preemption modes.
- Introduced user warnings in `with_node_selection` when preemptible node selectors, tolerations, or affinities are set based on environment configurations, clarifying that they may be pruned at runtime.
- Modified `allow` mode behavior to retain preemptible node selectors and affinity/anti-affinity, ensuring that a combination of `allow` + preemptible selector explicitly enforces scheduling on spot nodes.

For convenience, I also added a Notion table summarizing how each preemption mode affects node selection, tolerations, and affinity handling.

The warning for the users:
![image](https://github.com/user-attachments/assets/ca752e1c-f119-46af-9650-4a0f7d355bad)
