### PR TITLE
[Model Monitoring] Make sure the model outputs are not part of the model endpoint features

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -788,6 +788,8 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
 
         """
         event[mapping_dictionary] = {}
+        diff = len(named_iters) - len(values_iters)
+        values_iters += [None] * diff
         for name, value in zip(named_iters, values_iters):
             event[name] = value
             event[mapping_dictionary][name] = value

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -184,7 +184,7 @@ class V2ModelServer(StepToDict):
                     tsdb_metrics=False,
                 )
                 self.model_endpoint_uid = model_endpoint.metadata.uid
-                self.output_schema = model_endpoint.spec.outputs
+                self.output_schema = model_endpoint.spec.label_names
             except mlrun.errors.MLRunNotFoundError:
                 logger.info(
                     "Model endpoint not found for this step; monitoring for this model will not be performed",

--- a/mlrun/serving/v2_serving.py
+++ b/mlrun/serving/v2_serving.py
@@ -115,6 +115,7 @@ class V2ModelServer(StepToDict):
         self.shard_by_endpoint = shard_by_endpoint
         self._model_logger = None
         self.initialized = False
+        self.output_schema = []
 
     def _load_and_update_state(self):
         try:
@@ -175,17 +176,15 @@ class V2ModelServer(StepToDict):
                     "Model endpoint creation task name not provided",
                 )
             try:
-                self.model_endpoint_uid = (
-                    mlrun.get_run_db()
-                    .get_model_endpoint(
-                        project=server.project,
-                        name=self.name,
-                        function_name=server.function_name,
-                        function_tag=server.function_tag or "latest",
-                        tsdb_metrics=False,
-                    )
-                    .metadata.uid
+                model_endpoint = mlrun.get_run_db().get_model_endpoint(
+                    project=server.project,
+                    name=self.name,
+                    function_name=server.function_name,
+                    function_tag=server.function_tag or "latest",
+                    tsdb_metrics=False,
                 )
+                self.model_endpoint_uid = model_endpoint.metadata.uid
+                self.output_schema = model_endpoint.spec.outputs
             except mlrun.errors.MLRunNotFoundError:
                 logger.info(
                     "Model endpoint not found for this step; monitoring for this model will not be performed",
@@ -566,6 +565,17 @@ class _ModelLogPusher:
                     resp["outputs"] = [
                         resp["outputs"][i] for i in sampled_requests_indices
                     ]
+                if self.model.output_schema and len(self.model.output_schema) != len(
+                    resp["outputs"][0]
+                ):
+                    logger.info(
+                        "The number of outputs returned by the model does not match the number of outputs "
+                        "specified in the model endpoint.",
+                        model_endpoint=self.model.name,
+                        model_endpoint_id=self.model.model_endpoint_uid,
+                        output_len=len(resp["outputs"][0]),
+                        schema_len=len(self.model.output_schema),
+                    )
 
             data = self.base_data()
             data["request"] = request

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -513,7 +513,9 @@ class ModelEndpoints:
                     project=model_endpoint.metadata.project,
                 )
                 model_endpoint.spec.feature_names = [
-                    feature.name for feature in features
+                    feature.name
+                    for feature in features
+                    if feature.name not in model_endpoint.spec.label_names
                 ]
 
         return model_endpoint, features

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -122,7 +122,6 @@ class ModelEndpoints:
                 logger.info("The model endpoint is created on a non-existing function")
         model_obj = None
         if model_path and mlrun.datastore.is_store_uri(model_path):
-            logger.info("Getting model object from db")
             _, model_uri = mlrun.datastore.parse_store_uri(model_path)
             project, key, iteration, tag, tree, uid = parse_artifact_uri(
                 model_uri, model_endpoint.metadata.project
@@ -137,6 +136,7 @@ class ModelEndpoints:
                 model_endpoint.spec.model_uid,
             )
         try:
+            logger.info("Getting model object from db")
             model_obj = mlrun.artifacts.dict_to_artifact(
                 services.api.crud.Artifacts().get_artifact(
                     db_session,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -60,6 +60,7 @@ def mock_random_endpoint(
     function_tag: Optional[str] = "v1",
     model_name: Optional[str] = None,
     model_uid: Optional[str] = None,
+    model_db_key: Optional[str] = None,
     add_labels=True,
 ) -> mlrun.common.schemas.model_monitoring.ModelEndpoint:
     def random_labels():
@@ -77,6 +78,7 @@ def mock_random_endpoint(
             function_uid=function_uid,
             model_name=model_name,
             model_uid=model_uid,
+            model_db_key=model_db_key,
             model_class="modelcc",
             model_tag="latest",
         ),
@@ -385,6 +387,81 @@ class TestModelEndpointsOperations(TestMLRunSystem):
 
         assert mep.status.drift_measures_timestamp is not None
         assert mep.status.current_stats_timestamp is not None
+
+    def test_mep_with_model(self):
+        model_obj = self.project.log_model(
+            "my-model",
+            model_dir=str(self.assets_path),
+            model_file="model.pkl",
+            artifact_path=f"v3io:///projects/{self.project.metadata.name}",
+            outputs=[mlrun.feature_store.Feature(name="l1", value_type="float")],
+            inputs=[mlrun.feature_store.Feature(name="f1", value_type="float")],
+            tag="latest",
+        )
+
+        model_obj_2 = self.project.log_model(
+            "my-model-2",
+            model_dir=str(self.assets_path),
+            model_file="model.pkl",
+            artifact_path=f"v3io:///projects/{self.project.metadata.name}",
+            outputs=[
+                mlrun.feature_store.Feature(name="l1", value_type="float"),
+                mlrun.feature_store.Feature(name="l2", value_type="float"),
+            ],
+            inputs=[mlrun.feature_store.Feature(name="f1", value_type="float")],
+            tag="latest",
+        )
+
+        model_endpoint = mock_random_endpoint(
+            self.project_name,
+            "testing",
+            model_name=model_obj.key,
+            model_uid=model_obj.uid,
+            model_db_key=model_obj.db_key,
+        )
+
+        db = mlrun.get_run_db()
+        db.create_model_endpoint(model_endpoint)
+
+        mep = db.get_model_endpoint(
+            project=model_endpoint.metadata.project,
+            name=model_endpoint.metadata.name,
+            function_name=model_endpoint.spec.function_name,
+            function_tag=model_endpoint.spec.function_tag,
+        )
+        assert mep.spec.feature_names == ["f1"]
+        assert mep.spec.label_names == ["l1"]
+
+        model_endpoint_2 = mock_random_endpoint(
+            self.project_name,
+            "testing",
+            model_name=model_obj_2.key,
+            model_uid=model_obj_2.uid,
+            model_db_key=model_obj_2.db_key,
+        )
+
+        db.create_model_endpoint(model_endpoint_2)  # in-place update
+        mep_2 = db.get_model_endpoint(
+            project=model_endpoint_2.metadata.project,
+            name=model_endpoint_2.metadata.name,
+            function_name=model_endpoint_2.spec.function_name,
+            function_tag=model_endpoint_2.spec.function_tag,
+        )
+        assert mep_2.spec.feature_names == ["f1"]
+        assert mep_2.spec.label_names == ["l1"]
+
+        db.create_model_endpoint(
+            model_endpoint_2,
+            creation_strategy=mm_constants.ModelEndpointCreationStrategy.OVERWRITE,
+        )  # overwrite
+        mep_3 = db.get_model_endpoint(
+            project=model_endpoint_2.metadata.project,
+            name=model_endpoint_2.metadata.name,
+            function_name=model_endpoint_2.spec.function_name,
+            function_tag=model_endpoint_2.spec.function_tag,
+        )
+        assert mep_3.spec.feature_names == ["f1"]
+        assert mep_3.spec.label_names == ["l1", "l2"]
 
 
 @TestMLRunSystem.skip_test_if_env_not_configured


### PR DESCRIPTION
A few fixes: 
1. Model outputs are now correctly saved in the model endpoint (MEP) schema.  
2. When a user provides an actual output that does not match the MEP schema:  
   - If fewer outputs are provided, `None` is saved for the missing columns.  
   - If more outputs are provided, only the first set of outputs is saved.

[ML-9257](https://iguazio.atlassian.net/browse/ML-9257)


[ML-9257]: https://iguazio.atlassian.net/browse/ML-9257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ