### PR TITLE
[Pipelines] Add `Unknown` to retryable statuses

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.3.7",
+    version="0.3.8",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/models.py
@@ -111,3 +111,6 @@ class RunStatuses(StrEnum):
             for status in RunStatuses.all()
             if status not in RunStatuses.stable_statuses()
         ]
+
+    def retryable_statuses(self):
+        return self.stable_statuses() + [RunStatuses.unknown]

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/models.py
@@ -113,4 +113,7 @@ class RunStatuses(StrEnum):
         ]
 
     def retryable_statuses(self):
-        return self.stable_statuses() + [RunStatuses.unknown]
+        return self.stable_statuses() + [
+            RunStatuses.unknown,
+            RunStatuses.runtime_state_unspecified,
+        ]


### PR DESCRIPTION
Currently we only retry on a stable pipeline status (a terminal state basically), but an "Unknown" state can possibly also be terminated, and there is no reason to not allow retrying on it.

This PR creates the `retryable_statuses` list, and a followup will use this list in [here](https://github.com/mlrun/mlrun/blob/916f8e006b04216883bae9f8487d223935eb7554/server/py/services/api/crud/pipelines.py#L287).