### PR TITLE
[Runs] Improve delete runs flow

### DIFF
--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -145,7 +145,9 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def del_runs(self, session, name="", project="", labels=None, state="", days_ago=0):
+    def del_runs(
+        self, session, name="", project="", labels=None, state="", days_ago=0, uids=None
+    ):
         pass
 
     def overwrite_artifacts_with_tag(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -507,7 +507,14 @@ class SQLDB(DBInterface):
         self._delete(session, Run, uid=uid, project=project)
 
     def del_runs(
-        self, session, name=None, project=None, labels=None, state=None, days_ago=0
+        self,
+        session,
+        name=None,
+        project=None,
+        labels=None,
+        state=None,
+        days_ago=0,
+        uids=None,
     ):
         project = project or config.default_project
         query = self._find_runs(session, None, project, labels)
@@ -518,6 +525,8 @@ class SQLDB(DBInterface):
             query = self._add_run_name_query(query, name)
         if state:
             query = query.filter(Run.state == state)
+        if uids:
+            query = query.filter(Run.uid.in_(uids))
         for run in query:  # Can not use query.delete with join
             session.delete(run)
         session.commit()

--- a/server/py/services/api/api/endpoints/runs.py
+++ b/server/py/services/api/api/endpoints/runs.py
@@ -342,7 +342,7 @@ async def delete_runs(
         projects = set(run.project or mlrun.mlconf.default_project for run in runs)
         for run_project in projects:
             # currently we fail if the user doesn't has permissions to delete runs to one of the projects in the system
-            # TODO Delete only runs from projects that user has permissions to
+            # TODO: Delete only runs from projects that user has permissions to
             await framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
                 mlrun.common.schemas.AuthorizationResourceTypes.run,
                 run_project,

--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -73,6 +73,10 @@ class Logs(
         logger.debug("Deleting logs for run", project=project, run_uid=run_uid)
         await self._delete_logs(project, [run_uid])
 
+    async def delete_runs_logs(self, project: str, run_uids: list[str]):
+        logger.debug("Deleting logs for runs", project=project, run_uids=run_uids)
+        await self._delete_logs(project, run_uids)
+
     @staticmethod
     def delete_project_logs_legacy(
         project: str,


### PR DESCRIPTION
When deleting a job that has many runs (100s or 1000s), deleting each of the runs separately can cause stress on the DB even when done in batches.
For example, if more then 6 delete job requests arrive, with a batching of 10 we will get more than 60 concurrent select and deletion requests to the DB. The default MySQL QueuePool limit is 64, so we get the following error:
```
QueuePool limit of size 64 overflow 64 reached, connection timed out, timeout 30.00 (Background on this error at: https://sqlalche.me/e/14/3o7r)
```

In this PR, we introduce some improvements and optimizations to the `delete_runs` CRUD:
- Concurrently:
  - Delete each project's runs from the DB at once using a list of uids
  - Delete each project's runs' logs at once using a list of uids
- Use batched concurrency only for deleting each run's runtime resources
- Skip deletion of runtime resources if the time passed from the run's start time is more than the deletion grace period + 1 day. This heuristic should ensure the run are already deleted.
- Move some code around to reuse functionalities.

https://iguazio.atlassian.net/browse/ML-9155