### PR TITLE
[Images] Remove Go source code from python images

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -77,6 +77,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete]

--- a/dockerfiles/gpu/Dockerfile
+++ b/dockerfiles/gpu/Dockerfile
@@ -45,6 +45,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete]

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -61,6 +61,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete-api,kfp18]

--- a/dockerfiles/mlrun-kfp/Dockerfile
+++ b/dockerfiles/mlrun-kfp/Dockerfile
@@ -46,6 +46,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[kfp18]

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -79,6 +79,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete]

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -48,6 +48,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete]

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -64,6 +64,8 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 
 COPY . .
 
+RUN rm -rf ./server/go
+
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete] --python-version ${MLRUN_PYTHON_VERSION}


### PR DESCRIPTION
All MLRun images except the log-collector don't need the Go source code, so can be removed.

This resolves go-related vulnerabilities found in our Python images.

https://iguazio.atlassian.net/browse/ML-9260