### PR TITLE
[Config] Prioritize httpdb config first when reading env variables

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -26,7 +26,6 @@ __all__ = [
     "VolumeMount",
 ]
 
-import collections
 from os import environ, path
 from typing import Optional
 
@@ -215,40 +214,8 @@ def set_env_from_file(env_file: str, return_dict: bool = False) -> Optional[dict
     if None in env_vars.values():
         raise MLRunInvalidArgumentError("env file lines must be in the form key=value")
 
-    ordered_env_vars = order_env_vars(env_vars)
-    for key, value in ordered_env_vars.items():
+    for key, value in env_vars.items():
         environ[key] = value
 
     mlconf.reload()  # reload mlrun configuration
-    return ordered_env_vars if return_dict else None
-
-
-def order_env_vars(env_vars: dict[str, str]) -> dict[str, str]:
-    """
-    Order and process environment variables by first handling specific ordered keys,
-    then processing the remaining keys in the given dictionary.
-
-    The function ensures that environment variables defined in the `ordered_keys` list
-    are added to the result dictionary first. Any other environment variables from
-    `env_vars` are then added in the order they appear in the input dictionary.
-
-    :param env_vars: A dictionary where each key is the name of an environment variable (str),
-                      and each value is the corresponding environment variable value (str).
-    :return: A dictionary with the processed environment variables, ordered with the specific
-             keys first, followed by the rest in their original order.
-    """
-    ordered_keys = mlconf.get_ordered_keys()
-
-    ordered_env_vars = collections.OrderedDict()
-
-    # First, add the ordered keys to the dictionary
-    for key in ordered_keys:
-        if key in env_vars:
-            ordered_env_vars[key] = env_vars[key]
-
-    # Then, add the remaining keys (those not in ordered_keys)
-    for key, value in env_vars.items():
-        if key not in ordered_keys:
-            ordered_env_vars[key] = value
-
-    return ordered_env_vars
+    return env_vars if return_dict else None

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1402,13 +1402,6 @@ class Config:
             >= semver.VersionInfo.parse("1.12.10")
         )
 
-    @staticmethod
-    def get_ordered_keys():
-        # Define the keys to process first
-        return [
-            "MLRUN_HTTPDB__HTTP__VERIFY"  # Ensure this key is processed first for proper connection setup
-        ]
-
 
 # Global configuration
 config = Config.from_dict(default_config)

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1626,6 +1626,15 @@ def read_env(env=None, prefix=env_prefix):
     # The default function pod resource values are of type str; however, when reading from environment variable numbers,
     # it converts them to type int if contains only number, so we want to convert them to str.
     _convert_resources_to_str(config)
+
+    # If the environment variable MLRUN_HTTPDB__HTTP__VERIFY is set, we ensure SSL verification settings take precedence
+    # by moving the 'httpdb' configuration to the beginning of the config dictionary.
+    # This ensures that SSL verification is applied before other settings.
+    if "MLRUN_HTTPDB__HTTP__VERIFY" in env:
+        httpdb = config.pop("httpdb", None)
+        if httpdb:
+            config = {"httpdb": httpdb, **config}
+
     return config
 
 

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -224,16 +224,9 @@ class TestMLRunSystem:
         cls._logger.debug("Setting up test environment")
         cls._test_env.update(env)
 
-        ordered_keys = mlconf.get_ordered_keys()
-
-        # Process ordered keys
-        for key in ordered_keys & env.keys():
-            cls._process_env_var(key, env[key])
-
-        # Process remaining keys
+        # Process keys
         for key, value in env.items():
-            if key not in ordered_keys:
-                cls._process_env_var(key, value)
+            cls._process_env_var(key, value)
 
         # Reload the config so changes to the env vars will take effect
         mlrun.mlconf.reload()


### PR DESCRIPTION
This change ensures that the `MLRUN_HTTPDB__HTTP__VERIFY` environment variable is processed first in the configuration, allowing SSL verification settings to be applied early in the configuration process.

The changes that were introduced in this PRs to fix the issue:
https://github.com/mlrun/mlrun/pull/7065
https://github.com/mlrun/mlrun/pull/7221

were specific to `set_env_from_file`, but that was not the flow that caused the bug here, so those changes were reverted, and since setting env from file flow calls the config reload then this case is also covered in this PR.

Jira:
https://iguazio.atlassian.net/browse/ML-8460