### PR TITLE
[Notifications] Fix `add_notification` not taking effect on KFP engine workflows

### DIFF
--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -195,6 +195,10 @@ class RunStates:
         ]
 
     @staticmethod
+    def notification_states():
+        return RunStates.terminal_states() + [RunStates.running]
+
+    @staticmethod
     def run_state_to_pipeline_run_status(run_state: str):
         if not run_state:
             return mlrun_pipelines.common.models.RunStatuses.runtime_state_unspecified

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -615,11 +615,19 @@ class _KFPRunner(_PipelineRunner):
                 "Notifications will only be sent if you wait for pipeline completion. "
                 "Some of the features (like setting message or severity level) are not supported."
             )
-            # for start message, fallback to old notification behavior
             for notification in notifications or []:
                 params = notification.params
                 params.update(notification.secret_params)
-                project.notifiers.add_notification(notification.kind, params)
+                project.notifiers.add_notification(
+                    notification_type=notification.kind,
+                    params=params,
+                    name=notification.name,
+                    message=notification.message,
+                    severity=notification.severity,
+                    when=notification.when,
+                    condition=notification.condition,
+                    secret_params=notification.secret_params,
+                )
 
             project.spec.notifications = notifications
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -629,7 +629,7 @@ class _KFPRunner(_PipelineRunner):
                     secret_params=notification.secret_params,
                 )
 
-            project.spec.notifications = notifications
+            project.spec.notifications = project.notifiers.server_notifications
 
         run_id = _run_pipeline(
             workflow_handler,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2735,11 +2735,7 @@ class MlrunProject(ModelObj):
             current_run_state
         )
         db = mlrun.get_run_db()
-        notifications = (
-            notifications
-            or self.spec.notifications
-            or self.notifiers.server_notifications
-        )
+        notifications = notifications or self.spec.notifications
         notifications_to_send = []
         for notification in notifications:
             if current_run_state in notification.when:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2735,7 +2735,11 @@ class MlrunProject(ModelObj):
             current_run_state
         )
         db = mlrun.get_run_db()
-        notifications = notifications or self.spec.notifications
+        notifications = (
+            notifications
+            or self.spec.notifications
+            or self.notifiers.server_notifications
+        )
         notifications_to_send = []
         for notification in notifications:
             if current_run_state in notification.when:

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -516,13 +516,13 @@ class CustomNotificationPusher(_NotificationPusherBase):
         self,
         notification_type: str,
         params: typing.Optional[dict[str, str]] = None,
-        name: str = None,
-        message: str = None,
+        name: typing.Optional[str] = None,
+        message: typing.Optional[str] = None,
         severity: mlrun.common.schemas.notification.NotificationSeverity = (
             mlrun.common.schemas.notification.NotificationSeverity.INFO
         ),
         when: typing.Optional[list[str]] = None,
-        condition: str = None,
+        condition: typing.Optional[str] = None,
         secret_params: typing.Optional[dict[str, str]] = None,
     ):
         if notification_type not in [

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -537,13 +537,7 @@ class CustomNotificationPusher(_NotificationPusherBase):
                     name=name,
                     message=message,
                     severity=severity,
-                    when=when
-                    or [
-                        runtimes_constants.RunStates.running,
-                        runtimes_constants.RunStates.completed,
-                        runtimes_constants.RunStates.error,
-                        runtimes_constants.RunStates.aborted,
-                    ],
+                    when=when or runtimes_constants.RunStates.notification_states(),
                     params=params,
                     secret_params=secret_params,
                 )

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -474,12 +474,17 @@ class CustomNotificationPusher(_NotificationPusherBase):
             for notification_type, notification in notifications.items()
             if notification.is_async
         }
+        self._server_notifications = []
 
     @property
     def notifications(self):
         notifications = self._sync_notifications.copy()
         notifications.update(self._async_notifications)
         return notifications
+
+    @property
+    def server_notifications(self):
+        return self._server_notifications
 
     def push(
         self,
@@ -511,6 +516,14 @@ class CustomNotificationPusher(_NotificationPusherBase):
         self,
         notification_type: str,
         params: typing.Optional[dict[str, str]] = None,
+        name: str = None,
+        message: str = None,
+        severity: mlrun.common.schemas.notification.NotificationSeverity = (
+            mlrun.common.schemas.notification.NotificationSeverity.INFO
+        ),
+        when: typing.Optional[list[str]] = None,
+        condition: str = None,
+        secret_params: typing.Optional[dict[str, str]] = None,
     ):
         if notification_type not in [
             notification_module.NotificationTypes.console,
@@ -518,6 +531,23 @@ class CustomNotificationPusher(_NotificationPusherBase):
         ]:
             # We want that only the console and ipython notifications will be notified by the client.
             # The rest of the notifications will be notified by the BE.
+            self._server_notifications.append(
+                mlrun.model.Notification(
+                    kind=notification_type,
+                    name=name,
+                    message=message,
+                    severity=severity,
+                    when=when
+                    or [
+                        runtimes_constants.RunStates.running,
+                        runtimes_constants.RunStates.completed,
+                        runtimes_constants.RunStates.error,
+                        runtimes_constants.RunStates.aborted,
+                    ],
+                    params=params,
+                    secret_params=secret_params,
+                )
+            )
             return
 
         if notification_type in self._async_notifications:


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-9097

The `project.notifiers` isn't aware of the project spec where the notifications are now saved, moreover `add_notification` didn't supply all the schema of the notification. Causing the new logic of calling MLRun API to ad-hoc send the notifications only works when supplying them fully with `project.run(..., notifications=[...])` which adds the notifications to the project spec.

Added `server_notifactions` member to `project.notifiers` and extended `add_notification`'s function signature to accept all notification attributes (the `when` will be all supported states if not given explicitly). When `add_notification` receives a server side notification it is added to that list. And finally when running the pipeline, the notifications get added to `project.notifiers.server_notifactions` via `add_notification` and ultimately get inserted in the project spec.