### PR TITLE
[Pipelines] Fix class method `retryable_statuses`

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.3.8",
+    version="0.3.9",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/models.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/models.py
@@ -112,8 +112,9 @@ class RunStatuses(StrEnum):
             if status not in RunStatuses.stable_statuses()
         ]
 
-    def retryable_statuses(self):
-        return self.stable_statuses() + [
+    @classmethod
+    def retryable_statuses(cls):
+        return cls.stable_statuses() + [
             RunStatuses.unknown,
             RunStatuses.runtime_state_unspecified,
         ]


### PR DESCRIPTION
It should be a `classmethod` to be available directly from the class.