### PR TITLE
[Pipelines] Use mlrun-pipelines' retryable statuses for retry validation

### DIFF
--- a/dockerfiles/base/locked-requirements.txt
+++ b/dockerfiles/base/locked-requirements.txt
@@ -2514,9 +2514,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -2522,9 +2522,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -1904,9 +1904,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -2069,9 +2069,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -1099,9 +1099,9 @@ mistune==3.1.1 \
     --hash=sha256:02106ac2aa4f66e769debbfa028509a275069dcffce0dfa578edd7b991ee700a \
     --hash=sha256:e0740d635f515119f7d1feb6f9b192ee60f0cc649f80a8f944f905706a21654c
     # via nbconvert
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -1901,9 +1901,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -2278,9 +2278,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -2281,9 +2281,9 @@ mlflow-skinny==2.20.1 \
     --hash=sha256:98c3c73aea528a03a25ba422506a9d37dff4061707569e6e6cb8ea6e7382385e \
     --hash=sha256:de094d6495e2e6a842bd47a68641aa400528b6ea48be258f269cc4e2a43b3288
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.7 \
-    --hash=sha256:3a15de546c6f01bfb1b3c4e871acfca6d8f58f3c2b321ac862f05d5d66db74fd \
-    --hash=sha256:81070e948039d448b28db2a40a09eaa656ab5d884a77233de2f559a27d3dc104
+mlrun-pipelines-kfp-common==0.3.9 \
+    --hash=sha256:7a39476cc921e73c8da86b3d5f2b14c45fe72f9fb3feba749b16a96895929c27 \
+    --hash=sha256:a45f606cd4f7476f333738b5391df4d1b213011d578963222f679cd51dd867e2
     # via -r requirements.txt
 mlrun-pipelines-kfp-v1-8==0.3.6 ; python_full_version < '3.11' \
     --hash=sha256:7912aa00b9acc4de5fef6273d2be5b5bf5b2589bbc01c04b5397ebafef29021c \

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ deprecated~=1.2
 jinja2~=3.1, >=3.1.3
 orjson>=3.9.15, <4
 # mlrun pipeline adapters
-mlrun-pipelines-kfp-common~=0.3.7
+mlrun-pipelines-kfp-common~=0.3.9
 mlrun-pipelines-kfp-v1-8~=0.3.5; python_version < "3.11"
 docstring_parser~=0.16
 # TODO: Remove it after moving notificaions to the server side(ML-8069)

--- a/server/py/services/api/crud/pipelines.py
+++ b/server/py/services/api/crud/pipelines.py
@@ -284,7 +284,7 @@ class Pipelines(
         # Check if the pipeline is in a completed state
         if (
             run.status
-            not in mlrun_pipelines.common.models.RunStatuses.stable_statuses()
+            not in mlrun_pipelines.common.models.RunStatuses.retryable_statuses()
         ):
             raise mlrun.errors.MLRunBadRequestError(
                 f"Pipeline run {run_id} is not in a completed state. Current status: {run.status}"


### PR DESCRIPTION
Use `retryable_statuses` (introduced in https://github.com/mlrun/mlrun/pull/7231) when validating run status before retrying pipeline run.